### PR TITLE
fix(approval): extend gateway-lifecycle guard to launchctl and pidof-based kills

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -875,6 +875,61 @@ class TestPgrepKillExpansion:
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    def test_kill_dollar_pidof_detected(self):
+        """`kill $(pidof hermes)` is the BSD/Linux equivalent of the
+        pgrep expansion and bypasses the pkill/killall name pattern
+        in the same way. See issue #33071."""
+        cmd = "kill -TERM $(pidof hermes_cli.main)"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "pidof" in desc.lower() or "pgrep" in desc.lower()
+
+    def test_kill_backtick_pidof_detected(self):
+        cmd = "kill -9 `pidof hermes`"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+
+class TestLaunchctlGatewayLifecycle:
+    """launchctl stop/kickstart/bootout/unload against the Hermes service
+    label achieves the same effect as `hermes gateway stop|restart` and
+    must require the same approval. See issue #33071.
+    """
+
+    def test_launchctl_stop_hermes_detected(self):
+        cmd = "launchctl stop ai.hermes.gateway"
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "launchd" in desc.lower() or "hermes" in desc.lower()
+
+    def test_launchctl_kickstart_hermes_detected(self):
+        cmd = "launchctl kickstart -k system/ai.hermes.gateway"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_bootout_hermes_detected(self):
+        cmd = "launchctl bootout system/ai.hermes.gateway"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_unload_hermes_detected(self):
+        cmd = "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway.plist"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_launchctl_print_unrelated_not_flagged(self):
+        """Read-only inspection of an unrelated launchd label must stay safe."""
+        cmd = "launchctl print system/com.apple.WindowServer"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_launchctl_stop_unrelated_not_flagged(self):
+        """`launchctl stop` on a non-Hermes label is out of scope for the
+        gateway-lifecycle guard."""
+        cmd = "launchctl stop com.example.unrelated"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False
+
 
 class TestGitDestructiveOps:
     """git reset --hard, push --force, clean -f, branch -D can destroy

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -398,8 +398,15 @@ DANGEROUS_PATTERNS = [
     # The name-based pattern above catches `pkill hermes` but not
     # `kill -9 $(pgrep -f hermes)` because the substitution is opaque
     # to regex at detection time. Catch the structural pattern instead.
-    (r'\bkill\b.*\$\(\s*pgrep\b', "kill process via pgrep expansion (self-termination)"),
-    (r'\bkill\b.*`\s*pgrep\b', "kill process via backtick pgrep expansion (self-termination)"),
+    # `pidof` is the BSD/Linux alternative to `pgrep` and is equally
+    # opaque, so include it in the same alternation.
+    (r'\bkill\b.*\$\(\s*(pgrep|pidof)\b', "kill process via pgrep/pidof expansion (self-termination)"),
+    (r'\bkill\b.*`\s*(pgrep|pidof)\b', "kill process via backtick pgrep/pidof expansion (self-termination)"),
+    # launchctl-driven gateway stop/restart on macOS. The agent can bypass
+    # the `hermes gateway stop|restart` pattern above by driving launchd
+    # directly against the service label (commonly `ai.hermes.gateway`).
+    # Catch the operations that stop, restart, or unload it.
+    (r'\blaunchctl\s+(stop|kickstart|bootout|unload|kill|disable|remove)\b.*\b(hermes|ai\.hermes)\b', "stop/restart hermes launchd service (kills running agents)"),
     # File copy/move/edit into sensitive system paths (/etc/ and macOS
     # /private/etc/ mirror).
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),


### PR DESCRIPTION
## What does this PR do?

The dangerous-command approval layer in `tools/approval.py` already blocks `hermes gateway (stop|restart)`, `pkill/killall hermes|gateway`, and `kill ... $(pgrep ...)`. Issue #33071 reports a distinct vector confirmed by alt-glitch as not covered by the existing related security PRs (#30882, #22557, #33057, #29159): the agent can still achieve a gateway restart by driving launchd directly against the service label (`launchctl stop ai.hermes.gateway`, `launchctl kickstart -k system/ai.hermes.gateway`) or by substituting `pidof` for `pgrep` in the kill-expansion form.

This widens the existing "Gateway lifecycle protection" block to cover both vectors with explicit, narrowly-scoped patterns:

- `launchctl (stop|kickstart|bootout|unload|kill|disable|remove)` is flagged only when the target includes a Hermes label (`hermes` or `ai.hermes`). Read-only inspection (`launchctl print …`, `launchctl list`) and operations against unrelated labels stay unflagged — both verified by regression tests.
- `kill ... $(pidof …)` and the backtick form are added alongside the existing `pgrep` expansion. `pidof` is the BSD/Linux equivalent and is equally opaque to the `(pkill|killall) … hermes` name pattern.

Mirrors the existing block's precedence: explicit hermes-named target > generic command shape > literal-PID kills stay safe. The literal-PID case (`kill -TERM <numeric_pid>` looked up out-of-band) is intentionally still allowed — catching it would require runtime PID state and would break the existing `TestPgrepKillExpansion::test_safe_kill_pid_not_flagged` contract.

## Related Issue

Fixes #33071

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py` — extended the `pgrep` kill-expansion pattern to also match `pidof`, and added a `launchctl (stop|kickstart|bootout|unload|kill|disable|remove)` pattern scoped to Hermes labels in the existing "Gateway lifecycle protection" block.
- `tests/tools/test_approval.py` — added `TestLaunchctlGatewayLifecycle` (6 cases: stop/kickstart/bootout/unload all flagged; `launchctl print` against an unrelated label and `launchctl stop com.example.unrelated` stay safe) and two new `TestPgrepKillExpansion` cases for `$(pidof …)` and ``` `pidof …` ```. Existing `test_safe_kill_pid_not_flagged` preserved as the explicit safety boundary.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_approval.py -v -k "Pgrep or Launchctl"` — 13 pass (5 pre-existing + 8 new).
2. Full file as regression guard: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_approval.py` — 196 pass.
3. Manual repro of the issue: `from tools.approval import detect_dangerous_command; print(detect_dangerous_command('launchctl stop ai.hermes.gateway'))` → `(True, …, 'stop/restart hermes launchd service (kills running agents)')`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; existing `# Self-termination protection` and `# Gateway lifecycle protection` comments updated inline
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `launchctl` is macOS-only; Linux/`systemctl` is already covered at line 338 (`systemctl … (stop|restart|disable|mask)`). Windows service-manager equivalents (`sc.exe stop`, `taskkill /F /IM`) are not currently covered by any pattern in this block — could be a follow-up if Windows gateway-as-a-service usage grows.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

> Audited siblings: confirmed every existing pattern in the "Gateway lifecycle protection" block (lines 365-380) has either a CLI form (`hermes gateway …`, `hermes update`), a service-manager form (`systemctl … (stop|restart|disable|mask)` at line 338), a name-based form (`pkill|killall … hermes|gateway`), or a shell-expansion form (`$(pgrep)` / `` `pgrep` ``). The two added patterns close the macOS-launchd and `pidof` gaps respectively. No further widening needed within the same block; a Windows-`sc.exe`/`taskkill` follow-up would be cleanly orthogonal if/when the project gains a Windows service manifest. Happy to widen further if preferred.