### PR TITLE
feat(mcp): add config-gated lazy MCP schema loading

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -420,6 +420,27 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
 
+    # Plugin hook: let registered plugins rewrite the tool list before
+    # it enters the API request. First non-empty list returned wins.
+    # See ``hermes_cli/plugins.py:VALID_HOOKS`` (``transform_tools``)
+    # for the contract. Failures here must not break the call — we
+    # silently fall back to the original tools on any error.
+    if tools_for_api:
+        try:
+            from hermes_cli.plugins import invoke_hook  # noqa: PLC0415
+            hook_results = invoke_hook(
+                "transform_tools",
+                tools=tools_for_api,
+                agent=agent,
+                api_messages=api_messages,
+            )
+            for result in (hook_results or []):
+                if isinstance(result, list) and result:
+                    tools_for_api = result
+                    break
+        except Exception:
+            pass
+
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1602,6 +1602,12 @@ DEFAULT_CONFIG = {
         "max_parallel_jobs": None,
     },
 
+    # MCP lazy-loading Phase 1 (opt-in; no behavior change when disabled).
+    "mcp": {
+        "lazy_loading": False,
+        "lazy_stub_max_desc": 200,
+    },
+
     # Kanban multi-agent coordination — controls the dispatcher loop that
     # spawns workers for ready tasks. The dispatcher ticks every N seconds
     # (default 60), reclaims stale claims, promotes dependency-satisfied

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -134,6 +134,14 @@ VALID_HOOKS: Set[str] = {
     # Plugins return a string to replace the response text, or None/empty to leave unchanged.
     # First non-None string wins. Useful for vocabulary/personality transformation.
     "transform_llm_output",
+    # Transform the tool list (agent.tools) just before it enters the
+    # API request kwargs. Plugins return a list[dict] to replace the
+    # tools array, or None/empty to leave unchanged. First non-None
+    # list wins. Use cases: lazy MCP schema loading (stub un-promoted
+    # tools), cost-cap injection (drop tools when token budget is
+    # exhausted), per-platform telemetry tagging.
+    # Kwargs: tools: list[dict], agent: AIAgent, api_messages: list
+    "transform_tools",
     "pre_llm_call",
     "post_llm_call",
     "pre_api_request",

--- a/plugins/mcp_lazy/README.md
+++ b/plugins/mcp_lazy/README.md
@@ -1,0 +1,16 @@
+# mcp_lazy
+
+Config-gated Phase 1 lazy MCP schema loading for Hermes Agent.
+
+When `mcp.lazy_loading: true` is enabled, MCP tool schemas are replaced
+with lightweight stubs in API requests. The model can call
+`load_mcp_tools` to promote selected MCP tools to their full schemas for
+the rest of the current session.
+
+This Phase 1 slice intentionally covers only:
+- request-time MCP tool stubs
+- on-demand tool promotion
+- per-session promoted-tool state
+
+It does not include server-level discovery, eager server promotion, or
+baseline telemetry/reporting.

--- a/plugins/mcp_lazy/__init__.py
+++ b/plugins/mcp_lazy/__init__.py
@@ -1,0 +1,35 @@
+"""mcp_lazy — lazy MCP tool schema loading.
+
+Phase 1: stub MCP tool schemas at request time and promote selected
+MCP tools on demand via the ``load_mcp_tools`` meta-tool. Each session
+keeps its own promoted-tool set so promoted MCP tools stay full for the
+rest of that conversation only.
+
+Activation: opt-in via ``hermes plugins enable mcp_lazy`` and
+``mcp.lazy_loading: true`` in ``config.yaml``.
+"""
+from __future__ import annotations
+
+import logging
+
+from . import hook_impl
+from . import meta_tool
+
+logger = logging.getLogger(__name__)
+
+
+def register(ctx) -> None:  # noqa: ANN001
+    """Register the Phase 1 meta-tool + request-time hook surface."""
+    ctx.register_tool(
+        name="load_mcp_tools",
+        toolset="mcp_lazy",
+        schema=meta_tool.SCHEMA,
+        handler=meta_tool.handler,
+        check_fn=meta_tool.check,
+        is_async=True,
+        description=meta_tool.SCHEMA.get("description", ""),
+        emoji="📦",
+    )
+    ctx.register_hook("transform_tools", hook_impl.transform_tools)
+    ctx.register_hook("on_session_reset", hook_impl.on_session_reset)
+    logger.info("mcp_lazy: registered Phase 1 hooks and load_mcp_tools meta-tool")

--- a/plugins/mcp_lazy/hook_impl.py
+++ b/plugins/mcp_lazy/hook_impl.py
@@ -1,0 +1,94 @@
+"""Hook implementations for the mcp_lazy plugin.
+
+* ``transform_tools`` — rewrites the agent's tool list at request time,
+  stubbing MCP tools that haven't been promoted in this session.
+* ``on_session_reset`` — drops the per-session pool when the user
+  starts a new session (via ``/new`` or its ``/reset`` alias).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .pool import _current_agent_var, evict, get_pool
+from .stubs import mix_full_and_stubs
+
+logger = logging.getLogger(__name__)
+
+
+def _load_config() -> Dict[str, Any]:
+    """Read ``mcp`` config block; tolerate missing config."""
+    try:
+        from hermes_cli.config import load_config  # noqa: PLC0415
+        return load_config().get("mcp", {}) or {}
+    except Exception:
+        return {}
+
+
+def transform_tools(
+    tools: List[Dict[str, Any]],
+    agent: Any = None,
+    **_kwargs: Any,
+) -> Optional[List[Dict[str, Any]]]:
+    """Return a tool list with un-promoted MCP tools replaced by stubs.
+
+    Returns ``None`` when lazy loading is disabled, when the agent has
+    no session_id, or on any internal error — letting the caller use
+    the original ``tools`` list unchanged (fail-open).
+    """
+    try:
+        cfg = _load_config()
+        if not cfg.get("lazy_loading"):
+            return None  # master toggle off
+
+        session_id = getattr(agent, "session_id", None) if agent is not None else None
+        if not session_id:
+            return None
+
+        pool = get_pool(session_id)
+        # Anchor the pool on the agent so the registry's weak refs
+        # don't lose it between calls.
+        if agent is not None:
+            try:
+                setattr(agent, "_mcp_lazy_pool", pool)
+            except Exception:
+                pass
+
+        # Stash the agent in a ContextVar so the load_mcp_tools
+        # meta-tool handler can resolve it without registry.dispatch
+        # having to plumb the agent reference explicitly. Tool
+        # dispatch runs in the same task; contextvars propagate.
+        try:
+            _current_agent_var.set(agent)
+        except Exception:
+            pass
+
+        return mix_full_and_stubs(
+            tools,
+            promoted_names=pool.snapshot(),
+            max_desc=int(cfg.get("lazy_stub_max_desc", 200) or 200),
+        )
+    except Exception:
+        logger.debug("mcp_lazy: transform_tools failed; returning None", exc_info=True)
+        return None
+
+
+def on_session_reset(session_id: str = None, **_kwargs: Any) -> None:
+    """Drop the previous session's pool.
+
+    cli.py fires this AFTER agent.session_id has rotated to the new
+    id — at this point any pool keyed on the old id is dead weight.
+    We can't know the old id from kwargs, but the registry's
+    WeakValueDictionary will GC it automatically once the agent's
+    `_mcp_lazy_pool` attribute is overwritten on next ``transform_tools``
+    call.
+
+    This handler exists primarily as an explicit hook for future
+    extensions (e.g. emitting a "session reset" event to a dashboard);
+    the cleanup itself is GC-driven.
+    """
+    # Best-effort: if the caller passed an old_session_id (extension),
+    # evict immediately.
+    old_id = _kwargs.get("old_session_id")
+    if isinstance(old_id, str) and old_id:
+        evict(old_id)

--- a/plugins/mcp_lazy/meta_tool.py
+++ b/plugins/mcp_lazy/meta_tool.py
@@ -1,0 +1,94 @@
+"""``mcp_load_tools`` meta-tool.
+
+Registered only when ``mcp.lazy_loading: true``. Lets the model
+request the full parameter schemas for one or more MCP tools by name.
+Once promoted, the tools stay full for the rest of the session.
+
+Usage from the model::
+
+    mcp_load_tools(tool_names=["mcp_trek_search_files", "mcp_dart_get_task"])
+
+The call returns a JSON status string. The model is expected to wait
+for the next turn (where the full schemas will be present in the
+tool list) before invoking the promoted tools with real parameters.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from .promote import promote_tools
+
+SCHEMA: Dict[str, Any] = {
+    # Name deliberately does NOT start with ``mcp_`` so the stub
+    # filter in ``stubs.is_mcp_tool`` never collapses this tool to
+    # a stub. If it were ``mcp_load_tools`` it would target itself.
+    "name": "load_mcp_tools",
+    "description": (
+        "Load full parameter schemas for MCP tools by name. Use when "
+        "you need to call an MCP tool whose visible schema is a [LAZY] "
+        "stub. After this call returns, the next turn will see the "
+        "full parameter spec for each promoted tool; invoke the tool "
+        "normally on that turn."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "tool_names": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of MCP tool names to load full schemas for "
+                    "(e.g. ['mcp_trek_search_files'])."
+                ),
+            },
+        },
+        "required": ["tool_names"],
+    },
+}
+
+
+def check() -> bool:
+    """Always-on once the plugin is enabled; auth happens at request time."""
+    return True
+
+
+async def handler(args: Dict[str, Any], **kwargs: Any) -> str:
+    """Promote the named tools in the current session's pool.
+
+    Agent is resolved (in order) from ``kwargs["_agent"]``,
+    ``kwargs["agent"]``, then the ``mcp_lazy`` plugin's per-request
+    ContextVar set by ``hook_impl.transform_tools``. The fallback is
+    necessary because ``registry.dispatch`` does not natively forward
+    the agent reference to tool handlers.
+    """
+    agent = kwargs.get("_agent") or kwargs.get("agent")
+    if agent is None:
+        try:
+            from .pool import _current_agent_var  # noqa: PLC0415
+            agent = _current_agent_var.get()
+        except Exception:
+            agent = None
+
+    raw_names = args.get("tool_names") or []
+    if not isinstance(raw_names, list):
+        return json.dumps({"ok": False, "error": "tool_names must be an array"})
+
+    if agent is None:
+        return json.dumps({
+            "ok": False,
+            "error": "mcp_load_tools: agent context unavailable",
+        })
+
+    accepted: List[str] = promote_tools(agent, raw_names)
+    rejected = [n for n in raw_names if isinstance(n, str) and n.strip() and n.strip() not in accepted]
+
+    return json.dumps({
+        "ok": True,
+        "promoted": accepted,
+        "rejected": rejected,
+        "note": (
+            "Full schemas will be visible on the next turn. Call the "
+            "promoted tools with proper parameters then."
+        ),
+    })

--- a/plugins/mcp_lazy/plugin.yaml
+++ b/plugins/mcp_lazy/plugin.yaml
@@ -1,0 +1,7 @@
+name: mcp_lazy
+version: "0.1.0"
+description: "Config-gated lazy MCP tool schema loading. Replaces full MCP schemas with request-time stubs and promotes selected tools on demand via load_mcp_tools."
+author: Interstellar-code
+hooks:
+  - transform_tools
+  - on_session_reset

--- a/plugins/mcp_lazy/pool.py
+++ b/plugins/mcp_lazy/pool.py
@@ -1,0 +1,146 @@
+"""Per-session deferred-tool pool for lazy MCP loading.
+
+Each conversation session gets its own ``DeferredToolPool`` keyed by
+``agent.session_id``. The pool tracks which MCP tools have been
+promoted (loaded with full schemas) within that session, so a
+subsequent turn knows to keep them visible as full tools rather than
+collapsing them back into stubs.
+
+Cross-session isolation is the whole point: session A promoting
+``mcp_trek_search`` must NOT cause session B to also see the full
+schema. The pool registry keys on session_id and uses a weak-value
+dictionary so finished sessions get garbage-collected naturally.
+
+Session-end events (``/new`` and its ``/reset`` alias both route to
+``new_session()`` in ``hermes_cli/cli.py``) fire a ``pre_session_reset``
+hook that calls :func:`evict` explicitly — belt for the GC suspenders.
+"""
+from __future__ import annotations
+
+import contextvars
+import logging
+import threading
+import weakref
+from typing import Dict, Optional, Set
+
+# Set by ``hook_impl.transform_tools`` on every request, so downstream
+# code paths (notably the ``mcp_load_tools`` meta-tool handler) can
+# resolve the active agent's session without the tool registry having
+# to plumb agent references through ``registry.dispatch``.
+_current_agent_var: "contextvars.ContextVar[Optional[object]]" = contextvars.ContextVar(
+    "mcp_lazy_current_agent", default=None,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DeferredToolPool:
+    """Per-session state for promoted MCP tools.
+
+    The pool only remembers *names* of promoted tools — the schemas
+    themselves come from ``get_tool_definitions()`` at request build
+    time, so a session's promoted set survives MCP-server hot-reloads
+    without holding stale schema copies.
+    """
+
+    # ``__weakref__`` is required so WeakValueDictionary can hold us.
+    __slots__ = ("session_id", "_promoted", "_lock", "__weakref__")
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self._promoted: Set[str] = set()
+        self._lock = threading.RLock()
+
+    def promote(self, names) -> None:
+        """Mark one or more tool names as promoted in this session.
+
+        Accepts a string or any iterable of strings. Whitespace-only
+        and empty entries are silently dropped — defensive against
+        the model passing junk.
+        """
+        if isinstance(names, str):
+            names = (names,)
+        with self._lock:
+            for n in names:
+                if isinstance(n, str) and n.strip():
+                    self._promoted.add(n.strip())
+
+    def snapshot(self) -> frozenset:
+        """Immutable view of currently-promoted names.
+
+        Returns a ``frozenset`` so callers can pass it across thread
+        boundaries (e.g. into the tool-list builder) without worrying
+        about mid-iteration mutation.
+        """
+        with self._lock:
+            return frozenset(self._promoted)
+
+    def is_promoted(self, name: str) -> bool:
+        with self._lock:
+            return name in self._promoted
+
+    def clear(self) -> None:
+        """Drop all promoted tools — used by explicit session reset."""
+        with self._lock:
+            self._promoted.clear()
+
+
+# Module-level registry. WeakValueDictionary so dropped sessions GC
+# naturally; explicit ``evict()`` for deterministic cleanup at /new.
+_pools: "weakref.WeakValueDictionary[str, DeferredToolPool]" = weakref.WeakValueDictionary()
+# We must keep strong refs *somewhere* otherwise the weak dict drops
+# every entry the moment we hand it back. The agent itself holds the
+# pool via its ``mcp_lazy_pool`` attribute (see hook_impl.attach_pool).
+# This list exists only so the weak dict doesn't lose entries while a
+# pool is being created and before the agent attaches.
+_strong_recent: list = []
+_strong_recent_lock = threading.Lock()
+_STRONG_RECENT_MAX = 32
+
+
+def get_pool(session_id: str) -> DeferredToolPool:
+    """Return the pool for ``session_id``, creating one if absent.
+
+    Called from the lazy-loading hook on every relevant request, so
+    must be cheap.
+    """
+    if not session_id:
+        # Unknown / unset session — use a single shared "unattributed"
+        # pool. Better than crashing; promotion still works, only
+        # isolation degrades.
+        session_id = "__unattributed__"
+    pool = _pools.get(session_id)
+    if pool is None:
+        pool = DeferredToolPool(session_id)
+        _pools[session_id] = pool
+        # Keep a brief strong-ref window so the weak dict doesn't lose
+        # us before the caller attaches the pool to the agent.
+        with _strong_recent_lock:
+            _strong_recent.append(pool)
+            if len(_strong_recent) > _STRONG_RECENT_MAX:
+                _strong_recent.pop(0)
+    return pool
+
+
+def evict(session_id: str) -> None:
+    """Drop the pool for ``session_id`` immediately.
+
+    Called from the ``pre_session_reset`` hook at ``cli.py:5900``
+    before the old session's ``end_session()`` fires.
+    """
+    pool = _pools.pop(session_id, None)
+    if pool is not None:
+        pool.clear()
+        with _strong_recent_lock:
+            try:
+                _strong_recent.remove(pool)
+            except ValueError:
+                pass
+        logger.debug("mcp_lazy: evicted pool for session %s", session_id)
+
+
+def _reset_for_tests() -> None:
+    """Test-only hard reset of the registry."""
+    _pools.clear()
+    with _strong_recent_lock:
+        _strong_recent.clear()

--- a/plugins/mcp_lazy/promote.py
+++ b/plugins/mcp_lazy/promote.py
@@ -1,0 +1,58 @@
+"""Promotion — switch an MCP tool from stub to full schema for the session.
+
+Promotion does NOT rebuild ``agent.tools``: that list stays the
+canonical full set. Instead the per-session pool records which names
+are promoted, and the request-time hook (``hook_impl.transform_tools``)
+substitutes stubs for everything in ``agent.tools`` *except* what the
+pool says is promoted.
+
+This keeps the model very simple — one place to read the answer
+("what tools are full for this session?") and one place to mutate it
+("add this name to the promoted set"). Compared to a rebuild-based
+design, we avoid all the cache-key / valid_tool_names / threading
+edge cases.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+from .pool import get_pool
+
+logger = logging.getLogger(__name__)
+
+
+def promote_tools(agent, tool_names: Iterable[str]) -> List[str]:
+    """Promote ``tool_names`` in the session's pool.
+
+    Returns the de-duplicated list of names actually promoted. Names
+    that are not registered MCP tools (i.e. not in
+    ``agent.valid_tool_names``) are silently dropped so a hallucinated
+    request doesn't crash the call — the caller checks the return
+    value if it cares.
+    """
+    session_id = getattr(agent, "session_id", None) or "__unattributed__"
+    valid = getattr(agent, "valid_tool_names", None) or set()
+    pool = get_pool(session_id)
+
+    accepted: List[str] = []
+    for name in tool_names:
+        if not isinstance(name, str):
+            continue
+        name = name.strip()
+        if not name:
+            continue
+        if valid and name not in valid:
+            logger.debug(
+                "mcp_lazy: refusing to promote unknown tool '%s' (not in valid_tool_names)",
+                name,
+            )
+            continue
+        accepted.append(name)
+    if accepted:
+        pool.promote(accepted)
+        logger.debug(
+            "mcp_lazy: promoted %d tool(s) for session %s",
+            len(accepted), session_id,
+        )
+    return accepted

--- a/plugins/mcp_lazy/stubs.py
+++ b/plugins/mcp_lazy/stubs.py
@@ -1,0 +1,133 @@
+"""Stub-schema construction + detection.
+
+A *stub* is a minimal OpenAI-format tool schema sent to the model in
+place of the full MCP tool schema. It carries the name and a
+truncated description but no real parameter spec — just a sentinel
+field so we can identify stub-calls when the model invokes them.
+
+Why a sentinel field rather than args-based detection: Hermes already
+canonicalizes empty/whitespace tool args to ``"{}"`` at
+``agent/conversation_loop.py:3103-3105``, which would make
+"empty args = stub call" indistinguishable from legitimate zero-arg
+MCP tools like ``mcp_zai_web_search_search``. The sentinel lives in
+the schema, not the call, so detection happens on the schema we
+registered — not on what the model sent back.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Set
+
+LAZY_SENTINEL = "__lazy_stub__"
+LAZY_DESC_PREFIX = "[LAZY] "
+
+# Tool names beginning with this prefix are MCP tools by convention.
+# Universal across the codebase (see ``tools/mcp_tool.py:3316``
+# ``is_mcp_tool_parallel_safe`` which uses the same check).
+MCP_PREFIX = "mcp_"
+
+
+def is_mcp_tool(schema: Dict[str, Any]) -> bool:
+    """Return True if the schema is for an MCP-sourced tool."""
+    name = schema.get("function", {}).get("name", "")
+    return isinstance(name, str) and name.startswith(MCP_PREFIX)
+
+
+def is_stub_schema(schema: Dict[str, Any]) -> bool:
+    """Return True if ``schema`` is a stub we produced.
+
+    Checked against the schema we built — not against the model's
+    tool-call args. Real zero-arg MCP tools have no sentinel and so
+    are never flagged as stubs.
+    """
+    params = schema.get("function", {}).get("parameters", {})
+    if not isinstance(params, dict):
+        return False
+    props = params.get("properties", {})
+    return isinstance(props, dict) and LAZY_SENTINEL in props
+
+
+def make_stub_schema(full: Dict[str, Any], max_desc: int = 200) -> Dict[str, Any]:
+    """Build a stub schema from a full MCP tool schema.
+
+    Preserves the name; truncates the description; replaces parameters
+    with a single sentinel field so we can detect stub-calls later.
+
+    ``max_desc`` is intentionally small — stub size is the whole point.
+    Default 200 chars matches ``mcp.lazy_stub_max_desc`` config default.
+    """
+    func = full.get("function", {})
+    name = func.get("name", "")
+    desc = (func.get("description", "") or "")[:max_desc]
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{LAZY_DESC_PREFIX}{desc}" if desc else LAZY_DESC_PREFIX.strip(),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    LAZY_SENTINEL: {
+                        "type": "boolean",
+                        "const": True,
+                        "description": (
+                            "Internal marker — do not set. Calling this stub "
+                            "will trigger full-schema load + auto-retry."
+                        ),
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def mix_full_and_stubs(
+    all_tools: List[Dict[str, Any]],
+    *,
+    promoted_names: "Iterable[str] | Set[str] | frozenset",
+    lazy_servers: "Set[str] | None" = None,
+    max_desc: int = 200,
+) -> List[Dict[str, Any]]:
+    """Return a new tool list: builtins full, MCP either stubbed or full.
+
+    - Builtin tools (no ``mcp_`` prefix) pass through unchanged.
+    - MCP tools whose name is in ``promoted_names`` pass through full.
+    - All other MCP tools are replaced with stubs.
+    - ``lazy_servers`` (optional): when set, only stub MCP tools whose
+      server name is in the set. MCP tool names have the shape
+      ``mcp_{server}_{tool}``; we extract the server segment for the
+      per-server toggle.
+    """
+    promoted = set(promoted_names) if not isinstance(promoted_names, (set, frozenset)) else promoted_names
+    result: List[Dict[str, Any]] = []
+    for tool in all_tools:
+        if not is_mcp_tool(tool):
+            result.append(tool)
+            continue
+        name = tool.get("function", {}).get("name", "")
+        if name in promoted:
+            result.append(tool)
+            continue
+        if lazy_servers is not None and not _server_in_set(name, lazy_servers):
+            # Per-server toggle says this server stays eager.
+            result.append(tool)
+            continue
+        result.append(make_stub_schema(tool, max_desc=max_desc))
+    return result
+
+
+def _server_in_set(tool_name: str, server_set: "Set[str] | frozenset") -> bool:
+    """Extract the server segment of an MCP tool name and check membership.
+
+    ``mcp_{server}_{rest}``; server may itself contain underscores after
+    sanitization. We match by prefix: any registered server in the set
+    whose canonical form is a prefix of the trailing tool name segment.
+    """
+    if not tool_name.startswith(MCP_PREFIX):
+        return False
+    rest = tool_name[len(MCP_PREFIX):]
+    for server in server_set:
+        sanitised = server.replace("-", "_").replace(".", "_")
+        if rest == sanitised or rest.startswith(sanitised + "_"):
+            return True
+    return False

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -206,3 +206,16 @@ class TestConfigIssueDataclass:
         a = ConfigIssue("error", "msg", "hint")
         b = ConfigIssue("error", "msg", "hint")
         assert a == b
+
+
+class TestMcpLazyConfigValidation:
+    """Phase 1 lazy-MCP config should be accepted as a valid root section."""
+
+    def test_mcp_lazy_root_section_no_issues(self):
+        issues = validate_config_structure({
+            "mcp": {
+                "lazy_loading": True,
+                "lazy_stub_max_desc": 200,
+            },
+        })
+        assert issues == []

--- a/tests/plugins/mcp_lazy/test_pool.py
+++ b/tests/plugins/mcp_lazy/test_pool.py
@@ -1,0 +1,135 @@
+"""Tests for the per-session DeferredToolPool registry."""
+from __future__ import annotations
+
+import pytest
+
+from plugins.mcp_lazy import pool as pool_mod
+from plugins.mcp_lazy.pool import DeferredToolPool, evict, get_pool
+
+
+@pytest.fixture(autouse=True)
+def _reset_pools():
+    pool_mod._reset_for_tests()
+    yield
+    pool_mod._reset_for_tests()
+
+
+def test_get_pool_returns_same_instance_for_same_session():
+    p1 = get_pool("session-a")
+    p2 = get_pool("session-a")
+    assert p1 is p2
+
+
+def test_get_pool_returns_distinct_instances_for_distinct_sessions():
+    p1 = get_pool("session-a")
+    p2 = get_pool("session-b")
+    assert p1 is not p2
+    assert p1.session_id == "session-a"
+    assert p2.session_id == "session-b"
+
+
+def test_promote_adds_to_set():
+    pool = get_pool("s1")
+    pool.promote("mcp_a_b")
+    assert "mcp_a_b" in pool.snapshot()
+
+
+def test_promote_accepts_iterable():
+    pool = get_pool("s1")
+    pool.promote(["mcp_a", "mcp_b"])
+    snap = pool.snapshot()
+    assert snap == frozenset({"mcp_a", "mcp_b"})
+
+
+def test_promote_dedupes():
+    pool = get_pool("s1")
+    pool.promote("x")
+    pool.promote("x")
+    pool.promote(["x", "x"])
+    assert pool.snapshot() == frozenset({"x"})
+
+
+def test_promote_strips_whitespace_and_drops_empties():
+    pool = get_pool("s1")
+    pool.promote(["  trim_me  ", "", "  ", "ok"])
+    assert pool.snapshot() == frozenset({"trim_me", "ok"})
+
+
+def test_promote_ignores_non_strings():
+    pool = get_pool("s1")
+    pool.promote([None, 42, {"foo": "bar"}, "real"])
+    assert pool.snapshot() == frozenset({"real"})
+
+
+def test_session_isolation():
+    pool_a = get_pool("session-a")
+    pool_b = get_pool("session-b")
+    pool_a.promote("tool_in_a_only")
+    assert "tool_in_a_only" not in pool_b.snapshot()
+
+
+def test_snapshot_is_immutable():
+    pool = get_pool("s")
+    pool.promote("x")
+    snap = pool.snapshot()
+    assert isinstance(snap, frozenset)
+    # frozenset has no .add — would raise AttributeError
+    with pytest.raises(AttributeError):
+        snap.add("y")  # type: ignore[attr-defined]
+
+
+def test_snapshot_decoupled_from_subsequent_mutations():
+    pool = get_pool("s")
+    pool.promote("first")
+    snap = pool.snapshot()
+    pool.promote("second")
+    # Earlier snapshot does not see later promotions.
+    assert "second" not in snap
+    assert "second" in pool.snapshot()
+
+
+def test_clear_drops_all_promotions():
+    pool = get_pool("s")
+    pool.promote(["a", "b", "c"])
+    pool.clear()
+    assert pool.snapshot() == frozenset()
+
+
+def test_evict_removes_pool_from_registry():
+    p1 = get_pool("evict-me")
+    p1.promote("x")
+    evict("evict-me")
+    # Subsequent get_pool returns a fresh pool with no promotions.
+    p2 = get_pool("evict-me")
+    assert p2 is not p1
+    assert p2.snapshot() == frozenset()
+
+
+def test_evict_unknown_session_is_noop():
+    # Should not raise.
+    evict("never-existed")
+
+
+def test_unattributed_session_falls_back_to_shared_pool():
+    pool = get_pool("")  # empty session_id
+    assert pool.session_id == "__unattributed__"
+
+
+def test_pool_thread_safe_under_concurrent_promotion():
+    import threading
+    pool = get_pool("threaded")
+    names = [f"tool_{i}" for i in range(50)]
+
+    def worker(start, end):
+        for i in range(start, end):
+            pool.promote(names[i])
+
+    threads = [
+        threading.Thread(target=worker, args=(0, 25)),
+        threading.Thread(target=worker, args=(25, 50)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert pool.snapshot() == frozenset(names)

--- a/tests/plugins/mcp_lazy/test_promote_and_hook.py
+++ b/tests/plugins/mcp_lazy/test_promote_and_hook.py
@@ -1,0 +1,190 @@
+"""End-to-end-ish tests for promote, transform_tools hook, and the
+``mcp_load_tools`` meta-tool. These don't spin up a real Hermes
+agent — they use a light SimpleNamespace stand-in with just the
+attributes the plugin actually touches.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from plugins.mcp_lazy import hook_impl, meta_tool, pool as pool_mod
+from plugins.mcp_lazy.promote import promote_tools
+from plugins.mcp_lazy.stubs import is_stub_schema
+
+
+@pytest.fixture(autouse=True)
+def _reset_pools():
+    pool_mod._reset_for_tests()
+    yield
+    pool_mod._reset_for_tests()
+
+
+def _fake_agent(session_id="s1", valid_names=None):
+    return SimpleNamespace(
+        session_id=session_id,
+        valid_tool_names=valid_names or set(),
+    )
+
+
+def _full(name: str):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"description for {name}",
+            "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+        },
+    }
+
+
+# -- promote_tools ------------------------------------------------------------
+
+def test_promote_tools_records_in_pool():
+    agent = _fake_agent("s1", {"mcp_a_b"})
+    accepted = promote_tools(agent, ["mcp_a_b"])
+    assert accepted == ["mcp_a_b"]
+    pool = pool_mod.get_pool("s1")
+    assert "mcp_a_b" in pool.snapshot()
+
+
+def test_promote_tools_drops_unknown_names():
+    agent = _fake_agent("s1", {"mcp_a_b"})
+    accepted = promote_tools(agent, ["mcp_a_b", "mcp_nope_x"])
+    assert accepted == ["mcp_a_b"]
+    pool = pool_mod.get_pool("s1")
+    assert "mcp_nope_x" not in pool.snapshot()
+
+
+def test_promote_tools_accepts_without_valid_names():
+    agent = SimpleNamespace(session_id="s1")  # no valid_tool_names attr
+    accepted = promote_tools(agent, ["mcp_anything"])
+    # When valid_tool_names is absent/empty we accept everything.
+    assert accepted == ["mcp_anything"]
+
+
+def test_promote_tools_skips_non_strings_and_whitespace():
+    agent = _fake_agent("s1", {"real"})
+    accepted = promote_tools(agent, ["", "  ", None, 42, "real"])  # type: ignore[list-item]
+    assert accepted == ["real"]
+
+
+# -- transform_tools hook -----------------------------------------------------
+
+def test_transform_tools_no_op_when_lazy_disabled():
+    with patch.object(hook_impl, "_load_config", return_value={"lazy_loading": False}):
+        agent = _fake_agent("s1")
+        out = hook_impl.transform_tools([_full("mcp_a_b")], agent=agent)
+        assert out is None
+
+
+def test_transform_tools_no_op_when_no_session_id():
+    with patch.object(hook_impl, "_load_config", return_value={"lazy_loading": True}):
+        agent = SimpleNamespace()  # no session_id
+        out = hook_impl.transform_tools([_full("mcp_a_b")], agent=agent)
+        assert out is None
+
+
+def test_transform_tools_stubs_mcp_tools():
+    cfg = {"lazy_loading": True, "lazy_stub_max_desc": 50}
+    with patch.object(hook_impl, "_load_config", return_value=cfg), \
+         patch("hermes_cli.config.load_config", return_value={"mcp_servers": {}}):
+        agent = _fake_agent("s1")
+        out = hook_impl.transform_tools([_full("mcp_a_b"), _full("terminal")], agent=agent)
+        assert out is not None
+        assert is_stub_schema(out[0])
+        assert not is_stub_schema(out[1])
+
+
+def test_transform_tools_keeps_promoted_full():
+    cfg = {"lazy_loading": True}
+    with patch.object(hook_impl, "_load_config", return_value=cfg), \
+         patch("hermes_cli.config.load_config", return_value={"mcp_servers": {}}):
+        agent = _fake_agent("s1")
+        promote_tools(agent, ["mcp_a_b"])
+        out = hook_impl.transform_tools([_full("mcp_a_b"), _full("mcp_c_d")], agent=agent)
+        assert not is_stub_schema(out[0])  # promoted
+        assert is_stub_schema(out[1])      # not promoted
+
+
+
+def test_transform_tools_isolates_sessions():
+    cfg = {"lazy_loading": True}
+    with patch.object(hook_impl, "_load_config", return_value=cfg), \
+         patch("hermes_cli.config.load_config", return_value={"mcp_servers": {}}):
+        agent_a = _fake_agent("s_a", {"mcp_x"})
+        agent_b = _fake_agent("s_b", {"mcp_x"})
+        promote_tools(agent_a, ["mcp_x"])
+
+        out_a = hook_impl.transform_tools([_full("mcp_x")], agent=agent_a)
+        out_b = hook_impl.transform_tools([_full("mcp_x")], agent=agent_b)
+
+        assert not is_stub_schema(out_a[0])  # a promoted it
+        assert is_stub_schema(out_b[0])      # b did not
+
+
+def test_transform_tools_swallows_internal_errors():
+    # Force _load_config to blow up → hook must return None, not raise.
+    with patch.object(hook_impl, "_load_config", side_effect=RuntimeError("boom")):
+        out = hook_impl.transform_tools([_full("mcp_a")], agent=_fake_agent())
+        assert out is None
+
+
+def test_transform_tools_sets_contextvar():
+    cfg = {"lazy_loading": True}
+    with patch.object(hook_impl, "_load_config", return_value=cfg), \
+         patch("hermes_cli.config.load_config", return_value={"mcp_servers": {}}):
+        agent = _fake_agent("s_ctx")
+        hook_impl.transform_tools([_full("mcp_a")], agent=agent)
+        assert pool_mod._current_agent_var.get() is agent
+
+
+# -- mcp_load_tools meta-tool -------------------------------------------------
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_meta_tool_accepts_via_kwargs():
+    agent = _fake_agent("s_meta", {"mcp_x_y"})
+    out = json.loads(_run(meta_tool.handler({"tool_names": ["mcp_x_y"]}, _agent=agent)))
+    assert out["ok"] is True
+    assert out["promoted"] == ["mcp_x_y"]
+    assert out["rejected"] == []
+
+
+def test_meta_tool_falls_back_to_contextvar():
+    agent = _fake_agent("s_meta_ctx", {"mcp_x_y"})
+    pool_mod._current_agent_var.set(agent)
+    out = json.loads(_run(meta_tool.handler({"tool_names": ["mcp_x_y"]})))
+    assert out["ok"] is True
+    assert out["promoted"] == ["mcp_x_y"]
+
+
+def test_meta_tool_reports_rejected_unknown_names():
+    agent = _fake_agent("s_meta_rej", {"mcp_known"})
+    out = json.loads(_run(meta_tool.handler(
+        {"tool_names": ["mcp_known", "mcp_typo"]},
+        _agent=agent,
+    )))
+    assert "mcp_typo" in out["rejected"]
+    assert "mcp_known" in out["promoted"]
+
+
+def test_meta_tool_rejects_non_list_tool_names():
+    agent = _fake_agent("s")
+    out = json.loads(_run(meta_tool.handler({"tool_names": "not-a-list"}, _agent=agent)))
+    assert out["ok"] is False
+    assert "must be an array" in out["error"]
+
+
+def test_meta_tool_fails_when_no_agent():
+    # No agent in kwargs and ContextVar not set.
+    pool_mod._current_agent_var.set(None)
+    out = json.loads(_run(meta_tool.handler({"tool_names": ["x"]})))
+    assert out["ok"] is False
+    assert "agent context unavailable" in out["error"]

--- a/tests/plugins/mcp_lazy/test_stubs.py
+++ b/tests/plugins/mcp_lazy/test_stubs.py
@@ -1,0 +1,132 @@
+"""Tests for stub schema construction + detection + mix."""
+from __future__ import annotations
+
+import pytest
+
+from plugins.mcp_lazy.stubs import (
+    LAZY_SENTINEL,
+    is_mcp_tool,
+    is_stub_schema,
+    make_stub_schema,
+    mix_full_and_stubs,
+)
+
+
+def _full(name: str, description: str = "A real tool", params=None):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": params or {"type": "object", "properties": {"x": {"type": "string"}}},
+        },
+    }
+
+
+def test_is_mcp_tool_by_prefix():
+    assert is_mcp_tool(_full("mcp_trek_search"))
+    assert not is_mcp_tool(_full("terminal"))
+    assert not is_mcp_tool(_full("read_file"))
+
+
+def test_make_stub_preserves_name():
+    full = _full("mcp_x_y", "X-ray scanner")
+    stub = make_stub_schema(full)
+    assert stub["function"]["name"] == "mcp_x_y"
+
+
+def test_make_stub_marks_description():
+    stub = make_stub_schema(_full("mcp_a_b", "Original description"))
+    assert stub["function"]["description"].startswith("[LAZY]")
+    assert "Original description" in stub["function"]["description"]
+
+
+def test_make_stub_truncates_description():
+    long_desc = "x" * 500
+    stub = make_stub_schema(_full("mcp_a_b", long_desc), max_desc=50)
+    # Should be [LAZY] + first 50 chars
+    assert len(stub["function"]["description"]) <= len("[LAZY] ") + 50
+
+
+def test_make_stub_injects_sentinel():
+    stub = make_stub_schema(_full("mcp_a_b"))
+    props = stub["function"]["parameters"]["properties"]
+    assert LAZY_SENTINEL in props
+
+
+def test_is_stub_schema_detects_sentinel():
+    stub = make_stub_schema(_full("mcp_a_b"))
+    assert is_stub_schema(stub)
+
+
+def test_is_stub_schema_rejects_full_tool():
+    full = _full("mcp_zero_arg", "Real zero-arg tool", params={"type": "object", "properties": {}})
+    assert not is_stub_schema(full)
+
+
+def test_is_stub_schema_rejects_builtin():
+    assert not is_stub_schema(_full("terminal"))
+
+
+def test_mix_passes_builtins_unchanged():
+    tools = [_full("terminal"), _full("read_file"), _full("mcp_x_y")]
+    out = mix_full_and_stubs(tools, promoted_names=set())
+    # First two unchanged
+    assert out[0] == tools[0]
+    assert out[1] == tools[1]
+    # Third is stubbed
+    assert is_stub_schema(out[2])
+
+
+def test_mix_keeps_promoted_full():
+    tools = [_full("mcp_a_one"), _full("mcp_a_two"), _full("mcp_b_three")]
+    out = mix_full_and_stubs(tools, promoted_names={"mcp_a_one"})
+    # mcp_a_one stays full; others stubbed
+    assert not is_stub_schema(out[0])
+    assert is_stub_schema(out[1])
+    assert is_stub_schema(out[2])
+
+
+def test_mix_respects_lazy_servers_filter():
+    tools = [_full("mcp_trek_x"), _full("mcp_gmail_send")]
+    # Only trek is in the lazy set → gmail stays full
+    out = mix_full_and_stubs(tools, promoted_names=set(), lazy_servers={"trek"})
+    assert is_stub_schema(out[0])  # mcp_trek_x stubbed
+    assert not is_stub_schema(out[1])  # mcp_gmail_send untouched
+
+
+def test_mix_with_empty_lazy_servers_stubs_all_mcp():
+    tools = [_full("mcp_a_one"), _full("mcp_b_two")]
+    out = mix_full_and_stubs(tools, promoted_names=set(), lazy_servers=None)
+    # lazy_servers=None means "stub all MCP tools"
+    assert all(is_stub_schema(t) for t in out)
+
+
+def test_mix_handles_promoted_frozenset():
+    tools = [_full("mcp_x_one")]
+    out = mix_full_and_stubs(tools, promoted_names=frozenset({"mcp_x_one"}))
+    assert not is_stub_schema(out[0])
+
+
+def test_mix_returns_new_list():
+    tools = [_full("mcp_x_y")]
+    out = mix_full_and_stubs(tools, promoted_names=set())
+    # Original list untouched.
+    assert tools[0]["function"]["name"] == "mcp_x_y"
+    assert "[LAZY]" not in tools[0]["function"]["description"]
+    # Out list has the stub.
+    assert is_stub_schema(out[0])
+
+
+def test_lazy_servers_handles_dashes_and_dots():
+    # Server names get sanitized to underscores in MCP tool names.
+    tools = [_full("mcp_my_server_x_y")]
+    out = mix_full_and_stubs(tools, promoted_names=set(), lazy_servers={"my-server-x"})
+    assert is_stub_schema(out[0])
+
+
+def test_make_stub_empty_description_is_safe():
+    stub = make_stub_schema(_full("mcp_a_b", ""))
+    assert "description" in stub["function"]
+    # Shouldn't crash; description is just "[LAZY]" (trimmed)
+    assert stub["function"]["description"].startswith("[LAZY]")


### PR DESCRIPTION
Refs #6839

## Summary

This PR adds a narrow, config-gated **Phase 1** implementation of lazy MCP schema loading to reduce per-turn tool-schema token overhead for MCP-heavy installs.

Scope in this PR:
- replace full MCP tool schemas with lightweight stubs at request time
- add a meta-tool to promote selected MCP tools to full schemas on demand
- keep promoted-tool state per session
- keep the feature off by default

This PR is intentionally limited to the core lazy-loading loop. It does **not** include later expansion ideas like server-level discovery, eager server promotion, or broader telemetry/reporting.

## Problem

Large MCP installations inject hundreds of full tool schemas into every API call, even when the conversation does not need them. This creates large fixed prompt overhead and can block lower-TPM providers entirely.

## Approach

When `mcp.lazy_loading` is enabled:
- MCP tools are exposed to the model as request-time stubs
- the model can call `load_mcp_tools` to request full schemas for selected tools
- promoted tools remain full for the rest of the session
- builtin/non-MCP tools remain unchanged

The hook is plugin-based and fail-open:
- `transform_tools` rewrites the outgoing tool list just before API dispatch
- on any internal failure, the original full tool list is used unchanged

## Backward compatibility

- off by default
- no behavior change unless explicitly enabled

## Included config keys

- `mcp.lazy_loading`
- `mcp.lazy_stub_max_desc`

## Not included in this PR

- server discovery / server stub mode
- eager server promotion thresholds
- telemetry/reporting extras
- semantic/RAG preselection

## Tests

Ran the narrowed Phase 1 suite:

- `tests/plugins/mcp_lazy/test_stubs.py`
- `tests/plugins/mcp_lazy/test_pool.py`
- `tests/plugins/mcp_lazy/test_promote_and_hook.py`
- `tests/hermes_cli/test_config_validation.py`

Command:

```bash
scripts/run_tests.sh tests/plugins/mcp_lazy/test_stubs.py tests/plugins/mcp_lazy/test_pool.py tests/plugins/mcp_lazy/test_promote_and_hook.py tests/hermes_cli/test_config_validation.py
```
