### PR TITLE
fix(gateway): report oversized request bodies as 413 instead of misleading 'Invalid JSON'

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -36,7 +36,7 @@ import sqlite3
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from aiohttp import web
@@ -519,6 +519,42 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
             "code": code,
         }
     }
+
+
+async def _read_json_body(
+    request: "web.Request",
+) -> Tuple[Optional[Any], Optional["web.Response"]]:
+    """Parse the request JSON body, distinguishing the real failure modes.
+
+    Returns ``(body, None)`` on success or ``(None, error_response)`` on a
+    client error.
+
+    An oversized body is surfaced as 413 rather than being swallowed into a
+    misleading "Invalid JSON in request body" 400.  ``aiohttp`` raises
+    ``HTTPRequestEntityTooLarge`` from ``request.json()`` when a streamed
+    (chunked, no Content-Length) upload exceeds ``client_max_size`` — the
+    earlier ``body_limit_middleware`` can only pre-check requests that carry a
+    Content-Length header, so chunked uploads slip past it.  Base64-encoded
+    image uploads are the common trigger (see #32986).
+    """
+    try:
+        body = await request.json()
+    except web.HTTPRequestEntityTooLarge:
+        return None, web.json_response(
+            _openai_error("Request body too large.", code="body_too_large"),
+            status=413,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        return None, web.json_response(
+            _openai_error(f"Invalid JSON in request body: {exc}"),
+            status=400,
+        )
+    if not isinstance(body, dict):
+        return None, web.json_response(
+            _openai_error("Request body must be a JSON object."),
+            status=400,
+        )
+    return body, None
 
 
 if AIOHTTP_AVAILABLE:
@@ -1111,10 +1147,9 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         # Parse request body
-        try:
-            body = await request.json()
-        except (json.JSONDecodeError, Exception):
-            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+        body, parse_err = await _read_json_body(request)
+        if parse_err is not None:
+            return parse_err
 
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
@@ -2185,13 +2220,9 @@ class APIServerAdapter(BasePlatformAdapter):
             return key_err
 
         # Parse request body
-        try:
-            body = await request.json()
-        except (json.JSONDecodeError, Exception):
-            return web.json_response(
-                {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
-                status=400,
-            )
+        body, parse_err = await _read_json_body(request)
+        if parse_err is not None:
+            return parse_err
 
         raw_input = body.get("input")
         if raw_input is None:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -403,10 +403,13 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
     return APIServerAdapter(config)
 
 
-def _create_app(adapter: APIServerAdapter) -> web.Application:
+def _create_app(adapter: APIServerAdapter, client_max_size: int = None) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
+    app_kwargs = {}
+    if client_max_size is not None:
+        app_kwargs["client_max_size"] = client_max_size
+    app = web.Application(middlewares=mws, **app_kwargs)
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
@@ -692,6 +695,64 @@ class TestChatCompletionsEndpoint:
             assert resp.status == 400
             data = await resp.json()
             assert "Invalid JSON" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_returns_413_not_invalid_json(self, adapter):
+        """An oversized upload must surface as 413, not a misleading 400 (#32986).
+
+        Base64 image uploads can exceed the request-size limit; aiohttp raises
+        HTTPRequestEntityTooLarge from request.json(), which previously got
+        swallowed into a generic "Invalid JSON in request body" 400.
+        """
+        app = _create_app(adapter, client_max_size=256)
+        async with TestClient(TestServer(app)) as cli:
+            big_image = "data:image/png;base64," + ("A" * 4096)
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "image_url", "image_url": {"url": big_image}}
+                            ],
+                        }
+                    ],
+                },
+            )
+            assert resp.status == 413
+            data = await resp.json()
+            assert data["error"]["code"] == "body_too_large"
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_message_includes_reason(self, adapter):
+        """Malformed JSON 400s should explain why, to aid client debugging."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                data="{not valid",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["message"] != "Invalid JSON in request body"
+            assert "Invalid JSON in request body:" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_non_object_json_body_returns_400(self, adapter):
+        """A valid-but-non-object JSON body returns a clean 400, not a 500."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                data="[1, 2, 3]",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert "JSON object" in data["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_missing_messages_returns_400(self, adapter):


### PR DESCRIPTION
## What does this PR do?

The OpenAI-compatible API server reported a confusing `400 Invalid JSON in request body` for image uploads that were actually too large, making the failure undebuggable for reporters.

Both `_handle_chat_completions` and `_handle_responses` wrapped `await request.json()` in `except (json.JSONDecodeError, Exception)` and returned the same generic "Invalid JSON" 400 for *every* failure. That broad catch swallowed aiohttp's `HTTPRequestEntityTooLarge`, which `request.json()` raises when a streamed (chunked, no `Content-Length`) upload exceeds `client_max_size`. The existing `body_limit_middleware` only pre-checks requests that carry a `Content-Length` header, so chunked uploads slip past it and hit the read-time limit instead. Base64-encoded image payloads are the common trigger.

This PR adds a shared `_read_json_body` helper that distinguishes the real failure modes:
- oversized body -> `413` with `code: body_too_large` (consistent with `body_limit_middleware`)
- malformed JSON -> `400` that includes the parse reason, so callers can tell a bad payload from a too-large one
- valid-but-non-object JSON (e.g. an array or `null`) -> clean `400` instead of a `500` on `body.get(...)`

## Related Issue

Refs #32986

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`: add `_read_json_body` helper that re-classifies `HTTPRequestEntityTooLarge` as a `413 body_too_large`, includes the parse reason in malformed-JSON `400`s, and rejects non-object bodies with a clean `400`; route both `_handle_chat_completions` and `_handle_responses` through it (replacing the two `except (json.JSONDecodeError, Exception)` blocks).
- `tests/gateway/test_api_server.py`: add tests for the oversized-upload `413`, the reason-bearing malformed-JSON `400`, and the non-object-body `400`; allow `_create_app` to set a small `client_max_size` for the oversized-body test.

## How to Test

1. `pytest tests/gateway/test_api_server.py -q` — all pass (the one pre-existing failure, `test_stream_sends_keepalive_during_quiet_tool_gap`, is an unrelated SSE-timing test that also fails on `main`).
2. New regression: `test_oversized_body_returns_413_not_invalid_json` posts a base64 `image_url` body larger than a small `client_max_size` and asserts `413` / `body_too_large` (previously this surfaced as `400 Invalid JSON`).
3. New checks: `test_invalid_json_message_includes_reason` asserts the `400` now names the parse error; `test_non_object_json_body_returns_400` asserts an array body returns `400`, not `500`.

## What platforms tested on

- macOS on darwin-arm64 (local) — `pytest tests/gateway/test_api_server.py`, `ruff check`, and `scripts/check-windows-footguns.py` (no process/path/signal changes in this diff).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_api_server.py -q` and tests pass (one unrelated pre-existing timing failure noted above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Note for maintainers

I couldn't run the actual Desktop TUI to confirm every image upload now succeeds, hence `Refs` rather than `Fixes`. This PR fixes the server-side misreporting and makes genuinely-oversized uploads return an actionable `413`. If images still fail after this, the remaining cause is either a payload above the `MAX_REQUEST_BYTES` (10 MB) limit — in which case the `413` now makes that explicit — or a client-side serialization issue in the TUI, which would be tracked separately. I deliberately did not raise `MAX_REQUEST_BYTES`, since that's a memory/policy decision for maintainers.

<!-- autocontrib:worker-id=issue-new-d3fda286 kind=pr-open -->