### PR TITLE
ci(docker): add shellcheck shell=sh directive to main-wrapper.sh

### DIFF
--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -1,4 +1,5 @@
 #!/command/with-contenv sh
+# shellcheck shell=sh
 # /opt/hermes/docker/main-wrapper.sh — wraps the container's CMD with
 # the same argument-routing logic the pre-s6 entrypoint.sh used. Runs
 # as /init's "main program" (Docker CMD) so it inherits stdin/stdout/


### PR DESCRIPTION
## Problem

The `Docker / shell lint` CI job currently fails on every PR that touches `docker/`. The actual error:

```
docker/main-wrapper.sh:1:1: error: This shebang was unrecognized.
  ShellCheck only supports sh/bash/dash/ksh/'busybox sh'.
  Add a 'shell' directive to specify. [SC1008]
```

shellcheck doesn't recognize the s6-overlay `#!/command/with-contenv sh` shebang and treats it as a hard error (the workflow runs with `--severity=error` but SC1008 fires at that severity anyway).

## How we got here

PR #32412 (commit `29c71e9`) correctly changed the shebang from `#!/bin/sh` → `#!/command/with-contenv sh` to fix env-propagation through s6-overlay's `/init` PID 1. That change is right.

The `# shellcheck shell=sh` directive — already present on the sibling `docker/cont-init.d/02-reconcile-profiles` and `015-supervise-perms` scripts which use the same shebang — was missed when `main-wrapper.sh` adopted it.

## Fix

Add `# shellcheck shell=sh` as the second line of `docker/main-wrapper.sh`. Same pattern as the working sibling scripts.

```
 #!/command/with-contenv sh
+# shellcheck shell=sh
 # /opt/hermes/docker/main-wrapper.sh — wraps the container's CMD with
```

The directive is a comment; script behavior is unchanged.

## Validation

Local reproduction of the CI failure (using `koalaman/shellcheck:stable`, the same image `ludeeus/action-shellcheck` shells out to):

```bash
docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
  --severity=error --format=gcc docker/main-wrapper.sh
```

- **Before:** `docker/main-wrapper.sh:1:1: error: [SC1008]`  (rc=1)
- **After:** (no output)  (rc=0)

Parser sanity-check (`sh -n` / `bash -n`) passes on both before and after — the directive doesn't change script semantics.

## After this lands

The Docker / shell lint job goes green for every PR touching `docker/`. Currently visible failures on at least #33060 will clear on rebase.
