### PR TITLE
feat(api): add run steer endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -12,6 +12,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
+- POST /v1/runs/{run_id}/steer      — inject guidance into a running agent
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
@@ -1084,6 +1085,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "run_steer": True,
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -1100,6 +1102,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
+                "run_steer": {"method": "POST", "path": "/v1/runs/{run_id}/steer"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
             },
         })
@@ -3398,6 +3401,98 @@ class APIServerAdapter(BasePlatformAdapter):
             "resolved": resolved,
         })
 
+
+    async def _handle_steer_run(self, request: "web.Request") -> "web.Response":
+        """POST /v1/runs/{run_id}/steer — inject guidance into a running agent."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        status = self._run_statuses.get(run_id)
+        if status is None:
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        raw_text = body.get("text")
+        if raw_text is None:
+            raw_text = body.get("input")
+        text = str(raw_text or "").strip()
+        if not text:
+            return web.json_response(
+                _openai_error("Missing or empty 'text' field", code="invalid_steer_text"),
+                status=400,
+            )
+
+        agent = self._active_run_agents.get(run_id)
+        if agent is None:
+            return web.json_response(
+                _openai_error(
+                    f"Run is not active or no longer steerable: {run_id}",
+                    code="not_steerable",
+                    param="run_id",
+                ),
+                status=409,
+            )
+
+        steer_fn = getattr(agent, "steer", None)
+        if not callable(steer_fn):
+            return web.json_response(
+                _openai_error(
+                    f"Run does not support steering: {run_id}",
+                    code="steer_not_supported",
+                    param="run_id",
+                ),
+                status=409,
+            )
+
+        try:
+            accepted = bool(steer_fn(text))
+        except Exception as exc:
+            logger.exception("[api_server] steer for run %s failed", run_id)
+            return web.json_response(_openai_error(str(exc)), status=500)
+
+        if not accepted:
+            return web.json_response(
+                _openai_error("Steer rejected", code="steer_rejected"),
+                status=409,
+            )
+
+        source = str(body.get("source") or "api").strip() or "api"
+        visibility = str(body.get("visibility") or "event").strip().lower() or "event"
+        event = {
+            "event": "run.steer.accepted",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "source": source,
+            "visibility": visibility,
+        }
+        self._set_run_status(run_id, "running", last_event="run.steer.accepted")
+        q = self._run_streams.get(run_id)
+        if q is not None:
+            try:
+                q.put_nowait(event)
+            except Exception:
+                pass
+
+        return web.json_response(
+            {
+                "object": "hermes.run.steer",
+                "run_id": run_id,
+                "accepted": True,
+                "status": "accepted",
+                "delivery": "pending",
+            },
+            status=202,
+        )
+
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/stop — interrupt a running agent."""
         auth_err = self._check_auth(request)
@@ -3510,6 +3605,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
+            self._app.router.add_post("/v1/runs/{run_id}/steer", self._handle_steer_run)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -50,6 +50,7 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post("/v1/runs/{run_id}/steer", adapter._handle_steer_run)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
 
@@ -369,6 +370,100 @@ class TestRunEvents:
         app = _create_runs_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
+        assert resp.status == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs/{run_id}/steer — inject guidance into a running agent
+# ---------------------------------------------------------------------------
+
+
+class TestSteerRun:
+    @pytest.mark.asyncio
+    async def test_steer_running_agent(self, adapter):
+        """Steer should call the active agent's steer() and emit an event."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, interrupted = _make_slow_agent()
+                mock_agent.steer = MagicMock(return_value=True)
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                agent_ready.wait(timeout=3.0)
+                await asyncio.sleep(0.1)
+                assert run_id in adapter._active_run_agents
+
+                steer_resp = await cli.post(
+                    f"/v1/runs/{run_id}/steer",
+                    json={"text": "prefer a shorter answer", "source": "test"},
+                )
+                assert steer_resp.status == 202
+                steer_data = await steer_resp.json()
+                assert steer_data == {
+                    "object": "hermes.run.steer",
+                    "run_id": run_id,
+                    "accepted": True,
+                    "status": "accepted",
+                    "delivery": "pending",
+                }
+                mock_agent.steer.assert_called_once_with("prefer a shorter answer")
+
+                event = adapter._run_streams[run_id].get_nowait()
+                assert event["event"] == "run.steer.accepted"
+                assert event["run_id"] == run_id
+                assert event["source"] == "test"
+
+                interrupted.set()
+
+    @pytest.mark.asyncio
+    async def test_steer_nonexistent_run_returns_404(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs/run_nonexistent/steer",
+                json={"text": "hello"},
+            )
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_steer_completed_run_returns_409(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_completed"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "completed"}
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/v1/runs/{run_id}/steer",
+                json={"text": "too late"},
+            )
+            data = await resp.json()
+        assert resp.status == 409
+        assert data["error"]["code"] == "not_steerable"
+
+    @pytest.mark.asyncio
+    async def test_steer_empty_text_returns_400(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_active"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._active_run_agents[run_id] = MagicMock()
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/v1/runs/{run_id}/steer", json={"text": "   "})
+            data = await resp.json()
+        assert resp.status == 400
+        assert data["error"]["code"] == "invalid_steer_text"
+
+    @pytest.mark.asyncio
+    async def test_steer_requires_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs/run_any/steer",
+                json={"text": "hello"},
+            )
         assert resp.status == 401
 
 


### PR DESCRIPTION
## Summary
- add `POST /v1/runs/{run_id}/steer` to the API server
- forward accepted steer text to the active run's existing `AIAgent.steer()` primitive
- advertise the endpoint in `/v1/capabilities` and emit `run.steer.accepted` on the run SSE stream

## Design notes
This intentionally exposes the existing in-process steer mechanism for API-owned active runs instead of mutating session history. The injected text is accepted as pending guidance and delivered by the agent at its existing safe steering boundary.

This first slice keeps scope narrow: it does not add gateway session-key steering or queued fallback semantics yet. Those can build on the same API pattern if maintainers want steering for gateway-owned live sessions while preserving platform delivery.

## Test Plan
- `PYTHONPATH=. python -m pytest tests/gateway/test_api_server_runs.py -q -o 'addopts='`
- `PYTHONPATH=. python -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py -q -o 'addopts='`
