### PR TITLE
fix(file-tools): guard read_file against no-progress re-read loops

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -425,3 +425,154 @@ class TestPatchSchemaShape:
         params = PATCH_SCHEMA["parameters"]
         assert params["required"] == ["mode"]
         assert "anyOf" not in params and "oneOf" not in params
+
+
+class TestPathLevelLoopDetection:
+    """Tests for the path-level read loop guard (issue #14991).
+
+    The guard counts *consecutive reads that surface no new lines* of the
+    same file — overlapping or re-read regions — rather than the raw read
+    count.  Legitimate forward pagination through a large file (advancing,
+    non-overlapping windows) always surfaces new lines and is therefore
+    never warned or blocked.  Thresholds in tools.file_tools: warn after 4
+    consecutive no-progress reads, hard-block after 6.
+    """
+
+    def _make_mock_ops(self, content="line1\nline2", total_lines=2):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = content
+        result_obj.to_dict.return_value = {
+            "content": content, "total_lines": total_lines,
+        }
+        mock_ops.read_file.return_value = result_obj
+        return mock_ops
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops")
+    def test_forward_pagination_never_blocks(self, mock_get, mock_mtime):
+        """Advancing, non-overlapping windows always surface new lines, so
+        sequential pagination through a large file is never warned/blocked."""
+        from tools.file_tools import read_file_tool, _read_tracker
+        mock_get.return_value = self._make_mock_ops()
+        _read_tracker.clear()
+
+        # 12 non-overlapping 500-line windows — far past the old count-based
+        # block at 8.  Each advances into brand-new content.
+        for i in range(12):
+            result = json.loads(
+                read_file_tool("/tmp/big.txt", offset=i * 500 + 1, limit=500)
+            )
+            assert "_warning" not in result, f"unexpected warning at read {i+1}"
+            assert "BLOCKED" not in result.get("error", ""), \
+                f"unexpected block at read {i+1}"
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops")
+    def test_overlapping_rereads_trigger_warning(self, mock_get, mock_mtime):
+        """Re-reading already-covered regions (no new lines) warns after the
+        4th consecutive no-progress read."""
+        from tools.file_tools import read_file_tool, _read_tracker
+        mock_get.return_value = self._make_mock_ops()
+        _read_tracker.clear()
+
+        # Establish coverage of lines [1, 501).
+        read_file_tool("/tmp/t.txt", offset=1, limit=500)
+
+        # Sub-region re-reads: distinct (offset,limit) keys (so no dedup
+        # short-circuit) but every window is already covered -> no new lines.
+        for lim in (400, 300, 200):           # no-progress reads 1, 2, 3
+            result = json.loads(read_file_tool("/tmp/t.txt", offset=1, limit=lim))
+            assert "_warning" not in result
+
+        # 4th consecutive no-progress read -> warning.
+        result = json.loads(read_file_tool("/tmp/t.txt", offset=1, limit=100))
+        assert "_warning" in result
+        assert "BLOCKED" not in result.get("error", "")
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops")
+    def test_overlapping_rereads_trigger_block(self, mock_get, mock_mtime):
+        """6 consecutive no-progress reads escalate to a hard block."""
+        from tools.file_tools import read_file_tool, _read_tracker
+        mock_get.return_value = self._make_mock_ops()
+        _read_tracker.clear()
+
+        read_file_tool("/tmp/t.txt", offset=1, limit=500)   # coverage [1, 501)
+        result = None
+        for lim in (450, 400, 350, 300, 250, 200):          # 6 no-progress reads
+            result = json.loads(read_file_tool("/tmp/t.txt", offset=1, limit=lim))
+
+        assert "error" in result
+        assert "BLOCKED" in result["error"]
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops")
+    def test_different_file_resets_no_progress_counter(self, mock_get, mock_mtime):
+        """Reading a different file resets the no-progress counter to 0."""
+        from tools.file_tools import read_file_tool, _read_tracker
+        mock_get.return_value = self._make_mock_ops()
+        _read_tracker.clear()
+
+        # Build up no-progress reads on file A (counter -> 3).
+        read_file_tool("/tmp/fileA.txt", offset=1, limit=500)
+        for lim in (400, 300, 200):
+            read_file_tool("/tmp/fileA.txt", offset=1, limit=lim)
+        assert _read_tracker["default"]["path_consecutive"] == 3
+
+        # Reading file B switches the tracked path and zeroes the counter.
+        read_file_tool("/tmp/fileB.txt", offset=1, limit=500)
+        assert _read_tracker["default"]["path_consecutive"] == 0
+
+        # Re-reading file A (a fresh key, so no dedup) starts from 0, not 3.
+        read_file_tool("/tmp/fileA.txt", offset=1, limit=450)
+        assert _read_tracker["default"]["path_consecutive"] == 0
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops")
+    def test_notify_other_tool_call_resets_no_progress_counter(self, mock_get, mock_mtime):
+        """A non-read tool call resets the no-progress counter, so a
+        following overlapping read does not warn."""
+        from tools.file_tools import read_file_tool, notify_other_tool_call, _read_tracker
+        mock_get.return_value = self._make_mock_ops()
+        _read_tracker.clear()
+
+        # Drive the no-progress counter up to 3 on the same file.
+        read_file_tool("/tmp/test.txt", offset=1, limit=500)
+        for lim in (400, 300, 200):
+            read_file_tool("/tmp/test.txt", offset=1, limit=lim)
+        assert _read_tracker["default"]["path_consecutive"] == 3
+
+        # An intervening non-read tool call breaks the loop.
+        notify_other_tool_call("default")
+        assert _read_tracker["default"]["path_consecutive"] == 0
+
+        # A following overlapping read (distinct key) starts fresh: no warning,
+        # even though it covers already-seen lines.  Regression guard: if the
+        # reset were dropped, this would be the 4th no-progress read and warn.
+        result = json.loads(read_file_tool("/tmp/test.txt", offset=1, limit=350))
+        assert "_warning" not in result
+        assert "BLOCKED" not in result.get("error", "")
+
+    @patch("tools.file_tools.os.path.getmtime", return_value=1000.0)
+    @patch("tools.file_tools._get_file_ops")
+    def test_reset_file_dedup_resets_no_progress_counter(self, mock_get, mock_mtime):
+        """reset_file_dedup clears the path-level no-progress counter."""
+        from tools.file_tools import read_file_tool, reset_file_dedup, _read_tracker
+        mock_get.return_value = self._make_mock_ops()
+        _read_tracker.clear()
+
+        read_file_tool("/tmp/test.txt", offset=1, limit=500)
+        for lim in (400, 300, 200):
+            read_file_tool("/tmp/test.txt", offset=1, limit=lim)
+        assert _read_tracker["default"]["path_consecutive"] == 3
+
+        # Context compression resets dedup + path-level loop state.
+        reset_file_dedup("default")
+        assert _read_tracker["default"]["path_consecutive"] == 0
+
+        # Fresh key (350 was never read above) so this is a real read; it
+        # covers already-seen lines but starts from a reset counter -> no warn.
+        result = json.loads(read_file_tool("/tmp/test.txt", offset=1, limit=350))
+        assert "_warning" not in result
+        assert "BLOCKED" not in result.get("error", "")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -300,6 +300,7 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
 _READ_HISTORY_CAP = 500       # set; used only by get_read_files_summary
 _DEDUP_CAP = 1000             # dict; skip-identical-reread guard
 _READ_TIMESTAMPS_CAP = 1000   # dict; external-edit detection for write/patch
+_PATH_RANGES_CAP = 64         # list; covered-line intervals for path-loop guard
 _READ_DEDUP_STATUS_MESSAGE = (
     "File unchanged since last read. The content from "
     "the earlier read_file result in this conversation is "
@@ -356,6 +357,62 @@ def _cap_read_tracker_data(task_data: dict) -> None:
                 ts.pop(next(iter(ts)))
             except (StopIteration, KeyError):
                 break
+
+    pr = task_data.get("path_ranges")
+    if pr is not None and len(pr) > _PATH_RANGES_CAP:
+        # Too many disjoint intervals on one file (lots of scattered reads).
+        # Forget the coverage history and restart path tracking.  Costs at
+        # most one delayed loop detection; keeps the list bounded.
+        task_data["path_ranges"] = []
+        task_data["path_consecutive"] = 0
+
+
+def _range_uncovered_lines(ranges: list, start: int, end: int) -> int:
+    """Return how many line positions in [start, end) are NOT already covered
+    by ``ranges`` — a sorted list of disjoint ``[s, e)`` intervals.
+
+    Used by the path-level loop guard to tell "this read surfaced new lines"
+    (forward progress) from "this read only re-covered lines we already had"
+    (a no-progress loop).
+    """
+    if end <= start:
+        return 0
+    uncovered = end - start
+    for s, e in ranges:
+        if e <= start:
+            continue
+        if s >= end:
+            break
+        overlap = min(e, end) - max(s, start)
+        if overlap > 0:
+            uncovered -= overlap
+    return uncovered
+
+
+def _merge_range(ranges: list, start: int, end: int) -> list:
+    """Insert ``[start, end)`` into ``ranges`` (sorted, disjoint ``[s, e)``
+    intervals), merging any overlapping or adjacent intervals.  Returns a new
+    sorted list.  Adjacent intervals are merged so sequential pagination
+    collapses to a single interval (keeping ``path_ranges`` small)."""
+    if end <= start:
+        return ranges
+    result = []
+    new_s, new_e = start, end
+    placed = False
+    for s, e in ranges:
+        if e < new_s:            # interval ends before the new one begins
+            result.append([s, e])
+        elif s > new_e:          # interval begins after the new one ends
+            if not placed:
+                result.append([new_s, new_e])
+                placed = True
+            result.append([s, e])
+        else:                    # overlapping or adjacent — absorb
+            new_s = min(new_s, s)
+            new_e = max(new_e, e)
+    if not placed:
+        result.append([new_s, new_e])
+    return result
 
 
 def _is_internal_file_status_text(content: str) -> bool:
@@ -582,6 +639,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "last_key": None, "consecutive": 0,
                 "read_history": set(), "dedup": {},
                 "dedup_hits": {}, "read_timestamps": {},
+                "path_last": None, "path_consecutive": 0,
+                "path_ranges": [],
             })
             # Backward-compat for pre-existing tracker entries that predate
             # dedup_hits/read_timestamps (long-lived task or crossed an
@@ -630,6 +689,65 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                     }, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
+
+        # ── Path-level loop pre-check ─────────────────────────────────
+        # Count *consecutive reads that surface no new lines* of this file
+        # and bail out BEFORE the (potentially expensive) read + redaction
+        # when we've been re-reading it in a loop.  Forward pagination
+        # (advancing, non-overlapping windows) always covers new lines and
+        # resets the counter, so this never fires on legitimate sequential
+        # reads.  Counting happens here, not after the read, so a blocked
+        # retry costs nothing — mirroring the dedup guard above.  Identical
+        # re-reads with a churning mtime stay on the per-key count>=4 guard
+        # below; this tier catches varying-parameter no-progress loops.
+        # See issue #14991.
+        _PATH_NO_PROGRESS_LIMIT = 6
+        _PATH_NO_PROGRESS_WARN = 4
+        read_start, read_end = offset, offset + limit
+        with _read_tracker_lock:
+            # Backward-compat for trackers that predate the path-level fields.
+            if "path_last" not in task_data:
+                task_data["path_last"] = None
+            if "path_consecutive" not in task_data:
+                task_data["path_consecutive"] = 0
+            if "path_ranges" not in task_data:
+                task_data["path_ranges"] = []
+            if task_data["path_last"] != resolved_str:
+                # Switched files — start tracking this one fresh.
+                task_data["path_last"] = resolved_str
+                task_data["path_ranges"] = [[read_start, read_end]]
+                task_data["path_consecutive"] = 0
+            elif _range_uncovered_lines(
+                    task_data["path_ranges"], read_start, read_end) > 0:
+                # Surfaced new lines — real progress, not a loop.
+                task_data["path_ranges"] = _merge_range(
+                    task_data["path_ranges"], read_start, read_end)
+                task_data["path_consecutive"] = 0
+            else:
+                # Whole window already covered — no progress.
+                task_data["path_consecutive"] += 1
+            path_count = task_data["path_consecutive"]
+            _cap_read_tracker_data(task_data)
+
+        if path_count >= _PATH_NO_PROGRESS_LIMIT:
+            return json.dumps({
+                "error": (
+                    f"BLOCKED: You have re-read the file '{path}' {path_count} "
+                    "times in a row without reaching any new content. You "
+                    "already have this information from earlier reads. STOP "
+                    "reading this file and proceed with your task using what "
+                    "you already know."
+                ),
+                "path": path,
+                "already_read": path_count,
+            }, ensure_ascii=False)
+        _path_warning = None
+        if path_count >= _PATH_NO_PROGRESS_WARN:
+            _path_warning = (
+                f"You have re-read '{path}' {path_count} times without reaching "
+                "new content. If you are stuck in a loop, stop reading and "
+                "proceed with writing or responding."
+            )
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
@@ -743,6 +861,12 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
 
+        # Path-level loop guard (warn tier): the hard block already ran in
+        # the pre-check before the read; here we just surface the warning it
+        # computed, if any.  See issue #14991.
+        if _path_warning is not None:
+            result_dict.setdefault("_warning", _path_warning)
+
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -769,12 +893,20 @@ def reset_file_dedup(task_id: str = None):
                     task_data["dedup"].clear()
                 if "dedup_hits" in task_data:
                     task_data["dedup_hits"].clear()
+                # Also reset path-level loop state so reads after
+                # compression start fresh (issue #14991).
+                task_data["path_last"] = None
+                task_data["path_consecutive"] = 0
+                task_data["path_ranges"] = []
         else:
             for task_data in _read_tracker.values():
                 if "dedup" in task_data:
                     task_data["dedup"].clear()
                 if "dedup_hits" in task_data:
                     task_data["dedup_hits"].clear()
+                task_data["path_last"] = None
+                task_data["path_consecutive"] = 0
+                task_data["path_ranges"] = []
 
 
 def notify_other_tool_call(task_id: str = "default"):
@@ -791,6 +923,11 @@ def notify_other_tool_call(task_id: str = "default"):
         if task_data:
             task_data["last_key"] = None
             task_data["consecutive"] = 0
+            # Also reset path-level loop state — a different tool call
+            # breaks the "consecutive same-file reads" pattern (issue #14991).
+            task_data["path_last"] = None
+            task_data["path_consecutive"] = 0
+            task_data["path_ranges"] = []
             # An intervening non-read tool call breaks any stub-loop in
             # progress, so clear per-key dedup hit counters too.
             if "dedup_hits" in task_data:


### PR DESCRIPTION
## Summary

Adds a path-level loop guard to `read_file_tool` that catches dead loops where the agent re-reads the same file with varying pagination parameters — a pattern the existing dedup and per-key guards miss.

## Problem

`read_file_tool` already has two loop guards:

1. **Dedup** (mtime-based): skips re-reads of an unchanged file.
2. **Per-key consecutive guard**: blocks after 4 consecutive reads with the same `(path, offset, limit)`.

Both miss issue #14991: when the agent re-reads one file with **different offsets/limits**, each read is a distinct key so the per-key counter never accumulates; and a **churning mtime** (e.g. a synced file) also defeats the dedup skip. The agent re-read one skill file ~47 times before anything stopped it.

## Solution

Track covered-line intervals per file and count **consecutive reads that surface no new lines** (overlapping / re-read regions) rather than raw read count:

| consecutive no-progress reads | action |
|---|---|
| 0–3 | normal |
| 4–5 | `_warning` field |
| 6+ | `BLOCKED` error |

Because forward pagination (advancing, non-overlapping windows) always surfaces new lines, sequential reads through a large file **never** trip the guard. The check runs as a pre-check before the (potentially expensive) read + redaction, so a blocked retry costs nothing.

The counter resets when:

- a different file is read,
- a non-read tool call intervenes (`notify_other_tool_call`),
- context compression runs (`reset_file_dedup`).

`path_ranges` is capped at 64 disjoint intervals to keep memory bounded.

## Changes

- **`tools/file_tools.py`**: covered-interval helpers (`_range_uncovered_lines`, `_merge_range`), the path-level pre-check in `read_file_tool`, counter resets in `reset_file_dedup` / `notify_other_tool_call`, and the cap in `_cap_read_tracker_data`.
- **`tests/tools/test_file_tools.py`**: `TestPathLevelLoopDetection` with 6 cases — forward pagination never blocks, overlapping re-reads warn at 4 / block at 6, and resets on file switch / other-tool call / dedup reset.

## Test Results

Run with `pytest` (Python 3.13, pytest 9.0.2):

- `tests/tools/test_file_tools.py`: **37 passed** (31 pre-existing + 6 new `TestPathLevelLoopDetection`).
- `tests/tools/test_file_operations.py`: **77 passed** (no regression in the underlying read path).

The 6 new cases cover, against the path-level guard:

| Scenario | Expected | Result |
|---|---|---|
| 12 advancing, non-overlapping windows | never warned / blocked | ✅ |
| Overlapping re-reads (no new lines) | `_warning` at the 4th | ✅ |
| Overlapping re-reads continue | `BLOCKED` at the 6th | ✅ |
| Switch to a different file | counter resets to 0 | ✅ |
| Non-read tool call between reads | counter resets to 0 | ✅ |
| Context compression (`reset_file_dedup`) | counter resets to 0 | ✅ |

Closes #14991
