### PR TITLE
fix(codex): expose output_text after null-output stream recovery

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -99,38 +99,13 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
+from agent.codex_stream_recovery import get_field, run_responses_stream_with_recovery
 from agent.credential_pool import load_pool
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
 
 logger = logging.getLogger(__name__)
-
-
-def _responses_null_output_iterable_error(exc: BaseException) -> bool:
-    """True when the OpenAI SDK trips over terminal response.output=None."""
-    text = str(exc)
-    return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
-
-
-def _responses_backfilled_response(output_items: List[Any], text_parts: List[str], *, has_function_calls: bool, model: str = None) -> Optional[Any]:
-    """Build a minimal Responses-like object from already streamed events."""
-    if output_items:
-        return SimpleNamespace(output=list(output_items), usage=None, status="completed", model=model)
-    if text_parts and not has_function_calls:
-        assembled = "".join(text_parts)
-        return SimpleNamespace(
-            output=[SimpleNamespace(
-                type="message",
-                role="assistant",
-                status="completed",
-                content=[SimpleNamespace(type="output_text", text=assembled)],
-            )],
-            usage=None,
-            status="completed",
-            model=model,
-        )
-    return None
 
 
 def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
@@ -811,101 +786,41 @@ class _CodexCompletionsAdapter:
                 pass
 
         try:
-            # Collect output items and text deltas during streaming —
-            # the Codex backend can return empty response.output from
-            # get_final_response() even when items were streamed.
-            collected_output_items: List[Any] = []
-            collected_text_deltas: List[str] = []
-            has_function_calls = False
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
-            final = None
-            with self._client.responses.stream(**resp_kwargs) as stream:
-                try:
-                    for _event in stream:
-                        _check_cancelled()
-                        _etype = getattr(_event, "type", "")
-                        if _etype == "response.output_item.done":
-                            _done = getattr(_event, "item", None)
-                            if _done is not None:
-                                collected_output_items.append(_done)
-                        elif "output_text.delta" in _etype:
-                            _delta = getattr(_event, "delta", "")
-                            if _delta:
-                                collected_text_deltas.append(_delta)
-                        elif "function_call" in _etype:
-                            has_function_calls = True
-                    _check_cancelled()
-                    final = stream.get_final_response()
-                except TypeError as exc:
-                    if not _responses_null_output_iterable_error(exc):
-                        raise
-                    final = _responses_backfilled_response(
-                        collected_output_items,
-                        collected_text_deltas,
-                        has_function_calls=has_function_calls,
-                        model=resp_kwargs.get("model"),
-                    )
-                    if final is None:
-                        raise
-                    logger.debug(
-                        "Codex auxiliary Responses stream parser hit response.output=None; "
-                        "recovered from streamed events (items=%d, text_parts=%d)",
-                        len(collected_output_items),
-                        len(collected_text_deltas),
-                    )
+            final, _state = run_responses_stream_with_recovery(
+                lambda: self._client.responses.stream(**resp_kwargs),
+                on_event=lambda _event, _state: _check_cancelled(),
+                model=resp_kwargs.get("model"),
+                logger=logger,
+                operation="Codex auxiliary Responses stream",
+            )
+            _check_cancelled()
 
             if final is None:
                 raise RuntimeError("Codex auxiliary Responses stream did not return a final response")
 
-            # Backfill empty output from collected stream events
-            _output = getattr(final, "output", None)
-            if _output is None or (isinstance(_output, list) and not _output):
-                recovered = _responses_backfilled_response(
-                    collected_output_items,
-                    collected_text_deltas,
-                    has_function_calls=has_function_calls,
-                    model=resp_kwargs.get("model"),
-                )
-                if recovered is not None:
-                    final.output = recovered.output
-                    logger.debug(
-                        "Codex auxiliary: backfilled missing output from stream events "
-                        "(items=%d, text_parts=%d)",
-                        len(collected_output_items),
-                        len(collected_text_deltas),
-                    )
-
-            # Extract text and tool calls from the Responses output.
-            # Items may be SDK objects (attrs) or dicts (raw/fallback paths),
-            # so use a helper that handles both shapes.
-            def _item_get(obj: Any, key: str, default: Any = None) -> Any:
-                val = getattr(obj, key, None)
-                if val is None and isinstance(obj, dict):
-                    val = obj.get(key, default)
-                return val if val is not None else default
-
-            for item in getattr(final, "output", []):
-                item_type = _item_get(item, "type")
+            for item in get_field(final, "output", []) or []:
+                item_type = get_field(item, "type")
                 if item_type == "message":
-                    for part in (_item_get(item, "content") or []):
-                        ptype = _item_get(part, "type")
+                    for part in (get_field(item, "content") or []):
+                        ptype = get_field(part, "type")
                         if ptype in {"output_text", "text"}:
-                            text_parts.append(_item_get(part, "text", ""))
+                            text_parts.append(get_field(part, "text", ""))
                 elif item_type == "function_call":
                     tool_calls_raw.append(SimpleNamespace(
-                        id=_item_get(item, "call_id", ""),
+                        id=get_field(item, "call_id", ""),
                         type="function",
                         function=SimpleNamespace(
-                            name=_item_get(item, "name", ""),
-                            arguments=_item_get(item, "arguments", "{}"),
+                            name=get_field(item, "name", ""),
+                            arguments=get_field(item, "arguments", "{}"),
                         ),
                     ))
 
-            resp_usage = getattr(final, "usage", None)
+            resp_usage = get_field(final, "usage")
             if resp_usage:
                 usage = SimpleNamespace(
                     prompt_tokens=getattr(resp_usage, "input_tokens", 0),

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -23,6 +23,14 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
+from agent.codex_stream_recovery import (
+    ResponsesStreamState,
+    build_recovered_response,
+    get_field,
+    run_responses_stream_with_recovery,
+    set_field,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -173,150 +181,71 @@ def run_codex_app_server_turn(
         "codex_turn_id": turn.turn_id,
     }
 
-
-
-
-def _responses_null_output_iterable_error(exc: BaseException) -> bool:
-    """True when the OpenAI SDK trips over terminal response.output=None."""
-    text = str(exc)
-    return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
-
-
-def _codex_output_text_from_items(output_items: list) -> str:
-    text_parts: list[str] = []
-    for item in output_items:
-        if getattr(item, "type", None) != "message":
-            continue
-        content = getattr(item, "content", None)
-        if not isinstance(content, list):
-            continue
-        for part in content:
-            if getattr(part, "type", None) not in {"output_text", "text"}:
-                continue
-            text = getattr(part, "text", None)
-            if isinstance(text, str) and text:
-                text_parts.append(text)
-    return "".join(text_parts)
-
-
-def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str = None):
-    """Build a minimal Responses-like object from events already streamed."""
-    if output_items:
-        return SimpleNamespace(
-            output=list(output_items),
-            output_text=_codex_output_text_from_items(output_items),
-            usage=None,
-            status="completed",
-            model=model,
-        )
-    if text_parts and not has_tool_calls:
-        assembled = "".join(text_parts)
-        return SimpleNamespace(
-            output=[SimpleNamespace(
-                type="message",
-                role="assistant",
-                status="completed",
-                content=[SimpleNamespace(type="output_text", text=assembled)],
-            )],
-            output_text=assembled,
-            usage=None,
-            status="completed",
-            model=model,
-        )
-    return None
-
-
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
     """Execute one streaming Responses API request and return the final response."""
     import httpx as _httpx
 
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
     max_stream_retries = 1
-    has_tool_calls = False
     first_delta_fired = False
-    # Accumulate streamed text so we can recover if get_final_response()
-    # returns empty output (e.g. chatgpt.com backend-api sends
-    # response.incomplete instead of response.completed).
-    agent._codex_streamed_text_parts: list = []
+
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
-        collected_output_items: list = []
+
+        def _handle_event(event, state) -> None:
+            nonlocal first_delta_fired
+
+            # Mark stream activity for the TTFB watchdog in
+            # interruptible_api_call. The Codex backend can accept the
+            # connection but never emit a single event; this timestamp
+            # staying None tells the watchdog no bytes are flowing.
+            agent._codex_stream_last_event_ts = time.time()
+            agent._touch_activity("receiving stream response")
+            if agent._interrupt_requested:
+                raise InterruptedError("Agent interrupted during Codex stream")
+
+            event_type = get_field(event, "type", "") or ""
+            # Fire callbacks on text content deltas (suppress during tool calls)
+            if "output_text.delta" in event_type or event_type == "response.output_text.delta":
+                delta_text = get_field(event, "delta", "")
+                if delta_text and not state.has_function_calls:
+                    if not first_delta_fired:
+                        first_delta_fired = True
+                        if on_first_delta:
+                            try:
+                                on_first_delta()
+                            except Exception:
+                                pass
+                    agent._fire_stream_delta(delta_text)
+            # Fire reasoning callbacks
+            elif "reasoning" in event_type and "delta" in event_type:
+                reasoning_text = get_field(event, "delta", "")
+                if reasoning_text:
+                    agent._fire_reasoning_delta(reasoning_text)
+            # Log non-completed terminal events for diagnostics
+            elif event_type in {"response.incomplete", "response.failed"}:
+                resp_obj = get_field(event, "response")
+                status = get_field(resp_obj, "status") if resp_obj else None
+                incomplete_details = get_field(resp_obj, "incomplete_details") if resp_obj else None
+                logger.warning(
+                    "Codex Responses stream received terminal event %s "
+                    "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
+                    event_type, status, incomplete_details,
+                    state.streamed_chars,
+                    agent._client_log_context(),
+                )
+
         try:
-            with active_client.responses.stream(**api_kwargs) as stream:
-                for event in stream:
-                    # Mark stream activity for the TTFB watchdog in
-                    # interruptible_api_call. The Codex backend can accept the
-                    # connection but never emit a single event; this timestamp
-                    # staying None tells the watchdog no bytes are flowing.
-                    agent._codex_stream_last_event_ts = time.time()
-                    agent._touch_activity("receiving stream response")
-                    if agent._interrupt_requested:
-                        break
-                    event_type = getattr(event, "type", "")
-                    # Fire callbacks on text content deltas (suppress during tool calls)
-                    if "output_text.delta" in event_type or event_type == "response.output_text.delta":
-                        delta_text = getattr(event, "delta", "")
-                        if delta_text:
-                            agent._codex_streamed_text_parts.append(delta_text)
-                        if delta_text and not has_tool_calls:
-                            if not first_delta_fired:
-                                first_delta_fired = True
-                                if on_first_delta:
-                                    try:
-                                        on_first_delta()
-                                    except Exception:
-                                        pass
-                            agent._fire_stream_delta(delta_text)
-                    # Track tool calls to suppress text streaming
-                    elif "function_call" in event_type:
-                        has_tool_calls = True
-                    # Fire reasoning callbacks
-                    elif "reasoning" in event_type and "delta" in event_type:
-                        reasoning_text = getattr(event, "delta", "")
-                        if reasoning_text:
-                            agent._fire_reasoning_delta(reasoning_text)
-                    # Collect completed output items — some backends
-                    # (chatgpt.com/backend-api/codex) stream valid items
-                    # via response.output_item.done but the SDK's
-                    # get_final_response() returns an empty output list.
-                    elif event_type == "response.output_item.done":
-                        done_item = getattr(event, "item", None)
-                        if done_item is not None:
-                            collected_output_items.append(done_item)
-                    # Log non-completed terminal events for diagnostics
-                    elif event_type in {"response.incomplete", "response.failed"}:
-                        resp_obj = getattr(event, "response", None)
-                        status = getattr(resp_obj, "status", None) if resp_obj else None
-                        incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
-                        logger.warning(
-                            "Codex Responses stream received terminal event %s "
-                            "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
-                            event_type, status, incomplete_details,
-                            sum(len(p) for p in agent._codex_streamed_text_parts),
-                            agent._client_log_context(),
-                        )
-                final_response = stream.get_final_response()
-                # PATCH: ChatGPT Codex backend streams valid output items
-                # but get_final_response() can return an empty output list.
-                # Backfill from collected items or synthesize from deltas.
-                _out = getattr(final_response, "output", None)
-                if _out is None or (isinstance(_out, list) and not _out):
-                    recovered = _codex_backfilled_response(
-                        collected_output_items,
-                        agent._codex_streamed_text_parts,
-                        has_tool_calls=has_tool_calls,
-                        model=api_kwargs.get("model"),
-                    )
-                    if recovered is not None:
-                        final_response.output = recovered.output
-                        logger.debug(
-                            "Codex stream: backfilled missing output from stream events "
-                            "(items=%d, text_parts=%d)",
-                            len(collected_output_items),
-                            len(agent._codex_streamed_text_parts),
-                        )
-                return final_response
+            final_response, _state = run_responses_stream_with_recovery(
+                lambda: active_client.responses.stream(**api_kwargs),
+                on_event=_handle_event,
+                model=api_kwargs.get("model"),
+                logger=logger,
+                operation="Codex Responses stream",
+                log_context=agent._client_log_context(),
+            )
+            return final_response
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(
@@ -333,30 +262,6 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
-        except TypeError as exc:
-            if _responses_null_output_iterable_error(exc):
-                recovered = _codex_backfilled_response(
-                    collected_output_items,
-                    agent._codex_streamed_text_parts,
-                    has_tool_calls=has_tool_calls,
-                    model=api_kwargs.get("model"),
-                )
-                if recovered is not None:
-                    logger.debug(
-                        "Codex Responses stream parser hit response.output=None; "
-                        "recovered from streamed events (items=%d, text_parts=%d). %s",
-                        len(collected_output_items),
-                        len(agent._codex_streamed_text_parts),
-                        agent._client_log_context(),
-                    )
-                    return recovered
-                logger.debug(
-                    "Codex Responses stream parser hit response.output=None without "
-                    "recoverable events; falling back to create(stream=True). %s",
-                    agent._client_log_context(),
-                )
-                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
-            raise
         except RuntimeError as exc:
             err_text = str(exc)
             missing_completed = "response.completed" in err_text
@@ -486,16 +391,20 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                 terminal_response = event.get("response")
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
-                _out = getattr(terminal_response, "output", None)
+                _out = get_field(terminal_response, "output")
                 if _out is None or (isinstance(_out, list) and not _out):
-                    recovered = _codex_backfilled_response(
-                        collected_output_items,
-                        collected_text_deltas,
-                        has_tool_calls=has_tool_calls,
+                    recovered = build_recovered_response(
+                        ResponsesStreamState(
+                            output_items=list(collected_output_items),
+                            text_deltas=list(collected_text_deltas),
+                            has_function_calls=has_tool_calls,
+                        ),
                         model=fallback_kwargs.get("model"),
                     )
                     if recovered is not None:
-                        terminal_response.output = recovered.output
+                        set_field(terminal_response, "output", recovered.output)
+                        if not get_field(terminal_response, "output_text"):
+                            set_field(terminal_response, "output_text", recovered.output_text)
                         logger.debug(
                             "Codex fallback stream: backfilled missing output "
                             "(items=%d, text_parts=%d)",

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -182,11 +182,29 @@ def _responses_null_output_iterable_error(exc: BaseException) -> bool:
     return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
 
 
+def _codex_output_text_from_items(output_items: list) -> str:
+    text_parts: list[str] = []
+    for item in output_items:
+        if getattr(item, "type", None) != "message":
+            continue
+        content = getattr(item, "content", None)
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if getattr(part, "type", None) not in {"output_text", "text"}:
+                continue
+            text = getattr(part, "text", None)
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+    return "".join(text_parts)
+
+
 def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str = None):
     """Build a minimal Responses-like object from events already streamed."""
     if output_items:
         return SimpleNamespace(
             output=list(output_items),
+            output_text=_codex_output_text_from_items(output_items),
             usage=None,
             status="completed",
             model=model,
@@ -200,6 +218,7 @@ def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool
                 status="completed",
                 content=[SimpleNamespace(type="output_text", text=assembled)],
             )],
+            output_text=assembled,
             usage=None,
             status="completed",
             model=model,

--- a/agent/codex_stream_recovery.py
+++ b/agent/codex_stream_recovery.py
@@ -1,0 +1,233 @@
+"""Shared recovery for Codex/Responses streaming parser drift.
+
+Some Codex-compatible Responses backends stream valid output items, then send
+a terminal response payload whose ``response.output`` is ``null``. OpenAI's
+Python SDK may raise ``TypeError("'NoneType' object is not iterable")`` while
+folding that terminal event, even though the useful output already arrived in
+``response.output_item.done`` events. Keep the workaround in one place so each
+caller only supplies its own per-event side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from threading import Lock
+from typing import Any, Callable, List, Optional, Tuple
+
+
+_WARNED_RECOVERY_KEYS = set()
+_WARNED_RECOVERY_LOCK = Lock()
+
+
+@dataclass
+class ResponsesStreamState:
+    """Collected facts from a Responses stream."""
+
+    output_items: List[Any] = field(default_factory=list)
+    text_deltas: List[str] = field(default_factory=list)
+    has_function_calls: bool = False
+    recovered_from_parser_error: bool = False
+    backfilled_final_output: bool = False
+
+    @property
+    def streamed_chars(self) -> int:
+        return sum(len(part) for part in self.text_deltas)
+
+
+def get_field(obj: Any, key: str, default: Any = None) -> Any:
+    """Read a field from SDK objects or dict-shaped events/items."""
+    value = getattr(obj, key, None)
+    if value is None and isinstance(obj, dict):
+        value = obj.get(key, default)
+    return value if value is not None else default
+
+
+def set_field(obj: Any, key: str, value: Any) -> None:
+    """Write a field to SDK objects or dict-shaped responses."""
+    if isinstance(obj, dict):
+        obj[key] = value
+    else:
+        setattr(obj, key, value)
+
+
+def is_null_output_iterable_error(exc: BaseException) -> bool:
+    """True when the OpenAI SDK trips over terminal ``response.output=None``."""
+    text = str(exc)
+    return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
+
+
+def output_text_from_items(output_items: List[Any]) -> str:
+    """Extract assistant text from Responses output items."""
+    text_parts: List[str] = []
+    for item in output_items:
+        if get_field(item, "type") != "message":
+            continue
+        content = get_field(item, "content", []) or []
+        for part in content:
+            part_type = get_field(part, "type")
+            if part_type not in {"output_text", "text"}:
+                continue
+            text = get_field(part, "text", "")
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+    return "".join(text_parts)
+
+
+def build_recovered_response(
+    state: ResponsesStreamState,
+    *,
+    model: Optional[str] = None,
+    usage: Any = None,
+) -> Optional[Any]:
+    """Build a minimal Responses-like object from already streamed events."""
+    if state.output_items:
+        output_items = list(state.output_items)
+    elif state.text_deltas and not state.has_function_calls:
+        output_items = [
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[
+                    SimpleNamespace(
+                        type="output_text",
+                        text="".join(state.text_deltas),
+                    )
+                ],
+            )
+        ]
+    else:
+        return None
+
+    return SimpleNamespace(
+        output=output_items,
+        output_text=output_text_from_items(output_items) or None,
+        usage=usage,
+        status="completed",
+        model=model,
+    )
+
+
+def record_response_stream_event(event: Any, state: ResponsesStreamState) -> None:
+    """Collect recovery data from one Responses stream event."""
+    event_type = get_field(event, "type", "") or ""
+    if event_type == "response.output_item.done":
+        item = get_field(event, "item")
+        if item is not None:
+            state.output_items.append(item)
+            if get_field(item, "type") == "function_call":
+                state.has_function_calls = True
+    elif "output_text.delta" in event_type:
+        delta = get_field(event, "delta", "")
+        if isinstance(delta, str) and delta:
+            state.text_deltas.append(delta)
+    elif "function_call" in event_type:
+        state.has_function_calls = True
+
+
+def backfill_response_output(
+    response: Any,
+    state: ResponsesStreamState,
+    *,
+    model: Optional[str] = None,
+) -> Any:
+    """Fill missing/empty final output from stream events when possible."""
+    if response is None:
+        return None
+
+    output = get_field(response, "output")
+    if output is not None and not (isinstance(output, list) and not output):
+        if not get_field(response, "output_text"):
+            text = output_text_from_items(list(output)) if isinstance(output, list) else ""
+            if text:
+                set_field(response, "output_text", text)
+        return response
+
+    recovered = build_recovered_response(state, model=model, usage=get_field(response, "usage"))
+    if recovered is None:
+        return response
+
+    set_field(response, "output", recovered.output)
+    if not get_field(response, "output_text"):
+        set_field(response, "output_text", recovered.output_text)
+    state.backfilled_final_output = True
+    return response
+
+
+def run_responses_stream_with_recovery(
+    stream_factory: Callable[[], Any],
+    *,
+    on_event: Optional[Callable[[Any, ResponsesStreamState], None]] = None,
+    model: Optional[str] = None,
+    logger: Any = None,
+    operation: str = "Codex Responses stream",
+    log_context: str = "",
+) -> Tuple[Any, ResponsesStreamState]:
+    """Run a Responses stream and recover from terminal ``output=null`` drift.
+
+    ``on_event`` runs after the shared collector has recorded the event, so
+    callers can inspect ``state`` without duplicating parser-recovery state.
+    """
+    state = ResponsesStreamState()
+
+    def _recover_or_raise(exc: TypeError) -> Any:
+        if not is_null_output_iterable_error(exc):
+            raise exc
+        recovered = build_recovered_response(state, model=model)
+        if recovered is None:
+            raise exc
+        state.recovered_from_parser_error = True
+        if logger is not None:
+            suffix = f" {log_context}" if log_context else ""
+            log_method = logger.debug
+            warn_key = (operation, model)
+            with _WARNED_RECOVERY_LOCK:
+                if warn_key not in _WARNED_RECOVERY_KEYS:
+                    _WARNED_RECOVERY_KEYS.add(warn_key)
+                    log_method = logger.warning
+            log_method(
+                "%s parser failed on terminal response.output=None; "
+                "recovered %d output item(s), %d text delta part(s).%s",
+                operation,
+                len(state.output_items),
+                len(state.text_deltas),
+                suffix,
+            )
+        return recovered
+
+    with stream_factory() as stream:
+        try:
+            iterator = iter(stream)
+        except TypeError as exc:
+            return _recover_or_raise(exc), state
+
+        while True:
+            try:
+                event = next(iterator)
+            except StopIteration:
+                break
+            except TypeError as exc:
+                return _recover_or_raise(exc), state
+
+            record_response_stream_event(event, state)
+            if on_event is not None:
+                on_event(event, state)
+
+        try:
+            final_response = stream.get_final_response()
+        except TypeError as exc:
+            return _recover_or_raise(exc), state
+
+    final_response = backfill_response_output(final_response, state, model=model)
+    if state.backfilled_final_output and logger is not None:
+        suffix = f" {log_context}" if log_context else ""
+        logger.debug(
+            "%s backfilled missing final output from stream events "
+            "(items=%d, text_parts=%d).%s",
+            operation,
+            len(state.output_items),
+            len(state.text_deltas),
+            suffix,
+        )
+    return final_response, state

--- a/tests/agent/test_codex_stream_recovery.py
+++ b/tests/agent/test_codex_stream_recovery.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+from agent.codex_stream_recovery import run_responses_stream_with_recovery
+
+
+class _FakeStream:
+    def __init__(self, events, final_response=None, final_error=None, iteration_error=None):
+        self._events = list(events)
+        self._final_response = final_response
+        self._final_error = final_error
+        self._iteration_error = iteration_error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+        if self._iteration_error is not None:
+            raise self._iteration_error
+
+    def get_final_response(self):
+        if self._final_error is not None:
+            raise self._final_error
+        return self._final_response
+
+
+def test_recovers_output_item_when_sdk_parser_raises_during_iteration():
+    output_item = SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text="survived")],
+    )
+
+    final, state = run_responses_stream_with_recovery(
+        lambda: _FakeStream(
+            [SimpleNamespace(type="response.output_item.done", item=output_item)],
+            iteration_error=TypeError("'NoneType' object is not iterable"),
+        ),
+        model="gpt-5.5",
+    )
+
+    assert state.recovered_from_parser_error is True
+    assert final.status == "completed"
+    assert final.output == [output_item]
+    assert final.output_text == "survived"
+
+
+def test_backfills_empty_final_output_from_text_deltas():
+    final, state = run_responses_stream_with_recovery(
+        lambda: _FakeStream(
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="hel"),
+                SimpleNamespace(type="response.output_text.delta", delta="lo"),
+            ],
+            final_response=SimpleNamespace(output=[], output_text=None, usage=None),
+        ),
+        model="gpt-5.5",
+    )
+
+    assert state.backfilled_final_output is True
+    assert final.output[0].content[0].text == "hello"
+    assert final.output_text == "hello"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -506,7 +506,7 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
 
 
 def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(monkeypatch):
-    """Regression for #11179: the SDK can raise while iterating response.completed.
+    """Regression for #32991/#11179: SDK parsing can fail at response.completed.
 
     The failure happens before get_final_response(), so post-loop backfill alone is
     not enough. Preserve already streamed output_item.done events.
@@ -536,6 +536,7 @@ def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(mo
 
     assert calls["stream"] == 1
     assert response.output == [output_item]
+    assert response.output_text == "stream item survived"
     assert response.status == "completed"
 
 


### PR DESCRIPTION
## Summary
- derive `output_text` when recovering a Codex Responses stream from already-seen output items
- keep synthesized text-delta recovery aligned with the same response shape
- extend the null-output streaming regression test to assert recovered `output_text`

Closes #32991

## Test
- `/opt/hermes/src/venv/bin/python -m pytest -o addopts='' tests/run_agent/test_run_agent_codex_responses.py -q`

## Notes
No credentials, tokens, hostnames, user IDs, or deployment-specific logs are included.