### PR TITLE
fix(computer_use): add fallback when list_windows(on_screen_only=True) returns empty (#32766)

### DIFF
--- a/tests/tools/test_cua_backend_fallback_32766.py
+++ b/tests/tools/test_cua_backend_fallback_32766.py
@@ -1,0 +1,156 @@
+"""Regression tests for #32766 — cua_backend capture() fallback when on_screen_only returns empty."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_window(app_name: str, pid: int, window_id: int,
+                 is_on_screen: bool = True, title: str = "",
+                 z_index: int = 0) -> dict[str, Any]:
+    return {
+        "app_name": app_name,
+        "pid": pid,
+        "window_id": window_id,
+        "is_on_screen": is_on_screen,
+        "title": title,
+        "z_index": z_index,
+    }
+
+
+def _make_list_windows_response(windows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a structuredContent response as returned by cua-driver."""
+    return {
+        "structuredContent": {"windows": windows},
+        "data": "",
+    }
+
+
+@pytest.fixture
+def mock_session():
+    """Return a MagicMock that behaves like _CuaDriverSession."""
+    return MagicMock()
+
+
+@pytest.fixture
+def backend(mock_session):
+    """Create a CuaBackend with a mocked session."""
+    from tools.computer_use.cua_backend import CuaDriverBackend
+    b = CuaDriverBackend.__new__(CuaDriverBackend)
+    b._session = mock_session
+    b._active_pid = None
+    b._active_window_id = None
+    b._last_app = None
+    return b
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCaptureFallbackWhenOnScreenOnlyEmpty:
+    """When list_windows(on_screen_only=True) returns zero windows, capture()
+    must retry without the filter rather than giving up immediately."""
+
+    def test_fallback_to_unfiltered_when_on_screen_only_empty(self, backend, mock_session):
+        """Primary path empty → fallback succeeds → capture uses fallback windows."""
+        # First call (on_screen_only=True) → empty
+        # Second call (on_screen_only=False) → has windows
+        def call_tool(tool_name: str, args: dict):
+            if tool_name == "list_windows":
+                if args.get("on_screen_only") is True:
+                    return _make_list_windows_response([])
+                else:
+                    return _make_list_windows_response([
+                        _make_window("Terminal", 100, 1, is_on_screen=True,
+                                     title="bash", z_index=0),
+                    ])
+            if tool_name == "screenshot":
+                return {"images": []}
+            if tool_name == "get_window_state":
+                return {"data": "No elements", "images": []}
+            return {}
+
+        mock_session.call_tool.side_effect = call_tool
+
+        result = backend.capture(mode="vision")
+
+        # Should have called list_windows twice
+        assert mock_session.call_tool.call_count >= 2
+        calls = mock_session.call_tool.call_args_list
+        first_call = calls[0]
+        assert first_call[0] == ("list_windows", {"on_screen_only": True})
+        second_call = calls[1]
+        assert second_call[0] == ("list_windows", {"on_screen_only": False})
+
+        # Should have found the fallback window
+        assert result.app == "Terminal"
+
+    def test_fallback_also_empty_returns_empty_result(self, backend, mock_session):
+        """Both on_screen_only=True and fallback return empty → graceful empty result."""
+        mock_session.call_tool.return_value = _make_list_windows_response([])
+
+        result = backend.capture(mode="vision")
+
+        assert result.width == 0
+        assert result.height == 0
+        assert result.png_b64 is None
+        assert result.app == ""
+
+    def test_fallback_respects_app_filter(self, backend, mock_session):
+        """Fallback windows are still filtered by app name."""
+        def call_tool(tool_name: str, args: dict):
+            if tool_name == "list_windows":
+                if args.get("on_screen_only") is True:
+                    return _make_list_windows_response([])
+                else:
+                    return _make_list_windows_response([
+                        _make_window("Terminal", 100, 1, is_on_screen=True,
+                                     title="bash", z_index=0),
+                        _make_window("Chrome", 200, 2, is_on_screen=True,
+                                     title="Google", z_index=1),
+                    ])
+            if tool_name == "screenshot":
+                return {"images": []}
+            if tool_name == "get_window_state":
+                return {"data": "No elements", "images": []}
+            return {}
+
+        mock_session.call_tool.side_effect = call_tool
+
+        result = backend.capture(mode="vision", app="Chrome")
+
+        assert result.app == "Chrome"
+
+    def test_fallback_applies_client_side_on_screen_filter(self, backend, mock_session):
+        """Fallback windows respect is_on_screen for picking the target."""
+        def call_tool(tool_name: str, args: dict):
+            if tool_name == "list_windows":
+                if args.get("on_screen_only") is True:
+                    return _make_list_windows_response([])
+                else:
+                    return _make_list_windows_response([
+                        _make_window("Hidden", 100, 1, is_on_screen=False,
+                                     title="bg", z_index=0),
+                        _make_window("Visible", 200, 2, is_on_screen=True,
+                                     title="fg", z_index=1),
+                    ])
+            if tool_name == "screenshot":
+                return {"images": []}
+            if tool_name == "get_window_state":
+                return {"data": "No elements", "images": []}
+            return {}
+
+        mock_session.call_tool.side_effect = call_tool
+
+        result = backend.capture(mode="vision")
+
+        # Should prefer the on-screen window from the fallback
+        assert result.app == "Visible"

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -389,6 +389,37 @@ class CuaDriverBackend(ComputerUseBackend):
             windows = _parse_windows_from_text(raw_text)
 
         if not windows:
+            # Fallback: retry without on_screen_only filter — the driver's
+            # is_on_screen detection can be unreliable (e.g. on certain window
+            # managers, virtual desktops, or when no window is focused).
+            # When the retry succeeds, we do client-side filtering.
+            lw_fallback = self._session.call_tool(
+                "list_windows", {"on_screen_only": False}
+            )
+            sc_fb = lw_fallback.get("structuredContent") or {}
+            raw_fb = sc_fb.get("windows") if sc_fb else None
+            if raw_fb:
+                windows = [
+                    {
+                        "app_name": w.get("app_name", ""),
+                        "pid": int(w["pid"]),
+                        "window_id": int(w["window_id"]),
+                        "off_screen": not w.get("is_on_screen", True),
+                        "title": w.get("title", ""),
+                        "z_index": w.get("z_index", 0),
+                    }
+                    for w in raw_fb
+                ]
+                windows.sort(key=lambda w: w["z_index"])
+            else:
+                raw_fb_text = (
+                    lw_fallback["data"]
+                    if isinstance(lw_fallback.get("data"), str)
+                    else ""
+                )
+                windows = _parse_windows_from_text(raw_fb_text)
+
+        if not windows:
             return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
                                  elements=[], app="", window_title="", png_bytes_len=0)
 


### PR DESCRIPTION
## What does this PR do?

Fixes fragility in `CuaDriverBackend.capture()` where `list_windows(on_screen_only=True)` can return zero windows due to unreliable `is_on_screen` detection in the underlying cua-driver. This causes the entire `computer_use` toolset to fail hard, breaking auxiliary vision routing for text-only main models.

**Fix**: Adds a fallback retry without the `on_screen_only` filter when the primary call returns empty. The fallback applies client-side `is_on_screen` filtering. If the fallback also returns empty, a graceful empty `CaptureResult` is returned.

## Related Issue

Fixes #32766

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `tests/tools/test_cua_backend_fallback_32766.py` (+156): 4 focused regression tests
- `tools/computer_use/cua_backend.py` (+31): Fallback retry when primary on_screen_only returns empty, with client-side filtering and identical normalization

## How to Test
```bash
python3 -m pytest tests/tools/test_cua_backend_fallback_32766.py tests/tools/test_computer_use.py -v -o "addopts="
```
78 tests passed (4 new + 74 existing). Fail-without-fix proven: 3/4 new tests fail without production change.

## Related PRs
- PR #25674 handles explicit `app=...` targeting fallback — complementary narrower fix. This PR covers the broader zero-window case regardless of app targeting.

---

**Checklist:**
- [x] Code compiles/runs correctly
- [x] Tests pass locally
- [x] No extraneous changes
- [x] PR contains only intended changes (2 files, +187)
- [x] Fix targets root cause, not symptoms
- [x] All edge cases covered
