### PR TITLE
fix: recover planned gateway restarts and Codex null-output streams

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -200,6 +200,7 @@ def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool
                 status="completed",
                 content=[SimpleNamespace(type="output_text", text=assembled)],
             )],
+            output_text=assembled,
             usage=None,
             status="completed",
             model=model,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18321,6 +18321,17 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         except Exception as e:
             logger.debug("Takeover marker check failed: %s", e)
 
+        # Planned restart check: launchd restart fallbacks may send SIGTERM
+        # before `kickstart -k`.  The CLI writes a marker first so we can
+        # report a restart (not a shutdown) and exit with the restart code.
+        planned_restart = False
+        if not planned_takeover:
+            try:
+                from gateway.status import consume_planned_restart_marker_for_self
+                planned_restart = consume_planned_restart_marker_for_self()
+            except Exception as e:
+                logger.debug("Planned restart marker check failed: %s", e)
+
         # Planned stop check: service managers and `hermes gateway stop`
         # also send SIGTERM, which is indistinguishable from an unexpected
         # external kill unless the CLI marks it first. SIGINT comes from an
@@ -18328,7 +18339,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         planned_stop = False
         if received_signal == signal.SIGINT:
             planned_stop = True
-        elif not planned_takeover:
+        elif not planned_takeover and not planned_restart:
             try:
                 from gateway.status import consume_planned_stop_marker_for_self
                 planned_stop = consume_planned_stop_marker_for_self()
@@ -18355,6 +18366,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if planned_takeover:
             logger.info(
                 "Received %s as a planned --replace takeover — exiting cleanly",
+                _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM",
+            )
+        elif planned_restart:
+            runner._restart_requested = True
+            runner._restart_detached = False
+            runner._restart_via_service = True
+            logger.info(
+                "Received %s as a planned gateway restart — draining before service relaunch",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM",
             )
         elif planned_stop:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -762,6 +762,8 @@ _TAKEOVER_MARKER_FILENAME = ".gateway-takeover.json"
 _TAKEOVER_MARKER_TTL_S = 60  # Marker older than this is treated as stale
 _PLANNED_STOP_MARKER_FILENAME = ".gateway-planned-stop.json"
 _PLANNED_STOP_MARKER_TTL_S = 60
+_PLANNED_RESTART_MARKER_FILENAME = ".gateway-planned-restart.json"
+_PLANNED_RESTART_MARKER_TTL_S = 60
 
 
 def _get_takeover_marker_path() -> Path:
@@ -774,6 +776,12 @@ def _get_planned_stop_marker_path() -> Path:
     """Return the path to the intentional gateway stop marker file."""
     home = get_hermes_home()
     return home / _PLANNED_STOP_MARKER_FILENAME
+
+
+def _get_planned_restart_marker_path() -> Path:
+    """Return the path to the intentional gateway restart marker file."""
+    home = get_hermes_home()
+    return home / _PLANNED_RESTART_MARKER_FILENAME
 
 
 def _marker_is_stale(written_at: str, ttl_s: int) -> bool:
@@ -918,6 +926,46 @@ def clear_planned_stop_marker() -> None:
     """Remove the planned-stop marker unconditionally."""
     try:
         _get_planned_stop_marker_path().unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def write_planned_restart_marker(target_pid: int) -> bool:
+    """Record that ``target_pid`` is being restarted intentionally.
+
+    Some launchd restart fallbacks send SIGTERM before ``kickstart -k``.  The
+    target gateway cannot distinguish that from an unexpected external kill
+    unless the CLI marks the PID first.  This marker lets the target report a
+    restart (not a shutdown) and exit with the service-restart code.
+    """
+    try:
+        target_start_time = _get_process_start_time(target_pid)
+        record = {
+            "target_pid": target_pid,
+            "target_start_time": target_start_time,
+            "restarter_pid": os.getpid(),
+            "written_at": _utc_now_iso(),
+        }
+        _write_json_file(_get_planned_restart_marker_path(), record)
+        return True
+    except (OSError, PermissionError):
+        return False
+
+
+def consume_planned_restart_marker_for_self() -> bool:
+    """Return True when the current process is being intentionally restarted."""
+    return _consume_pid_marker_for_self(
+        _get_planned_restart_marker_path(),
+        pid_field="target_pid",
+        start_time_field="target_start_time",
+        ttl_s=_PLANNED_RESTART_MARKER_TTL_S,
+    )
+
+
+def clear_planned_restart_marker() -> None:
+    """Remove the planned-restart marker unconditionally."""
+    try:
+        _get_planned_restart_marker_path().unlink(missing_ok=True)
     except OSError:
         pass
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3061,6 +3061,11 @@ def launchd_restart():
             return
         if pid is not None:
             try:
+                from gateway.status import write_planned_restart_marker
+                write_planned_restart_marker(pid)
+            except Exception:
+                pass
+            try:
                 terminate_pid(pid, force=False)
             except (ProcessLookupError, PermissionError, OSError):
                 pid = None

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "bot00@eonofpixel.com": "eonofpixel",
     "9592417+adam91holt@users.noreply.github.com": "adam91holt",
     "45688690+fujinice@users.noreply.github.com": "fujinice",
     "276689385+carltonawong@users.noreply.github.com": "carltonawong",

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -900,6 +900,72 @@ class TestPlannedStopMarker:
         assert ok is False
 
 
+class TestPlannedRestartMarker:
+    """Tests for intentional service restart markers."""
+
+    def test_write_marker_records_target_identity(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+
+        ok = status.write_planned_restart_marker(target_pid=12345)
+
+        assert ok is True
+        marker = tmp_path / ".gateway-planned-restart.json"
+        assert marker.exists()
+        payload = json.loads(marker.read_text())
+        assert payload["target_pid"] == 12345
+        assert payload["target_start_time"] == 42
+        assert payload["restarter_pid"] == os.getpid()
+        assert "written_at" in payload
+
+    def test_consume_returns_true_when_marker_names_self(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 100)
+        ok = status.write_planned_restart_marker(target_pid=os.getpid())
+        assert ok is True
+
+        result = status.consume_planned_restart_marker_for_self()
+
+        assert result is True
+        assert not (tmp_path / ".gateway-planned-restart.json").exists()
+
+    def test_consume_returns_false_for_different_pid(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 100)
+        ok = status.write_planned_restart_marker(target_pid=os.getpid() + 9999)
+        assert ok is True
+
+        result = status.consume_planned_restart_marker_for_self()
+
+        assert result is False
+        assert not (tmp_path / ".gateway-planned-restart.json").exists()
+
+    def test_clear_planned_restart_marker_is_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 100)
+
+        status.clear_planned_restart_marker()
+        status.write_planned_restart_marker(target_pid=12345)
+        assert (tmp_path / ".gateway-planned-restart.json").exists()
+
+        status.clear_planned_restart_marker()
+
+        assert not (tmp_path / ".gateway-planned-restart.json").exists()
+        status.clear_planned_restart_marker()
+
+    def test_write_marker_returns_false_on_write_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        def raise_oserror(*args, **kwargs):
+            raise OSError("simulated write failure")
+
+        monkeypatch.setattr(status, "_write_json_file", raise_oserror)
+
+        ok = status.write_planned_restart_marker(target_pid=12345)
+
+        assert ok is False
+
+
 class TestReadProcessCmdlinePsFallback:
     """Tests for _read_process_cmdline falling back to ps on non-Linux."""
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -566,6 +566,10 @@ class TestLaunchdServiceRecovery:
             "gateway.status.get_running_pid",
             lambda: 321,
         )
+        monkeypatch.setattr(
+            "gateway.status.write_planned_restart_marker",
+            lambda pid: calls.append(("restart-marker", pid)) or True,
+        )
 
         def fake_run(cmd, check=False, **kwargs):
             calls.append(cmd)
@@ -576,6 +580,7 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert calls == [
+            ("restart-marker", 321),
             ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
         ]

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -166,7 +167,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -467,6 +468,57 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
     assert calls["stream"] == 2
     assert calls["create"] == 1
     assert response.output[0].content[0].text == "create fallback ok"
+
+
+def test_run_codex_stream_recovers_output_items_when_final_snapshot_output_is_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="stream item ok")],
+    )
+
+    calls = {"create": 0}
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                events=[SimpleNamespace(type="response.output_item.done", item=item)],
+                final_error=TypeError("'NoneType' object is not iterable"),
+            ),
+            create=lambda **kwargs: calls.__setitem__("create", calls["create"] + 1),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response is not None
+    assert response.status == "completed"
+    assert response.output == [item]
+    assert calls["create"] == 0
+
+
+def test_run_codex_stream_recovers_text_deltas_when_final_snapshot_output_is_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    calls = {"create": 0}
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                events=[
+                    SimpleNamespace(type="response.output_text.delta", delta="hello"),
+                    SimpleNamespace(type="response.output_text.delta", delta=" world"),
+                ],
+                final_error=TypeError("'NoneType' object is not iterable"),
+            ),
+            create=lambda **kwargs: calls.__setitem__("create", calls["create"] + 1),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response is not None
+    assert response.status == "completed"
+    assert response.output_text == "hello world"
+    assert response.output[0].content[0].text == "hello world"
+    assert calls["create"] == 0
 
 
 def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):


### PR DESCRIPTION
## Summary
- mark launchd-triggered gateway restarts as planned before SIGTERM so shutdown handling reports restart instead of stop
- add planned restart marker validation and focused regression coverage
- preserve synthesized Codex Responses output_text when recovering from SDK final snapshots with output=None

## Test Plan
- python -m pytest tests/gateway/test_status.py tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='
- python -m py_compile gateway/status.py gateway/run.py hermes_cli/gateway.py agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py
- git diff --check