### PR TITLE
fix(docker): chown ui-tui and node_modules on UID remap so TUI esbuild works (#28851)

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -68,12 +68,26 @@ if [ "$needs_chown" = true ]; then
                 echo "[stage2] Warning: chown $HERMES_HOME/$sub failed (rootless container?) — continuing"
         fi
     done
-    # The .venv must also be re-chowned when UID is remapped, otherwise
-    # lazy_deps.py cannot install platform packages (discord.py, etc.).
-    # This is under $INSTALL_DIR, not $HERMES_HOME, so the bind-mount
+    # Hermes-owned trees under $INSTALL_DIR must be re-chowned when the UID
+    # is remapped — otherwise:
+    #   - .venv: lazy_deps.py cannot install platform packages (discord.py,
+    #     telegram, slack, etc.) with EACCES (#15012, #21100)
+    #   - ui-tui: esbuild rebuilds dist/entry.js on every TUI launch (when
+    #     the source mtime is newer than dist/ or when HERMES_TUI_FORCE_BUILD
+    #     is set) and writes to ui-tui/dist/. Without this chown the new
+    #     hermes UID can't write the build output (#28851).
+    #   - node_modules: root-level dependencies (puppeteer, web tooling)
+    #     that runtime code may walk/update.
+    # The set mirrors the build-time `chown -R hermes:hermes` line in the
+    # Dockerfile — keep them in sync if the Dockerfile chown set changes.
+    # These are under $INSTALL_DIR (not $HERMES_HOME), so the bind-mount
     # concern doesn't apply — recursive is fine.
-    chown -R hermes:hermes "$INSTALL_DIR/.venv" 2>/dev/null || \
-        echo "[stage2] Warning: chown .venv failed (rootless container?) — continuing"
+    chown -R hermes:hermes \
+        "$INSTALL_DIR/.venv" \
+        "$INSTALL_DIR/ui-tui" \
+        "$INSTALL_DIR/node_modules" \
+        2>/dev/null || \
+        echo "[stage2] Warning: chown of build trees failed (rootless container?) — continuing"
 fi
 
 # Always reset ownership of $HERMES_HOME/profiles to hermes on every


### PR DESCRIPTION
Salvages #28851 (@deas).

## Problem

When `HERMES_UID` remaps the hermes user from the build-time UID 10000 to
another UID (typical use case: matching the host user's UID so bind-mounted
files are owned correctly), the TUI launcher's esbuild step fails:

```
$ docker run -e HERMES_UID=1000 -e HERMES_GID=1000 nousresearch/hermes-agent --tui

  ✘ [ERROR] Failed to write to output file:
     open /opt/hermes/ui-tui/dist/entry.js: permission denied
  TUI build failed.
  Error: Build failed with 1 error
```

This is because the Dockerfile's build-time `chown -R hermes:hermes` on
`/opt/hermes/{.venv,ui-tui,node_modules}` (line 154) wrote UID 10000, and
`stage2-hook.sh` only re-chowned `.venv` on UID remap — leaving the TUI
build trees still owned by the old UID. esbuild needs to rewrite
`ui-tui/dist/entry.js` on every launch where the source mtime is newer
than `dist/` (or when `HERMES_TUI_FORCE_BUILD=1` is set), and it runs
as the new hermes UID, which can no longer write to `dist/`.

## Fix

Extend the stage2 re-chown to include the same set as the build-time
Dockerfile chown:

```sh
chown -R hermes:hermes \
    "$INSTALL_DIR/.venv" \
    "$INSTALL_DIR/ui-tui" \
    "$INSTALL_DIR/node_modules"
```

These are the runtime-writable trees under `$INSTALL_DIR`. Everything else
under `/opt/hermes` is read-only at runtime so keeping it root-owned is fine.

Sync rule documented in the comment so future Dockerfile chown changes
keep stage2 in step.

## Validation

Wrote an isolated TUI UID-remap E2E harness that forces the build path
(`HERMES_TUI_FORCE_BUILD=1`) and runs `docker run --tui` with `HERMES_UID=1000`.

### Baseline (`origin/main`, current behavior)

```
✗ Bug #28851 reproduced: esbuild EACCES on ui-tui/dist/
  ✘ [ERROR] Failed to write to output file: open /opt/hermes/ui-tui/dist/entry.js: permission denied
✗ TUI launcher reports build failed
✓ stage2 chown path triggered: [stage2] Fixing ownership of /opt/data (targeted) to hermes (1000)
✓ stage2 chown of $INSTALL_DIR build trees succeeded silently

Result: 3 pass, 2 fail — bug reproduces cleanly, container exits rc=1
```

### Salvage (this PR)

```
✓ No esbuild EACCES on ui-tui/dist/ — fix in place
✓ TUI build did not fail
✓ ui-tui/dist/entry.js present in image after build
✓ Container reached TTY-check stage (expected non-interactive exit point)
✓ stage2 chown path triggered: [stage2] Fixing ownership of /opt/data (targeted) to hermes (1000)
✓ stage2 chown of $INSTALL_DIR build trees succeeded silently

Result: 6 pass, 0 fail — container exits rc=0
```

### Regression checks

- **Standard image smoke battery** (`--version`, hermes_cli import, `_tui_need_npm_install: False`, `--tui` no-TTY exit, `tools.lazy_deps` import, `gcc` present): **6 pass, 0 fail**
- **Chown E2E from #19788** (host file ownership preserved under bind-mount): **7 pass, 0 fail**

## Authorship

Original change by @deas in #28851. Their branch targeted
`docker/entrypoint.sh` (a deprecated shim since the s6-overlay rework
moved the real cont-init logic into `docker/stage2-hook.sh`);
retargeted the fix accordingly. Preserved attribution via
`Co-authored-by:`.

Closes #28851.
