### PR TITLE
fix: restore Discord auto-threading with free-response channels

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -51,6 +51,7 @@ from gateway.config import Platform, PlatformConfig
 import re
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
+from plugins.platforms.discord.thread_labels import extract_thread_labels
 from utils import atomic_json_write
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -4324,13 +4325,18 @@ class DiscordAdapter(BasePlatformAdapter):
         guild_name = getattr(guild, "name", None)
         parent_name = getattr(parent, "name", None)
 
+        label_suffix = ""
+        labels = extract_thread_labels(thread_name)
+        if labels:
+            label_suffix = " [labels: " + ", ".join(label["id"] for label in labels) + "]"
+
         if self._is_forum_parent(parent) and guild_name and parent_name:
-            return f"{guild_name} / {parent_name} / {thread_name}"
+            return f"{guild_name} / {parent_name} / {thread_name}{label_suffix}"
         if parent_name and guild_name:
-            return f"{guild_name} / #{parent_name} / {thread_name}"
+            return f"{guild_name} / #{parent_name} / {thread_name}{label_suffix}"
         if parent_name:
-            return f"{parent_name} / {thread_name}"
-        return thread_name
+            return f"{parent_name} / {thread_name}{label_suffix}"
+        return f"{thread_name}{label_suffix}"
 
     # ------------------------------------------------------------------
     # Attachment download helpers
@@ -4552,7 +4558,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/plugins/platforms/discord/thread_labels.json
+++ b/plugins/platforms/discord/thread_labels.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "labels": {
+    "wtupdate": {
+      "display": "WT Update",
+      "scope": "worktree",
+      "description": "Thread contains a worktree status/update for handoff or review."
+    },
+    "wtsignoff": {
+      "display": "WT Signoff",
+      "scope": "worktree",
+      "description": "Thread contains final worktree signoff and completion evidence."
+    }
+  }
+}

--- a/plugins/platforms/discord/thread_labels.py
+++ b/plugins/platforms/discord/thread_labels.py
@@ -1,0 +1,58 @@
+"""Local registry and parsing helpers for Discord thread labels.
+
+These labels are intentionally independent of Discord forum tags so they work
+for ordinary text-channel threads, forum posts, and test doubles alike.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_REGISTRY_PATH = Path(__file__).with_name("thread_labels.json")
+_LABEL_TOKEN_RE = re.compile(r"\[([a-z][a-z0-9_-]{1,31})\]")
+
+
+def _load_registry() -> dict[str, dict[str, Any]]:
+    try:
+        data = json.loads(_REGISTRY_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+    labels = data.get("labels") if isinstance(data, dict) else None
+    if not isinstance(labels, dict):
+        return {}
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for label_id, metadata in labels.items():
+        if not isinstance(label_id, str) or not isinstance(metadata, dict):
+            continue
+        key = label_id.strip().lower()
+        if not key:
+            continue
+        normalized[key] = {"id": key, **metadata}
+    return normalized
+
+
+DISCORD_THREAD_LABELS = _load_registry()
+
+
+def extract_thread_labels(thread_name: str | None) -> list[dict[str, Any]]:
+    """Return registered labels present as ``[label]`` tokens in a thread name."""
+    if not isinstance(thread_name, str) or not thread_name:
+        return []
+
+    seen: set[str] = set()
+    labels: list[dict[str, Any]] = []
+    for match in _LABEL_TOKEN_RE.finditer(thread_name):
+        label_id = match.group(1).lower()
+        if label_id in seen:
+            continue
+        metadata = DISCORD_THREAD_LABELS.get(label_id)
+        if metadata is None:
+            continue
+        seen.add(label_id)
+        labels.append(dict(metadata))
+    return labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
+vercel = ["vercel==0.5.7"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
@@ -188,7 +189,7 @@ all = [
   #
   # Removed from [all] on 2026-05-12 (covered by lazy-install):
   #   anthropic, exa, firecrawl, parallel-web, fal, edge-tts,
-  #   modal, daytona, messaging (telegram/discord/slack),
+  #   modal, daytona, vercel, messaging (telegram/discord/slack),
   #   matrix, slack, honcho, voice (faster-whisper),
   #   dingtalk, feishu, bedrock, tts-premium (elevenlabs)
   #
@@ -226,6 +227,7 @@ plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",
+  "platforms/discord/thread_labels.json",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -108,6 +108,8 @@ def _ensure_discord_mock() -> None:
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
+    discord_mod.Object = lambda *, id: SimpleNamespace(id=id)
     discord_mod.Interaction = object
     discord_mod.Message = type("Message", (), {})
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -22,6 +22,8 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
+    discord_mod.Object = lambda *, id: SimpleNamespace(id=id)
     discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
     discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
     discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
@@ -518,21 +520,14 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
 
 
 @pytest.mark.asyncio
-async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypatch):
-    """Free-response channels should reply inline, never spawn a new thread.
-
-    Without this, every message in a free-response channel would auto-create
-    a fresh thread (since the channel bypasses the @mention gate, every
-    message looks like a fresh trigger).  That turns a "lightweight chat"
-    channel into a thread-spawning machine — see the docs at
-    website/docs/user-guide/messaging/discord.md which already describe
-    this as the intended behavior.
-    """
+async def test_discord_free_response_channel_still_auto_threads_when_enabled(adapter, monkeypatch):
+    """Free-response mention gating is independent from auto-thread routing."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
-    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "*")
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
 
-    adapter._auto_create_thread = AsyncMock()
+    fake_thread = FakeThread(channel_id=999, name="auto-thread", parent=FakeTextChannel(channel_id=789))
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
 
     message = make_message(
         channel=FakeTextChannel(channel_id=789),
@@ -541,10 +536,34 @@ async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypa
 
     await adapter._handle_message(message)
 
-    adapter._auto_create_thread.assert_not_awaited()
+    adapter._auto_create_thread.assert_awaited_once()
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "casual chat in free-response channel"
+    assert event.source.chat_id == "999"
+    assert event.source.thread_id == "999"
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_no_thread_channels_still_bypass_auto_thread(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="inline chat in explicit no-thread channel",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
     assert event.source.chat_type == "group"
 
 

--- a/tests/gateway/test_discord_thread_labels.py
+++ b/tests/gateway/test_discord_thread_labels.py
@@ -1,0 +1,52 @@
+"""Tests for local Discord thread label registry support."""
+
+from pathlib import Path
+from types import SimpleNamespace
+import tomllib
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+from plugins.platforms.discord.thread_labels import (
+    DISCORD_THREAD_LABELS,
+    extract_thread_labels,
+)
+
+
+def test_discord_thread_label_registry_includes_wt_labels():
+    assert "wtupdate" in DISCORD_THREAD_LABELS
+    assert "wtsignoff" in DISCORD_THREAD_LABELS
+    assert DISCORD_THREAD_LABELS["wtupdate"]["scope"] == "worktree"
+    assert DISCORD_THREAD_LABELS["wtsignoff"]["scope"] == "worktree"
+
+
+def test_discord_thread_label_registry_json_is_packaged():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    assert (
+        "platforms/discord/thread_labels.json"
+        in pyproject["tool"]["setuptools"]["package-data"]["plugins"]
+    )
+
+
+def test_discord_thread_labels_extracted_from_thread_name_prefixes():
+    labels = extract_thread_labels("[wtupdate] [wtsignoff] Ship the Discord patch")
+
+    assert [label["id"] for label in labels] == ["wtupdate", "wtsignoff"]
+    assert labels[0]["display"] == "WT Update"
+
+
+def test_discord_thread_labels_are_added_to_formatted_chat_name():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    parent = SimpleNamespace(id=123, name="dev", guild=SimpleNamespace(name="Hermes Server"))
+    thread = SimpleNamespace(
+        id=456,
+        name="[wtupdate] Routing status",
+        parent=parent,
+        parent_id=123,
+        guild=parent.guild,
+    )
+
+    assert (
+        adapter._format_thread_chat_name(thread)
+        == "Hermes Server / #dev / [wtupdate] Routing status [labels: wtupdate]"
+    )


### PR DESCRIPTION
## Summary
- Decouples Discord `free_response_channels` from auto-thread creation so `free_response_channels: '*'` no longer bypasses thread routing.
- Adds a WT-style Discord thread label registry for machine-readable thread metadata.
- Adds regression coverage for free-response auto-threading and thread-label loading.

## Test Plan
- `pytest tests/` → 369 passed, 2 warnings

## Linear
- Project: https://linear.app/redcloudventures/project/discord-thread-routing-labels-sprint-2026-05-27-815a5f124abc
- Epic: https://linear.app/redcloudventures/issue/RED-500/epic-discord-auto-thread-routing-policy-wt-style-thread-labels
- Tasks: RED-501, RED-502, RED-503, RED-504, RED-505
