### PR TITLE
fix(gateway): deliver .json and .md files sent via MEDIA: tags

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|json|md|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|json|md|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|json|md|html?|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16853,7 +16853,7 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|csv|json|md|apk|ipa))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -17159,7 +17159,7 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'txt|csv|json|md|apk|ipa))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16853,7 +16853,7 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|json|md|apk|ipa))',
+                            r'txt|csv|json|md|html?|apk|ipa))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -17159,7 +17159,7 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|json|md|apk|ipa))',
+                                r'txt|csv|json|md|html?|apk|ipa))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -338,6 +338,13 @@ class TestExtractMedia:
             assert media == [(path, False)]
             assert cleaned == ""
 
+    def test_media_tag_supports_html_documents(self):
+        # Regression: .html/.htm were missing from the extension whitelist.
+        for path in ("/tmp/report.html", "/tmp/page.htm"):
+            media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:{path}")
+            assert media == [(path, False)]
+            assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -330,6 +330,14 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_supports_json_and_md_documents(self):
+        # Regression: .json and .md were missing from the extension whitelist,
+        # so these tags were never extracted and got delivered as raw text.
+        for path in ("/tmp/data.json", "/tmp/notes.md"):
+            media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:{path}")
+            assert media == [(path, False)]
+            assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
## Summary

`MEDIA:<path>` tags emitted by the agent are only turned into native file
attachments if the path ends in a whitelisted extension. The whitelist
listed common document/data types (`txt`, `csv`, `docx`, `xlsx`, `pdf`,
`zip`, …) but was **missing `.json` and `.md`**. As a result, when the agent
produced a JSON or Markdown file and sent `MEDIA:/path/file.json` /
`MEDIA:/path/file.md`, the tag was never matched, so the literal text was
delivered to the chat instead of the file. Every other document type worked,
which made this look type-specific.

The extension list appears in three places (one `extract_media` regex plus
two `GatewayRunner` tool-result MEDIA regexes); `json|md` is added to all
three so behavior is consistent across the CLI/tool and platform-reply paths.

## Changes

- `gateway/platforms/base.py` — add `json|md` to the `extract_media` extension whitelist
- `gateway/run.py` — add `json|md` to the two `GatewayRunner` MEDIA tool-result regexes
- `tests/gateway/test_platform_base.py` — regression test asserting `MEDIA:/…/.json` and `/…/.md` are extracted

Reproduced live on Telegram (personal WeChat affected identically): with the
fix, freshly-produced `.json`/`.md` files are now delivered as native
attachments. Files outside the cache allowlist and older than the recency
window are still gated by `validate_media_delivery_path`, unchanged.

## Test plan

- [x] `pytest tests/gateway/test_platform_base.py::TestExtractMedia -q` → 15 passed
- [x] Manual: `send_message(MEDIA:/tmp/x.json)` and `MEDIA:/tmp/x.md` to a Telegram chat deliver as document attachments