### PR TITLE
fix(telegram): notify user when clarify button tap arrives after expiry

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3936,6 +3936,31 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    async def _notify_clarify_expired(self, query, user_display: str) -> None:
+        """Tell the user a clarify tap arrived too late to be delivered.
+
+        Fires when the clarify entry was evicted by ``clarify_timeout`` or the
+        gateway restarted between asking and the tap. In both cases the agent
+        thread is no longer waiting, so the tap would otherwise leave a
+        misleading ✓ (or an "awaiting typed response" prompt) on a button the
+        agent never receives.
+        """
+        try:
+            await query.answer(text="⚠️ This prompt expired — please /retry.")
+        except Exception:
+            pass
+        try:
+            await query.edit_message_text(
+                text=(
+                    f"❓ {_html.escape(query.message.text or '')}\n\n"
+                    "<i>⚠️ This question expired or the session reset — please /retry.</i>"
+                ),
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
+        except Exception:
+            pass
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -4173,11 +4198,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     # clarify.  Do NOT pop _clarify_state yet — we still
                     # need it if the user is slow to respond and the entry
                     # is cleared by something else.
+                    flipped = False
                     try:
                         from tools.clarify_gateway import mark_awaiting_text
-                        mark_awaiting_text(clarify_id)
+                        flipped = mark_awaiting_text(clarify_id)
                     except Exception as exc:
                         logger.warning("[%s] mark_awaiting_text failed: %s", self.name, exc)
+
+                    if not flipped:
+                        # Entry evicted (clarify_timeout) or gateway restarted
+                        # between ask and tap — a typed answer would go nowhere.
+                        self._clarify_state.pop(clarify_id, None)
+                        await self._notify_clarify_expired(query, user_display)
+                        return
 
                     await query.answer(text="✏️ Type your answer in the chat.")
                     try:
@@ -4224,22 +4257,25 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
                     resolved = False
 
-                await query.answer(text=f"✓ {resolved_text[:60]}")
-                try:
-                    await query.edit_message_text(
-                        text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
-                        parse_mode=ParseMode.HTML,
-                        reply_markup=None,
-                    )
-                except Exception:
-                    pass
-
                 if resolved:
+                    await query.answer(text=f"✓ {resolved_text[:60]}")
+                    try:
+                        await query.edit_message_text(
+                            text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
                     logger.info(
                         "Telegram clarify button resolved (id=%s, choice=%r, user=%s)",
                         clarify_id, resolved_text, user_display,
                     )
                 else:
+                    # Entry evicted (clarify_timeout) or gateway restarted
+                    # between ask and tap — surface this instead of leaving a
+                    # misleading ✓ on a button the agent will never receive.
+                    await self._notify_clarify_expired(query, user_display)
                     logger.warning(
                         "Telegram clarify button: resolve_gateway_clarify returned False (id=%s)",
                         clarify_id,

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -352,6 +352,71 @@ class TestTelegramClarifyCallback:
         assert adapter._clarify_state["cidC"] == "sk-auth"
 
     @pytest.mark.asyncio
+    async def test_numeric_choice_expired_notifies_user(self):
+        """Late tap after the entry was evicted (timeout) or the gateway
+        restarted must surface an expiry notice, not a misleading ✓."""
+        adapter = _make_adapter()
+        # _clarify_state still maps the id (timeout eviction does not pop it),
+        # but the clarify primitive entry is gone → resolve returns False.
+        adapter._clarify_state["cidExpired"] = "sk-expired"
+
+        query = AsyncMock()
+        query.data = "cl:cidExpired:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.text = "Pick"
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, context)
+
+        # User is told the prompt expired — not a misleading checkmark.
+        answer_text = query.answer.call_args[1]["text"].lower()
+        assert "expired" in answer_text
+        edit_text = query.edit_message_text.call_args[1]["text"].lower()
+        assert "expired" in edit_text or "session reset" in edit_text
+        assert "/retry" in edit_text
+
+    @pytest.mark.asyncio
+    async def test_other_button_expired_notifies_user(self):
+        """Tapping 'Other' after the entry was evicted must tell the user the
+        prompt expired instead of silently entering text-capture mode."""
+        adapter = _make_adapter()
+        # No clarify primitive entry → mark_awaiting_text returns False.
+        adapter._clarify_state["cidOtherExpired"] = "sk-other-expired"
+
+        query = AsyncMock()
+        query.data = "cl:cidOtherExpired:other"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.text = "Pick"
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, context)
+
+        answer_text = query.answer.call_args[1]["text"].lower()
+        assert "expired" in answer_text
+        # State popped so a subsequent typed message is not mis-captured.
+        assert "cidOtherExpired" not in adapter._clarify_state
+
+    @pytest.mark.asyncio
     async def test_invalid_choice_token(self):
         from tools import clarify_gateway as cm
 


### PR DESCRIPTION
Telegram clarify button taps that arrive after the clarify entry is gone (evicted by `clarify_timeout`, or lost when the gateway restarts between ask and tap) previously did nothing useful: the numeric-choice path left a misleading ✓ with the user's answer, and the “Other” path silently entered text-capture mode. In both cases the agent thread is no longer waiting, so the response is dropped and the agent hangs on `running: clarify`. This surfaces an expiry notice on both paths so the user knows to `/retry`.

## What does this PR do?

Addresses the user-visible symptom in #32762 (Telegram clarify button silently does nothing): when `resolve_gateway_clarify` returns `False` (numeric choice) or `mark_awaiting_text` returns `False` (“Other” button) — i.e. the clarify entry was evicted by the 600s `clarify_timeout` or the gateway restarted between the prompt and the tap — the callback now edits the original message to “⚠️ This question expired or the session reset — please /retry.” instead of showing a misleading ✓ or silently waiting for typed input the agent will never receive.

This is the smallest-scope fix the reporter explicitly offered (their suggestion #2). It does **not** add durable persistence (#1) or change `clarify_timeout` (#3) / eviction-grace (#4) — those need an architectural decision (a persisted entry still can't resume the dead agent thread + its `threading.Event` after a restart), so they remain open. Hence `Refs`, not `Fixes`.

## Related Issue

Refs #32762

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: add `_notify_clarify_expired(query, user_display)` helper; in the `cl:` callback, branch the numeric-choice path on the `resolved` flag (show ✓ only when truly resolved, expiry notice otherwise) and check the `mark_awaiting_text` return on the “Other” path (notify + drop stale `_clarify_state` when the entry is gone).
- `tests/gateway/test_telegram_clarify_buttons.py`: add `test_numeric_choice_expired_notifies_user` and `test_other_button_expired_notifies_user` covering both expiry paths.

## How to Test

1. Set `agent.clarify_timeout: 600` (default) and trigger an agent task that ends in `clarify` with choice buttons on Telegram.
2. Wait > 600s (or restart the gateway) so the clarify entry is evicted, then tap a choice button.
3. Before the fix: the button shows a ✓ / your answer (or “awaiting typed response”) but the agent hangs on `running: clarify`. After the fix: the message is edited to “⚠️ This question expired or the session reset — please /retry.”
4. Automated: `pytest tests/gateway/test_telegram_clarify_buttons.py -q` (14 passing, incl. the 2 new expiry tests).

## What platforms tested on

- macOS on darwin-arm64 (local): `pytest tests/gateway/test_telegram_clarify_buttons.py -q` → 14 passed; `ruff check` clean on changed files; `scripts/check-windows-footguns.py` clean (no signals/subprocess/paths touched).
- Change is platform-agnostic Python (async Telegram callback editing) — no OS-specific behavior.

## Checklist

- [x] My commit messages follow Conventional Commits (`fix(telegram): …`)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests locally and they pass
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact (no platform-specific code paths touched)

<!-- autocontrib:worker-id=issue-new-2348a4a4 kind=pr-open -->