### PR TITLE
fix(docker): mkdir HERMES_HOME as root in stage2 before chown / privilege drop (#18488)

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -20,6 +20,18 @@ set -eu
 HERMES_HOME="${HERMES_HOME:-/opt/data}"
 INSTALL_DIR="/opt/hermes"
 
+# --- Bootstrap HERMES_HOME as root ---
+# Create the directory (and any missing parents) while we still have root
+# privileges so the chown checks below see real metadata and the later
+# `s6-setuidgid hermes mkdir -p` block doesn't EACCES on root-owned
+# ancestors. Without this, custom HERMES_HOME paths whose parents only
+# root can create (e.g. `HERMES_HOME=/home/hermes/.hermes` in a Compose
+# file, or any path under a fresh / not pre-populated by the image)
+# fail on first boot with `mkdir: cannot create directory '/...': Permission
+# denied` and the cont-init hook exits non-zero. Idempotent — `mkdir -p`
+# is a no-op if the dir already exists. (#18482, salvages #18488)
+mkdir -p "$HERMES_HOME"
+
 # --- UID/GID remap ---
 if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "$(id -u hermes)" ]; then
     echo "[stage2] Changing hermes UID to $HERMES_UID"


### PR DESCRIPTION
Salvages #18488 (@wpengpeng168) — fixes #18482.

## Problem

When `HERMES_HOME` points at a custom path whose parent directories only root can create (e.g. `HERMES_HOME=/home/hermes/.hermes` in a Compose file, or any path under a fresh root not pre-populated by the image), `stage2-hook.sh` fails on first boot:

```
[stage2] Warning: chown /custom/hermes-home/.hermes failed (rootless container?) — continuing
mkdir: cannot create directory '/custom': Permission denied
mkdir: cannot create directory '/custom': Permission denied
... (one per s6-setuidgid hermes mkdir invocation, 10 total)
cont-init: info: /etc/cont-init.d/01-hermes-setup exited 1
```

The mkdirs fail because `s6-setuidgid hermes` drops to UID 10000 before invoking `mkdir -p`, and the runtime user has no permission to create root-owned ancestor directories like `/home/` or `/custom/`. `02-reconcile-profiles` then crashes with three `FileNotFoundError`s, `.install_method` never lands, and the container limps on in a half-initialized state.

This was originally reported as #18482 and #18488 attempted to fix the pre-s6 `docker/entrypoint.sh`. The shim is deprecated now but the underlying bug moved into `docker/stage2-hook.sh` during the s6-overlay rework.

## Fix

Bootstrap `HERMES_HOME` with `mkdir -p` while still root, before the ownership normalization and the `s6-setuidgid hermes mkdir -p` block. Idempotent on the default `/opt/data` path (directory already exists from the Dockerfile's `RUN mkdir -p`) and on any subsequent container restart.

```sh
# --- Bootstrap HERMES_HOME as root ---
# Create the directory (and any missing parents) while we still have root
# privileges so the chown checks below see real metadata and the later
# `s6-setuidgid hermes mkdir -p` block doesn't EACCES on root-owned
# ancestors.
mkdir -p "$HERMES_HOME"
```

## Validation

### Bug reproduction (baseline vs salvage)

Built an isolated E2E that runs `docker run -e HERMES_HOME=/custom/hermes-home/.hermes <tag> --version` (no volume — exercises the in-container fs) and inspects the stage2 log + post-run filesystem state. Compares baseline (`origin/main`) against this salvage:

| Check | Baseline | Salvage |
|---|---|---|
| `01-hermes-setup exited 0` | ✗ exit 1 | ✓ |
| No `mkdir EACCES` errors | ✗ 10 failures | ✓ |
| No `FileNotFoundError` in 02-reconcile-profiles | ✗ 3 tracebacks | ✓ |
| stage2 chown path triggered | ✓ | ✓ |
| `HERMES_HOME` directory created on disk | partial | ✓ |
| stage2 mkdir block populated `cron/`, `logs/`, ... | ✗ | ✓ |
| `.install_method` stamp written | ✗ | ✓ |
| Default `HERMES_HOME=/opt/data` still boots cleanly | ✓ | ✓ |
| **Total** | **3 / 8** | **8 / 8** |

### Regression battery (all on the salvage image)

| Suite | Result |
|---|---|
| Image smoke (`--version`, `hermes_cli`, TUI launcher, lazy_deps, gcc) | 6/6 |
| Chown E2E (#19788 regression check from salvage 2) | 6/6 |
| TUI UID-remap E2E (#28851 regression check from salvage 3) | 4/4 |
| Node version E2E (#4977 regression check) | 8/8 |
| **Total** | **24 / 24** |

## Authorship

Original change by @wpengpeng168 in #18488 — they identified and patched the same root cause in the pre-s6 `docker/entrypoint.sh`. Retargeted to `docker/stage2-hook.sh` and adjusted the placement to fit the s6-overlay cont-init flow. Preserved attribution via `Co-authored-by:`.

Closes #18488.
Fixes #18482.
