### PR TITLE
fix(agent): add Claude, Kimi, and MiniMax to tool enforcement auto list

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -260,7 +260,10 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek")
+TOOL_USE_ENFORCEMENT_MODELS = (
+    "gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek",
+    "claude", "anthropic", "kimi", "moonshot", "minimax",
+)
 
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1150,6 +1150,15 @@ class TestToolUseEnforcementGuidance:
     def test_enforcement_models_includes_deepseek(self):
         assert "deepseek" in TOOL_USE_ENFORCEMENT_MODELS
 
+    def test_enforcement_models_includes_claude(self):
+        assert "claude" in TOOL_USE_ENFORCEMENT_MODELS
+        assert "anthropic" in TOOL_USE_ENFORCEMENT_MODELS
+
+    def test_enforcement_models_includes_kimi_and_minimax(self):
+        assert "kimi" in TOOL_USE_ENFORCEMENT_MODELS
+        assert "moonshot" in TOOL_USE_ENFORCEMENT_MODELS
+        assert "minimax" in TOOL_USE_ENFORCEMENT_MODELS
+
     def test_enforcement_models_is_tuple(self):
         assert isinstance(TOOL_USE_ENFORCEMENT_MODELS, tuple)
 
@@ -1192,6 +1201,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1187,11 +1187,11 @@ class TestToolUseEnforcementConfig:
         prompt = agent._build_system_prompt()
         assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
 
-    def test_auto_skips_for_claude(self):
+    def test_auto_injects_for_claude(self):
         from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
         agent = self._make_agent(model="anthropic/claude-sonnet-4", tool_use_enforcement="auto")
         prompt = agent._build_system_prompt()
-        assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
 
     def test_auto_injects_for_grok(self):
         """xAI Grok / xai-oauth models hit the same enforcement path as GPT."""
@@ -1211,6 +1211,18 @@ class TestToolUseEnforcementConfig:
         """DeepSeek models default to chatty/hallucinatory tool use without enforcement."""
         from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
         agent = self._make_agent(model="deepseek/deepseek-r1", tool_use_enforcement="auto")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_auto_injects_for_kimi(self):
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(model="kimi-for-coding", tool_use_enforcement="auto")
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_auto_injects_for_minimax(self):
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(model="minimax/minimax-m2", tool_use_enforcement="auto")
         prompt = agent._build_system_prompt()
         assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
 


### PR DESCRIPTION
## Summary

Adds Claude/Anthropic, Kimi/Moonshot, and MiniMax model substrings to `TOOL_USE_ENFORCEMENT_MODELS` so `agent.tool_use_enforcement: auto` injects tool-use enforcement guidance for these model families.

## Why

I hit this with Claude locally: Hermes received the SOUL/system guidance, but on verification-style prompts Claude could still answer directly without first calling tools. The model was using `tool_choice: auto`, and because Claude was not in the auto enforcement list, `TOOL_USE_ENFORCEMENT_GUIDANCE` was not injected.

This is the same failure shape previously fixed for Qwen and DeepSeek: the model describes or infers work instead of actually using available tools.

## Changes

- Add `claude`, `anthropic`, `kimi`, `moonshot`, and `minimax` to `TOOL_USE_ENFORCEMENT_MODELS`.
- Update Claude auto-mode test from skip to inject.
- Add coverage for Kimi and MiniMax.
- Add prompt-builder tuple coverage for the new substrings.

## Validation

```bash
python -m pytest -o addopts=''   tests/agent/test_prompt_builder.py::TestToolUseEnforcementGuidance   tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig -q
```

Result:

```text
31 passed
```
