### PR TITLE
feat: add dashboard memory view

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2869,6 +2869,119 @@ def _profile_setup_command(name: str) -> str:
     return "hermes setup" if name == "default" else f"{name} setup"
 
 
+_MEMORY_TARGET_FILES: Dict[str, Tuple[str, str]] = {
+    "memory": ("MEMORY.md", "memory"),
+    "user": ("USER.md", "user_profile"),
+}
+
+
+def _resolve_memory_targets(target: str) -> List[str]:
+    target = (target or "all").strip().lower()
+    if target == "all":
+        return ["memory", "user"]
+    if target not in _MEMORY_TARGET_FILES:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid target. Use 'all', 'memory', or 'user'.",
+        )
+    return [target]
+
+
+def _read_memory_entries(path: Path) -> List[str]:
+    """Read Hermes' §-delimited memory file without mutating it."""
+    if not path.exists():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        _log.warning("Could not read memory file %s: %s", path, e)
+        raise HTTPException(status_code=500, detail="Could not read memory file")
+    if not raw.strip():
+        return []
+    from tools.memory_tool import ENTRY_DELIMITER
+
+    return [entry.strip() for entry in raw.split(ENTRY_DELIMITER) if entry.strip()]
+
+
+def _memory_tags(profile_name: str, target: str) -> List[str]:
+    _, store_tag = _MEMORY_TARGET_FILES[target]
+    return [
+        f"agent:{profile_name}",
+        f"profile:{profile_name}",
+        f"target:{target}",
+        f"store:{store_tag}",
+    ]
+
+
+def _memory_profile_sources(profile: str) -> List[Dict[str, Any]]:
+    from hermes_cli import profiles as profiles_mod
+
+    profile = (profile or "all").strip()
+    if not profile or profile == "all":
+        return [_profile_to_dict(p) for p in profiles_mod.list_profiles()]
+
+    profile_dir = _resolve_profile_dir(profile)
+    return [{
+        "name": profiles_mod.normalize_profile_name(profile),
+        "path": str(profile_dir),
+        "is_default": profiles_mod.normalize_profile_name(profile) == "default",
+    }]
+
+
+@app.get("/api/memories")
+async def list_memories_endpoint(profile: str = "all", target: str = "all"):
+    """Return built-in Hermes memories across profiles, tagged by agent/profile.
+
+    Hermes' built-in memory is file-backed under each profile's
+    ``memories/MEMORY.md`` and ``memories/USER.md``.  The dashboard treats a
+    profile as an agent identity, so every entry carries both ``agent:<name>``
+    and ``profile:<name>`` tags in addition to target/store tags.
+    """
+    targets = _resolve_memory_targets(target)
+    sources = _memory_profile_sources(profile)
+    memories: List[Dict[str, Any]] = []
+    profile_summaries: List[Dict[str, Any]] = []
+    target_counts = {"memory": 0, "user": 0}
+
+    for source in sources:
+        profile_name = str(source.get("name") or "default")
+        profile_path = Path(str(source.get("path") or ""))
+        memory_dir = profile_path / "memories"
+        counts = {"memory": 0, "user": 0}
+
+        for selected_target in targets:
+            filename, _store_tag = _MEMORY_TARGET_FILES[selected_target]
+            path = memory_dir / filename
+            entries = _read_memory_entries(path)
+            counts[selected_target] = len(entries)
+            target_counts[selected_target] += len(entries)
+            for idx, content in enumerate(entries):
+                memories.append({
+                    "id": f"{profile_name}:{selected_target}:{idx}",
+                    "profile": profile_name,
+                    "agent": profile_name,
+                    "target": selected_target,
+                    "entry_index": idx,
+                    "content": content,
+                    "tags": _memory_tags(profile_name, selected_target),
+                })
+
+        profile_summaries.append({
+            "name": profile_name,
+            "is_default": bool(source.get("is_default", False)),
+            "memory_count": counts["memory"],
+            "user_count": counts["user"],
+            "entry_count": counts["memory"] + counts["user"],
+        })
+
+    return {
+        "memories": memories,
+        "profiles": profile_summaries,
+        "targets": target_counts,
+        "total": len(memories),
+    }
+
+
 @app.get("/api/profiles")
 async def list_profiles_endpoint():
     from hermes_cli import profiles as profiles_mod

--- a/tests/hermes_cli/test_dashboard_memory_view.py
+++ b/tests/hermes_cli/test_dashboard_memory_view.py
@@ -1,0 +1,199 @@
+"""Dashboard memory-view integration tests."""
+from pathlib import Path
+
+
+ENTRY_DELIMITER = "\n§\n"
+
+
+def _write_memory(profile_dir: Path, *, memory=(), user=()):
+    mem_dir = profile_dir / "memories"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    (mem_dir / "MEMORY.md").write_text(ENTRY_DELIMITER.join(memory), encoding="utf-8")
+    (mem_dir / "USER.md").write_text(ENTRY_DELIMITER.join(user), encoding="utf-8")
+
+
+class TestDashboardMemoryEndpoints:
+    def test_list_memories_returns_profile_and_agent_tags(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:  # pragma: no cover - optional dependency in tiny envs
+            import pytest
+
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        hermes_home = get_hermes_home()
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", hermes_home / "state.db")
+
+        _write_memory(
+            hermes_home,
+            memory=("Default agent memory",),
+            user=("Default user profile",),
+        )
+        coder_home = hermes_home / "profiles" / "coder"
+        _write_memory(
+            coder_home,
+            memory=("Coder agent memory", "Coder second note"),
+            user=("Coder user profile",),
+        )
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+        resp = client.get("/api/memories?profile=all")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 5
+        assert {profile["name"] for profile in data["profiles"]} == {"default", "coder"}
+        assert all("path" not in profile for profile in data["profiles"])
+        by_content = {entry["content"]: entry for entry in data["memories"]}
+
+        coder_entry = by_content["Coder agent memory"]
+        assert coder_entry["profile"] == "coder"
+        assert coder_entry["agent"] == "coder"
+        assert coder_entry["target"] == "memory"
+        assert "path" not in coder_entry
+        assert coder_entry["tags"] == [
+            "agent:coder",
+            "profile:coder",
+            "target:memory",
+            "store:memory",
+        ]
+
+        user_entry = by_content["Default user profile"]
+        assert user_entry["tags"] == [
+            "agent:default",
+            "profile:default",
+            "target:user",
+            "store:user_profile",
+        ]
+
+    def test_list_memories_can_filter_profile_and_target(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:  # pragma: no cover - optional dependency in tiny envs
+            import pytest
+
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        hermes_home = get_hermes_home()
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", hermes_home / "state.db")
+        _write_memory(hermes_home, memory=("Default memory",), user=("Default user",))
+        writer_home = hermes_home / "profiles" / "writer"
+        _write_memory(writer_home, memory=("Writer memory",), user=("Writer user",))
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+        resp = client.get("/api/memories?profile=writer&target=user")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["memories"][0]["content"] == "Writer user"
+        assert data["memories"][0]["tags"] == [
+            "agent:writer",
+            "profile:writer",
+            "target:user",
+            "store:user_profile",
+        ]
+
+    def test_list_memories_requires_dashboard_session_token(self, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:  # pragma: no cover - optional dependency in tiny envs
+            import pytest
+
+            pytest.skip("fastapi/starlette not installed")
+
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+
+        resp = unauth_client.get("/api/memories")
+
+        assert resp.status_code == 401
+
+    def test_list_memories_rejects_invalid_target(self, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:  # pragma: no cover - optional dependency in tiny envs
+            import pytest
+
+            pytest.skip("fastapi/starlette not installed")
+
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+        resp = client.get("/api/memories?target=secrets")
+
+        assert resp.status_code == 400
+        assert "Invalid target" in resp.text
+
+    def test_list_memories_read_error_does_not_disclose_paths(
+        self,
+        monkeypatch,
+        _isolate_hermes_home,
+    ):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:  # pragma: no cover - optional dependency in tiny envs
+            import pytest
+
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        hermes_home = get_hermes_home()
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", hermes_home / "state.db")
+        _write_memory(hermes_home, memory=("Default memory",), user=())
+
+        real_read_text = Path.read_text
+
+        def fail_memory_reads(path, *args, **kwargs):
+            if path.name == "MEMORY.md":
+                raise OSError(f"Permission denied: '{path}'")
+            return real_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fail_memory_reads)
+        client = TestClient(app)
+        client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+        resp = client.get("/api/memories?target=memory")
+
+        assert resp.status_code == 500
+        assert "Could not read memory file" in resp.text
+        assert str(hermes_home) not in resp.text
+        assert "MEMORY.md" not in resp.text
+
+
+class TestDashboardMemoryPageStaticWiring:
+    def test_dashboard_has_memory_route_nav_and_api_client(self):
+        repo = Path(__file__).resolve().parents[2]
+        app = (repo / "web" / "src" / "App.tsx").read_text(encoding="utf-8")
+        api = (repo / "web" / "src" / "lib" / "api.ts").read_text(encoding="utf-8")
+        page = repo / "web" / "src" / "pages" / "MemoryPage.tsx"
+
+        assert page.exists()
+        page_content = page.read_text(encoding="utf-8")
+        assert "agent:" in page_content
+        assert "profile:" in page_content
+        assert "target:" in page_content
+
+        assert "MemoryPage" in app
+        assert '"/memories": MemoryPage' in app
+        assert 'path: "/memories"' in app
+        assert "getMemories" in api
+        assert '"/api/memories' in api

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,7 @@ import ConfigPage from "@/pages/ConfigPage";
 import DocsPage from "@/pages/DocsPage";
 import EnvPage from "@/pages/EnvPage";
 import SessionsPage from "@/pages/SessionsPage";
+import MemoryPage from "@/pages/MemoryPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
@@ -108,6 +109,7 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/memories": MemoryPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -135,6 +137,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     label: "Sessions",
     icon: MessageSquare,
   },
+  { path: "/memories", label: "Memory", icon: Database },
   {
     path: "/analytics",
     labelKey: "analytics",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -163,6 +163,14 @@ export const api = {
   // Profiles (minimal)
   getProfiles: () =>
     fetchJSON<{ profiles: ProfileInfo[] }>("/api/profiles"),
+  getMemories: (params: { profile?: string; target?: "all" | "memory" | "user" } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.profile) qs.set("profile", params.profile);
+    if (params.target) qs.set("target", params.target);
+    const query = qs.toString();
+    const endpoint = "/api/memories";
+    return fetchJSON<MemoriesResponse>(`${endpoint}${query ? `?${query}` : ""}`);
+  },
   createProfile: (body: { name: string; clone_from_default: boolean }) =>
     fetchJSON<{ ok: boolean; name: string; path: string }>("/api/profiles", {
       method: "POST",
@@ -515,6 +523,33 @@ export interface ProfileInfo {
   provider: string | null;
   has_env: boolean;
   skill_count: number;
+}
+
+export type MemoryTarget = "memory" | "user";
+
+export interface MemoryEntryInfo {
+  id: string;
+  profile: string;
+  agent: string;
+  target: MemoryTarget;
+  entry_index: number;
+  content: string;
+  tags: string[];
+}
+
+export interface MemoryProfileSummary {
+  name: string;
+  is_default: boolean;
+  memory_count: number;
+  user_count: number;
+  entry_count: number;
+}
+
+export interface MemoriesResponse {
+  memories: MemoryEntryInfo[];
+  profiles: MemoryProfileSummary[];
+  targets: Record<MemoryTarget, number>;
+  total: number;
 }
 
 export interface ModelsAnalyticsModelEntry {

--- a/web/src/pages/MemoryPage.tsx
+++ b/web/src/pages/MemoryPage.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { Brain, Database, Filter, RefreshCw, Search, User } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Toast } from "@/components/Toast";
+import { useToast } from "@/hooks/useToast";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api } from "@/lib/api";
+import type { MemoriesResponse, MemoryEntryInfo, MemoryProfileSummary, MemoryTarget } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type TargetFilter = "all" | MemoryTarget;
+
+const TARGET_LABELS: Record<TargetFilter, string> = {
+  all: "All memory",
+  memory: "Agent notes",
+  user: "User profile",
+};
+
+export default function MemoryPage() {
+  const [data, setData] = useState<MemoriesResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [search, setSearch] = useState("");
+  const [activeProfile, setActiveProfile] = useState("all");
+  const [activeTarget, setActiveTarget] = useState<TargetFilter>("all");
+  const { toast, showToast } = useToast();
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const load = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const res = await api.getMemories({ profile: "all" });
+      setData(res);
+    } catch (e) {
+      showToast(`Error loading memory: ${e}`, "error");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      void load();
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [load]);
+
+  const profiles = useMemo(() => data?.profiles ?? [], [data]);
+  const memories = useMemo(() => data?.memories ?? [], [data]);
+  const lowerSearch = search.trim().toLowerCase();
+
+  const filtered = useMemo(() => {
+    return memories.filter((entry) => {
+      if (activeProfile !== "all" && entry.profile !== activeProfile) return false;
+      if (activeTarget !== "all" && entry.target !== activeTarget) return false;
+      if (!lowerSearch) return true;
+      return (
+        entry.content.toLowerCase().includes(lowerSearch) ||
+        entry.tags.some((tag) => tag.toLowerCase().includes(lowerSearch))
+      );
+    });
+  }, [activeProfile, activeTarget, lowerSearch, memories]);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <span className="whitespace-nowrap text-xs text-muted-foreground">
+        {filtered.length} of {memories.length} entries
+      </span>,
+    );
+    setEnd(
+      <div className="flex items-center gap-2">
+        <div className="relative hidden min-w-0 sm:block sm:w-64">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="h-8 rounded-none pl-8 text-xs"
+            placeholder="Search memory or tags..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <Button ghost size="sm" onClick={load} disabled={refreshing}>
+          {refreshing ? <Spinner /> : <RefreshCw className="h-3.5 w-3.5" />}
+          <span className="sr-only">Refresh memory</span>
+        </Button>
+      </div>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [filtered.length, load, memories.length, refreshing, search, setAfterTitle, setEnd]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Spinner className="text-2xl text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Toast toast={toast} />
+
+      <div className="relative sm:hidden">
+        <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          className="h-9 rounded-none pl-8 text-xs"
+          placeholder="Search memory or tags..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[16rem_minmax(0,1fr)]">
+        <aside className="flex flex-col gap-3">
+          <FilterPanel
+            profiles={profiles}
+            activeProfile={activeProfile}
+            activeTarget={activeTarget}
+            onProfileChange={setActiveProfile}
+            onTargetChange={setActiveTarget}
+          />
+        </aside>
+
+        <section className="min-w-0">
+          <Card className="rounded-none">
+            <CardHeader className="py-3 px-4">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <Database className="h-4 w-4" />
+                  Hermes memory
+                </CardTitle>
+                <Badge tone="secondary" className="text-xs">
+                  {filtered.length} entr{filtered.length === 1 ? "y" : "ies"}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="px-4 pb-4">
+              {filtered.length === 0 ? (
+                <div className="py-10 text-center text-sm text-muted-foreground">
+                  No memory entries match these filters.
+                </div>
+              ) : (
+                <div className="grid gap-3">
+                  {filtered.map((entry) => (
+                    <MemoryEntryCard key={entry.id} entry={entry} />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function FilterPanel({
+  profiles,
+  activeProfile,
+  activeTarget,
+  onProfileChange,
+  onTargetChange,
+}: {
+  profiles: MemoryProfileSummary[];
+  activeProfile: string;
+  activeTarget: TargetFilter;
+  onProfileChange: (profile: string) => void;
+  onTargetChange: (target: TargetFilter) => void;
+}) {
+  const totalEntries = profiles.reduce((sum, profile) => sum + profile.entry_count, 0);
+
+  return (
+    <div className="rounded-none border border-border bg-muted/20">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <Filter className="h-3 w-3 text-text-tertiary" />
+        <span className="font-mondwest text-display text-xs tracking-[0.12em] text-text-secondary">
+          Filters
+        </span>
+      </div>
+
+      <div className="p-2">
+        <div className="px-2 pb-1 font-mondwest text-display text-xs tracking-[0.12em] text-text-tertiary">
+          Agent / profile tags
+        </div>
+        <FilterButton
+          active={activeProfile === "all"}
+          label="All agents"
+          count={totalEntries}
+          onClick={() => onProfileChange("all")}
+        />
+        {profiles.map((profile) => (
+          <FilterButton
+            key={profile.name}
+            active={activeProfile === profile.name}
+            label={`agent:${profile.name}`}
+            count={profile.entry_count}
+            onClick={() => onProfileChange(profile.name)}
+          />
+        ))}
+      </div>
+
+      <div className="border-t border-border p-2">
+        <div className="px-2 pb-1 font-mondwest text-display text-xs tracking-[0.12em] text-text-tertiary">
+          Store tags
+        </div>
+        {(["all", "memory", "user"] as TargetFilter[]).map((target) => (
+          <FilterButton
+            key={target}
+            active={activeTarget === target}
+            label={target === "all" ? TARGET_LABELS[target] : `target:${target}`}
+            onClick={() => onTargetChange(target)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FilterButton({
+  active,
+  label,
+  count,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  count?: number;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center justify-between gap-2 px-2 py-1.5 text-left text-xs transition-colors",
+        active ? "bg-midground/10 text-midground" : "text-text-secondary hover:text-midground",
+      )}
+    >
+      <span className="truncate font-mono">{label}</span>
+      {count !== undefined && (
+        <span className="shrink-0 tabular-nums text-text-tertiary">{count}</span>
+      )}
+    </button>
+  );
+}
+
+function MemoryEntryCard({ entry }: { entry: MemoryEntryInfo }) {
+  return (
+    <article className="rounded-none border border-border bg-background/40 p-4">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        {entry.target === "user" ? (
+          <User className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <Brain className="h-4 w-4 text-muted-foreground" />
+        )}
+        <Badge tone={entry.target === "user" ? "success" : "secondary"} className="text-xs">
+          {TARGET_LABELS[entry.target]}
+        </Badge>
+        <span className="font-mono text-xs text-muted-foreground">
+          #{entry.entry_index + 1}
+        </span>
+      </div>
+
+      <p className="whitespace-pre-wrap text-sm leading-relaxed text-text-primary">
+        {entry.content}
+      </p>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {entry.tags.map((tag) => (
+          <Badge key={tag} tone="outline" className="font-mono text-xs">
+            {tag}
+          </Badge>
+        ))}
+      </div>
+
+      <div className="mt-2 truncate font-mono text-[0.68rem] text-text-tertiary">
+        profile:{entry.profile} · agent:{entry.agent} · target:{entry.target}
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a dashboard `/api/memories` endpoint for profile-scoped Hermes memory and user-profile entries
- Add a React Memory page with search plus agent/profile/target/store tags
- Wire the new page into dashboard navigation and typed frontend API client
- Add regression coverage for auth, filtering, invalid targets, and filesystem path leakage in success/error responses

## Test Plan
- `python -m pytest tests/hermes_cli/test_dashboard_memory_view.py tests/hermes_cli/test_web_server.py -q`
- `npm run build` from `web/`
- `npx eslint src/pages/MemoryPage.tsx` from `web/`
