### PR TITLE
fix(codex): handle Responses stream whose completed event has output=null

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -796,26 +796,42 @@ class _CodexCompletionsAdapter:
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
-            with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
+            try:
+                with self._client.responses.stream(**resp_kwargs) as stream:
+                    for _event in stream:
+                        _check_cancelled()
+                        _etype = getattr(_event, "type", "")
+                        if _etype == "response.output_item.done":
+                            _done = getattr(_event, "item", None)
+                            if _done is not None:
+                                collected_output_items.append(_done)
+                        elif "output_text.delta" in _etype:
+                            _delta = getattr(_event, "delta", "")
+                            if _delta:
+                                collected_text_deltas.append(_delta)
+                        elif "function_call" in _etype:
+                            has_function_calls = True
                     _check_cancelled()
-                    _etype = getattr(_event, "type", "")
-                    if _etype == "response.output_item.done":
-                        _done = getattr(_event, "item", None)
-                        if _done is not None:
-                            collected_output_items.append(_done)
-                    elif "output_text.delta" in _etype:
-                        _delta = getattr(_event, "delta", "")
-                        if _delta:
-                            collected_text_deltas.append(_delta)
-                    elif "function_call" in _etype:
-                        has_function_calls = True
-                _check_cancelled()
-                final = stream.get_final_response()
+                    final = stream.get_final_response()
+            except TypeError as _te:
+                # openai SDK parse_response() iterates response.output with no
+                # None guard (lib/_parsing/_responses.py). chatgpt.com/backend-api/codex
+                # sends the terminal response.completed with output=null, crashing the
+                # .stream() accumulator mid-iteration. The streamed items were already
+                # collected above, so synthesize the final response from them instead
+                # of failing this auxiliary call (e.g. title generation).
+                if "not iterable" not in str(_te):
+                    raise
+                logger.debug(
+                    "Codex auxiliary: .stream() accumulator hit None output; "
+                    "synthesizing from %d collected item(s)/%d delta(s)",
+                    len(collected_output_items), len(collected_text_deltas),
+                )
+                final = SimpleNamespace(output=None, usage=None)
 
             # Backfill empty output from collected stream events
             _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
+            if not _output:
                 if collected_output_items:
                     final.output = list(collected_output_items)
                     logger.debug(
@@ -845,7 +861,7 @@ class _CodexCompletionsAdapter:
                     val = obj.get(key, default)
                 return val if val is not None else default
 
-            for item in getattr(final, "output", []):
+            for item in (getattr(final, "output", None) or []):
                 item_type = _item_get(item, "type")
                 if item_type == "message":
                     for part in (_item_get(item, "content") or []):

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -287,7 +287,28 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
-        except RuntimeError as exc:
+        except (RuntimeError, TypeError) as exc:
+            # openai 2.24.0's Responses .stream() accumulator calls
+            # parse_response() on the terminal response.completed event,
+            # which iterates ``response.output`` with no None guard
+            # (lib/_parsing/_responses.py). The chatgpt.com/backend-api/codex
+            # backend streams the answer via output_item.done /
+            # output_text.delta events but sends the terminal
+            # response.completed with output=null, so the SDK raises
+            # TypeError(NoneType object is not iterable) mid-stream. The
+            # byte stream is intact; create(stream=True) skips the SDK
+            # accumulator and recovers content via the same backfill path
+            # the other Codex-quirk handlers below already use.
+            if isinstance(exc, TypeError):
+                if "not iterable" not in str(exc):
+                    raise
+                logger.debug(
+                    "Responses .stream() accumulator hit None output "
+                    "(SDK parse_response); falling back to create(stream=True). %s err=%s",
+                    agent._client_log_context(),
+                    exc,
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             err_text = str(exc)
             missing_completed = "response.completed" in err_text
             # The OpenAI SDK's Responses streaming state machine raises
@@ -414,7 +435,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if not _out:
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(


### PR DESCRIPTION
## Problem

The ChatGPT Codex backend (`https://chatgpt.com/backend-api/codex`, gpt-5.x) streams the answer via `response.output_item.done` / `response.output_text.delta` events, then sends the terminal `response.completed` event with **`response.output = null`**.

openai-python's Responses streaming accumulator calls `parse_response()` on that completed event, and `parse_response` does:

```python
for output in response.output:
```

with no `None` guard (observed on `openai==2.24.0`, `openai/lib/_parsing/_responses.py`). When `response.output` is `null`, this raises `TypeError: 'NoneType' object is not iterable` **mid-stream**.

`run_codex_stream` only catches `httpx`/`RuntimeError`, so the `TypeError` propagates and **every** request against that backend fails. Schedulers that wrap it re-surface it as `RuntimeError: 'NoneType' object is not iterable`.

## Fix

- **`run_codex_stream`**: catch the `parse_response` `None`-output `TypeError` and route to the existing `create(stream=True)` fallback, which iterates SSE events manually and never calls `parse_response`. This mirrors how the code already handles the `response.created`/`response.completed` prelude/postlude quirks for this same backend.
- **`run_codex_create_stream_fallback`** and the auxiliary Codex adapter: backfill `output` from the collected stream items when the terminal `output` is `None` (previously only handled the empty-list case), so the already-streamed content is recovered instead of lost.

No behavior change for backends that send a well-formed `response.completed`.

## Verification

Reproduced against the live backend (the streamed events arrive, the terminal `response.completed` carries `output: null`, and the SDK raises the `TypeError`). With the fix, requests that previously crashed return their content normally. Both the main conversation path and the auxiliary path (title generation, etc.) recover.
