### PR TITLE
feat(web): register web_crawl as a model-callable tool

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -509,6 +509,74 @@ class TestWebSearchSchema:
         fake_search.assert_called_once_with("docs", 100)
 
 
+class TestWebCrawlSchema:
+    """Test suite for web_crawl tool schema and handler wiring."""
+
+    def test_schema_requires_url_and_makes_instructions_optional(self):
+        import tools.web_tools
+
+        schema = tools.web_tools.WEB_CRAWL_SCHEMA
+        properties = schema["parameters"]["properties"]
+
+        assert schema["name"] == "web_crawl"
+        assert "url" in properties
+        assert properties["url"]["type"] == "string"
+        assert "instructions" in properties
+        assert properties["instructions"]["type"] == "string"
+        assert schema["parameters"]["required"] == ["url"]
+        assert "instructions" not in schema["parameters"]["required"]
+
+    def test_tool_is_registered(self):
+        import tools.web_tools
+
+        entry = tools.web_tools.registry.get_entry("web_crawl")
+
+        assert entry is not None
+        assert entry.toolset == "web"
+        assert entry.is_async is True
+
+    def test_registered_handler_forwards_url_and_instructions(self):
+        import tools.web_tools
+
+        entry = tools.web_tools.registry.get_entry("web_crawl")
+        # web_crawl_tool is async; the real dispatcher awaits the coroutine
+        # via is_async=True. Here we only inspect arg forwarding, so close
+        # the returned coroutine to suppress the unawaited-coroutine warning.
+        with patch("tools.web_tools.web_crawl_tool") as mock_crawl:
+            entry.handler({
+                "url": "https://example.com",
+                "instructions": "list product pages",
+            }).close()
+
+        mock_crawl.assert_called_once_with(
+            "https://example.com", instructions="list product pages",
+        )
+
+    def test_registered_handler_passes_none_instructions_when_absent(self):
+        import tools.web_tools
+
+        entry = tools.web_tools.registry.get_entry("web_crawl")
+        with patch("tools.web_tools.web_crawl_tool") as mock_crawl:
+            entry.handler({"url": "https://example.com"}).close()
+
+        mock_crawl.assert_called_once_with("https://example.com", instructions=None)
+
+    def test_web_crawl_in_expected_toolsets(self):
+        from toolsets import _HERMES_CORE_TOOLS, TOOLSETS
+
+        assert "web_crawl" in _HERMES_CORE_TOOLS
+        assert "web_crawl" in TOOLSETS["web"]["tools"]
+        assert "web_crawl" in TOOLSETS["hermes-acp"]["tools"]
+        assert "web_crawl" in TOOLSETS["hermes-api-server"]["tools"]
+
+    def test_web_crawl_excluded_from_webhook_safe_tools(self):
+        """Webhook content is untrusted; crawl widens the prompt-injection
+        attack surface, so it must stay out of the webhook default."""
+        from toolsets import _HERMES_WEBHOOK_SAFE_TOOLS
+
+        assert "web_crawl" not in _HERMES_WEBHOOK_SAFE_TOOLS
+
+
 class TestWebSearchErrorHandling:
     """Test suite for web_search_tool() error responses."""
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1537,6 +1537,25 @@ WEB_EXTRACT_SCHEMA = {
     }
 }
 
+WEB_CRAWL_SCHEMA = {
+    "name": "web_crawl",
+    "description": "Crawl a website starting from a seed URL with natural-language instructions for what content to extract from each crawled page. Returns one entry per crawled page with url, title, and content (markdown). Use this for multi-page traversal of a single site (catalog/docs/blog); for single-URL extraction use web_extract instead.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "Seed URL to crawl from. The crawler follows links from this page."
+            },
+            "instructions": {
+                "type": "string",
+                "description": "What to extract from each crawled page (e.g. 'list all product pages with name and price')."
+            }
+        },
+        "required": ["url"]
+    }
+}
+
 registry.register(
     name="web_search",
     toolset="web",
@@ -1557,5 +1576,16 @@ registry.register(
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="web_crawl",
+    toolset="web",
+    schema=WEB_CRAWL_SCHEMA,
+    handler=lambda args, **kw: web_crawl_tool(args.get("url", ""), instructions=args.get("instructions")),
+    check_fn=check_web_api_key,
+    requires_env=_web_requires_env(),
+    is_async=True,
+    emoji="🕸️",
     max_result_size_chars=100_000,
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "web_crawl",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -89,7 +89,7 @@ TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
+        "tools": ["web_search", "web_extract", "web_crawl"],
         "includes": []  # No other toolsets included
     },
     
@@ -341,7 +341,7 @@ TOOLSETS = {
     "hermes-acp": {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_crawl",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
@@ -361,7 +361,7 @@ TOOLSETS = {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
             # Web
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_crawl",
             # Terminal + process management
             "terminal", "process",
             # File manipulation


### PR DESCRIPTION
## What does this PR do?

Registers `web_crawl` as a model-callable tool. Before this PR, `web_crawl_tool()` existed as an async Python function in `tools/web_tools.py` but no `registry.register(name="web_crawl", ...)` call existed — so every crawl-capable provider (Firecrawl, Tavily, any future plugin advertising `supports_crawl()`) was unreachable from the model. Crawl was only invokable programmatically.

This change is strictly additive: it adds the schema, the registration, and the toolset memberships needed to surface `web_crawl` to the model. No existing tool changes behavior; no existing provider is affected.

## Related Issue

Fixes #32598

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

(The new functionality is the *exposure* of an existing implementation — the dispatcher and provider infrastructure was already in place via `agent.web_search_registry.get_active_crawl_provider()`. The fix is registering the tool so models can actually call it.)

## Changes Made

### `tools/web_tools.py`

- **Add `WEB_CRAWL_SCHEMA`** next to the existing `WEB_SEARCH_SCHEMA` and `WEB_EXTRACT_SCHEMA`. Two parameters: `url` (required), `instructions` (optional). Other `web_crawl_tool()` params (`depth`, `use_llm_processing`, `model`, `min_length`) have sensible defaults and stay internal — this mirrors how `WEB_EXTRACT_SCHEMA` hides post-processing toggles like `format`.

- **Add `registry.register(name="web_crawl", toolset="web", ...)`** after the `web_extract` registration. Same shape as the two siblings: same `check_fn=check_web_api_key`, same `requires_env=_web_requires_env()`, same `max_result_size_chars=100_000`. `is_async=True` because `web_crawl_tool` is async (like `web_extract_tool`). Emoji is 🕸️ to match the UI convention of distinct icons per web tool.

### `toolsets.py`

Adds `"web_crawl"` to four toolset memberships, matching where `web_search` and `web_extract` already appear:

- `_HERMES_CORE_TOOLS` — canonical list for interactive sessions
- `TOOLSETS["web"]["tools"]` — explicit `web` toolset
- `TOOLSETS["hermes-acp"]["tools"]` — editor-integration toolset (VS Code, Zed, JetBrains)
- `TOOLSETS["hermes-api-server"]["tools"]` — OpenAI-compatible HTTP API toolset

**Deliberately NOT added to `_HERMES_WEBHOOK_SAFE_TOOLS`.** That list carries the comment *"Keep the default webhook toolset intentionally constrained to avoid local file/system execution by prompt injection."* Webhook content (PR titles, issue comments, etc.) is untrusted, and crawl is a heavier fan-out operation than `web_search` / `web_extract`. Adding it to the webhook default would meaningfully widen the prompt-injection attack surface. Flagged here so the omission isn't read as oversight; happy to add if the maintainers prefer the symmetry.

### `tests/tools/test_web_tools_config.py`

New `TestWebCrawlSchema` class mirroring `TestWebSearchSchema`. Six tests covering: schema shape (url required, instructions optional, types), registry entry presence + async flag + correct toolset, handler arg forwarding both with and without `instructions`, toolset inclusion in all four expected lists, and explicit non-inclusion in `_HERMES_WEBHOOK_SAFE_TOOLS` (locks the prompt-injection-safety decision in place against future drift).

## How to Test

1. Configure any crawl-capable backend with a valid API key (e.g. `FIRECRAWL_API_KEY` or `TAVILY_API_KEY`).
2. Start a Hermes session.
3. Ask:
   > Use web_crawl on https://example.com with instructions "list pages with their titles"
4. Verify the model calls `web_crawl` directly (visible as `🕸️ web_crawl` in the tool trace) rather than improvising via `terminal`/`browser_navigate`.
5. Confirm `web_search` and `web_extract` still work (no regression).
6. Check `hermes tools` lists `web_crawl` under the `web` category alongside the other two.

Verified end-to-end locally against a public site: model invoked `web_crawl`, dispatcher routed through the provider, results returned. No regression in `web_search` / `web_extract`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(web):` here)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_web_tools_config.py -q` and all tests pass (10/10 in `TestWebSearchSchema` + `TestWebCrawlSchema`)
- [x] I've added tests for my changes — new `TestWebCrawlSchema` class in `tests/tools/test_web_tools_config.py` (6 tests: schema shape, registry entry, handler arg forwarding with/without instructions, toolset inclusions, webhook-safe-tools exclusion)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no behavior change for users; the tool description in `WEB_CRAWL_SCHEMA` is the documentation surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure registry wiring; no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — yes, `WEB_CRAWL_SCHEMA` is the new tool description

## Open Questions for Reviewer

1. **Schema scope.** Two parameters as proposed (`url`, `instructions`), or include `depth` as well? Current shape mirrors how `WEB_EXTRACT_SCHEMA` hides `format` and post-processing toggles.
2. **Toolset inclusions.** Four toolsets as listed above feel right by symmetry with `web_search` / `web_extract`. Specifically curious about `hermes-acp` (does editor-integration crawl make sense?) and `hermes-api-server` (the API server toolset is "full agent tools accessible via HTTP" — does the broad surface justify including crawl?). Easy to drop either if the maintainers disagree.
3. **`_HERMES_WEBHOOK_SAFE_TOOLS`.** Excluded by default for prompt-injection safety, but if there's an established norm I missed, happy to flip.

## Notes

- This change does **not** alter dispatch behavior, provider gating, or response shape. `web_crawl_tool()` is unchanged; only the registry layer above it is touched.
- The pre-existing crawl provider resolution path (`get_active_crawl_provider()` in `agent/web_search_registry.py`) is fully exercised; this PR just gives models a way to trigger it.
- The hardcoded backend whitelists in `_is_backend_available` / `check_web_api_key` / `_get_backend` are out of scope here. Tracked separately as #31873 (and acknowledged in #32600's discussion of a follow-up plugin).
