### PR TITLE
feat(vision): probe Ollama /api/show for vision capability on catalog miss

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -302,6 +302,7 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
     "kimi-coding",
     "kimi-coding-cn",
+    "ollama-cloud",
 })
 
 # OpenRouter app attribution headers (base — always sent).
@@ -1734,7 +1735,14 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested="custom")
+        # Resolve the default configured provider first. If it's a custom
+        # runtime (e.g. a user-defined named custom provider like
+        # ollama-launch) we use it directly; otherwise fall back to an
+        # explicit "custom" request so the legacy single-custom path still
+        # works.
+        runtime = resolve_runtime_provider(requested=None)
+        if not isinstance(runtime, dict) or runtime.get("provider") != "custom":
+            runtime = resolve_runtime_provider(requested="custom")
     except Exception as exc:
         logger.debug("Auxiliary client: custom runtime resolution failed: %s", exc)
         runtime = None

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -528,6 +528,27 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
 
+    # When the current turn already has a native image attached (an
+    # image_url content part on any message), suppress the vision_analyze
+    # tool so the model reads the pixels directly rather than calling a
+    # redundant — and on local/custom endpoints often unconfigured — tool.
+    has_native_images = False
+    for msg in api_messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "image_url":
+                    has_native_images = True
+                    break
+        if has_native_images:
+            break
+
+    if has_native_images and tools_for_api:
+        tools_for_api = [
+            t for t in tools_for_api
+            if not (isinstance(t, dict) and t.get("function", {}).get("name") == "vision_analyze")
+        ]
+
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -266,7 +266,10 @@ def _lookup_supports_vision(
 
     Consults the user's ``supports_vision`` override in config.yaml first
     (so custom/local models declared as vision-capable don't fall through to
-    text routing in ``auto`` mode), then falls back to models.dev.
+    text routing in ``auto`` mode), then falls back to models.dev. On a
+    models.dev catalog miss, falls back to probing the live Ollama endpoint
+    so locally-served vision models with custom tags (e.g. ``gemma4:latest``)
+    route natively instead of through the lossy text pipeline.
     """
     override = _supports_vision_override(cfg, provider, model)
     if override is not None:
@@ -278,10 +281,72 @@ def _lookup_supports_vision(
         caps = get_model_capabilities(provider, model)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("image_routing: caps lookup failed for %s:%s — %s", provider, model, exc)
-        return None
-    if caps is None:
-        return None
-    return bool(caps.supports_vision)
+        caps = None
+
+    if caps is not None:
+        return bool(caps.supports_vision)
+
+    # Catalog miss — fall back to the live Ollama endpoint capability probe
+    # if we can resolve a base_url from cfg.
+    if isinstance(cfg, dict):
+        base_url = ""
+        api_key = ""
+
+        providers = cfg.get("providers") or {}
+        model_cfg = cfg.get("model") or {}
+        config_provider = str(model_cfg.get("provider") or "").strip()
+
+        candidates: list = []
+        for p in (provider, config_provider):
+            if p and p != "custom" and p not in candidates:
+                candidates.append(p)
+        if provider and provider not in candidates:
+            candidates.append(provider)
+
+        provider_cfg = None
+        if isinstance(providers, dict):
+            for cand in candidates:
+                if cand in providers:
+                    provider_cfg = providers[cand]
+                    break
+
+        if not isinstance(provider_cfg, dict):
+            custom_provs = cfg.get("custom_providers") or []
+            if isinstance(custom_provs, list):
+                for cand in candidates:
+                    for p in custom_provs:
+                        if isinstance(p, dict) and str(p.get("name") or "").strip().lower() == cand.lower():
+                            provider_cfg = p
+                            break
+                    if provider_cfg:
+                        break
+
+        if isinstance(provider_cfg, dict):
+            for url_key in ("base_url", "url", "api"):
+                val = provider_cfg.get(url_key)
+                if isinstance(val, str) and val.strip():
+                    base_url = val.strip()
+                    break
+
+            api_key = str(provider_cfg.get("api_key") or "").strip()
+            if not api_key:
+                key_env = str(provider_cfg.get("key_env") or provider_cfg.get("api_key_env") or "").strip()
+                if key_env:
+                    import os
+                    api_key = os.environ.get(key_env, "")
+
+        if not base_url:
+            if isinstance(model_cfg, dict):
+                base_url = str(model_cfg.get("base_url") or "").strip()
+                api_key = str(model_cfg.get("api_key") or "").strip()
+
+        if base_url:
+            try:
+                from agent.model_metadata import endpoint_supports_vision
+                return endpoint_supports_vision(model, base_url, api_key)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("image_routing: endpoint vision probe failed for %s — %s", model, exc)
+    return None
 
 
 def decide_image_input_mode(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1116,6 +1116,65 @@ def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> Opti
     return None
 
 
+# Process-lifetime cache for endpoint-reported vision capability, keyed by
+# ``model@base_url``. Only definitive True/False results are cached so
+# transient probe failures (server down, timeout) get retried on the next
+# call rather than locking in a sticky "unknown".
+_ENDPOINT_VISION_CACHE: Dict[str, bool] = {}
+
+
+def _query_ollama_capabilities(model: str, base_url: str, api_key: str = "") -> Optional[List[str]]:
+    """Return an Ollama server's ``/api/show`` capabilities list for *model*.
+
+    Ollama reports a top-level ``capabilities`` array, e.g.
+    ``["completion", "vision", "tools", "thinking"]``. Provider-agnostic:
+    works against any Ollama-compatible endpoint regardless of hostname.
+    Returns ``None`` for non-Ollama servers (they 404/405 the POST) or when
+    the field is absent.
+    """
+    import httpx
+
+    server_url = base_url.rstrip("/")
+    if server_url.endswith("/v1"):
+        server_url = server_url[:-3]
+
+    headers = _auth_headers(api_key)
+    try:
+        with httpx.Client(timeout=5.0, headers=headers) as client:
+            resp = client.post(f"{server_url}/api/show", json={"name": model})
+            if resp.status_code != 200:
+                return None
+            caps = resp.json().get("capabilities")
+            if isinstance(caps, list):
+                return [str(c).lower() for c in caps]
+    except Exception:
+        pass
+    return None
+
+
+def endpoint_supports_vision(model: str, base_url: str, api_key: str = "") -> Optional[bool]:
+    """Return whether an Ollama endpoint reports vision support for *model*.
+
+    Fallback for image-routing capability checks when models.dev has no
+    entry for the model (e.g. a locally-served Ollama tag like
+    ``gemma4:latest``). Returns ``True``/``False`` when the endpoint
+    reports its capabilities, or ``None`` when capability can't be
+    determined. Cached for the process lifetime keyed by
+    ``model@base_url``; ``None`` results are not cached.
+    """
+    if not model or not base_url:
+        return None
+    key = f"{model}@{base_url}"
+    if key in _ENDPOINT_VISION_CACHE:
+        return _ENDPOINT_VISION_CACHE[key]
+    caps = _query_ollama_capabilities(model, base_url, api_key=api_key)
+    if caps is None:
+        return None
+    result = "vision" in caps
+    _ENDPOINT_VISION_CACHE[key] = result
+    return result
+
+
 def _model_name_suggests_kimi(model: str) -> bool:
     """Return True if the model name looks like a Kimi-family model.
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2641,12 +2641,39 @@ class TestVisionAutoSkipsKimiCoding:
         assert client is fake_kimi_client
         gcc_mock.assert_called_once()
 
+    def test_ollama_cloud_skips_to_aggregator_chain(self, monkeypatch):
+        """Ollama Cloud should fall through to the aggregator chain for vision."""
+        fake_or_client = MagicMock(name="openrouter_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "ollama-cloud",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "glm-5.1:cloud",
+        )
+        rpc_mock = MagicMock(side_effect=AssertionError(
+            "resolve_provider_client should NOT be called for ollama-cloud"))
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            lambda p, m=None: (fake_or_client, "gemini")
+            if p == "openrouter"
+            else (None, None),
+        )
+
+        provider, client, _ = resolve_vision_provider_client()
+        assert provider == "openrouter"
+        assert client is fake_or_client
+
     def test_skip_set_covers_exactly_known_entries(self):
         """Guard against accidental widening of the skip list."""
         from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
         assert _PROVIDERS_WITHOUT_VISION == frozenset({
             "kimi-coding",
             "kimi-coding-cn",
+            "ollama-cloud",
         })
 
 
@@ -3427,3 +3454,28 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+def test_resolve_custom_runtime_with_named_custom_provider():
+    """``_resolve_custom_runtime`` should first try the default-configured
+    provider (which may be a named custom provider like ``ollama-launch``)
+    before falling back to an explicit ``requested="custom"`` call.
+    """
+    from agent.auxiliary_client import _resolve_custom_runtime
+
+    mock_runtime_first = {
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "base_url": "http://192.168.1.210:11434/v1",
+        "api_key": "ollama-key",
+    }
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=mock_runtime_first,
+    ) as mock_resolve:
+        base, key, mode = _resolve_custom_runtime()
+        assert base == "http://192.168.1.210:11434/v1"
+        assert key == "ollama-key"
+        assert mode == "chat_completions"
+        mock_resolve.assert_called_once_with(requested=None)

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -290,6 +290,112 @@ class TestAutoModeRespectsOverride:
             assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "text"
 
 
+# ─── Ollama capability-probe fallback (models.dev catalog miss) ──────────────
+
+
+class TestOllamaVisionFallback:
+    """When models.dev has no entry for a model, the routing falls back to the
+    live Ollama ``/api/show`` capability probe so locally-served vision models
+    with custom tags (e.g. ``gemma4:latest``) route natively instead of via
+    the lossy text pipeline.
+    """
+
+    def test_lookup_probes_endpoint_on_catalog_miss(self):
+        from agent.image_routing import _lookup_supports_vision
+        cfg = {
+            "model": {"base_url": "http://localhost:11434/v1", "api_key": "ollama"},
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=True) as probe:
+            assert _lookup_supports_vision(
+                "ollama-launch", "gemma4:latest", cfg
+            ) is True
+        probe.assert_called_once_with(
+            "gemma4:latest", "http://localhost:11434/v1", "ollama"
+        )
+
+    def test_lookup_probes_endpoint_with_named_provider_v12(self):
+        from agent.image_routing import _lookup_supports_vision
+        cfg = {
+            "providers": {
+                "ollama-launch": {
+                    "api": "http://192.168.1.210:11434/v1",
+                    "api_key": "secret-key",
+                }
+            }
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=True) as probe:
+            assert _lookup_supports_vision(
+                "ollama-launch", "gemma4:latest", cfg
+            ) is True
+        probe.assert_called_once_with(
+            "gemma4:latest", "http://192.168.1.210:11434/v1", "secret-key"
+        )
+
+    def test_lookup_probes_endpoint_with_legacy_custom_providers(self):
+        from agent.image_routing import _lookup_supports_vision
+        cfg = {
+            "custom_providers": [
+                {
+                    "name": "my-local-ollama",
+                    "url": "http://127.0.0.1:11434/v1",
+                    "key_env": "OLLAMA_SECRET_KEY",
+                }
+            ]
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=True) as probe, \
+             patch.dict("os.environ", {"OLLAMA_SECRET_KEY": "env-secret"}):
+            assert _lookup_supports_vision(
+                "my-local-ollama", "qwen3.6:35b", cfg
+            ) is True
+        probe.assert_called_once_with(
+            "qwen3.6:35b", "http://127.0.0.1:11434/v1", "env-secret"
+        )
+
+    def test_lookup_no_probe_without_base_url(self):
+        from agent.image_routing import _lookup_supports_vision
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision") as probe:
+            assert _lookup_supports_vision("custom", "gemma4:latest", {}) is None
+            probe.assert_not_called()
+
+    def test_lookup_prefers_catalog_over_probe(self):
+        """When the catalog knows the model, the endpoint isn't probed."""
+        from agent.image_routing import _lookup_supports_vision
+        from types import SimpleNamespace
+        caps = SimpleNamespace(supports_vision=True)
+        cfg = {
+            "model": {"base_url": "https://api.anthropic.com", "api_key": "key"},
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=caps), \
+             patch("agent.model_metadata.endpoint_supports_vision") as probe:
+            assert _lookup_supports_vision(
+                "anthropic", "claude-sonnet-4", cfg
+            ) is True
+            probe.assert_not_called()
+
+    def test_auto_routes_native_for_ollama_vision_model_not_in_catalog(self):
+        cfg = {
+            "agent": {"image_input_mode": "auto"},
+            "model": {"base_url": "http://localhost:11434/v1", "api_key": "ollama"},
+            "auxiliary": {"vision": {"provider": "auto", "model": "", "base_url": ""}},
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=True):
+            assert decide_image_input_mode("ollama-launch", "gemma4:latest", cfg) == "native"
+
+    def test_auto_routes_text_when_endpoint_reports_no_vision(self):
+        cfg = {
+            "agent": {"image_input_mode": "auto"},
+            "model": {"base_url": "http://localhost:11434/v1", "api_key": "ollama"},
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=False):
+            assert decide_image_input_mode("ollama-launch", "llama3:latest", cfg) == "text"
+
+
 # ─── build_native_content_parts ──────────────────────────────────────────────
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1247,3 +1247,78 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# ─── endpoint_supports_vision (Ollama /api/show capability probe) ────────────
+
+
+class TestEndpointSupportsVision:
+    """Probe an Ollama endpoint's reported ``capabilities`` to decide vision
+    support for models that models.dev doesn't list (custom local tags).
+    """
+
+    def setup_method(self):
+        from agent import model_metadata as mm
+        mm._ENDPOINT_VISION_CACHE.clear()
+
+    def _client(self, payload, status=200):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json.return_value = payload
+        client = MagicMock()
+        client.post.return_value = resp
+        client.__enter__.return_value = client
+        client.__exit__.return_value = False
+        return client
+
+    def test_vision_capability_true(self):
+        from agent.model_metadata import endpoint_supports_vision
+        client = self._client({"capabilities": ["completion", "vision", "tools"]})
+        with patch("httpx.Client", return_value=client):
+            assert endpoint_supports_vision(
+                "gemma4:latest", "http://host:11434/v1", "ollama"
+            ) is True
+
+    def test_text_only_model_false(self):
+        from agent.model_metadata import endpoint_supports_vision
+        client = self._client({"capabilities": ["completion", "tools"]})
+        with patch("httpx.Client", return_value=client):
+            assert endpoint_supports_vision("llama3:latest", "http://host:11434/v1") is False
+
+    def test_non_ollama_endpoint_returns_none(self):
+        from agent.model_metadata import endpoint_supports_vision
+        client = self._client({}, status=404)
+        with patch("httpx.Client", return_value=client):
+            assert endpoint_supports_vision("gpt-4o", "https://api.openai.com/v1", "sk") is None
+
+    def test_missing_capabilities_field_returns_none(self):
+        from agent.model_metadata import endpoint_supports_vision
+        client = self._client({"model_info": {}})  # no "capabilities" key
+        with patch("httpx.Client", return_value=client):
+            assert endpoint_supports_vision("m", "http://host:11434/v1") is None
+
+    def test_network_error_returns_none_and_is_not_cached(self):
+        from agent import model_metadata as mm
+        with patch("httpx.Client", side_effect=RuntimeError("boom")):
+            assert mm.endpoint_supports_vision("m", "http://host:11434/v1") is None
+        assert "m@http://host:11434/v1" not in mm._ENDPOINT_VISION_CACHE
+
+    def test_result_is_cached_after_first_probe(self):
+        from agent import model_metadata as mm
+        client = self._client({"capabilities": ["vision"]})
+        with patch("httpx.Client", return_value=client) as mk:
+            assert mm.endpoint_supports_vision("m", "http://host:11434/v1") is True
+            assert mm.endpoint_supports_vision("m", "http://host:11434/v1") is True
+            assert mk.call_count == 1  # second call served from cache
+
+    def test_strips_v1_suffix_and_targets_api_show(self):
+        from agent.model_metadata import endpoint_supports_vision
+        client = self._client({"capabilities": ["vision"]})
+        with patch("httpx.Client", return_value=client):
+            endpoint_supports_vision("m", "http://host:11434/v1")
+        assert client.post.call_args[0][0] == "http://host:11434/api/show"
+
+    def test_empty_args_return_none(self):
+        from agent.model_metadata import endpoint_supports_vision
+        assert endpoint_supports_vision("", "http://host:11434/v1") is None
+        assert endpoint_supports_vision("m", "") is None

--- a/tests/agent/test_vision_suppression.py
+++ b/tests/agent/test_vision_suppression.py
@@ -1,0 +1,98 @@
+from unittest.mock import MagicMock, patch
+import pytest
+
+from agent.chat_completion_helpers import build_api_kwargs
+from tools.vision_tools import _supports_media_in_tool_results
+
+def test_supports_media_in_tool_results_for_custom_providers():
+    """Verify that _supports_media_in_tool_results returns True for custom and ollama-launch."""
+    assert _supports_media_in_tool_results("custom", "gemma4:latest") is True
+    assert _supports_media_in_tool_results("ollama-launch", "gemma4:latest") is True
+    assert _supports_media_in_tool_results("openai", "gpt-4o") is True
+    assert _supports_media_in_tool_results("unknown-provider", "some-model") is False
+
+def test_build_api_kwargs_suppresses_vision_analyze():
+    """Verify that build_api_kwargs filters out the vision_analyze tool when native images are present."""
+    # Create mock agent
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent.provider = "custom"
+    agent.model = "gemma4:latest"
+    agent.base_url = "http://localhost:11434/v1"
+    agent.max_tokens = 2048
+    agent.reasoning_config = None
+    agent.request_overrides = {}
+    agent.providers_allowed = None
+    agent.providers_ignored = None
+    agent.providers_order = None
+    agent.provider_sort = None
+    agent.provider_require_parameters = False
+    agent.provider_data_collection = None
+    agent._ephemeral_max_output_tokens = None
+    agent._ollama_num_ctx = None
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "vision_analyze",
+                "description": "Load an image",
+            }
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "run_command",
+                "description": "Run shell command",
+            }
+        }
+    ]
+    
+    # 1. Test when no native images are present
+    messages_no_images = [
+        {"role": "user", "content": "hello world"}
+    ]
+    
+    # Mock transport builder
+    mock_transport = MagicMock()
+    agent._get_transport.return_value = mock_transport
+    
+    # Mock the return value of _prepare_messages_for_non_vision_model
+    agent._prepare_messages_for_non_vision_model = lambda x: x
+    agent._is_qwen_portal.return_value = False
+    agent._is_openrouter_url.return_value = False
+    agent._is_azure_openai_url.return_value = False
+    agent._is_direct_openai_url.return_value = False
+    agent._supports_reasoning_extra_body.return_value = False
+    agent._resolved_api_call_timeout.return_value = 1800
+    agent._max_tokens_param = lambda x: {}
+    
+    # We patch the provider profile resolver to return None (so it hits the legacy flag path in build_api_kwargs)
+    with patch("providers.get_provider_profile", return_value=None):
+        build_api_kwargs(agent, messages_no_images)
+        
+        # Verify that all tools (including vision_analyze) are passed to transport
+        called_tools = mock_transport.build_kwargs.call_args[1].get("tools")
+        assert len(called_tools) == 2
+        assert any(t["function"]["name"] == "vision_analyze" for t in called_tools)
+        
+        # Reset mock
+        mock_transport.reset_mock()
+        
+        # 2. Test when a native image is attached
+        messages_with_images = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this image"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+                ]
+            }
+        ]
+        
+        build_api_kwargs(agent, messages_with_images)
+        
+        # Verify that vision_analyze is filtered out of the tools list passed to transport
+        called_tools = mock_transport.build_kwargs.call_args[1].get("tools")
+        assert len(called_tools) == 1
+        assert called_tools[0]["function"]["name"] == "run_command"
+        assert not any(t["function"]["name"] == "vision_analyze" for t in called_tools)

--- a/tests/run_agent/test_vision_aware_preprocessing.py
+++ b/tests/run_agent/test_vision_aware_preprocessing.py
@@ -207,3 +207,77 @@ class TestModelSupportsVision:
         with patch("hermes_cli.config.load_config", return_value={"model": {"supports_vision": False}}), \
              patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
             assert agent._model_supports_vision() is False
+
+
+class TestModelSupportsVisionOllamaFallback:
+    """On a models.dev catalog miss, ``_model_supports_vision`` falls back to
+    the live Ollama endpoint capability probe so locally-served vision models
+    with custom tags aren't treated as text-only (which would strip image
+    parts).
+    """
+
+    def _ollama_agent(self) -> AIAgent:
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.model = "gemma4:latest"
+        agent.base_url = "http://localhost:11434/v1"
+        agent.api_key = "ollama"
+        return agent
+
+    def test_probes_endpoint_on_catalog_miss(self):
+        agent = self._ollama_agent()
+        cfg = {"model": {"base_url": "http://localhost:11434/v1", "api_key": "ollama"}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=True) as probe:
+            assert agent._model_supports_vision() is True
+        probe.assert_called_once_with("gemma4:latest", "http://localhost:11434/v1", "ollama")
+
+    def test_endpoint_reports_no_vision_returns_false(self):
+        agent = self._ollama_agent()
+        cfg = {"model": {"base_url": "http://localhost:11434/v1", "api_key": "ollama"}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=False):
+            assert agent._model_supports_vision() is False
+
+    def test_probe_unknown_returns_false(self):
+        agent = self._ollama_agent()
+        cfg = {"model": {"base_url": "http://localhost:11434/v1", "api_key": "ollama"}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=None):
+            assert agent._model_supports_vision() is False
+
+    def test_image_parts_preserved_for_ollama_vision_model(self):
+        """Regression: a local Ollama vision model not in models.dev must keep
+        its image_url parts on the chat.completions path (previously stripped
+        to a text description, so the model never saw the pixels).
+        """
+        agent = self._ollama_agent()
+        cfg = {"model": {"base_url": "http://localhost:11434/v1", "api_key": "ollama"}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=True):
+            out = agent._prepare_messages_for_non_vision_model([IMG_PARTS_USER_MSG])
+        assert out[0]["content"][1]["type"] == "image_url"
+
+    def test_lookup_supports_vision_with_custom_provider_rewriting(self):
+        """Verify that ``_lookup_supports_vision`` can resolve the base URL of
+        custom named providers (like ``ollama-launch``) even when the
+        passed provider has been rewritten to ``custom``.
+        """
+        from agent.image_routing import _lookup_supports_vision
+        cfg = {
+            "model": {"provider": "ollama-launch"},
+            "providers": {
+                "ollama-launch": {
+                    "api": "http://192.168.1.210:11434/v1",
+                    "api_key": "ollama-key",
+                }
+            },
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None), \
+             patch("agent.model_metadata.endpoint_supports_vision", return_value=True) as probe:
+            assert _lookup_supports_vision("custom", "gemma4:26b", cfg) is True
+        probe.assert_called_once_with("gemma4:26b", "http://192.168.1.210:11434/v1", "ollama-key")

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -500,7 +500,7 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return True
 
     # OpenAI Chat Completions and Responses
-    if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
+    if p in {"openai", "openai-chat", "openai-codex", "azure-openai", "custom", "ollama", "ollama-launch"}:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support


### PR DESCRIPTION
## What does this PR do?

When the active model isn't in the models.dev catalog (typical for locally-served Ollama tags like `gemma4:latest`), image routing previously fell back to the text pipeline — stripping `image_url` parts before the model ever saw the pixels. This PR adds a thin Ollama `/api/show` capability probe and wires it into the routing layer so vision-capable local models route natively, without requiring the user to manually declare `supports_vision: true` in config.

The same change also closes the ollama-cloud aggregator-chain fallthrough (#14744) by adding `ollama-cloud` to `_PROVIDERS_WITHOUT_VISION`, and suppresses the redundant `vision_analyze` tool when a native image is already attached to the turn.

## Related Issue

Fixes #14744 — `vision_analyze` falling through to non-vision models on Ollama Cloud.
Addresses #17940 — vision capability detection for custom-provider models (this provides the auto-detection path; the manual `supports_vision: true` config flag proposed in the issue is unchanged and still works first via the existing override).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: new `endpoint_supports_vision()` / `_query_ollama_capabilities()`, with a process-lifetime cache keyed by `model@base_url`. Only definitive True/False results are cached so transient probe failures get retried.
- `agent/image_routing.py`: `_lookup_supports_vision` falls back to the endpoint probe on a models.dev catalog miss. Resolves the active endpoint from the v12 `providers.<name>` schema, the legacy `custom_providers` list, or top-level `model.base_url` — so the probe works for named custom providers even when the routing call rewrites `provider` to `"custom"`.
- `agent/chat_completion_helpers.py`: `build_api_kwargs` suppresses the `vision_analyze` tool when the current turn already has a native `image_url` content part, so the model reads the pixels directly instead of calling a redundant (and on local endpoints often unconfigured) auxiliary tool.
- `agent/auxiliary_client.py`: add `"ollama-cloud"` to `_PROVIDERS_WITHOUT_VISION` so vision requests fall through to the aggregator chain. `_resolve_custom_runtime` resolves the default-configured runtime first so named custom providers (e.g. `ollama-launch`) are honored before the legacy `requested="custom"` fallback.
- `tools/vision_tools.py`: mark `"custom"`, `"ollama"`, and `"ollama-launch"` as supporting media in tool results.
- Tests: new `TestEndpointSupportsVision`, `TestOllamaVisionFallback`, `TestModelSupportsVisionOllamaFallback`, plus `test_vision_suppression.py` and two new `test_auxiliary_client.py` cases. 25 new tests, all passing.

## How to Test

1. Configure a custom Ollama provider (a tag not in models.dev, e.g. `gemma4:latest`):
   ```yaml
   model:
     provider: ollama-launch
     default: gemma4:latest
     base_url: http://localhost:11434/v1
     api_key: ollama
   ```
2. Send an image-bearing prompt. Before this PR the image parts get stripped to text; after this PR the model receives the native `image_url` content (Ollama's `/api/show` reports the `vision` capability).
3. Run the new tests: `venv/bin/pytest tests/agent/test_image_routing.py tests/agent/test_model_metadata.py tests/agent/test_vision_suppression.py tests/agent/test_auxiliary_client.py tests/run_agent/test_vision_aware_preprocessing.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(vision): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test files and all tests pass (386 tests across the touched files, 0 regressions)
- [x] I've added tests for my changes (25 new tests)
- [x] I've tested on my platform: macOS 15.5 (Darwin 25.5.0, Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; docstrings on new public functions cover behavior.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no new config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses `httpx.Client` with a 5s timeout, no platform-specific code paths.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; `vision_analyze` is suppressed conditionally but its schema is unchanged.

## Screenshots / Logs

