### PR TITLE
fix(auth): prefer built-in providers before custom aliases

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -79,6 +79,13 @@ def _normalize_provider(provider: str) -> str:
         return "openrouter"
     if normalized in {"grok-oauth", "xai-oauth", "x-ai-oauth", "xai-grok-oauth"}:
         return "xai-oauth"
+    # Built-in providers win over profile-defined provider aliases. Profiles
+    # commonly carry provider config blocks named "anthropic" or
+    # "openai-codex"; treating those as custom pools makes OAuth-capable
+    # built-ins unreachable (e.g. `hermes auth add anthropic --type oauth`
+    # becomes `custom:anthropic`).
+    if normalized in PROVIDER_REGISTRY or normalized == "openrouter":
+        return normalized
     # Check if it matches a custom provider name
     custom_key = _resolve_custom_provider_input(normalized)
     if custom_key:

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -62,6 +62,20 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_normalize_provider_prefers_builtin_over_custom_alias(monkeypatch):
+    from hermes_cli import auth_commands
+
+    monkeypatch.setattr(
+        auth_commands,
+        "_resolve_custom_provider_input",
+        lambda provider: f"custom:{provider}",
+    )
+
+    assert auth_commands._normalize_provider("anthropic") == "anthropic"
+    assert auth_commands._normalize_provider("openai-codex") == "openai-codex"
+    assert auth_commands._normalize_provider("local-qwen") == "custom:local-qwen"
+
+
 def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)


### PR DESCRIPTION
## Problem

Profile-scoped configs can define provider blocks with names that match built-in OAuth-capable providers, such as `openai-codex` and `anthropic`.

When running commands like:

```bash
hermes --profile neorix auth add openai-codex --type oauth
hermes --profile voltrix auth add anthropic --type oauth
```

`auth_commands._normalize_provider()` resolved those names through the custom-provider lookup before checking the built-in provider registry. As a result, the CLI treated them as `custom:openai-codex` / `custom:anthropic` and failed with:

```text
`hermes auth add custom:openai-codex` is not implemented for auth type oauth yet.
`hermes auth add custom:anthropic` is not implemented for auth type oauth yet.
```

## Root cause

`_normalize_provider()` checked `_resolve_custom_provider_input()` before giving built-in provider IDs priority. A user-defined provider config with the same key/name as a built-in provider could shadow the built-in OAuth implementation.

## Fix

- Prefer built-in provider IDs from `PROVIDER_REGISTRY` before custom-provider alias resolution.
- Keep custom provider aliases working for non-built-in names.
- Add a regression test that forces custom alias resolution to return `custom:<provider>` and verifies:
  - `anthropic` stays `anthropic`
  - `openai-codex` stays `openai-codex`
  - a non-built-in provider like `local-qwen` still resolves as custom

## Validation

```bash
python -m pytest tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_anthropic_oauth_flow.py -q
# 65 passed

ruff check hermes_cli/auth_commands.py tests/hermes_cli/test_auth_commands.py
# All checks passed!

python -m compileall -q hermes_cli/auth_commands.py tests/hermes_cli/test_auth_commands.py
```

Manual smoke check:

```text
openai-codex -> openai-codex
anthropic -> anthropic
local-qwen -> custom:local-qwen
```

## Known gaps/blockers

None known.

## Production expectation

After this change, profile users can run OAuth auth commands for built-in providers even when their profile config also contains provider blocks named `openai-codex` or `anthropic`. Custom provider aliases remain supported for non-built-in provider names.