### PR TITLE
fix(gateway): forward per-run model override from POST /v1/runs to agent (#33072)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -941,6 +941,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        model_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -956,6 +957,10 @@ class APIServerAdapter(BasePlatformAdapter):
         key is meant to persist across transcripts so long-term memory
         providers (e.g. Honcho) can scope their per-chat state correctly
         — matching the semantics of the native gateway's ``session_key``.
+
+        ``model_override`` allows per-request model selection (e.g. from
+        the ``model`` field in ``POST /v1/runs``).  When provided and
+        non-empty it replaces the config.yaml default for this run only.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, GatewayRunner
@@ -964,6 +969,8 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+        if model_override:
+            model = model_override
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -3031,6 +3038,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id = body.get("session_id") or stored_session_id or run_id
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
+        requested_model: Optional[str] = body.get("model") or None
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
         created_at = time.time()
@@ -3071,6 +3079,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
+                    model_override=requested_model,
                 )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -529,3 +529,79 @@ class TestStopRun:
                 body = await events_resp.text()
                 # Stream should have received run.failed and closed
                 assert "run.failed" in body or "stream closed" in body
+
+
+class TestRunsModelOverride:
+    """POST /v1/runs — model override is forwarded to _create_agent."""
+
+    @pytest.fixture
+    def adapter(self):
+        return _make_adapter()
+
+    @pytest.mark.asyncio
+    async def test_model_override_forwarded_to_create_agent(self, adapter):
+        """When 'model' is provided in the request body it must be forwarded
+        to _create_agent as model_override so the agent runs with the
+        requested model instead of the config.yaml default (fixes #33072)."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "which model are you?", "model": "claude-haiku-4-5-20251001"},
+                )
+                assert resp.status == 202
+
+                # Wait for the agent to actually run (it may still be in
+                # progress on the executor thread — poll the status briefly).
+                run_id = (await resp.json())["run_id"]
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    if (await status_resp.json()).get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.1)
+
+                # _create_agent must have been called with the override.
+                mock_create.assert_called_once()
+                call_kwargs = mock_create.call_args.kwargs
+                assert call_kwargs.get("model_override") == "claude-haiku-4-5-20251001", (
+                    "model_override was not forwarded to _create_agent; "
+                    "the per-run model field is silently ignored (issue #33072)"
+                )
+
+    @pytest.mark.asyncio
+    async def test_no_model_field_leaves_override_none(self, adapter):
+        """When no 'model' field is present the override must be None so the
+        default config.yaml model is used unchanged."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+
+                run_id = (await resp.json())["run_id"]
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    if (await status_resp.json()).get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.1)
+
+                mock_create.assert_called_once()
+                call_kwargs = mock_create.call_args.kwargs
+                assert call_kwargs.get("model_override") is None, (
+                    "model_override should be None when no model field provided"
+                )


### PR DESCRIPTION
## Problem

`POST /v1/runs` accepts a `model` field documented as a per-run model override, but the agent always runs with the `config.yaml` default. The requested model is echoed back in `GET /v1/runs/{run_id}` but never used for the actual LLM call.

**Root cause:** `_create_agent()` unconditionally calls `_resolve_gateway_model()` which reads from config. The `/v1/runs` handler stored the requested model in the status record (`self._set_run_status(..., model=body.get('model', ...))`) but had no path to pass it into `_create_agent()`.

## Fix

- Add an optional `model_override: Optional[str] = None` parameter to `_create_agent()`.
- When `model_override` is provided and non-empty it replaces the config-resolved model for that single agent instantiation — no global state is mutated, no other callers are affected.
- In `_handle_runs()`, capture `body.get('model') or None` as `requested_model` and pass it as `model_override=requested_model` to `_create_agent()`.

## Before / After

```
# config.yaml model.default = claude-opus-4-7
POST /v1/runs {"input": "which model are you?", "model": "claude-haiku-4-5-20251001"}

Before: agent runs with claude-opus-4-7
After:  agent runs with claude-haiku-4-5-20251001
```

## Testing

```bash
python3 -m pytest tests/gateway/test_api_server_runs.py -v
# 24 passed
```

Two new tests in `TestRunsModelOverride`:
- `test_model_override_forwarded_to_create_agent` — verifies the override reaches `_create_agent` when the `model` field is present.
- `test_no_model_field_leaves_override_none` — verifies the default path is unchanged when no `model` field is provided.

Fixes #33072
