### PR TITLE
fix(error_classifier): set should_fallback=True on non-validation 500/502 (#32961)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -781,7 +781,15 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
-        return result_fn(FailoverReason.server_error, retryable=True)
+        # Non-validation 500/502: a genuine upstream server error. Advance
+        # the fallback_providers chain (retrying the same provider that just
+        # returned 5xx is unlikely to help, and proxies returning 502 for
+        # deprecated model names need a different provider to make progress).
+        return result_fn(
+            FailoverReason.server_error,
+            retryable=True,
+            should_fallback=True,
+        )
 
     if status_code in {503, 529}:
         return result_fn(FailoverReason.overloaded, retryable=True)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -365,6 +365,32 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.server_error
         assert result.retryable is True
 
+    def test_500_status_sets_should_fallback_true(self):
+        """500s (non-validation) must advance fallback_providers.
+
+        Regression guard for issue #32961: returning should_fallback=False on
+        a genuine 500 caused Hermes to retry the same provider instead of
+        moving to the next fallback in the chain.
+        """
+        e = MockAPIError("Internal Server Error", status_code=500)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_fallback is True
+
+    def test_502_status_sets_should_fallback_true(self):
+        """502s (non-validation) must advance fallback_providers.
+
+        Regression guard for issue #32961: a proxy returning 502 for a
+        deprecated model name needs the chain to advance to a different
+        provider — retrying the same one yields the identical 502.
+        """
+        e = MockAPIError("Bad Gateway", status_code=502)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_fallback is True
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):


### PR DESCRIPTION
Closes #32961.

## Root cause

`_classify_by_status` handles HTTP 500/502 in two branches:

1. **Request-validation lookalikes** (lines 773–782) — some OpenAI-compatible proxies return validation errors with a 5xx status. This branch correctly sets `should_fallback=True`.
2. **Genuine upstream server errors** (line 784) — returned `should_fallback=False` (the dataclass default).

`ClassifiedError.should_fallback` defaults to `False`, so the second path never advanced the `fallback_providers` chain. A proxy returning 502 for a deprecated model name (the reporter's scenario) would loop on the same provider instead of moving to the next configured fallback. Connection-error fallback worked correctly; the 5xx-from-proxy path did not.

## Fix

Set `should_fallback=True` on the non-validation 500/502 return, matching the documented intent of `fallback_providers` and the reporter's Option A. If a provider is consistently returning 5xx for a given request, the next provider in the chain is a reasonable alternative — retrying the same provider yields the identical failure.

A short inline comment explains the reasoning so the next reader doesn't have to re-derive it.

The adjacent `return result_fn(FailoverReason.server_error, retryable=True)` at the bottom of `_classify_by_status` (catch-all for other 5xx) is left untouched to keep this change surgical and scoped to what the issue specifies.

## Tests

Two regression guards added to `tests/agent/test_error_classifier.py`:

- `test_500_status_sets_should_fallback_true` — asserts plain 500 sets `should_fallback=True`.
- `test_502_status_sets_should_fallback_true` — asserts plain 502 sets `should_fallback=True`.

Both assert `reason`, `retryable`, and `should_fallback` together so the contract is fully pinned.

Existing tests (`test_500_server_error`, `test_502_server_error`, `test_502_plain_bad_gateway_still_retryable`, and the request-validation 5xx tests) continue to pass unchanged — they didn't assert `should_fallback` previously, so the new behavior doesn't conflict with them.

## Verification

```
$ pytest tests/agent/test_error_classifier.py -q
147 passed in 1.02s
```

Broader sweep of `tests/agent/` shows no new failures introduced by this change. (A handful of unrelated pre-existing failures exist on `main` in `test_anthropic_adapter.py`, `test_curator.py`, and `test_vision_routing_31179.py` — verified by re-running them against `main` directly.)

## Diff size

`agent/error_classifier.py`: +9 / −1
`tests/agent/test_error_classifier.py`: +26 / −0