### PR TITLE
fix(gateway): guard Codex null output and provider SDK errors

### DIFF
--- a/agent/_openai_sdk_compat.py
+++ b/agent/_openai_sdk_compat.py
@@ -1,0 +1,113 @@
+"""OpenAI SDK compatibility shims.
+
+Surgical, idempotent monkey-patches applied at import time so we can stay
+on a pinned ``openai`` version (see ``pyproject.toml`` — other releases
+trigger a pydantic-core segfault) while working around bugs that only
+surface against the chatgpt.com ``backend-api/codex`` endpoint.
+
+Currently installs one guard:
+
+* :func:`install_codex_responses_output_guard` — coerces
+  ``Response.output is None`` to ``[]`` before
+  ``openai.lib._parsing._responses.parse_response`` iterates it.
+  chatgpt.com emits early streaming snapshots where ``output`` is
+  ``null``; the SDK iterates without a None-guard at
+  ``_parsing/_responses.py:61`` (called from
+  ``lib/streaming/responses/_responses.py:360`` inside
+  ``accumulate_event``), which crashes the entire ``for event in stream``
+  loop *before* our own normalizers in ``run_codex_stream`` /
+  ``_normalize_codex_response`` get a chance to run.
+
+  Because ``streaming/responses/_responses.py`` does
+  ``from ..._parsing._responses import parse_response``, the symbol is
+  bound in two namespaces; both must be patched.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_PATCH_MARKER = "_hermes_codex_output_none_guard"
+
+
+def _wrap_parse_response(original: Any) -> Any:
+    """Return a wrapper that coerces ``response.output is None`` → ``[]``.
+
+    The wrapped ``parse_response`` is keyword-only in current openai
+    releases, but we look in positional args too so a future signature
+    change cannot break us.
+    """
+
+    @functools.wraps(original)
+    def _guarded_parse_response(*args: Any, **kwargs: Any) -> Any:
+        try:
+            resp = kwargs.get("response")
+            if resp is None and args:
+                resp = args[-1]
+            if resp is not None and getattr(resp, "output", _MISSING) is None:
+                try:
+                    resp.output = []
+                except Exception:
+                    # Pydantic model could reject direct assignment in some
+                    # configs; swallow so we still defer to the original
+                    # and surface its (clearer) error instead of ours.
+                    logger.debug(
+                        "codex output None-guard: could not coerce response.output to []",
+                        exc_info=True,
+                    )
+        except Exception:
+            logger.debug(
+                "codex output None-guard: pre-call inspection failed; "
+                "passing through to original parse_response",
+                exc_info=True,
+            )
+        return original(*args, **kwargs)
+
+    setattr(_guarded_parse_response, _PATCH_MARKER, True)
+    return _guarded_parse_response
+
+
+_MISSING = object()
+
+
+def install_codex_responses_output_guard() -> None:
+    """Patch ``parse_response`` in both namespaces.
+
+    Idempotent: re-invocation is a no-op once the marker attribute is
+    present. Defensive: if the openai layout changes and the target
+    modules/symbols disappear, we log at DEBUG and bail without raising —
+    a future SDK that fixed this upstream should not break Hermes
+    startup.
+    """
+    try:
+        import openai.lib._parsing._responses as _origin_mod  # type: ignore
+        import openai.lib.streaming.responses._responses as _streaming_mod  # type: ignore
+    except Exception:
+        logger.debug(
+            "codex output None-guard: openai SDK modules not importable; skipping",
+            exc_info=True,
+        )
+        return
+
+    for mod in (_origin_mod, _streaming_mod):
+        try:
+            current = getattr(mod, "parse_response", None)
+            if current is None:
+                logger.debug(
+                    "codex output None-guard: %s has no parse_response attribute; skipping",
+                    getattr(mod, "__name__", repr(mod)),
+                )
+                continue
+            if getattr(current, _PATCH_MARKER, False):
+                continue
+            mod.parse_response = _wrap_parse_response(current)  # type: ignore[attr-defined]
+        except Exception:
+            logger.debug(
+                "codex output None-guard: failed to patch %s",
+                getattr(mod, "__name__", repr(mod)),
+                exc_info=True,
+            )

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -23,7 +23,15 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
+from agent._openai_sdk_compat import install_codex_responses_output_guard
+
 logger = logging.getLogger(__name__)
+
+# chatgpt.com backend-api/codex emits early streaming snapshots where
+# ``response.output`` is ``null``; openai 2.24.0 iterates it without a
+# None-guard and crashes ``accumulate_event`` mid-``for event in stream``.
+# Patch the SDK's ``parse_response`` so the whole turn no longer aborts.
+install_codex_responses_output_guard()
 
 
 def run_codex_app_server_turn(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -226,6 +226,12 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     return redacted
 
 
+_GATEWAY_SDK_STREAMING_BUG_RE = re.compile(
+    r"provider\s+sdk\s+streaming\s+bug",
+    re.IGNORECASE,
+)
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -240,6 +246,11 @@ def _gateway_provider_error_reply(text: str) -> str:
         )
     if _GATEWAY_RATE_LIMIT_RE.search(text):
         return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    if _GATEWAY_SDK_STREAMING_BUG_RE.search(text):
+        return (
+            "⚠️ The model provider sent a malformed streaming response. "
+            "Please try again; raw diagnostics are in the gateway logs."
+        )
     return (
         "⚠️ The model provider failed after retries. I kept raw provider details "
         "out of chat; check gateway logs for diagnostics."

--- a/run_agent.py
+++ b/run_agent.py
@@ -285,6 +285,18 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+# Python's stock "'<TypeName>' object is not iterable / has no attribute /
+# is not subscriptable" exception messages are unique to bare interpreter
+# errors — real provider HTTP bodies don't emit them.  Matching this
+# signature in `_summarize_api_error` lets us wrap leaked SDK-internal
+# crashes (notably openai 2.24.0's accumulate_event on chatgpt.com codex
+# null-output snapshots) in a stable user-facing category instead of
+# leaking raw Python error text to Telegram/Slack/CLI.
+_PROVIDER_SDK_LEAK_SIGNATURE = re.compile(
+    r"^'[A-Za-z_][\w.]*' object (is not |has no attribute)"
+)
+
+
 class _StreamErrorEvent(Exception):
     """Synthesized provider error surfaced from a Responses ``error`` SSE frame.
 
@@ -1556,6 +1568,27 @@ class AIAgent:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""
                 return f"{prefix}{msg[:300]}"
+
+        # Provider SDK streaming bug envelope.  Bare Python exceptions like
+        # ``TypeError("'NoneType' object is not iterable")`` come from
+        # provider SDK internals (openai 2.24.0's accumulate_event on
+        # chatgpt.com codex snapshots is the canonical case) and look like
+        # nonsense in a Telegram bubble.  Wrap them in a stable category
+        # string so the final reply reads as "provider sent something the
+        # SDK could not parse" instead of leaking raw Python internals.
+        # Pattern is intentionally narrow: status_code unset AND the raw
+        # message matches Python's stock "'<TypeName>' object …" shape that
+        # real provider bodies do not emit.
+        if (
+            isinstance(error, (TypeError, AttributeError))
+            and not getattr(error, "status_code", None)
+            and _PROVIDER_SDK_LEAK_SIGNATURE.match(raw)
+        ):
+            return (
+                "Provider SDK streaming bug — upstream returned a snapshot "
+                f"the SDK could not parse ({raw[:160]}). Raw diagnostics in "
+                "gateway logs."
+            )
 
         # Fallback: truncate the raw string but give more room than 200 chars
         status_code = getattr(error, "status_code", None)

--- a/tests/run_agent/test_codex_stream_null_output_guard.py
+++ b/tests/run_agent/test_codex_stream_null_output_guard.py
@@ -1,0 +1,159 @@
+"""Regression: openai SDK parse_response must not crash when a streaming
+snapshot's ``response.output`` is ``None``.
+
+chatgpt.com's backend-api/codex emits early streaming snapshots where
+``output`` is ``null``. openai 2.24.0 iterates that field without a
+None-guard at ``openai/lib/_parsing/_responses.py:61`` (called from
+``openai/lib/streaming/responses/_responses.py:360`` inside
+``accumulate_event``), which raises ``TypeError: 'NoneType' object is
+not iterable`` mid-``for event in stream`` and aborts every codex turn.
+
+We can't bump the pin (other openai releases segfault pydantic-core), so
+``agent._openai_sdk_compat.install_codex_responses_output_guard`` wraps
+``parse_response`` in both bound namespaces and coerces
+``response.output`` to ``[]`` before delegating. These tests pin that
+contract.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+# Importing codex_runtime triggers install_codex_responses_output_guard()
+# at module import time — exactly how it ships in production.
+import agent.codex_runtime  # noqa: F401  (import for side effect)
+import openai.lib._parsing._responses as _origin_mod
+import openai.lib.streaming.responses._responses as _streaming_mod
+from agent._openai_sdk_compat import (
+    _PATCH_MARKER,
+    install_codex_responses_output_guard,
+)
+
+
+def _is_patched(fn) -> bool:
+    return bool(getattr(fn, _PATCH_MARKER, False))
+
+
+def test_parse_response_is_patched_in_both_namespaces() -> None:
+    """Both bindings of ``parse_response`` must carry the guard marker."""
+    assert _is_patched(_origin_mod.parse_response), (
+        "openai.lib._parsing._responses.parse_response is not wrapped"
+    )
+    assert _is_patched(_streaming_mod.parse_response), (
+        "openai.lib.streaming.responses._responses.parse_response is not wrapped"
+    )
+
+
+def test_install_is_idempotent() -> None:
+    """Calling the installer twice must not stack wrappers."""
+    before_origin = _origin_mod.parse_response
+    before_streaming = _streaming_mod.parse_response
+    install_codex_responses_output_guard()
+    install_codex_responses_output_guard()
+    assert _origin_mod.parse_response is before_origin
+    assert _streaming_mod.parse_response is before_streaming
+
+
+def test_null_output_no_longer_raises_typeerror() -> None:
+    """Snapshot with ``output=None`` must reach the wrapped body and not crash.
+
+    We don't need a fully valid Response — only that the wrapper coerces
+    ``output`` to ``[]`` before delegating. We stub the original so we
+    don't depend on the rest of ``parse_response``'s real machinery.
+    """
+    captured = {}
+
+    def _fake_original(*, text_format, input_tools, response):
+        # If the guard fired, output is now [] and iteration works.
+        captured["output"] = response.output
+        # Mimic what the real fn returns: a ParsedResponse-ish stub.
+        return SimpleNamespace(output=list(response.output))
+
+    # Temporarily swap the underlying original behind both wrappers.
+    # Each wrapped fn closes over its own ``original``; the cleanest way
+    # to inject is to install the guard around _fake_original directly,
+    # which is what production does at import time.
+    from agent._openai_sdk_compat import _wrap_parse_response
+
+    guarded = _wrap_parse_response(_fake_original)
+
+    snapshot = SimpleNamespace(output=None)
+    # Should NOT raise TypeError.
+    result = guarded(text_format=None, input_tools=None, response=snapshot)
+
+    assert captured["output"] == []
+    assert result.output == []
+
+
+def test_non_null_output_is_passed_through_unchanged() -> None:
+    """Sanity: when ``output`` is already a list the guard must not touch it."""
+    from agent._openai_sdk_compat import _wrap_parse_response
+
+    seen = {}
+
+    def _fake_original(*, text_format, input_tools, response):
+        seen["output"] = response.output
+        return SimpleNamespace(output=response.output)
+
+    guarded = _wrap_parse_response(_fake_original)
+    sentinel = [SimpleNamespace(type="message", content=[])]
+    snapshot = SimpleNamespace(output=sentinel)
+
+    guarded(text_format=None, input_tools=None, response=snapshot)
+    # Same object — no replacement, no copy.
+    assert seen["output"] is sentinel
+
+
+def test_guard_survives_pydantic_assignment_rejection(caplog) -> None:
+    """If a future SDK rejects direct ``response.output = []`` assignment,
+    the guard must swallow the error and still delegate to the original
+    (which will then raise its own, clearer error). The point of the
+    swallow is: the guard never makes things *worse* than upstream.
+    """
+    from agent._openai_sdk_compat import _wrap_parse_response
+
+    class FrozenResponse:
+        # __slots__-less but with a property that rejects assignment.
+        @property
+        def output(self):
+            return None
+
+        @output.setter
+        def output(self, _value):
+            raise AttributeError("frozen")
+
+    delegated = {"called": False}
+
+    def _fake_original(*, text_format, input_tools, response):
+        delegated["called"] = True
+        # Mimic upstream behaviour: try to iterate, blow up with the
+        # SAME error the user would see without the guard.
+        for _ in response.output:  # noqa: B007
+            pass
+
+    guarded = _wrap_parse_response(_fake_original)
+
+    with pytest.raises(TypeError):
+        guarded(text_format=None, input_tools=None, response=FrozenResponse())
+
+    # The guard must still have delegated rather than masking the call.
+    assert delegated["called"] is True
+
+
+def test_guard_tolerates_positional_response_arg() -> None:
+    """Defensive path: even if a future SDK changes ``parse_response`` to
+    accept ``response`` positionally, the guard must still find it."""
+    from agent._openai_sdk_compat import _wrap_parse_response
+
+    captured = {}
+
+    def _fake_original(text_format, input_tools, response):
+        captured["output"] = response.output
+        return None
+
+    guarded = _wrap_parse_response(_fake_original)
+    snapshot = SimpleNamespace(output=None)
+    guarded(None, None, snapshot)
+    assert captured["output"] == []

--- a/tests/run_agent/test_provider_sdk_error_envelope.py
+++ b/tests/run_agent/test_provider_sdk_error_envelope.py
@@ -1,0 +1,160 @@
+"""Provider/SDK streaming bug envelope on the user-facing error boundary.
+
+When ``openai`` 2.24.0's ``accumulate_event`` iterates a streaming
+snapshot whose ``response.output`` is ``null`` (the canonical case is
+chatgpt.com's backend-api/codex prelude), it raises bare
+``TypeError("'NoneType' object is not iterable")`` mid-``for event in
+stream``.  The SDK-level guard installed by
+``agent._openai_sdk_compat.install_codex_responses_output_guard``
+prevents the crash, but the conversation retry loop also has to
+withstand other future provider SDK leaks of the same shape.
+
+The defense in depth: ``AIAgent._summarize_api_error`` recognises bare
+Python ``TypeError``/``AttributeError`` whose ``str(error)`` matches
+Python's stock ``"'<TypeName>' object …"`` shape (a signature that real
+provider HTTP bodies never emit) and rewrites them as a compact
+``Provider SDK streaming bug`` envelope.  The final retry-loop reply
+then reads cleanly on Telegram/CLI/Slack/web instead of leaking raw
+Python interpreter text into the chat bubble.
+"""
+from __future__ import annotations
+
+
+def test_summarize_typeerror_nonetype_iterable_is_wrapped() -> None:
+    """The canonical codex streaming bug must be rewrapped, not leaked."""
+    from run_agent import AIAgent
+
+    summary = AIAgent._summarize_api_error(
+        TypeError("'NoneType' object is not iterable")
+    )
+    assert "Provider SDK streaming bug" in summary
+    # The original signature should be quoted inside the envelope so
+    # logs still carry the technical detail, but the prefix lets the
+    # gateway shape regex classify the reply as infrastructure-level.
+    assert "NoneType" in summary
+    # Envelope must be short — this becomes part of a Telegram bubble.
+    assert len(summary) < 400
+
+
+def test_summarize_attributeerror_object_no_attribute_is_wrapped() -> None:
+    """Similar SDK-internal shapes (AttributeError on Response objects)
+    must follow the same envelope path so future provider SDK churn does
+    not surface raw Python text either."""
+    from run_agent import AIAgent
+
+    summary = AIAgent._summarize_api_error(
+        AttributeError("'Response' object has no attribute 'output_text'")
+    )
+    assert "Provider SDK streaming bug" in summary
+
+
+def test_summarize_typeerror_not_subscriptable_is_wrapped() -> None:
+    from run_agent import AIAgent
+
+    summary = AIAgent._summarize_api_error(
+        TypeError("'NoneType' object is not subscriptable")
+    )
+    assert "Provider SDK streaming bug" in summary
+
+
+def test_summarize_typeerror_with_status_code_is_not_rewrapped() -> None:
+    """If a TypeError carries provider HTTP context, treat it as a normal
+    provider error — the SDK-leak envelope only fires on bare exceptions
+    that lack any provider response context."""
+    from run_agent import AIAgent
+
+    class _ProviderTypeError(TypeError):
+        status_code = 400
+
+    summary = AIAgent._summarize_api_error(
+        _ProviderTypeError("'NoneType' object is not iterable")
+    )
+    # Should fall through to the HTTP-prefixed fallback, not the SDK-bug
+    # envelope, because the provider attached a real status code.
+    assert "Provider SDK streaming bug" not in summary
+    assert "HTTP 400" in summary
+
+
+def test_summarize_typeerror_with_random_message_falls_through() -> None:
+    """Non-stock TypeError messages (anything that isn't Python's
+    ``'<TypeName>' object …`` shape) are not SDK-internal leaks — leave
+    them alone so they keep flowing through the legacy fallback."""
+    from run_agent import AIAgent
+
+    summary = AIAgent._summarize_api_error(
+        TypeError("custom validation rejected your payload at field foo")
+    )
+    assert "Provider SDK streaming bug" not in summary
+    assert "custom validation rejected" in summary
+
+
+def test_summarize_provider_json_body_message_is_not_rewrapped() -> None:
+    """Errors that carry a structured provider body keep their existing
+    extraction path — the envelope must not steal them."""
+    from run_agent import AIAgent
+
+    class _ProviderErr(Exception):
+        status_code = 403
+        body = {"error": {"message": "Forbidden: missing scope"}}
+
+    summary = AIAgent._summarize_api_error(_ProviderErr("403 forbidden"))
+    assert "Provider SDK streaming bug" not in summary
+    assert "Forbidden: missing scope" in summary
+    assert "HTTP 403" in summary
+
+
+def test_final_retry_response_keeps_gateway_shape_prefix() -> None:
+    """The retry loop wraps the summary in ``"API call failed after N
+    retries: <summary>"``.  Even with the new envelope content, the
+    composed string must still trigger the Telegram shape regex so the
+    gateway's ``_gateway_provider_error_reply`` swaps it for a chat-safe
+    reply rather than dumping technical text to the user."""
+    from run_agent import AIAgent
+    from gateway.run import _looks_like_gateway_provider_error
+
+    summary = AIAgent._summarize_api_error(
+        TypeError("'NoneType' object is not iterable")
+    )
+    composed = f"API call failed after 5 retries: {summary}"
+    assert _looks_like_gateway_provider_error(composed)
+
+
+def test_telegram_sanitizer_uses_sdk_bug_specific_reply() -> None:
+    """Telegram replies for the SDK-streaming-bug envelope must be the
+    targeted reply (so users know it is upstream-malformed-response, not
+    auth / rate-limit / policy)."""
+    from gateway.config import Platform
+    from gateway.run import _sanitize_gateway_final_response
+
+    raw = (
+        "API call failed after 5 retries: Provider SDK streaming bug — "
+        "upstream returned a snapshot the SDK could not parse "
+        "('NoneType' object is not iterable). Raw diagnostics in gateway logs."
+    )
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    # User-facing reply must not leak the Python-internal phrase.
+    assert "NoneType" not in sanitized
+    assert "object is not iterable" not in sanitized
+    # And it should specifically call out malformed streaming, not the
+    # generic provider-failed-after-retries fallback.
+    assert "malformed" in sanitized.lower()
+
+
+def test_non_telegram_final_response_gets_clean_envelope() -> None:
+    """Other gateway platforms (CLI / Slack / WhatsApp / Discord / web)
+    skip Telegram-only sanitization, so the in-string envelope is the
+    only defence.  Verify the user sees the classified envelope rather
+    than raw Python text on those platforms."""
+    from run_agent import AIAgent
+    from gateway.run import _sanitize_gateway_final_response
+
+    summary = AIAgent._summarize_api_error(
+        TypeError("'NoneType' object is not iterable")
+    )
+    composed = f"API call failed after 5 retries: {summary}"
+
+    # Discord is one of the non-Telegram platforms that passes through.
+    passthrough = _sanitize_gateway_final_response("discord", composed)
+    assert passthrough == composed
+    assert "Provider SDK streaming bug" in passthrough


### PR DESCRIPTION
## Summary
- Guard Codex Responses streaming against SDK `Response.output=None` snapshots by normalizing the value before `parse_response` consumes it.
- Wrap bare provider SDK `TypeError`/`AttributeError` failures into a user-visible provider error envelope instead of letting raw Python exceptions surface in Telegram.
- Add regression coverage for the Codex null-output guard and Telegram/provider error sanitization path.

## Test plan
- `python -m pytest tests/run_agent/test_codex_stream_null_output_guard.py tests/run_agent/test_provider_sdk_error_envelope.py -q -o 'addopts='`

## Operational notes
- This branch was rebuilt in a clean worktree from current `origin/main` and cherry-picked from the earlier local incident branch.
- No gateway restart/deploy has been performed from this branch.
