### PR TITLE
fix(trajectory_compressor): return placeholder string when max_retries=0 instead of None (#32847)

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -508,3 +508,53 @@ class TestGenerateSummary:
         summary = await tc._generate_summary_async("Turn content", metrics)
 
         assert summary == "[CONTEXT SUMMARY]:"
+
+    def test_generate_summary_with_zero_retries_returns_string_not_none(self):
+        """With max_retries=0 the retry loop never runs.
+
+        Regression guard for issue #32847: previously the function returned
+        implicit None, which was then injected as a conversation "value" and
+        crashed downstream string operations.
+        """
+        config = CompressionConfig(max_retries=0)
+        tc = _make_compressor(config)
+        tc.client = MagicMock()
+        # Even if the client somehow returned a value, range(0) is empty,
+        # so the loop body — and this mock — are never reached.
+        tc.client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="unused"))]
+        )
+        metrics = TrajectoryMetrics()
+
+        summary = tc._generate_summary("Turn content", metrics)
+
+        assert summary is not None
+        assert isinstance(summary, str)
+        assert summary.startswith("[CONTEXT SUMMARY]")
+        assert "skipped" in summary.lower()
+        # The retry loop did not execute, so no API call was attempted.
+        assert metrics.summarization_api_calls == 0
+        tc.client.chat.completions.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_summary_async_with_zero_retries_returns_string_not_none(self):
+        """Async variant of the max_retries=0 regression guard for issue #32847."""
+        config = CompressionConfig(max_retries=0)
+        tc = _make_compressor(config)
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="unused"))]
+            )
+        )
+        tc._get_async_client = MagicMock(return_value=mock_client)
+        metrics = TrajectoryMetrics()
+
+        summary = await tc._generate_summary_async("Turn content", metrics)
+
+        assert summary is not None
+        assert isinstance(summary, str)
+        assert summary.startswith("[CONTEXT SUMMARY]")
+        assert "skipped" in summary.lower()
+        assert metrics.summarization_api_calls == 0
+        mock_client.chat.completions.create.assert_not_called()

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -636,7 +636,16 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 else:
                     # Fallback: create a basic summary
                     return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"
-    
+
+        # Fallback when the retry loop never executes (max_retries=0).
+        # Without this, the function returns implicit None, which is then
+        # injected as message content downstream and crashes string ops.
+        self.logger.warning(
+            "Summary generation skipped (max_retries=%d); using placeholder",
+            self.config.max_retries,
+        )
+        return "[CONTEXT SUMMARY]: [Summary generation skipped - turns compressed without LLM summary.]"
+
     async def _generate_summary_async(self, content: str, metrics: TrajectoryMetrics) -> str:
         """
         Generate a summary of the compressed turns using OpenRouter (async version).
@@ -705,7 +714,16 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 else:
                     # Fallback: create a basic summary
                     return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"
-    
+
+        # Fallback when the retry loop never executes (max_retries=0).
+        # Without this, the function returns implicit None, which is then
+        # injected as message content downstream and crashes string ops.
+        self.logger.warning(
+            "Summary generation skipped (max_retries=%d); using placeholder",
+            self.config.max_retries,
+        )
+        return "[CONTEXT SUMMARY]: [Summary generation skipped - turns compressed without LLM summary.]"
+
     def compress_trajectory(
         self,
         trajectory: List[Dict[str, str]]


### PR DESCRIPTION
Closes #32847.

## Root cause

`_generate_summary` and `_generate_summary_async` in `trajectory_compressor.py` are structured as:

```python
for attempt in range(self.config.max_retries):
    try:
        ...
        return self._ensure_summary_prefix(summary)
    except Exception as e:
        ...
        if attempt < self.config.max_retries - 1:
            time.sleep(...)
        else:
            return "[CONTEXT SUMMARY]: [Summary generation failed ...]"
```

When `max_retries=0`, `range(0)` is empty, the loop body never executes, and the function falls through to an implicit `return None`. The existing fallback string lives **inside** the `except` branch, so it only fires when an exception occurred during a retry attempt — with `max_retries=0` the except block never runs either.

That `None` is then injected into the compressed conversation as a message `value` in `compress_trajectory` (around lines 795 / 894), and downstream string operations (`len()`, concatenation, encoding) crash with `TypeError`.

## Fix

Add an outside-the-loop fallback to both the sync and async variants that returns a placeholder string and logs a warning. The string is intentionally distinguishable from the all-retries-exhausted fallback (`"... skipped ..."` vs `"... failed ..."`) so operators can tell the two paths apart in logs and in compressed transcripts.

```python
# Fallback when the retry loop never executes (max_retries=0).
# Without this, the function returns implicit None, which is then
# injected as message content downstream and crashes string ops.
self.logger.warning(
    "Summary generation skipped (max_retries=%d); using placeholder",
    self.config.max_retries,
)
return "[CONTEXT SUMMARY]: [Summary generation skipped - turns compressed without LLM summary.]"
```

Applied identically to `_generate_summary` (sync) and `_generate_summary_async` (async).

## Tests

Two regression guards added to `tests/test_trajectory_compressor.py::TestGenerateSummary`:

- `test_generate_summary_with_zero_retries_returns_string_not_none` — constructs a compressor with `max_retries=0`, calls `_generate_summary`, and asserts the result is a non-empty string starting with `"[CONTEXT SUMMARY]"`. Also asserts no API call was attempted.
- `test_generate_summary_async_with_zero_retries_returns_string_not_none` — same contract for the async variant via `pytest-asyncio` (matches the pattern used by the existing async test in the same class).

Both tests assert the **type** of the return value (`str`, not None), the `[CONTEXT SUMMARY]` prefix, the `"skipped"` marker, and zero API calls. The existing `test_generate_summary_handles_none_content` / `test_generate_summary_async_handles_none_content` pass unchanged.

## Verification

```
$ pytest tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py -q
41 passed in 0.58s

$ pytest $(find tests -name '*trajectory*.py' -o -name '*compress*.py') -q
243 passed in 11.61s
```

## Diff size

`trajectory_compressor.py`: +20 / −2
`tests/test_trajectory_compressor.py`: +50 / −0