### PR TITLE
fix: handle Codex auxiliary null output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -888,7 +888,11 @@ class _CodexCompletionsAdapter:
                     val = obj.get(key, default)
                 return val if val is not None else default
 
-            for item in getattr(final, "output", []):
+            output_items = getattr(final, "output", None)
+            if not isinstance(output_items, list):
+                output_items = []
+
+            for item in output_items:
                 item_type = _item_get(item, "type")
                 if item_type == "message":
                     for part in (_item_get(item, "content") or []):
@@ -922,6 +926,10 @@ class _CodexCompletionsAdapter:
                 timeout_timer.cancel()
 
         content = "".join(text_parts).strip() or None
+        if not content:
+            final_output_text = getattr(final, "output_text", None)
+            if isinstance(final_output_text, str) and final_output_text.strip():
+                content = final_output_text.strip()
 
         # Build a response that looks like chat.completions
         message = SimpleNamespace(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2592,6 +2592,37 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
         assert response.choices[0].message.content == "aux survived"
         fake_client.responses.create.assert_not_called()
 
+    def test_uses_output_text_when_final_output_is_none(self):
+        """Regression for Codex responses that complete with output=None."""
+
+        class NullOutputFinalStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=None,
+                    output_text="aux fallback text",
+                    usage=None,
+                )
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return NullOutputFinalStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize"}])
+
+        assert response.choices[0].message.content == "aux fallback text"
+
 
 # ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail


### PR DESCRIPTION
## Summary\n- guard Codex auxiliary Responses extraction when final.output is None/non-list\n- recover assistant content from final.output_text when output items are absent\n- add regression coverage for output=None with output_text fallback\n\n## Test plan\n- uv run --extra dev python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_empty_output_with_output_text tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_empty_output_no_output_text_retries tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterNullOutputRecovery -q\n\nNotes: direct push to NousResearch/hermes-agent was denied for s2saction-official, so this PR is from the s2saction-official fork.