### PR TITLE
fix(cli): sync credential_pool on Codex re-auth

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3232,6 +3232,48 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     }
 
 
+def _sync_codex_pool_entries(
+    auth_store: Dict[str, Any],
+    tokens: Dict[str, str],
+    last_refresh: Optional[str],
+) -> None:
+    """Mirror a fresh Codex re-auth into the credential_pool singleton entries.
+
+    The runtime selects credentials from ``credential_pool.openai-codex``, not
+    from ``providers.openai-codex.tokens``.  A re-auth invalidates the prior
+    OAuth pair server-side, but the pool's ``device_code`` entry keeps holding
+    the now-consumed refresh token plus any stale error markers — so the next
+    request spends a dead token and gets a 401 ``token_invalidated``.  Update
+    the singleton-seeded entries in lockstep with the provider tokens and clear
+    the error state so the fresh credentials take effect immediately.  Manual
+    (``manual:*``) entries are independent credentials and are left untouched.
+    """
+    access_token = tokens.get("access_token")
+    if not access_token:
+        return
+    refresh_token = tokens.get("refresh_token")
+    pool = auth_store.get("credential_pool")
+    if not isinstance(pool, dict):
+        return
+    entries = pool.get("openai-codex")
+    if not isinstance(entries, list):
+        return
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("source") != "device_code":
+            continue
+        entry["access_token"] = access_token
+        if refresh_token:
+            entry["refresh_token"] = refresh_token
+        if last_refresh:
+            entry["last_refresh"] = last_refresh
+        entry["last_status"] = None
+        entry["last_status_at"] = None
+        entry["last_error_code"] = None
+        entry["last_error_reason"] = None
+        entry["last_error_message"] = None
+        entry["last_error_reset_at"] = None
+
+
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
@@ -3243,6 +3285,7 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
         _save_provider_state(auth_store, "openai-codex", state)
+        _sync_codex_pool_entries(auth_store, tokens, last_refresh)
         _save_auth_store(auth_store)
 
 

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -144,6 +144,73 @@ def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
     assert data["tokens"]["refresh_token"] == "rt456"
 
 
+def test_save_codex_tokens_syncs_credential_pool(tmp_path, monkeypatch):
+    """Re-auth must update the credential_pool device_code entry, not just providers.
+
+    Regression for #33000: the runtime selects from credential_pool, so a
+    re-auth that only refreshed providers.openai-codex.tokens left the pool
+    holding a consumed refresh token and stale error markers, causing an
+    immediate 401 token_invalidated on the next request.
+    """
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                "last_refresh": "2026-01-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "abc123",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "old-at",
+                    "refresh_token": "old-rt",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                    "last_error_reason": "token_invalidated",
+                    "last_error_reset_at": 9999999999,
+                },
+                {
+                    "id": "manual1",
+                    "source": "manual:codex",
+                    "auth_type": "oauth",
+                    "access_token": "manual-at",
+                    "refresh_token": "manual-rt",
+                },
+            ],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_codex_tokens({"access_token": "new-at", "refresh_token": "new-rt"},
+                       last_refresh="2026-05-27T00:00:00Z")
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    pool = auth["credential_pool"]["openai-codex"]
+    seeded = next(e for e in pool if e["source"] == "device_code")
+    assert seeded["access_token"] == "new-at"
+    assert seeded["refresh_token"] == "new-rt"
+    assert seeded["last_refresh"] == "2026-05-27T00:00:00Z"
+    assert seeded["last_status"] is None
+    assert seeded["last_error_code"] is None
+    assert seeded["last_error_reason"] is None
+    assert seeded["last_error_reset_at"] is None
+
+    # Manual entries are independent credentials and must not be overwritten.
+    manual = next(e for e in pool if e["source"] == "manual:codex")
+    assert manual["access_token"] == "manual-at"
+    assert manual["refresh_token"] == "manual-rt"
+
+    # Provider singleton is updated too.
+    assert auth["providers"]["openai-codex"]["tokens"]["access_token"] == "new-at"
+
+
 def test_import_codex_cli_tokens(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-cli"
     codex_home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

Codex re-authentication via `hermes setup` / `hermes model` wrote the fresh OAuth pair to `providers.openai-codex.tokens` but never updated `credential_pool.openai-codex`. Because the runtime selects credentials from the pool (not from the provider singleton), the pool's `device_code` entry kept holding the now-consumed refresh token plus the stale `last_error_*` / `last_status` markers from the prior invalidation. The next request spent a dead token and got an immediate `401 token_invalidated` from OpenAI.

This makes `_save_codex_tokens` update the singleton-seeded pool entries in lockstep with the provider tokens — within the same `_auth_store_lock`, so the write is atomic — and clears the entry's error state. Manual (`manual:*`) pool entries are independent credentials and are deliberately left untouched, matching the existing `_sync_device_code_entry_to_auth_store` convention.

Scope note: the linked issue also reports a secondary `agent/codex_runtime.py` bug (a `null` `output` field crashing `parse_response`). That is an unrelated change in a different module, so it is intentionally out of scope here and the issue is referenced with `Refs` rather than auto-closed.

## Related Issue

Refs #33000

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: add `_sync_codex_pool_entries()` and call it from `_save_codex_tokens()` so re-auth updates the `device_code` `credential_pool.openai-codex` entries (access/refresh token, `last_refresh`) and clears `last_status` / `last_error_*` markers, atomically under `_auth_store_lock`.
- `tests/hermes_cli/test_auth_codex_provider.py`: add `test_save_codex_tokens_syncs_credential_pool` covering the device_code entry sync, error-marker clearing, and that manual entries are left untouched.

## How to Test

1. Authenticate Hermes with the `openai-codex` provider, then re-auth via `hermes setup` / `hermes model` (e.g. after a token invalidation).
2. Inspect `~/.hermes/auth.json`: `credential_pool.openai-codex[0]` now carries the same `access_token` / `refresh_token` as `providers.openai-codex.tokens`, and its `last_error_*` / `last_status` fields are cleared.
3. Restart the gateway and confirm API calls no longer fail with `401 token_invalidated`.
4. Automated: `pytest tests/hermes_cli/test_auth_codex_provider.py -q` (17 passing, including the new regression test).

Verified locally on macOS (darwin-arm64) with the repo venv; `ruff check` clean on the changed files and `scripts/check-windows-footguns.py` clean (the change is pure dict manipulation — no process, path, signal, or subprocess surface).

## What platforms tested on

- macOS on darwin-arm64 (local): `pytest tests/hermes_cli/test_auth_codex_provider.py` (17 passed), plus `tests/agent/test_credential_pool.py` and `tests/hermes_cli/test_auth_commands.py` (116 passed) with no regressions.
- Linux / Windows / WSL2: not run locally; trusting CI. The change touches no platform-specific APIs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests (`pytest tests/hermes_cli/test_auth_codex_provider.py -q`) and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-03ed5673 kind=pr-open -->