### PR TITLE
fix: harden Codex replay and Qwen auxiliary compression

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -202,6 +202,18 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
     return bare == "trinity-large-thinking"
 
 
+def _is_bob_prime_qwen_fallback(model: Optional[str]) -> bool:
+    """True for the local Qwen fallback used by Bob Prime's gateway.
+
+    Bob Prime's Telegram sessions carry a large standing prompt/tool/skill
+    footprint. With the global 19% compression threshold, the local Qwen
+    fallback starts compacting at ~25k tokens despite having a 131k context
+    window, which can cause repeated compaction immediately after fallback.
+    """
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return bare == "qwen3.6-35b-a3b-fp8"
+
+
 def _fixed_temperature_for_model(
     model: Optional[str],
     base_url: Optional[str] = None,
@@ -235,6 +247,8 @@ def _compression_threshold_for_model(model: Optional[str]) -> Optional[float]:
     config value, or ``None`` to leave the user's config value unchanged.
     """
     if _is_arcee_trinity_thinking(model):
+        return 0.75
+    if _is_bob_prime_qwen_fallback(model):
         return 0.75
     return None
 

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -22,6 +22,29 @@ from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 logger = logging.getLogger(__name__)
 
+_RESPONSES_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _sanitize_responses_name(value: Any, *, fallback: str = "tool") -> str:
+    """Return a Responses-API-safe function/tool name.
+
+    OpenAI's Responses API rejects replayed ``function_call.name`` values
+    containing dots or other punctuation (``^[a-zA-Z0-9_-]+$``). Hermes can
+    legitimately have historical tool-call names from wrapper namespaces such
+    as ``multi_tool_use.parallel`` in the session transcript; when those are
+    replayed to Codex they should be normalized rather than poisoning the
+    whole conversation and forcing provider fallback.
+    """
+    raw = str(value or "").strip()
+    if raw and _RESPONSES_NAME_RE.match(raw):
+        return raw
+    sanitized = re.sub(r"[^A-Za-z0-9_-]+", "_", raw).strip("_")
+    if not sanitized:
+        sanitized = fallback
+    if not re.match(r"^[A-Za-z0-9_]", sanitized):
+        sanitized = f"{fallback}_{sanitized}"
+    return sanitized
+
 
 # Matches Codex/Harmony tool-call serialization that occasionally leaks into
 # assistant-message content when the model fails to emit a structured
@@ -392,6 +415,7 @@ def _chat_messages_to_responses_input(
                         fn_name = fn.get("name")
                         if not isinstance(fn_name, str) or not fn_name.strip():
                             continue
+                        fn_name = _sanitize_responses_name(fn_name, fallback="tool")
 
                         embedded_call_id, embedded_response_item_id = _split_responses_tool_id(
                             tc.get("id")
@@ -492,6 +516,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
             if not isinstance(name, str) or not name.strip():
                 raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
+            name = _sanitize_responses_name(name, fallback="tool")
 
             arguments = item.get("arguments", "{}")
             if isinstance(arguments, dict):
@@ -504,7 +529,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 {
                     "type": "function_call",
                     "call_id": call_id.strip(),
-                    "name": name.strip(),
+                    "name": name,
                     "arguments": arguments,
                 }
             )

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -17,6 +17,7 @@ from agent.auxiliary_client import (
     _compression_threshold_for_model,
     _fixed_temperature_for_model,
     _is_arcee_trinity_thinking,
+    _is_bob_prime_qwen_fallback,
 )
 
 
@@ -65,6 +66,14 @@ def test_fixed_temperature_sibling_arcee_models_unaffected() -> None:
 def test_compression_threshold_for_trinity_thinking() -> None:
     assert _compression_threshold_for_model("trinity-large-thinking") == 0.75
     assert _compression_threshold_for_model("arcee-ai/trinity-large-thinking") == 0.75
+
+
+def test_bob_prime_qwen_fallback_compression_threshold() -> None:
+    assert _is_bob_prime_qwen_fallback("qwen3.6-35b-a3b-fp8") is True
+    assert _is_bob_prime_qwen_fallback("Qwen/Qwen3.6-35B-A3B-FP8") is True
+    assert _is_bob_prime_qwen_fallback("qwen3.6-14b") is False
+    assert _compression_threshold_for_model("qwen3.6-35b-a3b-fp8") == 0.75
+    assert _compression_threshold_for_model("qwen/qwen3.6-35b-a3b-fp8") == 0.75
 
 
 def test_compression_threshold_default_none_for_other_models() -> None:

--- a/tests/agent/test_codex_responses_name_sanitization.py
+++ b/tests/agent/test_codex_responses_name_sanitization.py
@@ -1,0 +1,52 @@
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _preflight_codex_api_kwargs,
+)
+
+
+def test_replayed_function_call_names_are_sanitized_for_codex_responses():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_abc123",
+                    "function": {
+                        "name": "multi_tool_use.parallel",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert items == [
+        {
+            "type": "function_call",
+            "call_id": "call_abc123",
+            "name": "multi_tool_use_parallel",
+            "arguments": "{}",
+        }
+    ]
+
+
+def test_preflight_sanitizes_historical_function_call_names():
+    kwargs = {
+        "model": "gpt-5.5",
+        "instructions": "You are helpful.",
+        "input": [
+            {
+                "type": "function_call",
+                "call_id": "call_abc123",
+                "name": "multi_tool_use.parallel",
+                "arguments": "{}",
+            }
+        ],
+    }
+
+    normalized = _preflight_codex_api_kwargs(kwargs)
+
+    assert normalized["input"][0]["name"] == "multi_tool_use_parallel"


### PR DESCRIPTION
## Summary
- sanitize replayed Codex Responses function-call names so invalid historical tool names do not break Telegram session replay
- add regression coverage for Codex name sanitization
- tune Bob Prime Qwen auxiliary compression behavior to avoid repeated compaction thrash on local fallback

## Tests
- python -m pytest tests/agent/test_codex_responses_name_sanitization.py tests/agent/test_arcee_trinity_overrides.py -o 'addopts=' -q