### PR TITLE
fix: explicit model priority chain for cron job execution

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1284,7 +1284,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 else str(delivery_target["thread_id"])
             )
 
-        # Model resolution: job.model > HERMES_MODEL env var > config.yaml default
+        # Model resolution: job.model > config.yaml default > HERMES_MODEL env var
         model = job.get("model")  # May be None if not persisted
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1284,7 +1284,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 else str(delivery_target["thread_id"])
             )
 
-        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        # Model resolution: job.model > HERMES_MODEL env var > config.yaml default
+        model = job.get("model")  # May be None if not persisted
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -1296,13 +1297,18 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     _cfg = yaml.safe_load(_f) or {}
                 _cfg = _expand_env_vars(_cfg)
                 _model_cfg = _cfg.get("model", {})
-                if not job.get("model"):
+                # Only apply config default if job doesn't have an explicit model
+                if model is None:
                     if isinstance(_model_cfg, str):
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
-                        model = _model_cfg.get("default", model)
+                        model = _model_cfg.get("default", "")
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
+
+        # Fall back to environment variable if still no model
+        if not model:
+            model = os.getenv("HERMES_MODEL", "")
 
         # Apply IPv4 preference if configured.
         try:


### PR DESCRIPTION
## Problem

When running cron jobs, config.yaml model default was silently bypassed whenever HERMES_MODEL was set in the environment.

The original one-liner used Python or-chaining:

    model = job.get("model") or os.getenv("HERMES_MODEL") or ""

If HERMES_MODEL is set (common in multi-profile deployments), it takes priority over the profile config.yaml default — the opposite of the intended hierarchy.

## Fix

Makes the priority chain explicit using None-checks at each step:

1. Job-level model — explicitly set on the cron job
2. config.yaml default — profile configured model
3. HERMES_MODEL env var — environment-level fallback
4. Empty string — final fallback

Also fixes a secondary issue where _model_cfg.get("default", model) could fall back to a stale model value captured before config was loaded.

## Impact

Affects deployments where HERMES_MODEL is set and cron jobs rely on the profile config.yaml model default. The job would silently run with the wrong model with no error or warning.
