### PR TITLE
feat(api): add conversation input endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -19,6 +19,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
+- POST /v1/conversations/input         — inject input into a gateway conversation
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
@@ -1105,6 +1106,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "conversation_input": True,
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_resources": True,
@@ -1143,6 +1145,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
+                "conversation_input": {"method": "POST", "path": "/v1/conversations/input"},
             },
         })
 
@@ -1667,6 +1670,59 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
         return response
+
+    async def _handle_conversation_input(self, request: "web.Request") -> "web.Response":
+        """POST /v1/conversations/input — inject input into a gateway conversation."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        if not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "Conversation input requires API key authentication because it injects internal gateway messages. Configure API_SERVER_KEY.",
+                    code="api_key_required",
+                ),
+                status=403,
+            )
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response(_openai_error("Invalid JSON body", code="invalid_json"), status=400)
+
+        session_key = (body.get("session_key") or body.get("conversation_id") or "").strip()
+        text = body.get("input", body.get("text", ""))
+        if not session_key:
+            return web.json_response(_openai_error("session_key is required", param="session_key", code="missing_session_key"), status=400)
+
+        runner = getattr(self, "gateway_runner", None)
+        if runner is None or not hasattr(runner, "inject_session_input"):
+            return web.json_response(
+                _openai_error("Gateway runner is unavailable; conversation delivery is not active.", code="gateway_runner_unavailable"),
+                status=409,
+            )
+
+        result = await runner.inject_session_input(
+            session_key=session_key,
+            text=str(text or ""),
+            mode=body.get("mode", "auto"),
+            fallback=body.get("fallback", "message"),
+            input_visibility=body.get("input_visibility", body.get("visibility", "silent")),
+            output_delivery=body.get("output_delivery", "conversation"),
+            source_label=body.get("source", "api"),
+            session_id=body.get("session_id"),
+        )
+        if not result.get("ok"):
+            status = int(result.get("status", 400))
+            return web.json_response(
+                _openai_error(
+                    result.get("message", "Conversation input failed."),
+                    code=result.get("code"),
+                    param=result.get("param"),
+                ),
+                status=status,
+            )
+        result.pop("ok", None)
+        return web.json_response(result, status=202)
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -4125,6 +4181,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
+            self._app.router.add_post("/v1/conversations/input", self._handle_conversation_input)
             # Store the adapter after native routes are registered. Local Hermes-Relay
             # bootstrap shims use this key as a feature-detection hook; registering
             # native routes first lets those shims no-op instead of shadowing the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2758,8 +2758,17 @@ class GatewayRunner:
         if mode == "steer" and fallback == "reject":
             return {"ok": False, "status": 409, "code": "not_steerable", "message": "Conversation has no active steerable run."}
 
+        event_text = text
+        slash_escaped = False
+        if event_text.startswith("/"):
+            # External conversation input is peer text, not operator control.
+            # Preserve the visible slash while preventing gateway slash-command
+            # dispatch when the synthetic message falls back to a normal turn.
+            event_text = "\u200b" + event_text
+            slash_escaped = True
+
         event = MessageEvent(
-            text=text,
+            text=event_text,
             message_type=MessageType.TEXT,
             source=entry.origin,
             internal=True,
@@ -2770,6 +2779,8 @@ class GatewayRunner:
                 "fallback": fallback,
                 "input_visibility": input_visibility,
                 "output_delivery": output_delivery,
+                "slash_escaped": slash_escaped,
+                "original_text": text if slash_escaped else None,
             },
         )
         action = self._queue_or_start_session_input(session_key=session_key, event=event, adapter=adapter)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2648,6 +2648,144 @@ class GatewayRunner:
         else:
             pending_slot[session_key] = queued_event
 
+    def _queue_or_start_session_input(
+        self,
+        *,
+        session_key: str,
+        event: "MessageEvent",
+        adapter: Any,
+    ) -> str:
+        """Queue or start a synthetic event while preserving platform delivery."""
+        if adapter is None:
+            raise ValueError("adapter_unavailable")
+
+        heal = getattr(adapter, "_heal_stale_session_lock", None)
+        if callable(heal):
+            try:
+                heal(session_key)
+            except Exception as exc:
+                logger.debug("session input stale-lock heal failed for %s: %s", session_key, exc)
+
+        if session_key in getattr(adapter, "_active_sessions", {}):
+            self._enqueue_fifo(session_key, event, adapter)
+            return "queued"
+
+        starter = getattr(adapter, "_start_session_processing", None)
+        if callable(starter):
+            try:
+                if starter(event, session_key):
+                    return "started"
+            except Exception as exc:
+                logger.warning("session input start failed for %s: %s", session_key, exc)
+
+        self._enqueue_fifo(session_key, event, adapter)
+        return "queued"
+
+    async def inject_session_input(
+        self,
+        *,
+        session_key: str,
+        text: str,
+        mode: str = "auto",
+        fallback: str = "message",
+        input_visibility: str = "silent",
+        output_delivery: str = "conversation",
+        source_label: str = "api",
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Inject text into an existing gateway conversation.
+
+        This is the conversation-native companion to run-level steer: when a
+        gateway session has a running steerable agent, callers may steer it;
+        otherwise the same input can be queued or started as a normal gateway
+        message so the final response is delivered by the original platform
+        adapter.
+        """
+        text = (text or "").strip()
+        if not text:
+            return {"ok": False, "status": 400, "code": "invalid_input", "message": "Input text is required."}
+
+        mode = (mode or "auto").strip().lower()
+        fallback = (fallback or "message").strip().lower()
+        input_visibility = (input_visibility or "silent").strip().lower()
+        output_delivery = (output_delivery or "conversation").strip().lower()
+        if mode not in {"auto", "steer", "queue", "message", "normal"}:
+            return {"ok": False, "status": 400, "code": "invalid_mode", "message": "mode must be one of auto, steer, queue, message."}
+        if fallback not in {"reject", "queue", "message", "normal"}:
+            return {"ok": False, "status": 400, "code": "invalid_fallback", "message": "fallback must be one of reject, queue, message."}
+        if input_visibility != "silent":
+            return {"ok": False, "status": 400, "code": "unsupported_input_visibility", "message": "Only input_visibility=silent is currently supported."}
+        if output_delivery != "conversation":
+            return {"ok": False, "status": 400, "code": "unsupported_output_delivery", "message": "Only output_delivery=conversation is currently supported."}
+
+        entry = self.session_store.get_entry(session_key)
+        if entry is None:
+            return {"ok": False, "status": 404, "code": "session_not_found", "message": f"No gateway session found for key: {session_key}"}
+        if session_id and session_id != entry.session_id:
+            return {"ok": False, "status": 409, "code": "session_id_mismatch", "message": "Session id does not match the current entry for this session key."}
+        if entry.origin is None:
+            return {"ok": False, "status": 409, "code": "session_origin_missing", "message": "Session has no persisted platform origin for conversation delivery."}
+
+        adapter = self.adapters.get(entry.origin.platform)
+        if adapter is None:
+            return {"ok": False, "status": 409, "code": "adapter_unavailable", "message": f"Platform adapter is not connected: {entry.origin.platform.value}"}
+
+        running_agent = self._running_agents.get(session_key)
+        can_try_steer = (
+            mode in {"auto", "steer"}
+            and running_agent is not None
+            and running_agent is not _AGENT_PENDING_SENTINEL
+            and hasattr(running_agent, "steer")
+        )
+        if can_try_steer:
+            try:
+                if bool(running_agent.steer(text)):
+                    return {
+                        "ok": True,
+                        "object": "hermes.conversation.input",
+                        "session_key": session_key,
+                        "session_id": entry.session_id,
+                        "accepted": True,
+                        "action": "steered",
+                        "mode": mode,
+                        "fallback": fallback,
+                        "input_visibility": input_visibility,
+                        "output_delivery": output_delivery,
+                    }
+            except Exception as exc:
+                logger.warning("session input steer failed for %s: %s", session_key, exc)
+
+        if mode == "steer" and fallback == "reject":
+            return {"ok": False, "status": 409, "code": "not_steerable", "message": "Conversation has no active steerable run."}
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=entry.origin,
+            internal=True,
+            raw_message={
+                "synthetic": True,
+                "source": source_label,
+                "mode": mode,
+                "fallback": fallback,
+                "input_visibility": input_visibility,
+                "output_delivery": output_delivery,
+            },
+        )
+        action = self._queue_or_start_session_input(session_key=session_key, event=event, adapter=adapter)
+        return {
+            "ok": True,
+            "object": "hermes.conversation.input",
+            "session_key": session_key,
+            "session_id": entry.session_id,
+            "accepted": True,
+            "action": action,
+            "mode": mode,
+            "fallback": fallback,
+            "input_visibility": input_visibility,
+            "output_delivery": output_delivery,
+        }
+
     def _promote_queued_event(
         self,
         session_key: str,
@@ -6499,7 +6637,9 @@ class GatewayRunner:
             if not check_api_server_requirements():
                 logger.warning("API Server: aiohttp not installed")
                 return None
-            return APIServerAdapter(config)
+            adapter = APIServerAdapter(config)
+            adapter.gateway_runner = self
+            return adapter
 
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -954,6 +954,12 @@ class SessionStore:
 
         return entry
 
+    def get_entry(self, session_key: str) -> Optional[SessionEntry]:
+        """Return the persisted entry for a session key, if known."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def update_session(
         self,
         session_key: str,

--- a/tests/gateway/test_conversation_input_api.py
+++ b/tests/gateway/test_conversation_input_api.py
@@ -175,6 +175,37 @@ async def test_gateway_runner_inject_session_input_starts_idle_platform_delivery
 
 
 @pytest.mark.asyncio
+async def test_gateway_runner_conversation_input_escapes_leading_slash_as_plain_text():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = _FakeSessionStore(_entry())
+    platform_adapter = _FakeAdapter()
+    runner.adapters = {Platform.MATRIX: platform_adapter}
+    runner._running_agents = {}
+    runner._queued_events = {}
+
+    result = await GatewayRunner.inject_session_input(
+        runner,
+        session_key="matrix:room:user",
+        text="/new should be discussed, not executed",
+        mode="auto",
+        fallback="message",
+        source_label="pi-worker-smoke",
+    )
+
+    assert result["ok"] is True
+    assert result["action"] == "started"
+    session_key, event = platform_adapter.started[0]
+    assert session_key == "matrix:room:user"
+    assert event.message_type == MessageType.TEXT
+    assert event.internal is True
+    assert event.text == "\u200b/new should be discussed, not executed"
+    assert event.get_command() is None
+    assert event.raw_message["slash_escaped"] is True
+
+
+@pytest.mark.asyncio
 async def test_gateway_runner_inject_session_input_steers_without_queueing():
     from gateway.run import GatewayRunner
 

--- a/tests/gateway/test_conversation_input_api.py
+++ b/tests/gateway/test_conversation_input_api.py
@@ -1,0 +1,225 @@
+"""Tests for conversation-native API input injection."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.base import MessageType
+from gateway.session import SessionEntry, SessionSource
+
+
+def _make_adapter(api_key: str = "test-key") -> APIServerAdapter:
+    config = PlatformConfig(enabled=True, extra={"key": api_key})
+    return APIServerAdapter(config)
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/conversations/input", adapter._handle_conversation_input)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+def _entry(session_key: str = "matrix:room:user") -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(
+            platform=Platform.MATRIX,
+            chat_id="!room:lumeny.io",
+            chat_type="dm",
+            user_id="user-1",
+            user_name="Agent Peer",
+            thread_id="thread-1",
+        ),
+        platform=Platform.MATRIX,
+        chat_type="dm",
+    )
+
+
+class _FakeSessionStore:
+    def __init__(self, entry=None):
+        self.entry = entry
+
+    def get_entry(self, session_key):
+        if self.entry and self.entry.session_key == session_key:
+            return self.entry
+        return None
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self._active_sessions = {}
+        self._pending_messages = {}
+        self.started = []
+
+    def _heal_stale_session_lock(self, session_key):
+        return False
+
+    def _start_session_processing(self, event, session_key):
+        self.started.append((session_key, event))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_conversation_input_requires_api_key_even_on_local_server():
+    adapter = _make_adapter(api_key="")
+    adapter.gateway_runner = MagicMock()
+    app = _create_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/v1/conversations/input",
+            json={"session_key": "matrix:room:user", "text": "hello"},
+        )
+        data = await resp.json()
+
+    assert resp.status == 403
+    assert data["error"]["code"] == "api_key_required"
+
+
+@pytest.mark.asyncio
+async def test_conversation_input_steers_running_session():
+    adapter = _make_adapter()
+    runner = MagicMock()
+    runner.inject_session_input = AsyncMock(return_value={
+        "ok": True,
+        "object": "hermes.conversation.input",
+        "session_key": "matrix:room:user",
+        "session_id": "sess-1",
+        "accepted": True,
+        "action": "steered",
+        "mode": "auto",
+        "fallback": "message",
+        "input_visibility": "silent",
+        "output_delivery": "conversation",
+    })
+    adapter.gateway_runner = runner
+    app = _create_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/v1/conversations/input",
+            headers={"Authorization": "Bearer test-key"},
+            json={"session_key": "matrix:room:user", "text": "notice this", "mode": "auto"},
+        )
+        data = await resp.json()
+
+    assert resp.status == 202
+    assert data["action"] == "steered"
+    runner.inject_session_input.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_conversation_input_unknown_session_returns_404():
+    adapter = _make_adapter()
+    runner = MagicMock()
+    runner.inject_session_input = AsyncMock(return_value={
+        "ok": False,
+        "status": 404,
+        "code": "session_not_found",
+        "message": "No gateway session found for key: missing",
+    })
+    adapter.gateway_runner = runner
+    app = _create_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/v1/conversations/input",
+            headers={"Authorization": "Bearer test-key"},
+            json={"session_key": "missing", "text": "hello"},
+        )
+        data = await resp.json()
+
+    assert resp.status == 404
+    assert data["error"]["code"] == "session_not_found"
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_inject_session_input_starts_idle_platform_delivery():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = _FakeSessionStore(_entry())
+    platform_adapter = _FakeAdapter()
+    runner.adapters = {Platform.MATRIX: platform_adapter}
+    runner._running_agents = {}
+    runner._queued_events = {}
+
+    result = await GatewayRunner.inject_session_input(
+        runner,
+        session_key="matrix:room:user",
+        text="peer update",
+        mode="auto",
+        fallback="message",
+    )
+
+    assert result["ok"] is True
+    assert result["action"] == "started"
+    assert result["output_delivery"] == "conversation"
+    session_key, event = platform_adapter.started[0]
+    assert session_key == "matrix:room:user"
+    assert event.text == "peer update"
+    assert event.internal is True
+    assert event.message_type == MessageType.TEXT
+    assert event.source.thread_id == "thread-1"
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_inject_session_input_steers_without_queueing():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = _FakeSessionStore(_entry())
+    platform_adapter = _FakeAdapter()
+    runner.adapters = {Platform.MATRIX: platform_adapter}
+    agent = MagicMock()
+    agent.steer.return_value = True
+    runner._running_agents = {"matrix:room:user": agent}
+    runner._queued_events = {}
+
+    result = await GatewayRunner.inject_session_input(
+        runner,
+        session_key="matrix:room:user",
+        text="prefer concise",
+        mode="steer",
+        fallback="message",
+    )
+
+    assert result["ok"] is True
+    assert result["action"] == "steered"
+    agent.steer.assert_called_once_with("prefer concise")
+    assert platform_adapter.started == []
+    assert platform_adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_runner_inject_session_input_strict_steer_rejects_when_idle():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = _FakeSessionStore(_entry())
+    runner.adapters = {Platform.MATRIX: _FakeAdapter()}
+    runner._running_agents = {}
+    runner._queued_events = {}
+
+    result = await GatewayRunner.inject_session_input(
+        runner,
+        session_key="matrix:room:user",
+        text="must steer",
+        mode="steer",
+        fallback="reject",
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == 409
+    assert result["code"] == "not_steerable"

--- a/tests/tools/test_mcp_session_meta.py
+++ b/tests/tools/test_mcp_session_meta.py
@@ -1,0 +1,80 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mcp.client.auth.oauth2")
+
+
+def _install_stub_server(mcp_tool_module, name: str, call_tool_impl):
+    server = MagicMock()
+    server.name = name
+    session = MagicMock()
+    session.call_tool = call_tool_impl
+    server.session = session
+    server._reconnect_event = MagicMock()
+    server._ready = MagicMock()
+    server._ready.is_set.return_value = True
+    mcp_tool_module._servers[name] = server
+    mcp_tool_module._server_error_counts.pop(name, None)
+    if hasattr(mcp_tool_module, "_server_breaker_opened_at"):
+        mcp_tool_module._server_breaker_opened_at.pop(name, None)
+    return server
+
+
+def _cleanup(mcp_tool_module, name: str) -> None:
+    mcp_tool_module._servers.pop(name, None)
+    mcp_tool_module._server_error_counts.pop(name, None)
+    if hasattr(mcp_tool_module, "_server_breaker_opened_at"):
+        mcp_tool_module._server_breaker_opened_at.pop(name, None)
+
+
+def test_mcp_tool_handler_passes_current_hermes_session_meta(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_GATEWAY_API_BASE_URL", "http://gateway:8642")
+    monkeypatch.setenv("HERMES_GATEWAY_API_KEY", "secret")
+
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    captured = {}
+
+    async def _call_tool_success(*a, **kw):
+        captured.update(kw)
+        result = MagicMock()
+        result.isError = False
+        block = MagicMock()
+        block.text = "ok"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    tokens = set_session_vars(
+        platform="matrix",
+        chat_id="!room:lumeny.io",
+        thread_id="$thread",
+        user_id="@user:lumeny.io",
+        user_name="lumenyang",
+        session_key="agent:main:matrix:group:!room:lumeny.io:$thread",
+        message_id="$msg",
+    )
+    _install_stub_server(mcp_tool, "session-meta-srv", _call_tool_success)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("session-meta-srv", "tool1", 10.0)
+        parsed = json.loads(handler({"x": 1}))
+        assert parsed.get("result") == "ok", parsed
+        assert captured["arguments"] == {"x": 1}
+        meta = captured["meta"]["hermes_session"]
+        assert meta["platform"] == "matrix"
+        assert meta["chat_id"] == "!room:lumeny.io"
+        assert meta["thread_id"] == "$thread"
+        assert meta["session_key"] == "agent:main:matrix:group:!room:lumeny.io:$thread"
+        assert meta["message_id"] == "$msg"
+        assert meta["api_base_url"] == "http://gateway:8642"
+        assert meta["api_key"] == "secret"
+    finally:
+        _cleanup(mcp_tool, "session-meta-srv")
+        clear_session_vars(tokens)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2457,6 +2457,48 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
 # Handler / check-fn factories
 # ---------------------------------------------------------------------------
 
+def _current_hermes_session_meta() -> Dict[str, Any]:
+    """Build per-call Hermes session metadata for MCP tools.
+
+    Long-lived stdio MCP servers cannot read the active gateway session from
+    their process env. Pass it on every tools/call request as MCP _meta so
+    session-aware MCP tools can target the current chat/topic safely.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return {}
+
+    mapping = {
+        "platform": "HERMES_SESSION_PLATFORM",
+        "chat_id": "HERMES_SESSION_CHAT_ID",
+        "chat_name": "HERMES_SESSION_CHAT_NAME",
+        "thread_id": "HERMES_SESSION_THREAD_ID",
+        "user_id": "HERMES_SESSION_USER_ID",
+        "user_name": "HERMES_SESSION_USER_NAME",
+        "session_key": "HERMES_SESSION_KEY",
+        "session_id": "HERMES_SESSION_ID",
+        "message_id": "HERMES_SESSION_MESSAGE_ID",
+    }
+    meta = {key: get_session_env(env_name, "") for key, env_name in mapping.items()}
+    meta = {key: value for key, value in meta.items() if value}
+
+    # Conversation Input needs the gateway API endpoint/credential in addition
+    # to the session target. These are process/config scoped rather than
+    # per-chat, but including them here makes same-session MCP tools fully
+    # self-contained while still avoiding model-visible arguments.
+    for key, env_names in {
+        "api_base_url": ("HERMES_GATEWAY_API_BASE_URL", "HERMES_API_SERVER_BASE_URL"),
+        "api_key": ("HERMES_GATEWAY_API_KEY", "HERMES_API_SERVER_KEY", "API_SERVER_KEY"),
+    }.items():
+        for env_name in env_names:
+            value = os.getenv(env_name, "")
+            if value:
+                meta[key] = value
+                break
+    return meta
+
+
 def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """Return a sync handler that calls an MCP tool via the background loop.
 
@@ -2500,8 +2542,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             }, ensure_ascii=False)
 
         async def _call():
+            hermes_session_meta = _current_hermes_session_meta()
+            call_kwargs = {"arguments": args}
+            if hermes_session_meta:
+                call_kwargs["meta"] = {"hermes_session": hermes_session_meta}
             async with server._rpc_lock:
-                result = await server.session.call_tool(tool_name, arguments=args)
+                result = await server.session.call_tool(tool_name, **call_kwargs)
             # MCP CallToolResult has .content (list of content blocks) and .isError
             if result.isError:
                 error_text = ""


### PR DESCRIPTION
## Summary
- add `POST /v1/conversations/input` for conversation-native external input
- support mode switching: `auto`, `steer`, `queue`, `message`, plus `fallback=message|queue|reject`
- inject synthetic gateway `MessageEvent(internal=True)` through the original platform adapter so assistant output is delivered back to the source conversation/thread
- add `SessionStore.get_entry()` for safe session-key → origin lookup

## Why
This is motivated by agent-to-agent coordination. Today an external agent or sidecar can start API-owned `/v1/runs`, but it cannot naturally provide another message to an existing Hermes gateway session and have Hermes respond through that session's original platform. A strict steer endpoint is useful for active runs, but from a caller's perspective it is brittle: by the time the message arrives, the agent may already be idle.

This endpoint treats the target as a conversation rather than a single run:

- if a steerable agent is currently running and `mode=auto|steer`, it calls `agent.steer(text)`
- otherwise it can queue/start a normal gateway message according to `fallback`
- the final assistant response is delivered by the original Matrix/Telegram/Slack/etc. adapter, preserving platform/thread routing

## Relationship to #33061
#33061 adds a low-level `POST /v1/runs/{run_id}/steer` primitive for API-owned active runs. This PR is the higher-level conversation-native interface we prefer for external peers and agent-to-agent communication because it handles the realistic running-vs-idle race.

The two APIs are complementary:

- `/v1/runs/{run_id}/steer`: strict active-run control; no fallback; API-run scoped
- `/v1/conversations/input`: session/conversation scoped; mode/fallback aware; preserves original platform delivery

Keeping them separate lets upstream choose how much of the conversation-level behavior it wants without overloading run-level steer semantics.

## API shape

```http
POST /v1/conversations/input
Authorization: Bearer $API_SERVER_KEY
Content-Type: application/json

{
  "session_key": "...",
  "text": "peer observation or wakeup input",
  "mode": "auto",
  "fallback": "message",
  "input_visibility": "silent",
  "output_delivery": "conversation",
  "source": "agent-to-agent"
}
```

First slice support:

- `input_visibility=silent` only
- `output_delivery=conversation` only
- requires `API_SERVER_KEY`, because it injects internal gateway messages

## Test Plan
- `python -m py_compile gateway/session.py gateway/run.py gateway/platforms/api_server.py tests/gateway/test_conversation_input_api.py`
- `PYTHONPATH=. python -m pytest tests/gateway/test_conversation_input_api.py -q -o addopts=`
- `PYTHONPATH=. python -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_conversation_input_api.py -q -o addopts=`
