### PR TITLE
fix(kanban): correct dashboard task counts

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1755,7 +1755,6 @@
     const list = props.boardList || [];
     const current = list.find(function (b) { return b.slug === props.board; });
     const currentName = current && current.name ? current.name : props.board;
-    const currentTotal = current ? current.total : 0;
     const hasMultipleBoards = list.length > 1;
 
     // Hide entirely when only the default board exists AND it's empty —
@@ -1798,8 +1797,6 @@
                 return h(SelectOption, { key: b.slug, value: b.slug }, label);
               }),
             ),
-            h("span", { className: "text-xs text-muted-foreground" },
-              `${currentTotal || 0} task${currentTotal === 1 ? "" : "s"}`),
           ),
         ),
         h("div", { className: "flex-1" }),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1762,7 +1762,8 @@ def _board_counts(slug: str) -> dict[str, int]:
         conn = kanban_db.connect(board=slug)
         try:
             rows = conn.execute(
-                "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
+                "SELECT status, COUNT(*) AS n "
+                "FROM tasks WHERE status != 'archived' GROUP BY status"
             ).fetchall()
             return {r["status"]: int(r["n"]) for r in rows}
         finally:

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -153,6 +153,31 @@ def test_tenant_filter(client):
     assert total == 1
 
 
+def test_board_list_counts_exclude_archived_tasks(client):
+    active = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "visible task"},
+    ).json()["task"]
+    archived = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "archived task"},
+    ).json()["task"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{archived['id']}",
+        json={"status": "archived"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.get("/api/plugins/kanban/boards")
+    assert r.status_code == 200
+    default_board = next(b for b in r.json()["boards"] if b["slug"] == "default")
+
+    assert default_board["total"] == 1
+    assert default_board["counts"] == {active["status"]: 1}
+    assert "archived" not in default_board["counts"]
+
+
 def test_board_query_param_default_overrides_current_board_pointer(client):
     """Dashboard ``?board=default`` must win even if the CLI's current-board
     pointer targets a non-default board.
@@ -245,6 +270,18 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     assert "if (!storedBoard && !board && data && data.current)" in js
     assert "setBoard(data.current);" in js
     assert 'readSelectedBoard() || "default"' not in js
+
+
+def test_dashboard_board_switcher_keeps_single_task_count():
+    """The selected board's task count should only appear in the dropdown label."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "? `${b.name || b.slug} · ${b.total}`" in js
+    assert "const currentTotal = current ? current.total : 0;" not in js
+    assert 'task${currentTotal === 1 ? "" : "s"}' not in js
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes Kanban dashboard board totals so archived tasks are not included in board list counts, and removes the duplicate selected-board task counter outside the board selector. The board selector option labels still show counts.

## Related Issue

None.

## Type of Change

- Bug fix
- Tests

## Changes Made

- Updated `plugins/kanban/dashboard/plugin_api.py` so board counts exclude tasks with `status = 'archived'`.
- Updated `plugins/kanban/dashboard/dist/index.js` so the selected board task count is shown only in the board selector label.
- Added regression coverage in `tests/plugins/test_kanban_dashboard_plugin.py` for archived-task counts and duplicate count rendering.

## How to Test

1. Create two Kanban dashboard tasks and archive one of them.
2. Request `/api/plugins/kanban/boards` and confirm the board total only includes the active task.
3. Open the dashboard board selector and confirm the selected board count appears once.

## Validation

- `/home/oscar/.hermes/runtime/hermes-agent/.venv/bin/python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q` passed: 96 tests, 1 warning.
- Runtime dashboard reloaded on Linux at `http://127.0.0.1:9119`; the fix was manually verified.
- Cross-platform impact: no OS-specific behavior changed; this updates a SQL filter and static dashboard rendering.

## Checklist

- Read `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md`.
- Conventional commit used: `fix(kanban): correct dashboard task counts`.
- Checked for existing matching PRs before opening this one.
- PR is scoped to the Kanban dashboard count fix.
- Regression tests added.
- Documentation, config examples, architecture docs, and tool schemas are not applicable.
