### PR TITLE
fix(release): add wubu.bounty.hunter to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1322,6 +1322,7 @@ AUTHOR_MAP = {
     "dearmayo@localhost": "ffr31mr",  # PR #32103 (SubdirectoryHintTracker workspace boundary)
     "TheOnlyMika@users.noreply.github.com": "TheOnlyMika",  # PR #32155 (dashboard XSS + defusedxml)
     "krislidimo@gmail.com": "krislidimo",  # PR #29775 (tighten Telegram table row-group spacing; drop redundant first bullet)
+    "wubu.bounty.hunter@users.noreply.github.com": "WuBuBountyHunter",  # PR #32835 author
 }
 
 


### PR DESCRIPTION
Adds wubu.bounty.hunter@users.noreply.github.com -> WuBuBountyHunter mapping to fix check-attribution CI blocking PR #32835.