### PR TITLE
feat(docker): upgrade Node to 22 LTS via multi-stage from node:22-bookworm-slim (#4977)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df22866bd7857e5d304b67a564f4feab6ac22044dde719b AS uv_source
+# Node 22 LTS source stage. Debian trixie's bundled nodejs is pinned to 20.x
+# which reached EOL in April 2026 — we copy node + npm + corepack from the
+# upstream node:22 image instead so we can stay on a supported LTS without
+# waiting for Debian 14 (forky, ~mid-2027).  Bookworm-based slim image used
+# so the produced binary links against glibc 2.36, which runs cleanly on
+# our Debian 13 (trixie, glibc 2.41) runtime.  Bumping to a new Node major
+# is a one-line ARG change; see #4977.
+FROM node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732 AS node_source
 FROM debian:13.4
 
 # Disable Python stdout buffering to ensure logs are printed immediately
@@ -17,7 +25,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # hermes process, the dashboard, and per-profile gateways.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
+    ca-certificates curl python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------- s6-overlay install ----------
@@ -72,6 +80,18 @@ RUN useradd -u 10000 -m -d /opt/data hermes
 
 COPY --chmod=0755 --from=uv_source /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 
+# Node 22 LTS: copy the node binary plus the bundled npm + corepack JS
+# installs from the upstream image.  npm and npx are recreated as symlinks
+# because they're symlinks in the source image (and need to live on PATH).
+# See node_source stage at the top of the file for the version-bump
+# rationale (#4977).
+COPY --chmod=0755 --from=node_source /usr/local/bin/node /usr/local/bin/
+COPY --from=node_source /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+COPY --from=node_source /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/corepack
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+    ln -sf /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
+
 WORKDIR /opt/hermes
 
 # ---------- Layer-cached dependency install ----------
@@ -88,14 +108,15 @@ COPY ui-tui/package.json ui-tui/package-lock.json ui-tui/
 COPY ui-tui/packages/hermes-ink/ ui-tui/packages/hermes-ink/
 
 # `npm_config_install_links=false` forces npm to install `file:` deps as
-# symlinks (the npm 10+ default) even on Debian's older bundled npm 9.x,
-# which defaults to `install-links=true` and installs file deps as *copies*.
-# The host-side package-lock.json is generated with a newer npm that uses
-# symlinks, so an install-as-copy produces a hidden node_modules/.package-lock.json
-# that permanently disagrees with the root lock on the @hermes/ink entry.
-# That disagreement trips the TUI launcher's `_tui_need_npm_install()`
-# check on every startup and triggers a runtime `npm install` that then
-# fails with EACCES (node_modules/ is root-owned from build time).
+# symlinks instead of copies.  This is the default since npm 10+, which is
+# what the image ships now (via the node:22 source stage).  We set it
+# explicitly anyway as defense-in-depth: the previous Debian-bundled npm
+# 9.x defaulted to install-as-copy, which produced a hidden
+# node_modules/.package-lock.json that permanently disagreed with the root
+# lock on the @hermes/ink entry, tripped the TUI launcher's
+# `_tui_need_npm_install()` check on every startup, and triggered a
+# runtime `npm install` that then failed with EACCES.  Keeping the env
+# guards against a future regression if the source npm version changes.
 ENV npm_config_install_links=false
 
 RUN npm install --prefer-offline --no-audit && \


### PR DESCRIPTION
Salvages #4977 (@Prithvi1994).

## Problem

Debian trixie's bundled `nodejs` package is pinned to `20.19.2+dfsg-1+deb13u2`. Node 20 LTS reached EOL on **April 30, 2026** — security patches stopped landing upstream. Trixie won't bump in place; the next Debian release (forky / 14), where the apt `nodejs` package is 24.x, isn't expected until ~mid-2027. So the published image has been shipping a Node version with no upstream security backports for ~1 month and counting.

## Fix

Adopt the multi-stage `node_source` pattern already used by `uv_source` and `gosu_source` in this Dockerfile:

```dockerfile
FROM node:22-bookworm-slim@sha256:7af03b14… AS node_source
```

Then `COPY` the `node` binary plus the bundled `npm` / `corepack` JS installs into the runtime image, recreating the `/usr/local/bin/{npm,npx,corepack}` symlinks. The bookworm-based slim source produces a glibc-2.36-linked binary, which runs cleanly under our trixie runtime (glibc 2.41 — backward-compatible).

Future Node major bumps (24, 26, …) become a one-line `@sha256:` change.

### Other necessary tweak

Removed `nodejs npm` from the apt-get install line. The apt `nodejs` package transitively pulled in `ca-certificates`; without it, the s6-overlay download step's `curl -fsSL` fails with `(77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt`. Added `ca-certificates` explicitly to keep the existing build steps working.

### `install-links=false` comment refresh

`npm_config_install_links=false` was originally set to make Debian's bundled npm 9.2.0 behave like npm 10's default. The salvage ships npm 10.9.8 from `node:22-bookworm-slim` so the env is now a no-op — kept as defense-in-depth against future source-version regressions. Comment updated to reflect the new reality.

## Validation

Built `--no-cache` against current `origin/main` (`22eb4d13f` — includes salvages 1-3 already merged). Build succeeds in 1m42s.

### Image size

| | size | layers |
|---|---|---|
| original baseline (pre-salvage-1) | 3.27 GB | 25 |
| current main (post-salvage-1 → -3) | 3.21 GB | 25 |
| salvage (this PR) | **3.14 GB** | 29 |
| **net delta** | **−130 MiB cumulative** (−60 MiB from this PR alone) | |

The size win comes from dropping apt's `nodejs npm` (which pulls libssl variants, libuv, c-ares, etc. — all duplicating what the upstream node binary statically bundles).

### Smoke + E2E batteries (all pass)

| Suite | Score |
|---|---|
| Image smoke battery (`--version`, hermes_cli, TUI launcher, lazy_deps, gcc) | **6/6** |
| Node version E2E (node v22.22.3 / npm 10.9.8 / npx / corepack / no apt-nodejs / TUI launcher / glibc compat / esbuild) | **8/8** |
| Chown E2E (#19788 regression check from salvage 2) | **6/6** |
| TUI UID-remap E2E (#28851 regression check from salvage 3) | **4/4** |
| **Total** | **24 / 24** |

### Versions inside the image

- node: `v22.22.3`
- npm: `10.9.8`
- npx: `10.9.8`
- corepack: present
- esbuild (under Node 22): `0.27.7`
- glibc (runtime base, trixie): `2.41` — node binary compiled against bookworm's `2.36`, backward-compatible

## Authorship

Original change by @Prithvi1994 in #4977 — their commit proposed the NodeSource apt-repo approach. Cherry-pick was infeasible (the contributor's branch was on a pre-s6-overlay base and the commit conflicted with months of intervening Dockerfile work); reconstructed the equivalent fix against current `main` using the project's existing multi-stage source-image idiom. Preserved attribution via `Co-authored-by:`.

Closes #4977.
