### PR TITLE
fix(qqbot): add receive_timeout to WebSocket to detect CLOSE_WAIT dea…

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -98,6 +98,7 @@ from gateway.platforms.qqbot.constants import (
     DEFAULT_API_TIMEOUT,
     FILE_UPLOAD_TIMEOUT,
     CONNECT_TIMEOUT_SECONDS,
+    RECEIVE_TIMEOUT,
     RECONNECT_BACKOFF,
     MAX_RECONNECT_ATTEMPTS,
     RATE_LIMIT_DELAY,
@@ -468,6 +469,7 @@ class QQAdapter(BasePlatformAdapter):
                 "User-Agent": build_user_agent(),
             },
             timeout=CONNECT_TIMEOUT_SECONDS,
+            receive_timeout=RECEIVE_TIMEOUT,
             proxy=ws_proxy,
         )
         logger.info("[%s] WebSocket connected to %s", self._log_tag, gateway_url)

--- a/gateway/platforms/qqbot/constants.py
+++ b/gateway/platforms/qqbot/constants.py
@@ -37,6 +37,14 @@ QR_URL_TEMPLATE = (
 DEFAULT_API_TIMEOUT = 30.0
 FILE_UPLOAD_TIMEOUT = 120.0
 CONNECT_TIMEOUT_SECONDS = 20.0
+# If no WebSocket frame arrives within this window the connection is
+# considered dead and the adapter will reconnect.  Covers CLOSE_WAIT
+# half-open sockets where the transport has already failed but aiohttp
+# hasn't detected it yet (no TCP RST, no close frame).
+# Set well above 3x heartbeat_interval so transient lag doesn't trigger
+# false reconnects.  QQ's default server-side heartbeat is 30 s;
+# Hermes sends at 80 % = 24 s.  90 s = 3.7 heartbeat periods.
+RECEIVE_TIMEOUT = 90.0
 
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 MAX_RECONNECT_ATTEMPTS = 100


### PR DESCRIPTION
Problem

    When QQ server drops the WebSocket connection silently (TCP CLOSE_WAIT state),
    aiohttp ws.receive() blocks indefinitely because no receive_timeout was set.
    This causes the adapter to appear connected while it is actually dead, and
    messages never reach the agent.

    Add RECEIVE_TIMEOUT=90s (well above 3x heartbeat_interval) so receive()
    raises after 90s of silence, triggering the existing reconnect logic.

    Fixes: QQBot going silent after ~2h session timeout with no auto-recovery.

    What does this PR do?

    Add receive_timeout=RECEIVE_TIMEOUT to the aiohttp ws_connect() call in
    the QQBot adapter so that dead WebSocket connections (TCP CLOSE_WAIT) are
    detected and the reconnect loop is triggered automatically.

    Related Issue

    Fixes N/A

    Type of Change

    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    - [ ] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 🔒 Security fix
    - [ ] 📝 Documentation update
    - [ ] ✅ Tests (adding or improving test coverage)
    - [ ] ♻️ Refactor (no behavior change)
    - [ ] 🎯 New skill (bundled or hub)

    Changes Made

    - gateway/platforms/qqbot/constants.py: add RECEIVE_TIMEOUT = 90.0 constant with documentation explaining the CLOSE_WAIT detection rationale
    - gateway/platforms/qqbot/adapter.py: import RECEIVE_TIMEOUT and pass receive_timeout=RECEIVE_TIMEOUT to self._session.ws_connect() in _open_ws()

    How to Test

    1. Run QQBot gateway in production (>2 hours)
    2. Verify normal session timeout (code 4009) is handled by existing reconnect logic
    3. Simulate silent disconnect (TCP CLOSE_WAIT) — adapter should detect dead connection within 90s and reconnect
    4. Confirm no false reconnects during normal operation (90s >> 3x heartbeat interval)

    Checklist

    Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [ ] I've run pytest tests/ -q and all tests pass
    - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
    - [x] I've tested on my platform: WSL (Windows Subsystem for Linux)

    Documentation & Housekeeping

    - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
    - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
    - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
    - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
    - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A