### PR TITLE
feat(memory): pass provider runtime config into memory providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ final-confirmation-review-required requests into read-only review outcome
 candidates without issuing tokens, persisting approvals, writing token files,
 creating real proposals, or creating operation-ledger events.
 
+Memory Human Approval Token Write Execution Dry Run v0.1 lives in
+`agent.memory_human_approval_token_write_execution_dry_run`. It previews token
+write payloads, approval audit payloads, target paths, and final preflight from
+manual-token-write-execution-plan-required candidates without issuing tokens,
+persisting approvals, writing token files, writing approval audit, creating real
+proposals, or creating operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ candidates and never creates real proposals, persists approvals, writes memory,
 writes graph state, modifies config, submits to governance, or creates
 operation-ledger events.
 
+Memory Real Proposal Write Lock Gate v0.1 lives in
+`agent.memory_real_proposal_write_lock_gate`. It turns valid dry-run previews
+into read-only write-lock candidates that are only eligible for a separate human
+approval token flow; it never creates real proposals, writes proposal files, or
+creates operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ It turns queue items into decision candidates only: `approve_to_proposal`,
 create proposals, write memory, write graph state, modify config, or create
 operation-ledger events.
 
+Memory Proposal Governance Gate v0.1 lives in
+`agent.memory_proposal_governance_gate`. It validates proposal draft candidates
+and creates read-only `governance_review_required` submission candidates for
+manual governed proposal creation without submitting, approving, persisting, or
+creating real proposals or operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ eligible final-gate candidates into read-only executor contract candidates that
 define future inputs, hard locks, audit fields, rollback rules, and execution
 boundaries without implementing or invoking a real executor.
 
+Memory Human Approval Token Real Write Executor Contract Review Gate v0.1 lives
+in `agent.memory_human_approval_token_real_write_executor_contract_review_gate`.
+It turns executor contract candidates into read-only review outcomes for a
+later implementation plan without issuing tokens, writing files, persisting
+approvals, creating ledger events, or implementing or invoking an executor.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ manual-token-write-execution-plan-required candidates without issuing tokens,
 persisting approvals, writing token files, writing approval audit, creating real
 proposals, or creating operation-ledger events.
 
+Memory Human Approval Token Write Final Gate v0.1 lives in
+`agent.memory_human_approval_token_write_final_gate`. It marks valid final
+preflight dry-run candidates as eligible for a separate real token write
+executor without invoking that executor, issuing tokens, persisting approvals,
+writing token files, writing approval audit, creating real proposals, or
+creating operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ and creates read-only `governance_review_required` submission candidates for
 manual governed proposal creation without submitting, approving, persisting, or
 creating real proposals or operation-ledger events.
 
+Memory Governance Submission Packet v0.1 lives in
+`agent.memory_governance_submission_packet`. It turns valid governance
+submission candidates into deterministic `human_review_packet_required` review
+packet candidates with evidence summaries, review checklists, and explicit
+read-only policy before any real proposal creation.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ implementation plan candidates for future executor dry runs without writing
 files, issuing tokens, persisting approvals, creating ledger events, or
 implementing or invoking an executor.
 
+Memory Human Approval Token Real Write Executor Implementation Dry Run v0.1
+lives in
+`agent.memory_human_approval_token_real_write_executor_implementation_dry_run`.
+It previews future executor module boundaries, interfaces, filesystem safety,
+audit, rollback, and tests without creating executor source files, implementing
+or invoking the executor, issuing tokens, or writing token/audit/ledger state.
+
+Memory Human Approval Token Real Write Executor Code Review Plan v0.1 lives in
+`agent.memory_human_approval_token_real_write_executor_code_review_plan`. It
+turns valid implementation dry-run candidates into read-only code-review-plan
+candidates for a later gate, defining future static-analysis, security,
+write-safety, test, and acceptance checks without creating executor source
+files or tests.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ into read-only human approval token request candidates for manual review without
 issuing tokens, persisting approvals, creating real proposals, writing proposal
 files, or creating operation-ledger events.
 
+Memory Human Approval Token Issuance Dry Run v0.1 lives in
+`agent.memory_human_approval_token_issuance_dry_run`. It previews approval token
+issuance records and final token preflight without issuing tokens, persisting
+approvals, writing token files, creating real proposals, or creating
+operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ issuance records and final token preflight without issuing tokens, persisting
 approvals, writing token files, creating real proposals, or creating
 operation-ledger events.
 
+Memory Human Approval Token Final Confirmation Request v0.1 lives in
+`agent.memory_human_approval_token_final_confirmation_request`. It turns
+eligible token write-lock gates into read-only final confirmation request
+candidates without issuing tokens, persisting approvals, writing token files,
+creating real proposals, or creating operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 
 The local Memory Fabric foundations include deterministic, read-only modules for
 benchmarking, retrieval fusion, bi-temporal fact reasoning, and contradiction
-classification, compiler candidates, and review-only memory block candidates.
+classification, compiler candidates, review-only memory block candidates, and a
+read-only review queue for those block candidates.
 
 Contradiction Engine v0.1 lives in `agent.memory_contradiction_engine`. It
 classifies fact relationships as `supports`, `updates`, `contradicts`,
@@ -140,6 +141,11 @@ Memory Blocks v0.1 lives in `agent.memory_blocks`. It creates deterministic
 `review_required` candidates such as `procedural_rules`, with `proposal_only`
 mutation policy and explicit proof that no memory, graph, config, proposal, or
 operation-ledger write is performed.
+
+Memory Block Review Queue v0.1 lives in `agent.memory_block_review_queue`. It
+wraps block candidates as deterministic `pending_review` queue items with
+priority, risk, validation, recommendation, source ids, and explicit read-only
+policy; it does not apply blocks or create proposals or ledger events.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 
 The local Memory Fabric foundations include deterministic, read-only modules for
 benchmarking, retrieval fusion, bi-temporal fact reasoning, and contradiction
-classification.
+classification, compiler candidates, and review-only memory block candidates.
 
 Contradiction Engine v0.1 lives in `agent.memory_contradiction_engine`. It
 classifies fact relationships as `supports`, `updates`, `contradicts`,
@@ -135,6 +135,11 @@ classifies fact relationships as `supports`, `updates`, `contradicts`,
 provenance through `normalize_fact`. Contradictions are flagged for review and
 future governed proposal handling; they are not directly written to durable
 memory or the Memory Graph.
+
+Memory Blocks v0.1 lives in `agent.memory_blocks`. It creates deterministic
+`review_required` candidates such as `procedural_rules`, with `proposal_only`
+mutation policy and explicit proof that no memory, graph, config, proposal, or
+operation-ledger write is performed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ read-only outcome candidates such as `approve_real_proposal_creation`,
 `request_changes`, `reject`, and `defer`; it still requires manual real proposal
 creation and never persists approvals or creates proposal records.
 
+Memory Real Proposal Creation Plan v0.1 lives in
+`agent.memory_real_proposal_creation_plan`. It turns approved human-review
+outcome candidates into read-only `manual_creation_plan_required` plan
+candidates and never creates real proposals, persists approvals, writes memory,
+writes graph state, modifies config, submits to governance, or creates
+operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ into read-only write-lock candidates that are only eligible for a separate human
 approval token flow; it never creates real proposals, writes proposal files, or
 creates operation-ledger events.
 
+Memory Human Approval Token Request v0.1 lives in
+`agent.memory_human_approval_token_request`. It turns eligible write-lock gates
+into read-only human approval token request candidates for manual review without
+issuing tokens, persisting approvals, creating real proposals, writing proposal
+files, or creating operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -234,6 +234,13 @@ It turns executor contract candidates into read-only review outcomes for a
 later implementation plan without issuing tokens, writing files, persisting
 approvals, creating ledger events, or implementing or invoking an executor.
 
+Memory Human Approval Token Real Write Executor Implementation Plan v0.1 lives
+in `agent.memory_human_approval_token_real_write_executor_implementation_plan`.
+It turns approved executor contract review outcomes into read-only
+implementation plan candidates for future executor dry runs without writing
+files, issuing tokens, persisting approvals, creating ledger events, or
+implementing or invoking an executor.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 
 ---
 
+## Hermes Memory Fabric Foundations
+
+The local Memory Fabric foundations include deterministic, read-only modules for
+benchmarking, retrieval fusion, bi-temporal fact reasoning, and contradiction
+classification.
+
+Contradiction Engine v0.1 lives in `agent.memory_contradiction_engine`. It
+classifies fact relationships as `supports`, `updates`, `contradicts`,
+`unrelated`, or `needs_review` while preserving bi-temporal fields and
+provenance through `normalize_fact`. Contradictions are flagged for review and
+future governed proposal handling; they are not directly written to durable
+memory or the Memory Graph.
+
+---
+
 ## Migrating from OpenClaw
 
 If you're coming from OpenClaw, Hermes can automatically import your settings, memories, skills, and API keys.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 The local Memory Fabric foundations include deterministic, read-only modules for
 benchmarking, retrieval fusion, bi-temporal fact reasoning, and contradiction
 classification, compiler candidates, review-only memory block candidates, and a
-read-only review queue for those block candidates.
+read-only review queue and decision gate for those block candidates.
 
 Contradiction Engine v0.1 lives in `agent.memory_contradiction_engine`. It
 classifies fact relationships as `supports`, `updates`, `contradicts`,
@@ -146,6 +146,12 @@ Memory Block Review Queue v0.1 lives in `agent.memory_block_review_queue`. It
 wraps block candidates as deterministic `pending_review` queue items with
 priority, risk, validation, recommendation, source ids, and explicit read-only
 policy; it does not apply blocks or create proposals or ledger events.
+
+Memory Review Decision Gate v0.1 lives in `agent.memory_review_decision_gate`.
+It turns queue items into decision candidates only: `approve_to_proposal`,
+`reject`, `request_more_evidence`, or `defer`. It does not apply decisions,
+create proposals, write memory, write graph state, modify config, or create
+operation-ledger events.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ submission candidates into deterministic `human_review_packet_required` review
 packet candidates with evidence summaries, review checklists, and explicit
 read-only policy before any real proposal creation.
 
+Memory Human Review Outcome Gate v0.1 lives in
+`agent.memory_human_review_outcome_gate`. It turns review packet candidates into
+read-only outcome candidates such as `approve_real_proposal_creation`,
+`request_changes`, `reject`, and `defer`; it still requires manual real proposal
+creation and never persists approvals or creates proposal records.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ executor without invoking that executor, issuing tokens, persisting approvals,
 writing token files, writing approval audit, creating real proposals, or
 creating operation-ledger events.
 
+Memory Human Approval Token Real Write Executor Contract v0.1 lives in
+`agent.memory_human_approval_token_real_write_executor_contract`. It turns
+eligible final-gate candidates into read-only executor contract candidates that
+define future inputs, hard locks, audit fields, rollback rules, and execution
+boundaries without implementing or invoking a real executor.
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ eligible token write-lock gates into read-only final confirmation request
 candidates without issuing tokens, persisting approvals, writing token files,
 creating real proposals, or creating operation-ledger events.
 
+Memory Human Approval Token Final Confirmation Review Gate v0.1 lives in
+`agent.memory_human_approval_token_final_confirmation_review_gate`. It turns
+final-confirmation-review-required requests into read-only review outcome
+candidates without issuing tokens, persisting approvals, writing token files,
+creating real proposals, or creating operation-ledger events.
+
 ---
 
 ## Migrating from OpenClaw

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1045,6 +1045,9 @@ def init_agent(
                         _init_kwargs["agent_workspace"] = "hermes"
                     except Exception:
                         pass
+                    _provider_config = mem_config.get(_mem_provider_name, {})
+                    if isinstance(_provider_config, dict):
+                        _init_kwargs["runtime_config"] = dict(_provider_config)
                     agent._memory_manager.initialize_all(**_init_kwargs)
                     _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:

--- a/agent/memory_bitemporal_fact_graph.py
+++ b/agent/memory_bitemporal_fact_graph.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime
+from typing import Any, Iterable, Mapping
+
+
+BITEMPORAL_FACT_GRAPH_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+}
+
+
+@dataclass(frozen=True)
+class BitemporalFact:
+    fact_id: str
+    subject: str
+    predicate: str
+    object: str
+    project_id: str | None = None
+    source_episode_id: str | None = None
+    provenance: Any = None
+    confidence: float = 1.0
+    valid_from: datetime | None = None
+    valid_until: datetime | None = None
+    system_created_at: datetime | None = None
+    system_invalidated_at: datetime | None = None
+    supersedes: tuple[str, ...] = ()
+    contradiction_group: str | None = None
+    governance: Mapping[str, Any] | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        payload = asdict(self)
+        for key in ("valid_from", "valid_until", "system_created_at", "system_invalidated_at"):
+            payload[key] = _datetime_to_json(payload[key])
+        payload["supersedes"] = list(self.supersedes)
+        payload["governance"] = dict(self.governance or BITEMPORAL_FACT_GRAPH_POLICY)
+        return payload
+
+
+def normalize_fact(fact: Mapping[str, Any] | BitemporalFact | None = None, **overrides: Any) -> BitemporalFact:
+    """Return a normalized immutable fact record without writing external state."""
+    data: dict[str, Any]
+    if isinstance(fact, BitemporalFact):
+        data = fact.to_json()
+    else:
+        data = dict(fact or {})
+    data.update(overrides)
+
+    fact_id = str(data.get("fact_id") or "").strip()
+    subject = str(data.get("subject") or "").strip()
+    predicate = str(data.get("predicate") or "").strip()
+    obj = str(data.get("object") or "").strip()
+    if not fact_id:
+        raise ValueError("fact_id is required")
+    if not subject:
+        raise ValueError("subject is required")
+    if not predicate:
+        raise ValueError("predicate is required")
+    if not obj:
+        raise ValueError("object is required")
+
+    confidence = float(data.get("confidence", 1.0))
+    confidence = min(max(confidence, 0.0), 1.0)
+    governance = data.get("governance") or BITEMPORAL_FACT_GRAPH_POLICY
+
+    return BitemporalFact(
+        fact_id=fact_id,
+        subject=subject,
+        predicate=predicate,
+        object=obj,
+        project_id=_optional_str(data.get("project_id")),
+        source_episode_id=_optional_str(data.get("source_episode_id")),
+        provenance=data.get("provenance"),
+        confidence=confidence,
+        valid_from=_coerce_datetime(data.get("valid_from")),
+        valid_until=_coerce_datetime(data.get("valid_until")),
+        system_created_at=_coerce_datetime(data.get("system_created_at")),
+        system_invalidated_at=_coerce_datetime(data.get("system_invalidated_at")),
+        supersedes=tuple(str(item) for item in _as_list(data.get("supersedes")) if str(item)),
+        contradiction_group=_optional_str(data.get("contradiction_group")),
+        governance=dict(governance),
+    )
+
+
+def fact_is_valid_at(fact: Mapping[str, Any] | BitemporalFact, at_time: str | datetime) -> bool:
+    normalized = normalize_fact(fact)
+    at = _require_datetime(at_time, "at_time")
+    if normalized.valid_from and at < normalized.valid_from:
+        return False
+    if normalized.valid_until and at >= normalized.valid_until:
+        return False
+    if normalized.system_invalidated_at and at >= normalized.system_invalidated_at:
+        return False
+    return True
+
+
+def select_current_facts(
+    facts: Iterable[Mapping[str, Any] | BitemporalFact],
+    at_time: str | datetime,
+    project_scope: str | None = None,
+) -> list[BitemporalFact]:
+    normalized = [normalize_fact(fact) for fact in facts]
+    scoped = [
+        fact
+        for fact in normalized
+        if fact_is_valid_at(fact, at_time)
+        and (project_scope is None or fact.project_id == project_scope)
+    ]
+    winners: dict[tuple[str, str, str | None], BitemporalFact] = {}
+    for fact in scoped:
+        key = (fact.subject, fact.predicate, fact.project_id)
+        current = winners.get(key)
+        if current is None or _fact_sort_key(fact) > _fact_sort_key(current):
+            winners[key] = fact
+    return sorted(winners.values(), key=lambda fact: (fact.project_id or "", fact.subject, fact.predicate, fact.fact_id))
+
+
+def supersede_fact(
+    old_fact: Mapping[str, Any] | BitemporalFact,
+    new_fact: Mapping[str, Any] | BitemporalFact,
+    superseded_at: str | datetime,
+) -> tuple[BitemporalFact, BitemporalFact]:
+    superseded_time = _require_datetime(superseded_at, "superseded_at")
+    old = normalize_fact(old_fact)
+    new = normalize_fact(new_fact)
+    updated_old = replace(
+        old,
+        valid_until=old.valid_until or superseded_time,
+        system_invalidated_at=old.system_invalidated_at or superseded_time,
+    )
+    updated_new = replace(
+        new,
+        valid_from=new.valid_from or superseded_time,
+        supersedes=tuple(dict.fromkeys((*new.supersedes, old.fact_id))),
+    )
+    return updated_old, updated_new
+
+
+def detect_fact_contradictions(facts: Iterable[Mapping[str, Any] | BitemporalFact]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str, str | None], list[BitemporalFact]] = {}
+    for fact in (normalize_fact(item) for item in facts):
+        groups.setdefault((fact.subject, fact.predicate, fact.project_id), []).append(fact)
+
+    contradictions: list[dict[str, Any]] = []
+    for (subject, predicate, project_id), group in groups.items():
+        objects = sorted({fact.object for fact in group})
+        if len(objects) < 2:
+            continue
+        contradictions.append(
+            {
+                "subject": subject,
+                "predicate": predicate,
+                "project_id": project_id,
+                "objects": objects,
+                "fact_ids": sorted(fact.fact_id for fact in group),
+                "contradiction_group": group[0].contradiction_group
+                or _contradiction_group_id(subject, predicate, project_id),
+            }
+        )
+    return sorted(contradictions, key=lambda item: (item["project_id"] or "", item["subject"], item["predicate"]))
+
+
+def explain_fact_lineage(fact_id: str, facts: Iterable[Mapping[str, Any] | BitemporalFact]) -> dict[str, Any]:
+    normalized = [normalize_fact(fact) for fact in facts]
+    by_id = {fact.fact_id: fact for fact in normalized}
+    target = by_id.get(fact_id)
+    if target is None:
+        return {
+            "fact_id": fact_id,
+            "found": False,
+            "policy": dict(BITEMPORAL_FACT_GRAPH_POLICY),
+            "lineage": [],
+            "superseded_by": [],
+        }
+
+    lineage: list[BitemporalFact] = []
+    seen: set[str] = set()
+    stack = list(target.supersedes)
+    while stack:
+        current_id = stack.pop(0)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+        current = by_id.get(current_id)
+        if current is None:
+            continue
+        lineage.append(current)
+        stack.extend(current.supersedes)
+
+    superseded_by = [fact for fact in normalized if target.fact_id in fact.supersedes]
+    return {
+        "fact_id": fact_id,
+        "found": True,
+        "fact": target.to_json(),
+        "lineage": [fact.to_json() for fact in lineage],
+        "superseded_by": [fact.to_json() for fact in sorted(superseded_by, key=_fact_sort_key)],
+        "policy": dict(BITEMPORAL_FACT_GRAPH_POLICY),
+    }
+
+
+def _fact_sort_key(fact: BitemporalFact) -> tuple[datetime, datetime, float, str]:
+    return (
+        fact.valid_from or datetime.min.replace(tzinfo=UTC),
+        fact.system_created_at or datetime.min.replace(tzinfo=UTC),
+        fact.confidence,
+        fact.fact_id,
+    )
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if not value:
+        return None
+    text = str(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"Invalid datetime: {value}") from exc
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _require_datetime(value: str | datetime, name: str) -> datetime:
+    parsed = _coerce_datetime(value)
+    if parsed is None:
+        raise ValueError(f"{name} is required")
+    return parsed
+
+
+def _datetime_to_json(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _contradiction_group_id(subject: str, predicate: str, project_id: str | None) -> str:
+    return "|".join((project_id or "*", subject, predicate))

--- a/agent/memory_block_review_queue.py
+++ b/agent/memory_block_review_queue.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_blocks import (
+    MEMORY_BLOCK_POLICY,
+    normalize_memory_block,
+    recommend_memory_block_action,
+    validate_memory_block_candidate,
+)
+
+
+MEMORY_BLOCK_REVIEW_QUEUE_VERSION = "0.1"
+MEMORY_BLOCK_REVIEW_QUEUE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_review_candidates_only": True,
+    "applies_blocks": False,
+}
+
+_TYPE_PRIORITY: dict[str, tuple[int, str]] = {
+    "safety_policy": (90, "high"),
+    "procedural_rules": (70, "medium"),
+    "methodology": (70, "medium"),
+    "persona": (60, "medium"),
+    "collaboration_style": (60, "medium"),
+    "human_profile": (60, "medium"),
+    "project_context": (40, "low"),
+    "current_task_state": (40, "low"),
+}
+
+
+def create_review_queue_item(
+    block: Mapping[str, Any],
+    reason: str | None = None,
+    reviewer: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only review queue item for a memory block candidate."""
+    normalized = normalize_memory_block(block)
+    validation = validate_memory_block_candidate(normalized)
+    priority, risk_level = _priority_for_block(normalized, validation)
+    recommended_action = recommend_memory_block_action(normalized)
+    item = {
+        "queue_item_id": None,
+        "block_id": normalized["block_id"],
+        "block_type": normalized["block_type"],
+        "project_scope": normalized["project_scope"],
+        "status": "pending_review",
+        "priority": priority,
+        "risk_level": risk_level,
+        "reason": reason or _default_reason(normalized, validation),
+        "reviewer": reviewer,
+        "source_pattern_ids": deepcopy(normalized["source_pattern_ids"]),
+        "source_fact_ids": deepcopy(normalized["source_fact_ids"]),
+        "validation": deepcopy(validation),
+        "recommended_action": deepcopy(recommended_action),
+        "block_snapshot": deepcopy(normalized),
+        "policy": dict(MEMORY_BLOCK_REVIEW_QUEUE_POLICY),
+    }
+    item["queue_item_id"] = _queue_item_id(item)
+    return item
+
+
+def build_review_queue(
+    blocks: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+    reviewer: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build and prioritize a read-only review queue from memory block candidates."""
+    return prioritize_review_queue([create_review_queue_item(block, reviewer=reviewer) for block in blocks])
+
+
+def prioritize_review_queue(items: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...]) -> list[dict[str, Any]]:
+    """Return queue items sorted by priority, then stable deterministic tie-breakers."""
+    copied = [deepcopy(dict(item)) for item in items]
+    return sorted(
+        copied,
+        key=lambda item: (
+            -int(item.get("priority", 0)),
+            str(item.get("risk_level", "")),
+            str(item.get("block_type", "")),
+            str(item.get("project_scope", "")),
+            str(item.get("block_id", "")),
+            str(item.get("queue_item_id", "")),
+        ),
+    )
+
+
+def validate_review_queue_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(item.get("policy"))
+    validation = _as_dict(item.get("validation"))
+
+    for key in (
+        "queue_item_id",
+        "block_id",
+        "block_type",
+        "status",
+        "priority",
+        "risk_level",
+        "validation",
+        "recommended_action",
+        "block_snapshot",
+        "policy",
+    ):
+        if key not in item:
+            errors.append(f"missing_{key}")
+    if item.get("status") != "pending_review":
+        errors.append("status_must_be_pending_review")
+    if not isinstance(item.get("priority"), int):
+        errors.append("priority_must_be_int")
+    if item.get("risk_level") not in {"low", "medium", "high"}:
+        errors.append("risk_level_must_be_low_medium_or_high")
+    if not isinstance(validation.get("valid"), bool):
+        errors.append("validation_valid_must_be_bool")
+    for key, expected in MEMORY_BLOCK_REVIEW_QUEUE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": errors}
+
+
+def summarize_review_queue(items: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...]) -> dict[str, Any]:
+    by_risk = {"high": 0, "medium": 0, "low": 0}
+    by_block_type: dict[str, int] = {}
+    invalid_count = 0
+    for item in items:
+        risk = str(item.get("risk_level", "medium"))
+        if risk in by_risk:
+            by_risk[risk] += 1
+        block_type = str(item.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        validation = _as_dict(item.get("validation"))
+        if validation.get("valid") is not True:
+            invalid_count += 1
+    return {
+        "total": len(items),
+        "by_risk": by_risk,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "invalid_count": invalid_count,
+        "policy": dict(MEMORY_BLOCK_REVIEW_QUEUE_POLICY),
+    }
+
+
+def explain_review_queue_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_review_queue_item(item)
+    return {
+        "queue_item_id": item.get("queue_item_id"),
+        "block_id": item.get("block_id"),
+        "block_type": item.get("block_type"),
+        "project_scope": item.get("project_scope"),
+        "status": item.get("status"),
+        "priority": item.get("priority"),
+        "risk_level": item.get("risk_level"),
+        "reviewer": item.get("reviewer"),
+        "source_pattern_count": len(item.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(item.get("source_fact_ids", []) or []),
+        "validation": validation,
+        "block_validation": deepcopy(item.get("validation", {})),
+        "recommended_action": deepcopy(item.get("recommended_action", {})),
+        "applied": False,
+        "policy": dict(MEMORY_BLOCK_REVIEW_QUEUE_POLICY),
+    }
+
+
+def recommend_review_queue_action(item: Mapping[str, Any]) -> dict[str, Any]:
+    validation = _as_dict(item.get("validation"))
+    if validation.get("valid") is not True:
+        action = "review_and_reject_invalid_block"
+        reason = "The queued memory block candidate violates the v0.1 validation contract."
+    else:
+        action = "human_review_required"
+        reason = "The queued memory block candidate is valid but must stay pending until a governed proposal path is used."
+    return {
+        "action": action,
+        "reason": reason,
+        "creates_review_candidates_only": True,
+        "applies_blocks": False,
+        "policy": dict(MEMORY_BLOCK_REVIEW_QUEUE_POLICY),
+    }
+
+
+def _priority_for_block(block: Mapping[str, Any], validation: Mapping[str, Any]) -> tuple[int, str]:
+    if validation.get("valid") is not True:
+        return 100, "high"
+    return _TYPE_PRIORITY.get(str(block.get("block_type")), (50, "medium"))
+
+
+def _default_reason(block: Mapping[str, Any], validation: Mapping[str, Any]) -> str:
+    if validation.get("valid") is not True:
+        return "Invalid memory block candidate requires review before rejection."
+    return f"{block.get('block_type')} memory block candidate requires read-only review."
+
+
+def _queue_item_id(item: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_BLOCK_REVIEW_QUEUE_VERSION,
+        "block_id": item.get("block_id"),
+        "block_type": item.get("block_type"),
+        "project_scope": item.get("project_scope"),
+        "reason": item.get("reason"),
+        "reviewer": item.get("reviewer"),
+        "source_pattern_ids": list(item.get("source_pattern_ids", [])),
+        "source_fact_ids": list(item.get("source_fact_ids", [])),
+        "validation": item.get("validation", {}),
+        "policy": item.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-block-review:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}

--- a/agent/memory_blocks.py
+++ b/agent/memory_blocks.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_compiler import compile_memory_patterns
+
+
+SUPPORTED_MEMORY_BLOCK_TYPES = (
+    "human_profile",
+    "persona",
+    "collaboration_style",
+    "project_context",
+    "procedural_rules",
+    "safety_policy",
+    "methodology",
+    "current_task_state",
+)
+
+MEMORY_BLOCK_VERSION = "0.1"
+MEMORY_BLOCK_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_review_candidates_only": True,
+}
+MEMORY_BLOCK_MUTATION_POLICY = {
+    "mutation_policy": "proposal_only",
+    "direct_write_allowed": False,
+}
+
+
+def normalize_memory_block(block: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a deterministic memory-block candidate envelope without side effects."""
+    normalized = deepcopy(dict(block))
+    metadata = _as_dict(normalized.get("metadata"))
+    source_pattern_ids = _sorted_strings(normalized.get("source_pattern_ids", []))
+    source_fact_ids = _sorted_strings(normalized.get("source_fact_ids", []))
+    policy = {**MEMORY_BLOCK_POLICY, **_as_dict(normalized.get("policy"))}
+    mutation = {
+        **MEMORY_BLOCK_MUTATION_POLICY,
+        "mutation_policy": normalized.get("mutation_policy", MEMORY_BLOCK_MUTATION_POLICY["mutation_policy"]),
+        "direct_write_allowed": normalized.get(
+            "direct_write_allowed",
+            MEMORY_BLOCK_MUTATION_POLICY["direct_write_allowed"],
+        ),
+    }
+
+    candidate = {
+        "block_id": normalized.get("block_id"),
+        "block_type": normalized.get("block_type"),
+        "status": normalized.get("status", "review_required"),
+        "project_scope": normalized.get("project_scope"),
+        "content": deepcopy(normalized.get("content")),
+        "source_pattern_ids": source_pattern_ids,
+        "source_fact_ids": source_fact_ids,
+        "metadata": metadata,
+        "version": str(normalized.get("version", MEMORY_BLOCK_VERSION)),
+        "source_event_id": normalized.get("source_event_id", metadata.get("source_event_id")),
+        "confidence": _confidence(normalized.get("confidence", metadata.get("confidence", 0.0))),
+        "last_reviewed_at": normalized.get("last_reviewed_at"),
+        "validity": deepcopy(normalized.get("validity", {"valid": None, "errors": []})),
+        "mutation_policy": mutation["mutation_policy"],
+        "direct_write_allowed": mutation["direct_write_allowed"],
+        "policy": policy,
+    }
+    candidate["block_id"] = candidate["block_id"] or _block_id(candidate)
+    candidate["validity"] = validate_memory_block_candidate(candidate)
+    return candidate
+
+
+def create_memory_block_candidate(
+    block_type: str,
+    content: Any,
+    project_scope: str | None = None,
+    source_pattern_ids: list[str] | tuple[str, ...] | None = None,
+    source_fact_ids: list[str] | tuple[str, ...] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a review-only memory block candidate; never apply or persist it."""
+    return normalize_memory_block(
+        {
+            "block_type": block_type,
+            "status": "review_required",
+            "project_scope": project_scope,
+            "content": deepcopy(content),
+            "source_pattern_ids": list(source_pattern_ids or []),
+            "source_fact_ids": list(source_fact_ids or []),
+            "metadata": deepcopy(dict(metadata or {})),
+            "version": MEMORY_BLOCK_VERSION,
+            "policy": dict(MEMORY_BLOCK_POLICY),
+            "mutation_policy": MEMORY_BLOCK_MUTATION_POLICY["mutation_policy"],
+            "direct_write_allowed": MEMORY_BLOCK_MUTATION_POLICY["direct_write_allowed"],
+        }
+    )
+
+
+def compile_blocks_from_compiler_result(
+    compiler_result: Mapping[str, Any],
+    project_scope: str | None = None,
+) -> list[dict[str, Any]]:
+    """Convert Memory Compiler candidates into review-only Memory Blocks."""
+    source = deepcopy(dict(compiler_result))
+    if "procedure_block_candidate" not in source and "facts" in source:
+        source = compile_memory_patterns(
+            source.get("facts", []),
+            project_scope=project_scope or source.get("project_scope"),
+        )
+
+    procedure = source.get("procedure_block_candidate")
+    if not isinstance(procedure, Mapping):
+        return []
+
+    scope = project_scope if project_scope is not None else procedure.get("project_scope", source.get("project_scope"))
+    source_pattern_ids = list(procedure.get("source_pattern_ids", []))
+    source_fact_ids = _sorted_strings(procedure.get("source_fact_ids", [])) or _fact_ids_from_compiler_result(source)
+    content = {
+        "rules": deepcopy(list(procedure.get("rules", []))),
+        "safety_notes": deepcopy(list(procedure.get("safety_notes", []))),
+        "compiler_candidate_type": procedure.get("block_type"),
+        "applied": False,
+    }
+    return [
+        create_memory_block_candidate(
+            "procedural_rules",
+            content,
+            project_scope=scope,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+            metadata={
+                "source": "memory_compiler",
+                "source_event_id": source.get("source_event_id"),
+                "compiler_policy": deepcopy(source.get("policy", {})),
+            },
+        )
+    ]
+
+
+def validate_memory_block_candidate(block: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    block_type = block.get("block_type")
+    policy = _as_dict(block.get("policy"))
+
+    if block_type not in SUPPORTED_MEMORY_BLOCK_TYPES:
+        errors.append(f"unsupported_block_type:{block_type}")
+    if block.get("status") != "review_required":
+        errors.append("status_must_be_review_required")
+    if block.get("mutation_policy") != "proposal_only":
+        errors.append("mutation_policy_must_be_proposal_only")
+    if block.get("direct_write_allowed") is not False:
+        errors.append("direct_write_allowed_must_be_false")
+    for key, expected in MEMORY_BLOCK_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    if block.get("version") != MEMORY_BLOCK_VERSION:
+        errors.append("unsupported_version")
+    if not block.get("block_id"):
+        errors.append("missing_block_id")
+    if "content" not in block:
+        errors.append("missing_content")
+
+    return {"valid": not errors, "errors": errors}
+
+
+def explain_memory_block_candidate(block: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = normalize_memory_block(block)
+    return {
+        "block_id": normalized["block_id"],
+        "block_type": normalized["block_type"],
+        "status": normalized["status"],
+        "project_scope": normalized["project_scope"],
+        "source_pattern_count": len(normalized["source_pattern_ids"]),
+        "source_fact_count": len(normalized["source_fact_ids"]),
+        "review_required": True,
+        "applied": False,
+        "policy": dict(normalized["policy"]),
+        "validity": deepcopy(normalized["validity"]),
+    }
+
+
+def recommend_memory_block_action(block: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = normalize_memory_block(block)
+    validity = normalized["validity"]
+    if not validity["valid"]:
+        action = "reject_candidate"
+        reason = "The memory block candidate violates the v0.1 validation contract."
+    else:
+        action = "review_candidate"
+        reason = "The memory block candidate is valid but requires review before any governed proposal path."
+    return {
+        "action": action,
+        "reason": reason,
+        "creates_review_candidates_only": True,
+        "policy": dict(MEMORY_BLOCK_POLICY),
+    }
+
+
+def _block_id(block: Mapping[str, Any]) -> str:
+    identity = {
+        "block_type": block.get("block_type"),
+        "project_scope": block.get("project_scope"),
+        "content": block.get("content"),
+        "source_pattern_ids": list(block.get("source_pattern_ids", [])),
+        "source_fact_ids": list(block.get("source_fact_ids", [])),
+        "metadata": block.get("metadata", {}),
+        "version": block.get("version", MEMORY_BLOCK_VERSION),
+        "source_event_id": block.get("source_event_id"),
+        "confidence": block.get("confidence", 0.0),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-block:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _fact_ids_from_compiler_result(result: Mapping[str, Any]) -> list[str]:
+    fact_ids: list[str] = []
+    for pattern in result.get("patterns", []):
+        if isinstance(pattern, Mapping):
+            fact_ids.extend(_sorted_strings(pattern.get("fact_ids", [])))
+    return _sorted_strings(fact_ids)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _sorted_strings(values: Any) -> list[str]:
+    if values is None:
+        return []
+    return sorted({str(value) for value in values})
+
+
+def _confidence(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/agent/memory_compiler.py
+++ b/agent/memory_compiler.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Iterable, Mapping
+
+from agent.memory_bitemporal_fact_graph import BitemporalFact, normalize_fact, select_current_facts
+from agent.memory_contradiction_engine import explain_contradiction_group, group_contradictions
+
+
+MEMORY_COMPILER_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_review_candidates_only": True,
+}
+
+
+def compile_memory_patterns(
+    facts: Iterable[Mapping[str, Any] | BitemporalFact],
+    contradiction_groups: Iterable[Mapping[str, Any]] | None = None,
+    project_scope: str | None = None,
+) -> dict[str, Any]:
+    """Compile low-level facts into review-only methodology/procedure candidates."""
+    normalized = [normalize_fact(fact) for fact in facts]
+    scoped_facts = [fact for fact in normalized if project_scope is None or fact.project_id == project_scope]
+    compilation_time = _compilation_time(scoped_facts)
+    current_facts = select_current_facts(scoped_facts, compilation_time, project_scope=project_scope)
+    groups = _scoped_contradiction_groups(
+        contradiction_groups if contradiction_groups is not None else group_contradictions(scoped_facts),
+        project_scope,
+    )
+    patterns = _extract_patterns(scoped_facts, current_facts, groups, project_scope)
+    methodology = compile_methodology_candidate(patterns, project_scope=project_scope)
+    procedure = compile_procedure_block_candidate(methodology, project_scope=project_scope)
+    result = {
+        "project_scope": project_scope,
+        "input_fact_count": len(normalized),
+        "current_fact_count": len(current_facts),
+        "contradiction_group_count": len(groups),
+        "patterns": patterns,
+        "methodology_candidate": methodology,
+        "procedure_block_candidate": procedure,
+        "review_recommendation": recommend_compilation_action(
+            {
+                "patterns": patterns,
+                "methodology_candidate": methodology,
+                "procedure_block_candidate": procedure,
+                "policy": dict(MEMORY_COMPILER_POLICY),
+            }
+        ),
+        "trace": [],
+        "policy": dict(MEMORY_COMPILER_POLICY),
+    }
+    result["trace"] = explain_compilation_trace(result)
+    return result
+
+
+def compile_methodology_candidate(
+    patterns: Iterable[Mapping[str, Any]],
+    project_scope: str | None = None,
+) -> dict[str, Any]:
+    pattern_list = [dict(pattern) for pattern in patterns]
+    rules = [_rule_for_pattern(pattern) for pattern in pattern_list]
+    return {
+        "candidate_type": "methodology_candidate",
+        "status": "review_required",
+        "project_scope": project_scope,
+        "summary": "Review-only methodology candidate compiled from provided memory facts; it has not been applied.",
+        "rules": rules,
+        "source_pattern_ids": [pattern["pattern_id"] for pattern in pattern_list],
+        "pattern_count": len(pattern_list),
+        "policy": dict(MEMORY_COMPILER_POLICY),
+    }
+
+
+def compile_procedure_block_candidate(
+    methodology: Mapping[str, Any],
+    project_scope: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "block_type": "procedure_candidate",
+        "status": "review_required",
+        "project_scope": project_scope,
+        "rules": list(methodology.get("rules", [])),
+        "source_pattern_ids": list(methodology.get("source_pattern_ids", [])),
+        "safety_notes": [
+            "Candidate only; requires human review before any durable memory or graph action.",
+            "Compiler is read-only and does not create proposals or operation-ledger events.",
+            "Do not infer beyond the cited source patterns.",
+        ],
+        "policy": dict(MEMORY_COMPILER_POLICY),
+    }
+
+
+def explain_compilation_trace(result: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "step": "normalize_facts",
+            "detail": "Input facts were normalized with agent.memory_bitemporal_fact_graph.normalize_fact.",
+            "count": result.get("input_fact_count", 0),
+        },
+        {
+            "step": "select_current_facts",
+            "detail": "Current facts were selected with project-scope isolation.",
+            "count": result.get("current_fact_count", 0),
+        },
+        {
+            "step": "group_contradictions",
+            "detail": "Contradiction groups were included as review-required evidence.",
+            "count": result.get("contradiction_group_count", 0),
+        },
+        {
+            "step": "compile_candidates",
+            "detail": "Patterns were compiled into review-only methodology and procedure candidates.",
+            "pattern_count": len(result.get("patterns", [])),
+        },
+    ]
+
+
+def recommend_compilation_action(result: Mapping[str, Any]) -> dict[str, Any]:
+    patterns = list(result.get("patterns", []))
+    contradiction_patterns = [pattern for pattern in patterns if pattern.get("pattern_type") == "contradiction_review_required"]
+    if contradiction_patterns:
+        action = "review_contradictions_before_methodology"
+        reason = "One or more compiled patterns comes from contradiction groups and must be resolved before use."
+    elif patterns:
+        action = "review_candidate"
+        reason = "Compiled methodology and procedure candidates require review before any application or write path."
+    else:
+        action = "no_candidate"
+        reason = "No stable, evolutionary, or contradictory memory pattern was detected."
+    return {
+        "action": action,
+        "reason": reason,
+        "creates_review_candidates_only": True,
+        "policy": dict(MEMORY_COMPILER_POLICY),
+    }
+
+
+def _extract_patterns(
+    scoped_facts: list[BitemporalFact],
+    current_facts: list[BitemporalFact],
+    contradiction_groups: list[dict[str, Any]],
+    project_scope: str | None,
+) -> list[dict[str, Any]]:
+    patterns: list[dict[str, Any]] = []
+    patterns.extend(_stable_claim_patterns(scoped_facts))
+    patterns.extend(_evolution_patterns(scoped_facts, current_facts))
+    patterns.extend(_contradiction_patterns(contradiction_groups))
+    return sorted(
+        patterns,
+        key=lambda item: (
+            item.get("project_id") or project_scope or "",
+            item["pattern_type"],
+            item["pattern_id"],
+        ),
+    )
+
+
+def _stable_claim_patterns(facts: list[BitemporalFact]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str | None, str], list[BitemporalFact]] = {}
+    for fact in facts:
+        grouped.setdefault((fact.subject, fact.predicate, fact.project_id, fact.object), []).append(fact)
+
+    patterns: list[dict[str, Any]] = []
+    for (subject, predicate, project_id, obj), group in grouped.items():
+        if len(group) < 2:
+            continue
+        fact_ids = sorted(fact.fact_id for fact in group)
+        patterns.append(
+            {
+                "pattern_id": _pattern_id("stable", project_id, subject, predicate, obj),
+                "pattern_type": "stable_repeated_claim",
+                "subject": subject,
+                "predicate": predicate,
+                "project_id": project_id,
+                "object": obj,
+                "fact_ids": fact_ids,
+                "support_count": len(group),
+                "status": "review_required",
+                "summary": f"Repeated claim observed for {subject} / {predicate}; candidate only.",
+            }
+        )
+    return patterns
+
+
+def _evolution_patterns(scoped_facts: list[BitemporalFact], current_facts: list[BitemporalFact]) -> list[dict[str, Any]]:
+    by_id = {fact.fact_id: fact for fact in scoped_facts}
+    current_ids = {fact.fact_id for fact in current_facts}
+    patterns: list[dict[str, Any]] = []
+    for fact in scoped_facts:
+        superseded_ids = [fact_id for fact_id in fact.supersedes if fact_id in by_id]
+        if not superseded_ids:
+            continue
+        patterns.append(
+            {
+                "pattern_id": _pattern_id("evolution", fact.project_id, fact.subject, fact.predicate, fact.fact_id),
+                "pattern_type": "superseded_lineage_evolution",
+                "subject": fact.subject,
+                "predicate": fact.predicate,
+                "project_id": fact.project_id,
+                "current_fact_id": fact.fact_id,
+                "current_fact_is_selected": fact.fact_id in current_ids,
+                "superseded_fact_ids": sorted(superseded_ids),
+                "fact_ids": sorted([fact.fact_id, *superseded_ids]),
+                "status": "review_required",
+                "summary": "A fact supersedes earlier provided facts; treat as an evolution candidate requiring review.",
+            }
+        )
+    return patterns
+
+
+def _contradiction_patterns(contradiction_groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    patterns: list[dict[str, Any]] = []
+    for group in contradiction_groups:
+        explanation = explain_contradiction_group(group)
+        patterns.append(
+            {
+                "pattern_id": _pattern_id("contradiction", group.get("project_id"), group.get("subject"), group.get("predicate")),
+                "pattern_type": "contradiction_review_required",
+                "subject": group.get("subject"),
+                "predicate": group.get("predicate"),
+                "project_id": group.get("project_id"),
+                "group_id": group.get("group_id"),
+                "objects": list(group.get("objects", [])),
+                "fact_ids": list(group.get("fact_ids", [])),
+                "status": "review_required",
+                "explanation": explanation,
+                "summary": "Contradictory claims were detected; no methodology should be applied before review.",
+            }
+        )
+    return patterns
+
+
+def _rule_for_pattern(pattern: Mapping[str, Any]) -> dict[str, Any]:
+    pattern_type = pattern.get("pattern_type")
+    if pattern_type == "stable_repeated_claim":
+        text = "Candidate rule from repeated evidence: preserve the observed subject/predicate/object claim pending review."
+    elif pattern_type == "superseded_lineage_evolution":
+        text = "Candidate rule from lineage: preserve both current and superseded facts as an evolution trail pending review."
+    elif pattern_type == "contradiction_review_required":
+        text = "Candidate rule from contradiction: require human review before selecting or applying any conflicting claim."
+    else:
+        text = "Candidate rule requires review before use."
+    return {
+        "rule_id": f"rule:{pattern.get('pattern_id')}",
+        "status": "review_required",
+        "text": text,
+        "source_pattern_id": pattern.get("pattern_id"),
+    }
+
+
+def _scoped_contradiction_groups(
+    groups: Iterable[Mapping[str, Any]],
+    project_scope: str | None,
+) -> list[dict[str, Any]]:
+    scoped = [dict(group) for group in groups if project_scope is None or group.get("project_id") == project_scope]
+    return sorted(scoped, key=lambda item: (item.get("project_id") or "", item.get("subject") or "", item.get("predicate") or ""))
+
+
+def _compilation_time(facts: list[BitemporalFact]) -> datetime:
+    timestamps: list[datetime] = []
+    for fact in facts:
+        timestamps.extend(
+            timestamp
+            for timestamp in (fact.valid_from, fact.system_created_at, fact.valid_until, fact.system_invalidated_at)
+            if timestamp is not None
+        )
+    if not timestamps:
+        return datetime.max.replace(tzinfo=UTC)
+    return max(timestamps)
+
+
+def _pattern_id(kind: str, project_id: Any, subject: Any, predicate: Any, suffix: Any = None) -> str:
+    parts = [kind, str(project_id or "*"), str(subject or ""), str(predicate or "")]
+    if suffix is not None:
+        parts.append(str(suffix))
+    return "|".join(part.strip().replace(" ", "_") for part in parts if part is not None)

--- a/agent/memory_contradiction_engine.py
+++ b/agent/memory_contradiction_engine.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from itertools import combinations
+from typing import Any, Iterable, Mapping
+
+from agent.memory_bitemporal_fact_graph import BitemporalFact, normalize_fact
+
+
+CONTRADICTION_ENGINE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_review_recommendations_only": True,
+}
+
+RELATION_LABELS = (
+    "supports",
+    "updates",
+    "contradicts",
+    "unrelated",
+    "needs_review",
+)
+
+_UNSAFE_GOVERNANCE_TRUE_KEYS = (
+    "unsafe",
+    "write_allowed",
+    "would_write_memory",
+    "would_modify_config",
+    "would_write_graph",
+    "creates_operation_event",
+    "create_operation_event",
+    "approves_allowlist",
+    "approve_allowlist",
+    "external_auto_recall_allowed",
+)
+
+
+def classify_fact_relation(
+    existing_fact: Mapping[str, Any] | BitemporalFact,
+    candidate_fact: Mapping[str, Any] | BitemporalFact,
+) -> dict[str, Any]:
+    """Classify one existing/candidate fact pair without mutating either input."""
+    existing = normalize_fact(existing_fact)
+    candidate = normalize_fact(candidate_fact)
+    reasons: list[str] = []
+    risks: list[str] = []
+
+    same_scope = (
+        existing.subject == candidate.subject
+        and existing.predicate == candidate.predicate
+        and existing.project_id == candidate.project_id
+    )
+    if not same_scope:
+        relation = "unrelated"
+        reasons.append("subject_predicate_or_project_scope_differs")
+    else:
+        missing_provenance = _missing_provenance(existing) or _missing_provenance(candidate)
+        unsafe_governance = _unsafe_governance_reasons(existing.governance) + _unsafe_governance_reasons(candidate.governance)
+        low_confidence = min(existing.confidence, candidate.confidence) < 0.5
+
+        if missing_provenance:
+            risks.append("missing_provenance")
+        if unsafe_governance:
+            risks.extend(f"unsafe_governance:{reason}" for reason in sorted(set(unsafe_governance)))
+        if low_confidence:
+            risks.append("low_confidence")
+
+        if existing.object == candidate.object:
+            relation = "needs_review" if risks else "supports"
+            reasons.append("same_subject_predicate_project_and_object")
+        elif _candidate_updates_existing(existing, candidate):
+            relation = "needs_review" if risks else "updates"
+            reasons.append("candidate_validity_starts_after_existing_validity")
+        else:
+            relation = "needs_review" if risks else "contradicts"
+            reasons.append("same_subject_predicate_project_with_different_object")
+            if _validity_windows_overlap(existing, candidate):
+                reasons.append("validity_windows_overlap_or_are_open")
+            else:
+                reasons.append("validity_windows_do_not_overlap")
+
+    return {
+        "relation": relation,
+        "existing_fact": existing.to_json(),
+        "candidate_fact": candidate.to_json(),
+        "same_subject": existing.subject == candidate.subject,
+        "same_predicate": existing.predicate == candidate.predicate,
+        "same_project_id": existing.project_id == candidate.project_id,
+        "same_object": existing.object == candidate.object,
+        "validity_windows_overlap": _validity_windows_overlap(existing, candidate),
+        "confidence": {
+            "existing": existing.confidence,
+            "candidate": candidate.confidence,
+            "minimum": min(existing.confidence, candidate.confidence),
+        },
+        "risks": risks,
+        "reasons": reasons,
+        "policy": dict(CONTRADICTION_ENGINE_POLICY),
+    }
+
+
+def detect_contradiction_candidates(
+    existing_facts: Iterable[Mapping[str, Any] | BitemporalFact],
+    candidate_facts: Iterable[Mapping[str, Any] | BitemporalFact],
+) -> list[dict[str, Any]]:
+    """Return candidate classifications that need review or represent conflicts."""
+    classifications: list[dict[str, Any]] = []
+    for existing in existing_facts:
+        for candidate in candidate_facts:
+            relation = classify_fact_relation(existing, candidate)
+            if relation["relation"] in {"contradicts", "needs_review", "updates"}:
+                classifications.append(relation)
+    return sorted(
+        classifications,
+        key=lambda item: (
+            item["candidate_fact"].get("project_id") or "",
+            item["candidate_fact"]["subject"],
+            item["candidate_fact"]["predicate"],
+            item["candidate_fact"]["fact_id"],
+            item["existing_fact"]["fact_id"],
+        ),
+    )
+
+
+def group_contradictions(facts: Iterable[Mapping[str, Any] | BitemporalFact]) -> list[dict[str, Any]]:
+    """Group same subject/predicate/project facts that have conflicting objects."""
+    normalized = [normalize_fact(fact) for fact in facts]
+    grouped: dict[tuple[str, str, str | None], list[BitemporalFact]] = {}
+    for fact in normalized:
+        grouped.setdefault((fact.subject, fact.predicate, fact.project_id), []).append(fact)
+
+    contradiction_groups: list[dict[str, Any]] = []
+    for (subject, predicate, project_id), group in grouped.items():
+        objects = sorted({fact.object for fact in group})
+        if len(objects) < 2:
+            continue
+        relation_items = [
+            classify_fact_relation(existing, candidate)
+            for existing, candidate in combinations(sorted(group, key=lambda fact: fact.fact_id), 2)
+        ]
+        contradiction_groups.append(
+            {
+                "group_id": _group_id(subject, predicate, project_id),
+                "subject": subject,
+                "predicate": predicate,
+                "project_id": project_id,
+                "objects": objects,
+                "fact_ids": sorted(fact.fact_id for fact in group),
+                "facts": [fact.to_json() for fact in sorted(group, key=lambda fact: fact.fact_id)],
+                "relations": relation_items,
+                "policy": dict(CONTRADICTION_ENGINE_POLICY),
+            }
+        )
+    return sorted(
+        contradiction_groups,
+        key=lambda item: (item["project_id"] or "", item["subject"], item["predicate"], item["group_id"]),
+    )
+
+
+def explain_contradiction_group(group: Mapping[str, Any]) -> dict[str, Any]:
+    relations = list(group.get("relations", []))
+    labels = sorted({relation.get("relation") for relation in relations if relation.get("relation")})
+    risks = sorted({risk for relation in relations for risk in relation.get("risks", [])})
+    return {
+        "group_id": group.get("group_id"),
+        "subject": group.get("subject"),
+        "predicate": group.get("predicate"),
+        "project_id": group.get("project_id"),
+        "objects": list(group.get("objects", [])),
+        "fact_ids": list(group.get("fact_ids", [])),
+        "relation_labels": labels,
+        "risks": risks,
+        "summary": _summary_for_labels(labels, risks),
+        "recommended_action": recommend_contradiction_action(group),
+        "policy": dict(CONTRADICTION_ENGINE_POLICY),
+    }
+
+
+def recommend_contradiction_action(group: Mapping[str, Any]) -> dict[str, Any]:
+    """Recommend review-only next steps; this never creates proposals or writes state."""
+    relations = list(group.get("relations", []))
+    labels = {relation.get("relation") for relation in relations}
+    risks = sorted({risk for relation in relations for risk in relation.get("risks", [])})
+
+    if "needs_review" in labels:
+        action = "review_required"
+        reason = "One or more facts lack provenance, have low confidence, or carry unsafe governance indicators."
+    elif "contradicts" in labels:
+        action = "review_contradiction"
+        reason = "Conflicting objects share the same subject, predicate, and project scope."
+    elif "updates" in labels:
+        action = "review_update"
+        reason = "A newer candidate appears to update an expired or superseded fact."
+    else:
+        action = "no_action"
+        reason = "No contradictory relation was detected."
+
+    return {
+        "action": action,
+        "reason": reason,
+        "risks": risks,
+        "creates_review_recommendations_only": True,
+        "policy": dict(CONTRADICTION_ENGINE_POLICY),
+    }
+
+
+def _candidate_updates_existing(existing: BitemporalFact, candidate: BitemporalFact) -> bool:
+    if existing.fact_id in candidate.supersedes:
+        return True
+    if existing.valid_until and candidate.valid_from and existing.valid_until <= candidate.valid_from:
+        return True
+    if existing.system_invalidated_at and candidate.system_created_at:
+        return existing.system_invalidated_at <= candidate.system_created_at
+    return False
+
+
+def _validity_windows_overlap(left: BitemporalFact, right: BitemporalFact) -> bool:
+    left_start = left.valid_from or datetime.min.replace(tzinfo=UTC)
+    left_end = left.valid_until or datetime.max.replace(tzinfo=UTC)
+    right_start = right.valid_from or datetime.min.replace(tzinfo=UTC)
+    right_end = right.valid_until or datetime.max.replace(tzinfo=UTC)
+    return left_start < right_end and right_start < left_end
+
+
+def _missing_provenance(fact: BitemporalFact) -> bool:
+    return not (fact.provenance or fact.source_episode_id)
+
+
+def _unsafe_governance_reasons(governance: Mapping[str, Any] | None) -> list[str]:
+    if not governance:
+        return []
+    if not isinstance(governance, Mapping):
+        return []
+    reasons = [key for key in _UNSAFE_GOVERNANCE_TRUE_KEYS if governance.get(key) is True]
+    mode = str(governance.get("mode", "")).lower()
+    if any(marker in mode for marker in ("write", "mutate", "modify")):
+        reasons.append("mode")
+    if governance.get("read_only") is False:
+        reasons.append("read_only")
+    return reasons
+
+
+def _group_id(subject: str, predicate: str, project_id: str | None) -> str:
+    return "|".join((project_id or "*", subject, predicate))
+
+
+def _summary_for_labels(labels: list[str], risks: list[str]) -> str:
+    if "needs_review" in labels:
+        return "Conflicting memory facts require human review before any proposal or write path is considered."
+    if "contradicts" in labels:
+        return "Conflicting memory facts were detected in the same subject, predicate, and project scope."
+    if "updates" in labels:
+        return "A candidate appears to update an older expired fact and should be reviewed as a lineage change."
+    if risks:
+        return "Memory facts carry review risks even though no hard contradiction was detected."
+    return "No contradiction was detected."

--- a/agent/memory_evidence_repair_apply_preview.py
+++ b/agent/memory_evidence_repair_apply_preview.py
@@ -1,0 +1,355 @@
+"""Read-only apply previews for memory evidence repair candidates.
+
+The preview layer shows the exact evidence metadata patch that would be applied
+after a user confirms a repair candidate. It never writes to durable memory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+
+PATCH_OPERATION = "merge_evidence_metadata"
+PREVIEW_STATUS_AWAITING_CONFIRMATION = "awaiting_user_confirmation"
+PREVIEW_STATUS_READY_FOR_MANUAL_APPLY = "ready_for_manual_apply"
+PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE = "blocked_missing_evidence"
+PENDING_VALUE = "<pending>"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApplyPreview:
+    """One read-only evidence repair patch preview."""
+
+    id: str
+    candidate_id: str
+    status: str
+    provider: str
+    priority: str
+    repair_action: str
+    operation: str
+    target: dict[str, Any]
+    evidence_patch: dict[str, Any]
+    memory_patch_preview: dict[str, Any]
+    would_update_fields: tuple[str, ...]
+    missing_evidence: tuple[str, ...]
+    preconditions: tuple[str, ...]
+    content_preview: str
+    source: str
+    reason: str
+    safety_note: str
+    source_candidate: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "candidate_id": self.candidate_id,
+            "status": self.status,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "operation": self.operation,
+            "target": dict(self.target),
+            "evidence_patch": dict(self.evidence_patch),
+            "memory_patch_preview": dict(self.memory_patch_preview),
+            "would_update_fields": list(self.would_update_fields),
+            "missing_evidence": list(self.missing_evidence),
+            "preconditions": list(self.preconditions),
+            "content_preview": self.content_preview,
+            "source": self.source,
+            "reason": self.reason,
+            "safety_note": self.safety_note,
+            "source_candidate": dict(self.source_candidate),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApplyPreviewReport:
+    """Read-only evidence repair apply preview report."""
+
+    generated_at: str
+    previews: tuple[MemoryEvidenceRepairApplyPreview, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_status: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        missing_evidence_count = 0
+        ready_count = 0
+        awaiting_confirmation_count = 0
+        for preview in self.previews:
+            by_status[preview.status] = by_status.get(preview.status, 0) + 1
+            by_repair_action[preview.repair_action] = (
+                by_repair_action.get(preview.repair_action, 0) + 1
+            )
+            if preview.provider:
+                by_provider[preview.provider] = by_provider.get(preview.provider, 0) + 1
+            if preview.missing_evidence:
+                missing_evidence_count += 1
+            if preview.status == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY:
+                ready_count += 1
+            if preview.status == PREVIEW_STATUS_AWAITING_CONFIRMATION:
+                awaiting_confirmation_count += 1
+        return {
+            "preview_count": len(self.previews),
+            "ready_count": ready_count,
+            "awaiting_confirmation_count": awaiting_confirmation_count,
+            "missing_evidence_count": missing_evidence_count,
+            "by_status": by_status,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_user_confirmation": awaiting_confirmation_count > 0,
+            "has_previews": bool(self.previews),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "previews": [preview.to_dict() for preview in self.previews],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_apply_preview(
+    *,
+    approval: Mapping[str, Any] | None = None,
+    candidates: Sequence[Mapping[str, Any]] | None = None,
+    approved_candidate_ids: Sequence[str] | None = None,
+    proposed_evidence: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairApplyPreviewReport:
+    """Build read-only patch previews from evidence repair approval candidates."""
+
+    approval = approval if isinstance(approval, Mapping) else {}
+    proposed_evidence = (
+        proposed_evidence if isinstance(proposed_evidence, Mapping) else {}
+    )
+    candidate_rows = _candidate_rows(approval=approval, candidates=candidates)
+    approved_ids = _string_set(approved_candidate_ids)
+    filter_to_approved = approved_candidate_ids is not None
+
+    previews: list[MemoryEvidenceRepairApplyPreview] = []
+    for candidate in candidate_rows:
+        if not isinstance(candidate, Mapping):
+            continue
+        candidate_id = _str(candidate.get("id"))
+        if filter_to_approved and candidate_id not in approved_ids:
+            continue
+        preview = _preview_from_candidate(
+            candidate,
+            approved_ids=approved_ids,
+            approval_filter_enabled=filter_to_approved,
+            proposed_evidence=proposed_evidence,
+        )
+        if preview is not None:
+            previews.append(preview)
+
+    return MemoryEvidenceRepairApplyPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        previews=tuple(_dedupe_previews(previews)),
+    )
+
+
+def empty_evidence_repair_apply_preview() -> MemoryEvidenceRepairApplyPreviewReport:
+    """Return an empty read-only apply preview report."""
+
+    return MemoryEvidenceRepairApplyPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        previews=(),
+    )
+
+
+def _preview_from_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    approved_ids: set[str],
+    approval_filter_enabled: bool,
+    proposed_evidence: Mapping[str, Any],
+) -> MemoryEvidenceRepairApplyPreview | None:
+    candidate_id = _str(candidate.get("id"))
+    repair_action = _str(candidate.get("repair_action") or candidate.get("action"))
+    reason = _str(candidate.get("reason"))
+    if not candidate_id and not repair_action and not reason:
+        return None
+
+    if not candidate_id:
+        candidate_id = _stable_preview_source_id(candidate)
+    provider = _str(candidate.get("provider")) or "memory"
+    priority = _str(candidate.get("priority")) or "medium"
+    source = _str(candidate.get("source")) or "memory_evidence_repair_approval"
+    required_evidence = _required_evidence(candidate)
+    evidence_patch = _evidence_patch(
+        candidate_id=candidate_id,
+        required_evidence=required_evidence,
+        candidate=candidate,
+        proposed_evidence=proposed_evidence,
+    )
+    missing_evidence = tuple(
+        field for field in required_evidence if _is_missing(evidence_patch.get(field))
+    )
+    status = _preview_status(
+        candidate_id=candidate_id,
+        approved_ids=approved_ids,
+        approval_filter_enabled=approval_filter_enabled,
+        missing_evidence=missing_evidence,
+    )
+    target = {
+        "candidate_id": candidate_id,
+        "provider": provider,
+        "source": source,
+    }
+    memory_patch = {
+        "operation": PATCH_OPERATION,
+        "target": target,
+        "set": {
+            "evidence": evidence_patch,
+            "evidence_repair": {
+                "candidate_id": candidate_id,
+                "repair_action": repair_action,
+                "reason": reason,
+                "source": source,
+            },
+        },
+    }
+    return MemoryEvidenceRepairApplyPreview(
+        id=_stable_preview_id(candidate_id, evidence_patch),
+        candidate_id=candidate_id,
+        status=status,
+        provider=provider,
+        priority=priority,
+        repair_action=repair_action or "attach_provenance",
+        operation=PATCH_OPERATION,
+        target=target,
+        evidence_patch=evidence_patch,
+        memory_patch_preview=memory_patch,
+        would_update_fields=tuple(evidence_patch.keys()),
+        missing_evidence=missing_evidence,
+        preconditions=_preconditions(status, missing_evidence),
+        content_preview=_str(candidate.get("content_preview"))[:280],
+        source=source,
+        reason=reason or "Evidence repair apply preview needs review.",
+        safety_note=(
+            "Preview only. This patch must not be applied to durable memory "
+            "until the user explicitly confirms it."
+        ),
+        source_candidate=dict(candidate),
+    )
+
+
+def _candidate_rows(
+    *,
+    approval: Mapping[str, Any],
+    candidates: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if candidates is not None:
+        return list(candidates)
+    value = approval.get("candidates")
+    return value if isinstance(value, list) else []
+
+
+def _evidence_patch(
+    *,
+    candidate_id: str,
+    required_evidence: tuple[str, ...],
+    candidate: Mapping[str, Any],
+    proposed_evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    candidate_patch = candidate.get("proposed_evidence_patch")
+    candidate_patch = candidate_patch if isinstance(candidate_patch, Mapping) else {}
+    scoped_patch = proposed_evidence.get(candidate_id)
+    scoped_patch = scoped_patch if isinstance(scoped_patch, Mapping) else {}
+    patch: dict[str, Any] = {}
+    for field in required_evidence:
+        if field in scoped_patch and not _is_missing(scoped_patch[field]):
+            patch[field] = scoped_patch[field]
+        elif field in proposed_evidence and not _is_missing(proposed_evidence[field]):
+            patch[field] = proposed_evidence[field]
+        elif field in candidate_patch:
+            patch[field] = candidate_patch[field]
+        else:
+            patch[field] = PENDING_VALUE
+    return patch
+
+
+def _preview_status(
+    *,
+    candidate_id: str,
+    approved_ids: set[str],
+    approval_filter_enabled: bool,
+    missing_evidence: tuple[str, ...],
+) -> str:
+    if missing_evidence:
+        return PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE
+    if approval_filter_enabled and candidate_id in approved_ids:
+        return PREVIEW_STATUS_READY_FOR_MANUAL_APPLY
+    return PREVIEW_STATUS_AWAITING_CONFIRMATION
+
+
+def _preconditions(status: str, missing_evidence: tuple[str, ...]) -> tuple[str, ...]:
+    preconditions = ["explicit_user_confirmation"]
+    if missing_evidence:
+        preconditions.append("complete_required_evidence")
+    if status == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY:
+        preconditions.append("manual_apply_only")
+    return tuple(preconditions)
+
+
+def _required_evidence(candidate: Mapping[str, Any]) -> tuple[str, ...]:
+    required = candidate.get("required_evidence")
+    if isinstance(required, (list, tuple)):
+        fields = tuple(_str(item) for item in required if _str(item))
+        if fields:
+            return fields
+    patch = candidate.get("proposed_evidence_patch")
+    if isinstance(patch, Mapping) and patch:
+        return tuple(_str(field) for field in patch.keys() if _str(field))
+    return ("source_url", "observed_at", "verification_signal")
+
+
+def _dedupe_previews(
+    previews: list[MemoryEvidenceRepairApplyPreview],
+) -> list[MemoryEvidenceRepairApplyPreview]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairApplyPreview] = []
+    for preview in previews:
+        if preview.id in seen:
+            continue
+        seen.add(preview.id)
+        deduped.append(preview)
+    return deduped
+
+
+def _stable_preview_id(candidate_id: str, evidence_patch: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        {"candidate_id": candidate_id, "evidence_patch": dict(evidence_patch)},
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"preview-{digest}"
+
+
+def _stable_preview_source_id(candidate: Mapping[str, Any]) -> str:
+    raw = json.dumps(dict(candidate), sort_keys=True, ensure_ascii=False, default=str)
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"repair-{digest}"
+
+
+def _string_set(value: Sequence[str] | None) -> set[str]:
+    if value is None:
+        return set()
+    return {_str(item) for item in value if _str(item)}
+
+
+def _is_missing(value: Any) -> bool:
+    return value in (None, "", PENDING_VALUE)
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_approval.py
+++ b/agent/memory_evidence_repair_approval.py
@@ -1,0 +1,246 @@
+"""Read-only approval candidates for memory evidence repair.
+
+This layer converts an evidence repair plan into human-confirmable candidate
+records. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+CANDIDATE_TYPE = "memory_evidence_repair"
+STATUS_NEEDS_CONFIRMATION = "needs_user_confirmation"
+PENDING_VALUE = "<pending>"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalCandidate:
+    """One read-only repair candidate that needs user confirmation."""
+
+    id: str
+    candidate_type: str
+    status: str
+    provider: str
+    priority: str
+    repair_action: str
+    source: str
+    reason: str
+    content_preview: str
+    required_evidence: tuple[str, ...]
+    proposed_evidence_patch: dict[str, Any]
+    confirmation_question: str
+    safety_note: str
+    source_repair: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "candidate_type": self.candidate_type,
+            "status": self.status,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "source": self.source,
+            "reason": self.reason,
+            "content_preview": self.content_preview,
+            "required_evidence": list(self.required_evidence),
+            "proposed_evidence_patch": dict(self.proposed_evidence_patch),
+            "confirmation_question": self.confirmation_question,
+            "safety_note": self.safety_note,
+            "source_repair": dict(self.source_repair),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalReport:
+    """Read-only approval candidate report."""
+
+    generated_at: str
+    candidates: tuple[MemoryEvidenceRepairApprovalCandidate, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_priority: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        for candidate in self.candidates:
+            by_priority[candidate.priority] = by_priority.get(candidate.priority, 0) + 1
+            by_repair_action[candidate.repair_action] = (
+                by_repair_action.get(candidate.repair_action, 0) + 1
+            )
+            if candidate.provider:
+                by_provider[candidate.provider] = by_provider.get(candidate.provider, 0) + 1
+        return {
+            "candidate_count": len(self.candidates),
+            "by_priority": by_priority,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_user_confirmation": bool(self.candidates),
+            "has_candidates": bool(self.candidates),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+
+def build_evidence_repair_approval_candidates(
+    *,
+    plan: Mapping[str, Any] | None = None,
+    proposed_evidence: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairApprovalReport:
+    """Build read-only approval candidates from an evidence repair plan."""
+
+    plan = plan if isinstance(plan, Mapping) else {}
+    proposed_evidence = (
+        proposed_evidence if isinstance(proposed_evidence, Mapping) else {}
+    )
+    candidates: list[MemoryEvidenceRepairApprovalCandidate] = []
+    for repair in _list(plan.get("repairs")):
+        if not isinstance(repair, Mapping):
+            continue
+        candidate = _candidate_from_repair(repair, proposed_evidence)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    return MemoryEvidenceRepairApprovalReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        candidates=tuple(_dedupe_candidates(candidates)),
+    )
+
+
+def empty_evidence_repair_approval_candidates() -> MemoryEvidenceRepairApprovalReport:
+    """Return an empty read-only approval candidate report."""
+
+    return MemoryEvidenceRepairApprovalReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        candidates=(),
+    )
+
+
+def _candidate_from_repair(
+    repair: Mapping[str, Any],
+    proposed_evidence: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalCandidate | None:
+    action = _str(repair.get("action") or repair.get("repair_action"))
+    reason = _str(repair.get("reason"))
+    if not action and not reason:
+        return None
+
+    provider = _str(repair.get("provider")) or "memory"
+    priority = _str(repair.get("priority")) or "medium"
+    source = _str(repair.get("source")) or "memory_evidence_repair_plan"
+    content_preview = _content_preview(repair)
+    required_evidence = _required_evidence(repair.get("required_evidence"))
+    candidate_id = _stable_candidate_id(
+        provider=provider,
+        action=action,
+        source=source,
+        reason=reason,
+        content_preview=content_preview,
+    )
+    proposed_patch = {
+        field: _proposed_value(field, proposed_evidence) for field in required_evidence
+    }
+    return MemoryEvidenceRepairApprovalCandidate(
+        id=candidate_id,
+        candidate_type=CANDIDATE_TYPE,
+        status=STATUS_NEEDS_CONFIRMATION,
+        provider=provider,
+        priority=priority,
+        repair_action=action,
+        source=source,
+        reason=reason or "Evidence repair needs user confirmation.",
+        content_preview=content_preview,
+        required_evidence=required_evidence,
+        proposed_evidence_patch=proposed_patch,
+        confirmation_question=_confirmation_question(action, required_evidence),
+        safety_note=(
+            "Read-only candidate. Do not write this repair to memory until the "
+            "user explicitly confirms the evidence patch."
+        ),
+        source_repair=dict(repair),
+    )
+
+
+def _dedupe_candidates(
+    candidates: list[MemoryEvidenceRepairApprovalCandidate],
+) -> list[MemoryEvidenceRepairApprovalCandidate]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairApprovalCandidate] = []
+    for candidate in candidates:
+        if candidate.id in seen:
+            continue
+        seen.add(candidate.id)
+        deduped.append(candidate)
+    return deduped
+
+
+def _stable_candidate_id(
+    *,
+    provider: str,
+    action: str,
+    source: str,
+    reason: str,
+    content_preview: str,
+) -> str:
+    raw = json.dumps(
+        {
+            "provider": provider,
+            "action": action,
+            "source": source,
+            "reason": reason,
+            "content_preview": content_preview,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"repair-{digest}"
+
+
+def _required_evidence(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ("source_url", "observed_at", "verification_signal")
+    fields = tuple(_str(item) for item in value if _str(item))
+    return fields or ("source_url", "observed_at", "verification_signal")
+
+
+def _proposed_value(field: str, proposed_evidence: Mapping[str, Any]) -> Any:
+    if field in proposed_evidence and proposed_evidence[field] not in (None, ""):
+        return proposed_evidence[field]
+    return PENDING_VALUE
+
+
+def _confirmation_question(action: str, required_evidence: tuple[str, ...]) -> str:
+    evidence_list = ", ".join(required_evidence) or "the required evidence"
+    if action == "refresh_observation":
+        return f"Can you confirm the refreshed {evidence_list} for this memory?"
+    if action == "review_conflict":
+        return f"Can you confirm the conflict resolution and {evidence_list}?"
+    return f"Can you confirm {evidence_list} for this memory evidence repair?"
+
+
+def _content_preview(repair: Mapping[str, Any]) -> str:
+    preview = _str(repair.get("content_preview"))
+    if not preview:
+        preview = _str(repair.get("evidence"))
+    return preview[:280]
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_approval_token_gate.py
+++ b/agent/memory_evidence_repair_approval_token_gate.py
@@ -1,0 +1,617 @@
+"""Read-only approval token verification gate for memory evidence repair.
+
+The gate verifies a drafted human approval token against the current dry-run,
+confirmation text, expiry window, and one-time-use hints. It never writes to
+durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_human_approval_token import (
+    APPROVAL_TOKEN_SCOPE,
+    APPROVAL_TOKEN_TYPE,
+    TOKEN_STATUS_DRAFT_READY,
+    TOKEN_STATUS_NO_ACTION_NEEDED,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+    DRY_RUN_STATUS_NO_ACTION_NEEDED,
+    DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+)
+
+
+TOKEN_GATE_STATUS_VERIFIED = "verified_for_manual_commit"
+TOKEN_GATE_STATUS_BLOCKED = "blocked"
+TOKEN_GATE_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_TOKEN_SHAPE = "token_shape"
+CHECK_CONFIRMATION_TEXT = "confirmation_text"
+CHECK_TOKEN_DIGEST = "token_digest"
+CHECK_DRY_RUN_DIGEST = "dry_run_digest"
+CHECK_PATCH_DIGESTS = "patch_digests"
+CHECK_EXPIRY = "expiry"
+CHECK_ONE_TIME_CONSTRAINTS = "one_time_constraints"
+CHECK_REUSE = "reuse"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalTokenGateCheck:
+    """One read-only approval token verification check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairApprovalTokenGateReport:
+    """Read-only approval token gate report."""
+
+    generated_at: str
+    status: str
+    token_id: str
+    dry_run_status: str
+    checks: tuple[MemoryEvidenceRepairApprovalTokenGateCheck, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    verified_operation_ids: tuple[str, ...]
+    verified_candidate_ids: tuple[str, ...]
+    verified_patch_digests: tuple[str, ...]
+    source_token: dict[str, Any]
+    source_dry_run: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "token_id": self.token_id,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "verified_operation_count": len(self.verified_operation_ids),
+            "manual_commit_verified": self.status == TOKEN_GATE_STATUS_VERIFIED,
+            "has_blocks": self.status == TOKEN_GATE_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "token_id": self.token_id,
+            "dry_run_status": self.dry_run_status,
+            "checks": [check.to_dict() for check in self.checks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "verified_operation_ids": list(self.verified_operation_ids),
+            "verified_candidate_ids": list(self.verified_candidate_ids),
+            "verified_patch_digests": list(self.verified_patch_digests),
+            "source_token": dict(self.source_token),
+            "source_dry_run": dict(self.source_dry_run),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_approval_token_gate(
+    *,
+    approval_token: Mapping[str, Any] | None = None,
+    dry_run: Mapping[str, Any] | None = None,
+    confirmation_text: str = "",
+    used_token_ids: Sequence[str] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairApprovalTokenGateReport:
+    """Verify a human approval token without mutating memory."""
+
+    token, issued_at = _extract_token_and_issued_at(approval_token)
+    explicit_dry_run = dry_run if isinstance(dry_run, Mapping) else {}
+    token_dry_run = token.get("source_dry_run") if isinstance(token, Mapping) else {}
+    current_dry_run = explicit_dry_run or (
+        token_dry_run if isinstance(token_dry_run, Mapping) else {}
+    )
+    current_dry_run = current_dry_run if isinstance(current_dry_run, Mapping) else {}
+
+    approval_token_status = (
+        _str(approval_token.get("status")) if isinstance(approval_token, Mapping) else ""
+    )
+    if not token:
+        dry_run_status = _str(current_dry_run.get("status"))
+        if (
+            approval_token_status == TOKEN_STATUS_NO_ACTION_NEEDED
+            or dry_run_status == DRY_RUN_STATUS_NO_ACTION_NEEDED
+            or (not current_dry_run and not approval_token_status)
+        ):
+            return _empty_report(dry_run=current_dry_run)
+        source_blocking = _list(approval_token.get("blocking_reasons")) if isinstance(approval_token, Mapping) else []
+        source_actions = _list(approval_token.get("required_actions")) if isinstance(approval_token, Mapping) else []
+        return _blocked_report(
+            token_id="",
+            dry_run=current_dry_run,
+            checks=(
+                _fail(
+                    CHECK_TOKEN_SHAPE,
+                    "No approval token was supplied."
+                    if not source_blocking
+                    else "; ".join(_str(item) for item in source_blocking if _str(item)),
+                    tuple(_str(item) for item in source_actions if _str(item))
+                    or ("draft_human_approval_token",),
+                    {"approval_token_status": approval_token_status},
+                ),
+            ),
+        )
+
+    checks = tuple(
+        check
+        for check in (
+            _token_shape_check(token),
+            _confirmation_check(token, confirmation_text),
+            _token_digest_check(token),
+            _dry_run_digest_check(token, current_dry_run),
+            _patch_digest_check(token, current_dry_run),
+            _expiry_check(token, issued_at, current_time),
+            _one_time_constraint_check(token),
+            _reuse_check(token, used_token_ids),
+        )
+        if check is not None
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    status = (
+        TOKEN_GATE_STATUS_VERIFIED
+        if checks and not blocking_reasons
+        else TOKEN_GATE_STATUS_BLOCKED
+    )
+    operations = _operation_rows(current_dry_run)
+    return MemoryEvidenceRepairApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        token_id=_str(token.get("id")),
+        dry_run_status=_str(current_dry_run.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=tuple(_str(operation.get("id")) for operation in operations),
+        verified_candidate_ids=tuple(_str(operation.get("candidate_id")) for operation in operations),
+        verified_patch_digests=tuple(_str(operation.get("patch_digest")) for operation in operations),
+        source_token=dict(token),
+        source_dry_run=dict(current_dry_run),
+    )
+
+
+def empty_evidence_repair_approval_token_gate() -> MemoryEvidenceRepairApprovalTokenGateReport:
+    """Return an empty read-only approval token gate report."""
+
+    return _empty_report(dry_run={})
+
+
+def _empty_report(*, dry_run: Mapping[str, Any]) -> MemoryEvidenceRepairApprovalTokenGateReport:
+    return MemoryEvidenceRepairApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+        token_id="",
+        dry_run_status=_str(dry_run.get("status")),
+        checks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        verified_operation_ids=(),
+        verified_candidate_ids=(),
+        verified_patch_digests=(),
+        source_token={},
+        source_dry_run=dict(dry_run),
+    )
+
+
+def _blocked_report(
+    *,
+    token_id: str,
+    dry_run: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairApprovalTokenGateCheck, ...],
+) -> MemoryEvidenceRepairApprovalTokenGateReport:
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    return MemoryEvidenceRepairApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=TOKEN_GATE_STATUS_BLOCKED,
+        token_id=token_id,
+        dry_run_status=_str(dry_run.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=(),
+        verified_candidate_ids=(),
+        verified_patch_digests=(),
+        source_token={},
+        source_dry_run=dict(dry_run),
+    )
+
+
+def _extract_token_and_issued_at(
+    approval_token: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], str]:
+    if not isinstance(approval_token, Mapping):
+        return {}, ""
+    report_issued_at = _str(approval_token.get("generated_at"))
+    token: Mapping[str, Any] | None = None
+    tokens = approval_token.get("tokens")
+    if isinstance(tokens, list):
+        token = next((item for item in tokens if isinstance(item, Mapping)), None)
+    elif _str(approval_token.get("id")):
+        token = approval_token
+    if not isinstance(token, Mapping):
+        return {}, report_issued_at
+    issued_at = (
+        _str(token.get("issued_at"))
+        or _str(token.get("generated_at"))
+        or report_issued_at
+    )
+    return dict(token), issued_at
+
+
+def _token_shape_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    reasons: list[str] = []
+    if not _str(token.get("id")).startswith("approval-token-"):
+        reasons.append("Token id is missing or invalid.")
+    if _str(token.get("token_type")) != APPROVAL_TOKEN_TYPE:
+        reasons.append("Token type is not a memory evidence repair human approval token.")
+    if _str(token.get("scope")) != APPROVAL_TOKEN_SCOPE:
+        reasons.append("Token scope does not match manual memory evidence repair commit.")
+    if _str(token.get("status")) != TOKEN_STATUS_DRAFT_READY:
+        reasons.append("Token is not a ready approval draft.")
+    if reasons:
+        return _fail(
+            CHECK_TOKEN_SHAPE,
+            " ".join(reasons),
+            ("regenerate_human_approval_token",),
+            {"token_id": _str(token.get("id"))},
+        )
+    return _pass(
+        CHECK_TOKEN_SHAPE,
+        "Approval token shape is valid.",
+        {"token_id": _str(token.get("id"))},
+    )
+
+
+def _confirmation_check(
+    token: Mapping[str, Any],
+    confirmation_text: str,
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    expected = _str(token.get("required_confirmation_text"))
+    actual = _str(confirmation_text)
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str(constraints.get("requires_exact_confirmation_text"))
+    expected_values = {item for item in (expected, constraint_expected) if item}
+    if not actual or actual not in expected_values:
+        return _fail(
+            CHECK_CONFIRMATION_TEXT,
+            "Confirmation text does not exactly match the approval token.",
+            ("provide_exact_confirmation_text",),
+            {"expected_confirmation_text": expected or constraint_expected, "provided": actual},
+        )
+    return _pass(
+        CHECK_CONFIRMATION_TEXT,
+        "Confirmation text matches the approval token.",
+        {"provided": actual},
+    )
+
+
+def _token_digest_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    expected_digest = _expected_token_digest(token)
+    actual_digest = _str(token.get("token_digest"))
+    expected_id = f"approval-token-{expected_digest[:16]}" if expected_digest else ""
+    if actual_digest != expected_digest or _str(token.get("id")) != expected_id:
+        return _fail(
+            CHECK_TOKEN_DIGEST,
+            "Approval token digest or id does not match its declared payload.",
+            ("regenerate_human_approval_token",),
+            {
+                "expected_token_digest": expected_digest,
+                "actual_token_digest": actual_digest,
+                "expected_token_id": expected_id,
+                "actual_token_id": _str(token.get("id")),
+            },
+        )
+    return _pass(
+        CHECK_TOKEN_DIGEST,
+        "Approval token digest matches its declared payload.",
+        {"token_digest": actual_digest, "token_id": expected_id},
+    )
+
+
+def _dry_run_digest_check(
+    token: Mapping[str, Any],
+    dry_run: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    if _str(dry_run.get("status")) != DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT:
+        return _fail(
+            CHECK_DRY_RUN_DIGEST,
+            "Current dry-run is not ready for manual commit.",
+            ("produce_ready_manual_commit_dry_run",),
+            {"dry_run_status": _str(dry_run.get("status"))},
+        )
+    actual = _dry_run_digest(dry_run)
+    expected = _str(token.get("dry_run_digest"))
+    if not expected or actual != expected:
+        return _fail(
+            CHECK_DRY_RUN_DIGEST,
+            "Current dry-run digest does not match the approval token.",
+            ("regenerate_human_approval_token_for_current_dry_run",),
+            {"expected_dry_run_digest": expected, "actual_dry_run_digest": actual},
+        )
+    return _pass(
+        CHECK_DRY_RUN_DIGEST,
+        "Current dry-run digest matches the approval token.",
+        {"dry_run_digest": actual},
+    )
+
+
+def _patch_digest_check(
+    token: Mapping[str, Any],
+    dry_run: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    expected = _str_list(token.get("patch_digests"))
+    actual = [_str(operation.get("patch_digest")) for operation in _operation_rows(dry_run)]
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str_list(constraints.get("requires_same_patch_digests"))
+    if expected != actual or (constraint_expected and constraint_expected != actual):
+        return _fail(
+            CHECK_PATCH_DIGESTS,
+            "Current dry-run patch digests do not match the approval token.",
+            ("regenerate_human_approval_token_for_current_patch_set",),
+            {
+                "expected_patch_digests": expected,
+                "constraint_patch_digests": constraint_expected,
+                "actual_patch_digests": actual,
+            },
+        )
+    return _pass(
+        CHECK_PATCH_DIGESTS,
+        "Current dry-run patch digests match the approval token.",
+        {"patch_digests": actual},
+    )
+
+
+def _expiry_check(
+    token: Mapping[str, Any],
+    issued_at: str,
+    current_time: str | datetime | None,
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    issued = _parse_datetime(issued_at)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+    expires_in_minutes = _positive_int(token.get("expires_in_minutes")) or 30
+    if issued is None:
+        return _fail(
+            CHECK_EXPIRY,
+            "Approval token issue time is missing or invalid.",
+            ("provide_token_generated_at_or_regenerate_token",),
+            {"issued_at": issued_at},
+        )
+    expires_at = issued + timedelta(minutes=expires_in_minutes)
+    if now > expires_at:
+        return _fail(
+            CHECK_EXPIRY,
+            "Approval token has expired.",
+            ("regenerate_human_approval_token",),
+            {
+                "issued_at": issued.isoformat(),
+                "expires_at": expires_at.isoformat(),
+                "current_time": now.isoformat(),
+            },
+        )
+    return _pass(
+        CHECK_EXPIRY,
+        "Approval token is within its expiry window.",
+        {
+            "issued_at": issued.isoformat(),
+            "expires_at": expires_at.isoformat(),
+            "current_time": now.isoformat(),
+        },
+    )
+
+
+def _one_time_constraint_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    constraints = _dict(token.get("one_time_constraints"))
+    if constraints.get("one_time_use") is not True:
+        return _fail(
+            CHECK_ONE_TIME_CONSTRAINTS,
+            "Approval token does not declare one-time-use constraints.",
+            ("regenerate_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    expected_dry_run = _str(constraints.get("requires_exact_dry_run_digest"))
+    if expected_dry_run != _str(token.get("dry_run_digest")):
+        return _fail(
+            CHECK_ONE_TIME_CONSTRAINTS,
+            "Approval token dry-run constraint does not match its digest.",
+            ("regenerate_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    return _pass(
+        CHECK_ONE_TIME_CONSTRAINTS,
+        "Approval token one-time constraints are declared.",
+        {"one_time_constraints": constraints},
+    )
+
+
+def _reuse_check(
+    token: Mapping[str, Any],
+    used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    token_id = _str(token.get("id"))
+    used = {_str(item) for item in used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_REUSE,
+            "Approval token is already marked as used.",
+            ("regenerate_human_approval_token",),
+            {"token_id": token_id},
+        )
+    return _pass(
+        CHECK_REUSE,
+        "Approval token is not marked as used in the supplied read-only ledger.",
+        {"token_id": token_id, "used_token_id_count": len(used)},
+    )
+
+
+def _expected_token_digest(token: Mapping[str, Any]) -> str:
+    token_seed = {
+        "token_type": APPROVAL_TOKEN_TYPE,
+        "scope": APPROVAL_TOKEN_SCOPE,
+        "approver": _str(token.get("approver")) or "human",
+        "approval_reason": _str(token.get("approval_reason")),
+        "dry_run_digest": _str(token.get("dry_run_digest")),
+        "operation_ids": _str_list(token.get("operation_ids")),
+        "ledger_entry_ids": _str_list(token.get("ledger_entry_ids")),
+        "candidate_ids": _str_list(token.get("candidate_ids")),
+        "patch_digests": _str_list(token.get("patch_digests")),
+        "expires_in_minutes": _positive_int(token.get("expires_in_minutes")) or 30,
+    }
+    return _digest(token_seed)
+
+
+def _dry_run_digest(dry_run: Mapping[str, Any]) -> str:
+    return _digest(
+        {
+            "status": dry_run.get("status"),
+            "operations": _operation_rows(dry_run),
+            "checks": dry_run.get("checks"),
+        }
+    )
+
+
+def _operation_rows(dry_run: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    return MemoryEvidenceRepairApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairApprovalTokenGateCheck:
+    return MemoryEvidenceRepairApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | None) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _str_list(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_commit_gate.py
+++ b/agent/memory_evidence_repair_commit_gate.py
@@ -1,0 +1,354 @@
+"""Read-only commit gate for memory evidence repair previews.
+
+The gate decides whether a repair preview is ready for a later manual write.
+It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_apply_preview import (
+    PATCH_OPERATION,
+    PREVIEW_STATUS_READY_FOR_MANUAL_APPLY,
+)
+
+
+DECISION_ALLOW_MANUAL_COMMIT = "allow_manual_commit"
+DECISION_BLOCK_COMMIT = "block_commit"
+DECISION_NEEDS_USER_CONFIRMATION = "needs_user_confirmation"
+
+REASON_MISSING_EVIDENCE = "missing_evidence"
+REASON_MISSING_CONFIRMATION = "missing_user_confirmation"
+REASON_PREVIEW_NOT_READY = "preview_not_ready"
+REASON_UNSAFE_OPERATION = "unsafe_operation"
+REASON_PATCH_SHAPE_INVALID = "patch_shape_invalid"
+REASON_CONFLICT_REQUIRES_REVIEW = "conflict_requires_review"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitGateDecision:
+    """One read-only commit gate decision for a repair preview."""
+
+    id: str
+    preview_id: str
+    candidate_id: str
+    decision: str
+    provider: str
+    priority: str
+    repair_action: str
+    reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    target: dict[str, Any]
+    evidence_patch: dict[str, Any]
+    memory_patch_preview: dict[str, Any]
+    conflict_risk: str
+    safety_note: str
+    source_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "preview_id": self.preview_id,
+            "candidate_id": self.candidate_id,
+            "decision": self.decision,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "reasons": list(self.reasons),
+            "required_actions": list(self.required_actions),
+            "target": dict(self.target),
+            "evidence_patch": dict(self.evidence_patch),
+            "memory_patch_preview": dict(self.memory_patch_preview),
+            "conflict_risk": self.conflict_risk,
+            "safety_note": self.safety_note,
+            "source_preview": dict(self.source_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitGateReport:
+    """Read-only commit gate report."""
+
+    generated_at: str
+    decisions: tuple[MemoryEvidenceRepairCommitGateDecision, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_decision: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        allow_count = 0
+        blocked_count = 0
+        needs_confirmation_count = 0
+        for decision in self.decisions:
+            by_decision[decision.decision] = by_decision.get(decision.decision, 0) + 1
+            by_repair_action[decision.repair_action] = (
+                by_repair_action.get(decision.repair_action, 0) + 1
+            )
+            if decision.provider:
+                by_provider[decision.provider] = by_provider.get(decision.provider, 0) + 1
+            if decision.decision == DECISION_ALLOW_MANUAL_COMMIT:
+                allow_count += 1
+            elif decision.decision == DECISION_NEEDS_USER_CONFIRMATION:
+                needs_confirmation_count += 1
+            elif decision.decision == DECISION_BLOCK_COMMIT:
+                blocked_count += 1
+        return {
+            "decision_count": len(self.decisions),
+            "allow_count": allow_count,
+            "blocked_count": blocked_count,
+            "needs_confirmation_count": needs_confirmation_count,
+            "by_decision": by_decision,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "has_allowances": allow_count > 0,
+            "has_blocks": blocked_count > 0,
+            "requires_user_confirmation": needs_confirmation_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "decisions": [decision.to_dict() for decision in self.decisions],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_commit_gate(
+    *,
+    preview: Mapping[str, Any] | None = None,
+    previews: Sequence[Mapping[str, Any]] | None = None,
+    confirmed_preview_ids: Sequence[str] | None = None,
+    user_confirmed: bool = False,
+) -> MemoryEvidenceRepairCommitGateReport:
+    """Build read-only commit gate decisions from apply previews."""
+
+    preview = preview if isinstance(preview, Mapping) else {}
+    preview_rows = _preview_rows(preview=preview, previews=previews)
+    confirmed_ids = _string_set(confirmed_preview_ids)
+    decisions: list[MemoryEvidenceRepairCommitGateDecision] = []
+    for row in preview_rows:
+        if not isinstance(row, Mapping):
+            continue
+        decision = _decision_from_preview(
+            row,
+            confirmed_preview_ids=confirmed_ids,
+            user_confirmed=user_confirmed,
+        )
+        if decision is not None:
+            decisions.append(decision)
+
+    return MemoryEvidenceRepairCommitGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        decisions=tuple(_dedupe_decisions(decisions)),
+    )
+
+
+def empty_evidence_repair_commit_gate() -> MemoryEvidenceRepairCommitGateReport:
+    """Return an empty read-only commit gate report."""
+
+    return MemoryEvidenceRepairCommitGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        decisions=(),
+    )
+
+
+def _decision_from_preview(
+    preview: Mapping[str, Any],
+    *,
+    confirmed_preview_ids: set[str],
+    user_confirmed: bool,
+) -> MemoryEvidenceRepairCommitGateDecision | None:
+    preview_id = _str(preview.get("id"))
+    candidate_id = _str(preview.get("candidate_id"))
+    repair_action = _str(preview.get("repair_action"))
+    if not preview_id and not candidate_id and not repair_action:
+        return None
+
+    provider = _str(preview.get("provider")) or "memory"
+    priority = _str(preview.get("priority")) or "medium"
+    target = preview.get("target") if isinstance(preview.get("target"), Mapping) else {}
+    evidence_patch = (
+        preview.get("evidence_patch")
+        if isinstance(preview.get("evidence_patch"), Mapping)
+        else {}
+    )
+    memory_patch_preview = (
+        preview.get("memory_patch_preview")
+        if isinstance(preview.get("memory_patch_preview"), Mapping)
+        else {}
+    )
+    reasons, required_actions = _evaluate_reasons(
+        preview=preview,
+        preview_id=preview_id,
+        confirmed_preview_ids=confirmed_preview_ids,
+        user_confirmed=user_confirmed,
+        evidence_patch=evidence_patch,
+        memory_patch_preview=memory_patch_preview,
+    )
+    decision = _decision_for_reasons(reasons)
+    return MemoryEvidenceRepairCommitGateDecision(
+        id=f"gate-{preview_id or candidate_id}",
+        preview_id=preview_id,
+        candidate_id=candidate_id,
+        decision=decision,
+        provider=provider,
+        priority=priority,
+        repair_action=repair_action or "attach_provenance",
+        reasons=tuple(reasons),
+        required_actions=tuple(required_actions),
+        target=dict(target),
+        evidence_patch=dict(evidence_patch),
+        memory_patch_preview=dict(memory_patch_preview),
+        conflict_risk=_conflict_risk(preview),
+        safety_note=(
+            "Read-only gate. An allow decision means this preview is eligible "
+            "for a later manual write; this gate never writes memory."
+        ),
+        source_preview=dict(preview),
+    )
+
+
+def _evaluate_reasons(
+    *,
+    preview: Mapping[str, Any],
+    preview_id: str,
+    confirmed_preview_ids: set[str],
+    user_confirmed: bool,
+    evidence_patch: Mapping[str, Any],
+    memory_patch_preview: Mapping[str, Any],
+) -> tuple[list[str], list[str]]:
+    reasons: list[str] = []
+    required_actions: list[str] = []
+
+    missing_evidence = _list_of_str(preview.get("missing_evidence"))
+    if missing_evidence:
+        reasons.append(REASON_MISSING_EVIDENCE)
+        required_actions.append("complete_required_evidence")
+    if _str(preview.get("status")) != PREVIEW_STATUS_READY_FOR_MANUAL_APPLY:
+        reasons.append(REASON_PREVIEW_NOT_READY)
+        required_actions.append("regenerate_ready_apply_preview")
+    if not _is_preview_confirmed(
+        preview_id=preview_id,
+        confirmed_preview_ids=confirmed_preview_ids,
+        user_confirmed=user_confirmed,
+    ):
+        reasons.append(REASON_MISSING_CONFIRMATION)
+        required_actions.append("obtain_explicit_user_confirmation")
+    if _str(preview.get("operation")) != PATCH_OPERATION:
+        reasons.append(REASON_UNSAFE_OPERATION)
+        required_actions.append("use_evidence_metadata_merge_operation")
+    if _str(memory_patch_preview.get("operation")) != PATCH_OPERATION:
+        reasons.append(REASON_PATCH_SHAPE_INVALID)
+        required_actions.append("repair_memory_patch_preview_shape")
+    if not evidence_patch:
+        reasons.append(REASON_PATCH_SHAPE_INVALID)
+        required_actions.append("provide_non_empty_evidence_patch")
+    if _conflict_risk(preview) == "high":
+        evidence_resolution = _str(evidence_patch.get("conflict_resolution"))
+        if not evidence_resolution:
+            reasons.append(REASON_CONFLICT_REQUIRES_REVIEW)
+            required_actions.append("provide_conflict_resolution")
+
+    return _dedupe_strings(reasons), _dedupe_strings(required_actions)
+
+
+def _decision_for_reasons(reasons: list[str]) -> str:
+    if not reasons:
+        return DECISION_ALLOW_MANUAL_COMMIT
+    if reasons == [REASON_MISSING_CONFIRMATION]:
+        return DECISION_NEEDS_USER_CONFIRMATION
+    if (
+        REASON_MISSING_CONFIRMATION in reasons
+        and all(reason == REASON_MISSING_CONFIRMATION for reason in reasons)
+    ):
+        return DECISION_NEEDS_USER_CONFIRMATION
+    return DECISION_BLOCK_COMMIT
+
+
+def _is_preview_confirmed(
+    *,
+    preview_id: str,
+    confirmed_preview_ids: set[str],
+    user_confirmed: bool,
+) -> bool:
+    if confirmed_preview_ids:
+        return preview_id in confirmed_preview_ids
+    return bool(user_confirmed)
+
+
+def _conflict_risk(preview: Mapping[str, Any]) -> str:
+    repair_action = _str(preview.get("repair_action"))
+    if repair_action == "review_conflict":
+        return "high"
+    source_candidate = preview.get("source_candidate")
+    if isinstance(source_candidate, Mapping):
+        source_repair = source_candidate.get("source_repair")
+        if isinstance(source_repair, Mapping):
+            source = f"{source_repair.get('action', '')} {source_repair.get('reason', '')}"
+            if "conflict" in source.lower():
+                return "high"
+        reason = _str(source_candidate.get("reason"))
+        if "conflict" in reason.lower():
+            return "medium"
+    reason = _str(preview.get("reason"))
+    if "conflict" in reason.lower():
+        return "medium"
+    return "low"
+
+
+def _preview_rows(
+    *,
+    preview: Mapping[str, Any],
+    previews: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if previews is not None:
+        return list(previews)
+    if "id" in preview:
+        return [preview]
+    value = preview.get("previews")
+    return value if isinstance(value, list) else []
+
+
+def _dedupe_decisions(
+    decisions: list[MemoryEvidenceRepairCommitGateDecision],
+) -> list[MemoryEvidenceRepairCommitGateDecision]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairCommitGateDecision] = []
+    for decision in decisions:
+        if decision.id in seen:
+            continue
+        seen.add(decision.id)
+        deduped.append(decision)
+    return deduped
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _string_set(value: Sequence[str] | None) -> set[str]:
+    if value is None:
+        return set()
+    return {_str(item) for item in value if _str(item)}
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_commit_ledger.py
+++ b/agent/memory_evidence_repair_commit_ledger.py
@@ -1,0 +1,338 @@
+"""Read-only commit ledger draft for memory evidence repair decisions.
+
+The ledger turns commit gate decisions into audit-ready records. It never
+writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_gate import (
+    DECISION_ALLOW_MANUAL_COMMIT,
+    DECISION_BLOCK_COMMIT,
+    DECISION_NEEDS_USER_CONFIRMATION,
+)
+
+
+LEDGER_EVENT_TYPE = "memory_evidence_repair_commit_gate_decision"
+LEDGER_STATUS_DRAFT = "draft"
+OUTCOME_ALLOWED = "allowed_for_manual_commit"
+OUTCOME_BLOCKED = "blocked"
+OUTCOME_NEEDS_CONFIRMATION = "needs_user_confirmation"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitLedgerEntry:
+    """One read-only audit ledger entry draft."""
+
+    id: str
+    sequence: int
+    event_type: str
+    status: str
+    outcome: str
+    decision_id: str
+    preview_id: str
+    candidate_id: str
+    provider: str
+    priority: str
+    repair_action: str
+    decision: str
+    reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    evidence_fields: tuple[str, ...]
+    patch_digest: str
+    manual_commit_allowed: bool
+    blocked: bool
+    requires_followup: bool
+    target: dict[str, Any]
+    metadata: dict[str, Any]
+    safety_note: str
+    source_decision: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "event_type": self.event_type,
+            "status": self.status,
+            "outcome": self.outcome,
+            "decision_id": self.decision_id,
+            "preview_id": self.preview_id,
+            "candidate_id": self.candidate_id,
+            "provider": self.provider,
+            "priority": self.priority,
+            "repair_action": self.repair_action,
+            "decision": self.decision,
+            "reasons": list(self.reasons),
+            "required_actions": list(self.required_actions),
+            "evidence_fields": list(self.evidence_fields),
+            "patch_digest": self.patch_digest,
+            "manual_commit_allowed": self.manual_commit_allowed,
+            "blocked": self.blocked,
+            "requires_followup": self.requires_followup,
+            "target": dict(self.target),
+            "metadata": dict(self.metadata),
+            "safety_note": self.safety_note,
+            "source_decision": dict(self.source_decision),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitLedgerDraft:
+    """Read-only commit ledger draft."""
+
+    generated_at: str
+    entries: tuple[MemoryEvidenceRepairCommitLedgerEntry, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_decision: dict[str, int] = {}
+        by_outcome: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        allow_count = 0
+        blocked_count = 0
+        followup_count = 0
+        for entry in self.entries:
+            by_decision[entry.decision] = by_decision.get(entry.decision, 0) + 1
+            by_outcome[entry.outcome] = by_outcome.get(entry.outcome, 0) + 1
+            by_repair_action[entry.repair_action] = (
+                by_repair_action.get(entry.repair_action, 0) + 1
+            )
+            if entry.provider:
+                by_provider[entry.provider] = by_provider.get(entry.provider, 0) + 1
+            if entry.manual_commit_allowed:
+                allow_count += 1
+            if entry.blocked:
+                blocked_count += 1
+            if entry.requires_followup:
+                followup_count += 1
+        return {
+            "entry_count": len(self.entries),
+            "allow_count": allow_count,
+            "blocked_count": blocked_count,
+            "followup_count": followup_count,
+            "by_decision": by_decision,
+            "by_outcome": by_outcome,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "has_allowances": allow_count > 0,
+            "has_blocks": blocked_count > 0,
+            "requires_followup": followup_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "entries": [entry.to_dict() for entry in self.entries],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_commit_ledger(
+    *,
+    commit_gate: Mapping[str, Any] | None = None,
+    decisions: Sequence[Mapping[str, Any]] | None = None,
+    ledger_actor: str = "hermes",
+    ledger_reason: str = "",
+) -> MemoryEvidenceRepairCommitLedgerDraft:
+    """Build a read-only audit ledger draft from commit gate decisions."""
+
+    commit_gate = commit_gate if isinstance(commit_gate, Mapping) else {}
+    rows = _decision_rows(commit_gate=commit_gate, decisions=decisions)
+    entries: list[MemoryEvidenceRepairCommitLedgerEntry] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            continue
+        entry = _entry_from_decision(
+            row,
+            sequence=index,
+            ledger_actor=ledger_actor,
+            ledger_reason=ledger_reason,
+        )
+        if entry is not None:
+            entries.append(entry)
+
+    return MemoryEvidenceRepairCommitLedgerDraft(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        entries=tuple(_dedupe_entries(entries)),
+    )
+
+
+def empty_evidence_repair_commit_ledger() -> MemoryEvidenceRepairCommitLedgerDraft:
+    """Return an empty read-only commit ledger draft."""
+
+    return MemoryEvidenceRepairCommitLedgerDraft(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        entries=(),
+    )
+
+
+def _entry_from_decision(
+    decision: Mapping[str, Any],
+    *,
+    sequence: int,
+    ledger_actor: str,
+    ledger_reason: str,
+) -> MemoryEvidenceRepairCommitLedgerEntry | None:
+    decision_id = _str(decision.get("id"))
+    preview_id = _str(decision.get("preview_id"))
+    candidate_id = _str(decision.get("candidate_id"))
+    decision_value = _str(decision.get("decision"))
+    if not decision_id and not preview_id and not candidate_id and not decision_value:
+        return None
+
+    evidence_patch = (
+        decision.get("evidence_patch")
+        if isinstance(decision.get("evidence_patch"), Mapping)
+        else {}
+    )
+    memory_patch_preview = (
+        decision.get("memory_patch_preview")
+        if isinstance(decision.get("memory_patch_preview"), Mapping)
+        else {}
+    )
+    reasons = tuple(_list_of_str(decision.get("reasons")))
+    required_actions = tuple(_list_of_str(decision.get("required_actions")))
+    outcome = _outcome(decision_value)
+    patch_digest = _patch_digest(
+        evidence_patch=evidence_patch,
+        memory_patch_preview=memory_patch_preview,
+    )
+    entry_id = _stable_entry_id(
+        decision_id=decision_id,
+        preview_id=preview_id,
+        candidate_id=candidate_id,
+        decision=decision_value,
+        patch_digest=patch_digest,
+        reasons=reasons,
+    )
+    return MemoryEvidenceRepairCommitLedgerEntry(
+        id=entry_id,
+        sequence=sequence,
+        event_type=LEDGER_EVENT_TYPE,
+        status=LEDGER_STATUS_DRAFT,
+        outcome=outcome,
+        decision_id=decision_id,
+        preview_id=preview_id,
+        candidate_id=candidate_id,
+        provider=_str(decision.get("provider")) or "memory",
+        priority=_str(decision.get("priority")) or "medium",
+        repair_action=_str(decision.get("repair_action")) or "attach_provenance",
+        decision=decision_value,
+        reasons=reasons,
+        required_actions=required_actions,
+        evidence_fields=tuple(str(field) for field in evidence_patch.keys()),
+        patch_digest=patch_digest,
+        manual_commit_allowed=decision_value == DECISION_ALLOW_MANUAL_COMMIT,
+        blocked=decision_value == DECISION_BLOCK_COMMIT,
+        requires_followup=bool(required_actions)
+        or decision_value == DECISION_NEEDS_USER_CONFIRMATION,
+        target=_dict(decision.get("target")),
+        metadata={
+            "ledger_actor": _str(ledger_actor) or "hermes",
+            "ledger_reason": _str(ledger_reason),
+            "conflict_risk": _str(decision.get("conflict_risk")) or "unknown",
+        },
+        safety_note=(
+            "Read-only ledger draft. This record is for audit and planning only; "
+            "it does not commit or mutate durable memory."
+        ),
+        source_decision=dict(decision),
+    )
+
+
+def _decision_rows(
+    *,
+    commit_gate: Mapping[str, Any],
+    decisions: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if decisions is not None:
+        return list(decisions)
+    if "decision" in commit_gate:
+        return [commit_gate]
+    value = commit_gate.get("decisions")
+    return value if isinstance(value, list) else []
+
+
+def _outcome(decision: str) -> str:
+    if decision == DECISION_ALLOW_MANUAL_COMMIT:
+        return OUTCOME_ALLOWED
+    if decision == DECISION_NEEDS_USER_CONFIRMATION:
+        return OUTCOME_NEEDS_CONFIRMATION
+    return OUTCOME_BLOCKED
+
+
+def _patch_digest(
+    *,
+    evidence_patch: Mapping[str, Any],
+    memory_patch_preview: Mapping[str, Any],
+) -> str:
+    raw = json.dumps(
+        {
+            "evidence_patch": dict(evidence_patch),
+            "memory_patch_preview": dict(memory_patch_preview),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _stable_entry_id(
+    *,
+    decision_id: str,
+    preview_id: str,
+    candidate_id: str,
+    decision: str,
+    patch_digest: str,
+    reasons: tuple[str, ...],
+) -> str:
+    raw = json.dumps(
+        {
+            "decision_id": decision_id,
+            "preview_id": preview_id,
+            "candidate_id": candidate_id,
+            "decision": decision,
+            "patch_digest": patch_digest,
+            "reasons": list(reasons),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"ledger-{digest}"
+
+
+def _dedupe_entries(
+    entries: list[MemoryEvidenceRepairCommitLedgerEntry],
+) -> list[MemoryEvidenceRepairCommitLedgerEntry]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairCommitLedgerEntry] = []
+    for entry in entries:
+        if entry.id in seen:
+            continue
+        seen.add(entry.id)
+        deduped.append(entry)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_commit_receipt.py
+++ b/agent/memory_evidence_repair_commit_receipt.py
@@ -1,0 +1,365 @@
+"""Read-only manual commit receipt ledger for memory evidence repair.
+
+The receipt layer turns a verified approval-token gate into a durable-looking
+receipt draft and a used-token ledger view. It never writes to durable memory
+stores; it only describes what a later manual commit would record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_approval_token_gate import (
+    TOKEN_GATE_STATUS_BLOCKED,
+    TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    TOKEN_GATE_STATUS_VERIFIED,
+)
+
+
+RECEIPT_TYPE = "memory_evidence_repair_manual_commit_receipt"
+RECEIPT_SCOPE = "manual_memory_evidence_repair_commit"
+RECEIPT_STATUS_READY = "receipt_ready_for_manual_commit"
+RECEIPT_STATUS_BLOCKED = "blocked"
+RECEIPT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitReceipt:
+    """One read-only manual commit receipt draft."""
+
+    id: str
+    receipt_type: str
+    status: str
+    scope: str
+    actor: str
+    commit_reason: str
+    token_id: str
+    token_digest: str
+    dry_run_digest: str
+    gate_status: str
+    receipt_digest: str
+    receipt_preview: str
+    operation_ids: tuple[str, ...]
+    ledger_entry_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    used_token_id: str
+    would_record_receipt: bool
+    would_mark_token_used: bool
+    safety_note: str
+    source_gate: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "receipt_type": self.receipt_type,
+            "status": self.status,
+            "scope": self.scope,
+            "actor": self.actor,
+            "commit_reason": self.commit_reason,
+            "token_id": self.token_id,
+            "token_digest": self.token_digest,
+            "dry_run_digest": self.dry_run_digest,
+            "gate_status": self.gate_status,
+            "receipt_digest": self.receipt_digest,
+            "receipt_preview": self.receipt_preview,
+            "operation_ids": list(self.operation_ids),
+            "ledger_entry_ids": list(self.ledger_entry_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "used_token_id": self.used_token_id,
+            "would_record_receipt": self.would_record_receipt,
+            "would_mark_token_used": self.would_mark_token_used,
+            "safety_note": self.safety_note,
+            "source_gate": dict(self.source_gate),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairCommitReceiptReport:
+    """Read-only manual commit receipt report."""
+
+    generated_at: str
+    status: str
+    receipts: tuple[MemoryEvidenceRepairCommitReceipt, ...]
+    used_token_ids: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "receipt_count": len(self.receipts),
+            "used_token_count": len(self.used_token_ids),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "commit_receipt_available": bool(self.receipts),
+            "would_record_receipt_count": sum(
+                1 for receipt in self.receipts if receipt.would_record_receipt
+            ),
+            "would_mark_token_used_count": sum(
+                1 for receipt in self.receipts if receipt.would_mark_token_used
+            ),
+            "has_blocks": self.status == RECEIPT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "receipts": [receipt.to_dict() for receipt in self.receipts],
+            "used_token_ids": list(self.used_token_ids),
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_gate": dict(self.source_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_commit_receipt(
+    *,
+    token_gate: Mapping[str, Any] | None = None,
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    actor: str = "human",
+    commit_reason: str = "",
+) -> MemoryEvidenceRepairCommitReceiptReport:
+    """Build a read-only receipt draft from a verified approval-token gate."""
+
+    token_gate = token_gate if isinstance(token_gate, Mapping) else {}
+    gate_status = _str(token_gate.get("status"))
+    existing_used = _used_token_ids(existing_receipts, used_token_ids)
+
+    if not token_gate or gate_status == TOKEN_GATE_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+        )
+
+    if gate_status != TOKEN_GATE_STATUS_VERIFIED:
+        blocking_reasons = tuple(_list_of_str(token_gate.get("blocking_reasons")))
+        required_actions = tuple(_list_of_str(token_gate.get("required_actions")))
+        if not blocking_reasons:
+            blocking_reasons = ("Approval token gate is not verified.",)
+        if not required_actions:
+            required_actions = ("verify_approval_token_gate",)
+        return _blocked_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+        )
+
+    token_id = _str(token_gate.get("token_id"))
+    operation_ids = tuple(_list_of_str(token_gate.get("verified_operation_ids")))
+    if not token_id or not operation_ids:
+        return _blocked_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+            blocking_reasons=(
+                "Verified approval token gate is missing token id or operations.",
+            ),
+            required_actions=("regenerate_approval_token_gate",),
+        )
+    if token_id in set(existing_used):
+        return _blocked_report(
+            token_gate=token_gate,
+            used_token_ids=existing_used,
+            blocking_reasons=("Approval token is already present in the used-token ledger.",),
+            required_actions=("regenerate_human_approval_token",),
+        )
+
+    receipt = _receipt_from_gate(
+        token_gate=token_gate,
+        actor=actor,
+        commit_reason=commit_reason,
+    )
+    return MemoryEvidenceRepairCommitReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECEIPT_STATUS_READY,
+        receipts=(receipt,),
+        used_token_ids=tuple(_dedupe_strings([*existing_used, receipt.used_token_id])),
+        blocking_reasons=(),
+        required_actions=(),
+        source_gate=dict(token_gate),
+    )
+
+
+def empty_evidence_repair_commit_receipt() -> MemoryEvidenceRepairCommitReceiptReport:
+    """Return an empty read-only manual commit receipt report."""
+
+    return _empty_report(token_gate={}, used_token_ids=())
+
+
+def _receipt_from_gate(
+    *,
+    token_gate: Mapping[str, Any],
+    actor: str,
+    commit_reason: str,
+) -> MemoryEvidenceRepairCommitReceipt:
+    source_token = _dict(token_gate.get("source_token"))
+    source_dry_run = _dict(token_gate.get("source_dry_run"))
+    operations = _operation_rows(source_dry_run)
+    token_id = _str(token_gate.get("token_id"))
+    operation_ids = tuple(_list_of_str(token_gate.get("verified_operation_ids")))
+    candidate_ids = tuple(_list_of_str(token_gate.get("verified_candidate_ids")))
+    patch_digests = tuple(_list_of_str(token_gate.get("verified_patch_digests")))
+    ledger_entry_ids = tuple(_str(operation.get("ledger_entry_id")) for operation in operations)
+    token_digest = _str(source_token.get("token_digest"))
+    dry_run_digest = _str(source_token.get("dry_run_digest"))
+    receipt_seed = {
+        "receipt_type": RECEIPT_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "actor": _str(actor) or "human",
+        "commit_reason": _str(commit_reason),
+        "token_id": token_id,
+        "token_digest": token_digest,
+        "dry_run_digest": dry_run_digest,
+        "gate_status": _str(token_gate.get("status")),
+        "operation_ids": operation_ids,
+        "ledger_entry_ids": ledger_entry_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+    }
+    receipt_digest = _digest(receipt_seed)
+    receipt_id = f"commit-receipt-{receipt_digest[:16]}"
+    return MemoryEvidenceRepairCommitReceipt(
+        id=receipt_id,
+        receipt_type=RECEIPT_TYPE,
+        status=RECEIPT_STATUS_READY,
+        scope=RECEIPT_SCOPE,
+        actor=_str(actor) or "human",
+        commit_reason=_str(commit_reason),
+        token_id=token_id,
+        token_digest=token_digest,
+        dry_run_digest=dry_run_digest,
+        gate_status=_str(token_gate.get("status")),
+        receipt_digest=receipt_digest,
+        receipt_preview=f"{receipt_id}:{receipt_digest[:12]}",
+        operation_ids=operation_ids,
+        ledger_entry_ids=ledger_entry_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        used_token_id=token_id,
+        would_record_receipt=True,
+        would_mark_token_used=True,
+        safety_note=(
+            "Read-only receipt draft. It previews a future commit receipt and "
+            "used-token ledger update, but does not persist either."
+        ),
+        source_gate=dict(token_gate),
+    )
+
+
+def _empty_report(
+    *,
+    token_gate: Mapping[str, Any],
+    used_token_ids: Sequence[str],
+) -> MemoryEvidenceRepairCommitReceiptReport:
+    return MemoryEvidenceRepairCommitReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECEIPT_STATUS_NO_ACTION_NEEDED,
+        receipts=(),
+        used_token_ids=tuple(_dedupe_strings(used_token_ids)),
+        blocking_reasons=(),
+        required_actions=(),
+        source_gate=dict(token_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    token_gate: Mapping[str, Any],
+    used_token_ids: Sequence[str],
+    blocking_reasons: Sequence[str],
+    required_actions: Sequence[str],
+) -> MemoryEvidenceRepairCommitReceiptReport:
+    return MemoryEvidenceRepairCommitReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECEIPT_STATUS_BLOCKED,
+        receipts=(),
+        used_token_ids=tuple(_dedupe_strings(used_token_ids)),
+        blocking_reasons=tuple(_dedupe_strings(blocking_reasons)),
+        required_actions=tuple(_dedupe_strings(required_actions)),
+        source_gate=dict(token_gate),
+    )
+
+
+def _used_token_ids(
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    explicit_used_token_ids: Sequence[str] | None,
+) -> tuple[str, ...]:
+    candidates: list[str] = _list_of_str(explicit_used_token_ids)
+    if isinstance(existing_receipts, Mapping):
+        candidates.extend(_list_of_str(existing_receipts.get("used_token_ids")))
+        receipt_rows = existing_receipts.get("receipts")
+        if isinstance(receipt_rows, list):
+            candidates.extend(_token_ids_from_receipts(receipt_rows))
+        elif _str(existing_receipts.get("token_id")):
+            candidates.append(_str(existing_receipts.get("token_id")))
+        elif _str(existing_receipts.get("used_token_id")):
+            candidates.append(_str(existing_receipts.get("used_token_id")))
+    elif isinstance(existing_receipts, list):
+        candidates.extend(_token_ids_from_receipts(existing_receipts))
+    return tuple(_dedupe_strings(candidates))
+
+
+def _token_ids_from_receipts(receipts: Sequence[Any]) -> list[str]:
+    token_ids: list[str] = []
+    for receipt in receipts:
+        if not isinstance(receipt, Mapping):
+            continue
+        token_id = _str(receipt.get("used_token_id")) or _str(receipt.get("token_id"))
+        if token_id:
+            token_ids.append(token_id)
+    return token_ids
+
+
+def _operation_rows(dry_run: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_executor_preview.py
+++ b/agent/memory_evidence_repair_executor_preview.py
@@ -1,0 +1,754 @@
+"""Read-only manual commit executor preview for memory evidence repair.
+
+The executor preview turns a verified write-lock gate into an ordered execution
+plan for a later manual memory repair commit. It never writes to durable memory
+stores and never acquires or releases a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_receipt import RECEIPT_SCOPE
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    LOCK_DRAFT_STATUS_READY,
+    WRITE_LOCK_STATUS_BLOCKED,
+    WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    WRITE_LOCK_STATUS_READY,
+    WRITE_LOCK_TYPE,
+)
+
+
+EXECUTOR_PREVIEW_STATUS_READY = "executor_preview_ready_for_manual_commit"
+EXECUTOR_PREVIEW_STATUS_BLOCKED = "blocked"
+EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_WRITE_LOCK_READY = "write_lock_ready"
+CHECK_WRITE_LOCK_INTEGRITY = "write_lock_integrity"
+CHECK_WRITE_LOCK_EXPIRY = "write_lock_expiry"
+CHECK_EXECUTION_OPERATIONS = "execution_operations"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorPreviewCheck:
+    """One read-only executor preview readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorStep:
+    """One future executor step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    operation_id: str
+    candidate_id: str
+    ledger_entry_id: str
+    patch_digest: str
+    target: dict[str, Any]
+    evidence_fields: tuple[str, ...]
+    source_operation: dict[str, Any]
+    future_would_write_memory: bool
+    stop_on_failure: bool
+    rollback_hint: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "operation_id": self.operation_id,
+            "candidate_id": self.candidate_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "patch_digest": self.patch_digest,
+            "target": dict(self.target),
+            "evidence_fields": list(self.evidence_fields),
+            "source_operation": dict(self.source_operation),
+            "future_would_write_memory": self.future_would_write_memory,
+            "stop_on_failure": self.stop_on_failure,
+            "rollback_hint": self.rollback_hint,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorPreview:
+    """One read-only executor preview."""
+
+    id: str
+    status: str
+    lock_id: str
+    receipt_id: str
+    token_id: str
+    operation_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    preview_digest: str
+    preview_preview: str
+    execution_mode: str
+    failure_policy: str
+    steps: tuple[MemoryEvidenceRepairExecutorStep, ...]
+    would_apply_memory_patches: bool
+    would_record_receipt: bool
+    would_mark_token_used: bool
+    would_release_write_lock: bool
+    safety_note: str
+    source_lock: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "lock_id": self.lock_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "operation_ids": list(self.operation_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "step_ids": list(self.step_ids),
+            "preview_digest": self.preview_digest,
+            "preview_preview": self.preview_preview,
+            "execution_mode": self.execution_mode,
+            "failure_policy": self.failure_policy,
+            "steps": [step.to_dict() for step in self.steps],
+            "would_apply_memory_patches": self.would_apply_memory_patches,
+            "would_record_receipt": self.would_record_receipt,
+            "would_mark_token_used": self.would_mark_token_used,
+            "would_release_write_lock": self.would_release_write_lock,
+            "safety_note": self.safety_note,
+            "source_lock": dict(self.source_lock),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairExecutorPreviewReport:
+    """Read-only manual commit executor preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairExecutorPreviewCheck, ...]
+    previews: tuple[MemoryEvidenceRepairExecutorPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_write_lock_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        step_count = sum(len(preview.steps) for preview in self.previews)
+        future_write_step_count = sum(
+            1
+            for preview in self.previews
+            for step in preview.steps
+            if step.future_would_write_memory
+        )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "step_count": step_count,
+            "future_write_step_count": future_write_step_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "executor_preview_available": bool(self.previews),
+            "manual_executor_preview_ready": self.status == EXECUTOR_PREVIEW_STATUS_READY,
+            "has_blocks": self.status == EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_write_lock_gate": dict(self.source_write_lock_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_executor_preview(
+    *,
+    write_lock_gate: Mapping[str, Any] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairExecutorPreviewReport:
+    """Build a read-only executor preview from a write-lock gate."""
+
+    write_lock_gate = write_lock_gate if isinstance(write_lock_gate, Mapping) else {}
+    gate_status = _str(write_lock_gate.get("status"))
+    lock = _extract_lock(write_lock_gate)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not lock:
+        if not write_lock_gate or gate_status == WRITE_LOCK_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(write_lock_gate=write_lock_gate)
+        source_blocking = tuple(_list_of_str(write_lock_gate.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(write_lock_gate.get("required_actions")))
+        return _blocked_report(
+            write_lock_gate=write_lock_gate,
+            checks=(
+                _fail(
+                    CHECK_WRITE_LOCK_READY,
+                    "No write-lock draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_write_lock_gate",),
+                    {"write_lock_gate_status": gate_status},
+                ),
+            ),
+        )
+
+    operations = tuple(_operations_from_lock(lock))
+    checks = (
+        _write_lock_ready_check(write_lock_gate, lock),
+        _write_lock_integrity_check(lock),
+        _write_lock_expiry_check(lock, now),
+        _execution_operations_check(lock, operations),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairExecutorPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_write_lock_gate=dict(write_lock_gate),
+        )
+
+    preview = _preview_from_lock(lock=lock, operations=operations)
+    return MemoryEvidenceRepairExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=EXECUTOR_PREVIEW_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_write_lock_gate=dict(write_lock_gate),
+    )
+
+
+def empty_evidence_repair_executor_preview() -> MemoryEvidenceRepairExecutorPreviewReport:
+    """Return an empty read-only manual commit executor preview."""
+
+    return _empty_report(write_lock_gate={})
+
+
+def _extract_lock(write_lock_gate: Mapping[str, Any]) -> dict[str, Any]:
+    locks = write_lock_gate.get("locks")
+    if isinstance(locks, list):
+        for lock in locks:
+            if isinstance(lock, Mapping):
+                return dict(lock)
+    if _str(write_lock_gate.get("id")).startswith("write-lock-"):
+        return dict(write_lock_gate)
+    return {}
+
+
+def _write_lock_ready_check(
+    write_lock_gate: Mapping[str, Any],
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    gate_status = _str(write_lock_gate.get("status"))
+    lock_status = _str(lock.get("status"))
+    if gate_status and gate_status != WRITE_LOCK_STATUS_READY:
+        return _fail(
+            CHECK_WRITE_LOCK_READY,
+            "Write-lock gate is not ready for manual commit execution.",
+            tuple(_list_of_str(write_lock_gate.get("required_actions")))
+            or ("produce_ready_write_lock_gate",),
+            {"write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    if lock_status != LOCK_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_WRITE_LOCK_READY,
+            "Write-lock draft is not ready.",
+            ("produce_ready_write_lock_gate",),
+            {"write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    return _pass(
+        CHECK_WRITE_LOCK_READY,
+        "Write-lock gate and draft are ready.",
+        {"lock_id": _str(lock.get("id"))},
+    )
+
+
+def _write_lock_integrity_check(
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    expected_digest = _expected_lock_digest(lock)
+    actual_digest = _str(lock.get("lock_digest"))
+    expected_id = f"write-lock-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in ("receipt_id", "token_id", "operation_ids", "patch_digests"):
+        value = lock.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(lock.get("id")) != expected_id
+        or _str(lock.get("lock_type")) != WRITE_LOCK_TYPE
+        or _str(lock.get("scope")) != RECEIPT_SCOPE
+    ):
+        return _fail(
+            CHECK_WRITE_LOCK_INTEGRITY,
+            "Write-lock digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_write_lock_gate",),
+            {
+                "expected_lock_digest": expected_digest,
+                "actual_lock_digest": actual_digest,
+                "expected_lock_id": expected_id,
+                "actual_lock_id": _str(lock.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_WRITE_LOCK_INTEGRITY,
+        "Write-lock integrity checks pass.",
+        {"lock_id": expected_id, "lock_digest": actual_digest},
+    )
+
+
+def _write_lock_expiry_check(
+    lock: Mapping[str, Any],
+    now: datetime,
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is None:
+        return _fail(
+            CHECK_WRITE_LOCK_EXPIRY,
+            "Write-lock expiry is missing or invalid.",
+            ("regenerate_write_lock_gate",),
+            {"expires_at": _str(lock.get("expires_at"))},
+        )
+    if expires_at <= now:
+        return _fail(
+            CHECK_WRITE_LOCK_EXPIRY,
+            "Write-lock draft has expired.",
+            ("regenerate_write_lock_gate",),
+            {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+        )
+    return _pass(
+        CHECK_WRITE_LOCK_EXPIRY,
+        "Write-lock draft is within its expiry window.",
+        {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+    )
+
+
+def _execution_operations_check(
+    lock: Mapping[str, Any],
+    operations: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    lock_operation_ids = _list_of_str(lock.get("operation_ids"))
+    operation_ids = [_str(operation.get("id")) for operation in operations]
+    lock_patch_digests = _list_of_str(lock.get("patch_digests"))
+    operation_patch_digests = [_str(operation.get("patch_digest")) for operation in operations]
+    if not operations:
+        return _fail(
+            CHECK_EXECUTION_OPERATIONS,
+            "No executable dry-run operations were found in the write-lock source receipt.",
+            ("regenerate_commit_receipt_with_source_operations",),
+            {"lock_operation_ids": lock_operation_ids},
+        )
+    if lock_operation_ids != operation_ids or lock_patch_digests != operation_patch_digests:
+        return _fail(
+            CHECK_EXECUTION_OPERATIONS,
+            "Write-lock operation ids or patch digests do not match source operations.",
+            ("regenerate_write_lock_gate",),
+            {
+                "lock_operation_ids": lock_operation_ids,
+                "operation_ids": operation_ids,
+                "lock_patch_digests": lock_patch_digests,
+                "operation_patch_digests": operation_patch_digests,
+            },
+        )
+    return _pass(
+        CHECK_EXECUTION_OPERATIONS,
+        "Executable operations match the write-lock draft.",
+        {"operation_count": len(operations), "operation_ids": operation_ids},
+    )
+
+
+def _preview_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    operations: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairExecutorPreview:
+    steps = tuple(_steps_from_lock(lock=lock, operations=operations))
+    step_ids = tuple(step.id for step in steps)
+    operation_ids = tuple(_list_of_str(lock.get("operation_ids")))
+    candidate_ids = tuple(_list_of_str(lock.get("candidate_ids")))
+    patch_digests = tuple(_list_of_str(lock.get("patch_digests")))
+    preview_seed = {
+        "lock_id": _str(lock.get("id")),
+        "receipt_id": _str(lock.get("receipt_id")),
+        "token_id": _str(lock.get("token_id")),
+        "operation_ids": operation_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+        "step_ids": step_ids,
+        "execution_mode": "manual_ordered_commit",
+        "failure_policy": "stop_on_first_write_failure_then_release_lock",
+    }
+    preview_digest = _digest(preview_seed)
+    preview_id = f"executor-preview-{preview_digest[:16]}"
+    return MemoryEvidenceRepairExecutorPreview(
+        id=preview_id,
+        status=EXECUTOR_PREVIEW_STATUS_READY,
+        lock_id=_str(lock.get("id")),
+        receipt_id=_str(lock.get("receipt_id")),
+        token_id=_str(lock.get("token_id")),
+        operation_ids=operation_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        step_ids=step_ids,
+        preview_digest=preview_digest,
+        preview_preview=f"{preview_id}:{preview_digest[:12]}",
+        execution_mode="manual_ordered_commit",
+        failure_policy="stop_on_first_write_failure_then_release_lock",
+        steps=steps,
+        would_apply_memory_patches=True,
+        would_record_receipt=True,
+        would_mark_token_used=True,
+        would_release_write_lock=True,
+        safety_note=(
+            "Read-only executor preview. It describes a future ordered manual "
+            "commit and does not write memory, acquire locks, or mark tokens used."
+        ),
+        source_lock=dict(lock),
+    )
+
+
+def _steps_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    operations: Sequence[Mapping[str, Any]],
+) -> list[MemoryEvidenceRepairExecutorStep]:
+    steps: list[MemoryEvidenceRepairExecutorStep] = []
+    steps.append(
+        _step(
+            sequence=1,
+            phase="preflight",
+            action="verify_write_lock_and_receipt",
+            description="Verify write-lock, commit receipt, token, and operation digests.",
+            lock=lock,
+        )
+    )
+    sequence = 2
+    for operation in operations:
+        steps.append(
+            _operation_step(
+                sequence=sequence,
+                operation=operation,
+            )
+        )
+        sequence += 1
+    steps.append(
+        _step(
+            sequence=sequence,
+            phase="audit",
+            action="record_commit_receipt",
+            description="Record the manual commit receipt after all memory patch steps succeed.",
+            lock=lock,
+            future_would_write_memory=False,
+            rollback_hint="skip_receipt_recording_if_any_write_step_fails",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _step(
+            sequence=sequence,
+            phase="audit",
+            action="mark_approval_token_used",
+            description="Mark the approval token as used only after receipt recording is ready.",
+            lock=lock,
+            future_would_write_memory=False,
+            rollback_hint="do_not_mark_token_used_if_receipt_recording_fails",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _step(
+            sequence=sequence,
+            phase="cleanup",
+            action="release_write_lock",
+            description="Release the write lock regardless of success or failure.",
+            lock=lock,
+            future_would_write_memory=False,
+            stop_on_failure=False,
+            rollback_hint="release_lock_in_finally_block",
+        )
+    )
+    return steps
+
+
+def _operation_step(
+    *,
+    sequence: int,
+    operation: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorStep:
+    operation_id = _str(operation.get("id"))
+    return MemoryEvidenceRepairExecutorStep(
+        id=f"executor-step-{sequence}-{operation_id or 'operation'}",
+        sequence=sequence,
+        phase="write",
+        action="apply_evidence_metadata_patch",
+        description="Apply the approved evidence metadata patch for one dry-run operation.",
+        operation_id=operation_id,
+        candidate_id=_str(operation.get("candidate_id")),
+        ledger_entry_id=_str(operation.get("ledger_entry_id")),
+        patch_digest=_str(operation.get("patch_digest")),
+        target=_dict(operation.get("target")),
+        evidence_fields=tuple(_list_of_str(operation.get("evidence_fields"))),
+        source_operation=dict(operation),
+        future_would_write_memory=True,
+        stop_on_failure=True,
+        rollback_hint="stop_executor_and_use_pre_commit_snapshot_or_rollback_plan",
+    )
+
+
+def _step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    description: str,
+    lock: Mapping[str, Any],
+    future_would_write_memory: bool = False,
+    stop_on_failure: bool = True,
+    rollback_hint: str = "stop_executor_before_memory_write",
+) -> MemoryEvidenceRepairExecutorStep:
+    return MemoryEvidenceRepairExecutorStep(
+        id=f"executor-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=description,
+        operation_id="",
+        candidate_id="",
+        ledger_entry_id="",
+        patch_digest="",
+        target={
+            "lock_id": _str(lock.get("id")),
+            "receipt_id": _str(lock.get("receipt_id")),
+            "token_id": _str(lock.get("token_id")),
+        },
+        evidence_fields=(),
+        source_operation={},
+        future_would_write_memory=future_would_write_memory,
+        stop_on_failure=stop_on_failure,
+        rollback_hint=rollback_hint,
+    )
+
+
+def _operations_from_lock(lock: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    receipt = _dict(lock.get("source_receipt"))
+    source_gate = _dict(receipt.get("source_gate"))
+    dry_run = _dict(source_gate.get("source_dry_run"))
+    operations = [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+    if operations:
+        return operations
+    operation_ids = _list_of_str(lock.get("operation_ids"))
+    candidate_ids = _list_of_str(lock.get("candidate_ids"))
+    patch_digests = _list_of_str(lock.get("patch_digests"))
+    return [
+        {
+            "id": operation_id,
+            "candidate_id": candidate_ids[index] if index < len(candidate_ids) else "",
+            "patch_digest": patch_digests[index] if index < len(patch_digests) else "",
+            "target": {},
+            "evidence_fields": [],
+        }
+        for index, operation_id in enumerate(operation_ids)
+    ]
+
+
+def _expected_lock_digest(lock: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_type": WRITE_LOCK_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "owner": _str(lock.get("owner")) or "human",
+        "receipt_id": _str(lock.get("receipt_id")),
+        "token_id": _str(lock.get("token_id")),
+        "operation_ids": tuple(_list_of_str(lock.get("operation_ids"))),
+        "candidate_ids": tuple(_list_of_str(lock.get("candidate_ids"))),
+        "patch_digests": tuple(_list_of_str(lock.get("patch_digests"))),
+        "expires_in_minutes": _positive_int(lock.get("expires_in_minutes")) or 10,
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    write_lock_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewReport:
+    return MemoryEvidenceRepairExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_write_lock_gate=dict(write_lock_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    write_lock_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairExecutorPreviewCheck, ...],
+) -> MemoryEvidenceRepairExecutorPreviewReport:
+    return MemoryEvidenceRepairExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=EXECUTOR_PREVIEW_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_write_lock_gate=dict(write_lock_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    return MemoryEvidenceRepairExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairExecutorPreviewCheck:
+    return MemoryEvidenceRepairExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_human_approval_token.py
+++ b/agent/memory_evidence_repair_human_approval_token.py
@@ -1,0 +1,277 @@
+"""Read-only human approval token draft for memory evidence repair.
+
+The token layer creates an approval-token draft only after a manual commit
+dry-run is ready. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    DRY_RUN_STATUS_BLOCKED,
+    DRY_RUN_STATUS_NO_ACTION_NEEDED,
+    DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+)
+
+
+APPROVAL_TOKEN_TYPE = "memory_evidence_repair_human_approval"
+APPROVAL_TOKEN_SCOPE = "manual_memory_evidence_repair_commit"
+TOKEN_STATUS_DRAFT_READY = "draft_ready_for_human_approval"
+TOKEN_STATUS_BLOCKED = "blocked"
+TOKEN_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+DEFAULT_EXPIRES_IN_MINUTES = 30
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairHumanApprovalToken:
+    """One read-only human approval token draft."""
+
+    id: str
+    token_type: str
+    status: str
+    scope: str
+    approver: str
+    approval_reason: str
+    dry_run_status: str
+    dry_run_digest: str
+    token_digest: str
+    token_preview: str
+    expires_in_minutes: int
+    operation_ids: tuple[str, ...]
+    ledger_entry_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    required_confirmation_text: str
+    one_time_constraints: dict[str, Any]
+    safety_note: str
+    source_dry_run: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "token_type": self.token_type,
+            "status": self.status,
+            "scope": self.scope,
+            "approver": self.approver,
+            "approval_reason": self.approval_reason,
+            "dry_run_status": self.dry_run_status,
+            "dry_run_digest": self.dry_run_digest,
+            "token_digest": self.token_digest,
+            "token_preview": self.token_preview,
+            "expires_in_minutes": self.expires_in_minutes,
+            "operation_ids": list(self.operation_ids),
+            "ledger_entry_ids": list(self.ledger_entry_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "required_confirmation_text": self.required_confirmation_text,
+            "one_time_constraints": dict(self.one_time_constraints),
+            "safety_note": self.safety_note,
+            "source_dry_run": dict(self.source_dry_run),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairHumanApprovalTokenReport:
+    """Read-only human approval token draft report."""
+
+    generated_at: str
+    status: str
+    tokens: tuple[MemoryEvidenceRepairHumanApprovalToken, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "token_count": len(self.tokens),
+            "ready_count": 1 if self.status == TOKEN_STATUS_DRAFT_READY else 0,
+            "blocked_count": 1 if self.status == TOKEN_STATUS_BLOCKED else 0,
+            "no_action_count": 1 if self.status == TOKEN_STATUS_NO_ACTION_NEEDED else 0,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "human_approval_token_available": bool(self.tokens),
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "tokens": [token.to_dict() for token in self.tokens],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_human_approval_token(
+    *,
+    dry_run: Mapping[str, Any] | None = None,
+    approver: str = "human",
+    approval_reason: str = "",
+    expires_in_minutes: int = DEFAULT_EXPIRES_IN_MINUTES,
+) -> MemoryEvidenceRepairHumanApprovalTokenReport:
+    """Build a read-only human approval token draft from a dry-run."""
+
+    dry_run = dry_run if isinstance(dry_run, Mapping) else {}
+    dry_run_status = _str(dry_run.get("status"))
+    operations = _operation_rows(dry_run)
+    if dry_run_status == DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT and operations:
+        token = _token_from_dry_run(
+            dry_run=dry_run,
+            approver=approver,
+            approval_reason=approval_reason,
+            expires_in_minutes=expires_in_minutes,
+        )
+        return MemoryEvidenceRepairHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=TOKEN_STATUS_DRAFT_READY,
+            tokens=(token,),
+            blocking_reasons=(),
+            required_actions=(),
+        )
+
+    blocking_reasons = tuple(_list_of_str(dry_run.get("blocking_reasons")))
+    required_actions = tuple(_list_of_str(dry_run.get("required_actions")))
+    if dry_run_status == DRY_RUN_STATUS_BLOCKED:
+        status = TOKEN_STATUS_BLOCKED
+        if not blocking_reasons:
+            blocking_reasons = ("Manual commit dry-run is blocked.",)
+        if not required_actions:
+            required_actions = ("resolve_manual_commit_dry_run_blocks",)
+    elif dry_run_status == DRY_RUN_STATUS_NO_ACTION_NEEDED or not operations:
+        status = TOKEN_STATUS_NO_ACTION_NEEDED
+    else:
+        status = TOKEN_STATUS_BLOCKED
+        blocking_reasons = blocking_reasons or ("Manual commit dry-run is not ready.",)
+        required_actions = required_actions or ("produce_ready_manual_commit_dry_run",)
+
+    return MemoryEvidenceRepairHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        tokens=(),
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+    )
+
+
+def empty_evidence_repair_human_approval_token() -> MemoryEvidenceRepairHumanApprovalTokenReport:
+    """Return an empty read-only human approval token report."""
+
+    return MemoryEvidenceRepairHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=TOKEN_STATUS_NO_ACTION_NEEDED,
+        tokens=(),
+        blocking_reasons=(),
+        required_actions=(),
+    )
+
+
+def _token_from_dry_run(
+    *,
+    dry_run: Mapping[str, Any],
+    approver: str,
+    approval_reason: str,
+    expires_in_minutes: int,
+) -> MemoryEvidenceRepairHumanApprovalToken:
+    operations = _operation_rows(dry_run)
+    dry_run_digest = _digest(
+        {
+            "status": dry_run.get("status"),
+            "operations": operations,
+            "checks": dry_run.get("checks"),
+        }
+    )
+    operation_ids = tuple(_str(operation.get("id")) for operation in operations)
+    ledger_entry_ids = tuple(_str(operation.get("ledger_entry_id")) for operation in operations)
+    candidate_ids = tuple(_str(operation.get("candidate_id")) for operation in operations)
+    patch_digests = tuple(_str(operation.get("patch_digest")) for operation in operations)
+    token_seed = {
+        "token_type": APPROVAL_TOKEN_TYPE,
+        "scope": APPROVAL_TOKEN_SCOPE,
+        "approver": _str(approver) or "human",
+        "approval_reason": _str(approval_reason),
+        "dry_run_digest": dry_run_digest,
+        "operation_ids": operation_ids,
+        "ledger_entry_ids": ledger_entry_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+        "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+    }
+    token_digest = _digest(token_seed)
+    token_id = f"approval-token-{token_digest[:16]}"
+    required_confirmation_text = (
+        f"APPROVE {APPROVAL_TOKEN_SCOPE} {token_id}"
+    )
+    return MemoryEvidenceRepairHumanApprovalToken(
+        id=token_id,
+        token_type=APPROVAL_TOKEN_TYPE,
+        status=TOKEN_STATUS_DRAFT_READY,
+        scope=APPROVAL_TOKEN_SCOPE,
+        approver=_str(approver) or "human",
+        approval_reason=_str(approval_reason),
+        dry_run_status=_str(dry_run.get("status")),
+        dry_run_digest=dry_run_digest,
+        token_digest=token_digest,
+        token_preview=f"{token_id}:{token_digest[:12]}",
+        expires_in_minutes=_expires_in_minutes(expires_in_minutes),
+        operation_ids=operation_ids,
+        ledger_entry_ids=ledger_entry_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        required_confirmation_text=required_confirmation_text,
+        one_time_constraints={
+            "one_time_use": True,
+            "requires_exact_dry_run_digest": dry_run_digest,
+            "requires_exact_confirmation_text": required_confirmation_text,
+            "requires_same_patch_digests": list(patch_digests),
+            "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+        },
+        safety_note=(
+            "Read-only approval token draft. This is not a persisted credential "
+            "and does not authorize or mutate durable memory by itself."
+        ),
+        source_dry_run=dict(dry_run),
+    )
+
+
+def _operation_rows(dry_run: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        operation
+        for operation in _list(dry_run.get("operations"))
+        if isinstance(operation, Mapping)
+    ]
+
+
+def _expires_in_minutes(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = DEFAULT_EXPIRES_IN_MINUTES
+    return parsed if parsed > 0 else DEFAULT_EXPIRES_IN_MINUTES
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_manual_commit_dry_run.py
+++ b/agent/memory_evidence_repair_manual_commit_dry_run.py
@@ -1,0 +1,428 @@
+"""Read-only manual commit dry-run for memory evidence repair.
+
+The dry-run layer summarizes whether a future manual evidence repair write is
+ready after commit gate, ledger, rollback, and snapshot checks. It never writes
+to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT = "ready_for_manual_commit"
+DRY_RUN_STATUS_BLOCKED = "blocked"
+DRY_RUN_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_STATUS_PASS = "pass"
+CHECK_STATUS_FAIL = "fail"
+CHECK_STATUS_SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairDryRunCheck:
+    """One readiness check in the manual commit dry-run."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairDryRunOperation:
+    """One future manual commit operation preview."""
+
+    id: str
+    ledger_entry_id: str
+    candidate_id: str
+    preview_id: str
+    provider: str
+    repair_action: str
+    patch_digest: str
+    target: dict[str, Any]
+    evidence_fields: tuple[str, ...]
+    source_entry: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "candidate_id": self.candidate_id,
+            "preview_id": self.preview_id,
+            "provider": self.provider,
+            "repair_action": self.repair_action,
+            "patch_digest": self.patch_digest,
+            "target": dict(self.target),
+            "evidence_fields": list(self.evidence_fields),
+            "source_entry": dict(self.source_entry),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairManualCommitDryRun:
+    """Read-only manual commit dry-run report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairDryRunCheck, ...]
+    operations: tuple[MemoryEvidenceRepairDryRunOperation, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "operation_count": len(self.operations),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "by_check_status": by_check_status,
+            "manual_commit_allowed": self.status == DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+            "has_blocks": self.status == DRY_RUN_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "operations": [operation.to_dict() for operation in self.operations],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_manual_commit_dry_run(
+    *,
+    snapshot_plan: Mapping[str, Any] | None = None,
+    commit_gate: Mapping[str, Any] | None = None,
+    ledger: Mapping[str, Any] | None = None,
+    rollback_plan: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairManualCommitDryRun:
+    """Build a read-only final dry-run before any manual repair write."""
+
+    snapshot_plan = snapshot_plan if isinstance(snapshot_plan, Mapping) else {}
+    commit_gate = commit_gate if isinstance(commit_gate, Mapping) else {}
+    ledger = ledger if isinstance(ledger, Mapping) else {}
+    rollback_plan = rollback_plan if isinstance(rollback_plan, Mapping) else {}
+
+    checks = (
+        _commit_gate_check(commit_gate),
+        _ledger_check(ledger),
+        _rollback_check(rollback_plan),
+        _snapshot_check(snapshot_plan),
+    )
+    operations = tuple(_operations_from_ledger(ledger))
+    blocking_reasons = tuple(
+        _dedupe_strings(
+            reason
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for reason in [check.reason]
+            if reason
+        )
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    status = _dry_run_status(checks=checks, operations=operations)
+    return MemoryEvidenceRepairManualCommitDryRun(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        checks=checks,
+        operations=operations,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+    )
+
+
+def empty_evidence_repair_manual_commit_dry_run() -> MemoryEvidenceRepairManualCommitDryRun:
+    """Return an empty read-only manual commit dry-run."""
+
+    return MemoryEvidenceRepairManualCommitDryRun(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=DRY_RUN_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        operations=(),
+        blocking_reasons=(),
+        required_actions=(),
+    )
+
+
+def _commit_gate_check(commit_gate: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(commit_gate.get("summary"))
+    decision_count = _int(summary.get("decision_count"))
+    if decision_count == 0:
+        return _check(
+            "commit_gate",
+            CHECK_STATUS_SKIPPED,
+            "No commit gate decisions were supplied.",
+            (),
+            summary,
+        )
+    blocked_count = _int(summary.get("blocked_count"))
+    needs_confirmation_count = _int(summary.get("needs_confirmation_count"))
+    allow_count = _int(summary.get("allow_count"))
+    if blocked_count or needs_confirmation_count or allow_count == 0:
+        actions: list[str] = []
+        if blocked_count:
+            actions.append("resolve_commit_gate_blocks")
+        if needs_confirmation_count:
+            actions.append("obtain_explicit_user_confirmation")
+        if allow_count == 0:
+            actions.append("produce_allowed_commit_gate_decision")
+        return _check(
+            "commit_gate",
+            CHECK_STATUS_FAIL,
+            "Commit gate is not allowing manual commit.",
+            tuple(actions),
+            summary,
+        )
+    return _check(
+        "commit_gate",
+        CHECK_STATUS_PASS,
+        "Commit gate allows manual commit.",
+        (),
+        summary,
+    )
+
+
+def _ledger_check(ledger: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(ledger.get("summary"))
+    entry_count = _int(summary.get("entry_count"))
+    if entry_count == 0:
+        return _check(
+            "commit_ledger",
+            CHECK_STATUS_SKIPPED,
+            "No commit ledger entries were supplied.",
+            (),
+            summary,
+        )
+    allow_count = _int(summary.get("allow_count"))
+    blocked_count = _int(summary.get("blocked_count"))
+    followup_count = _int(summary.get("followup_count"))
+    if blocked_count or followup_count or allow_count == 0:
+        actions: list[str] = []
+        if blocked_count:
+            actions.append("resolve_blocked_ledger_entries")
+        if followup_count:
+            actions.append("complete_ledger_followups")
+        if allow_count == 0:
+            actions.append("produce_allowed_ledger_entry")
+        return _check(
+            "commit_ledger",
+            CHECK_STATUS_FAIL,
+            "Commit ledger is not clean for manual commit.",
+            tuple(actions),
+            summary,
+        )
+    return _check(
+        "commit_ledger",
+        CHECK_STATUS_PASS,
+        "Commit ledger contains allowed entries with no follow-up.",
+        (),
+        summary,
+    )
+
+
+def _rollback_check(rollback_plan: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(rollback_plan.get("summary"))
+    step_count = _int(summary.get("rollback_step_count"))
+    if step_count == 0:
+        return _check(
+            "rollback_plan",
+            CHECK_STATUS_SKIPPED,
+            "No rollback steps were supplied.",
+            (),
+            summary,
+        )
+    snapshot_required_count = _int(summary.get("snapshot_required_count"))
+    ready_count = _int(summary.get("ready_count"))
+    if snapshot_required_count or ready_count == 0:
+        actions: list[str] = []
+        if snapshot_required_count:
+            actions.append("capture_pre_commit_snapshots")
+        if ready_count == 0:
+            actions.append("produce_ready_rollback_plan")
+        return _check(
+            "rollback_plan",
+            CHECK_STATUS_FAIL,
+            "Rollback plan is not ready for manual rollback.",
+            tuple(actions),
+            summary,
+        )
+    return _check(
+        "rollback_plan",
+        CHECK_STATUS_PASS,
+        "Rollback plan is ready.",
+        (),
+        summary,
+    )
+
+
+def _snapshot_check(snapshot_plan: Mapping[str, Any]) -> MemoryEvidenceRepairDryRunCheck:
+    summary = _dict(snapshot_plan.get("summary"))
+    request_count = _int(summary.get("snapshot_request_count"))
+    if request_count == 0:
+        return _check(
+            "snapshot_plan",
+            CHECK_STATUS_SKIPPED,
+            "No snapshot requests were supplied.",
+            (),
+            summary,
+        )
+    capture_required_count = _int(summary.get("capture_required_count"))
+    blocking_count = _int(summary.get("blocking_count"))
+    if capture_required_count or blocking_count:
+        return _check(
+            "snapshot_plan",
+            CHECK_STATUS_FAIL,
+            "Pre-commit snapshots are still required.",
+            ("capture_pre_commit_snapshots",),
+            summary,
+        )
+    return _check(
+        "snapshot_plan",
+        CHECK_STATUS_PASS,
+        "Pre-commit snapshots are available or not needed.",
+        (),
+        summary,
+    )
+
+
+def _operations_from_ledger(
+    ledger: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairDryRunOperation]:
+    operations: list[MemoryEvidenceRepairDryRunOperation] = []
+    for entry in _list(ledger.get("entries")):
+        if not isinstance(entry, Mapping):
+            continue
+        if not bool(entry.get("manual_commit_allowed")):
+            continue
+        entry_id = _str(entry.get("id"))
+        patch_digest = _str(entry.get("patch_digest"))
+        operations.append(
+            MemoryEvidenceRepairDryRunOperation(
+                id=_stable_operation_id(entry_id=entry_id, patch_digest=patch_digest),
+                ledger_entry_id=entry_id,
+                candidate_id=_str(entry.get("candidate_id")),
+                preview_id=_str(entry.get("preview_id")),
+                provider=_str(entry.get("provider")) or "memory",
+                repair_action=_str(entry.get("repair_action")) or "attach_provenance",
+                patch_digest=patch_digest,
+                target=_dict(entry.get("target")),
+                evidence_fields=tuple(_str(field) for field in _list(entry.get("evidence_fields")) if _str(field)),
+                source_entry=dict(entry),
+            )
+        )
+    return _dedupe_operations(operations)
+
+
+def _dry_run_status(
+    *,
+    checks: tuple[MemoryEvidenceRepairDryRunCheck, ...],
+    operations: tuple[MemoryEvidenceRepairDryRunOperation, ...],
+) -> str:
+    if any(check.status == CHECK_STATUS_FAIL for check in checks):
+        return DRY_RUN_STATUS_BLOCKED
+    if not operations:
+        return DRY_RUN_STATUS_NO_ACTION_NEEDED
+    return DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT
+
+
+def _check(
+    check_id: str,
+    status: str,
+    reason: str,
+    required_actions: tuple[str, ...],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairDryRunCheck:
+    return MemoryEvidenceRepairDryRunCheck(
+        id=check_id,
+        status=status,
+        reason=reason,
+        required_actions=required_actions,
+        details=dict(details),
+    )
+
+
+def _stable_operation_id(*, entry_id: str, patch_digest: str) -> str:
+    raw = json.dumps(
+        {"entry_id": entry_id, "patch_digest": patch_digest},
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"dryrun-op-{digest}"
+
+
+def _dedupe_operations(
+    operations: list[MemoryEvidenceRepairDryRunOperation],
+) -> list[MemoryEvidenceRepairDryRunOperation]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairDryRunOperation] = []
+    for operation in operations:
+        if operation.id in seen:
+            continue
+        seen.add(operation.id)
+        deduped.append(operation)
+    return deduped
+
+
+def _dedupe_strings(values) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_planner.py
+++ b/agent/memory_evidence_repair_planner.py
@@ -1,0 +1,319 @@
+"""Read-only planner for repairing weak memory provenance.
+
+The planner converts gate/audit/diagnostic/policy signals into repair
+candidates. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+ACTION_ATTACH_PROVENANCE = "attach_provenance"
+ACTION_VERIFY_SOURCE = "verify_source"
+ACTION_REFRESH_OBSERVATION = "refresh_observation"
+ACTION_REVIEW_CONFLICT = "review_conflict"
+
+REQUIRE_PROVENANCE = "require_provenance_before_reuse"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairItem:
+    """One read-only evidence repair candidate."""
+
+    provider: str
+    priority: str
+    action: str
+    reason: str
+    source: str
+    evidence: str = ""
+    content_preview: str = ""
+    blocked_by_gate: bool = False
+    required_evidence: tuple[str, ...] = ()
+    recommended_next_step: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "priority": self.priority,
+            "action": self.action,
+            "source": self.source,
+            "reason": self.reason,
+            "evidence": self.evidence,
+            "content_preview": self.content_preview,
+            "blocked_by_gate": self.blocked_by_gate,
+            "required_evidence": list(self.required_evidence),
+            "recommended_next_step": self.recommended_next_step,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPlan:
+    """Read-only evidence repair plan."""
+
+    generated_at: str
+    repairs: tuple[MemoryEvidenceRepairItem, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_priority: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_action: dict[str, int] = {}
+        blocked_count = 0
+        for repair in self.repairs:
+            by_priority[repair.priority] = by_priority.get(repair.priority, 0) + 1
+            by_action[repair.action] = by_action.get(repair.action, 0) + 1
+            if repair.provider:
+                by_provider[repair.provider] = by_provider.get(repair.provider, 0) + 1
+            if repair.blocked_by_gate:
+                blocked_count += 1
+        return {
+            "repair_count": len(self.repairs),
+            "blocked_count": blocked_count,
+            "by_priority": by_priority,
+            "by_provider": by_provider,
+            "by_action": by_action,
+            "has_repairs": bool(self.repairs),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "repairs": [repair.to_dict() for repair in self.repairs],
+            "read_only": True,
+        }
+
+
+def build_evidence_repair_plan(
+    *,
+    gate: Mapping[str, Any] | None = None,
+    audit: Mapping[str, Any] | None = None,
+    diagnostics: Mapping[str, Any] | None = None,
+    policy: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairPlan:
+    """Build a read-only evidence repair plan from memory quality signals."""
+
+    repairs: list[MemoryEvidenceRepairItem] = []
+    gate = gate if isinstance(gate, Mapping) else {}
+    audit = audit if isinstance(audit, Mapping) else {}
+    diagnostics = diagnostics if isinstance(diagnostics, Mapping) else {}
+    policy = policy if isinstance(policy, Mapping) else {}
+
+    repairs.extend(_repairs_from_gate(gate))
+    repairs.extend(_repairs_from_diagnostics(diagnostics))
+    repairs.extend(_repairs_from_policy(policy))
+    repairs.extend(_repairs_from_audit(audit))
+
+    return MemoryEvidenceRepairPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        repairs=tuple(_dedupe_repairs(repairs)),
+    )
+
+
+def empty_evidence_repair_plan() -> MemoryEvidenceRepairPlan:
+    """Return an empty read-only evidence repair plan."""
+
+    return MemoryEvidenceRepairPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        repairs=(),
+    )
+
+
+def _repairs_from_gate(gate: Mapping[str, Any]) -> list[MemoryEvidenceRepairItem]:
+    rows = _list(gate.get("provider_results")) or _list(gate.get("decisions"))
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        action = str(row.get("action", "") or "")
+        effect = str(row.get("effect", "") or "")
+        reason = str(row.get("reason", "") or "")
+        if action != REQUIRE_PROVENANCE and "provenance" not in reason.lower():
+            continue
+        repairs.append(
+            MemoryEvidenceRepairItem(
+                provider=str(row.get("provider", "") or ""),
+                priority="high" if effect == "filtered" else "medium",
+                action=ACTION_ATTACH_PROVENANCE,
+                source="policy_gate",
+                reason=reason or "Memory recall needs explicit provenance before reuse.",
+                evidence=str(row.get("evidence", "") or ""),
+                blocked_by_gate=effect == "filtered",
+                required_evidence=_default_required_evidence(),
+                recommended_next_step=(
+                    "Attach source_url, observed_at, and a verification signal before "
+                    "allowing this memory back into recall."
+                ),
+            )
+        )
+    return repairs
+
+
+def _repairs_from_diagnostics(
+    diagnostics: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairItem]:
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for issue in _list(diagnostics.get("issues")):
+        if not isinstance(issue, Mapping):
+            continue
+        code = str(issue.get("code", "") or "")
+        if code == "collect_evidence_before_reuse":
+            repairs.append(
+                MemoryEvidenceRepairItem(
+                    provider=str(issue.get("provider", "") or ""),
+                    priority="high",
+                    action=ACTION_ATTACH_PROVENANCE,
+                    source="diagnostics",
+                    reason=str(issue.get("reason", "") or "Recall has weak evidence."),
+                    evidence=str(issue.get("evidence", "") or ""),
+                    required_evidence=_default_required_evidence(),
+                    recommended_next_step=str(
+                        issue.get("recommended_next_step", "")
+                        or "Attach provenance before reuse."
+                    ),
+                )
+            )
+        elif code == "refresh_stale_recall":
+            repairs.append(
+                MemoryEvidenceRepairItem(
+                    provider=str(issue.get("provider", "") or ""),
+                    priority="medium",
+                    action=ACTION_REFRESH_OBSERVATION,
+                    source="diagnostics",
+                    reason=str(issue.get("reason", "") or "Recall may be stale."),
+                    evidence=str(issue.get("evidence", "") or ""),
+                    required_evidence=("observed_at", "freshness_check"),
+                    recommended_next_step=str(
+                        issue.get("recommended_next_step", "")
+                        or "Refresh observed_at and confirm the memory still applies."
+                    ),
+                )
+            )
+        elif code == "review_conflicting_recall":
+            repairs.append(
+                MemoryEvidenceRepairItem(
+                    provider=str(issue.get("provider", "") or ""),
+                    priority="high",
+                    action=ACTION_REVIEW_CONFLICT,
+                    source="diagnostics",
+                    reason=str(issue.get("reason", "") or "Recall may conflict."),
+                    evidence=str(issue.get("evidence", "") or ""),
+                    required_evidence=("conflict_resolution", "source_url"),
+                    recommended_next_step=str(
+                        issue.get("recommended_next_step", "")
+                        or "Resolve conflict before this memory is reused."
+                    ),
+                )
+            )
+    return repairs
+
+
+def _repairs_from_policy(policy: Mapping[str, Any]) -> list[MemoryEvidenceRepairItem]:
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for decision in _list(policy.get("decisions")):
+        if not isinstance(decision, Mapping):
+            continue
+        if str(decision.get("action", "") or "") != REQUIRE_PROVENANCE:
+            continue
+        repairs.append(
+            MemoryEvidenceRepairItem(
+                provider=str(decision.get("provider", "") or ""),
+                priority="high" if decision.get("provider") else "medium",
+                action=ACTION_ATTACH_PROVENANCE,
+                source="auto_policy",
+                reason=str(
+                    decision.get("reason", "")
+                    or "Auto-policy requires provenance before memory reuse."
+                ),
+                evidence=str(decision.get("evidence", "") or ""),
+                required_evidence=_default_required_evidence(),
+                recommended_next_step=str(
+                    decision.get("recommended_next_step", "")
+                    or "Repair provenance before reusing this memory."
+                ),
+            )
+        )
+    return repairs
+
+
+def _repairs_from_audit(audit: Mapping[str, Any]) -> list[MemoryEvidenceRepairItem]:
+    repairs: list[MemoryEvidenceRepairItem] = []
+    for entry in _list(audit.get("entries")):
+        if not isinstance(entry, Mapping):
+            continue
+        recommendation = str(entry.get("recommendation", "") or "")
+        dimensions = (
+            entry.get("dimensions") if isinstance(entry.get("dimensions"), Mapping) else {}
+        )
+        weak_source = _float(dimensions.get("source_strength")) < 0.5
+        weak_evidence = _float(dimensions.get("evidence_strength")) < 0.5
+        if recommendation != "needs_evidence" and not (weak_source or weak_evidence):
+            continue
+        decision = str(entry.get("decision", "") or "")
+        repairs.append(
+            MemoryEvidenceRepairItem(
+                provider=str(entry.get("provider", "") or ""),
+                priority="high" if decision in {"injected", "fallback_injected"} else "medium",
+                action=ACTION_ATTACH_PROVENANCE,
+                source="recall_audit",
+                reason=str(
+                    entry.get("reason", "")
+                    or "Recall audit found weak source or evidence strength."
+                ),
+                evidence=f"source_strength={dimensions.get('source_strength', 'n/a')}; "
+                f"evidence_strength={dimensions.get('evidence_strength', 'n/a')}",
+                content_preview=str(entry.get("content_preview", "") or ""),
+                required_evidence=_default_required_evidence(),
+                recommended_next_step=(
+                    "Attach source_url, observed_at, and verification before trusting "
+                    "this recall again."
+                ),
+            )
+        )
+    return repairs
+
+
+def _dedupe_repairs(
+    repairs: list[MemoryEvidenceRepairItem],
+) -> list[MemoryEvidenceRepairItem]:
+    seen: set[tuple[str, str, str, str]] = set()
+    deduped: list[MemoryEvidenceRepairItem] = []
+    priority_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    repairs.sort(
+        key=lambda item: (
+            priority_rank.get(item.priority, 9),
+            item.provider,
+            item.action,
+            item.source,
+        )
+    )
+    for repair in repairs:
+        key = (
+            repair.provider,
+            repair.action,
+            repair.reason,
+            repair.content_preview,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(repair)
+    return deduped
+
+
+def _default_required_evidence() -> tuple[str, ...]:
+    return ("source_url", "observed_at", "verification_signal")
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/agent/memory_evidence_repair_post_commit_audit_preview.py
+++ b/agent/memory_evidence_repair_post_commit_audit_preview.py
@@ -1,0 +1,789 @@
+"""Read-only post-commit audit preview for memory evidence repair.
+
+The post-commit audit preview turns an executor preview into an ordered
+verification plan for after a future manual commit. It can also validate
+optional observed post-commit state. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_executor_preview import (
+    EXECUTOR_PREVIEW_STATUS_BLOCKED,
+    EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    EXECUTOR_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+
+
+POST_COMMIT_AUDIT_STATUS_READY = "post_commit_audit_preview_ready"
+POST_COMMIT_AUDIT_STATUS_BLOCKED = "blocked"
+POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+AUDIT_STEP_STATUS_PLANNED = "planned"
+AUDIT_STEP_STATUS_PASS = "pass"
+AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_EXECUTOR_PREVIEW_READY = "executor_preview_ready"
+CHECK_EXECUTOR_PREVIEW_INTEGRITY = "executor_preview_integrity"
+CHECK_AUDIT_REQUIREMENTS = "audit_requirements"
+CHECK_OBSERVED_POST_STATE = "observed_post_state"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditCheck:
+    """One read-only post-commit audit preview check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditStep:
+    """One future post-commit audit step preview."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    operation_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "operation_id": self.operation_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditPreview:
+    """One read-only post-commit audit preview."""
+
+    id: str
+    status: str
+    executor_preview_id: str
+    lock_id: str
+    receipt_id: str
+    token_id: str
+    operation_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairPostCommitAuditStep, ...]
+    observed_state_supplied: bool
+    would_verify_memory_patches: bool
+    would_verify_receipt_recorded: bool
+    would_verify_token_used: bool
+    would_verify_lock_released: bool
+    would_verify_rollback_available: bool
+    safety_note: str
+    source_executor_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "executor_preview_id": self.executor_preview_id,
+            "lock_id": self.lock_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "operation_ids": list(self.operation_ids),
+            "patch_digests": list(self.patch_digests),
+            "audit_step_ids": list(self.audit_step_ids),
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "observed_state_supplied": self.observed_state_supplied,
+            "would_verify_memory_patches": self.would_verify_memory_patches,
+            "would_verify_receipt_recorded": self.would_verify_receipt_recorded,
+            "would_verify_token_used": self.would_verify_token_used,
+            "would_verify_lock_released": self.would_verify_lock_released,
+            "would_verify_rollback_available": self.would_verify_rollback_available,
+            "safety_note": self.safety_note,
+            "source_executor_preview": dict(self.source_executor_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    """Read-only post-commit audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairPostCommitAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairPostCommitAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_executor_preview_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "planned_audit_step_count": by_audit_step_status.get(AUDIT_STEP_STATUS_PLANNED, 0),
+            "observed_pass_step_count": by_audit_step_status.get(AUDIT_STEP_STATUS_PASS, 0),
+            "observed_fail_step_count": by_audit_step_status.get(AUDIT_STEP_STATUS_FAIL, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "post_commit_audit_preview_available": bool(self.previews),
+            "post_commit_audit_ready": self.status == POST_COMMIT_AUDIT_STATUS_READY,
+            "has_blocks": self.status == POST_COMMIT_AUDIT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_executor_preview_report": dict(self.source_executor_preview_report),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_post_commit_audit_preview(
+    *,
+    executor_preview: Mapping[str, Any] | None = None,
+    observed_memory_patches: Mapping[str, Any] | None = None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    released_lock_ids: Sequence[str] | None = None,
+    rollback_status: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    """Build a read-only post-commit audit preview from an executor preview."""
+
+    executor_preview = executor_preview if isinstance(executor_preview, Mapping) else {}
+    report_status = _str(executor_preview.get("status"))
+    preview = _extract_preview(executor_preview)
+    observed = _observed_context(
+        observed_memory_patches=observed_memory_patches,
+        recorded_receipts=recorded_receipts,
+        used_token_ids=used_token_ids,
+        released_lock_ids=released_lock_ids,
+        rollback_status=rollback_status,
+    )
+
+    if not preview:
+        if not executor_preview or report_status == EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(executor_preview=executor_preview)
+        source_blocking = tuple(_list_of_str(executor_preview.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(executor_preview.get("required_actions")))
+        return _blocked_report(
+            executor_preview=executor_preview,
+            checks=(
+                _fail(
+                    CHECK_EXECUTOR_PREVIEW_READY,
+                    "No executor preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_executor_preview",),
+                    {"executor_preview_status": report_status},
+                ),
+            ),
+        )
+
+    audit_steps = tuple(_audit_steps_from_preview(preview, observed))
+    checks = (
+        _executor_preview_ready_check(executor_preview, preview),
+        _executor_preview_integrity_check(preview),
+        _audit_requirements_check(preview, audit_steps),
+        _observed_post_state_check(observed, audit_steps),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=POST_COMMIT_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_executor_preview_report=dict(executor_preview),
+        )
+
+    post_preview = _preview_from_executor_preview(
+        preview=preview,
+        audit_steps=audit_steps,
+        observed_state_supplied=observed["supplied"],
+    )
+    return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=POST_COMMIT_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(post_preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_executor_preview_report=dict(executor_preview),
+    )
+
+
+def empty_evidence_repair_post_commit_audit_preview() -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    """Return an empty read-only post-commit audit preview."""
+
+    return _empty_report(executor_preview={})
+
+
+def _extract_preview(executor_preview: Mapping[str, Any]) -> dict[str, Any]:
+    previews = executor_preview.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(executor_preview.get("id")).startswith("executor-preview-"):
+        return dict(executor_preview)
+    return {}
+
+
+def _executor_preview_ready_check(
+    executor_preview: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    report_status = _str(executor_preview.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != EXECUTOR_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_EXECUTOR_PREVIEW_READY,
+            "Executor preview report is not ready for post-commit audit planning.",
+            tuple(_list_of_str(executor_preview.get("required_actions")))
+            or ("produce_ready_executor_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != EXECUTOR_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_EXECUTOR_PREVIEW_READY,
+            "Executor preview entry is not ready.",
+            ("produce_ready_executor_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_EXECUTOR_PREVIEW_READY,
+        "Executor preview is ready for post-commit audit planning.",
+        {"executor_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _executor_preview_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    expected_digest = _expected_executor_preview_digest(preview)
+    actual_digest = _str(preview.get("preview_digest"))
+    expected_id = f"executor-preview-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in ("lock_id", "receipt_id", "token_id", "operation_ids"):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if missing_fields or actual_digest != expected_digest or _str(preview.get("id")) != expected_id:
+        return _fail(
+            CHECK_EXECUTOR_PREVIEW_INTEGRITY,
+            "Executor preview digest, id, or required fields are invalid.",
+            ("regenerate_executor_preview",),
+            {
+                "expected_preview_digest": expected_digest,
+                "actual_preview_digest": actual_digest,
+                "expected_preview_id": expected_id,
+                "actual_preview_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_EXECUTOR_PREVIEW_INTEGRITY,
+        "Executor preview integrity checks pass.",
+        {"executor_preview_id": expected_id, "preview_digest": actual_digest},
+    )
+
+
+def _audit_requirements_check(
+    preview: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairPostCommitAuditStep],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    categories = {step.category for step in audit_steps}
+    required = {"memory_patch", "receipt", "token", "lock", "rollback"}
+    missing = sorted(required - categories)
+    write_steps = [
+        step
+        for step in _list(preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_write_memory") is True
+    ]
+    if missing or not write_steps:
+        return _fail(
+            CHECK_AUDIT_REQUIREMENTS,
+            "Post-commit audit requirements are incomplete.",
+            ("regenerate_executor_preview_with_audit_requirements",),
+            {"missing_categories": missing, "future_write_step_count": len(write_steps)},
+        )
+    return _pass(
+        CHECK_AUDIT_REQUIREMENTS,
+        "Post-commit audit requirements cover memory patch, receipt, token, lock, and rollback checks.",
+        {"audit_step_count": len(audit_steps), "future_write_step_count": len(write_steps)},
+    )
+
+
+def _observed_post_state_check(
+    observed: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairPostCommitAuditStep],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    if not observed.get("supplied"):
+        return _pass(
+            CHECK_OBSERVED_POST_STATE,
+            "No observed post-commit state supplied; audit remains a planned preview.",
+            {"observed_state_supplied": False},
+        )
+    failures = [step.to_dict() for step in audit_steps if step.status == AUDIT_STEP_STATUS_FAIL]
+    if failures:
+        return _fail(
+            CHECK_OBSERVED_POST_STATE,
+            "Observed post-commit state does not satisfy the audit preview.",
+            ("investigate_post_commit_audit_failures",),
+            {"observed_state_supplied": True, "failures": failures},
+        )
+    return _pass(
+        CHECK_OBSERVED_POST_STATE,
+        "Observed post-commit state satisfies the audit preview.",
+        {"observed_state_supplied": True},
+    )
+
+
+def _preview_from_executor_preview(
+    *,
+    preview: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairPostCommitAuditStep],
+    observed_state_supplied: bool,
+) -> MemoryEvidenceRepairPostCommitAuditPreview:
+    audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    patch_digests = tuple(_list_of_str(preview.get("patch_digests")))
+    audit_seed = {
+        "executor_preview_id": _str(preview.get("id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "token_id": _str(preview.get("token_id")),
+        "operation_ids": operation_ids,
+        "patch_digests": patch_digests,
+        "audit_step_ids": audit_step_ids,
+        "observed_state_supplied": observed_state_supplied,
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"post-commit-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairPostCommitAuditPreview(
+        id=audit_id,
+        status=POST_COMMIT_AUDIT_STATUS_READY,
+        executor_preview_id=_str(preview.get("id")),
+        lock_id=_str(preview.get("lock_id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        token_id=_str(preview.get("token_id")),
+        operation_ids=operation_ids,
+        patch_digests=patch_digests,
+        audit_step_ids=audit_step_ids,
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=tuple(audit_steps),
+        observed_state_supplied=observed_state_supplied,
+        would_verify_memory_patches=True,
+        would_verify_receipt_recorded=True,
+        would_verify_token_used=True,
+        would_verify_lock_released=True,
+        would_verify_rollback_available=True,
+        safety_note=(
+            "Read-only post-commit audit preview. It plans or checks future "
+            "verification signals but does not read or write durable memory."
+        ),
+        source_executor_preview=dict(preview),
+    )
+
+
+def _audit_steps_from_preview(
+    preview: Mapping[str, Any],
+    observed: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairPostCommitAuditStep]:
+    steps: list[MemoryEvidenceRepairPostCommitAuditStep] = []
+    observed_patches = _dict(observed.get("memory_patches"))
+    for sequence, write_step in enumerate(_write_steps(preview), start=1):
+        operation_id = _str(write_step.get("operation_id"))
+        expected = {
+            "operation_id": operation_id,
+            "patch_digest": _str(write_step.get("patch_digest")),
+            "target": _dict(write_step.get("target")),
+            "evidence_fields": _list_of_str(write_step.get("evidence_fields")),
+        }
+        observed_signal = _dict(observed_patches.get(operation_id))
+        steps.append(
+            _audit_step(
+                sequence=sequence,
+                category="memory_patch",
+                assertion="memory_patch_applied_with_expected_digest",
+                preview=preview,
+                operation_id=operation_id,
+                expected_signal=expected,
+                observed_signal=observed_signal,
+                status=_observed_patch_status(expected, observed_signal, observed["supplied"]),
+                required_action_on_fail="inspect_memory_patch_and_rollback_if_needed",
+            )
+        )
+    sequence = len(steps) + 1
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="receipt",
+            assertion="commit_receipt_recorded",
+            preview=preview,
+            expected_signal={"receipt_id": _str(preview.get("receipt_id"))},
+            observed_signal={"recorded": _receipt_recorded(preview, observed)},
+            status=_boolean_status(_receipt_recorded(preview, observed), observed["supplied"]),
+            required_action_on_fail="record_or_recover_commit_receipt",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="token",
+            assertion="approval_token_marked_used",
+            preview=preview,
+            expected_signal={"token_id": _str(preview.get("token_id"))},
+            observed_signal={"used": _token_used(preview, observed)},
+            status=_boolean_status(_token_used(preview, observed), observed["supplied"]),
+            required_action_on_fail="mark_token_used_or_block_reuse",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="lock",
+            assertion="write_lock_released",
+            preview=preview,
+            expected_signal={"lock_id": _str(preview.get("lock_id"))},
+            observed_signal={"released": _lock_released(preview, observed)},
+            status=_boolean_status(_lock_released(preview, observed), observed["supplied"]),
+            required_action_on_fail="release_write_lock_or_mark_lock_expired",
+        )
+    )
+    sequence += 1
+    rollback_ready = _rollback_available(observed)
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="rollback",
+            assertion="rollback_or_snapshot_reference_available",
+            preview=preview,
+            expected_signal={"rollback_reference_required": True},
+            observed_signal={"rollback_available": rollback_ready},
+            status=_boolean_status(rollback_ready, observed["supplied"]),
+            required_action_on_fail="verify_rollback_plan_or_pre_commit_snapshot",
+        )
+    )
+    return steps
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    preview: Mapping[str, Any],
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+    status: str,
+    required_action_on_fail: str,
+    operation_id: str = "",
+) -> MemoryEvidenceRepairPostCommitAuditStep:
+    return MemoryEvidenceRepairPostCommitAuditStep(
+        id=f"post-commit-audit-step-{sequence}-{category}",
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        operation_id=operation_id,
+        receipt_id=_str(preview.get("receipt_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=status,
+        required_action_on_fail=required_action_on_fail,
+    )
+
+
+def _observed_context(
+    *,
+    observed_memory_patches: Mapping[str, Any] | None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    used_token_ids: Sequence[str] | None,
+    released_lock_ids: Sequence[str] | None,
+    rollback_status: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    memory_patches = _dict(observed_memory_patches)
+    receipt_ids = _receipt_ids(recorded_receipts)
+    used_tokens = tuple(_list_of_str(used_token_ids))
+    released_locks = tuple(_list_of_str(released_lock_ids))
+    rollback = _dict(rollback_status)
+    supplied = bool(memory_patches or receipt_ids or used_tokens or released_locks or rollback)
+    return {
+        "supplied": supplied,
+        "memory_patches": memory_patches,
+        "receipt_ids": receipt_ids,
+        "used_token_ids": used_tokens,
+        "released_lock_ids": released_locks,
+        "rollback_status": rollback,
+    }
+
+
+def _observed_patch_status(
+    expected: Mapping[str, Any],
+    observed: Mapping[str, Any],
+    observed_supplied: bool,
+) -> str:
+    if not observed_supplied:
+        return AUDIT_STEP_STATUS_PLANNED
+    if (
+        observed.get("applied") is True
+        and _str(observed.get("patch_digest")) == _str(expected.get("patch_digest"))
+    ):
+        return AUDIT_STEP_STATUS_PASS
+    return AUDIT_STEP_STATUS_FAIL
+
+
+def _boolean_status(value: bool, observed_supplied: bool) -> str:
+    if not observed_supplied:
+        return AUDIT_STEP_STATUS_PLANNED
+    return AUDIT_STEP_STATUS_PASS if value else AUDIT_STEP_STATUS_FAIL
+
+
+def _receipt_recorded(preview: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(preview.get("receipt_id")) in set(observed.get("receipt_ids") or ())
+
+
+def _token_used(preview: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(preview.get("token_id")) in set(observed.get("used_token_ids") or ())
+
+
+def _lock_released(preview: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(preview.get("lock_id")) in set(observed.get("released_lock_ids") or ())
+
+
+def _rollback_available(observed: Mapping[str, Any]) -> bool:
+    rollback = _dict(observed.get("rollback_status"))
+    status = _str(rollback.get("status"))
+    if not rollback:
+        return False
+    return status in {
+        "ready",
+        "available",
+        "verified",
+        "rollback_ready",
+        "snapshot_available",
+    }
+
+
+def _write_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_write_memory") is True
+    ]
+
+
+def _receipt_ids(recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None) -> tuple[str, ...]:
+    ids: list[str] = []
+    if isinstance(recorded_receipts, Mapping):
+        ids.extend(_list_of_str(recorded_receipts.get("receipt_ids")))
+        rows = recorded_receipts.get("receipts")
+        if isinstance(rows, list):
+            ids.extend(_receipt_ids(rows))
+        if _str(recorded_receipts.get("id")):
+            ids.append(_str(recorded_receipts.get("id")))
+        if _str(recorded_receipts.get("receipt_id")):
+            ids.append(_str(recorded_receipts.get("receipt_id")))
+    elif isinstance(recorded_receipts, list):
+        for receipt in recorded_receipts:
+            if isinstance(receipt, Mapping):
+                ids.append(_str(receipt.get("id")) or _str(receipt.get("receipt_id")))
+    return tuple(_dedupe_strings(ids))
+
+
+def _expected_executor_preview_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_id": _str(preview.get("lock_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "token_id": _str(preview.get("token_id")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "candidate_ids": tuple(_list_of_str(preview.get("candidate_ids"))),
+        "patch_digests": tuple(_list_of_str(preview.get("patch_digests"))),
+        "step_ids": tuple(_list_of_str(preview.get("step_ids"))),
+        "execution_mode": "manual_ordered_commit",
+        "failure_policy": "stop_on_first_write_failure_then_release_lock",
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    executor_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_executor_preview_report=dict(executor_preview),
+    )
+
+
+def _blocked_report(
+    *,
+    executor_preview: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairPostCommitAuditCheck, ...],
+) -> MemoryEvidenceRepairPostCommitAuditPreviewReport:
+    return MemoryEvidenceRepairPostCommitAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=POST_COMMIT_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_executor_preview_report=dict(executor_preview),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    return MemoryEvidenceRepairPostCommitAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairPostCommitAuditCheck:
+    return MemoryEvidenceRepairPostCommitAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_approval_token_gate.py
+++ b/agent/memory_evidence_repair_recovery_approval_token_gate.py
@@ -1,0 +1,670 @@
+"""Read-only recovery approval token verification gate.
+
+The gate verifies a drafted recovery human approval token against the current
+recovery execution preview, confirmation text, expiry window, and one-time-use
+hints. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    RECOVERY_APPROVAL_TOKEN_SCOPE,
+    RECOVERY_APPROVAL_TOKEN_TYPE,
+    RECOVERY_TOKEN_STATUS_DRAFT_READY,
+    RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+)
+
+
+RECOVERY_TOKEN_GATE_STATUS_VERIFIED = "verified_for_manual_recovery"
+RECOVERY_TOKEN_GATE_STATUS_BLOCKED = "blocked"
+RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_RECOVERY_TOKEN_SHAPE = "recovery_token_shape"
+CHECK_RECOVERY_CONFIRMATION_TEXT = "recovery_confirmation_text"
+CHECK_RECOVERY_TOKEN_DIGEST = "recovery_token_digest"
+CHECK_EXECUTION_PREVIEW_DIGEST = "execution_preview_digest"
+CHECK_FUTURE_MUTATION_STEPS = "future_mutation_steps"
+CHECK_RECOVERY_EXPIRY = "recovery_expiry"
+CHECK_RECOVERY_ONE_TIME_CONSTRAINTS = "recovery_one_time_constraints"
+CHECK_RECOVERY_REUSE = "recovery_reuse"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    """One read-only recovery approval token verification check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    """Read-only recovery approval token gate report."""
+
+    generated_at: str
+    status: str
+    token_id: str
+    execution_preview_status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryApprovalTokenGateCheck, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    verified_operation_ids: tuple[str, ...]
+    verified_step_ids: tuple[str, ...]
+    verified_future_mutation_step_ids: tuple[str, ...]
+    source_token: dict[str, Any]
+    source_recovery_execution_preview: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "token_id": self.token_id,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "verified_operation_count": len(self.verified_operation_ids),
+            "verified_step_count": len(self.verified_step_ids),
+            "verified_future_mutation_step_count": len(
+                self.verified_future_mutation_step_ids
+            ),
+            "manual_recovery_verified": self.status == RECOVERY_TOKEN_GATE_STATUS_VERIFIED,
+            "has_blocks": self.status == RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "token_id": self.token_id,
+            "execution_preview_status": self.execution_preview_status,
+            "checks": [check.to_dict() for check in self.checks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "verified_operation_ids": list(self.verified_operation_ids),
+            "verified_step_ids": list(self.verified_step_ids),
+            "verified_future_mutation_step_ids": list(
+                self.verified_future_mutation_step_ids
+            ),
+            "source_token": dict(self.source_token),
+            "source_recovery_execution_preview": dict(
+                self.source_recovery_execution_preview
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_approval_token_gate(
+    *,
+    recovery_approval_token: Mapping[str, Any] | None = None,
+    recovery_execution: Mapping[str, Any] | None = None,
+    confirmation_text: str = "",
+    used_token_ids: Sequence[str] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    """Verify a recovery human approval token without mutating memory."""
+
+    token, issued_at = _extract_token_and_issued_at(recovery_approval_token)
+    explicit_execution = (
+        recovery_execution if isinstance(recovery_execution, Mapping) else {}
+    )
+    token_execution = token.get("source_execution_preview") if isinstance(token, Mapping) else {}
+    current_execution = explicit_execution or (
+        token_execution if isinstance(token_execution, Mapping) else {}
+    )
+    current_execution = current_execution if isinstance(current_execution, Mapping) else {}
+
+    token_report_status = (
+        _str(recovery_approval_token.get("status"))
+        if isinstance(recovery_approval_token, Mapping)
+        else ""
+    )
+    if not token:
+        execution_status = _str(current_execution.get("status"))
+        if (
+            token_report_status == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED
+            or execution_status == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED
+            or (not current_execution and not token_report_status)
+        ):
+            return _empty_report(recovery_execution=current_execution)
+        source_blocking = (
+            _list(recovery_approval_token.get("blocking_reasons"))
+            if isinstance(recovery_approval_token, Mapping)
+            else []
+        )
+        source_actions = (
+            _list(recovery_approval_token.get("required_actions"))
+            if isinstance(recovery_approval_token, Mapping)
+            else []
+        )
+        return _blocked_report(
+            token_id="",
+            recovery_execution=current_execution,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_TOKEN_SHAPE,
+                    "No recovery approval token was supplied."
+                    if not source_blocking
+                    else "; ".join(_str(item) for item in source_blocking if _str(item)),
+                    tuple(_str(item) for item in source_actions if _str(item))
+                    or ("draft_recovery_human_approval_token",),
+                    {"recovery_approval_token_status": token_report_status},
+                ),
+            ),
+        )
+
+    checks = tuple(
+        check
+        for check in (
+            _token_shape_check(token),
+            _confirmation_check(token, confirmation_text),
+            _token_digest_check(token),
+            _execution_preview_digest_check(token, current_execution),
+            _future_mutation_step_check(token, current_execution),
+            _expiry_check(token, issued_at, current_time),
+            _one_time_constraint_check(token),
+            _reuse_check(token, used_token_ids),
+        )
+        if check is not None
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    status = (
+        RECOVERY_TOKEN_GATE_STATUS_VERIFIED
+        if checks and not blocking_reasons
+        else RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    )
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=status,
+        token_id=_str(token.get("id")),
+        execution_preview_status=_str(current_execution.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=tuple(_list_of_str(current_execution.get("operation_ids"))),
+        verified_step_ids=tuple(_list_of_str(current_execution.get("step_ids"))),
+        verified_future_mutation_step_ids=tuple(_future_mutation_step_ids(current_execution)),
+        source_token=dict(token),
+        source_recovery_execution_preview=dict(current_execution),
+    )
+
+
+def empty_evidence_repair_recovery_approval_token_gate() -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    """Return an empty read-only recovery approval token gate report."""
+
+    return _empty_report(recovery_execution={})
+
+
+def _empty_report(
+    *,
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+        token_id="",
+        execution_preview_status=_str(recovery_execution.get("status")),
+        checks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        verified_operation_ids=(),
+        verified_step_ids=(),
+        verified_future_mutation_step_ids=(),
+        source_token={},
+        source_recovery_execution_preview=dict(recovery_execution),
+    )
+
+
+def _blocked_report(
+    *,
+    token_id: str,
+    recovery_execution: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryApprovalTokenGateCheck, ...],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateReport:
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+        token_id=token_id,
+        execution_preview_status=_str(recovery_execution.get("status")),
+        checks=checks,
+        blocking_reasons=blocking_reasons,
+        required_actions=required_actions,
+        verified_operation_ids=(),
+        verified_step_ids=(),
+        verified_future_mutation_step_ids=(),
+        source_token={},
+        source_recovery_execution_preview=dict(recovery_execution),
+    )
+
+
+def _extract_token_and_issued_at(
+    recovery_approval_token: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], str]:
+    if not isinstance(recovery_approval_token, Mapping):
+        return {}, ""
+    report_issued_at = _str(recovery_approval_token.get("generated_at"))
+    token: Mapping[str, Any] | None = None
+    tokens = recovery_approval_token.get("tokens")
+    if isinstance(tokens, list):
+        token = next((item for item in tokens if isinstance(item, Mapping)), None)
+    elif _str(recovery_approval_token.get("id")):
+        token = recovery_approval_token
+    if not isinstance(token, Mapping):
+        return {}, report_issued_at
+    issued_at = (
+        _str(token.get("issued_at"))
+        or _str(token.get("generated_at"))
+        or report_issued_at
+    )
+    return dict(token), issued_at
+
+
+def _token_shape_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    reasons: list[str] = []
+    if not _str(token.get("id")).startswith("recovery-approval-token-"):
+        reasons.append("Recovery token id is missing or invalid.")
+    if _str(token.get("token_type")) != RECOVERY_APPROVAL_TOKEN_TYPE:
+        reasons.append("Token type is not a memory evidence repair recovery token.")
+    if _str(token.get("scope")) != RECOVERY_APPROVAL_TOKEN_SCOPE:
+        reasons.append("Token scope does not match manual memory evidence repair recovery.")
+    if _str(token.get("status")) != RECOVERY_TOKEN_STATUS_DRAFT_READY:
+        reasons.append("Recovery token is not a ready approval draft.")
+    if reasons:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_SHAPE,
+            " ".join(reasons),
+            ("regenerate_recovery_human_approval_token",),
+            {"token_id": _str(token.get("id"))},
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_SHAPE,
+        "Recovery approval token shape is valid.",
+        {"token_id": _str(token.get("id"))},
+    )
+
+
+def _confirmation_check(
+    token: Mapping[str, Any],
+    confirmation_text: str,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    expected = _str(token.get("required_confirmation_text"))
+    actual = _str(confirmation_text)
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str(constraints.get("requires_exact_confirmation_text"))
+    expected_values = {item for item in (expected, constraint_expected) if item}
+    if not actual or actual not in expected_values:
+        return _fail(
+            CHECK_RECOVERY_CONFIRMATION_TEXT,
+            "Confirmation text does not exactly match the recovery approval token.",
+            ("provide_exact_recovery_confirmation_text",),
+            {"expected_confirmation_text": expected or constraint_expected, "provided": actual},
+        )
+    return _pass(
+        CHECK_RECOVERY_CONFIRMATION_TEXT,
+        "Confirmation text matches the recovery approval token.",
+        {"provided": actual},
+    )
+
+
+def _token_digest_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    expected_digest = _expected_token_digest(token)
+    actual_digest = _str(token.get("token_digest"))
+    expected_id = f"recovery-approval-token-{expected_digest[:16]}" if expected_digest else ""
+    if actual_digest != expected_digest or _str(token.get("id")) != expected_id:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_DIGEST,
+            "Recovery approval token digest or id does not match its declared payload.",
+            ("regenerate_recovery_human_approval_token",),
+            {
+                "expected_token_digest": expected_digest,
+                "actual_token_digest": actual_digest,
+                "expected_token_id": expected_id,
+                "actual_token_id": _str(token.get("id")),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_DIGEST,
+        "Recovery approval token digest matches its declared payload.",
+        {"token_digest": actual_digest, "token_id": expected_id},
+    )
+
+
+def _execution_preview_digest_check(
+    token: Mapping[str, Any],
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    if _str(recovery_execution.get("status")) != RECOVERY_EXECUTION_STATUS_READY:
+        return _fail(
+            CHECK_EXECUTION_PREVIEW_DIGEST,
+            "Current recovery execution preview is not ready.",
+            ("produce_ready_recovery_execution_preview",),
+            {"recovery_execution_status": _str(recovery_execution.get("status"))},
+        )
+    actual = _execution_preview_digest(recovery_execution)
+    expected = _str(token.get("execution_preview_digest"))
+    if not expected or actual != expected:
+        return _fail(
+            CHECK_EXECUTION_PREVIEW_DIGEST,
+            "Current recovery execution preview digest does not match the token.",
+            ("regenerate_recovery_human_approval_token_for_current_execution_preview",),
+            {
+                "expected_execution_preview_digest": expected,
+                "actual_execution_preview_digest": actual,
+            },
+        )
+    return _pass(
+        CHECK_EXECUTION_PREVIEW_DIGEST,
+        "Current recovery execution preview digest matches the token.",
+        {"execution_preview_digest": actual},
+    )
+
+
+def _future_mutation_step_check(
+    token: Mapping[str, Any],
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    expected = _str_list(token.get("future_mutation_step_ids"))
+    actual = _future_mutation_step_ids(recovery_execution)
+    constraints = _dict(token.get("one_time_constraints"))
+    constraint_expected = _str_list(
+        constraints.get("requires_same_future_mutation_step_ids")
+    )
+    if expected != actual or (constraint_expected and constraint_expected != actual):
+        return _fail(
+            CHECK_FUTURE_MUTATION_STEPS,
+            "Current future mutation steps do not match the recovery approval token.",
+            ("regenerate_recovery_human_approval_token_for_current_execution_preview",),
+            {
+                "expected_future_mutation_step_ids": expected,
+                "constraint_future_mutation_step_ids": constraint_expected,
+                "actual_future_mutation_step_ids": actual,
+            },
+        )
+    return _pass(
+        CHECK_FUTURE_MUTATION_STEPS,
+        "Current future mutation steps match the recovery approval token.",
+        {"future_mutation_step_ids": actual},
+    )
+
+
+def _expiry_check(
+    token: Mapping[str, Any],
+    issued_at: str,
+    current_time: str | datetime | None,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    issued = _parse_datetime(issued_at)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+    expires_in_minutes = _positive_int(token.get("expires_in_minutes")) or 15
+    if issued is None:
+        return _fail(
+            CHECK_RECOVERY_EXPIRY,
+            "Recovery approval token issue time is missing or invalid.",
+            ("provide_recovery_token_generated_at_or_regenerate_token",),
+            {"issued_at": issued_at},
+        )
+    expires_at = issued + timedelta(minutes=expires_in_minutes)
+    if now > expires_at:
+        return _fail(
+            CHECK_RECOVERY_EXPIRY,
+            "Recovery approval token has expired.",
+            ("regenerate_recovery_human_approval_token",),
+            {
+                "issued_at": issued.isoformat(),
+                "expires_at": expires_at.isoformat(),
+                "current_time": now.isoformat(),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_EXPIRY,
+        "Recovery approval token is within its expiry window.",
+        {
+            "issued_at": issued.isoformat(),
+            "expires_at": expires_at.isoformat(),
+            "current_time": now.isoformat(),
+        },
+    )
+
+
+def _one_time_constraint_check(
+    token: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    constraints = _dict(token.get("one_time_constraints"))
+    if constraints.get("one_time_use") is not True:
+        return _fail(
+            CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+            "Recovery approval token does not declare one-time-use constraints.",
+            ("regenerate_recovery_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    expected_execution = _str(
+        constraints.get("requires_exact_execution_preview_digest")
+    )
+    if expected_execution != _str(token.get("execution_preview_digest")):
+        return _fail(
+            CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+            "Recovery token execution-preview constraint does not match its digest.",
+            ("regenerate_recovery_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    if _str(constraints.get("requires_exact_decision_id")) != _str(token.get("decision_id")):
+        return _fail(
+            CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+            "Recovery token decision constraint does not match its decision id.",
+            ("regenerate_recovery_human_approval_token",),
+            {"one_time_constraints": constraints},
+        )
+    return _pass(
+        CHECK_RECOVERY_ONE_TIME_CONSTRAINTS,
+        "Recovery approval token one-time constraints are declared.",
+        {"one_time_constraints": constraints},
+    )
+
+
+def _reuse_check(
+    token: Mapping[str, Any],
+    used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    token_id = _str(token.get("id"))
+    used = {_str(item) for item in used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_RECOVERY_REUSE,
+            "Recovery approval token is already marked as used.",
+            ("regenerate_recovery_human_approval_token",),
+            {"token_id": token_id},
+        )
+    return _pass(
+        CHECK_RECOVERY_REUSE,
+        "Recovery approval token is not marked as used in the supplied read-only ledger.",
+        {"token_id": token_id, "used_token_id_count": len(used)},
+    )
+
+
+def _expected_token_digest(token: Mapping[str, Any]) -> str:
+    token_seed = {
+        "token_type": RECOVERY_APPROVAL_TOKEN_TYPE,
+        "scope": RECOVERY_APPROVAL_TOKEN_SCOPE,
+        "approver": _str(token.get("approver")) or "human",
+        "approval_reason": _str(token.get("approval_reason")),
+        "execution_preview_digest": _str(token.get("execution_preview_digest")),
+        "execution_preview_id": _str(token.get("execution_preview_id")),
+        "decision_id": _str(token.get("decision_id")),
+        "route": _str(token.get("route")),
+        "operation_ids": _str_list(token.get("operation_ids")),
+        "failed_audit_step_ids": _str_list(token.get("failed_audit_step_ids")),
+        "step_ids": _str_list(token.get("step_ids")),
+        "future_mutation_step_ids": _str_list(token.get("future_mutation_step_ids")),
+        "expires_in_minutes": _positive_int(token.get("expires_in_minutes")) or 15,
+    }
+    return _digest(token_seed)
+
+
+def _execution_preview_digest(recovery_execution: Mapping[str, Any]) -> str:
+    existing = _str(recovery_execution.get("preview_digest"))
+    if existing:
+        return existing
+    return _digest(
+        {
+            "id": _str(recovery_execution.get("id")),
+            "route": _str(recovery_execution.get("route")),
+            "decision_id": _str(recovery_execution.get("decision_id")),
+            "operation_ids": tuple(_list_of_str(recovery_execution.get("operation_ids"))),
+            "failed_audit_step_ids": tuple(
+                _list_of_str(recovery_execution.get("failed_audit_step_ids"))
+            ),
+            "step_ids": tuple(_list_of_str(recovery_execution.get("step_ids"))),
+        }
+    )
+
+
+def _future_mutation_step_ids(recovery_execution: Mapping[str, Any]) -> list[str]:
+    return [
+        _str(step.get("id"))
+        for step in _list(recovery_execution.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_mutate_memory") is True
+    ]
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryApprovalTokenGateCheck:
+    return MemoryEvidenceRepairRecoveryApprovalTokenGateCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | None) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str_list(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview.py
@@ -1,0 +1,1123 @@
+"""Read-only recovery closure finalization readiness audit preview.
+
+This layer audits a recovery closure finalization readiness draft so a later
+manual finalization path can trust the gate that would allow closure. It never
+writes durable memory, records a real audit, or finalizes a recovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_preview import (
+    RECOVERY_CLOSURE_FINALIZATION_DECISION,
+    RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_READY,
+    RECOVERY_CLOSURE_FINALIZATION_TYPE,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_READY = (
+    "recovery_closure_finalization_readiness_audit_preview_ready"
+)
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_NO_ACTION_NEEDED = (
+    "no_action_needed"
+)
+RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_STATUS_READY = (
+    "recovery_closure_finalization_readiness_audit_ready"
+)
+
+FINALIZATION_READINESS_AUDIT_STEP_STATUS_PASS = "pass"
+FINALIZATION_READINESS_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_FINALIZATION_READINESS_READY = "recovery_finalization_readiness_ready"
+CHECK_RECOVERY_FINALIZATION_READINESS_INTEGRITY = (
+    "recovery_finalization_readiness_integrity"
+)
+CHECK_RECOVERY_FINALIZATION_READINESS_SOURCE_CHAIN = (
+    "recovery_finalization_readiness_source_chain"
+)
+CHECK_RECOVERY_FINALIZATION_READINESS_AUDIT_REQUIREMENTS = (
+    "recovery_finalization_readiness_audit_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    """One read-only finalization readiness audit check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep:
+    """One structural audit step for a future finalization readiness draft."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    finalization_readiness_id: str
+    reference_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "finalization_readiness_id": self.finalization_readiness_id,
+            "reference_id": self.reference_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview:
+    """One read-only recovery closure finalization readiness audit preview."""
+
+    id: str
+    status: str
+    finalization_readiness_id: str
+    seal_audit_preview_id: str
+    seal_id: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    seal_audit_step_ids: tuple[str, ...]
+    readiness_audit_step_ids: tuple[str, ...]
+    finalization_digest: str
+    seal_audit_digest: str
+    seal_digest: str
+    ledger_audit_digest: str
+    ledger_entry_digest: str
+    closure_digest: str
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep, ...
+    ]
+    would_verify_finalization_integrity: bool
+    would_verify_manual_handoff: bool
+    would_verify_source_governance_chain: bool
+    would_verify_read_only_constraints: bool
+    safety_note: str
+    source_recovery_closure_finalization_readiness: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "finalization_readiness_id": self.finalization_readiness_id,
+            "seal_audit_preview_id": self.seal_audit_preview_id,
+            "seal_id": self.seal_id,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "seal_audit_step_ids": list(self.seal_audit_step_ids),
+            "readiness_audit_step_ids": list(self.readiness_audit_step_ids),
+            "finalization_digest": self.finalization_digest,
+            "seal_audit_digest": self.seal_audit_digest,
+            "seal_digest": self.seal_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "would_verify_finalization_integrity": (
+                self.would_verify_finalization_integrity
+            ),
+            "would_verify_manual_handoff": self.would_verify_manual_handoff,
+            "would_verify_source_governance_chain": (
+                self.would_verify_source_governance_chain
+            ),
+            "would_verify_read_only_constraints": (
+                self.would_verify_read_only_constraints
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_closure_finalization_readiness": dict(
+                self.source_recovery_closure_finalization_readiness
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    """Read-only finalization readiness audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck, ...
+    ]
+    previews: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview, ...
+    ]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_finalization_readiness_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "observed_pass_step_count": by_audit_step_status.get(
+                FINALIZATION_READINESS_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                FINALIZATION_READINESS_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_finalization_readiness_audit_preview_available": bool(
+                self.previews
+            ),
+            "recovery_closure_finalization_readiness_audit_ready": (
+                self.status
+                == RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_READY
+            ),
+            "has_blocks": (
+                self.status
+                == RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED
+            ),
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_finalization_readiness_report": dict(
+                self.source_recovery_closure_finalization_readiness_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_finalization_readiness_audit_preview(
+    *,
+    recovery_closure_finalization_readiness: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    """Build a read-only audit preview from a finalization readiness report."""
+
+    recovery_closure_finalization_readiness = (
+        recovery_closure_finalization_readiness
+        if isinstance(recovery_closure_finalization_readiness, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_finalization_readiness.get("status"))
+    readiness = _extract_readiness(recovery_closure_finalization_readiness)
+
+    if not readiness:
+        if (
+            not recovery_closure_finalization_readiness
+            or report_status == RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_finalization_readiness=(
+                    recovery_closure_finalization_readiness
+                )
+            )
+        source_blocking = tuple(
+            _list_of_str(
+                recovery_closure_finalization_readiness.get("blocking_reasons")
+            )
+        )
+        source_actions = tuple(
+            _list_of_str(
+                recovery_closure_finalization_readiness.get("required_actions")
+            )
+        )
+        return _blocked_report(
+            recovery_closure_finalization_readiness=(
+                recovery_closure_finalization_readiness
+            ),
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+                    "No recovery closure finalization readiness draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_finalization_readiness_preview",),
+                    {
+                        "recovery_closure_finalization_readiness_status": (
+                            report_status
+                        )
+                    },
+                ),
+            ),
+        )
+
+    checks = (
+        _readiness_ready_check(recovery_closure_finalization_readiness, readiness),
+        _readiness_integrity_check(readiness),
+        _readiness_source_chain_check(readiness),
+        _audit_requirements_check(readiness),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(
+            check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+        )
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_finalization_readiness_report=dict(
+                recovery_closure_finalization_readiness
+            ),
+        )
+
+    preview = _preview_from_readiness(readiness)
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_finalization_readiness_report=dict(
+            recovery_closure_finalization_readiness
+        ),
+    )
+
+
+def empty_evidence_repair_recovery_closure_finalization_readiness_audit_preview() -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    """Return an empty read-only finalization readiness audit preview."""
+
+    return _empty_report(recovery_closure_finalization_readiness={})
+
+
+def _extract_readiness(
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+) -> dict[str, Any]:
+    readiness = recovery_closure_finalization_readiness.get("readiness")
+    if isinstance(readiness, list):
+        for item in readiness:
+            if isinstance(item, Mapping):
+                return dict(item)
+    if _str(recovery_closure_finalization_readiness.get("id")).startswith(
+        "recovery-closure-finalization-readiness-"
+    ):
+        return dict(recovery_closure_finalization_readiness)
+    return {}
+
+
+def _readiness_ready_check(
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    report_status = _str(recovery_closure_finalization_readiness.get("status"))
+    readiness_status = _str(readiness.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_FINALIZATION_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+            "Recovery closure finalization readiness report is not ready for audit preview.",
+            tuple(
+                _list_of_str(
+                    recovery_closure_finalization_readiness.get("required_actions")
+                )
+            )
+            or ("produce_ready_recovery_closure_finalization_readiness_preview",),
+            {"report_status": report_status, "readiness_status": readiness_status},
+        )
+    if readiness_status != RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+            "Recovery closure finalization readiness draft is not ready for audit preview.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {"report_status": report_status, "readiness_status": readiness_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_READY,
+        "Recovery closure finalization readiness draft is ready for audit preview.",
+        {"finalization_readiness_id": _str(readiness.get("id"))},
+    )
+
+
+def _readiness_integrity_check(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    expected_digest = _expected_finalization_digest(readiness)
+    actual_digest = _str(readiness.get("finalization_digest"))
+    expected_id = (
+        f"recovery-closure-finalization-readiness-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "finalization_type",
+        "status",
+        "finalization_decision",
+        "finalization_scope",
+        "seal_audit_preview_id",
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "seal_audit_step_ids",
+        "seal_digest",
+        "seal_audit_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+        "finalization_digest",
+        "source_recovery_closure_governance_seal_audit_preview",
+    ):
+        value = readiness.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(readiness.get("id")) != expected_id
+        or _str(readiness.get("finalization_type"))
+        != RECOVERY_CLOSURE_FINALIZATION_TYPE
+        or _str(readiness.get("finalization_decision"))
+        != RECOVERY_CLOSURE_FINALIZATION_DECISION
+        or _str(readiness.get("finalization_scope"))
+        != RECOVERY_CLOSURE_FINALIZATION_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_INTEGRITY,
+            "Recovery closure finalization readiness digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {
+                "expected_finalization_digest": expected_digest,
+                "actual_finalization_digest": actual_digest,
+                "expected_finalization_readiness_id": expected_id,
+                "actual_finalization_readiness_id": _str(readiness.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_INTEGRITY,
+        "Recovery closure finalization readiness integrity checks pass.",
+        {
+            "finalization_readiness_id": expected_id,
+            "finalization_digest": actual_digest,
+        },
+    )
+
+
+def _readiness_source_chain_check(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    seal_audit = _dict(
+        readiness.get("source_recovery_closure_governance_seal_audit_preview")
+    )
+    seal = _dict(seal_audit.get("source_recovery_closure_governance_seal"))
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    entry = _dict(ledger_audit.get("source_recovery_closure_ledger_entry"))
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure_governance_seal_audit_preview", seal_audit),
+            ("source_recovery_closure_governance_seal", seal),
+            ("source_recovery_closure_ledger_audit_preview", ledger_audit),
+            ("source_recovery_closure_ledger_entry", entry),
+        )
+        if not source
+    ]
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "seal_audit_preview_id",
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "seal_digest",
+        "seal_audit_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        source_key = "id" if field_name == "seal_audit_preview_id" else field_name
+        if field_name == "seal_audit_digest":
+            source_key = "audit_digest"
+        _compare(mismatches, field_name, readiness, field_name, seal_audit, source_key)
+    if _str(readiness.get("seal_id")) != _str(seal.get("id")):
+        mismatches.append(
+            {
+                "field": "seal_id",
+                "left": _str(readiness.get("seal_id")),
+                "right": _str(seal.get("id")),
+                "right_key": "source_recovery_closure_governance_seal.id",
+            }
+        )
+    if _str(readiness.get("ledger_audit_preview_id")) != _str(ledger_audit.get("id")):
+        mismatches.append(
+            {
+                "field": "ledger_audit_preview_id",
+                "left": _str(readiness.get("ledger_audit_preview_id")),
+                "right": _str(ledger_audit.get("id")),
+                "right_key": "source_recovery_closure_ledger_audit_preview.id",
+            }
+        )
+    if _str(readiness.get("ledger_entry_id")) != _str(entry.get("id")):
+        mismatches.append(
+            {
+                "field": "ledger_entry_id",
+                "left": _str(readiness.get("ledger_entry_id")),
+                "right": _str(entry.get("id")),
+                "right_key": "source_recovery_closure_ledger_entry.id",
+            }
+        )
+    seal_audit_steps = _audit_steps(seal_audit)
+    ledger_audit_steps = _audit_steps(ledger_audit)
+    non_pass_seal_audit_steps = [
+        _str(step.get("id")) or f"seal-audit-step-{index}"
+        for index, step in enumerate(seal_audit_steps, start=1)
+        if _str(step.get("status")) != GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS
+    ]
+    non_pass_ledger_audit_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(ledger_audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(seal_audit.get("status"))
+        != RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY
+        or _str(seal.get("status")) != RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY
+        or _str(ledger_audit.get("status"))
+        != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_seal_audit_steps
+        or non_pass_ledger_audit_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_SOURCE_CHAIN,
+            "Recovery closure finalization readiness source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "seal_audit_status": _str(seal_audit.get("status")),
+                "seal_status": _str(seal.get("status")),
+                "ledger_audit_status": _str(ledger_audit.get("status")),
+                "entry_status": _str(entry.get("status")),
+                "non_pass_seal_audit_step_ids": non_pass_seal_audit_steps,
+                "non_pass_ledger_audit_step_ids": non_pass_ledger_audit_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_SOURCE_CHAIN,
+        "Recovery closure finalization readiness source chain preserves finalization, seal audit, seal, ledger audit, and ledger evidence.",
+        {
+            "finalization_readiness_id": _str(readiness.get("id")),
+            "seal_audit_preview_id": _str(readiness.get("seal_audit_preview_id")),
+            "seal_id": _str(readiness.get("seal_id")),
+            "ledger_audit_preview_id": _str(readiness.get("ledger_audit_preview_id")),
+            "seal_audit_step_count": len(seal_audit_steps),
+            "ledger_audit_step_count": len(ledger_audit_steps),
+        },
+    )
+
+
+def _audit_requirements_check(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    required_readiness_flags = (
+        "would_allow_final_closure",
+        "would_preserve_full_governance_chain",
+        "would_require_human_finalization",
+        "would_keep_read_only_until_manual_commit",
+    )
+    missing_readiness_flags = [
+        field_name
+        for field_name in required_readiness_flags
+        if readiness.get(field_name) is not True
+    ]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+            "seal_audit_step_ids",
+        )
+        if not _list_of_str(readiness.get(field_name))
+    ]
+    seal_audit = _dict(
+        readiness.get("source_recovery_closure_governance_seal_audit_preview")
+    )
+    source_flags = (
+        "would_verify_seal_integrity",
+        "would_verify_governance_handoff",
+        "would_verify_source_audit_evidence",
+        "would_verify_read_only_constraints",
+    )
+    missing_source_flags = [
+        field_name
+        for field_name in source_flags
+        if seal_audit.get(field_name) is not True
+    ]
+    categories = {_str(step.get("category")) for step in _audit_steps(seal_audit)}
+    required_categories = {
+        "seal_integrity",
+        "ledger_audit_source",
+        "ledger_entry_source",
+        "closure_trace",
+        "governance_controls",
+        "read_only",
+    }
+    missing_categories = sorted(required_categories - categories)
+    if (
+        missing_readiness_flags
+        or missing_lists
+        or missing_source_flags
+        or missing_categories
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_READINESS_AUDIT_REQUIREMENTS,
+            "Recovery closure finalization readiness audit requirements are incomplete.",
+            ("regenerate_recovery_closure_finalization_readiness_preview",),
+            {
+                "missing_readiness_flags": missing_readiness_flags,
+                "missing_lists": missing_lists,
+                "missing_source_flags": missing_source_flags,
+                "missing_categories": missing_categories,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_READINESS_AUDIT_REQUIREMENTS,
+        "Recovery closure finalization readiness audit can verify integrity, manual handoff, source governance chain, and read-only constraints.",
+        {
+            "seal_audit_step_count": len(_audit_steps(seal_audit)),
+            "milestone_count": len(_list_of_str(readiness.get("milestone_ids"))),
+        },
+    )
+
+
+def _preview_from_readiness(
+    readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview:
+    audit_steps = tuple(_audit_steps_from_readiness(readiness))
+    readiness_audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(readiness.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(readiness.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(
+        _list_of_str(readiness.get("future_mutation_step_ids"))
+    )
+    completion_audit_step_ids = tuple(
+        _list_of_str(readiness.get("completion_audit_step_ids"))
+    )
+    milestone_ids = tuple(_list_of_str(readiness.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(readiness.get("ledger_audit_step_ids")))
+    seal_audit_step_ids = tuple(_list_of_str(readiness.get("seal_audit_step_ids")))
+    audit_seed = {
+        "finalization_readiness_id": _str(readiness.get("id")),
+        "seal_audit_preview_id": _str(readiness.get("seal_audit_preview_id")),
+        "seal_id": _str(readiness.get("seal_id")),
+        "ledger_audit_preview_id": _str(readiness.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(readiness.get("ledger_entry_id")),
+        "closure_id": _str(readiness.get("closure_id")),
+        "audit_preview_id": _str(readiness.get("audit_preview_id")),
+        "receipt_id": _str(readiness.get("receipt_id")),
+        "executor_preview_id": _str(readiness.get("executor_preview_id")),
+        "decision_id": _str(readiness.get("decision_id")),
+        "execution_preview_id": _str(readiness.get("execution_preview_id")),
+        "token_id": _str(readiness.get("token_id")),
+        "lock_id": _str(readiness.get("lock_id")),
+        "route": _str(readiness.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "seal_audit_step_ids": seal_audit_step_ids,
+        "readiness_audit_step_ids": readiness_audit_step_ids,
+        "finalization_digest": _str(readiness.get("finalization_digest")),
+        "seal_audit_digest": _str(readiness.get("seal_audit_digest")),
+        "seal_digest": _str(readiness.get("seal_digest")),
+        "ledger_audit_digest": _str(readiness.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(readiness.get("ledger_entry_digest")),
+        "closure_digest": _str(readiness.get("closure_digest")),
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-closure-finalization-readiness-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreview(
+        id=audit_id,
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_STATUS_READY,
+        finalization_readiness_id=_str(readiness.get("id")),
+        seal_audit_preview_id=_str(readiness.get("seal_audit_preview_id")),
+        seal_id=_str(readiness.get("seal_id")),
+        ledger_audit_preview_id=_str(readiness.get("ledger_audit_preview_id")),
+        ledger_entry_id=_str(readiness.get("ledger_entry_id")),
+        closure_id=_str(readiness.get("closure_id")),
+        audit_preview_id=_str(readiness.get("audit_preview_id")),
+        receipt_id=_str(readiness.get("receipt_id")),
+        executor_preview_id=_str(readiness.get("executor_preview_id")),
+        decision_id=_str(readiness.get("decision_id")),
+        execution_preview_id=_str(readiness.get("execution_preview_id")),
+        token_id=_str(readiness.get("token_id")),
+        lock_id=_str(readiness.get("lock_id")),
+        route=_str(readiness.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        seal_audit_step_ids=seal_audit_step_ids,
+        readiness_audit_step_ids=readiness_audit_step_ids,
+        finalization_digest=_str(readiness.get("finalization_digest")),
+        seal_audit_digest=_str(readiness.get("seal_audit_digest")),
+        seal_digest=_str(readiness.get("seal_digest")),
+        ledger_audit_digest=_str(readiness.get("ledger_audit_digest")),
+        ledger_entry_digest=_str(readiness.get("ledger_entry_digest")),
+        closure_digest=_str(readiness.get("closure_digest")),
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=audit_steps,
+        would_verify_finalization_integrity=True,
+        would_verify_manual_handoff=True,
+        would_verify_source_governance_chain=True,
+        would_verify_read_only_constraints=True,
+        safety_note=(
+            "Read-only recovery closure finalization readiness audit preview. "
+            "It verifies that a future manual finalization gate is traceable "
+            "and guarded, but does not record an audit or mutate durable memory."
+        ),
+        source_recovery_closure_finalization_readiness=dict(readiness),
+    )
+
+
+def _audit_steps_from_readiness(
+    readiness: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep]:
+    seal_audit = _dict(
+        readiness.get("source_recovery_closure_governance_seal_audit_preview")
+    )
+    rows = (
+        (
+            "finalization_integrity",
+            "finalization_digest_valid",
+            _str(readiness.get("id")),
+            {"expected_finalization_digest": _expected_finalization_digest(readiness)},
+            {"actual_finalization_digest": _str(readiness.get("finalization_digest"))},
+        ),
+        (
+            "seal_audit_source",
+            "seal_audit_digest_consistent",
+            _str(readiness.get("seal_audit_preview_id")),
+            {"seal_audit_digest": _str(readiness.get("seal_audit_digest"))},
+            {"source_seal_audit_digest": _str(seal_audit.get("audit_digest"))},
+        ),
+        (
+            "governance_seal_source",
+            "governance_seal_digest_consistent",
+            _str(readiness.get("seal_id")),
+            {"seal_digest": _str(readiness.get("seal_digest"))},
+            {"source_seal_digest": _str(seal_audit.get("seal_digest"))},
+        ),
+        (
+            "ledger_audit_source",
+            "ledger_audit_digest_consistent",
+            _str(readiness.get("ledger_audit_preview_id")),
+            {"ledger_audit_digest": _str(readiness.get("ledger_audit_digest"))},
+            {"source_ledger_audit_digest": _str(seal_audit.get("ledger_audit_digest"))},
+        ),
+        (
+            "manual_handoff",
+            "human_finalization_required",
+            _str(readiness.get("id")),
+            {"would_require_human_finalization": True},
+            {
+                "would_require_human_finalization": readiness.get(
+                    "would_require_human_finalization"
+                )
+                is True
+            },
+        ),
+        (
+            "read_only",
+            "finalization_readiness_is_preview_only",
+            _str(readiness.get("id")),
+            {"would_keep_read_only_until_manual_commit": True},
+            {
+                "would_keep_read_only_until_manual_commit": readiness.get(
+                    "would_keep_read_only_until_manual_commit"
+                )
+                is True
+            },
+        ),
+    )
+    return [
+        _audit_step(
+            sequence=index,
+            category=category,
+            assertion=assertion,
+            readiness=readiness,
+            reference_id=reference_id,
+            expected_signal=expected_signal,
+            observed_signal=observed_signal,
+        )
+        for index, (
+            category,
+            assertion,
+            reference_id,
+            expected_signal,
+            observed_signal,
+        ) in enumerate(rows, start=1)
+    ]
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    readiness: Mapping[str, Any],
+    reference_id: str,
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep:
+    step_seed = {
+        "sequence": sequence,
+        "category": category,
+        "assertion": assertion,
+        "finalization_readiness_id": _str(readiness.get("id")),
+        "reference_id": _str(reference_id),
+    }
+    step_id = f"recovery-closure-finalization-readiness-audit-step-{_digest(step_seed)[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditStep(
+        id=step_id,
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        finalization_readiness_id=_str(readiness.get("id")),
+        reference_id=_str(reference_id),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=FINALIZATION_READINESS_AUDIT_STEP_STATUS_PASS,
+        required_action_on_fail=(
+            "regenerate_recovery_closure_finalization_readiness_preview"
+        ),
+    )
+
+
+def _expected_finalization_digest(readiness: Mapping[str, Any]) -> str:
+    seed = {
+        "finalization_type": RECOVERY_CLOSURE_FINALIZATION_TYPE,
+        "finalization_decision": RECOVERY_CLOSURE_FINALIZATION_DECISION,
+        "finalization_scope": RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+        "seal_audit_preview_id": _str(readiness.get("seal_audit_preview_id")),
+        "seal_id": _str(readiness.get("seal_id")),
+        "ledger_audit_preview_id": _str(readiness.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(readiness.get("ledger_entry_id")),
+        "closure_id": _str(readiness.get("closure_id")),
+        "audit_preview_id": _str(readiness.get("audit_preview_id")),
+        "receipt_id": _str(readiness.get("receipt_id")),
+        "executor_preview_id": _str(readiness.get("executor_preview_id")),
+        "decision_id": _str(readiness.get("decision_id")),
+        "execution_preview_id": _str(readiness.get("execution_preview_id")),
+        "token_id": _str(readiness.get("token_id")),
+        "lock_id": _str(readiness.get("lock_id")),
+        "route": _str(readiness.get("route")),
+        "operation_ids": tuple(_list_of_str(readiness.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(readiness.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(readiness.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(readiness.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(readiness.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(readiness.get("ledger_audit_step_ids"))
+        ),
+        "seal_audit_step_ids": tuple(
+            _list_of_str(readiness.get("seal_audit_step_ids"))
+        ),
+        "seal_digest": _str(readiness.get("seal_digest")),
+        "seal_audit_digest": _str(readiness.get("seal_audit_digest")),
+        "ledger_audit_digest": _str(readiness.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(readiness.get("ledger_entry_digest")),
+        "closure_digest": _str(readiness.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_finalization_readiness_report=dict(
+            recovery_closure_finalization_readiness
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_finalization_readiness: Mapping[str, Any],
+    checks: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck, ...
+    ],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(
+                check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+            )
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_finalization_readiness_report=dict(
+            recovery_closure_finalization_readiness
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
@@ -1,0 +1,938 @@
+"""Read-only recovery closure finalization readiness preview.
+
+This layer aggregates the closure, ledger, ledger audit, governance seal, and
+seal audit into a final readiness gate for a future manual closure. It never
+finalizes a recovery, writes durable memory, or freezes real state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_FINALIZATION_STATUS_READY = (
+    "recovery_closure_finalization_readiness_preview_ready"
+)
+RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY = (
+    "recovery_closure_finalization_readiness_ready"
+)
+RECOVERY_CLOSURE_FINALIZATION_TYPE = (
+    "memory_evidence_repair_recovery_closure_finalization_readiness"
+)
+RECOVERY_CLOSURE_FINALIZATION_DECISION = "ready_for_final_closure"
+RECOVERY_CLOSURE_FINALIZATION_SCOPE = (
+    "manual_memory_evidence_repair_recovery_finalization"
+)
+
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY = (
+    "recovery_governance_seal_audit_ready"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY = (
+    "recovery_governance_seal_audit_integrity"
+)
+CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN = "recovery_finalization_source_chain"
+CHECK_RECOVERY_FINALIZATION_REQUIREMENTS = "recovery_finalization_requirements"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    """One read-only finalization readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview:
+    """One read-only future finalization readiness draft."""
+
+    id: str
+    finalization_type: str
+    status: str
+    finalization_decision: str
+    finalization_scope: str
+    seal_audit_preview_id: str
+    seal_id: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    seal_audit_step_ids: tuple[str, ...]
+    seal_digest: str
+    seal_audit_digest: str
+    ledger_audit_digest: str
+    ledger_entry_digest: str
+    closure_digest: str
+    finalization_digest: str
+    finalization_preview: str
+    would_allow_final_closure: bool
+    would_preserve_full_governance_chain: bool
+    would_require_human_finalization: bool
+    would_keep_read_only_until_manual_commit: bool
+    safety_note: str
+    source_recovery_closure_governance_seal_audit_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "finalization_type": self.finalization_type,
+            "status": self.status,
+            "finalization_decision": self.finalization_decision,
+            "finalization_scope": self.finalization_scope,
+            "seal_audit_preview_id": self.seal_audit_preview_id,
+            "seal_id": self.seal_id,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "seal_audit_step_ids": list(self.seal_audit_step_ids),
+            "seal_digest": self.seal_digest,
+            "seal_audit_digest": self.seal_audit_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "finalization_digest": self.finalization_digest,
+            "finalization_preview": self.finalization_preview,
+            "would_allow_final_closure": self.would_allow_final_closure,
+            "would_preserve_full_governance_chain": (
+                self.would_preserve_full_governance_chain
+            ),
+            "would_require_human_finalization": self.would_require_human_finalization,
+            "would_keep_read_only_until_manual_commit": (
+                self.would_keep_read_only_until_manual_commit
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_closure_governance_seal_audit_preview": dict(
+                self.source_recovery_closure_governance_seal_audit_preview
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    """Read-only finalization readiness preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck, ...]
+    readiness: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview, ...
+    ]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_governance_seal_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "readiness_count": len(self.readiness),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_finalization_readiness_available": bool(
+                self.readiness
+            ),
+            "recovery_closure_finalization_ready": (
+                self.status == RECOVERY_CLOSURE_FINALIZATION_STATUS_READY
+            ),
+            "would_allow_final_closure_count": sum(
+                1 for item in self.readiness if item.would_allow_final_closure
+            ),
+            "would_preserve_full_governance_chain_count": sum(
+                1
+                for item in self.readiness
+                if item.would_preserve_full_governance_chain
+            ),
+            "would_require_human_finalization_count": sum(
+                1 for item in self.readiness if item.would_require_human_finalization
+            ),
+            "would_keep_read_only_until_manual_commit_count": sum(
+                1
+                for item in self.readiness
+                if item.would_keep_read_only_until_manual_commit
+            ),
+            "has_blocks": (
+                self.status == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+            ),
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "readiness": [item.to_dict() for item in self.readiness],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_governance_seal_audit_report": dict(
+                self.source_recovery_closure_governance_seal_audit_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_finalization_readiness_preview(
+    *,
+    recovery_closure_governance_seal_audit: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    """Build a read-only finalization readiness preview from a seal audit."""
+
+    recovery_closure_governance_seal_audit = (
+        recovery_closure_governance_seal_audit
+        if isinstance(recovery_closure_governance_seal_audit, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_governance_seal_audit.get("status"))
+    preview = _extract_preview(recovery_closure_governance_seal_audit)
+
+    if not preview:
+        if (
+            not recovery_closure_governance_seal_audit
+            or report_status
+            == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_governance_seal_audit=(
+                    recovery_closure_governance_seal_audit
+                )
+            )
+        source_blocking = tuple(
+            _list_of_str(
+                recovery_closure_governance_seal_audit.get("blocking_reasons")
+            )
+        )
+        source_actions = tuple(
+            _list_of_str(recovery_closure_governance_seal_audit.get("required_actions"))
+        )
+        return _blocked_report(
+            recovery_closure_governance_seal_audit=(
+                recovery_closure_governance_seal_audit
+            ),
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+                    "No recovery closure governance seal audit preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or (
+                        "produce_recovery_closure_governance_seal_audit_preview",
+                    ),
+                    {
+                        "recovery_closure_governance_seal_audit_status": (
+                            report_status
+                        )
+                    },
+                ),
+            ),
+        )
+
+    checks = (
+        _seal_audit_ready_check(recovery_closure_governance_seal_audit, preview),
+        _seal_audit_integrity_check(preview),
+        _source_chain_check(preview),
+        _finalization_requirements_check(preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(
+            check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+        )
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED,
+            checks=checks,
+            readiness=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_governance_seal_audit_report=dict(
+                recovery_closure_governance_seal_audit
+            ),
+        )
+
+    readiness = _readiness_from_seal_audit(preview)
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_STATUS_READY,
+        checks=checks,
+        readiness=(readiness,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_audit_report=dict(
+            recovery_closure_governance_seal_audit
+        ),
+    )
+
+
+def empty_evidence_repair_recovery_closure_finalization_readiness_preview() -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    """Return an empty read-only finalization readiness preview."""
+
+    return _empty_report(recovery_closure_governance_seal_audit={})
+
+
+def _extract_preview(
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+) -> dict[str, Any]:
+    previews = recovery_closure_governance_seal_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_closure_governance_seal_audit.get("id")).startswith(
+        "recovery-closure-governance-seal-audit-"
+    ):
+        return dict(recovery_closure_governance_seal_audit)
+    return {}
+
+
+def _seal_audit_ready_check(
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    report_status = _str(recovery_closure_governance_seal_audit.get("status"))
+    preview_status = _str(preview.get("status"))
+    if (
+        report_status
+        and report_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+            "Recovery closure governance seal audit report is not ready for finalization readiness preview.",
+            tuple(
+                _list_of_str(
+                    recovery_closure_governance_seal_audit.get("required_actions")
+                )
+            )
+            or ("produce_ready_recovery_closure_governance_seal_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+            "Recovery closure governance seal audit preview is not ready for finalization readiness preview.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_READY,
+        "Recovery closure governance seal audit preview is ready for finalization readiness preview.",
+        {"seal_audit_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _seal_audit_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    expected_digest = _expected_seal_audit_digest(preview)
+    actual_digest = _str(preview.get("audit_digest"))
+    expected_id = (
+        f"recovery-closure-governance-seal-audit-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "status",
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "seal_audit_step_ids",
+        "seal_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+        "audit_digest",
+        "audit_steps",
+        "source_recovery_closure_governance_seal",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(preview.get("id")) != expected_id
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY,
+            "Recovery closure governance seal audit digest, id, or required fields are invalid.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {
+                "expected_seal_audit_digest": expected_digest,
+                "actual_seal_audit_digest": actual_digest,
+                "expected_seal_audit_id": expected_id,
+                "actual_seal_audit_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY,
+        "Recovery closure governance seal audit integrity checks pass.",
+        {"seal_audit_preview_id": expected_id, "audit_digest": actual_digest},
+    )
+
+
+def _source_chain_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    seal = _dict(preview.get("source_recovery_closure_governance_seal"))
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    entry = _dict(ledger_audit.get("source_recovery_closure_ledger_entry"))
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure_governance_seal", seal),
+            ("source_recovery_closure_ledger_audit_preview", ledger_audit),
+            ("source_recovery_closure_ledger_entry", entry),
+        )
+        if not source
+    ]
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "seal_id",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "seal_digest",
+        "ledger_audit_digest",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        seal_key = "id" if field_name == "seal_id" else field_name
+        _compare(mismatches, field_name, preview, field_name, seal, seal_key)
+
+    for field_name in (
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        ledger_key = "id" if field_name == "ledger_audit_preview_id" else field_name
+        _compare(mismatches, field_name, preview, field_name, ledger_audit, ledger_key)
+    if _str(preview.get("ledger_audit_digest")) != _str(
+        ledger_audit.get("audit_digest")
+    ):
+        mismatches.append(
+            {
+                "field": "ledger_audit_digest",
+                "left": _str(preview.get("ledger_audit_digest")),
+                "right": _str(ledger_audit.get("audit_digest")),
+                "right_key": "source_recovery_closure_ledger_audit_preview.audit_digest",
+            }
+        )
+    _compare(mismatches, "ledger_entry_id", preview, "ledger_entry_id", entry, "id")
+    _compare(mismatches, "closure_id", preview, "closure_id", entry, "closure_id")
+    if _str(preview.get("ledger_entry_digest")) != _str(entry.get("entry_digest")):
+        mismatches.append(
+            {
+                "field": "ledger_entry_digest",
+                "left": _str(preview.get("ledger_entry_digest")),
+                "right": _str(entry.get("entry_digest")),
+                "right_key": "source_recovery_closure_ledger_entry.entry_digest",
+            }
+        )
+    seal_audit_steps = _audit_steps(preview)
+    ledger_audit_steps = _audit_steps(ledger_audit)
+    non_pass_seal_audit_steps = [
+        _str(step.get("id")) or f"seal-audit-step-{index}"
+        for index, step in enumerate(seal_audit_steps, start=1)
+        if _str(step.get("status")) != GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS
+    ]
+    non_pass_ledger_audit_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(ledger_audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(seal.get("status")) != RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY
+        or _str(ledger_audit.get("status"))
+        != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_seal_audit_steps
+        or non_pass_ledger_audit_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN,
+            "Recovery closure finalization source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "seal_status": _str(seal.get("status")),
+                "ledger_audit_status": _str(ledger_audit.get("status")),
+                "entry_status": _str(entry.get("status")),
+                "non_pass_seal_audit_step_ids": non_pass_seal_audit_steps,
+                "non_pass_ledger_audit_step_ids": non_pass_ledger_audit_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN,
+        "Recovery closure finalization source chain preserves seal, ledger audit, ledger entry, and closure evidence.",
+        {
+            "seal_audit_preview_id": _str(preview.get("id")),
+            "seal_id": _str(preview.get("seal_id")),
+            "ledger_audit_preview_id": _str(preview.get("ledger_audit_preview_id")),
+            "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+            "seal_audit_step_count": len(seal_audit_steps),
+            "ledger_audit_step_count": len(ledger_audit_steps),
+        },
+    )
+
+
+def _finalization_requirements_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    required_preview_flags = (
+        "would_verify_seal_integrity",
+        "would_verify_governance_handoff",
+        "would_verify_source_audit_evidence",
+        "would_verify_read_only_constraints",
+    )
+    missing_preview_flags = [
+        field_name
+        for field_name in required_preview_flags
+        if preview.get(field_name) is not True
+    ]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+            "seal_audit_step_ids",
+        )
+        if not _list_of_str(preview.get(field_name))
+    ]
+    seal = _dict(preview.get("source_recovery_closure_governance_seal"))
+    required_seal_flags = (
+        "would_freeze_recovery_closure",
+        "would_preserve_audit_evidence",
+        "would_enable_governed_handoff",
+        "would_block_unreviewed_mutation",
+    )
+    missing_seal_flags = [
+        field_name for field_name in required_seal_flags if seal.get(field_name) is not True
+    ]
+    categories = {_str(step.get("category")) for step in _audit_steps(preview)}
+    required_categories = {
+        "seal_integrity",
+        "ledger_audit_source",
+        "ledger_entry_source",
+        "closure_trace",
+        "governance_controls",
+        "read_only",
+    }
+    missing_categories = sorted(required_categories - categories)
+    if missing_preview_flags or missing_lists or missing_seal_flags or missing_categories:
+        return _fail(
+            CHECK_RECOVERY_FINALIZATION_REQUIREMENTS,
+            "Recovery closure finalization readiness requirements are incomplete.",
+            ("regenerate_recovery_closure_governance_seal_audit_preview",),
+            {
+                "missing_preview_flags": missing_preview_flags,
+                "missing_lists": missing_lists,
+                "missing_seal_flags": missing_seal_flags,
+                "missing_categories": missing_categories,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_FINALIZATION_REQUIREMENTS,
+        "Recovery closure finalization readiness covers integrity, handoff, source evidence, and read-only constraints.",
+        {
+            "seal_audit_step_count": len(_audit_steps(preview)),
+            "milestone_count": len(_list_of_str(preview.get("milestone_ids"))),
+        },
+    )
+
+
+def _readiness_from_seal_audit(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(
+        _list_of_str(preview.get("completion_audit_step_ids"))
+    )
+    milestone_ids = tuple(_list_of_str(preview.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(preview.get("ledger_audit_step_ids")))
+    seal_audit_step_ids = tuple(_list_of_str(preview.get("seal_audit_step_ids")))
+    finalization_seed = {
+        "finalization_type": RECOVERY_CLOSURE_FINALIZATION_TYPE,
+        "finalization_decision": RECOVERY_CLOSURE_FINALIZATION_DECISION,
+        "finalization_scope": RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+        "seal_audit_preview_id": _str(preview.get("id")),
+        "seal_id": _str(preview.get("seal_id")),
+        "ledger_audit_preview_id": _str(preview.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "seal_audit_step_ids": seal_audit_step_ids,
+        "seal_digest": _str(preview.get("seal_digest")),
+        "seal_audit_digest": _str(preview.get("audit_digest")),
+        "ledger_audit_digest": _str(preview.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    finalization_digest = _digest(finalization_seed)
+    finalization_id = (
+        f"recovery-closure-finalization-readiness-{finalization_digest[:16]}"
+    )
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreview(
+        id=finalization_id,
+        finalization_type=RECOVERY_CLOSURE_FINALIZATION_TYPE,
+        status=RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY,
+        finalization_decision=RECOVERY_CLOSURE_FINALIZATION_DECISION,
+        finalization_scope=RECOVERY_CLOSURE_FINALIZATION_SCOPE,
+        seal_audit_preview_id=_str(preview.get("id")),
+        seal_id=_str(preview.get("seal_id")),
+        ledger_audit_preview_id=_str(preview.get("ledger_audit_preview_id")),
+        ledger_entry_id=_str(preview.get("ledger_entry_id")),
+        closure_id=_str(preview.get("closure_id")),
+        audit_preview_id=_str(preview.get("audit_preview_id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        executor_preview_id=_str(preview.get("executor_preview_id")),
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        route=_str(preview.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        seal_audit_step_ids=seal_audit_step_ids,
+        seal_digest=_str(preview.get("seal_digest")),
+        seal_audit_digest=_str(preview.get("audit_digest")),
+        ledger_audit_digest=_str(preview.get("ledger_audit_digest")),
+        ledger_entry_digest=_str(preview.get("ledger_entry_digest")),
+        closure_digest=_str(preview.get("closure_digest")),
+        finalization_digest=finalization_digest,
+        finalization_preview=f"{finalization_id}:{finalization_digest[:12]}",
+        would_allow_final_closure=True,
+        would_preserve_full_governance_chain=True,
+        would_require_human_finalization=True,
+        would_keep_read_only_until_manual_commit=True,
+        safety_note=(
+            "Read-only recovery closure finalization readiness preview. It "
+            "allows a later human-governed final closure only if the complete "
+            "seal and audit chain remains intact; it does not finalize or "
+            "mutate durable memory."
+        ),
+        source_recovery_closure_governance_seal_audit_preview=dict(preview),
+    )
+
+
+def _expected_seal_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "seal_id": _str(preview.get("seal_id")),
+        "ledger_audit_preview_id": _str(preview.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(preview.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(preview.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(preview.get("ledger_audit_step_ids"))
+        ),
+        "seal_audit_step_ids": tuple(_list_of_str(preview.get("seal_audit_step_ids"))),
+        "seal_digest": _str(preview.get("seal_digest")),
+        "ledger_audit_digest": _str(preview.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        readiness=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_audit_report=dict(
+            recovery_closure_governance_seal_audit
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_governance_seal_audit: Mapping[str, Any],
+    checks: tuple[
+        MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck, ...
+    ],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED,
+        checks=checks,
+        readiness=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(
+                check.reason for check in checks if check.status == CHECK_STATUS_FAIL
+            )
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_governance_seal_audit_report=dict(
+            recovery_closure_governance_seal_audit
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck:
+    return MemoryEvidenceRepairRecoveryClosureFinalizationReadinessCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_gate.py
+++ b/agent/memory_evidence_repair_recovery_closure_gate.py
@@ -1,0 +1,616 @@
+"""Read-only recovery closure gate for memory evidence repair.
+
+The recovery closure gate verifies a recovery completion audit preview and only
+allows a future closure draft when observed recovery-completion state has been
+supplied and every audit step passes. It never writes durable memory and never
+marks recovery as closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    RECOVERY_AUDIT_STEP_STATUS_FAIL,
+    RECOVERY_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_AUDIT_STEP_STATUS_PLANNED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_STATUS_READY = "recovery_closure_ready"
+RECOVERY_CLOSURE_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_DRAFT_STATUS_READY = "recovery_closure_draft_ready"
+
+CHECK_RECOVERY_COMPLETION_AUDIT_READY = "recovery_completion_audit_ready"
+CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY = "recovery_completion_audit_integrity"
+CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS = "recovery_completion_audit_observed_pass"
+CHECK_RECOVERY_CLOSURE_REQUIREMENTS = "recovery_closure_requirements"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureCheck:
+    """One read-only recovery closure gate check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureDraft:
+    """One read-only future recovery closure draft."""
+
+    id: str
+    status: str
+    closure_type: str
+    closure_decision: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    closure_digest: str
+    closure_preview: str
+    would_close_recovery_loop: bool
+    would_mark_recovery_resolved: bool
+    would_preserve_audit_evidence: bool
+    safety_note: str
+    source_recovery_completion_audit_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "closure_type": self.closure_type,
+            "closure_decision": self.closure_decision,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "audit_step_ids": list(self.audit_step_ids),
+            "closure_digest": self.closure_digest,
+            "closure_preview": self.closure_preview,
+            "would_close_recovery_loop": self.would_close_recovery_loop,
+            "would_mark_recovery_resolved": self.would_mark_recovery_resolved,
+            "would_preserve_audit_evidence": self.would_preserve_audit_evidence,
+            "safety_note": self.safety_note,
+            "source_recovery_completion_audit_preview": dict(
+                self.source_recovery_completion_audit_preview
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGateReport:
+    """Read-only recovery closure gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureCheck, ...]
+    closures: tuple[MemoryEvidenceRepairRecoveryClosureDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_completion_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "closure_count": len(self.closures),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_available": bool(self.closures),
+            "recovery_closure_ready": self.status == RECOVERY_CLOSURE_STATUS_READY,
+            "would_close_recovery_loop_count": sum(
+                1 for closure in self.closures if closure.would_close_recovery_loop
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "closures": [closure.to_dict() for closure in self.closures],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_completion_audit_report": dict(
+                self.source_recovery_completion_audit_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_gate(
+    *,
+    recovery_completion_audit: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    """Build a read-only recovery closure gate from a completion audit."""
+
+    recovery_completion_audit = (
+        recovery_completion_audit if isinstance(recovery_completion_audit, Mapping) else {}
+    )
+    report_status = _str(recovery_completion_audit.get("status"))
+    preview = _extract_preview(recovery_completion_audit)
+
+    if not preview:
+        if (
+            not recovery_completion_audit
+            or report_status == RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_completion_audit=recovery_completion_audit)
+        source_blocking = tuple(_list_of_str(recovery_completion_audit.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_completion_audit.get("required_actions")))
+        return _blocked_report(
+            recovery_completion_audit=recovery_completion_audit,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+                    "No recovery completion audit preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_recovery_completion_audit_preview",),
+                    {"recovery_completion_audit_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _audit_ready_check(recovery_completion_audit, preview),
+        _audit_integrity_check(preview),
+        _audit_observed_pass_check(preview),
+        _closure_requirements_check(preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_STATUS_BLOCKED,
+            checks=checks,
+            closures=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_completion_audit_report=dict(recovery_completion_audit),
+        )
+
+    closure = _closure_from_audit(preview)
+    return MemoryEvidenceRepairRecoveryClosureGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_STATUS_READY,
+        checks=checks,
+        closures=(closure,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_audit_report=dict(recovery_completion_audit),
+    )
+
+
+def empty_evidence_repair_recovery_closure_gate() -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    """Return an empty read-only recovery closure gate report."""
+
+    return _empty_report(recovery_completion_audit={})
+
+
+def _extract_preview(recovery_completion_audit: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_completion_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_completion_audit.get("id")).startswith("recovery-completion-audit-"):
+        return dict(recovery_completion_audit)
+    return {}
+
+
+def _audit_ready_check(
+    recovery_completion_audit: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    report_status = _str(recovery_completion_audit.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != RECOVERY_COMPLETION_AUDIT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+            "Recovery completion audit report is not ready for closure.",
+            tuple(_list_of_str(recovery_completion_audit.get("required_actions")))
+            or ("produce_ready_recovery_completion_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != RECOVERY_COMPLETION_AUDIT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+            "Recovery completion audit preview entry is not ready.",
+            ("produce_ready_recovery_completion_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_READY,
+        "Recovery completion audit preview is ready for closure gating.",
+        {"audit_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _audit_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    expected_digest = _expected_audit_digest(preview)
+    actual_digest = _str(preview.get("audit_digest"))
+    expected_id = f"recovery-completion-audit-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "lock_id",
+        "token_id",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "audit_step_ids",
+        "audit_steps",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(preview.get("id")) != expected_id
+    ):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY,
+            "Recovery completion audit digest, id, or required fields are invalid.",
+            ("regenerate_recovery_completion_audit_preview",),
+            {
+                "expected_audit_digest": expected_digest,
+                "actual_audit_digest": actual_digest,
+                "expected_audit_id": expected_id,
+                "actual_audit_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY,
+        "Recovery completion audit integrity checks pass.",
+        {"audit_preview_id": expected_id, "audit_digest": actual_digest},
+    )
+
+
+def _audit_observed_pass_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    audit_steps = _audit_steps(preview)
+    statuses = [_str(step.get("status")) for step in audit_steps]
+    planned = [step for step in audit_steps if _str(step.get("status")) == RECOVERY_AUDIT_STEP_STATUS_PLANNED]
+    failed = [step for step in audit_steps if _str(step.get("status")) == RECOVERY_AUDIT_STEP_STATUS_FAIL]
+    passed = [step for step in audit_steps if _str(step.get("status")) == RECOVERY_AUDIT_STEP_STATUS_PASS]
+    if preview.get("observed_state_supplied") is not True:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+            "Recovery closure requires observed recovery-completion state; planned audit is not enough.",
+            ("provide_observed_recovery_completion_state",),
+            {"observed_state_supplied": bool(preview.get("observed_state_supplied"))},
+        )
+    if planned or failed or len(passed) != len(audit_steps):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+            "Recovery closure requires every completion audit step to pass.",
+            ("investigate_recovery_completion_audit_failures",),
+            {
+                "audit_step_count": len(audit_steps),
+                "pass_count": len(passed),
+                "planned_count": len(planned),
+                "fail_count": len(failed),
+                "statuses": statuses,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+        "Observed recovery-completion audit has passed every step.",
+        {"audit_step_count": len(audit_steps), "pass_count": len(passed)},
+    )
+
+
+def _closure_requirements_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    flags = {
+        "would_verify_completion_receipt_recorded": preview.get(
+            "would_verify_completion_receipt_recorded"
+        )
+        is True,
+        "would_verify_recovery_token_used": preview.get("would_verify_recovery_token_used")
+        is True,
+        "would_verify_recovery_lock_released": preview.get(
+            "would_verify_recovery_lock_released"
+        )
+        is True,
+        "would_verify_recovery_steps_completed": preview.get(
+            "would_verify_recovery_steps_completed"
+        )
+        is True,
+        "would_verify_post_recovery_audit_clear": preview.get(
+            "would_verify_post_recovery_audit_clear"
+        )
+        is True,
+        "would_verify_no_secondary_memory_contamination": preview.get(
+            "would_verify_no_secondary_memory_contamination"
+        )
+        is True,
+    }
+    missing = [name for name, ok in flags.items() if not ok]
+    required_categories = {
+        "completion_receipt",
+        "token",
+        "lock",
+        "recovery_step",
+        "post_recovery_audit",
+        "contamination_guard",
+    }
+    categories = {_str(step.get("category")) for step in _audit_steps(preview)}
+    missing_categories = sorted(required_categories - categories)
+    if missing or missing_categories or not _list_of_str(preview.get("future_mutation_step_ids")):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_REQUIREMENTS,
+            "Recovery closure requirements are incomplete.",
+            ("regenerate_recovery_completion_audit_preview",),
+            {
+                "missing_flags": missing,
+                "missing_categories": missing_categories,
+                "future_mutation_step_count": len(
+                    _list_of_str(preview.get("future_mutation_step_ids"))
+                ),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_REQUIREMENTS,
+        "Recovery closure requirements cover receipt, token, lock, steps, audit, and contamination guard.",
+        {
+            "category_count": len(categories),
+            "future_mutation_step_count": len(
+                _list_of_str(preview.get("future_mutation_step_ids"))
+            ),
+        },
+    )
+
+
+def _closure_from_audit(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureDraft:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    audit_step_ids = tuple(_list_of_str(preview.get("audit_step_ids")))
+    seed = {
+        "closure_type": "memory_evidence_repair_recovery_closure",
+        "closure_decision": "close_recovery_loop",
+        "audit_preview_id": _str(preview.get("id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "audit_step_ids": audit_step_ids,
+    }
+    closure_digest = _digest(seed)
+    closure_id = f"recovery-closure-{closure_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureDraft(
+        id=closure_id,
+        status=RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+        closure_type="memory_evidence_repair_recovery_closure",
+        closure_decision="close_recovery_loop",
+        audit_preview_id=_str(preview.get("id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        executor_preview_id=_str(preview.get("executor_preview_id")),
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        route=_str(preview.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        audit_step_ids=audit_step_ids,
+        closure_digest=closure_digest,
+        closure_preview=f"{closure_id}:{closure_digest[:12]}",
+        would_close_recovery_loop=True,
+        would_mark_recovery_resolved=True,
+        would_preserve_audit_evidence=True,
+        safety_note=(
+            "Read-only recovery closure draft. It states that a future closure "
+            "would be allowed, but does not persist closure state or mutate memory."
+        ),
+        source_recovery_completion_audit_preview=dict(preview),
+    )
+
+
+def _expected_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "token_id": _str(preview.get("token_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(preview.get("audit_step_ids"))),
+        "observed_state_supplied": preview.get("observed_state_supplied") is True,
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _empty_report(
+    *,
+    recovery_completion_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    return MemoryEvidenceRepairRecoveryClosureGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        closures=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_audit_report=dict(recovery_completion_audit),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_completion_audit: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureGateReport:
+    return MemoryEvidenceRepairRecoveryClosureGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_STATUS_BLOCKED,
+        checks=checks,
+        closures=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_completion_audit_report=dict(recovery_completion_audit),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    return MemoryEvidenceRepairRecoveryClosureCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureCheck:
+    return MemoryEvidenceRepairRecoveryClosureCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
@@ -1,0 +1,992 @@
+"""Read-only recovery closure governance seal audit preview.
+
+This layer audits a recovery closure governance seal draft so later governance
+layers can verify the seal itself before any future handoff or freeze. It never
+writes durable memory, records a real audit, or mutates a real seal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+    RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY = (
+    "recovery_closure_governance_seal_audit_preview_ready"
+)
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY = (
+    "recovery_closure_governance_seal_audit_ready"
+)
+
+GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS = "pass"
+GOVERNANCE_SEAL_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_GOVERNANCE_SEAL_READY = "recovery_governance_seal_ready"
+CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY = "recovery_governance_seal_integrity"
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN = (
+    "recovery_governance_seal_audit_source_chain"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS = (
+    "recovery_governance_seal_audit_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    """One read-only governance seal audit readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep:
+    """One structural audit step for a future governance seal."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    seal_id: str
+    reference_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "seal_id": self.seal_id,
+            "reference_id": self.reference_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview:
+    """One read-only recovery closure governance seal audit preview."""
+
+    id: str
+    status: str
+    seal_id: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    seal_audit_step_ids: tuple[str, ...]
+    seal_digest: str
+    ledger_audit_digest: str
+    ledger_entry_digest: str
+    closure_digest: str
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep, ...]
+    would_verify_seal_integrity: bool
+    would_verify_governance_handoff: bool
+    would_verify_source_audit_evidence: bool
+    would_verify_read_only_constraints: bool
+    safety_note: str
+    source_recovery_closure_governance_seal: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "seal_id": self.seal_id,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "seal_audit_step_ids": list(self.seal_audit_step_ids),
+            "seal_digest": self.seal_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "would_verify_seal_integrity": self.would_verify_seal_integrity,
+            "would_verify_governance_handoff": self.would_verify_governance_handoff,
+            "would_verify_source_audit_evidence": self.would_verify_source_audit_evidence,
+            "would_verify_read_only_constraints": self.would_verify_read_only_constraints,
+            "safety_note": self.safety_note,
+            "source_recovery_closure_governance_seal": dict(
+                self.source_recovery_closure_governance_seal
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    """Read-only recovery closure governance seal audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_governance_seal_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "observed_pass_step_count": by_audit_step_status.get(
+                GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                GOVERNANCE_SEAL_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_governance_seal_audit_preview_available": bool(
+                self.previews
+            ),
+            "recovery_closure_governance_seal_audit_ready": (
+                self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY
+            ),
+            "has_blocks": (
+                self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+            ),
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_governance_seal_report": dict(
+                self.source_recovery_closure_governance_seal_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+    *,
+    recovery_closure_governance_seal: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    """Build a read-only audit preview from a recovery governance seal report."""
+
+    recovery_closure_governance_seal = (
+        recovery_closure_governance_seal
+        if isinstance(recovery_closure_governance_seal, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_governance_seal.get("status"))
+    seal = _extract_seal(recovery_closure_governance_seal)
+
+    if not seal:
+        if (
+            not recovery_closure_governance_seal
+            or report_status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_governance_seal=recovery_closure_governance_seal
+            )
+        source_blocking = tuple(
+            _list_of_str(recovery_closure_governance_seal.get("blocking_reasons"))
+        )
+        source_actions = tuple(
+            _list_of_str(recovery_closure_governance_seal.get("required_actions"))
+        )
+        return _blocked_report(
+            recovery_closure_governance_seal=recovery_closure_governance_seal,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+                    "No recovery closure governance seal draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_governance_seal_preview",),
+                    {"recovery_closure_governance_seal_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _seal_ready_check(recovery_closure_governance_seal, seal),
+        _seal_integrity_check(seal),
+        _seal_source_chain_check(seal),
+        _audit_requirements_check(seal),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_governance_seal_report=dict(
+                recovery_closure_governance_seal
+            ),
+        )
+
+    preview = _preview_from_seal(seal)
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_report=dict(
+            recovery_closure_governance_seal
+        ),
+    )
+
+
+def empty_evidence_repair_recovery_closure_governance_seal_audit_preview() -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    """Return an empty read-only recovery closure governance seal audit preview."""
+
+    return _empty_report(recovery_closure_governance_seal={})
+
+
+def _extract_seal(recovery_closure_governance_seal: Mapping[str, Any]) -> dict[str, Any]:
+    seals = recovery_closure_governance_seal.get("seals")
+    if isinstance(seals, list):
+        for seal in seals:
+            if isinstance(seal, Mapping):
+                return dict(seal)
+    if _str(recovery_closure_governance_seal.get("id")).startswith(
+        "recovery-closure-governance-seal-"
+    ):
+        return dict(recovery_closure_governance_seal)
+    return {}
+
+
+def _seal_ready_check(
+    recovery_closure_governance_seal: Mapping[str, Any],
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    report_status = _str(recovery_closure_governance_seal.get("status"))
+    seal_status = _str(seal.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+            "Recovery closure governance seal report is not ready for audit preview.",
+            tuple(_list_of_str(recovery_closure_governance_seal.get("required_actions")))
+            or ("produce_ready_recovery_closure_governance_seal_preview",),
+            {"report_status": report_status, "seal_status": seal_status},
+        )
+    if seal_status != RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+            "Recovery closure governance seal draft is not ready for audit preview.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {"report_status": report_status, "seal_status": seal_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_READY,
+        "Recovery closure governance seal draft is ready for audit preview.",
+        {"seal_id": _str(seal.get("id"))},
+    )
+
+
+def _seal_integrity_check(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    expected_digest = _expected_seal_digest(seal)
+    actual_digest = _str(seal.get("seal_digest"))
+    expected_id = (
+        f"recovery-closure-governance-seal-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "seal_type",
+        "status",
+        "governance_decision",
+        "governance_scope",
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "ledger_entry_digest",
+        "closure_digest",
+        "ledger_audit_digest",
+        "seal_digest",
+        "source_recovery_closure_ledger_audit_preview",
+    ):
+        value = seal.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(seal.get("id")) != expected_id
+        or _str(seal.get("seal_type")) != RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE
+        or _str(seal.get("governance_decision"))
+        != RECOVERY_CLOSURE_GOVERNANCE_DECISION
+        or _str(seal.get("governance_scope")) != RECOVERY_CLOSURE_GOVERNANCE_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY,
+            "Recovery closure governance seal digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {
+                "expected_seal_digest": expected_digest,
+                "actual_seal_digest": actual_digest,
+                "expected_seal_id": expected_id,
+                "actual_seal_id": _str(seal.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY,
+        "Recovery closure governance seal integrity checks pass.",
+        {"seal_id": expected_id, "seal_digest": actual_digest},
+    )
+
+
+def _seal_source_chain_check(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    entry = _dict(ledger_audit.get("source_recovery_closure_ledger_entry"))
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "ledger_audit_preview_id",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "ledger_entry_digest",
+        "closure_digest",
+    ):
+        audit_key = "id" if field_name == "ledger_audit_preview_id" else field_name
+        if field_name == "ledger_audit_digest":
+            audit_key = "audit_digest"
+        _compare(mismatches, field_name, seal, field_name, ledger_audit, audit_key)
+    if _str(seal.get("ledger_audit_digest")) != _str(ledger_audit.get("audit_digest")):
+        mismatches.append(
+            {
+                "field": "ledger_audit_digest",
+                "left": _str(seal.get("ledger_audit_digest")),
+                "right": _str(ledger_audit.get("audit_digest")),
+                "right_key": "source_recovery_closure_ledger_audit_preview.audit_digest",
+            }
+        )
+    audit_steps = _audit_steps(ledger_audit)
+    non_pass_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure_ledger_audit_preview", ledger_audit),
+            ("source_recovery_closure_ledger_entry", entry),
+        )
+        if not source
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(ledger_audit.get("status"))
+        != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN,
+            "Recovery closure governance seal source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "ledger_audit_status": _str(ledger_audit.get("status")),
+                "entry_status": _str(entry.get("status")),
+                "non_pass_ledger_audit_step_ids": non_pass_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN,
+        "Recovery closure governance seal source chain is internally consistent.",
+        {
+            "seal_id": _str(seal.get("id")),
+            "ledger_audit_preview_id": _str(seal.get("ledger_audit_preview_id")),
+            "ledger_entry_id": _str(seal.get("ledger_entry_id")),
+            "ledger_audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _audit_requirements_check(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    required_flags = (
+        "would_freeze_recovery_closure",
+        "would_preserve_audit_evidence",
+        "would_enable_governed_handoff",
+        "would_block_unreviewed_mutation",
+    )
+    missing_flags = [field_name for field_name in required_flags if seal.get(field_name) is not True]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+        )
+        if not _list_of_str(seal.get(field_name))
+    ]
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    source_flags = (
+        "would_verify_ledger_entry_integrity",
+        "would_verify_closure_source_integrity",
+        "would_verify_lifecycle_milestones",
+        "would_verify_completion_audit_evidence",
+    )
+    missing_source_flags = [
+        field_name for field_name in source_flags if ledger_audit.get(field_name) is not True
+    ]
+    if missing_flags or missing_lists or missing_source_flags:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS,
+            "Recovery closure governance seal audit requirements are incomplete.",
+            ("regenerate_recovery_closure_governance_seal_preview",),
+            {
+                "missing_flags": missing_flags,
+                "missing_lists": missing_lists,
+                "missing_source_flags": missing_source_flags,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS,
+        "Recovery closure governance seal audit can verify integrity, handoff, source evidence, and read-only constraints.",
+        {
+            "ledger_audit_step_count": len(_audit_steps(ledger_audit)),
+            "milestone_count": len(_list_of_str(seal.get("milestone_ids"))),
+        },
+    )
+
+
+def _preview_from_seal(
+    seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview:
+    audit_steps = tuple(_audit_steps_from_seal(seal))
+    seal_audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(seal.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(seal.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(seal.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(_list_of_str(seal.get("completion_audit_step_ids")))
+    milestone_ids = tuple(_list_of_str(seal.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(seal.get("ledger_audit_step_ids")))
+    audit_seed = {
+        "seal_id": _str(seal.get("id")),
+        "ledger_audit_preview_id": _str(seal.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(seal.get("ledger_entry_id")),
+        "closure_id": _str(seal.get("closure_id")),
+        "audit_preview_id": _str(seal.get("audit_preview_id")),
+        "receipt_id": _str(seal.get("receipt_id")),
+        "executor_preview_id": _str(seal.get("executor_preview_id")),
+        "decision_id": _str(seal.get("decision_id")),
+        "execution_preview_id": _str(seal.get("execution_preview_id")),
+        "token_id": _str(seal.get("token_id")),
+        "lock_id": _str(seal.get("lock_id")),
+        "route": _str(seal.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "seal_audit_step_ids": seal_audit_step_ids,
+        "seal_digest": _str(seal.get("seal_digest")),
+        "ledger_audit_digest": _str(seal.get("ledger_audit_digest")),
+        "ledger_entry_digest": _str(seal.get("ledger_entry_digest")),
+        "closure_digest": _str(seal.get("closure_digest")),
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-closure-governance-seal-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreview(
+        id=audit_id,
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+        seal_id=_str(seal.get("id")),
+        ledger_audit_preview_id=_str(seal.get("ledger_audit_preview_id")),
+        ledger_entry_id=_str(seal.get("ledger_entry_id")),
+        closure_id=_str(seal.get("closure_id")),
+        audit_preview_id=_str(seal.get("audit_preview_id")),
+        receipt_id=_str(seal.get("receipt_id")),
+        executor_preview_id=_str(seal.get("executor_preview_id")),
+        decision_id=_str(seal.get("decision_id")),
+        execution_preview_id=_str(seal.get("execution_preview_id")),
+        token_id=_str(seal.get("token_id")),
+        lock_id=_str(seal.get("lock_id")),
+        route=_str(seal.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        seal_audit_step_ids=seal_audit_step_ids,
+        seal_digest=_str(seal.get("seal_digest")),
+        ledger_audit_digest=_str(seal.get("ledger_audit_digest")),
+        ledger_entry_digest=_str(seal.get("ledger_entry_digest")),
+        closure_digest=_str(seal.get("closure_digest")),
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=audit_steps,
+        would_verify_seal_integrity=True,
+        would_verify_governance_handoff=True,
+        would_verify_source_audit_evidence=True,
+        would_verify_read_only_constraints=True,
+        safety_note=(
+            "Read-only recovery closure governance seal audit preview. It checks "
+            "a future governance seal's traceability and handoff controls, but "
+            "does not record an audit or mutate durable memory."
+        ),
+        source_recovery_closure_governance_seal=dict(seal),
+    )
+
+
+def _audit_steps_from_seal(
+    seal: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep]:
+    ledger_audit = _dict(seal.get("source_recovery_closure_ledger_audit_preview"))
+    rows = (
+        (
+            "seal_integrity",
+            "seal_digest_valid",
+            _str(seal.get("id")),
+            {"expected_seal_digest": _expected_seal_digest(seal)},
+            {"actual_seal_digest": _str(seal.get("seal_digest"))},
+        ),
+        (
+            "ledger_audit_source",
+            "ledger_audit_digest_valid",
+            _str(seal.get("ledger_audit_preview_id")),
+            {"expected_ledger_audit_digest": _expected_ledger_audit_digest(ledger_audit)},
+            {"actual_ledger_audit_digest": _str(seal.get("ledger_audit_digest"))},
+        ),
+        (
+            "ledger_entry_source",
+            "ledger_entry_reference_consistent",
+            _str(seal.get("ledger_entry_id")),
+            {"ledger_entry_id": _str(seal.get("ledger_entry_id"))},
+            {"source_ledger_entry_id": _str(ledger_audit.get("ledger_entry_id"))},
+        ),
+        (
+            "closure_trace",
+            "closure_reference_consistent",
+            _str(seal.get("closure_id")),
+            {"closure_id": _str(seal.get("closure_id"))},
+            {"source_closure_id": _str(ledger_audit.get("closure_id"))},
+        ),
+        (
+            "governance_controls",
+            "governance_handoff_controls_present",
+            _str(seal.get("id")),
+            {
+                "would_freeze_recovery_closure": True,
+                "would_enable_governed_handoff": True,
+            },
+            {
+                "would_freeze_recovery_closure": seal.get("would_freeze_recovery_closure")
+                is True,
+                "would_enable_governed_handoff": seal.get("would_enable_governed_handoff")
+                is True,
+            },
+        ),
+        (
+            "read_only",
+            "seal_is_preview_only",
+            _str(seal.get("id")),
+            {"would_block_unreviewed_mutation": True},
+            {
+                "would_block_unreviewed_mutation": seal.get(
+                    "would_block_unreviewed_mutation"
+                )
+                is True
+            },
+        ),
+    )
+    return [
+        _audit_step(
+            sequence=index,
+            category=category,
+            assertion=assertion,
+            seal=seal,
+            reference_id=reference_id,
+            expected_signal=expected_signal,
+            observed_signal=observed_signal,
+        )
+        for index, (
+            category,
+            assertion,
+            reference_id,
+            expected_signal,
+            observed_signal,
+        ) in enumerate(rows, start=1)
+    ]
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    seal: Mapping[str, Any],
+    reference_id: str,
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep:
+    step_seed = {
+        "sequence": sequence,
+        "category": category,
+        "assertion": assertion,
+        "seal_id": _str(seal.get("id")),
+        "reference_id": _str(reference_id),
+    }
+    step_id = f"recovery-closure-governance-seal-audit-step-{_digest(step_seed)[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditStep(
+        id=step_id,
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        seal_id=_str(seal.get("id")),
+        reference_id=_str(reference_id),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=GOVERNANCE_SEAL_AUDIT_STEP_STATUS_PASS,
+        required_action_on_fail="regenerate_recovery_closure_governance_seal_preview",
+    )
+
+
+def _expected_seal_digest(seal: Mapping[str, Any]) -> str:
+    seed = {
+        "seal_type": RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+        "governance_decision": RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+        "governance_scope": RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+        "ledger_audit_preview_id": _str(seal.get("ledger_audit_preview_id")),
+        "ledger_entry_id": _str(seal.get("ledger_entry_id")),
+        "closure_id": _str(seal.get("closure_id")),
+        "audit_preview_id": _str(seal.get("audit_preview_id")),
+        "receipt_id": _str(seal.get("receipt_id")),
+        "executor_preview_id": _str(seal.get("executor_preview_id")),
+        "decision_id": _str(seal.get("decision_id")),
+        "execution_preview_id": _str(seal.get("execution_preview_id")),
+        "token_id": _str(seal.get("token_id")),
+        "lock_id": _str(seal.get("lock_id")),
+        "route": _str(seal.get("route")),
+        "operation_ids": tuple(_list_of_str(seal.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(seal.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(seal.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(seal.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(seal.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(seal.get("ledger_audit_step_ids"))
+        ),
+        "ledger_entry_digest": _str(seal.get("ledger_entry_digest")),
+        "closure_digest": _str(seal.get("closure_digest")),
+        "ledger_audit_digest": _str(seal.get("ledger_audit_digest")),
+    }
+    return _digest(seed)
+
+
+def _expected_ledger_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(preview.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(preview.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(preview.get("ledger_audit_step_ids"))
+        ),
+        "entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_governance_seal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_governance_seal_report=dict(
+            recovery_closure_governance_seal
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_governance_seal: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_governance_seal_report=dict(
+            recovery_closure_governance_seal
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_governance_seal_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_governance_seal_preview.py
@@ -1,0 +1,770 @@
+"""Read-only recovery closure governance seal preview for memory evidence repair.
+
+The governance seal preview turns a ready recovery closure ledger audit into a
+final governance seal draft. It never writes durable memory, records a real
+seal, or freezes a real recovery closure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    LEDGER_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY = (
+    "recovery_closure_governance_seal_preview_ready"
+)
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY = (
+    "recovery_closure_governance_seal_draft_ready"
+)
+RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE = (
+    "memory_evidence_repair_recovery_closure_governance_seal"
+)
+RECOVERY_CLOSURE_GOVERNANCE_DECISION = "seal_recovery_closure"
+RECOVERY_CLOSURE_GOVERNANCE_SCOPE = "manual_memory_evidence_repair_recovery_closure"
+
+CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY = "recovery_closure_ledger_audit_ready"
+CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY = (
+    "recovery_closure_ledger_audit_integrity"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN = (
+    "recovery_governance_seal_source_chain"
+)
+CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS = (
+    "recovery_governance_seal_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    """One read-only recovery closure governance seal check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft:
+    """One read-only future recovery closure governance seal draft."""
+
+    id: str
+    seal_type: str
+    status: str
+    governance_decision: str
+    governance_scope: str
+    ledger_audit_preview_id: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    ledger_entry_digest: str
+    closure_digest: str
+    ledger_audit_digest: str
+    seal_digest: str
+    seal_preview: str
+    would_freeze_recovery_closure: bool
+    would_preserve_audit_evidence: bool
+    would_enable_governed_handoff: bool
+    would_block_unreviewed_mutation: bool
+    safety_note: str
+    source_recovery_closure_ledger_audit_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "seal_type": self.seal_type,
+            "status": self.status,
+            "governance_decision": self.governance_decision,
+            "governance_scope": self.governance_scope,
+            "ledger_audit_preview_id": self.ledger_audit_preview_id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "ledger_audit_digest": self.ledger_audit_digest,
+            "seal_digest": self.seal_digest,
+            "seal_preview": self.seal_preview,
+            "would_freeze_recovery_closure": self.would_freeze_recovery_closure,
+            "would_preserve_audit_evidence": self.would_preserve_audit_evidence,
+            "would_enable_governed_handoff": self.would_enable_governed_handoff,
+            "would_block_unreviewed_mutation": self.would_block_unreviewed_mutation,
+            "safety_note": self.safety_note,
+            "source_recovery_closure_ledger_audit_preview": dict(
+                self.source_recovery_closure_ledger_audit_preview
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    """Read-only recovery closure governance seal preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck, ...]
+    seals: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_ledger_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "seal_count": len(self.seals),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_governance_seal_available": bool(self.seals),
+            "recovery_closure_governance_seal_ready": (
+                self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY
+            ),
+            "would_freeze_recovery_closure_count": sum(
+                1 for seal in self.seals if seal.would_freeze_recovery_closure
+            ),
+            "would_enable_governed_handoff_count": sum(
+                1 for seal in self.seals if seal.would_enable_governed_handoff
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "seals": [seal.to_dict() for seal in self.seals],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_ledger_audit_report": dict(
+                self.source_recovery_closure_ledger_audit_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_governance_seal_preview(
+    *,
+    recovery_closure_ledger_audit: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    """Build a read-only governance seal from a ready closure ledger audit."""
+
+    recovery_closure_ledger_audit = (
+        recovery_closure_ledger_audit
+        if isinstance(recovery_closure_ledger_audit, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_closure_ledger_audit.get("status"))
+    preview = _extract_preview(recovery_closure_ledger_audit)
+
+    if not preview:
+        if (
+            not recovery_closure_ledger_audit
+            or report_status == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_closure_ledger_audit=recovery_closure_ledger_audit
+            )
+        source_blocking = tuple(
+            _list_of_str(recovery_closure_ledger_audit.get("blocking_reasons"))
+        )
+        source_actions = tuple(
+            _list_of_str(recovery_closure_ledger_audit.get("required_actions"))
+        )
+        return _blocked_report(
+            recovery_closure_ledger_audit=recovery_closure_ledger_audit,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+                    "No recovery closure ledger audit preview was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_ledger_audit_preview",),
+                    {"recovery_closure_ledger_audit_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _ledger_audit_ready_check(recovery_closure_ledger_audit, preview),
+        _ledger_audit_integrity_check(preview),
+        _seal_source_chain_check(preview),
+        _seal_requirements_check(preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+            checks=checks,
+            seals=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_ledger_audit_report=dict(
+                recovery_closure_ledger_audit
+            ),
+        )
+
+    seal = _seal_from_ledger_audit(preview)
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY,
+        checks=checks,
+        seals=(seal,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_audit_report=dict(recovery_closure_ledger_audit),
+    )
+
+
+def empty_evidence_repair_recovery_closure_governance_seal_preview() -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    """Return an empty read-only recovery closure governance seal preview."""
+
+    return _empty_report(recovery_closure_ledger_audit={})
+
+
+def _extract_preview(recovery_closure_ledger_audit: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_closure_ledger_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_closure_ledger_audit.get("id")).startswith(
+        "recovery-closure-ledger-audit-"
+    ):
+        return dict(recovery_closure_ledger_audit)
+    return {}
+
+
+def _ledger_audit_ready_check(
+    recovery_closure_ledger_audit: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    report_status = _str(recovery_closure_ledger_audit.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+            "Recovery closure ledger audit report is not ready for governance sealing.",
+            tuple(_list_of_str(recovery_closure_ledger_audit.get("required_actions")))
+            or ("produce_ready_recovery_closure_ledger_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+            "Recovery closure ledger audit preview is not ready for governance sealing.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_READY,
+        "Recovery closure ledger audit preview is ready for governance sealing.",
+        {"ledger_audit_preview_id": _str(preview.get("id"))},
+    )
+
+
+def _ledger_audit_integrity_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    expected_digest = _expected_ledger_audit_digest(preview)
+    actual_digest = _str(preview.get("audit_digest"))
+    expected_id = (
+        f"recovery-closure-ledger-audit-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "status",
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "completion_audit_step_ids",
+        "milestone_ids",
+        "ledger_audit_step_ids",
+        "ledger_entry_digest",
+        "closure_digest",
+        "audit_digest",
+        "audit_steps",
+        "source_recovery_closure_ledger_entry",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(preview.get("id")) != expected_id
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY,
+            "Recovery closure ledger audit digest, id, or required fields are invalid.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {
+                "expected_audit_digest": expected_digest,
+                "actual_audit_digest": actual_digest,
+                "expected_audit_id": expected_id,
+                "actual_audit_id": _str(preview.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY,
+        "Recovery closure ledger audit integrity checks pass.",
+        {"ledger_audit_preview_id": expected_id, "audit_digest": actual_digest},
+    )
+
+
+def _seal_source_chain_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    entry = _dict(preview.get("source_recovery_closure_ledger_entry"))
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "ledger_entry_id",
+        "closure_id",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "closure_digest",
+    ):
+        entry_key = "id" if field_name == "ledger_entry_id" else field_name
+        _compare(mismatches, field_name, preview, field_name, entry, entry_key)
+    if _str(entry.get("entry_digest")) != _str(preview.get("ledger_entry_digest")):
+        mismatches.append(
+            {
+                "field": "ledger_entry_digest",
+                "left": _str(preview.get("ledger_entry_digest")),
+                "right": _str(entry.get("entry_digest")),
+                "right_key": "source_recovery_closure_ledger_entry.entry_digest",
+            }
+        )
+    audit_steps = _audit_steps(preview)
+    non_pass_steps = [
+        _str(step.get("id")) or f"ledger-audit-step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != LEDGER_AUDIT_STEP_STATUS_PASS
+    ]
+    if (
+        not entry
+        or mismatches
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+        or non_pass_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN,
+            "Recovery closure governance seal source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {
+                "missing_sources": [
+                    "source_recovery_closure_ledger_entry"
+                ]
+                if not entry
+                else [],
+                "mismatches": mismatches,
+                "entry_status": _str(entry.get("status")),
+                "non_pass_ledger_audit_step_ids": non_pass_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN,
+        "Recovery closure governance seal source chain is internally consistent.",
+        {
+            "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+            "closure_id": _str(preview.get("closure_id")),
+            "ledger_audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _seal_requirements_check(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    required_flags = (
+        "would_verify_ledger_entry_integrity",
+        "would_verify_closure_source_integrity",
+        "would_verify_lifecycle_milestones",
+        "would_verify_completion_audit_evidence",
+    )
+    missing_flags = [field_name for field_name in required_flags if preview.get(field_name) is not True]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "completion_audit_step_ids",
+            "milestone_ids",
+            "ledger_audit_step_ids",
+        )
+        if not _list_of_str(preview.get(field_name))
+    ]
+    categories = {_str(step.get("category")) for step in _audit_steps(preview)}
+    required_categories = {
+        "ledger_entry",
+        "closure_source",
+        "milestones",
+        "source_chain",
+        "completion_audit",
+        "read_only",
+    }
+    missing_categories = sorted(required_categories - categories)
+    if missing_flags or missing_lists or missing_categories:
+        return _fail(
+            CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS,
+            "Recovery closure governance seal requirements are incomplete.",
+            ("regenerate_recovery_closure_ledger_audit_preview",),
+            {
+                "missing_flags": missing_flags,
+                "missing_lists": missing_lists,
+                "missing_categories": missing_categories,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS,
+        "Recovery closure governance seal requirements cover integrity, lifecycle, audit, and read-only guarantees.",
+        {
+            "ledger_audit_step_count": len(_audit_steps(preview)),
+            "milestone_count": len(_list_of_str(preview.get("milestone_ids"))),
+        },
+    )
+
+
+def _seal_from_ledger_audit(
+    preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(_list_of_str(preview.get("completion_audit_step_ids")))
+    milestone_ids = tuple(_list_of_str(preview.get("milestone_ids")))
+    ledger_audit_step_ids = tuple(_list_of_str(preview.get("ledger_audit_step_ids")))
+    seal_seed = {
+        "seal_type": RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+        "governance_decision": RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+        "governance_scope": RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+        "ledger_audit_preview_id": _str(preview.get("id")),
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "ledger_entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+        "ledger_audit_digest": _str(preview.get("audit_digest")),
+    }
+    seal_digest = _digest(seal_seed)
+    seal_id = f"recovery-closure-governance-seal-{seal_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealDraft(
+        id=seal_id,
+        seal_type=RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+        governance_decision=RECOVERY_CLOSURE_GOVERNANCE_DECISION,
+        governance_scope=RECOVERY_CLOSURE_GOVERNANCE_SCOPE,
+        ledger_audit_preview_id=_str(preview.get("id")),
+        ledger_entry_id=_str(preview.get("ledger_entry_id")),
+        closure_id=_str(preview.get("closure_id")),
+        audit_preview_id=_str(preview.get("audit_preview_id")),
+        receipt_id=_str(preview.get("receipt_id")),
+        executor_preview_id=_str(preview.get("executor_preview_id")),
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        token_id=_str(preview.get("token_id")),
+        lock_id=_str(preview.get("lock_id")),
+        route=_str(preview.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        ledger_entry_digest=_str(preview.get("ledger_entry_digest")),
+        closure_digest=_str(preview.get("closure_digest")),
+        ledger_audit_digest=_str(preview.get("audit_digest")),
+        seal_digest=seal_digest,
+        seal_preview=f"{seal_id}:{seal_digest[:12]}",
+        would_freeze_recovery_closure=True,
+        would_preserve_audit_evidence=True,
+        would_enable_governed_handoff=True,
+        would_block_unreviewed_mutation=True,
+        safety_note=(
+            "Read-only recovery closure governance seal draft. It previews a "
+            "future governance seal for handoff and accountability, but does "
+            "not freeze, persist, or mutate durable memory."
+        ),
+        source_recovery_closure_ledger_audit_preview=dict(preview),
+    )
+
+
+def _expected_ledger_audit_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "ledger_entry_id": _str(preview.get("ledger_entry_id")),
+        "closure_id": _str(preview.get("closure_id")),
+        "audit_preview_id": _str(preview.get("audit_preview_id")),
+        "receipt_id": _str(preview.get("receipt_id")),
+        "executor_preview_id": _str(preview.get("executor_preview_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "token_id": _str(preview.get("token_id")),
+        "lock_id": _str(preview.get("lock_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(preview.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(preview.get("future_mutation_step_ids"))
+        ),
+        "completion_audit_step_ids": tuple(
+            _list_of_str(preview.get("completion_audit_step_ids"))
+        ),
+        "milestone_ids": tuple(_list_of_str(preview.get("milestone_ids"))),
+        "ledger_audit_step_ids": tuple(
+            _list_of_str(preview.get("ledger_audit_step_ids"))
+        ),
+        "entry_digest": _str(preview.get("ledger_entry_digest")),
+        "closure_digest": _str(preview.get("closure_digest")),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(preview: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(preview.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_ledger_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        seals=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_audit_report=dict(
+            recovery_closure_ledger_audit
+        ),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_ledger_audit: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+        checks=checks,
+        seals=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_ledger_audit_report=dict(
+            recovery_closure_ledger_audit
+        ),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck:
+    return MemoryEvidenceRepairRecoveryClosureGovernanceSealCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_ledger_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_ledger_audit_preview.py
@@ -1,0 +1,1024 @@
+"""Read-only recovery closure ledger audit preview for memory evidence repair.
+
+The ledger audit preview verifies that a recovery closure ledger entry can be
+trusted by later governance layers. It never writes durable memory, records a
+real audit, or marks a recovery closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    RECOVERY_CLOSURE_DECISION,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+    RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_STATUS_READY,
+    RECOVERY_CLOSURE_TYPE,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    RECOVERY_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY = (
+    "recovery_closure_ledger_audit_preview_ready"
+)
+RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY = (
+    "recovery_closure_ledger_audit_ready"
+)
+
+LEDGER_AUDIT_STEP_STATUS_PASS = "pass"
+LEDGER_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_CLOSURE_LEDGER_READY = "recovery_closure_ledger_ready"
+CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY = "recovery_closure_ledger_integrity"
+CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN = "recovery_closure_ledger_source_chain"
+CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS = (
+    "recovery_closure_ledger_audit_requirements"
+)
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    """One read-only recovery closure ledger audit check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditStep:
+    """One structural audit step for a future closure ledger entry."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    ledger_entry_id: str
+    reference_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "ledger_entry_id": self.ledger_entry_id,
+            "reference_id": self.reference_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview:
+    """One read-only recovery closure ledger audit preview."""
+
+    id: str
+    status: str
+    ledger_entry_id: str
+    closure_id: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    completion_audit_step_ids: tuple[str, ...]
+    milestone_ids: tuple[str, ...]
+    ledger_audit_step_ids: tuple[str, ...]
+    ledger_entry_digest: str
+    closure_digest: str
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditStep, ...]
+    would_verify_ledger_entry_integrity: bool
+    would_verify_closure_source_integrity: bool
+    would_verify_lifecycle_milestones: bool
+    would_verify_completion_audit_evidence: bool
+    safety_note: str
+    source_recovery_closure_ledger_entry: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "ledger_entry_id": self.ledger_entry_id,
+            "closure_id": self.closure_id,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "completion_audit_step_ids": list(self.completion_audit_step_ids),
+            "milestone_ids": list(self.milestone_ids),
+            "ledger_audit_step_ids": list(self.ledger_audit_step_ids),
+            "ledger_entry_digest": self.ledger_entry_digest,
+            "closure_digest": self.closure_digest,
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "would_verify_ledger_entry_integrity": (
+                self.would_verify_ledger_entry_integrity
+            ),
+            "would_verify_closure_source_integrity": (
+                self.would_verify_closure_source_integrity
+            ),
+            "would_verify_lifecycle_milestones": self.would_verify_lifecycle_milestones,
+            "would_verify_completion_audit_evidence": (
+                self.would_verify_completion_audit_evidence
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_closure_ledger_entry": dict(
+                self.source_recovery_closure_ledger_entry
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    """Read-only recovery closure ledger audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_ledger_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "observed_pass_step_count": by_audit_step_status.get(
+                LEDGER_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                LEDGER_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_ledger_audit_preview_available": bool(self.previews),
+            "recovery_closure_ledger_audit_ready": (
+                self.status == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_ledger_report": dict(
+                self.source_recovery_closure_ledger_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_ledger_audit_preview(
+    *,
+    recovery_closure_ledger: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    """Build a read-only audit preview from a recovery closure ledger report."""
+
+    recovery_closure_ledger = (
+        recovery_closure_ledger if isinstance(recovery_closure_ledger, Mapping) else {}
+    )
+    report_status = _str(recovery_closure_ledger.get("status"))
+    entry = _extract_entry(recovery_closure_ledger)
+
+    if not entry:
+        if (
+            not recovery_closure_ledger
+            or report_status == RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_closure_ledger=recovery_closure_ledger)
+        source_blocking = tuple(
+            _list_of_str(recovery_closure_ledger.get("blocking_reasons"))
+        )
+        source_actions = tuple(_list_of_str(recovery_closure_ledger.get("required_actions")))
+        return _blocked_report(
+            recovery_closure_ledger=recovery_closure_ledger,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+                    "No recovery closure ledger entry was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions
+                    or ("produce_recovery_closure_ledger_preview",),
+                    {"recovery_closure_ledger_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _ledger_ready_check(recovery_closure_ledger, entry),
+        _ledger_integrity_check(entry),
+        _source_chain_check(entry),
+        _audit_requirements_check(entry),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+        )
+
+    preview = _preview_from_entry(entry)
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+    )
+
+
+def empty_evidence_repair_recovery_closure_ledger_audit_preview() -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    """Return an empty read-only recovery closure ledger audit preview."""
+
+    return _empty_report(recovery_closure_ledger={})
+
+
+def _extract_entry(recovery_closure_ledger: Mapping[str, Any]) -> dict[str, Any]:
+    entries = recovery_closure_ledger.get("entries")
+    if isinstance(entries, list):
+        for entry in entries:
+            if isinstance(entry, Mapping):
+                return dict(entry)
+    if _str(recovery_closure_ledger.get("id")).startswith("recovery-closure-ledger-"):
+        return dict(recovery_closure_ledger)
+    return {}
+
+
+def _ledger_ready_check(
+    recovery_closure_ledger: Mapping[str, Any],
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    report_status = _str(recovery_closure_ledger.get("status"))
+    entry_status = _str(entry.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_LEDGER_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+            "Recovery closure ledger report is not ready for audit preview.",
+            tuple(_list_of_str(recovery_closure_ledger.get("required_actions")))
+            or ("produce_ready_recovery_closure_ledger_preview",),
+            {"report_status": report_status, "entry_status": entry_status},
+        )
+    if entry_status != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+            "Recovery closure ledger entry is not ready for audit preview.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {"report_status": report_status, "entry_status": entry_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_READY,
+        "Recovery closure ledger entry is ready for audit preview.",
+        {"ledger_entry_id": _str(entry.get("id"))},
+    )
+
+
+def _ledger_integrity_check(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    expected_digest = _expected_entry_digest(entry)
+    actual_digest = _str(entry.get("entry_digest"))
+    expected_id = (
+        f"recovery-closure-ledger-{expected_digest[:16]}" if expected_digest else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "entry_type",
+        "status",
+        "closure_id",
+        "closure_decision",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "audit_step_ids",
+        "closure_digest",
+        "entry_digest",
+        "milestones",
+        "source_recovery_closure",
+    ):
+        value = entry.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(entry.get("id")) != expected_id
+        or _str(entry.get("entry_type")) != RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE
+        or _str(entry.get("status")) != RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY,
+            "Recovery closure ledger entry digest, id, type, status, or required fields are invalid.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {
+                "expected_entry_digest": expected_digest,
+                "actual_entry_digest": actual_digest,
+                "expected_entry_id": expected_id,
+                "actual_entry_id": _str(entry.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY,
+        "Recovery closure ledger entry integrity checks pass.",
+        {"ledger_entry_id": expected_id, "entry_digest": actual_digest},
+    )
+
+
+def _source_chain_check(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    closure = _dict(entry.get("source_recovery_closure"))
+    audit = _dict(closure.get("source_recovery_completion_audit_preview"))
+    receipt = _dict(audit.get("source_recovery_completion_receipt"))
+    executor = _dict(receipt.get("source_recovery_executor_preview"))
+    expected_closure_digest = _expected_closure_digest(closure)
+    audit_steps = _audit_steps(audit)
+    non_pass_audit_steps = [
+        _str(step.get("id")) or f"audit-step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != RECOVERY_AUDIT_STEP_STATUS_PASS
+    ]
+    mismatches: list[dict[str, str]] = []
+    for field_name in (
+        "closure_id",
+        "closure_decision",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "closure_digest",
+    ):
+        closure_key = "id" if field_name == "closure_id" else field_name
+        _compare(mismatches, field_name, entry, field_name, closure, closure_key)
+    if _str(audit.get("id")) != _str(entry.get("audit_preview_id")):
+        mismatches.append(
+            {
+                "field": "audit_preview_id",
+                "left": _str(entry.get("audit_preview_id")),
+                "right": _str(audit.get("id")),
+                "right_key": "source_recovery_completion_audit_preview.id",
+            }
+        )
+    if _str(receipt.get("id")) != _str(entry.get("receipt_id")):
+        mismatches.append(
+            {
+                "field": "receipt_id",
+                "left": _str(entry.get("receipt_id")),
+                "right": _str(receipt.get("id")),
+                "right_key": "source_recovery_completion_receipt.id",
+            }
+        )
+    if _str(executor.get("id")) != _str(entry.get("executor_preview_id")):
+        mismatches.append(
+            {
+                "field": "executor_preview_id",
+                "left": _str(entry.get("executor_preview_id")),
+                "right": _str(executor.get("id")),
+                "right_key": "source_recovery_executor_preview.id",
+            }
+        )
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_closure", closure),
+            ("source_recovery_completion_audit_preview", audit),
+            ("source_recovery_completion_receipt", receipt),
+            ("source_recovery_executor_preview", executor),
+        )
+        if not source
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(closure.get("status")) != RECOVERY_CLOSURE_DRAFT_STATUS_READY
+        or _str(entry.get("closure_digest")) != expected_closure_digest
+        or _str(audit.get("status")) != RECOVERY_COMPLETION_AUDIT_STATUS_READY
+        or audit.get("observed_state_supplied") is not True
+        or non_pass_audit_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN,
+            "Recovery closure ledger source chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "closure_status": _str(closure.get("status")),
+                "expected_closure_digest": expected_closure_digest,
+                "actual_closure_digest": _str(entry.get("closure_digest")),
+                "audit_status": _str(audit.get("status")),
+                "observed_state_supplied": audit.get("observed_state_supplied") is True,
+                "non_pass_audit_step_ids": non_pass_audit_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN,
+        "Recovery closure ledger source chain is internally consistent.",
+        {
+            "closure_id": _str(entry.get("closure_id")),
+            "audit_preview_id": _str(entry.get("audit_preview_id")),
+            "receipt_id": _str(entry.get("receipt_id")),
+            "executor_preview_id": _str(entry.get("executor_preview_id")),
+            "audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _audit_requirements_check(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    milestones = _milestones(entry)
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "audit_step_ids",
+        )
+        if not _list_of_str(entry.get(field_name))
+    ]
+    missing_flags = [
+        field_name
+        for field_name in (
+            "would_record_ledger_entry",
+            "would_preserve_recovery_evidence",
+        )
+        if entry.get(field_name) is not True
+    ]
+    milestone_errors = _milestone_errors(entry)
+    if missing_lists or missing_flags or milestone_errors:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS,
+            "Recovery closure ledger audit requirements are incomplete.",
+            ("regenerate_recovery_closure_ledger_preview",),
+            {
+                "missing_lists": missing_lists,
+                "missing_flags": missing_flags,
+                "milestone_errors": milestone_errors,
+                "milestone_count": len(milestones),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS,
+        "Recovery closure ledger audit has all structural evidence needed.",
+        {
+            "milestone_count": len(milestones),
+            "operation_count": len(_list_of_str(entry.get("operation_ids"))),
+            "recovery_step_count": len(_list_of_str(entry.get("recovery_step_ids"))),
+            "completion_audit_step_count": len(_list_of_str(entry.get("audit_step_ids"))),
+        },
+    )
+
+
+def _preview_from_entry(
+    entry: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview:
+    audit_steps = tuple(_audit_steps_from_entry(entry))
+    ledger_audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(entry.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(entry.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(entry.get("future_mutation_step_ids")))
+    completion_audit_step_ids = tuple(_list_of_str(entry.get("audit_step_ids")))
+    milestone_ids = tuple(_str(milestone.get("id")) for milestone in _milestones(entry))
+    audit_seed = {
+        "ledger_entry_id": _str(entry.get("id")),
+        "closure_id": _str(entry.get("closure_id")),
+        "audit_preview_id": _str(entry.get("audit_preview_id")),
+        "receipt_id": _str(entry.get("receipt_id")),
+        "executor_preview_id": _str(entry.get("executor_preview_id")),
+        "decision_id": _str(entry.get("decision_id")),
+        "execution_preview_id": _str(entry.get("execution_preview_id")),
+        "token_id": _str(entry.get("token_id")),
+        "lock_id": _str(entry.get("lock_id")),
+        "route": _str(entry.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "completion_audit_step_ids": completion_audit_step_ids,
+        "milestone_ids": milestone_ids,
+        "ledger_audit_step_ids": ledger_audit_step_ids,
+        "entry_digest": _str(entry.get("entry_digest")),
+        "closure_digest": _str(entry.get("closure_digest")),
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-closure-ledger-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreview(
+        id=audit_id,
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+        ledger_entry_id=_str(entry.get("id")),
+        closure_id=_str(entry.get("closure_id")),
+        audit_preview_id=_str(entry.get("audit_preview_id")),
+        receipt_id=_str(entry.get("receipt_id")),
+        executor_preview_id=_str(entry.get("executor_preview_id")),
+        decision_id=_str(entry.get("decision_id")),
+        execution_preview_id=_str(entry.get("execution_preview_id")),
+        token_id=_str(entry.get("token_id")),
+        lock_id=_str(entry.get("lock_id")),
+        route=_str(entry.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        completion_audit_step_ids=completion_audit_step_ids,
+        milestone_ids=milestone_ids,
+        ledger_audit_step_ids=ledger_audit_step_ids,
+        ledger_entry_digest=_str(entry.get("entry_digest")),
+        closure_digest=_str(entry.get("closure_digest")),
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=audit_steps,
+        would_verify_ledger_entry_integrity=True,
+        would_verify_closure_source_integrity=True,
+        would_verify_lifecycle_milestones=True,
+        would_verify_completion_audit_evidence=True,
+        safety_note=(
+            "Read-only recovery closure ledger audit preview. It checks whether "
+            "a future closure ledger entry is structurally trustworthy, but does "
+            "not record the audit or mutate durable memory."
+        ),
+        source_recovery_closure_ledger_entry=dict(entry),
+    )
+
+
+def _audit_steps_from_entry(
+    entry: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureLedgerAuditStep]:
+    rows = (
+        (
+            "ledger_entry",
+            "ledger_entry_digest_valid",
+            _str(entry.get("id")),
+            {"expected_entry_digest": _expected_entry_digest(entry)},
+            {"actual_entry_digest": _str(entry.get("entry_digest"))},
+        ),
+        (
+            "closure_source",
+            "closure_source_digest_valid",
+            _str(entry.get("closure_id")),
+            {
+                "expected_closure_digest": _expected_closure_digest(
+                    _dict(entry.get("source_recovery_closure"))
+                )
+            },
+            {"actual_closure_digest": _str(entry.get("closure_digest"))},
+        ),
+        (
+            "milestones",
+            "lifecycle_milestones_ordered",
+            _str(entry.get("id")),
+            {"required_stages": list(_required_milestone_stages())},
+            {"stages": [_str(milestone.get("stage")) for milestone in _milestones(entry)]},
+        ),
+        (
+            "source_chain",
+            "source_chain_consistent",
+            _str(entry.get("closure_id")),
+            {"closure_id": _str(entry.get("closure_id"))},
+            {"source_closure_id": _str(_dict(entry.get("source_recovery_closure")).get("id"))},
+        ),
+        (
+            "completion_audit",
+            "completion_audit_observed_pass",
+            _str(entry.get("audit_preview_id")),
+            {"observed_state_supplied": True},
+            {
+                "observed_state_supplied": _dict(
+                    _dict(entry.get("source_recovery_closure")).get(
+                        "source_recovery_completion_audit_preview"
+                    )
+                ).get("observed_state_supplied")
+                is True
+            },
+        ),
+        (
+            "read_only",
+            "ledger_entry_is_preview_only",
+            _str(entry.get("id")),
+            {"would_record_ledger_entry": True},
+            {"would_record_ledger_entry": entry.get("would_record_ledger_entry") is True},
+        ),
+    )
+    return [
+        _audit_step(
+            sequence=index,
+            category=category,
+            assertion=assertion,
+            entry=entry,
+            reference_id=reference_id,
+            expected_signal=expected_signal,
+            observed_signal=observed_signal,
+        )
+        for index, (
+            category,
+            assertion,
+            reference_id,
+            expected_signal,
+            observed_signal,
+        ) in enumerate(rows, start=1)
+    ]
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    entry: Mapping[str, Any],
+    reference_id: str,
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditStep:
+    step_seed = {
+        "sequence": sequence,
+        "category": category,
+        "assertion": assertion,
+        "ledger_entry_id": _str(entry.get("id")),
+        "reference_id": _str(reference_id),
+    }
+    step_id = f"recovery-closure-ledger-audit-step-{_digest(step_seed)[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditStep(
+        id=step_id,
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        ledger_entry_id=_str(entry.get("id")),
+        reference_id=_str(reference_id),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=LEDGER_AUDIT_STEP_STATUS_PASS,
+        required_action_on_fail="regenerate_recovery_closure_ledger_preview",
+    )
+
+
+def _expected_entry_digest(entry: Mapping[str, Any]) -> str:
+    seed = {
+        "entry_type": RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+        "closure_id": _str(entry.get("closure_id")),
+        "closure_digest": _str(entry.get("closure_digest")),
+        "audit_preview_id": _str(entry.get("audit_preview_id")),
+        "receipt_id": _str(entry.get("receipt_id")),
+        "executor_preview_id": _str(entry.get("executor_preview_id")),
+        "decision_id": _str(entry.get("decision_id")),
+        "execution_preview_id": _str(entry.get("execution_preview_id")),
+        "token_id": _str(entry.get("token_id")),
+        "lock_id": _str(entry.get("lock_id")),
+        "route": _str(entry.get("route")),
+        "operation_ids": tuple(_list_of_str(entry.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(entry.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(entry.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(entry.get("audit_step_ids"))),
+        "milestone_ids": tuple(_str(milestone.get("id")) for milestone in _milestones(entry)),
+    }
+    return _digest(seed)
+
+
+def _expected_closure_digest(closure: Mapping[str, Any]) -> str:
+    seed = {
+        "closure_type": RECOVERY_CLOSURE_TYPE,
+        "closure_decision": RECOVERY_CLOSURE_DECISION,
+        "audit_preview_id": _str(closure.get("audit_preview_id")),
+        "receipt_id": _str(closure.get("receipt_id")),
+        "executor_preview_id": _str(closure.get("executor_preview_id")),
+        "decision_id": _str(closure.get("decision_id")),
+        "execution_preview_id": _str(closure.get("execution_preview_id")),
+        "token_id": _str(closure.get("token_id")),
+        "lock_id": _str(closure.get("lock_id")),
+        "route": _str(closure.get("route")),
+        "operation_ids": tuple(_list_of_str(closure.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(closure.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(closure.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(closure.get("audit_step_ids"))),
+    }
+    return _digest(seed)
+
+
+def _milestone_errors(entry: Mapping[str, Any]) -> list[dict[str, Any]]:
+    milestones = _milestones(entry)
+    errors: list[dict[str, Any]] = []
+    expected_reference_ids = {
+        "recovery_decision": _str(entry.get("decision_id")),
+        "recovery_execution_preview": _str(entry.get("execution_preview_id")),
+        "recovery_approval_token": _str(entry.get("token_id")),
+        "recovery_write_lock": _str(entry.get("lock_id")),
+        "recovery_executor_preview": _str(entry.get("executor_preview_id")),
+        "recovery_completion_receipt": _str(entry.get("receipt_id")),
+        "recovery_completion_audit": _str(entry.get("audit_preview_id")),
+        "recovery_closure": _str(entry.get("closure_id")),
+    }
+    stages = [_str(milestone.get("stage")) for milestone in milestones]
+    if tuple(stages) != _required_milestone_stages():
+        errors.append(
+            {
+                "type": "stage_order",
+                "expected": list(_required_milestone_stages()),
+                "actual": stages,
+            }
+        )
+    for expected_sequence, milestone in enumerate(milestones, start=1):
+        stage = _str(milestone.get("stage"))
+        reference_id = _str(milestone.get("reference_id"))
+        expected_reference_id = expected_reference_ids.get(stage, "")
+        expected_id = _milestone_id(stage, expected_reference_id, expected_sequence)
+        if int(milestone.get("sequence") or 0) != expected_sequence:
+            errors.append(
+                {
+                    "type": "sequence",
+                    "stage": stage,
+                    "expected": expected_sequence,
+                    "actual": milestone.get("sequence"),
+                }
+            )
+        if reference_id != expected_reference_id:
+            errors.append(
+                {
+                    "type": "reference_id",
+                    "stage": stage,
+                    "expected": expected_reference_id,
+                    "actual": reference_id,
+                }
+            )
+        if _str(milestone.get("id")) != expected_id:
+            errors.append(
+                {
+                    "type": "milestone_id",
+                    "stage": stage,
+                    "expected": expected_id,
+                    "actual": _str(milestone.get("id")),
+                }
+            )
+    return errors
+
+
+def _milestones(entry: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        milestone
+        for milestone in _list(entry.get("milestones"))
+        if isinstance(milestone, Mapping)
+    ]
+
+
+def _required_milestone_stages() -> tuple[str, ...]:
+    return (
+        "recovery_decision",
+        "recovery_execution_preview",
+        "recovery_approval_token",
+        "recovery_write_lock",
+        "recovery_executor_preview",
+        "recovery_completion_receipt",
+        "recovery_completion_audit",
+        "recovery_closure",
+    )
+
+
+def _milestone_id(stage: str, reference_id: str, sequence: int) -> str:
+    digest = _digest({"stage": stage, "reference_id": reference_id, "sequence": sequence})
+    return f"recovery-closure-milestone-{digest[:16]}"
+
+
+def _audit_steps(audit: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(audit.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_ledger: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_ledger: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_ledger_report=dict(recovery_closure_ledger),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_closure_ledger_preview.py
+++ b/agent/memory_evidence_repair_recovery_closure_ledger_preview.py
@@ -1,0 +1,822 @@
+"""Read-only recovery closure ledger preview for memory evidence repair.
+
+This layer turns a ready recovery closure draft into an audit-style lifecycle
+ledger entry. It never writes durable memory and never marks a recovery closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    RECOVERY_AUDIT_STEP_STATUS_PASS,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+)
+
+
+RECOVERY_CLOSURE_LEDGER_STATUS_READY = "recovery_closure_ledger_preview_ready"
+RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED = "blocked"
+RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY = "recovery_closure_ledger_entry_ready"
+RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE = (
+    "memory_evidence_repair_recovery_closure_ledger_entry"
+)
+
+CHECK_RECOVERY_CLOSURE_READY = "recovery_closure_ready"
+CHECK_RECOVERY_CLOSURE_INTEGRITY = "recovery_closure_integrity"
+CHECK_RECOVERY_LIFECYCLE_CHAIN = "recovery_lifecycle_chain"
+CHECK_RECOVERY_LEDGER_REQUIREMENTS = "recovery_ledger_requirements"
+
+RECOVERY_CLOSURE_TYPE = "memory_evidence_repair_recovery_closure"
+RECOVERY_CLOSURE_DECISION = "close_recovery_loop"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    """One read-only recovery closure ledger check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerMilestone:
+    """One lifecycle milestone inside a future recovery closure ledger entry."""
+
+    id: str
+    sequence: int
+    stage: str
+    reference_id: str
+    status: str
+    summary: str
+    source: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "stage": self.stage,
+            "reference_id": self.reference_id,
+            "status": self.status,
+            "summary": self.summary,
+            "source": dict(self.source),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerEntry:
+    """One read-only future recovery closure ledger entry preview."""
+
+    id: str
+    entry_type: str
+    status: str
+    closure_id: str
+    closure_decision: str
+    audit_preview_id: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    closure_digest: str
+    entry_digest: str
+    entry_preview: str
+    milestones: tuple[MemoryEvidenceRepairRecoveryClosureLedgerMilestone, ...]
+    would_record_ledger_entry: bool
+    would_preserve_recovery_evidence: bool
+    safety_note: str
+    source_recovery_closure: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "entry_type": self.entry_type,
+            "status": self.status,
+            "closure_id": self.closure_id,
+            "closure_decision": self.closure_decision,
+            "audit_preview_id": self.audit_preview_id,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "audit_step_ids": list(self.audit_step_ids),
+            "closure_digest": self.closure_digest,
+            "entry_digest": self.entry_digest,
+            "entry_preview": self.entry_preview,
+            "milestones": [milestone.to_dict() for milestone in self.milestones],
+            "would_record_ledger_entry": self.would_record_ledger_entry,
+            "would_preserve_recovery_evidence": self.would_preserve_recovery_evidence,
+            "safety_note": self.safety_note,
+            "source_recovery_closure": dict(self.source_recovery_closure),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    """Read-only recovery closure ledger preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerCheck, ...]
+    entries: tuple[MemoryEvidenceRepairRecoveryClosureLedgerEntry, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_closure_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        milestone_count = 0
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for entry in self.entries:
+            milestone_count += len(entry.milestones)
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "entry_count": len(self.entries),
+            "milestone_count": milestone_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_closure_ledger_preview_available": bool(self.entries),
+            "recovery_closure_ledger_ready": (
+                self.status == RECOVERY_CLOSURE_LEDGER_STATUS_READY
+            ),
+            "would_record_ledger_entry_count": sum(
+                1 for entry in self.entries if entry.would_record_ledger_entry
+            ),
+            "would_preserve_recovery_evidence_count": sum(
+                1 for entry in self.entries if entry.would_preserve_recovery_evidence
+            ),
+            "has_blocks": self.status == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "entries": [entry.to_dict() for entry in self.entries],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_closure_gate": dict(self.source_recovery_closure_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_closure_ledger_preview(
+    *,
+    recovery_closure_gate: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    """Build a read-only lifecycle ledger preview from a recovery closure gate."""
+
+    recovery_closure_gate = (
+        recovery_closure_gate if isinstance(recovery_closure_gate, Mapping) else {}
+    )
+    report_status = _str(recovery_closure_gate.get("status"))
+    closure = _extract_closure(recovery_closure_gate)
+
+    if not closure:
+        if (
+            not recovery_closure_gate
+            or report_status == RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_closure_gate=recovery_closure_gate)
+        source_blocking = tuple(_list_of_str(recovery_closure_gate.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_closure_gate.get("required_actions")))
+        return _blocked_report(
+            recovery_closure_gate=recovery_closure_gate,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_CLOSURE_READY,
+                    "No recovery closure draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_ready_recovery_closure_gate",),
+                    {"recovery_closure_gate_status": report_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _closure_ready_check(recovery_closure_gate, closure),
+        _closure_integrity_check(closure),
+        _lifecycle_chain_check(closure),
+        _ledger_requirements_check(closure),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+            checks=checks,
+            entries=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_closure_gate=dict(recovery_closure_gate),
+        )
+
+    entry = _entry_from_closure(closure)
+    return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_STATUS_READY,
+        checks=checks,
+        entries=(entry,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_gate=dict(recovery_closure_gate),
+    )
+
+
+def empty_evidence_repair_recovery_closure_ledger_preview() -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    """Return an empty read-only recovery closure ledger preview."""
+
+    return _empty_report(recovery_closure_gate={})
+
+
+def _extract_closure(recovery_closure_gate: Mapping[str, Any]) -> dict[str, Any]:
+    closures = recovery_closure_gate.get("closures")
+    if isinstance(closures, list):
+        for closure in closures:
+            if isinstance(closure, Mapping):
+                return dict(closure)
+    if _str(recovery_closure_gate.get("id")).startswith("recovery-closure-"):
+        return dict(recovery_closure_gate)
+    return {}
+
+
+def _closure_ready_check(
+    recovery_closure_gate: Mapping[str, Any],
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    report_status = _str(recovery_closure_gate.get("status"))
+    closure_status = _str(closure.get("status"))
+    if report_status and report_status != RECOVERY_CLOSURE_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_READY,
+            "Recovery closure gate report is not ready for ledger preview.",
+            tuple(_list_of_str(recovery_closure_gate.get("required_actions")))
+            or ("produce_ready_recovery_closure_gate",),
+            {"report_status": report_status, "closure_status": closure_status},
+        )
+    if closure_status != RECOVERY_CLOSURE_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_READY,
+            "Recovery closure draft is not ready for ledger preview.",
+            ("regenerate_recovery_closure_gate",),
+            {"report_status": report_status, "closure_status": closure_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_READY,
+        "Recovery closure draft is ready for ledger preview.",
+        {"closure_id": _str(closure.get("id"))},
+    )
+
+
+def _closure_integrity_check(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    expected_digest = _expected_closure_digest(closure)
+    actual_digest = _str(closure.get("closure_digest"))
+    expected_id = f"recovery-closure-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "status",
+        "closure_type",
+        "closure_decision",
+        "audit_preview_id",
+        "receipt_id",
+        "executor_preview_id",
+        "decision_id",
+        "execution_preview_id",
+        "token_id",
+        "lock_id",
+        "route",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "audit_step_ids",
+        "source_recovery_completion_audit_preview",
+    ):
+        value = closure.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif isinstance(value, Mapping) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, (list, Mapping)) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(closure.get("id")) != expected_id
+        or _str(closure.get("closure_type")) != RECOVERY_CLOSURE_TYPE
+        or _str(closure.get("closure_decision")) != RECOVERY_CLOSURE_DECISION
+    ):
+        return _fail(
+            CHECK_RECOVERY_CLOSURE_INTEGRITY,
+            "Recovery closure digest, id, type, decision, or required fields are invalid.",
+            ("regenerate_recovery_closure_gate",),
+            {
+                "expected_closure_digest": expected_digest,
+                "actual_closure_digest": actual_digest,
+                "expected_closure_id": expected_id,
+                "actual_closure_id": _str(closure.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_CLOSURE_INTEGRITY,
+        "Recovery closure integrity checks pass.",
+        {"closure_id": expected_id, "closure_digest": actual_digest},
+    )
+
+
+def _lifecycle_chain_check(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    audit = _dict(closure.get("source_recovery_completion_audit_preview"))
+    receipt = _dict(audit.get("source_recovery_completion_receipt"))
+    executor = _dict(receipt.get("source_recovery_executor_preview"))
+    mismatches: list[dict[str, str]] = []
+
+    _compare(mismatches, "audit_preview_id", closure, "audit_preview_id", audit, "id")
+    _compare(mismatches, "receipt_id", closure, "receipt_id", audit, "receipt_id")
+    _compare(mismatches, "receipt_id", closure, "receipt_id", receipt, "id")
+    _compare(
+        mismatches,
+        "executor_preview_id",
+        closure,
+        "executor_preview_id",
+        audit,
+        "executor_preview_id",
+    )
+    _compare(
+        mismatches,
+        "executor_preview_id",
+        closure,
+        "executor_preview_id",
+        receipt,
+        "executor_preview_id",
+    )
+    _compare(mismatches, "executor_preview_id", closure, "executor_preview_id", executor, "id")
+    for field_name in ("decision_id", "execution_preview_id", "token_id", "lock_id", "route"):
+        _compare(mismatches, field_name, closure, field_name, audit, field_name)
+        _compare(mismatches, field_name, closure, field_name, receipt, field_name)
+        _compare(mismatches, field_name, closure, field_name, executor, field_name)
+
+    audit_steps = _audit_steps(audit)
+    non_pass_steps = [
+        _str(step.get("id")) or f"step-{index}"
+        for index, step in enumerate(audit_steps, start=1)
+        if _str(step.get("status")) != RECOVERY_AUDIT_STEP_STATUS_PASS
+    ]
+    missing_sources = [
+        name
+        for name, source in (
+            ("source_recovery_completion_audit_preview", audit),
+            ("source_recovery_completion_receipt", receipt),
+            ("source_recovery_executor_preview", executor),
+        )
+        if not source
+    ]
+    if (
+        missing_sources
+        or mismatches
+        or _str(audit.get("status")) != RECOVERY_COMPLETION_AUDIT_STATUS_READY
+        or audit.get("observed_state_supplied") is not True
+        or non_pass_steps
+    ):
+        return _fail(
+            CHECK_RECOVERY_LIFECYCLE_CHAIN,
+            "Recovery closure lifecycle chain is incomplete or inconsistent.",
+            ("regenerate_recovery_closure_gate",),
+            {
+                "missing_sources": missing_sources,
+                "mismatches": mismatches,
+                "audit_status": _str(audit.get("status")),
+                "observed_state_supplied": audit.get("observed_state_supplied") is True,
+                "non_pass_audit_step_ids": non_pass_steps,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_LIFECYCLE_CHAIN,
+        "Recovery closure lifecycle chain is internally consistent.",
+        {
+            "closure_id": _str(closure.get("id")),
+            "audit_preview_id": _str(audit.get("id")),
+            "receipt_id": _str(receipt.get("id")),
+            "executor_preview_id": _str(executor.get("id")),
+            "audit_step_count": len(audit_steps),
+        },
+    )
+
+
+def _ledger_requirements_check(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    milestones = _milestones(closure)
+    missing_stages = [
+        stage
+        for stage in _required_milestone_stages()
+        if not any(
+            milestone.stage == stage and milestone.reference_id for milestone in milestones
+        )
+    ]
+    missing_lists = [
+        field_name
+        for field_name in (
+            "operation_ids",
+            "recovery_step_ids",
+            "future_mutation_step_ids",
+            "audit_step_ids",
+        )
+        if not _list_of_str(closure.get(field_name))
+    ]
+    missing_flags = [
+        field_name
+        for field_name in (
+            "would_close_recovery_loop",
+            "would_mark_recovery_resolved",
+            "would_preserve_audit_evidence",
+        )
+        if closure.get(field_name) is not True
+    ]
+    if missing_stages or missing_lists or missing_flags:
+        return _fail(
+            CHECK_RECOVERY_LEDGER_REQUIREMENTS,
+            "Recovery closure ledger requirements are incomplete.",
+            ("regenerate_recovery_closure_gate",),
+            {
+                "missing_stages": missing_stages,
+                "missing_lists": missing_lists,
+                "missing_flags": missing_flags,
+                "milestone_count": len(milestones),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_LEDGER_REQUIREMENTS,
+        "Recovery closure ledger has all lifecycle milestones and evidence ids.",
+        {
+            "milestone_count": len(milestones),
+            "operation_count": len(_list_of_str(closure.get("operation_ids"))),
+            "recovery_step_count": len(_list_of_str(closure.get("recovery_step_ids"))),
+            "audit_step_count": len(_list_of_str(closure.get("audit_step_ids"))),
+        },
+    )
+
+
+def _entry_from_closure(
+    closure: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerEntry:
+    operation_ids = tuple(_list_of_str(closure.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(closure.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(closure.get("future_mutation_step_ids")))
+    audit_step_ids = tuple(_list_of_str(closure.get("audit_step_ids")))
+    milestones = tuple(_milestones(closure))
+    entry_seed = {
+        "entry_type": RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+        "closure_id": _str(closure.get("id")),
+        "closure_digest": _str(closure.get("closure_digest")),
+        "audit_preview_id": _str(closure.get("audit_preview_id")),
+        "receipt_id": _str(closure.get("receipt_id")),
+        "executor_preview_id": _str(closure.get("executor_preview_id")),
+        "decision_id": _str(closure.get("decision_id")),
+        "execution_preview_id": _str(closure.get("execution_preview_id")),
+        "token_id": _str(closure.get("token_id")),
+        "lock_id": _str(closure.get("lock_id")),
+        "route": _str(closure.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "audit_step_ids": audit_step_ids,
+        "milestone_ids": tuple(milestone.id for milestone in milestones),
+    }
+    entry_digest = _digest(entry_seed)
+    entry_id = f"recovery-closure-ledger-{entry_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryClosureLedgerEntry(
+        id=entry_id,
+        entry_type=RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+        status=RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+        closure_id=_str(closure.get("id")),
+        closure_decision=_str(closure.get("closure_decision")),
+        audit_preview_id=_str(closure.get("audit_preview_id")),
+        receipt_id=_str(closure.get("receipt_id")),
+        executor_preview_id=_str(closure.get("executor_preview_id")),
+        decision_id=_str(closure.get("decision_id")),
+        execution_preview_id=_str(closure.get("execution_preview_id")),
+        token_id=_str(closure.get("token_id")),
+        lock_id=_str(closure.get("lock_id")),
+        route=_str(closure.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        audit_step_ids=audit_step_ids,
+        closure_digest=_str(closure.get("closure_digest")),
+        entry_digest=entry_digest,
+        entry_preview=f"{entry_id}:{entry_digest[:12]}",
+        milestones=milestones,
+        would_record_ledger_entry=True,
+        would_preserve_recovery_evidence=True,
+        safety_note=(
+            "Read-only recovery closure ledger preview. It records the intended "
+            "audit trail for a future closure, but does not persist a ledger "
+            "entry or mutate durable memory."
+        ),
+        source_recovery_closure=dict(closure),
+    )
+
+
+def _milestones(
+    closure: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryClosureLedgerMilestone]:
+    audit = _dict(closure.get("source_recovery_completion_audit_preview"))
+    receipt = _dict(audit.get("source_recovery_completion_receipt"))
+    executor = _dict(receipt.get("source_recovery_executor_preview"))
+    lock = _dict(executor.get("source_lock"))
+    token_gate = _dict(lock.get("source_recovery_token_gate"))
+    execution = _dict(token_gate.get("source_recovery_execution_preview"))
+    decision = _dict(execution.get("source_recovery_decision"))
+    sources = {
+        "recovery_decision": decision,
+        "recovery_execution_preview": execution,
+        "recovery_approval_token": _dict(token_gate.get("source_token")),
+        "recovery_write_lock": lock,
+        "recovery_executor_preview": executor,
+        "recovery_completion_receipt": receipt,
+        "recovery_completion_audit": audit,
+        "recovery_closure": dict(closure),
+    }
+    fallback_ids = {
+        "recovery_decision": _str(closure.get("decision_id")),
+        "recovery_execution_preview": _str(closure.get("execution_preview_id")),
+        "recovery_approval_token": _str(closure.get("token_id")),
+        "recovery_write_lock": _str(closure.get("lock_id")),
+        "recovery_executor_preview": _str(closure.get("executor_preview_id")),
+        "recovery_completion_receipt": _str(closure.get("receipt_id")),
+        "recovery_completion_audit": _str(closure.get("audit_preview_id")),
+        "recovery_closure": _str(closure.get("id")),
+    }
+    summaries = {
+        "recovery_decision": "Recovery route decision selected.",
+        "recovery_execution_preview": "Manual recovery execution preview prepared.",
+        "recovery_approval_token": "Recovery human approval token verified.",
+        "recovery_write_lock": "Recovery write lock drafted for the manual window.",
+        "recovery_executor_preview": "Recovery executor preview completed.",
+        "recovery_completion_receipt": "Recovery completion receipt drafted.",
+        "recovery_completion_audit": "Observed recovery completion audit passed.",
+        "recovery_closure": "Recovery closure draft is ready to close the loop.",
+    }
+    milestones: list[MemoryEvidenceRepairRecoveryClosureLedgerMilestone] = []
+    for sequence, stage in enumerate(_required_milestone_stages(), start=1):
+        source = sources.get(stage, {})
+        reference_id = _str(source.get("id")) or fallback_ids.get(stage, "")
+        status = _str(source.get("status")) or _str(closure.get("status"))
+        milestone_id = _milestone_id(stage, reference_id, sequence)
+        milestones.append(
+            MemoryEvidenceRepairRecoveryClosureLedgerMilestone(
+                id=milestone_id,
+                sequence=sequence,
+                stage=stage,
+                reference_id=reference_id,
+                status=status,
+                summary=summaries[stage],
+                source=_source_summary(source, fallback_id=reference_id),
+            )
+        )
+    return milestones
+
+
+def _required_milestone_stages() -> tuple[str, ...]:
+    return (
+        "recovery_decision",
+        "recovery_execution_preview",
+        "recovery_approval_token",
+        "recovery_write_lock",
+        "recovery_executor_preview",
+        "recovery_completion_receipt",
+        "recovery_completion_audit",
+        "recovery_closure",
+    )
+
+
+def _source_summary(source: Mapping[str, Any], *, fallback_id: str) -> dict[str, Any]:
+    return {
+        "id": _str(source.get("id")) or fallback_id,
+        "status": _str(source.get("status")),
+        "route": _str(source.get("route")),
+        "type": _str(source.get("closure_type"))
+        or _str(source.get("receipt_type"))
+        or _str(source.get("lock_type")),
+    }
+
+
+def _milestone_id(stage: str, reference_id: str, sequence: int) -> str:
+    digest = _digest({"stage": stage, "reference_id": reference_id, "sequence": sequence})
+    return f"recovery-closure-milestone-{digest[:16]}"
+
+
+def _expected_closure_digest(closure: Mapping[str, Any]) -> str:
+    seed = {
+        "closure_type": RECOVERY_CLOSURE_TYPE,
+        "closure_decision": RECOVERY_CLOSURE_DECISION,
+        "audit_preview_id": _str(closure.get("audit_preview_id")),
+        "receipt_id": _str(closure.get("receipt_id")),
+        "executor_preview_id": _str(closure.get("executor_preview_id")),
+        "decision_id": _str(closure.get("decision_id")),
+        "execution_preview_id": _str(closure.get("execution_preview_id")),
+        "token_id": _str(closure.get("token_id")),
+        "lock_id": _str(closure.get("lock_id")),
+        "route": _str(closure.get("route")),
+        "operation_ids": tuple(_list_of_str(closure.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(closure.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(closure.get("future_mutation_step_ids"))
+        ),
+        "audit_step_ids": tuple(_list_of_str(closure.get("audit_step_ids"))),
+    }
+    return _digest(seed)
+
+
+def _audit_steps(audit: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(audit.get("audit_steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _compare(
+    mismatches: list[dict[str, str]],
+    label: str,
+    left: Mapping[str, Any],
+    left_key: str,
+    right: Mapping[str, Any],
+    right_key: str,
+) -> None:
+    left_value = _str(left.get(left_key))
+    right_value = _str(right.get(right_key))
+    if left_value != right_value:
+        mismatches.append(
+            {
+                "field": label,
+                "left": left_value,
+                "right": right_value,
+                "right_key": right_key,
+            }
+        )
+
+
+def _empty_report(
+    *,
+    recovery_closure_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        entries=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_closure_gate=dict(recovery_closure_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_closure_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryClosureLedgerCheck, ...],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport:
+    return MemoryEvidenceRepairRecoveryClosureLedgerPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+        checks=checks,
+        entries=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_closure_gate=dict(recovery_closure_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryClosureLedgerCheck:
+    return MemoryEvidenceRepairRecoveryClosureLedgerCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_completion_audit_preview.py
+++ b/agent/memory_evidence_repair_recovery_completion_audit_preview.py
@@ -1,0 +1,916 @@
+"""Read-only recovery completion audit preview for memory evidence repair.
+
+The recovery completion audit preview turns a recovery completion receipt into
+an ordered verification plan for after a future manual recovery. It can also
+validate optional observed recovery-completion state. It never writes to durable
+memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    RECOVERY_COMPLETION_RECEIPT_SCOPE,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+    RECOVERY_COMPLETION_RECEIPT_TYPE,
+)
+
+
+RECOVERY_COMPLETION_AUDIT_STATUS_READY = "recovery_completion_audit_preview_ready"
+RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED = "blocked"
+RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+RECOVERY_AUDIT_STEP_STATUS_PLANNED = "planned"
+RECOVERY_AUDIT_STEP_STATUS_PASS = "pass"
+RECOVERY_AUDIT_STEP_STATUS_FAIL = "fail"
+
+CHECK_RECOVERY_COMPLETION_RECEIPT_READY = "recovery_completion_receipt_ready"
+CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY = "recovery_completion_receipt_integrity"
+CHECK_RECOVERY_COMPLETION_AUDIT_REQUIREMENTS = "recovery_completion_audit_requirements"
+CHECK_OBSERVED_RECOVERY_COMPLETION_STATE = "observed_recovery_completion_state"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    """One read-only recovery completion audit readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditStep:
+    """One future recovery completion audit step preview."""
+
+    id: str
+    sequence: int
+    category: str
+    assertion: str
+    operation_id: str
+    recovery_step_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    expected_signal: dict[str, Any]
+    observed_signal: dict[str, Any]
+    status: str
+    required_action_on_fail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "category": self.category,
+            "assertion": self.assertion,
+            "operation_id": self.operation_id,
+            "recovery_step_id": self.recovery_step_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "expected_signal": dict(self.expected_signal),
+            "observed_signal": dict(self.observed_signal),
+            "status": self.status,
+            "required_action_on_fail": self.required_action_on_fail,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditPreview:
+    """One read-only recovery completion audit preview."""
+
+    id: str
+    status: str
+    receipt_id: str
+    executor_preview_id: str
+    decision_id: str
+    execution_preview_id: str
+    lock_id: str
+    token_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    audit_step_ids: tuple[str, ...]
+    audit_digest: str
+    audit_preview: str
+    audit_steps: tuple[MemoryEvidenceRepairRecoveryCompletionAuditStep, ...]
+    observed_state_supplied: bool
+    would_verify_completion_receipt_recorded: bool
+    would_verify_recovery_token_used: bool
+    would_verify_recovery_lock_released: bool
+    would_verify_recovery_steps_completed: bool
+    would_verify_post_recovery_audit_clear: bool
+    would_verify_no_secondary_memory_contamination: bool
+    safety_note: str
+    source_recovery_completion_receipt: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "receipt_id": self.receipt_id,
+            "executor_preview_id": self.executor_preview_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "lock_id": self.lock_id,
+            "token_id": self.token_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "audit_step_ids": list(self.audit_step_ids),
+            "audit_digest": self.audit_digest,
+            "audit_preview": self.audit_preview,
+            "audit_steps": [step.to_dict() for step in self.audit_steps],
+            "observed_state_supplied": self.observed_state_supplied,
+            "would_verify_completion_receipt_recorded": (
+                self.would_verify_completion_receipt_recorded
+            ),
+            "would_verify_recovery_token_used": self.would_verify_recovery_token_used,
+            "would_verify_recovery_lock_released": self.would_verify_recovery_lock_released,
+            "would_verify_recovery_steps_completed": (
+                self.would_verify_recovery_steps_completed
+            ),
+            "would_verify_post_recovery_audit_clear": (
+                self.would_verify_post_recovery_audit_clear
+            ),
+            "would_verify_no_secondary_memory_contamination": (
+                self.would_verify_no_secondary_memory_contamination
+            ),
+            "safety_note": self.safety_note,
+            "source_recovery_completion_receipt": dict(
+                self.source_recovery_completion_receipt
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    """Read-only recovery completion audit preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryCompletionAuditCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryCompletionAuditPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_completion_receipt_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_audit_step_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            for step in preview.audit_steps:
+                by_audit_step_status[step.status] = (
+                    by_audit_step_status.get(step.status, 0) + 1
+                )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "audit_step_count": sum(len(preview.audit_steps) for preview in self.previews),
+            "planned_audit_step_count": by_audit_step_status.get(
+                RECOVERY_AUDIT_STEP_STATUS_PLANNED,
+                0,
+            ),
+            "observed_pass_step_count": by_audit_step_status.get(
+                RECOVERY_AUDIT_STEP_STATUS_PASS,
+                0,
+            ),
+            "observed_fail_step_count": by_audit_step_status.get(
+                RECOVERY_AUDIT_STEP_STATUS_FAIL,
+                0,
+            ),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_completion_audit_preview_available": bool(self.previews),
+            "recovery_completion_audit_ready": (
+                self.status == RECOVERY_COMPLETION_AUDIT_STATUS_READY
+            ),
+            "has_blocks": self.status == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_audit_step_status": by_audit_step_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_completion_receipt_report": dict(
+                self.source_recovery_completion_receipt_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_completion_audit_preview(
+    *,
+    recovery_completion_receipt: Mapping[str, Any] | None = None,
+    observed_recovery_steps: Mapping[str, Any] | None = None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    released_lock_ids: Sequence[str] | None = None,
+    post_recovery_audit_status: Mapping[str, Any] | None = None,
+    contamination_status: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    """Build a read-only recovery completion audit preview from a receipt."""
+
+    recovery_completion_receipt = (
+        recovery_completion_receipt
+        if isinstance(recovery_completion_receipt, Mapping)
+        else {}
+    )
+    report_status = _str(recovery_completion_receipt.get("status"))
+    receipt = _extract_receipt(recovery_completion_receipt)
+    observed = _observed_context(
+        observed_recovery_steps=observed_recovery_steps,
+        recorded_receipts=recorded_receipts,
+        used_token_ids=used_token_ids,
+        released_lock_ids=released_lock_ids,
+        post_recovery_audit_status=post_recovery_audit_status,
+        contamination_status=contamination_status,
+    )
+
+    if not receipt:
+        if (
+            not recovery_completion_receipt
+            or report_status == RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(recovery_completion_receipt=recovery_completion_receipt)
+        source_blocking = tuple(_list_of_str(recovery_completion_receipt.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_completion_receipt.get("required_actions")))
+        return _blocked_report(
+            recovery_completion_receipt=recovery_completion_receipt,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+                    "No recovery completion receipt was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_recovery_completion_receipt",),
+                    {"recovery_completion_receipt_status": report_status},
+                ),
+            ),
+        )
+
+    audit_steps = tuple(_audit_steps_from_receipt(receipt, observed))
+    checks = (
+        _receipt_ready_check(recovery_completion_receipt, receipt),
+        _receipt_integrity_check(receipt),
+        _audit_requirements_check(receipt, audit_steps),
+        _observed_recovery_completion_state_check(observed, audit_steps),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+        )
+
+    preview = _preview_from_receipt(
+        receipt=receipt,
+        audit_steps=audit_steps,
+        observed_state_supplied=observed["supplied"],
+    )
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+    )
+
+
+def empty_evidence_repair_recovery_completion_audit_preview() -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    """Return an empty read-only recovery completion audit preview."""
+
+    return _empty_report(recovery_completion_receipt={})
+
+
+def _extract_receipt(recovery_completion_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    receipts = recovery_completion_receipt.get("receipts")
+    if isinstance(receipts, list):
+        for receipt in receipts:
+            if isinstance(receipt, Mapping):
+                return dict(receipt)
+    if _str(recovery_completion_receipt.get("id")).startswith(
+        "recovery-completion-receipt-"
+    ):
+        return dict(recovery_completion_receipt)
+    return {}
+
+
+def _receipt_ready_check(
+    recovery_completion_receipt: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    report_status = _str(recovery_completion_receipt.get("status"))
+    receipt_status = _str(receipt.get("status"))
+    if report_status and report_status != RECOVERY_COMPLETION_RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+            "Recovery completion receipt report is not ready for audit planning.",
+            tuple(_list_of_str(recovery_completion_receipt.get("required_actions")))
+            or ("produce_ready_recovery_completion_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    if receipt_status != RECOVERY_COMPLETION_RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+            "Recovery completion receipt entry is not ready.",
+            ("produce_ready_recovery_completion_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_RECEIPT_READY,
+        "Recovery completion receipt is ready for audit planning.",
+        {"receipt_id": _str(receipt.get("id"))},
+    )
+
+
+def _receipt_integrity_check(
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    expected_digest = _expected_receipt_digest(receipt)
+    actual_digest = _str(receipt.get("receipt_digest"))
+    expected_id = (
+        f"recovery-completion-receipt-{expected_digest[:16]}"
+        if expected_digest
+        else ""
+    )
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "token_id",
+        "lock_id",
+        "decision_id",
+        "execution_preview_id",
+        "executor_preview_id",
+        "operation_ids",
+        "recovery_step_ids",
+        "future_mutation_step_ids",
+        "executor_step_ids",
+        "executor_preview_digest",
+    ):
+        value = receipt.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(receipt.get("id")) != expected_id
+        or _str(receipt.get("receipt_type")) != RECOVERY_COMPLETION_RECEIPT_TYPE
+        or _str(receipt.get("scope")) != RECOVERY_COMPLETION_RECEIPT_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY,
+            "Recovery completion receipt digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_completion_receipt",),
+            {
+                "expected_receipt_digest": expected_digest,
+                "actual_receipt_digest": actual_digest,
+                "expected_receipt_id": expected_id,
+                "actual_receipt_id": _str(receipt.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY,
+        "Recovery completion receipt integrity checks pass.",
+        {"receipt_id": expected_id, "receipt_digest": actual_digest},
+    )
+
+
+def _audit_requirements_check(
+    receipt: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairRecoveryCompletionAuditStep],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    categories = {step.category for step in audit_steps}
+    required = {
+        "completion_receipt",
+        "token",
+        "lock",
+        "recovery_step",
+        "post_recovery_audit",
+        "contamination_guard",
+    }
+    missing = sorted(required - categories)
+    if missing or not _list_of_str(receipt.get("future_mutation_step_ids")):
+        return _fail(
+            CHECK_RECOVERY_COMPLETION_AUDIT_REQUIREMENTS,
+            "Recovery completion audit requirements are incomplete.",
+            ("regenerate_recovery_completion_receipt_with_audit_requirements",),
+            {
+                "missing_categories": missing,
+                "future_mutation_step_count": len(
+                    _list_of_str(receipt.get("future_mutation_step_ids"))
+                ),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_COMPLETION_AUDIT_REQUIREMENTS,
+        "Recovery completion audit covers receipt, token, lock, recovery steps, post-audit, and contamination guard checks.",
+        {
+            "audit_step_count": len(audit_steps),
+            "future_mutation_step_count": len(
+                _list_of_str(receipt.get("future_mutation_step_ids"))
+            ),
+        },
+    )
+
+
+def _observed_recovery_completion_state_check(
+    observed: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairRecoveryCompletionAuditStep],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    if not observed.get("supplied"):
+        return _pass(
+            CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+            "No observed recovery-completion state supplied; audit remains a planned preview.",
+            {"observed_state_supplied": False},
+        )
+    failures = [
+        step.to_dict()
+        for step in audit_steps
+        if step.status == RECOVERY_AUDIT_STEP_STATUS_FAIL
+    ]
+    if failures:
+        return _fail(
+            CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+            "Observed recovery-completion state does not satisfy the audit preview.",
+            ("investigate_recovery_completion_audit_failures",),
+            {"observed_state_supplied": True, "failures": failures},
+        )
+    return _pass(
+        CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+        "Observed recovery-completion state satisfies the audit preview.",
+        {"observed_state_supplied": True},
+    )
+
+
+def _preview_from_receipt(
+    *,
+    receipt: Mapping[str, Any],
+    audit_steps: Sequence[MemoryEvidenceRepairRecoveryCompletionAuditStep],
+    observed_state_supplied: bool,
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreview:
+    audit_step_ids = tuple(step.id for step in audit_steps)
+    operation_ids = tuple(_list_of_str(receipt.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(receipt.get("recovery_step_ids")))
+    future_mutation_step_ids = tuple(
+        _list_of_str(receipt.get("future_mutation_step_ids"))
+    )
+    audit_seed = {
+        "receipt_id": _str(receipt.get("id")),
+        "executor_preview_id": _str(receipt.get("executor_preview_id")),
+        "decision_id": _str(receipt.get("decision_id")),
+        "execution_preview_id": _str(receipt.get("execution_preview_id")),
+        "lock_id": _str(receipt.get("lock_id")),
+        "token_id": _str(receipt.get("token_id")),
+        "route": _str(receipt.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "audit_step_ids": audit_step_ids,
+        "observed_state_supplied": observed_state_supplied,
+    }
+    audit_digest = _digest(audit_seed)
+    audit_id = f"recovery-completion-audit-{audit_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreview(
+        id=audit_id,
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+        receipt_id=_str(receipt.get("id")),
+        executor_preview_id=_str(receipt.get("executor_preview_id")),
+        decision_id=_str(receipt.get("decision_id")),
+        execution_preview_id=_str(receipt.get("execution_preview_id")),
+        lock_id=_str(receipt.get("lock_id")),
+        token_id=_str(receipt.get("token_id")),
+        route=_str(receipt.get("route")),
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        audit_step_ids=audit_step_ids,
+        audit_digest=audit_digest,
+        audit_preview=f"{audit_id}:{audit_digest[:12]}",
+        audit_steps=tuple(audit_steps),
+        observed_state_supplied=observed_state_supplied,
+        would_verify_completion_receipt_recorded=True,
+        would_verify_recovery_token_used=True,
+        would_verify_recovery_lock_released=True,
+        would_verify_recovery_steps_completed=True,
+        would_verify_post_recovery_audit_clear=True,
+        would_verify_no_secondary_memory_contamination=True,
+        safety_note=(
+            "Read-only recovery completion audit preview. It plans or checks "
+            "future recovery verification signals but does not read or write "
+            "durable memory."
+        ),
+        source_recovery_completion_receipt=dict(receipt),
+    )
+
+
+def _audit_steps_from_receipt(
+    receipt: Mapping[str, Any],
+    observed: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryCompletionAuditStep]:
+    steps: list[MemoryEvidenceRepairRecoveryCompletionAuditStep] = []
+    steps.append(
+        _audit_step(
+            sequence=1,
+            category="completion_receipt",
+            assertion="recovery_completion_receipt_recorded",
+            receipt=receipt,
+            expected_signal={"receipt_id": _str(receipt.get("id"))},
+            observed_signal={"recorded": _receipt_recorded(receipt, observed)},
+            status=_boolean_status(_receipt_recorded(receipt, observed), observed["supplied"]),
+            required_action_on_fail="record_or_recover_recovery_completion_receipt",
+        )
+    )
+    steps.append(
+        _audit_step(
+            sequence=2,
+            category="token",
+            assertion="recovery_approval_token_marked_used",
+            receipt=receipt,
+            expected_signal={"token_id": _str(receipt.get("token_id"))},
+            observed_signal={"used": _token_used(receipt, observed)},
+            status=_boolean_status(_token_used(receipt, observed), observed["supplied"]),
+            required_action_on_fail="mark_recovery_token_used_or_block_reuse",
+        )
+    )
+    steps.append(
+        _audit_step(
+            sequence=3,
+            category="lock",
+            assertion="recovery_write_lock_released",
+            receipt=receipt,
+            expected_signal={"lock_id": _str(receipt.get("lock_id"))},
+            observed_signal={"released": _lock_released(receipt, observed)},
+            status=_boolean_status(_lock_released(receipt, observed), observed["supplied"]),
+            required_action_on_fail="release_recovery_write_lock_or_mark_expired",
+        )
+    )
+    sequence = 4
+    observed_steps = _dict(observed.get("recovery_steps"))
+    for recovery_step_id in _list_of_str(receipt.get("recovery_step_ids")):
+        observed_signal = _dict(observed_steps.get(recovery_step_id))
+        completed = _recovery_step_completed(observed_signal)
+        steps.append(
+            _audit_step(
+                sequence=sequence,
+                category="recovery_step",
+                assertion="recovery_step_completed",
+                receipt=receipt,
+                recovery_step_id=recovery_step_id,
+                expected_signal={"recovery_step_id": recovery_step_id, "completed": True},
+                observed_signal=observed_signal,
+                status=_boolean_status(completed, observed["supplied"]),
+                required_action_on_fail="inspect_recovery_step_or_reopen_recovery_plan",
+            )
+        )
+        sequence += 1
+    post_status = _post_recovery_audit_clear(observed)
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="post_recovery_audit",
+            assertion="post_recovery_audit_clear",
+            receipt=receipt,
+            expected_signal={"post_recovery_audit_clear": True},
+            observed_signal=_dict(observed.get("post_recovery_audit_status")),
+            status=_boolean_status(post_status, observed["supplied"]),
+            required_action_on_fail="rerun_or_investigate_post_recovery_audit",
+        )
+    )
+    sequence += 1
+    contamination_clear = _contamination_clear(observed)
+    steps.append(
+        _audit_step(
+            sequence=sequence,
+            category="contamination_guard",
+            assertion="no_secondary_memory_contamination",
+            receipt=receipt,
+            expected_signal={"secondary_memory_contamination": False},
+            observed_signal=_dict(observed.get("contamination_status")),
+            status=_boolean_status(contamination_clear, observed["supplied"]),
+            required_action_on_fail="isolate_secondary_memory_contamination",
+        )
+    )
+    return steps
+
+
+def _audit_step(
+    *,
+    sequence: int,
+    category: str,
+    assertion: str,
+    receipt: Mapping[str, Any],
+    expected_signal: Mapping[str, Any],
+    observed_signal: Mapping[str, Any],
+    status: str,
+    required_action_on_fail: str,
+    recovery_step_id: str = "",
+    operation_id: str = "",
+) -> MemoryEvidenceRepairRecoveryCompletionAuditStep:
+    return MemoryEvidenceRepairRecoveryCompletionAuditStep(
+        id=f"recovery-completion-audit-step-{sequence}-{category}",
+        sequence=sequence,
+        category=category,
+        assertion=assertion,
+        operation_id=operation_id,
+        recovery_step_id=recovery_step_id,
+        receipt_id=_str(receipt.get("id")),
+        token_id=_str(receipt.get("token_id")),
+        lock_id=_str(receipt.get("lock_id")),
+        expected_signal=dict(expected_signal),
+        observed_signal=dict(observed_signal),
+        status=status,
+        required_action_on_fail=required_action_on_fail,
+    )
+
+
+def _observed_context(
+    *,
+    observed_recovery_steps: Mapping[str, Any] | None,
+    recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    used_token_ids: Sequence[str] | None,
+    released_lock_ids: Sequence[str] | None,
+    post_recovery_audit_status: Mapping[str, Any] | None,
+    contamination_status: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    recovery_steps = _dict(observed_recovery_steps)
+    receipt_ids = _receipt_ids(recorded_receipts)
+    used_tokens = tuple(_list_of_str(used_token_ids))
+    released_locks = tuple(_list_of_str(released_lock_ids))
+    post_audit = _dict(post_recovery_audit_status)
+    contamination = _dict(contamination_status)
+    supplied = bool(
+        recovery_steps
+        or receipt_ids
+        or used_tokens
+        or released_locks
+        or post_audit
+        or contamination
+    )
+    return {
+        "supplied": supplied,
+        "recovery_steps": recovery_steps,
+        "receipt_ids": receipt_ids,
+        "used_token_ids": used_tokens,
+        "released_lock_ids": released_locks,
+        "post_recovery_audit_status": post_audit,
+        "contamination_status": contamination,
+    }
+
+
+def _boolean_status(value: bool, observed_supplied: bool) -> str:
+    if not observed_supplied:
+        return RECOVERY_AUDIT_STEP_STATUS_PLANNED
+    return RECOVERY_AUDIT_STEP_STATUS_PASS if value else RECOVERY_AUDIT_STEP_STATUS_FAIL
+
+
+def _receipt_recorded(receipt: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(receipt.get("id")) in set(observed.get("receipt_ids") or ())
+
+
+def _token_used(receipt: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(receipt.get("token_id")) in set(observed.get("used_token_ids") or ())
+
+
+def _lock_released(receipt: Mapping[str, Any], observed: Mapping[str, Any]) -> bool:
+    return _str(receipt.get("lock_id")) in set(observed.get("released_lock_ids") or ())
+
+
+def _recovery_step_completed(observed_signal: Mapping[str, Any]) -> bool:
+    if not observed_signal:
+        return False
+    status = _str(observed_signal.get("status")).lower()
+    return observed_signal.get("completed") is True or status in {
+        "complete",
+        "completed",
+        "success",
+        "succeeded",
+        "pass",
+        "passed",
+        "verified",
+    }
+
+
+def _post_recovery_audit_clear(observed: Mapping[str, Any]) -> bool:
+    post_audit = _dict(observed.get("post_recovery_audit_status"))
+    if not post_audit:
+        return False
+    status = _str(post_audit.get("status")).lower()
+    return post_audit.get("clear") is True or status in {
+        "clear",
+        "clean",
+        "pass",
+        "passed",
+        "success",
+        "verified",
+        "no_issues",
+    }
+
+
+def _contamination_clear(observed: Mapping[str, Any]) -> bool:
+    contamination = _dict(observed.get("contamination_status"))
+    if not contamination:
+        return False
+    status = _str(contamination.get("status")).lower()
+    if contamination.get("contaminated") is False:
+        return True
+    return status in {"clear", "clean", "no_contamination", "verified", "pass"}
+
+
+def _receipt_ids(recorded_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None) -> tuple[str, ...]:
+    ids: list[str] = []
+    if isinstance(recorded_receipts, Mapping):
+        ids.extend(_list_of_str(recorded_receipts.get("receipt_ids")))
+        rows = recorded_receipts.get("receipts")
+        if isinstance(rows, list):
+            ids.extend(_receipt_ids(rows))
+        if _str(recorded_receipts.get("id")):
+            ids.append(_str(recorded_receipts.get("id")))
+        if _str(recorded_receipts.get("receipt_id")):
+            ids.append(_str(recorded_receipts.get("receipt_id")))
+    elif isinstance(recorded_receipts, list):
+        for receipt in recorded_receipts:
+            if isinstance(receipt, Mapping):
+                ids.append(_str(receipt.get("id")) or _str(receipt.get("receipt_id")))
+    return tuple(_dedupe_strings(ids))
+
+
+def _expected_receipt_digest(receipt: Mapping[str, Any]) -> str:
+    source_preview = _dict(receipt.get("source_recovery_executor_preview"))
+    seed = {
+        "receipt_type": RECOVERY_COMPLETION_RECEIPT_TYPE,
+        "scope": RECOVERY_COMPLETION_RECEIPT_SCOPE,
+        "actor": _str(receipt.get("actor")) or "human",
+        "recovery_reason": _str(receipt.get("recovery_reason")),
+        "token_id": _str(receipt.get("token_id")),
+        "lock_id": _str(receipt.get("lock_id")),
+        "decision_id": _str(receipt.get("decision_id")),
+        "execution_preview_id": _str(receipt.get("execution_preview_id")),
+        "executor_preview_id": _str(receipt.get("executor_preview_id")),
+        "route": _str(receipt.get("route")),
+        "operation_ids": tuple(_list_of_str(receipt.get("operation_ids"))),
+        "recovery_step_ids": tuple(_list_of_str(receipt.get("recovery_step_ids"))),
+        "future_mutation_step_ids": tuple(
+            _list_of_str(receipt.get("future_mutation_step_ids"))
+        ),
+        "executor_step_ids": tuple(_list_of_str(receipt.get("executor_step_ids"))),
+        "executor_preview_digest": _str(receipt.get("executor_preview_digest")),
+        "preview_status": _str(source_preview.get("status")),
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    recovery_completion_receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_completion_receipt: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryCompletionAuditCheck, ...],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport:
+    return MemoryEvidenceRepairRecoveryCompletionAuditPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_completion_receipt_report=dict(recovery_completion_receipt),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    return MemoryEvidenceRepairRecoveryCompletionAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryCompletionAuditCheck:
+    return MemoryEvidenceRepairRecoveryCompletionAuditCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_completion_receipt.py
+++ b/agent/memory_evidence_repair_recovery_completion_receipt.py
@@ -1,0 +1,527 @@
+"""Read-only recovery completion receipt draft for memory evidence repair.
+
+The recovery completion receipt layer turns a ready recovery executor preview
+into a durable-looking receipt draft and token/lock ledger view. It never writes
+to durable memory stores; it only describes what a later manual recovery would
+record after successful completion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    RECOVERY_WRITE_LOCK_SCOPE,
+)
+
+
+RECOVERY_COMPLETION_RECEIPT_TYPE = "memory_evidence_repair_recovery_completion_receipt"
+RECOVERY_COMPLETION_RECEIPT_SCOPE = RECOVERY_WRITE_LOCK_SCOPE
+RECOVERY_COMPLETION_RECEIPT_STATUS_READY = "recovery_completion_receipt_ready"
+RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED = "blocked"
+RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionReceipt:
+    """One read-only recovery completion receipt draft."""
+
+    id: str
+    receipt_type: str
+    status: str
+    scope: str
+    actor: str
+    recovery_reason: str
+    token_id: str
+    lock_id: str
+    decision_id: str
+    execution_preview_id: str
+    executor_preview_id: str
+    route: str
+    executor_preview_digest: str
+    receipt_digest: str
+    receipt_preview: str
+    operation_ids: tuple[str, ...]
+    recovery_step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    executor_step_ids: tuple[str, ...]
+    used_recovery_token_id: str
+    released_recovery_lock_id: str
+    would_record_receipt: bool
+    would_mark_recovery_token_used: bool
+    would_release_recovery_write_lock: bool
+    would_trigger_recovery_audit: bool
+    safety_note: str
+    source_recovery_executor_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "receipt_type": self.receipt_type,
+            "status": self.status,
+            "scope": self.scope,
+            "actor": self.actor,
+            "recovery_reason": self.recovery_reason,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "executor_preview_id": self.executor_preview_id,
+            "route": self.route,
+            "executor_preview_digest": self.executor_preview_digest,
+            "receipt_digest": self.receipt_digest,
+            "receipt_preview": self.receipt_preview,
+            "operation_ids": list(self.operation_ids),
+            "recovery_step_ids": list(self.recovery_step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "executor_step_ids": list(self.executor_step_ids),
+            "used_recovery_token_id": self.used_recovery_token_id,
+            "released_recovery_lock_id": self.released_recovery_lock_id,
+            "would_record_receipt": self.would_record_receipt,
+            "would_mark_recovery_token_used": self.would_mark_recovery_token_used,
+            "would_release_recovery_write_lock": self.would_release_recovery_write_lock,
+            "would_trigger_recovery_audit": self.would_trigger_recovery_audit,
+            "safety_note": self.safety_note,
+            "source_recovery_executor_preview": dict(self.source_recovery_executor_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    """Read-only recovery completion receipt report."""
+
+    generated_at: str
+    status: str
+    receipts: tuple[MemoryEvidenceRepairRecoveryCompletionReceipt, ...]
+    used_recovery_token_ids: tuple[str, ...]
+    released_recovery_lock_ids: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_executor_preview_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "receipt_count": len(self.receipts),
+            "used_recovery_token_count": len(self.used_recovery_token_ids),
+            "released_recovery_lock_count": len(self.released_recovery_lock_ids),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_completion_receipt_available": bool(self.receipts),
+            "would_record_receipt_count": sum(
+                1 for receipt in self.receipts if receipt.would_record_receipt
+            ),
+            "would_mark_recovery_token_used_count": sum(
+                1 for receipt in self.receipts if receipt.would_mark_recovery_token_used
+            ),
+            "would_release_recovery_write_lock_count": sum(
+                1 for receipt in self.receipts if receipt.would_release_recovery_write_lock
+            ),
+            "would_trigger_recovery_audit_count": sum(
+                1 for receipt in self.receipts if receipt.would_trigger_recovery_audit
+            ),
+            "has_blocks": self.status == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "receipts": [receipt.to_dict() for receipt in self.receipts],
+            "used_recovery_token_ids": list(self.used_recovery_token_ids),
+            "released_recovery_lock_ids": list(self.released_recovery_lock_ids),
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_executor_preview_report": dict(
+                self.source_recovery_executor_preview_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_completion_receipt(
+    *,
+    recovery_executor_preview: Mapping[str, Any] | None = None,
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    used_token_ids: Sequence[str] | None = None,
+    released_lock_ids: Sequence[str] | None = None,
+    actor: str = "human",
+    recovery_reason: str = "",
+) -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    """Build a read-only recovery completion receipt from an executor preview."""
+
+    recovery_executor_preview = (
+        recovery_executor_preview if isinstance(recovery_executor_preview, Mapping) else {}
+    )
+    report_status = _str(recovery_executor_preview.get("status"))
+    preview = _extract_preview(recovery_executor_preview)
+    existing_used = _used_recovery_token_ids(existing_receipts, used_token_ids)
+    existing_released = _released_recovery_lock_ids(existing_receipts, released_lock_ids)
+
+    if not preview:
+        if (
+            not recovery_executor_preview
+            or report_status == RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+        ):
+            return _empty_report(
+                recovery_executor_preview=recovery_executor_preview,
+                used_recovery_token_ids=existing_used,
+                released_recovery_lock_ids=existing_released,
+            )
+        source_blocking = tuple(_list_of_str(recovery_executor_preview.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_executor_preview.get("required_actions")))
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=source_blocking
+            or ("Recovery executor preview is not ready for completion receipt.",),
+            required_actions=source_actions or ("produce_recovery_executor_preview",),
+        )
+
+    validation_error = _preview_validation_error(recovery_executor_preview, preview)
+    if validation_error is not None:
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=(validation_error,),
+            required_actions=("regenerate_recovery_executor_preview",),
+        )
+
+    token_id = _str(preview.get("token_id"))
+    lock_id = _str(preview.get("lock_id"))
+    if token_id in set(existing_used):
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=(
+                "Recovery approval token is already present in the used-token ledger.",
+            ),
+            required_actions=("regenerate_recovery_human_approval_token",),
+        )
+    if lock_id in set(existing_released):
+        return _blocked_report(
+            recovery_executor_preview=recovery_executor_preview,
+            used_recovery_token_ids=existing_used,
+            released_recovery_lock_ids=existing_released,
+            blocking_reasons=(
+                "Recovery write lock is already present in the released-lock ledger.",
+            ),
+            required_actions=("regenerate_recovery_write_lock_gate",),
+        )
+
+    receipt = _receipt_from_preview(
+        preview=preview,
+        actor=actor,
+        recovery_reason=recovery_reason,
+    )
+    return MemoryEvidenceRepairRecoveryCompletionReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+        receipts=(receipt,),
+        used_recovery_token_ids=tuple(
+            _dedupe_strings([*existing_used, receipt.used_recovery_token_id])
+        ),
+        released_recovery_lock_ids=tuple(
+            _dedupe_strings([*existing_released, receipt.released_recovery_lock_id])
+        ),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_executor_preview_report=dict(recovery_executor_preview),
+    )
+
+
+def empty_evidence_repair_recovery_completion_receipt() -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    """Return an empty read-only recovery completion receipt report."""
+
+    return _empty_report(
+        recovery_executor_preview={},
+        used_recovery_token_ids=(),
+        released_recovery_lock_ids=(),
+    )
+
+
+def _receipt_from_preview(
+    *,
+    preview: Mapping[str, Any],
+    actor: str,
+    recovery_reason: str,
+) -> MemoryEvidenceRepairRecoveryCompletionReceipt:
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    recovery_step_ids = tuple(_list_of_str(preview.get("step_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(preview.get("future_mutation_step_ids")))
+    executor_step_ids = tuple(_list_of_str(preview.get("executor_step_ids")))
+    token_id = _str(preview.get("token_id"))
+    lock_id = _str(preview.get("lock_id"))
+    receipt_seed = {
+        "receipt_type": RECOVERY_COMPLETION_RECEIPT_TYPE,
+        "scope": RECOVERY_COMPLETION_RECEIPT_SCOPE,
+        "actor": _str(actor) or "human",
+        "recovery_reason": _str(recovery_reason),
+        "token_id": token_id,
+        "lock_id": lock_id,
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "executor_preview_id": _str(preview.get("id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "recovery_step_ids": recovery_step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "executor_step_ids": executor_step_ids,
+        "executor_preview_digest": _str(preview.get("preview_digest")),
+        "preview_status": _str(preview.get("status")),
+    }
+    receipt_digest = _digest(receipt_seed)
+    receipt_id = f"recovery-completion-receipt-{receipt_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryCompletionReceipt(
+        id=receipt_id,
+        receipt_type=RECOVERY_COMPLETION_RECEIPT_TYPE,
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+        scope=RECOVERY_COMPLETION_RECEIPT_SCOPE,
+        actor=_str(actor) or "human",
+        recovery_reason=_str(recovery_reason),
+        token_id=token_id,
+        lock_id=lock_id,
+        decision_id=_str(preview.get("decision_id")),
+        execution_preview_id=_str(preview.get("execution_preview_id")),
+        executor_preview_id=_str(preview.get("id")),
+        route=_str(preview.get("route")),
+        executor_preview_digest=_str(preview.get("preview_digest")),
+        receipt_digest=receipt_digest,
+        receipt_preview=f"{receipt_id}:{receipt_digest[:12]}",
+        operation_ids=operation_ids,
+        recovery_step_ids=recovery_step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        executor_step_ids=executor_step_ids,
+        used_recovery_token_id=token_id,
+        released_recovery_lock_id=lock_id,
+        would_record_receipt=True,
+        would_mark_recovery_token_used=True,
+        would_release_recovery_write_lock=True,
+        would_trigger_recovery_audit=True,
+        safety_note=(
+            "Read-only recovery completion receipt draft. It previews a future "
+            "completion receipt, used-token mark, released-lock mark, and audit "
+            "trigger, but does not persist any of them."
+        ),
+        source_recovery_executor_preview=dict(preview),
+    )
+
+
+def _preview_validation_error(
+    recovery_executor_preview: Mapping[str, Any],
+    preview: Mapping[str, Any],
+) -> str | None:
+    report_status = _str(recovery_executor_preview.get("status"))
+    preview_status = _str(preview.get("status"))
+    if report_status and report_status != RECOVERY_EXECUTOR_PREVIEW_STATUS_READY:
+        blocking = _list_of_str(recovery_executor_preview.get("blocking_reasons"))
+        return (
+            "; ".join(blocking)
+            if blocking
+            else "Recovery executor preview report is not ready."
+        )
+    if preview_status != RECOVERY_EXECUTOR_PREVIEW_STATUS_READY:
+        return "Recovery executor preview entry is not ready."
+
+    missing_fields: list[str] = []
+    for field_name in (
+        "id",
+        "lock_id",
+        "token_id",
+        "decision_id",
+        "execution_preview_id",
+        "operation_ids",
+        "step_ids",
+        "future_mutation_step_ids",
+        "executor_step_ids",
+        "preview_digest",
+    ):
+        value = preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    expected_digest = _expected_executor_preview_digest(preview)
+    actual_digest = _str(preview.get("preview_digest"))
+    expected_id = f"recovery-executor-preview-{expected_digest[:16]}" if expected_digest else ""
+    if missing_fields:
+        return (
+            "Recovery executor preview is missing required fields: "
+            + ", ".join(missing_fields)
+        )
+    if actual_digest != expected_digest or _str(preview.get("id")) != expected_id:
+        return "Recovery executor preview digest or id is invalid."
+    if not preview.get("would_execute_manual_recovery"):
+        return "Recovery executor preview does not indicate future manual recovery execution."
+    if not preview.get("would_release_recovery_write_lock"):
+        return "Recovery executor preview does not release the future recovery write lock."
+    if not preview.get("would_mark_recovery_token_used"):
+        return "Recovery executor preview does not mark the future recovery token used."
+    return None
+
+
+def _expected_executor_preview_digest(preview: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_id": _str(preview.get("lock_id")),
+        "token_id": _str(preview.get("token_id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "execution_preview_id": _str(preview.get("execution_preview_id")),
+        "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+        "step_ids": tuple(_list_of_str(preview.get("step_ids"))),
+        "future_mutation_step_ids": tuple(_list_of_str(preview.get("future_mutation_step_ids"))),
+        "executor_step_ids": tuple(_list_of_str(preview.get("executor_step_ids"))),
+        "execution_mode": _str(preview.get("execution_mode")),
+        "failure_policy": _str(preview.get("failure_policy")),
+    }
+    return _digest(seed)
+
+
+def _extract_preview(recovery_executor_preview: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_executor_preview.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_executor_preview.get("id")).startswith("recovery-executor-preview-"):
+        return dict(recovery_executor_preview)
+    return {}
+
+
+def _empty_report(
+    *,
+    recovery_executor_preview: Mapping[str, Any],
+    used_recovery_token_ids: Sequence[str],
+    released_recovery_lock_ids: Sequence[str],
+) -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    return MemoryEvidenceRepairRecoveryCompletionReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED,
+        receipts=(),
+        used_recovery_token_ids=tuple(_dedupe_strings(used_recovery_token_ids)),
+        released_recovery_lock_ids=tuple(_dedupe_strings(released_recovery_lock_ids)),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_executor_preview_report=dict(recovery_executor_preview),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_executor_preview: Mapping[str, Any],
+    used_recovery_token_ids: Sequence[str],
+    released_recovery_lock_ids: Sequence[str],
+    blocking_reasons: Sequence[str],
+    required_actions: Sequence[str],
+) -> MemoryEvidenceRepairRecoveryCompletionReceiptReport:
+    return MemoryEvidenceRepairRecoveryCompletionReceiptReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED,
+        receipts=(),
+        used_recovery_token_ids=tuple(_dedupe_strings(used_recovery_token_ids)),
+        released_recovery_lock_ids=tuple(_dedupe_strings(released_recovery_lock_ids)),
+        blocking_reasons=tuple(_dedupe_strings(blocking_reasons)),
+        required_actions=tuple(_dedupe_strings(required_actions)),
+        source_recovery_executor_preview_report=dict(recovery_executor_preview),
+    )
+
+
+def _used_recovery_token_ids(
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    explicit_used_token_ids: Sequence[str] | None,
+) -> tuple[str, ...]:
+    candidates: list[str] = _list_of_str(explicit_used_token_ids)
+    if isinstance(existing_receipts, Mapping):
+        candidates.extend(_list_of_str(existing_receipts.get("used_recovery_token_ids")))
+        candidates.extend(_list_of_str(existing_receipts.get("used_token_ids")))
+        receipt_rows = existing_receipts.get("receipts")
+        if isinstance(receipt_rows, list):
+            candidates.extend(_token_ids_from_receipts(receipt_rows))
+        else:
+            candidates.extend(_token_ids_from_receipts([existing_receipts]))
+    elif isinstance(existing_receipts, list):
+        candidates.extend(_token_ids_from_receipts(existing_receipts))
+    return tuple(_dedupe_strings(candidates))
+
+
+def _released_recovery_lock_ids(
+    existing_receipts: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None,
+    explicit_released_lock_ids: Sequence[str] | None,
+) -> tuple[str, ...]:
+    candidates: list[str] = _list_of_str(explicit_released_lock_ids)
+    if isinstance(existing_receipts, Mapping):
+        candidates.extend(_list_of_str(existing_receipts.get("released_recovery_lock_ids")))
+        candidates.extend(_list_of_str(existing_receipts.get("released_lock_ids")))
+        receipt_rows = existing_receipts.get("receipts")
+        if isinstance(receipt_rows, list):
+            candidates.extend(_lock_ids_from_receipts(receipt_rows))
+        else:
+            candidates.extend(_lock_ids_from_receipts([existing_receipts]))
+    elif isinstance(existing_receipts, list):
+        candidates.extend(_lock_ids_from_receipts(existing_receipts))
+    return tuple(_dedupe_strings(candidates))
+
+
+def _token_ids_from_receipts(receipts: Sequence[Any]) -> list[str]:
+    token_ids: list[str] = []
+    for receipt in receipts:
+        if not isinstance(receipt, Mapping):
+            continue
+        token_id = (
+            _str(receipt.get("used_recovery_token_id"))
+            or _str(receipt.get("used_token_id"))
+            or _str(receipt.get("token_id"))
+        )
+        if token_id:
+            token_ids.append(token_id)
+    return token_ids
+
+
+def _lock_ids_from_receipts(receipts: Sequence[Any]) -> list[str]:
+    lock_ids: list[str] = []
+    for receipt in receipts:
+        if not isinstance(receipt, Mapping):
+            continue
+        lock_id = _str(receipt.get("released_recovery_lock_id")) or _str(receipt.get("lock_id"))
+        if lock_id:
+            lock_ids.append(lock_id)
+    return lock_ids
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_decision_gate.py
+++ b/agent/memory_evidence_repair_recovery_decision_gate.py
@@ -1,0 +1,595 @@
+"""Read-only recovery decision gate for memory evidence repair.
+
+The recovery decision gate turns a rollback drill preview into a controlled
+decision about the next recovery route. It never performs rollback, never
+mutates durable memory, and never changes receipt, token, or lock state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    DRILL_STEP_STATUS_PLANNED,
+    ROLLBACK_DRILL_STATUS_BLOCKED,
+    ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_DRILL_STATUS_READY,
+    ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE,
+    ROLLBACK_DRILL_TRIGGER_PREPAREDNESS,
+)
+
+
+RECOVERY_DECISION_STATUS_READY = "recovery_decision_gate_ready"
+RECOVERY_DECISION_STATUS_BLOCKED = "blocked"
+RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+RECOVERY_ROUTE_PREPAREDNESS_ONLY = "preparedness_review_only"
+RECOVERY_ROUTE_ISOLATE_AND_REVIEW = "isolate_and_review"
+RECOVERY_ROUTE_MANUAL_ROLLBACK = "manual_rollback_required"
+RECOVERY_ROUTE_RERUN_AUDIT = "rerun_post_commit_audit"
+
+CHECK_ROLLBACK_DRILL_READY = "rollback_drill_ready"
+CHECK_ROLLBACK_DRILL_INTEGRITY = "rollback_drill_integrity"
+CHECK_OPERATOR_CONTROLS = "operator_controls"
+
+DECISION_STATUS_PLANNED = "planned"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryDecisionCheck:
+    """One read-only recovery decision readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryDecision:
+    """One read-only recovery route decision."""
+
+    id: str
+    status: str
+    route: str
+    priority: str
+    reason: str
+    rollback_drill_id: str
+    trigger: str
+    operation_ids: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    recommended_actions: tuple[str, ...]
+    required_preconditions: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    next_tool_hint: str
+    decision_digest: str
+    source_rollback_drill: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "route": self.route,
+            "priority": self.priority,
+            "reason": self.reason,
+            "rollback_drill_id": self.rollback_drill_id,
+            "trigger": self.trigger,
+            "operation_ids": list(self.operation_ids),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "recommended_actions": list(self.recommended_actions),
+            "required_preconditions": list(self.required_preconditions),
+            "blocked_actions": list(self.blocked_actions),
+            "next_tool_hint": self.next_tool_hint,
+            "decision_digest": self.decision_digest,
+            "source_rollback_drill": dict(self.source_rollback_drill),
+            "future_would_mutate_memory": False,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryDecisionGateReport:
+    """Read-only recovery decision gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryDecisionCheck, ...]
+    decisions: tuple[MemoryEvidenceRepairRecoveryDecision, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_rollback_drill_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_route: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for decision in self.decisions:
+            by_route[decision.route] = by_route.get(decision.route, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "decision_count": len(self.decisions),
+            "manual_rollback_required_count": by_route.get(
+                RECOVERY_ROUTE_MANUAL_ROLLBACK,
+                0,
+            ),
+            "isolate_and_review_count": by_route.get(
+                RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+                0,
+            ),
+            "preparedness_review_count": by_route.get(
+                RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+                0,
+            ),
+            "rerun_audit_count": by_route.get(RECOVERY_ROUTE_RERUN_AUDIT, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_decision_available": bool(self.decisions),
+            "recovery_decision_ready": self.status == RECOVERY_DECISION_STATUS_READY,
+            "has_blocks": self.status == RECOVERY_DECISION_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_route": by_route,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "decisions": [decision.to_dict() for decision in self.decisions],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_rollback_drill_report": dict(self.source_rollback_drill_report),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_decision_gate(
+    *,
+    rollback_drill: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    """Build a read-only recovery decision gate from a rollback drill preview."""
+
+    rollback_drill = rollback_drill if isinstance(rollback_drill, Mapping) else {}
+    drill_status = _str(rollback_drill.get("status"))
+    drill_preview = _extract_drill_preview(rollback_drill)
+
+    if not rollback_drill or drill_status == ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(rollback_drill=rollback_drill)
+
+    if drill_status == ROLLBACK_DRILL_STATUS_BLOCKED and not drill_preview:
+        return _blocked_report(
+            rollback_drill=rollback_drill,
+            checks=(
+                _fail(
+                    CHECK_ROLLBACK_DRILL_READY,
+                    "Rollback drill preview is blocked and cannot drive a recovery decision.",
+                    tuple(_list_of_str(rollback_drill.get("required_actions")))
+                    or ("produce_ready_rollback_drill_preview",),
+                    {"rollback_drill_status": drill_status},
+                ),
+            ),
+        )
+
+    if not drill_preview:
+        return _blocked_report(
+            rollback_drill=rollback_drill,
+            checks=(
+                _fail(
+                    CHECK_ROLLBACK_DRILL_READY,
+                    "No rollback drill preview was supplied.",
+                    ("produce_rollback_drill_preview",),
+                    {"rollback_drill_status": drill_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _rollback_drill_ready_check(rollback_drill=rollback_drill, drill_preview=drill_preview),
+        _rollback_drill_integrity_check(drill_preview),
+        _operator_controls_check(drill_preview),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryDecisionGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_DECISION_STATUS_BLOCKED,
+            checks=checks,
+            decisions=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_rollback_drill_report=dict(rollback_drill),
+        )
+
+    decision = _decision_from_drill(drill_preview)
+    return MemoryEvidenceRepairRecoveryDecisionGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_DECISION_STATUS_READY,
+        checks=checks,
+        decisions=(decision,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_rollback_drill_report=dict(rollback_drill),
+    )
+
+
+def empty_evidence_repair_recovery_decision_gate() -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    """Return an empty read-only recovery decision gate."""
+
+    return _empty_report(rollback_drill={})
+
+
+def _rollback_drill_ready_check(
+    *,
+    rollback_drill: Mapping[str, Any],
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    report_status = _str(rollback_drill.get("status"))
+    preview_status = _str(drill_preview.get("status"))
+    if report_status and report_status != ROLLBACK_DRILL_STATUS_READY:
+        return _fail(
+            CHECK_ROLLBACK_DRILL_READY,
+            "Rollback drill report is not ready for recovery decision planning.",
+            tuple(_list_of_str(rollback_drill.get("required_actions")))
+            or ("produce_ready_rollback_drill_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    if preview_status != ROLLBACK_DRILL_STATUS_READY:
+        return _fail(
+            CHECK_ROLLBACK_DRILL_READY,
+            "Rollback drill preview entry is not ready.",
+            ("produce_ready_rollback_drill_preview",),
+            {"report_status": report_status, "preview_status": preview_status},
+        )
+    return _pass(
+        CHECK_ROLLBACK_DRILL_READY,
+        "Rollback drill preview is ready for recovery decision planning.",
+        {"rollback_drill_id": _str(drill_preview.get("id"))},
+    )
+
+
+def _rollback_drill_integrity_check(
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    missing_fields: list[str] = []
+    for field_name in ("id", "trigger", "rollback_mode", "steps"):
+        value = drill_preview.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    step_statuses = [
+        _str(step.get("status"))
+        for step in _list(drill_preview.get("steps"))
+        if isinstance(step, Mapping)
+    ]
+    non_planned = [status for status in step_statuses if status != DRILL_STEP_STATUS_PLANNED]
+    if missing_fields or non_planned:
+        return _fail(
+            CHECK_ROLLBACK_DRILL_INTEGRITY,
+            "Rollback drill preview has missing fields or non-planned steps.",
+            ("regenerate_rollback_drill_preview",),
+            {
+                "missing_fields": missing_fields,
+                "non_planned_step_statuses": non_planned,
+            },
+        )
+    return _pass(
+        CHECK_ROLLBACK_DRILL_INTEGRITY,
+        "Rollback drill preview structure is usable for decision planning.",
+        {"rollback_drill_id": _str(drill_preview.get("id")), "step_count": len(step_statuses)},
+    )
+
+
+def _operator_controls_check(
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    return _pass(
+        CHECK_OPERATOR_CONTROLS,
+        "Future recovery execution remains gated by explicit human approval.",
+        {
+            "rollback_drill_id": _str(drill_preview.get("id")),
+            "requires_human_approval_before_execution": True,
+            "read_only_gate": True,
+        },
+    )
+
+
+def _decision_from_drill(
+    drill_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecision:
+    route = _route_for_drill(drill_preview)
+    recommended_actions = tuple(_recommended_actions(route))
+    required_preconditions = tuple(_required_preconditions(route))
+    blocked_actions = tuple(_blocked_actions(route))
+    operation_ids = tuple(_list_of_str(drill_preview.get("operation_ids")))
+    failed_step_ids = tuple(_list_of_str(drill_preview.get("failed_audit_step_ids")))
+    trigger = _str(drill_preview.get("trigger"))
+    seed = {
+        "route": route,
+        "rollback_drill_id": _str(drill_preview.get("id")),
+        "trigger": trigger,
+        "operation_ids": operation_ids,
+        "failed_audit_step_ids": failed_step_ids,
+        "recommended_actions": recommended_actions,
+        "required_preconditions": required_preconditions,
+    }
+    decision_digest = _digest(seed)
+    return MemoryEvidenceRepairRecoveryDecision(
+        id=f"recovery-decision-{decision_digest[:16]}",
+        status=DECISION_STATUS_PLANNED,
+        route=route,
+        priority=_priority(route),
+        reason=_reason(route, drill_preview),
+        rollback_drill_id=_str(drill_preview.get("id")),
+        trigger=trigger,
+        operation_ids=operation_ids,
+        failed_audit_step_ids=failed_step_ids,
+        receipt_id=_str(drill_preview.get("receipt_id")),
+        token_id=_str(drill_preview.get("token_id")),
+        lock_id=_str(drill_preview.get("lock_id")),
+        recommended_actions=recommended_actions,
+        required_preconditions=required_preconditions,
+        blocked_actions=blocked_actions,
+        next_tool_hint=_next_tool_hint(route),
+        decision_digest=decision_digest,
+        source_rollback_drill=dict(drill_preview),
+    )
+
+
+def _route_for_drill(drill_preview: Mapping[str, Any]) -> str:
+    trigger = _str(drill_preview.get("trigger"))
+    future_restore_steps = [
+        step
+        for step in _list(drill_preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_restore_memory") is True
+    ]
+    failed_steps = _list_of_str(drill_preview.get("failed_audit_step_ids"))
+    if trigger == ROLLBACK_DRILL_TRIGGER_PREPAREDNESS:
+        return RECOVERY_ROUTE_PREPAREDNESS_ONLY
+    if trigger == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE and future_restore_steps:
+        return RECOVERY_ROUTE_MANUAL_ROLLBACK
+    if trigger == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE or failed_steps:
+        return RECOVERY_ROUTE_ISOLATE_AND_REVIEW
+    return RECOVERY_ROUTE_RERUN_AUDIT
+
+
+def _recommended_actions(route: str) -> list[str]:
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return [
+            "preserve_failed_audit_context",
+            "isolate_impacted_memory_records",
+            "verify_pre_commit_snapshot_or_rollback_plan",
+            "request_explicit_human_recovery_approval",
+            "rerun_post_commit_audit_after_manual_recovery",
+        ]
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return [
+            "preserve_failed_audit_context",
+            "isolate_impacted_memory_records",
+            "inspect_failed_audit_signals",
+            "choose_manual_rollback_or_patch_regeneration",
+        ]
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return [
+            "keep_rollback_drill_available",
+            "verify_pre_commit_snapshot_or_rollback_plan_before_future_commit",
+            "rerun_post_commit_audit_after_future_commit",
+        ]
+    return ["rerun_post_commit_audit"]
+
+
+def _required_preconditions(route: str) -> list[str]:
+    common = [
+        "no_automatic_memory_mutation",
+        "explicit_human_approval_before_recovery_execution",
+    ]
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return [
+            *common,
+            "failed_audit_context_preserved",
+            "impacted_records_isolated",
+            "snapshot_or_rollback_plan_verified",
+        ]
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return [
+            *common,
+            "failed_audit_context_preserved",
+            "impacted_records_isolated",
+        ]
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return [
+            "no_automatic_memory_mutation",
+            "rollback_drill_kept_read_only",
+        ]
+    return common
+
+
+def _blocked_actions(route: str) -> list[str]:
+    blocked = [
+        "automatic_memory_rollback",
+        "automatic_receipt_rewrite",
+        "automatic_token_state_change",
+        "automatic_lock_state_change",
+    ]
+    if route in {RECOVERY_ROUTE_MANUAL_ROLLBACK, RECOVERY_ROUTE_ISOLATE_AND_REVIEW}:
+        blocked.append("future_memory_write_until_human_review")
+    return blocked
+
+
+def _next_tool_hint(route: str) -> str:
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return "memory_evidence_repair_recovery_execution_preview"
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return "memory_evidence_repair_post_commit_audit_preview"
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return "memory_evidence_repair_post_commit_audit_preview"
+    return "memory_evidence_repair_post_commit_audit_preview"
+
+
+def _priority(route: str) -> str:
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return "p0"
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return "p1"
+    return "p2"
+
+
+def _reason(route: str, drill_preview: Mapping[str, Any]) -> str:
+    failed_count = len(_list_of_str(drill_preview.get("failed_audit_step_ids")))
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        return f"{failed_count} failed audit step(s) require isolated manual rollback planning."
+    if route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        return f"{failed_count} failed audit step(s) require isolation and human review."
+    if route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        return "No observed audit failure; keep the rollback drill as preparedness coverage."
+    return "Recovery can proceed by rerunning the post-commit audit."
+
+
+def _extract_drill_preview(rollback_drill: Mapping[str, Any]) -> dict[str, Any]:
+    previews = rollback_drill.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(rollback_drill.get("id")).startswith("rollback-drill-"):
+        return dict(rollback_drill)
+    return {}
+
+
+def _empty_report(
+    *,
+    rollback_drill: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    return MemoryEvidenceRepairRecoveryDecisionGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        decisions=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_rollback_drill_report=dict(rollback_drill),
+    )
+
+
+def _blocked_report(
+    *,
+    rollback_drill: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryDecisionCheck, ...],
+) -> MemoryEvidenceRepairRecoveryDecisionGateReport:
+    return MemoryEvidenceRepairRecoveryDecisionGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_DECISION_STATUS_BLOCKED,
+        checks=checks,
+        decisions=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_rollback_drill_report=dict(rollback_drill),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    return MemoryEvidenceRepairRecoveryDecisionCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryDecisionCheck:
+    return MemoryEvidenceRepairRecoveryDecisionCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_execution_preview.py
+++ b/agent/memory_evidence_repair_recovery_execution_preview.py
@@ -1,0 +1,679 @@
+"""Read-only recovery execution preview for memory evidence repair.
+
+The recovery execution preview expands a recovery decision into an ordered
+manual execution plan. It never executes rollback, never mutates durable
+memory, and never changes receipt, token, or lock state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    DECISION_STATUS_PLANNED,
+    RECOVERY_DECISION_STATUS_BLOCKED,
+    RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_DECISION_STATUS_READY,
+    RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+    RECOVERY_ROUTE_MANUAL_ROLLBACK,
+    RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+    RECOVERY_ROUTE_RERUN_AUDIT,
+)
+
+
+RECOVERY_EXECUTION_STATUS_READY = "recovery_execution_preview_ready"
+RECOVERY_EXECUTION_STATUS_BLOCKED = "blocked"
+RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_RECOVERY_DECISION_READY = "recovery_decision_ready"
+CHECK_RECOVERY_DECISION_INTEGRITY = "recovery_decision_integrity"
+CHECK_EXECUTION_CONTROLS = "execution_controls"
+
+EXECUTION_STEP_STATUS_PLANNED = "planned"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionCheck:
+    """One read-only recovery execution preview check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionStep:
+    """One future manual recovery execution step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    status: str
+    route: str
+    operation_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    required_precondition: str
+    expected_result: str
+    source_decision_id: str
+    human_approval_required: bool
+    future_would_mutate_memory: bool
+    rollback_safe_point: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "status": self.status,
+            "route": self.route,
+            "operation_id": self.operation_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "required_precondition": self.required_precondition,
+            "expected_result": self.expected_result,
+            "source_decision_id": self.source_decision_id,
+            "human_approval_required": self.human_approval_required,
+            "future_would_mutate_memory": self.future_would_mutate_memory,
+            "rollback_safe_point": self.rollback_safe_point,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionPreview:
+    """One read-only recovery execution preview."""
+
+    id: str
+    status: str
+    route: str
+    priority: str
+    decision_id: str
+    operation_ids: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    step_ids: tuple[str, ...]
+    preview_digest: str
+    execution_preview: str
+    steps: tuple[MemoryEvidenceRepairRecoveryExecutionStep, ...]
+    future_would_mutate_memory: bool
+    human_approval_required: bool
+    blocked_actions: tuple[str, ...]
+    safety_note: str
+    source_recovery_decision: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "route": self.route,
+            "priority": self.priority,
+            "decision_id": self.decision_id,
+            "operation_ids": list(self.operation_ids),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "step_ids": list(self.step_ids),
+            "preview_digest": self.preview_digest,
+            "execution_preview": self.execution_preview,
+            "steps": [step.to_dict() for step in self.steps],
+            "future_would_mutate_memory": self.future_would_mutate_memory,
+            "human_approval_required": self.human_approval_required,
+            "blocked_actions": list(self.blocked_actions),
+            "safety_note": self.safety_note,
+            "source_recovery_decision": dict(self.source_recovery_decision),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    """Read-only recovery execution preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutionCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryExecutionPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_decision_gate_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_route: dict[str, int] = {}
+        future_mutation_count = 0
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            by_route[preview.route] = by_route.get(preview.route, 0) + 1
+            future_mutation_count += sum(
+                1 for step in preview.steps if step.future_would_mutate_memory
+            )
+        step_count = sum(len(preview.steps) for preview in self.previews)
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "execution_step_count": step_count,
+            "future_mutation_step_count": future_mutation_count,
+            "manual_rollback_preview_count": by_route.get(
+                RECOVERY_ROUTE_MANUAL_ROLLBACK,
+                0,
+            ),
+            "preparedness_preview_count": by_route.get(
+                RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+                0,
+            ),
+            "isolation_review_preview_count": by_route.get(
+                RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+                0,
+            ),
+            "rerun_audit_preview_count": by_route.get(RECOVERY_ROUTE_RERUN_AUDIT, 0),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_execution_preview_available": bool(self.previews),
+            "recovery_execution_ready": self.status == RECOVERY_EXECUTION_STATUS_READY,
+            "has_blocks": self.status == RECOVERY_EXECUTION_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_route": by_route,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_decision_gate_report": dict(
+                self.source_recovery_decision_gate_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_execution_preview(
+    *,
+    recovery_decision: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    """Build a read-only recovery execution preview from a decision gate."""
+
+    recovery_decision = recovery_decision if isinstance(recovery_decision, Mapping) else {}
+    decision_status = _str(recovery_decision.get("status"))
+    decision = _extract_decision(recovery_decision)
+
+    if not recovery_decision or decision_status == RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(recovery_decision=recovery_decision)
+
+    if decision_status == RECOVERY_DECISION_STATUS_BLOCKED and not decision:
+        return _blocked_report(
+            recovery_decision=recovery_decision,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_DECISION_READY,
+                    "Recovery decision gate is blocked and cannot drive execution preview.",
+                    tuple(_list_of_str(recovery_decision.get("required_actions")))
+                    or ("produce_ready_recovery_decision_gate",),
+                    {"recovery_decision_status": decision_status},
+                ),
+            ),
+        )
+
+    if not decision:
+        return _blocked_report(
+            recovery_decision=recovery_decision,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_DECISION_READY,
+                    "No recovery decision was supplied.",
+                    ("produce_recovery_decision_gate",),
+                    {"recovery_decision_status": decision_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _recovery_decision_ready_check(
+            recovery_decision=recovery_decision,
+            decision=decision,
+        ),
+        _recovery_decision_integrity_check(decision),
+        _execution_controls_check(decision),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_EXECUTION_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_decision_gate_report=dict(recovery_decision),
+        )
+
+    preview = _preview_from_decision(decision)
+    return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTION_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_decision_gate_report=dict(recovery_decision),
+    )
+
+
+def empty_evidence_repair_recovery_execution_preview() -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    """Return an empty read-only recovery execution preview."""
+
+    return _empty_report(recovery_decision={})
+
+
+def _recovery_decision_ready_check(
+    *,
+    recovery_decision: Mapping[str, Any],
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    report_status = _str(recovery_decision.get("status"))
+    decision_status = _str(decision.get("status"))
+    if report_status and report_status != RECOVERY_DECISION_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_DECISION_READY,
+            "Recovery decision gate report is not ready for execution preview.",
+            tuple(_list_of_str(recovery_decision.get("required_actions")))
+            or ("produce_ready_recovery_decision_gate",),
+            {"report_status": report_status, "decision_status": decision_status},
+        )
+    if decision_status != DECISION_STATUS_PLANNED:
+        return _fail(
+            CHECK_RECOVERY_DECISION_READY,
+            "Recovery decision entry is not planned.",
+            ("regenerate_recovery_decision_gate",),
+            {"report_status": report_status, "decision_status": decision_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_DECISION_READY,
+        "Recovery decision is ready for execution preview planning.",
+        {"decision_id": _str(decision.get("id"))},
+    )
+
+
+def _recovery_decision_integrity_check(
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    route = _str(decision.get("route"))
+    missing_fields: list[str] = []
+    for field_name in ("id", "route", "priority", "recommended_actions", "blocked_actions"):
+        value = decision.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if route not in _known_routes() or missing_fields:
+        return _fail(
+            CHECK_RECOVERY_DECISION_INTEGRITY,
+            "Recovery decision route or required fields are invalid.",
+            ("regenerate_recovery_decision_gate",),
+            {"route": route, "missing_fields": missing_fields},
+        )
+    return _pass(
+        CHECK_RECOVERY_DECISION_INTEGRITY,
+        "Recovery decision structure is usable for execution preview planning.",
+        {"decision_id": _str(decision.get("id")), "route": route},
+    )
+
+
+def _execution_controls_check(
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    preconditions = set(_list_of_str(decision.get("required_preconditions")))
+    blocked = set(_list_of_str(decision.get("blocked_actions")))
+    missing: list[str] = []
+    if "no_automatic_memory_mutation" not in preconditions:
+        missing.append("no_automatic_memory_mutation")
+    if "automatic_memory_rollback" not in blocked:
+        missing.append("automatic_memory_rollback_block")
+    if missing:
+        return _fail(
+            CHECK_EXECUTION_CONTROLS,
+            "Recovery decision does not preserve read-only execution controls.",
+            ("regenerate_recovery_decision_gate_with_controls",),
+            {"missing_controls": missing},
+        )
+    return _pass(
+        CHECK_EXECUTION_CONTROLS,
+        "Execution preview remains read-only and automatic recovery is blocked.",
+        {
+            "decision_id": _str(decision.get("id")),
+            "automatic_memory_rollback_blocked": True,
+        },
+    )
+
+
+def _preview_from_decision(
+    decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionPreview:
+    route = _str(decision.get("route"))
+    steps = tuple(_steps_for_decision(decision))
+    step_ids = tuple(step.id for step in steps)
+    operation_ids = tuple(_list_of_str(decision.get("operation_ids")))
+    failed_step_ids = tuple(_list_of_str(decision.get("failed_audit_step_ids")))
+    seed = {
+        "decision_id": _str(decision.get("id")),
+        "route": route,
+        "priority": _str(decision.get("priority")),
+        "operation_ids": operation_ids,
+        "failed_audit_step_ids": failed_step_ids,
+        "step_ids": step_ids,
+    }
+    preview_digest = _digest(seed)
+    preview_id = f"recovery-execution-preview-{preview_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryExecutionPreview(
+        id=preview_id,
+        status=RECOVERY_EXECUTION_STATUS_READY,
+        route=route,
+        priority=_str(decision.get("priority")),
+        decision_id=_str(decision.get("id")),
+        operation_ids=operation_ids,
+        failed_audit_step_ids=failed_step_ids,
+        receipt_id=_str(decision.get("receipt_id")),
+        token_id=_str(decision.get("token_id")),
+        lock_id=_str(decision.get("lock_id")),
+        step_ids=step_ids,
+        preview_digest=preview_digest,
+        execution_preview=f"{preview_id}:{preview_digest[:12]}",
+        steps=steps,
+        future_would_mutate_memory=any(step.future_would_mutate_memory for step in steps),
+        human_approval_required=any(step.human_approval_required for step in steps),
+        blocked_actions=tuple(_list_of_str(decision.get("blocked_actions"))),
+        safety_note=(
+            "Read-only recovery execution preview. It orders future manual "
+            "recovery actions but does not execute rollback or mutate durable memory."
+        ),
+        source_recovery_decision=dict(decision),
+    )
+
+
+def _steps_for_decision(
+    decision: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryExecutionStep]:
+    route = _str(decision.get("route"))
+    if route == RECOVERY_ROUTE_MANUAL_ROLLBACK:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("preserve", "preserve_failed_audit_context", "failed_audit_context_preserved"),
+            ("isolate", "isolate_impacted_memory_records", "impacted_records_isolated"),
+            ("verify", "verify_snapshot_or_rollback_plan", "snapshot_or_rollback_plan_verified"),
+            ("restore", "apply_manual_rollback_restore", "pre_commit_state_restored"),
+            ("reconcile", "reconcile_receipt_token_lock_state", "receipt_token_lock_state_consistent"),
+            ("audit", "rerun_post_commit_audit", "post_commit_audit_passes_after_recovery"),
+        )
+    elif route == RECOVERY_ROUTE_ISOLATE_AND_REVIEW:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("preserve", "preserve_failed_audit_context", "failed_audit_context_preserved"),
+            ("isolate", "isolate_impacted_memory_records", "impacted_records_isolated"),
+            ("review", "inspect_failed_audit_signals", "human_review_route_chosen"),
+            ("audit", "rerun_post_commit_audit_if_needed", "post_commit_audit_rechecked"),
+        )
+    elif route == RECOVERY_ROUTE_PREPAREDNESS_ONLY:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("prepare", "keep_rollback_drill_available", "rollback_drill_available"),
+            ("verify", "verify_snapshot_or_rollback_plan_before_future_commit", "future_rollback_source_verified"),
+            ("audit", "rerun_post_commit_audit_after_future_commit", "future_audit_plan_ready"),
+        )
+    else:
+        actions = (
+            ("preflight", "verify_recovery_decision_gate", "decision_gate_ready"),
+            ("audit", "rerun_post_commit_audit", "post_commit_audit_rechecked"),
+        )
+
+    operation_ids = _list_of_str(decision.get("operation_ids"))
+    operation_text = ",".join(operation_ids)
+    return [
+        _step(
+            sequence=index,
+            phase=phase,
+            action=action,
+            expected_result=expected,
+            decision=decision,
+            operation_id=operation_text if action in _operation_scoped_actions() else "",
+            future_would_mutate_memory=action == "apply_manual_rollback_restore",
+            rollback_safe_point=phase in {"preflight", "preserve", "verify", "audit"},
+        )
+        for index, (phase, action, expected) in enumerate(actions, start=1)
+    ]
+
+
+def _step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    expected_result: str,
+    decision: Mapping[str, Any],
+    operation_id: str,
+    future_would_mutate_memory: bool,
+    rollback_safe_point: bool,
+) -> MemoryEvidenceRepairRecoveryExecutionStep:
+    route = _str(decision.get("route"))
+    human_approval_required = future_would_mutate_memory or route in {
+        RECOVERY_ROUTE_MANUAL_ROLLBACK,
+        RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+    }
+    return MemoryEvidenceRepairRecoveryExecutionStep(
+        id=f"recovery-execution-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=_description(action),
+        status=EXECUTION_STEP_STATUS_PLANNED,
+        route=route,
+        operation_id=operation_id,
+        receipt_id=_str(decision.get("receipt_id")),
+        token_id=_str(decision.get("token_id")),
+        lock_id=_str(decision.get("lock_id")),
+        required_precondition=_required_precondition(action, decision),
+        expected_result=expected_result,
+        source_decision_id=_str(decision.get("id")),
+        human_approval_required=human_approval_required,
+        future_would_mutate_memory=future_would_mutate_memory,
+        rollback_safe_point=rollback_safe_point,
+    )
+
+
+def _description(action: str) -> str:
+    descriptions = {
+        "verify_recovery_decision_gate": "Verify the recovery decision gate, route, priority, and blocked actions.",
+        "preserve_failed_audit_context": "Preserve failed audit evidence before any future manual recovery work.",
+        "isolate_impacted_memory_records": "Mark impacted records for human review before further writes.",
+        "verify_snapshot_or_rollback_plan": "Verify a pre-commit snapshot or rollback plan before restore.",
+        "apply_manual_rollback_restore": "Manually restore impacted evidence from the verified rollback source.",
+        "reconcile_receipt_token_lock_state": "Reconcile receipt, approval-token, and write-lock state after recovery.",
+        "rerun_post_commit_audit": "Rerun post-commit audit after recovery handling.",
+        "inspect_failed_audit_signals": "Inspect failed audit signals before choosing the final recovery route.",
+        "rerun_post_commit_audit_if_needed": "Rerun post-commit audit if human review finds recoverable state.",
+        "keep_rollback_drill_available": "Keep the rollback drill available as preparedness coverage.",
+        "verify_snapshot_or_rollback_plan_before_future_commit": "Verify rollback sources before a future commit.",
+        "rerun_post_commit_audit_after_future_commit": "Run post-commit audit after the future commit occurs.",
+    }
+    return descriptions.get(action, "Preview the future manual recovery action.")
+
+
+def _required_precondition(action: str, decision: Mapping[str, Any]) -> str:
+    if action == "apply_manual_rollback_restore":
+        return "explicit_human_approval_before_recovery_execution"
+    if action == "verify_snapshot_or_rollback_plan":
+        return "snapshot_or_rollback_plan_verified"
+    if action == "isolate_impacted_memory_records":
+        return "failed_audit_context_preserved"
+    preconditions = _list_of_str(decision.get("required_preconditions"))
+    return preconditions[0] if preconditions else "no_automatic_memory_mutation"
+
+
+def _operation_scoped_actions() -> set[str]:
+    return {
+        "isolate_impacted_memory_records",
+        "verify_snapshot_or_rollback_plan",
+        "apply_manual_rollback_restore",
+        "verify_snapshot_or_rollback_plan_before_future_commit",
+    }
+
+
+def _extract_decision(recovery_decision: Mapping[str, Any]) -> dict[str, Any]:
+    decisions = recovery_decision.get("decisions")
+    if isinstance(decisions, list):
+        for decision in decisions:
+            if isinstance(decision, Mapping):
+                return dict(decision)
+    if _str(recovery_decision.get("id")).startswith("recovery-decision-"):
+        return dict(recovery_decision)
+    return {}
+
+
+def _known_routes() -> set[str]:
+    return {
+        RECOVERY_ROUTE_MANUAL_ROLLBACK,
+        RECOVERY_ROUTE_ISOLATE_AND_REVIEW,
+        RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+        RECOVERY_ROUTE_RERUN_AUDIT,
+    }
+
+
+def _empty_report(
+    *,
+    recovery_decision: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_decision_gate_report=dict(recovery_decision),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_decision: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutionCheck, ...],
+) -> MemoryEvidenceRepairRecoveryExecutionPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutionPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTION_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_decision_gate_report=dict(recovery_decision),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    return MemoryEvidenceRepairRecoveryExecutionCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutionCheck:
+    return MemoryEvidenceRepairRecoveryExecutionCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_executor_preview.py
+++ b/agent/memory_evidence_repair_recovery_executor_preview.py
@@ -1,0 +1,812 @@
+"""Read-only recovery executor preview for memory evidence repair.
+
+The recovery executor preview turns a verified recovery write-lock gate into
+an ordered manual recovery execution plan. It never executes rollback, never
+mutates durable memory, and never acquires, releases, or records a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    DEFAULT_RECOVERY_LOCK_TTL_MINUTES,
+    RECOVERY_LOCK_DRAFT_STATUS_READY,
+    RECOVERY_WRITE_LOCK_SCOPE,
+    RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_WRITE_LOCK_STATUS_READY,
+    RECOVERY_WRITE_LOCK_TYPE,
+)
+
+
+RECOVERY_EXECUTOR_PREVIEW_STATUS_READY = "recovery_executor_preview_ready_for_manual_recovery"
+RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED = "blocked"
+RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+CHECK_RECOVERY_WRITE_LOCK_READY = "recovery_write_lock_ready"
+CHECK_RECOVERY_WRITE_LOCK_INTEGRITY = "recovery_write_lock_integrity"
+CHECK_RECOVERY_WRITE_LOCK_EXPIRY = "recovery_write_lock_expiry"
+CHECK_RECOVERY_EXECUTION_STEPS = "recovery_execution_steps"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    """One read-only recovery executor readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorStep:
+    """One future manual recovery executor step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    recovery_execution_step_id: str
+    operation_id: str
+    decision_id: str
+    execution_preview_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    route: str
+    required_precondition: str
+    expected_result: str
+    source_recovery_execution_step: dict[str, Any]
+    future_would_mutate_memory: bool
+    stop_on_failure: bool
+    rollback_hint: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "recovery_execution_step_id": self.recovery_execution_step_id,
+            "operation_id": self.operation_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "route": self.route,
+            "required_precondition": self.required_precondition,
+            "expected_result": self.expected_result,
+            "source_recovery_execution_step": dict(self.source_recovery_execution_step),
+            "future_would_mutate_memory": self.future_would_mutate_memory,
+            "stop_on_failure": self.stop_on_failure,
+            "rollback_hint": self.rollback_hint,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorPreview:
+    """One read-only recovery executor preview."""
+
+    id: str
+    status: str
+    lock_id: str
+    token_id: str
+    decision_id: str
+    execution_preview_id: str
+    route: str
+    operation_ids: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    executor_step_ids: tuple[str, ...]
+    preview_digest: str
+    preview_preview: str
+    execution_mode: str
+    failure_policy: str
+    steps: tuple[MemoryEvidenceRepairRecoveryExecutorStep, ...]
+    would_execute_manual_recovery: bool
+    would_apply_memory_recovery: bool
+    would_mark_recovery_token_used: bool
+    would_release_recovery_write_lock: bool
+    would_rerun_post_commit_audit: bool
+    safety_note: str
+    source_lock: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "lock_id": self.lock_id,
+            "token_id": self.token_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "route": self.route,
+            "operation_ids": list(self.operation_ids),
+            "step_ids": list(self.step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "executor_step_ids": list(self.executor_step_ids),
+            "preview_digest": self.preview_digest,
+            "preview_preview": self.preview_preview,
+            "execution_mode": self.execution_mode,
+            "failure_policy": self.failure_policy,
+            "steps": [step.to_dict() for step in self.steps],
+            "would_execute_manual_recovery": self.would_execute_manual_recovery,
+            "would_apply_memory_recovery": self.would_apply_memory_recovery,
+            "would_mark_recovery_token_used": self.would_mark_recovery_token_used,
+            "would_release_recovery_write_lock": self.would_release_recovery_write_lock,
+            "would_rerun_post_commit_audit": self.would_rerun_post_commit_audit,
+            "safety_note": self.safety_note,
+            "source_lock": dict(self.source_lock),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    """Read-only recovery executor preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutorPreviewCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRecoveryExecutorPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_write_lock_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        step_count = sum(len(preview.steps) for preview in self.previews)
+        future_mutation_step_count = sum(
+            1
+            for preview in self.previews
+            for step in preview.steps
+            if step.future_would_mutate_memory
+        )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "step_count": step_count,
+            "future_mutation_step_count": future_mutation_step_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_executor_preview_available": bool(self.previews),
+            "manual_recovery_executor_preview_ready": (
+                self.status == RECOVERY_EXECUTOR_PREVIEW_STATUS_READY
+            ),
+            "would_apply_memory_recovery_count": sum(
+                1 for preview in self.previews if preview.would_apply_memory_recovery
+            ),
+            "has_blocks": self.status == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_write_lock_gate": dict(self.source_recovery_write_lock_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_executor_preview(
+    *,
+    recovery_write_lock_gate: Mapping[str, Any] | None = None,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    """Build a read-only recovery executor preview from a recovery write lock."""
+
+    recovery_write_lock_gate = (
+        recovery_write_lock_gate if isinstance(recovery_write_lock_gate, Mapping) else {}
+    )
+    gate_status = _str(recovery_write_lock_gate.get("status"))
+    lock = _extract_lock(recovery_write_lock_gate)
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not lock:
+        if not recovery_write_lock_gate or gate_status == RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(recovery_write_lock_gate=recovery_write_lock_gate)
+        source_blocking = tuple(_list_of_str(recovery_write_lock_gate.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(recovery_write_lock_gate.get("required_actions")))
+        return _blocked_report(
+            recovery_write_lock_gate=recovery_write_lock_gate,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_WRITE_LOCK_READY,
+                    "No recovery write-lock draft was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_recovery_write_lock_gate",),
+                    {"recovery_write_lock_gate_status": gate_status},
+                ),
+            ),
+        )
+
+    execution = _execution_from_lock(lock)
+    checks = (
+        _recovery_write_lock_ready_check(recovery_write_lock_gate, lock),
+        _recovery_write_lock_integrity_check(lock),
+        _recovery_write_lock_expiry_check(lock, now),
+        _recovery_execution_steps_check(lock, execution),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+        )
+
+    preview = _preview_from_lock(lock=lock, execution=execution)
+    return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+    )
+
+
+def empty_evidence_repair_recovery_executor_preview() -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    """Return an empty read-only recovery executor preview report."""
+
+    return _empty_report(recovery_write_lock_gate={})
+
+
+def _extract_lock(recovery_write_lock_gate: Mapping[str, Any]) -> dict[str, Any]:
+    locks = recovery_write_lock_gate.get("locks")
+    if isinstance(locks, list):
+        for lock in locks:
+            if isinstance(lock, Mapping):
+                return dict(lock)
+    if _str(recovery_write_lock_gate.get("id")).startswith("recovery-write-lock-"):
+        return dict(recovery_write_lock_gate)
+    return {}
+
+
+def _recovery_write_lock_ready_check(
+    recovery_write_lock_gate: Mapping[str, Any],
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    gate_status = _str(recovery_write_lock_gate.get("status"))
+    lock_status = _str(lock.get("status"))
+    if gate_status and gate_status != RECOVERY_WRITE_LOCK_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_READY,
+            "Recovery write-lock gate is not ready for manual recovery execution.",
+            tuple(_list_of_str(recovery_write_lock_gate.get("required_actions")))
+            or ("produce_ready_recovery_write_lock_gate",),
+            {"recovery_write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    if lock_status != RECOVERY_LOCK_DRAFT_STATUS_READY:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_READY,
+            "Recovery write-lock draft is not ready.",
+            ("produce_ready_recovery_write_lock_gate",),
+            {"recovery_write_lock_gate_status": gate_status, "lock_status": lock_status},
+        )
+    return _pass(
+        CHECK_RECOVERY_WRITE_LOCK_READY,
+        "Recovery write-lock gate and draft are ready.",
+        {"lock_id": _str(lock.get("id"))},
+    )
+
+
+def _recovery_write_lock_integrity_check(
+    lock: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    expected_digest = _expected_lock_digest(lock)
+    actual_digest = _str(lock.get("lock_digest"))
+    expected_id = f"recovery-write-lock-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in (
+        "token_id",
+        "decision_id",
+        "execution_preview_id",
+        "operation_ids",
+        "step_ids",
+        "future_mutation_step_ids",
+    ):
+        value = lock.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(lock.get("id")) != expected_id
+        or _str(lock.get("lock_type")) != RECOVERY_WRITE_LOCK_TYPE
+        or _str(lock.get("scope")) != RECOVERY_WRITE_LOCK_SCOPE
+    ):
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_INTEGRITY,
+            "Recovery write-lock digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_recovery_write_lock_gate",),
+            {
+                "expected_lock_digest": expected_digest,
+                "actual_lock_digest": actual_digest,
+                "expected_lock_id": expected_id,
+                "actual_lock_id": _str(lock.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_WRITE_LOCK_INTEGRITY,
+        "Recovery write-lock integrity checks pass.",
+        {"lock_id": expected_id, "lock_digest": actual_digest},
+    )
+
+
+def _recovery_write_lock_expiry_check(
+    lock: Mapping[str, Any],
+    now: datetime,
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is None:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+            "Recovery write-lock expiry is missing or invalid.",
+            ("regenerate_recovery_write_lock_gate",),
+            {"expires_at": _str(lock.get("expires_at"))},
+        )
+    if expires_at <= now:
+        return _fail(
+            CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+            "Recovery write-lock draft has expired.",
+            ("regenerate_recovery_write_lock_gate",),
+            {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+        )
+    return _pass(
+        CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+        "Recovery write-lock draft is within its expiry window.",
+        {"expires_at": expires_at.isoformat(), "current_time": now.isoformat()},
+    )
+
+
+def _recovery_execution_steps_check(
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    steps = _execution_steps(execution)
+    execution_step_ids = [_str(step.get("id")) for step in steps]
+    execution_future_mutation_step_ids = _future_mutation_step_ids(execution)
+    lock_step_ids = _list_of_str(lock.get("step_ids"))
+    lock_future_mutation_step_ids = _list_of_str(lock.get("future_mutation_step_ids"))
+    missing_fields: list[str] = []
+    if not execution:
+        missing_fields.append("source_recovery_execution_preview")
+    if not steps:
+        missing_fields.append("source_recovery_execution_preview.steps")
+    if (
+        missing_fields
+        or _str(execution.get("status")) != RECOVERY_EXECUTION_STATUS_READY
+        or _str(execution.get("id")) != _str(lock.get("execution_preview_id"))
+        or _str(execution.get("decision_id")) != _str(lock.get("decision_id"))
+        or _list_of_str(execution.get("operation_ids")) != _list_of_str(lock.get("operation_ids"))
+        or execution_step_ids != lock_step_ids
+        or execution_future_mutation_step_ids != lock_future_mutation_step_ids
+    ):
+        return _fail(
+            CHECK_RECOVERY_EXECUTION_STEPS,
+            "Recovery execution preview does not match the recovery write-lock draft.",
+            ("regenerate_recovery_write_lock_gate",),
+            {
+                "missing_fields": missing_fields,
+                "execution_preview_id": _str(execution.get("id")),
+                "lock_execution_preview_id": _str(lock.get("execution_preview_id")),
+                "execution_step_ids": execution_step_ids,
+                "lock_step_ids": lock_step_ids,
+                "execution_future_mutation_step_ids": execution_future_mutation_step_ids,
+                "lock_future_mutation_step_ids": lock_future_mutation_step_ids,
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_EXECUTION_STEPS,
+        "Recovery execution steps match the recovery write-lock draft.",
+        {
+            "execution_preview_id": _str(execution.get("id")),
+            "step_count": len(steps),
+            "future_mutation_step_count": len(execution_future_mutation_step_ids),
+        },
+    )
+
+
+def _preview_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreview:
+    steps = tuple(_steps_from_lock(lock=lock, execution=execution))
+    executor_step_ids = tuple(step.id for step in steps)
+    step_ids = tuple(_list_of_str(lock.get("step_ids")))
+    operation_ids = tuple(_list_of_str(lock.get("operation_ids")))
+    future_mutation_step_ids = tuple(_list_of_str(lock.get("future_mutation_step_ids")))
+    preview_seed = {
+        "lock_id": _str(lock.get("id")),
+        "token_id": _str(lock.get("token_id")),
+        "decision_id": _str(lock.get("decision_id")),
+        "execution_preview_id": _str(lock.get("execution_preview_id")),
+        "operation_ids": operation_ids,
+        "step_ids": step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "executor_step_ids": executor_step_ids,
+        "execution_mode": "manual_ordered_recovery",
+        "failure_policy": "stop_on_first_recovery_failure_then_release_lock",
+    }
+    preview_digest = _digest(preview_seed)
+    preview_id = f"recovery-executor-preview-{preview_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryExecutorPreview(
+        id=preview_id,
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+        lock_id=_str(lock.get("id")),
+        token_id=_str(lock.get("token_id")),
+        decision_id=_str(lock.get("decision_id")),
+        execution_preview_id=_str(lock.get("execution_preview_id")),
+        route=_str(execution.get("route")),
+        operation_ids=operation_ids,
+        step_ids=step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        executor_step_ids=executor_step_ids,
+        preview_digest=preview_digest,
+        preview_preview=f"{preview_id}:{preview_digest[:12]}",
+        execution_mode="manual_ordered_recovery",
+        failure_policy="stop_on_first_recovery_failure_then_release_lock",
+        steps=steps,
+        would_execute_manual_recovery=True,
+        would_apply_memory_recovery=bool(future_mutation_step_ids),
+        would_mark_recovery_token_used=True,
+        would_release_recovery_write_lock=True,
+        would_rerun_post_commit_audit=any(
+            step.action.startswith("rerun_post_commit_audit") for step in steps
+        ),
+        safety_note=(
+            "Read-only recovery executor preview. It describes a future ordered "
+            "manual recovery and does not execute rollback, write memory, mark "
+            "tokens used, or release a real lock."
+        ),
+        source_lock=dict(lock),
+    )
+
+
+def _steps_from_lock(
+    *,
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRecoveryExecutorStep]:
+    steps: list[MemoryEvidenceRepairRecoveryExecutorStep] = [
+        _control_step(
+            sequence=1,
+            phase="preflight",
+            action="verify_recovery_write_lock_token_and_execution",
+            description="Verify recovery write-lock, token gate, execution preview, and step ids.",
+            lock=lock,
+            execution=execution,
+        )
+    ]
+    sequence = 2
+    for source_step in _execution_steps(execution):
+        steps.append(
+            _source_step(
+                sequence=sequence,
+                source_step=source_step,
+                lock=lock,
+                execution=execution,
+            )
+        )
+        sequence += 1
+    steps.append(
+        _control_step(
+            sequence=sequence,
+            phase="audit",
+            action="mark_recovery_token_used",
+            description="Mark the recovery approval token as used only after manual recovery succeeds.",
+            lock=lock,
+            execution=execution,
+            rollback_hint="do_not_mark_recovery_token_used_if_recovery_steps_fail",
+        )
+    )
+    sequence += 1
+    steps.append(
+        _control_step(
+            sequence=sequence,
+            phase="cleanup",
+            action="release_recovery_write_lock",
+            description="Release the recovery write lock regardless of success or failure.",
+            lock=lock,
+            execution=execution,
+            stop_on_failure=False,
+            rollback_hint="release_recovery_lock_in_finally_block",
+        )
+    )
+    return steps
+
+
+def _source_step(
+    *,
+    sequence: int,
+    source_step: Mapping[str, Any],
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorStep:
+    action = _str(source_step.get("action")) or "recovery_step"
+    future_mutation = source_step.get("future_would_mutate_memory") is True
+    return MemoryEvidenceRepairRecoveryExecutorStep(
+        id=f"recovery-executor-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=_str(source_step.get("phase")) or "recovery",
+        action=action,
+        description=_str(source_step.get("description")) or "Preview the future manual recovery step.",
+        recovery_execution_step_id=_str(source_step.get("id")),
+        operation_id=_str(source_step.get("operation_id")),
+        decision_id=_str(source_step.get("source_decision_id")) or _str(lock.get("decision_id")),
+        execution_preview_id=_str(execution.get("id")),
+        receipt_id=_str(source_step.get("receipt_id")),
+        token_id=_str(lock.get("token_id")),
+        lock_id=_str(lock.get("id")),
+        route=_str(source_step.get("route")) or _str(execution.get("route")),
+        required_precondition=_str(source_step.get("required_precondition")),
+        expected_result=_str(source_step.get("expected_result")),
+        source_recovery_execution_step=dict(source_step),
+        future_would_mutate_memory=future_mutation,
+        stop_on_failure=True,
+        rollback_hint=_rollback_hint(action, future_mutation),
+    )
+
+
+def _control_step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    description: str,
+    lock: Mapping[str, Any],
+    execution: Mapping[str, Any],
+    future_would_mutate_memory: bool = False,
+    stop_on_failure: bool = True,
+    rollback_hint: str = "stop_executor_before_recovery_mutation",
+) -> MemoryEvidenceRepairRecoveryExecutorStep:
+    return MemoryEvidenceRepairRecoveryExecutorStep(
+        id=f"recovery-executor-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=description,
+        recovery_execution_step_id="",
+        operation_id="",
+        decision_id=_str(lock.get("decision_id")),
+        execution_preview_id=_str(execution.get("id")),
+        receipt_id=_str(execution.get("receipt_id")),
+        token_id=_str(lock.get("token_id")),
+        lock_id=_str(lock.get("id")),
+        route=_str(execution.get("route")),
+        required_precondition="verified_recovery_write_lock",
+        expected_result=f"{action}_complete",
+        source_recovery_execution_step={},
+        future_would_mutate_memory=future_would_mutate_memory,
+        stop_on_failure=stop_on_failure,
+        rollback_hint=rollback_hint,
+    )
+
+
+def _rollback_hint(action: str, future_mutation: bool) -> str:
+    if future_mutation:
+        return "stop_recovery_executor_and_use_verified_snapshot_or_rollback_plan"
+    if action.startswith("rerun_post_commit_audit"):
+        return "preserve_recovery_context_if_audit_still_fails"
+    return "stop_recovery_executor_before_next_manual_step"
+
+
+def _execution_from_lock(lock: Mapping[str, Any]) -> dict[str, Any]:
+    token_gate = _dict(lock.get("source_recovery_token_gate"))
+    execution = _dict(token_gate.get("source_recovery_execution_preview"))
+    return execution
+
+
+def _execution_steps(execution: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        step
+        for step in _list(execution.get("steps"))
+        if isinstance(step, Mapping)
+    ]
+
+
+def _future_mutation_step_ids(execution: Mapping[str, Any]) -> list[str]:
+    return [
+        _str(step.get("id"))
+        for step in _execution_steps(execution)
+        if step.get("future_would_mutate_memory") is True
+    ]
+
+
+def _expected_lock_digest(lock: Mapping[str, Any]) -> str:
+    seed = {
+        "lock_type": RECOVERY_WRITE_LOCK_TYPE,
+        "scope": RECOVERY_WRITE_LOCK_SCOPE,
+        "owner": _str(lock.get("owner")) or "human",
+        "token_id": _str(lock.get("token_id")),
+        "decision_id": _str(lock.get("decision_id")),
+        "execution_preview_id": _str(lock.get("execution_preview_id")),
+        "operation_ids": tuple(_list_of_str(lock.get("operation_ids"))),
+        "step_ids": tuple(_list_of_str(lock.get("step_ids"))),
+        "future_mutation_step_ids": tuple(_list_of_str(lock.get("future_mutation_step_ids"))),
+        "expires_in_minutes": (
+            _positive_int(lock.get("expires_in_minutes"))
+            or DEFAULT_RECOVERY_LOCK_TTL_MINUTES
+        ),
+    }
+    return _digest(seed)
+
+
+def _empty_report(
+    *,
+    recovery_write_lock_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_write_lock_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryExecutorPreviewCheck, ...],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewReport:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_recovery_write_lock_gate=dict(recovery_write_lock_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryExecutorPreviewCheck:
+    return MemoryEvidenceRepairRecoveryExecutorPreviewCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_human_approval_token.py
+++ b/agent/memory_evidence_repair_recovery_human_approval_token.py
@@ -1,0 +1,347 @@
+"""Read-only human approval token draft for memory recovery execution.
+
+The recovery token layer creates a dedicated approval-token draft only after
+a recovery execution preview is ready and requires human approval. It never
+writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_BLOCKED,
+    RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+
+
+RECOVERY_APPROVAL_TOKEN_TYPE = "memory_evidence_repair_recovery_human_approval"
+RECOVERY_APPROVAL_TOKEN_SCOPE = "manual_memory_evidence_repair_recovery"
+RECOVERY_TOKEN_STATUS_DRAFT_READY = "draft_ready_for_recovery_human_approval"
+RECOVERY_TOKEN_STATUS_BLOCKED = "blocked"
+RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+DEFAULT_EXPIRES_IN_MINUTES = 15
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryHumanApprovalToken:
+    """One read-only recovery human approval token draft."""
+
+    id: str
+    token_type: str
+    status: str
+    scope: str
+    approver: str
+    approval_reason: str
+    execution_preview_status: str
+    execution_preview_id: str
+    execution_preview_digest: str
+    decision_id: str
+    route: str
+    priority: str
+    token_digest: str
+    token_preview: str
+    expires_in_minutes: int
+    operation_ids: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    required_confirmation_text: str
+    one_time_constraints: dict[str, Any]
+    safety_note: str
+    source_execution_preview: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "token_type": self.token_type,
+            "status": self.status,
+            "scope": self.scope,
+            "approver": self.approver,
+            "approval_reason": self.approval_reason,
+            "execution_preview_status": self.execution_preview_status,
+            "execution_preview_id": self.execution_preview_id,
+            "execution_preview_digest": self.execution_preview_digest,
+            "decision_id": self.decision_id,
+            "route": self.route,
+            "priority": self.priority,
+            "token_digest": self.token_digest,
+            "token_preview": self.token_preview,
+            "expires_in_minutes": self.expires_in_minutes,
+            "operation_ids": list(self.operation_ids),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "step_ids": list(self.step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "required_confirmation_text": self.required_confirmation_text,
+            "one_time_constraints": dict(self.one_time_constraints),
+            "safety_note": self.safety_note,
+            "source_execution_preview": dict(self.source_execution_preview),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    """Read-only recovery human approval token draft report."""
+
+    generated_at: str
+    status: str
+    tokens: tuple[MemoryEvidenceRepairRecoveryHumanApprovalToken, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_recovery_execution_preview_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "token_count": len(self.tokens),
+            "ready_count": 1 if self.status == RECOVERY_TOKEN_STATUS_DRAFT_READY else 0,
+            "blocked_count": 1 if self.status == RECOVERY_TOKEN_STATUS_BLOCKED else 0,
+            "no_action_count": 1 if self.status == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED else 0,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_human_approval_token_available": bool(self.tokens),
+            "requires_followup": bool(self.required_actions),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "tokens": [token.to_dict() for token in self.tokens],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_recovery_execution_preview_report": dict(
+                self.source_recovery_execution_preview_report
+            ),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_human_approval_token(
+    *,
+    recovery_execution: Mapping[str, Any] | None = None,
+    approver: str = "human",
+    approval_reason: str = "",
+    expires_in_minutes: int = DEFAULT_EXPIRES_IN_MINUTES,
+) -> MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    """Build a read-only recovery approval token draft from an execution preview."""
+
+    recovery_execution = (
+        recovery_execution if isinstance(recovery_execution, Mapping) else {}
+    )
+    execution_status = _str(recovery_execution.get("status"))
+    preview = _extract_execution_preview(recovery_execution)
+
+    if not recovery_execution or execution_status == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(recovery_execution=recovery_execution)
+
+    if execution_status == RECOVERY_EXECUTION_STATUS_BLOCKED and not preview:
+        blocking_reasons = tuple(_list_of_str(recovery_execution.get("blocking_reasons")))
+        required_actions = tuple(_list_of_str(recovery_execution.get("required_actions")))
+        return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_TOKEN_STATUS_BLOCKED,
+            tokens=(),
+            blocking_reasons=blocking_reasons
+            or ("Recovery execution preview is blocked.",),
+            required_actions=required_actions
+            or ("produce_ready_recovery_execution_preview",),
+            source_recovery_execution_preview_report=dict(recovery_execution),
+        )
+
+    if execution_status != RECOVERY_EXECUTION_STATUS_READY or not preview:
+        return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_TOKEN_STATUS_BLOCKED,
+            tokens=(),
+            blocking_reasons=("Recovery execution preview is not ready.",),
+            required_actions=("produce_ready_recovery_execution_preview",),
+            source_recovery_execution_preview_report=dict(recovery_execution),
+        )
+
+    if not _requires_recovery_approval(preview):
+        return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+            tokens=(),
+            blocking_reasons=(),
+            required_actions=(),
+            source_recovery_execution_preview_report=dict(recovery_execution),
+        )
+
+    token = _token_from_execution_preview(
+        preview=preview,
+        approver=approver,
+        approval_reason=approval_reason,
+        expires_in_minutes=expires_in_minutes,
+    )
+    return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_STATUS_DRAFT_READY,
+        tokens=(token,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_execution_preview_report=dict(recovery_execution),
+    )
+
+
+def empty_evidence_repair_recovery_human_approval_token() -> MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    """Return an empty read-only recovery human approval token report."""
+
+    return _empty_report(recovery_execution={})
+
+
+def _token_from_execution_preview(
+    *,
+    preview: Mapping[str, Any],
+    approver: str,
+    approval_reason: str,
+    expires_in_minutes: int,
+) -> MemoryEvidenceRepairRecoveryHumanApprovalToken:
+    execution_preview_digest = _execution_preview_digest(preview)
+    step_ids = tuple(_list_of_str(preview.get("step_ids")))
+    future_mutation_step_ids = tuple(
+        _str(step.get("id"))
+        for step in _list(preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_mutate_memory") is True
+    )
+    operation_ids = tuple(_list_of_str(preview.get("operation_ids")))
+    failed_step_ids = tuple(_list_of_str(preview.get("failed_audit_step_ids")))
+    token_seed = {
+        "token_type": RECOVERY_APPROVAL_TOKEN_TYPE,
+        "scope": RECOVERY_APPROVAL_TOKEN_SCOPE,
+        "approver": _str(approver) or "human",
+        "approval_reason": _str(approval_reason),
+        "execution_preview_digest": execution_preview_digest,
+        "execution_preview_id": _str(preview.get("id")),
+        "decision_id": _str(preview.get("decision_id")),
+        "route": _str(preview.get("route")),
+        "operation_ids": operation_ids,
+        "failed_audit_step_ids": failed_step_ids,
+        "step_ids": step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+    }
+    token_digest = _digest(token_seed)
+    token_id = f"recovery-approval-token-{token_digest[:16]}"
+    required_confirmation_text = (
+        f"APPROVE {RECOVERY_APPROVAL_TOKEN_SCOPE} {token_id}"
+    )
+    return MemoryEvidenceRepairRecoveryHumanApprovalToken(
+        id=token_id,
+        token_type=RECOVERY_APPROVAL_TOKEN_TYPE,
+        status=RECOVERY_TOKEN_STATUS_DRAFT_READY,
+        scope=RECOVERY_APPROVAL_TOKEN_SCOPE,
+        approver=_str(approver) or "human",
+        approval_reason=_str(approval_reason),
+        execution_preview_status=_str(preview.get("status")),
+        execution_preview_id=_str(preview.get("id")),
+        execution_preview_digest=execution_preview_digest,
+        decision_id=_str(preview.get("decision_id")),
+        route=_str(preview.get("route")),
+        priority=_str(preview.get("priority")),
+        token_digest=token_digest,
+        token_preview=f"{token_id}:{token_digest[:12]}",
+        expires_in_minutes=_expires_in_minutes(expires_in_minutes),
+        operation_ids=operation_ids,
+        failed_audit_step_ids=failed_step_ids,
+        step_ids=step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        required_confirmation_text=required_confirmation_text,
+        one_time_constraints={
+            "one_time_use": True,
+            "requires_exact_execution_preview_digest": execution_preview_digest,
+            "requires_exact_execution_preview_id": _str(preview.get("id")),
+            "requires_exact_decision_id": _str(preview.get("decision_id")),
+            "requires_exact_route": _str(preview.get("route")),
+            "requires_exact_confirmation_text": required_confirmation_text,
+            "requires_same_future_mutation_step_ids": list(future_mutation_step_ids),
+            "expires_in_minutes": _expires_in_minutes(expires_in_minutes),
+        },
+        safety_note=(
+            "Read-only recovery approval token draft. This is not a persisted "
+            "credential and does not execute recovery or mutate durable memory by itself."
+        ),
+        source_execution_preview=dict(preview),
+    )
+
+
+def _extract_execution_preview(recovery_execution: Mapping[str, Any]) -> dict[str, Any]:
+    previews = recovery_execution.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(recovery_execution.get("id")).startswith("recovery-execution-preview-"):
+        return dict(recovery_execution)
+    return {}
+
+
+def _requires_recovery_approval(preview: Mapping[str, Any]) -> bool:
+    if preview.get("future_would_mutate_memory") is True:
+        return True
+    return preview.get("human_approval_required") is True
+
+
+def _execution_preview_digest(preview: Mapping[str, Any]) -> str:
+    existing = _str(preview.get("preview_digest"))
+    if existing:
+        return existing
+    return _digest(
+        {
+            "id": _str(preview.get("id")),
+            "route": _str(preview.get("route")),
+            "decision_id": _str(preview.get("decision_id")),
+            "operation_ids": tuple(_list_of_str(preview.get("operation_ids"))),
+            "failed_audit_step_ids": tuple(_list_of_str(preview.get("failed_audit_step_ids"))),
+            "step_ids": tuple(_list_of_str(preview.get("step_ids"))),
+        }
+    )
+
+
+def _empty_report(
+    *,
+    recovery_execution: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryHumanApprovalTokenReport:
+    return MemoryEvidenceRepairRecoveryHumanApprovalTokenReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+        tokens=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_recovery_execution_preview_report=dict(recovery_execution),
+    )
+
+
+def _expires_in_minutes(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = DEFAULT_EXPIRES_IN_MINUTES
+    return parsed if parsed > 0 else DEFAULT_EXPIRES_IN_MINUTES
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_recovery_write_lock_gate.py
+++ b/agent/memory_evidence_repair_recovery_write_lock_gate.py
@@ -1,0 +1,634 @@
+"""Read-only write-lock gate for memory evidence repair recovery.
+
+The recovery write-lock gate verifies a recovery approval token gate, checks
+supplied active locks and used-token ids, then drafts a future recovery write
+lock. It never writes to durable memory stores and never acquires a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+    RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_TOKEN_GATE_STATUS_VERIFIED,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_READY,
+)
+
+
+RECOVERY_WRITE_LOCK_TYPE = "memory_evidence_repair_recovery_write_lock"
+RECOVERY_WRITE_LOCK_SCOPE = "manual_memory_evidence_repair_recovery"
+RECOVERY_WRITE_LOCK_STATUS_READY = "recovery_write_lock_ready_for_manual_recovery"
+RECOVERY_WRITE_LOCK_STATUS_BLOCKED = "blocked"
+RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+RECOVERY_LOCK_DRAFT_STATUS_READY = "recovery_write_lock_draft_ready"
+DEFAULT_RECOVERY_LOCK_TTL_MINUTES = 10
+
+CHECK_RECOVERY_TOKEN_GATE_READY = "recovery_token_gate_ready"
+CHECK_RECOVERY_TOKEN_GATE_INTEGRITY = "recovery_token_gate_integrity"
+CHECK_RECOVERY_TOKEN_REUSE = "recovery_token_reuse"
+CHECK_RECOVERY_ACTIVE_LOCKS = "recovery_active_locks"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryWriteLockCheck:
+    """One read-only recovery write-lock readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryWriteLockDraft:
+    """One read-only future recovery write-lock draft."""
+
+    id: str
+    lock_type: str
+    status: str
+    scope: str
+    owner: str
+    token_id: str
+    decision_id: str
+    execution_preview_id: str
+    operation_ids: tuple[str, ...]
+    step_ids: tuple[str, ...]
+    future_mutation_step_ids: tuple[str, ...]
+    lock_digest: str
+    lock_preview: str
+    issued_at: str
+    expires_at: str
+    expires_in_minutes: int
+    would_acquire_write_lock: bool
+    would_release_after_recovery: bool
+    safety_note: str
+    source_recovery_token_gate: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "lock_type": self.lock_type,
+            "status": self.status,
+            "scope": self.scope,
+            "owner": self.owner,
+            "token_id": self.token_id,
+            "decision_id": self.decision_id,
+            "execution_preview_id": self.execution_preview_id,
+            "operation_ids": list(self.operation_ids),
+            "step_ids": list(self.step_ids),
+            "future_mutation_step_ids": list(self.future_mutation_step_ids),
+            "lock_digest": self.lock_digest,
+            "lock_preview": self.lock_preview,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "expires_in_minutes": self.expires_in_minutes,
+            "would_acquire_write_lock": self.would_acquire_write_lock,
+            "would_release_after_recovery": self.would_release_after_recovery,
+            "safety_note": self.safety_note,
+            "source_recovery_token_gate": dict(self.source_recovery_token_gate),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    """Read-only recovery write-lock gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRecoveryWriteLockCheck, ...]
+    locks: tuple[MemoryEvidenceRepairRecoveryWriteLockDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    active_lock_conflicts: tuple[dict[str, Any], ...]
+    source_recovery_token_gate: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "lock_count": len(self.locks),
+            "active_lock_conflict_count": len(self.active_lock_conflicts),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "recovery_write_lock_available": bool(self.locks),
+            "recovery_executor_preview_allowed": self.status == RECOVERY_WRITE_LOCK_STATUS_READY,
+            "would_acquire_write_lock_count": sum(
+                1 for lock in self.locks if lock.would_acquire_write_lock
+            ),
+            "has_blocks": self.status == RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "locks": [lock.to_dict() for lock in self.locks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "active_lock_conflicts": [dict(conflict) for conflict in self.active_lock_conflicts],
+            "source_recovery_token_gate": dict(self.source_recovery_token_gate),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_recovery_write_lock_gate(
+    *,
+    recovery_token_gate: Mapping[str, Any] | None = None,
+    active_locks: Sequence[Mapping[str, Any]] | None = None,
+    already_used_token_ids: Sequence[str] | None = None,
+    lock_owner: str = "human",
+    lock_ttl_minutes: int = DEFAULT_RECOVERY_LOCK_TTL_MINUTES,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    """Build a read-only recovery write-lock gate from a verified token gate."""
+
+    recovery_token_gate = recovery_token_gate if isinstance(recovery_token_gate, Mapping) else {}
+    gate_status = _str(recovery_token_gate.get("status"))
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not recovery_token_gate or gate_status == RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(recovery_token_gate=recovery_token_gate)
+
+    if gate_status == RECOVERY_TOKEN_GATE_STATUS_BLOCKED:
+        return _blocked_report(
+            recovery_token_gate=recovery_token_gate,
+            checks=(
+                _fail(
+                    CHECK_RECOVERY_TOKEN_GATE_READY,
+                    "; ".join(_list_of_str(recovery_token_gate.get("blocking_reasons")))
+                    or "Recovery approval token gate is blocked.",
+                    tuple(_list_of_str(recovery_token_gate.get("required_actions")))
+                    or ("produce_verified_recovery_approval_token_gate",),
+                    {"recovery_token_gate_status": gate_status},
+                ),
+            ),
+            conflicts=(),
+        )
+
+    checks: list[MemoryEvidenceRepairRecoveryWriteLockCheck] = [
+        _token_gate_ready_check(recovery_token_gate),
+        _token_gate_integrity_check(recovery_token_gate),
+        _token_reuse_check(recovery_token_gate, already_used_token_ids),
+    ]
+    conflicts = tuple(_active_lock_conflicts(recovery_token_gate, active_locks, now))
+    checks.append(_active_lock_check(conflicts))
+
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+            checks=tuple(checks),
+            locks=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            active_lock_conflicts=conflicts,
+            source_recovery_token_gate=dict(recovery_token_gate),
+        )
+
+    lock = _lock_from_gate(
+        recovery_token_gate=recovery_token_gate,
+        lock_owner=lock_owner,
+        lock_ttl_minutes=lock_ttl_minutes,
+        issued_at=now,
+    )
+    return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_WRITE_LOCK_STATUS_READY,
+        checks=tuple(checks),
+        locks=(lock,),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def empty_evidence_repair_recovery_write_lock_gate() -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    """Return an empty read-only recovery write-lock gate report."""
+
+    return _empty_report(recovery_token_gate={})
+
+
+def _token_gate_ready_check(
+    recovery_token_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    status = _str(recovery_token_gate.get("status"))
+    if status != RECOVERY_TOKEN_GATE_STATUS_VERIFIED:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_GATE_READY,
+            "Recovery approval token gate is not verified for manual recovery.",
+            tuple(_list_of_str(recovery_token_gate.get("required_actions")))
+            or ("produce_verified_recovery_approval_token_gate",),
+            {"recovery_token_gate_status": status},
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_GATE_READY,
+        "Recovery approval token gate is verified for manual recovery.",
+        {"token_id": _str(recovery_token_gate.get("token_id"))},
+    )
+
+
+def _token_gate_integrity_check(
+    recovery_token_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    token = _dict(recovery_token_gate.get("source_token"))
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    future_mutation_step_ids = _list_of_str(
+        recovery_token_gate.get("verified_future_mutation_step_ids")
+    )
+    missing_fields: list[str] = []
+    for field_name in ("token_id", "verified_operation_ids", "verified_step_ids"):
+        value = recovery_token_gate.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if not future_mutation_step_ids:
+        missing_fields.append("verified_future_mutation_step_ids")
+    if not _str(execution.get("id")):
+        missing_fields.append("source_recovery_execution_preview.id")
+    if not _str(execution.get("decision_id")):
+        missing_fields.append("source_recovery_execution_preview.decision_id")
+    if (
+        missing_fields
+        or _str(token.get("id")) != _str(recovery_token_gate.get("token_id"))
+        or _str(execution.get("status")) != RECOVERY_EXECUTION_STATUS_READY
+        or _list_of_str(execution.get("operation_ids"))
+        != _list_of_str(recovery_token_gate.get("verified_operation_ids"))
+        or _list_of_str(execution.get("step_ids"))
+        != _list_of_str(recovery_token_gate.get("verified_step_ids"))
+        or _future_mutation_step_ids(execution) != future_mutation_step_ids
+    ):
+        return _fail(
+            CHECK_RECOVERY_TOKEN_GATE_INTEGRITY,
+            "Recovery token gate source token, execution preview, or verified ids are invalid.",
+            ("regenerate_recovery_approval_token_gate",),
+            {
+                "missing_fields": missing_fields,
+                "token_id": _str(recovery_token_gate.get("token_id")),
+                "source_token_id": _str(token.get("id")),
+                "execution_preview_status": _str(execution.get("status")),
+            },
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_GATE_INTEGRITY,
+        "Recovery token gate integrity checks pass.",
+        {
+            "token_id": _str(recovery_token_gate.get("token_id")),
+            "future_mutation_step_count": len(future_mutation_step_ids),
+        },
+    )
+
+
+def _token_reuse_check(
+    recovery_token_gate: Mapping[str, Any],
+    already_used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    token_id = _str(recovery_token_gate.get("token_id"))
+    used = {_str(item) for item in already_used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_RECOVERY_TOKEN_REUSE,
+            "Recovery approval token is already present in the external used-token ledger.",
+            ("regenerate_recovery_human_approval_token",),
+            {"token_id": token_id, "already_used_token_count": len(used)},
+        )
+    return _pass(
+        CHECK_RECOVERY_TOKEN_REUSE,
+        "Recovery approval token is not present in the external used-token ledger.",
+        {"token_id": token_id, "already_used_token_count": len(used)},
+    )
+
+
+def _active_lock_check(
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    if conflicts:
+        return _fail(
+            CHECK_RECOVERY_ACTIVE_LOCKS,
+            "Active recovery write locks conflict with the planned memory evidence repair recovery.",
+            ("wait_for_recovery_write_lock_release", "retry_recovery_write_lock_gate"),
+            {"conflict_count": len(conflicts), "conflicts": list(conflicts)},
+        )
+    return _pass(
+        CHECK_RECOVERY_ACTIVE_LOCKS,
+        "No active recovery write-lock conflicts were supplied.",
+        {"conflict_count": 0},
+    )
+
+
+def _lock_from_gate(
+    *,
+    recovery_token_gate: Mapping[str, Any],
+    lock_owner: str,
+    lock_ttl_minutes: int,
+    issued_at: datetime,
+) -> MemoryEvidenceRepairRecoveryWriteLockDraft:
+    ttl = _positive_int(lock_ttl_minutes) or DEFAULT_RECOVERY_LOCK_TTL_MINUTES
+    expires_at = issued_at + timedelta(minutes=ttl)
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    operation_ids = tuple(_list_of_str(recovery_token_gate.get("verified_operation_ids")))
+    step_ids = tuple(_list_of_str(recovery_token_gate.get("verified_step_ids")))
+    future_mutation_step_ids = tuple(
+        _list_of_str(recovery_token_gate.get("verified_future_mutation_step_ids"))
+    )
+    seed = {
+        "lock_type": RECOVERY_WRITE_LOCK_TYPE,
+        "scope": RECOVERY_WRITE_LOCK_SCOPE,
+        "owner": _str(lock_owner) or "human",
+        "token_id": _str(recovery_token_gate.get("token_id")),
+        "decision_id": _str(execution.get("decision_id")),
+        "execution_preview_id": _str(execution.get("id")),
+        "operation_ids": operation_ids,
+        "step_ids": step_ids,
+        "future_mutation_step_ids": future_mutation_step_ids,
+        "expires_in_minutes": ttl,
+    }
+    lock_digest = _digest(seed)
+    lock_id = f"recovery-write-lock-{lock_digest[:16]}"
+    return MemoryEvidenceRepairRecoveryWriteLockDraft(
+        id=lock_id,
+        lock_type=RECOVERY_WRITE_LOCK_TYPE,
+        status=RECOVERY_LOCK_DRAFT_STATUS_READY,
+        scope=RECOVERY_WRITE_LOCK_SCOPE,
+        owner=_str(lock_owner) or "human",
+        token_id=_str(recovery_token_gate.get("token_id")),
+        decision_id=_str(execution.get("decision_id")),
+        execution_preview_id=_str(execution.get("id")),
+        operation_ids=operation_ids,
+        step_ids=step_ids,
+        future_mutation_step_ids=future_mutation_step_ids,
+        lock_digest=lock_digest,
+        lock_preview=f"{lock_id}:{lock_digest[:12]}",
+        issued_at=issued_at.isoformat(),
+        expires_at=expires_at.isoformat(),
+        expires_in_minutes=ttl,
+        would_acquire_write_lock=True,
+        would_release_after_recovery=True,
+        safety_note=(
+            "Read-only recovery write-lock draft. This does not acquire a real "
+            "lock and does not mutate durable memory."
+        ),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def _active_lock_conflicts(
+    recovery_token_gate: Mapping[str, Any],
+    active_locks: Sequence[Mapping[str, Any]] | None,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    for lock in active_locks or []:
+        if not isinstance(lock, Mapping) or not _is_active_lock(lock, now):
+            continue
+        if _lock_conflicts_with_gate(lock, recovery_token_gate):
+            conflicts.append(
+                {
+                    "lock_id": _str(lock.get("id")),
+                    "owner": _str(lock.get("owner")),
+                    "scope": _str(lock.get("scope")),
+                    "expires_at": _str(lock.get("expires_at")),
+                    "reason": _conflict_reason(lock, recovery_token_gate),
+                }
+            )
+    return conflicts
+
+
+def _is_active_lock(lock: Mapping[str, Any], now: datetime) -> bool:
+    status = _str(lock.get("status")).lower()
+    if status in {"released", "expired", "cancelled", "canceled", "inactive"}:
+        return False
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is not None and expires_at <= now:
+        return False
+    return status in {"", "active", "recovery_write_lock_active", RECOVERY_LOCK_DRAFT_STATUS_READY}
+
+
+def _lock_conflicts_with_gate(
+    lock: Mapping[str, Any],
+    recovery_token_gate: Mapping[str, Any],
+) -> bool:
+    lock_scope = _str(lock.get("scope"))
+    if lock_scope and lock_scope != RECOVERY_WRITE_LOCK_SCOPE:
+        return False
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    if _str(lock.get("token_id")) and _str(lock.get("token_id")) == _str(recovery_token_gate.get("token_id")):
+        return True
+    if _str(lock.get("decision_id")) and _str(lock.get("decision_id")) == _str(execution.get("decision_id")):
+        return True
+    if _str(lock.get("execution_preview_id")) and _str(lock.get("execution_preview_id")) == _str(execution.get("id")):
+        return True
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(recovery_token_gate.get("verified_operation_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("step_ids")), _list_of_str(recovery_token_gate.get("verified_step_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("future_mutation_step_ids")), _list_of_str(recovery_token_gate.get("verified_future_mutation_step_ids"))):
+        return True
+    identifiers = (
+        _str(lock.get("token_id")),
+        _str(lock.get("decision_id")),
+        _str(lock.get("execution_preview_id")),
+        *_list_of_str(lock.get("operation_ids")),
+        *_list_of_str(lock.get("step_ids")),
+        *_list_of_str(lock.get("future_mutation_step_ids")),
+    )
+    return not any(identifiers)
+
+
+def _conflict_reason(lock: Mapping[str, Any], recovery_token_gate: Mapping[str, Any]) -> str:
+    execution = _dict(recovery_token_gate.get("source_recovery_execution_preview"))
+    if _str(lock.get("token_id")) == _str(recovery_token_gate.get("token_id")):
+        return "same_token_id"
+    if _str(lock.get("decision_id")) == _str(execution.get("decision_id")):
+        return "same_decision_id"
+    if _str(lock.get("execution_preview_id")) == _str(execution.get("id")):
+        return "same_execution_preview_id"
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(recovery_token_gate.get("verified_operation_ids"))):
+        return "overlapping_operation_ids"
+    if _intersects(_list_of_str(lock.get("step_ids")), _list_of_str(recovery_token_gate.get("verified_step_ids"))):
+        return "overlapping_step_ids"
+    if _intersects(_list_of_str(lock.get("future_mutation_step_ids")), _list_of_str(recovery_token_gate.get("verified_future_mutation_step_ids"))):
+        return "overlapping_future_mutation_step_ids"
+    return "global_scope_lock"
+
+
+def _future_mutation_step_ids(recovery_execution: Mapping[str, Any]) -> list[str]:
+    return [
+        _str(step.get("id"))
+        for step in _list(recovery_execution.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_mutate_memory") is True
+    ]
+
+
+def _empty_report(
+    *,
+    recovery_token_gate: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        locks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def _blocked_report(
+    *,
+    recovery_token_gate: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRecoveryWriteLockCheck, ...],
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairRecoveryWriteLockGateReport:
+    return MemoryEvidenceRepairRecoveryWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+        checks=checks,
+        locks=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        active_lock_conflicts=tuple(dict(conflict) for conflict in conflicts),
+        source_recovery_token_gate=dict(recovery_token_gate),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    return MemoryEvidenceRepairRecoveryWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRecoveryWriteLockCheck:
+    return MemoryEvidenceRepairRecoveryWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _intersects(left: Sequence[str], right: Sequence[str]) -> bool:
+    return bool(set(left).intersection(set(right)))
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_rollback_drill_preview.py
+++ b/agent/memory_evidence_repair_rollback_drill_preview.py
@@ -1,0 +1,971 @@
+"""Read-only rollback drill preview for memory evidence repair audits.
+
+The rollback drill preview turns a post-commit audit preview or observed
+post-commit audit failure into a rehearsal plan. It never rolls back durable
+memory and never mutates receipts, approval tokens, or write locks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    AUDIT_STEP_STATUS_FAIL,
+    POST_COMMIT_AUDIT_STATUS_BLOCKED,
+    POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED,
+    POST_COMMIT_AUDIT_STATUS_READY,
+)
+
+
+ROLLBACK_DRILL_STATUS_READY = "rollback_drill_preview_ready"
+ROLLBACK_DRILL_STATUS_BLOCKED = "blocked"
+ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE = "post_commit_audit_failure"
+ROLLBACK_DRILL_TRIGGER_PREPAREDNESS = "post_commit_audit_preparedness"
+
+DRILL_STEP_STATUS_PLANNED = "planned"
+
+CHECK_POST_COMMIT_AUDIT_AVAILABLE = "post_commit_audit_available"
+CHECK_AUDIT_FAILURE_CONTEXT = "audit_failure_context"
+CHECK_ROLLBACK_DRILL_SOURCES = "rollback_drill_sources"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillCheck:
+    """One read-only rollback drill readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillStep:
+    """One future rollback drill step preview."""
+
+    id: str
+    sequence: int
+    phase: str
+    action: str
+    description: str
+    status: str
+    operation_id: str
+    audit_step_id: str
+    audit_category: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    patch_digest: str
+    rollback_source: str
+    expected_result: str
+    required_operator_action: str
+    source_audit_step: dict[str, Any]
+    future_would_restore_memory: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "phase": self.phase,
+            "action": self.action,
+            "description": self.description,
+            "status": self.status,
+            "operation_id": self.operation_id,
+            "audit_step_id": self.audit_step_id,
+            "audit_category": self.audit_category,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "patch_digest": self.patch_digest,
+            "rollback_source": self.rollback_source,
+            "expected_result": self.expected_result,
+            "required_operator_action": self.required_operator_action,
+            "source_audit_step": dict(self.source_audit_step),
+            "future_would_restore_memory": self.future_would_restore_memory,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillPreview:
+    """One read-only rollback drill preview."""
+
+    id: str
+    status: str
+    trigger: str
+    rollback_mode: str
+    post_commit_audit_id: str
+    executor_preview_id: str
+    receipt_id: str
+    token_id: str
+    lock_id: str
+    operation_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    failed_audit_step_ids: tuple[str, ...]
+    drill_step_ids: tuple[str, ...]
+    drill_digest: str
+    drill_preview: str
+    steps: tuple[MemoryEvidenceRepairRollbackDrillStep, ...]
+    would_preserve_failed_audit_evidence: bool
+    would_isolate_failed_memory: bool
+    would_restore_snapshots: bool
+    would_reconcile_receipt_token_lock: bool
+    would_rerun_post_commit_audit: bool
+    safety_note: str
+    source_post_commit_audit: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "trigger": self.trigger,
+            "rollback_mode": self.rollback_mode,
+            "post_commit_audit_id": self.post_commit_audit_id,
+            "executor_preview_id": self.executor_preview_id,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "lock_id": self.lock_id,
+            "operation_ids": list(self.operation_ids),
+            "patch_digests": list(self.patch_digests),
+            "failed_audit_step_ids": list(self.failed_audit_step_ids),
+            "drill_step_ids": list(self.drill_step_ids),
+            "drill_digest": self.drill_digest,
+            "drill_preview": self.drill_preview,
+            "steps": [step.to_dict() for step in self.steps],
+            "would_preserve_failed_audit_evidence": self.would_preserve_failed_audit_evidence,
+            "would_isolate_failed_memory": self.would_isolate_failed_memory,
+            "would_restore_snapshots": self.would_restore_snapshots,
+            "would_reconcile_receipt_token_lock": self.would_reconcile_receipt_token_lock,
+            "would_rerun_post_commit_audit": self.would_rerun_post_commit_audit,
+            "safety_note": self.safety_note,
+            "source_post_commit_audit": dict(self.source_post_commit_audit),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackDrillPreviewReport:
+    """Read-only rollback drill preview report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairRollbackDrillCheck, ...]
+    previews: tuple[MemoryEvidenceRepairRollbackDrillPreview, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    source_post_commit_audit_report: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        by_trigger: dict[str, int] = {}
+        future_restore_count = 0
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        for preview in self.previews:
+            by_trigger[preview.trigger] = by_trigger.get(preview.trigger, 0) + 1
+            future_restore_count += sum(
+                1 for step in preview.steps if step.future_would_restore_memory
+            )
+        drill_step_count = sum(len(preview.steps) for preview in self.previews)
+        failed_step_count = sum(
+            len(preview.failed_audit_step_ids) for preview in self.previews
+        )
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "preview_count": len(self.previews),
+            "drill_step_count": drill_step_count,
+            "failed_audit_step_count": failed_step_count,
+            "future_restore_step_count": future_restore_count,
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "rollback_drill_preview_available": bool(self.previews),
+            "rollback_drill_ready": self.status == ROLLBACK_DRILL_STATUS_READY,
+            "has_blocks": self.status == ROLLBACK_DRILL_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+            "by_trigger": by_trigger,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "previews": [preview.to_dict() for preview in self.previews],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "source_post_commit_audit_report": dict(self.source_post_commit_audit_report),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_rollback_drill_preview(
+    *,
+    post_commit_audit: Mapping[str, Any] | None = None,
+    rollback_plan: Mapping[str, Any] | None = None,
+    snapshot_plan: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    """Build a read-only rollback drill from a post-commit audit report."""
+
+    post_commit_audit = post_commit_audit if isinstance(post_commit_audit, Mapping) else {}
+    rollback_plan = rollback_plan if isinstance(rollback_plan, Mapping) else {}
+    snapshot_plan = snapshot_plan if isinstance(snapshot_plan, Mapping) else {}
+    audit_status = _str(post_commit_audit.get("status"))
+    audit_preview = _extract_audit_preview(post_commit_audit)
+    failed_steps = tuple(_failed_audit_steps(post_commit_audit, audit_preview))
+    executor_preview = _extract_executor_preview(post_commit_audit, audit_preview)
+
+    if not post_commit_audit or audit_status == POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED:
+        return _empty_report(post_commit_audit=post_commit_audit)
+
+    if not audit_preview and not failed_steps:
+        return _blocked_report(
+            post_commit_audit=post_commit_audit,
+            checks=(
+                _fail(
+                    CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+                    "No usable post-commit audit preview or observed audit failure was supplied.",
+                    tuple(_list_of_str(post_commit_audit.get("required_actions")))
+                    or ("produce_post_commit_audit_preview",),
+                    {"post_commit_audit_status": audit_status},
+                ),
+            ),
+        )
+
+    if (
+        audit_status
+        and audit_status not in {POST_COMMIT_AUDIT_STATUS_READY, POST_COMMIT_AUDIT_STATUS_BLOCKED}
+        and not audit_preview
+    ):
+        return _blocked_report(
+            post_commit_audit=post_commit_audit,
+            checks=(
+                _fail(
+                    CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+                    "Post-commit audit status is not ready for rollback drill planning.",
+                    ("produce_ready_or_failed_post_commit_audit",),
+                    {"post_commit_audit_status": audit_status},
+                ),
+            ),
+        )
+
+    checks = (
+        _post_commit_audit_available_check(
+            post_commit_audit=post_commit_audit,
+            audit_preview=audit_preview,
+            failed_steps=failed_steps,
+        ),
+        _audit_failure_context_check(failed_steps=failed_steps, audit_preview=audit_preview),
+        _rollback_drill_sources_check(
+            rollback_plan=rollback_plan,
+            snapshot_plan=snapshot_plan,
+            audit_preview=audit_preview,
+            executor_preview=executor_preview,
+        ),
+    )
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairRollbackDrillPreviewReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=ROLLBACK_DRILL_STATUS_BLOCKED,
+            checks=checks,
+            previews=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            source_post_commit_audit_report=dict(post_commit_audit),
+        )
+
+    preview = _preview_from_audit(
+        post_commit_audit=post_commit_audit,
+        audit_preview=audit_preview,
+        failed_steps=failed_steps,
+        executor_preview=executor_preview,
+        rollback_plan=rollback_plan,
+        snapshot_plan=snapshot_plan,
+    )
+    return MemoryEvidenceRepairRollbackDrillPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=ROLLBACK_DRILL_STATUS_READY,
+        checks=checks,
+        previews=(preview,),
+        blocking_reasons=(),
+        required_actions=(),
+        source_post_commit_audit_report=dict(post_commit_audit),
+    )
+
+
+def empty_evidence_repair_rollback_drill_preview() -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    """Return an empty read-only rollback drill preview."""
+
+    return _empty_report(post_commit_audit={})
+
+
+def _post_commit_audit_available_check(
+    *,
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    failed_steps: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    audit_status = _str(post_commit_audit.get("status"))
+    if audit_preview or failed_steps:
+        return _pass(
+            CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+            "Post-commit audit context is available for rollback drill planning.",
+            {
+                "post_commit_audit_status": audit_status,
+                "audit_preview_id": _str(audit_preview.get("id")),
+                "failed_audit_step_count": len(failed_steps),
+            },
+        )
+    return _fail(
+        CHECK_POST_COMMIT_AUDIT_AVAILABLE,
+        "No post-commit audit preview or failure context is available.",
+        ("produce_post_commit_audit_preview",),
+        {"post_commit_audit_status": audit_status},
+    )
+
+
+def _audit_failure_context_check(
+    *,
+    failed_steps: Sequence[Mapping[str, Any]],
+    audit_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    if failed_steps:
+        return _pass(
+            CHECK_AUDIT_FAILURE_CONTEXT,
+            "Observed audit failures can drive a rollback drill.",
+            {"failed_audit_step_ids": [_str(step.get("id")) for step in failed_steps]},
+        )
+    return _pass(
+        CHECK_AUDIT_FAILURE_CONTEXT,
+        "No observed audit failure supplied; rollback drill remains a preparedness rehearsal.",
+        {
+            "audit_preview_id": _str(audit_preview.get("id")),
+            "trigger": ROLLBACK_DRILL_TRIGGER_PREPAREDNESS,
+        },
+    )
+
+
+def _rollback_drill_sources_check(
+    *,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    sources = _rollback_sources(
+        rollback_plan=rollback_plan,
+        snapshot_plan=snapshot_plan,
+        audit_preview=audit_preview,
+        executor_preview=executor_preview,
+    )
+    return _pass(
+        CHECK_ROLLBACK_DRILL_SOURCES,
+        "Rollback drill source references are captured for future human verification.",
+        {"sources": sources},
+    )
+
+
+def _preview_from_audit(
+    *,
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    failed_steps: Sequence[Mapping[str, Any]],
+    executor_preview: Mapping[str, Any],
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillPreview:
+    trigger = (
+        ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE
+        if failed_steps
+        else ROLLBACK_DRILL_TRIGGER_PREPAREDNESS
+    )
+    operation_ids = tuple(
+        _operation_ids(
+            audit_preview=audit_preview,
+            executor_preview=executor_preview,
+            failed_steps=failed_steps,
+        )
+    )
+    patch_digests = tuple(
+        _patch_digests(
+            audit_preview=audit_preview,
+            executor_preview=executor_preview,
+            operation_ids=operation_ids,
+        )
+    )
+    receipt_id = _first_nonempty(
+        _str(audit_preview.get("receipt_id")),
+        _str(executor_preview.get("receipt_id")),
+        _first_from_steps(failed_steps, "receipt_id"),
+    )
+    token_id = _first_nonempty(
+        _str(audit_preview.get("token_id")),
+        _str(executor_preview.get("token_id")),
+        _first_from_steps(failed_steps, "token_id"),
+    )
+    lock_id = _first_nonempty(
+        _str(audit_preview.get("lock_id")),
+        _str(executor_preview.get("lock_id")),
+        _first_from_steps(failed_steps, "lock_id"),
+    )
+    steps = tuple(
+        _drill_steps(
+            trigger=trigger,
+            operation_ids=operation_ids,
+            patch_digests=patch_digests,
+            failed_steps=failed_steps,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            rollback_plan=rollback_plan,
+            snapshot_plan=snapshot_plan,
+            executor_preview=executor_preview,
+        )
+    )
+    drill_step_ids = tuple(step.id for step in steps)
+    failed_step_ids = tuple(
+        _dedupe_strings(_str(step.get("id")) for step in failed_steps)
+    )
+    drill_seed = {
+        "trigger": trigger,
+        "post_commit_audit_id": _str(audit_preview.get("id")),
+        "executor_preview_id": _str(executor_preview.get("id")),
+        "receipt_id": receipt_id,
+        "token_id": token_id,
+        "lock_id": lock_id,
+        "operation_ids": operation_ids,
+        "patch_digests": patch_digests,
+        "failed_audit_step_ids": failed_step_ids,
+        "drill_step_ids": drill_step_ids,
+    }
+    drill_digest = _digest(drill_seed)
+    drill_id = f"rollback-drill-{drill_digest[:16]}"
+    return MemoryEvidenceRepairRollbackDrillPreview(
+        id=drill_id,
+        status=ROLLBACK_DRILL_STATUS_READY,
+        trigger=trigger,
+        rollback_mode="failure_response" if failed_steps else "preparedness_rehearsal",
+        post_commit_audit_id=_str(audit_preview.get("id")),
+        executor_preview_id=_str(executor_preview.get("id")),
+        receipt_id=receipt_id,
+        token_id=token_id,
+        lock_id=lock_id,
+        operation_ids=operation_ids,
+        patch_digests=patch_digests,
+        failed_audit_step_ids=failed_step_ids,
+        drill_step_ids=drill_step_ids,
+        drill_digest=drill_digest,
+        drill_preview=f"{drill_id}:{drill_digest[:12]}",
+        steps=steps,
+        would_preserve_failed_audit_evidence=True,
+        would_isolate_failed_memory=True,
+        would_restore_snapshots=True,
+        would_reconcile_receipt_token_lock=True,
+        would_rerun_post_commit_audit=True,
+        safety_note=(
+            "Read-only rollback drill preview. It rehearses future isolation, "
+            "snapshot restoration, reconciliation, and re-audit steps but does "
+            "not mutate durable memory."
+        ),
+        source_post_commit_audit=dict(post_commit_audit),
+    )
+
+
+def _drill_steps(
+    *,
+    trigger: str,
+    operation_ids: Sequence[str],
+    patch_digests: Sequence[str],
+    failed_steps: Sequence[Mapping[str, Any]],
+    receipt_id: str,
+    token_id: str,
+    lock_id: str,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> list[MemoryEvidenceRepairRollbackDrillStep]:
+    steps: list[MemoryEvidenceRepairRollbackDrillStep] = []
+    failure_mode = trigger == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE
+    source_step = failed_steps[0] if failed_steps else {}
+    steps.append(
+        _step(
+            sequence=1,
+            phase="preserve",
+            action=(
+                "preserve_failed_audit_context"
+                if failure_mode
+                else "prepare_rollback_context"
+            ),
+            description=(
+                "Preserve the failed post-commit audit report, executor preview, and observed signals."
+                if failure_mode
+                else "Prepare the audit, executor, receipt, token, and lock context for a future rollback rehearsal."
+            ),
+            operation_id="",
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="rollback_drill_context_preserved",
+            required_operator_action="archive_audit_report_executor_preview_and_observed_signals",
+        )
+    )
+    steps.append(
+        _step(
+            sequence=2,
+            phase="isolation",
+            action=(
+                "isolate_impacted_memory_records"
+                if failure_mode
+                else "define_impacted_operation_isolation"
+            ),
+            description=(
+                "Identify and isolate memory records touched by failed audit steps before any manual rollback."
+                if failure_mode
+                else "Define which memory records would be isolated if the post-commit audit later fails."
+            ),
+            operation_id=",".join(operation_ids),
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="impacted_operations_isolated_for_review",
+            required_operator_action="mark_impacted_operations_read_only_until_review_completes",
+        )
+    )
+    next_sequence = 3
+    restore_targets = list(operation_ids) or [""]
+    for index, operation_id in enumerate(restore_targets):
+        patch_digest = patch_digests[index] if index < len(patch_digests) else ""
+        steps.append(
+            _step(
+                sequence=next_sequence,
+                phase="restore",
+                action=(
+                    "restore_from_pre_commit_snapshot_or_rollback_plan"
+                    if failure_mode
+                    else "verify_pre_commit_snapshot_or_rollback_plan"
+                ),
+                description=(
+                    "Restore the impacted operation from its pre-commit snapshot or approved rollback plan."
+                    if failure_mode
+                    else "Verify a pre-commit snapshot or rollback plan exists for the operation before any future write."
+                ),
+                operation_id=operation_id,
+                source_step=_failed_step_for_operation(failed_steps, operation_id),
+                receipt_id=receipt_id,
+                token_id=token_id,
+                lock_id=lock_id,
+                patch_digest=patch_digest,
+                rollback_source=_rollback_source_for_operation(
+                    operation_id=operation_id,
+                    patch_digest=patch_digest,
+                    rollback_plan=rollback_plan,
+                    snapshot_plan=snapshot_plan,
+                    executor_preview=executor_preview,
+                ),
+                expected_result="pre_commit_state_restored_or_verified",
+                required_operator_action="verify_snapshot_digest_then_restore_manually",
+                future_would_restore_memory=failure_mode,
+            )
+        )
+        next_sequence += 1
+    steps.append(
+        _step(
+            sequence=next_sequence,
+            phase="reconcile",
+            action="reconcile_commit_receipt_token_and_lock",
+            description="Reconcile receipt, approval-token, and write-lock state after rollback handling.",
+            operation_id="",
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="receipt_token_lock_state_consistent",
+            required_operator_action="verify_receipt_token_and_lock_state_before_unlocking_future_writes",
+        )
+    )
+    next_sequence += 1
+    steps.append(
+        _step(
+            sequence=next_sequence,
+            phase="audit",
+            action="rerun_post_commit_audit",
+            description="Rerun the post-commit audit after rollback or preparedness checks complete.",
+            operation_id="",
+            source_step=source_step,
+            receipt_id=receipt_id,
+            token_id=token_id,
+            lock_id=lock_id,
+            expected_result="post_commit_audit_passes_after_rollback_drill",
+            required_operator_action="rerun_memory_evidence_repair_post_commit_audit_preview",
+        )
+    )
+    return steps
+
+
+def _step(
+    *,
+    sequence: int,
+    phase: str,
+    action: str,
+    description: str,
+    operation_id: str,
+    source_step: Mapping[str, Any],
+    receipt_id: str,
+    token_id: str,
+    lock_id: str,
+    expected_result: str,
+    required_operator_action: str,
+    patch_digest: str = "",
+    rollback_source: str = "",
+    future_would_restore_memory: bool = False,
+) -> MemoryEvidenceRepairRollbackDrillStep:
+    audit_step_id = _str(source_step.get("id"))
+    audit_category = _str(source_step.get("category"))
+    if not patch_digest:
+        patch_digest = _patch_digest_from_audit_step(source_step)
+    if not rollback_source:
+        rollback_source = "pre_commit_snapshot_or_rollback_plan_required"
+    return MemoryEvidenceRepairRollbackDrillStep(
+        id=f"rollback-drill-step-{sequence}-{action}",
+        sequence=sequence,
+        phase=phase,
+        action=action,
+        description=description,
+        status=DRILL_STEP_STATUS_PLANNED,
+        operation_id=operation_id,
+        audit_step_id=audit_step_id,
+        audit_category=audit_category,
+        receipt_id=receipt_id or _str(source_step.get("receipt_id")),
+        token_id=token_id or _str(source_step.get("token_id")),
+        lock_id=lock_id or _str(source_step.get("lock_id")),
+        patch_digest=patch_digest,
+        rollback_source=rollback_source,
+        expected_result=expected_result,
+        required_operator_action=required_operator_action,
+        source_audit_step=dict(source_step),
+        future_would_restore_memory=future_would_restore_memory,
+    )
+
+
+def _extract_audit_preview(post_commit_audit: Mapping[str, Any]) -> dict[str, Any]:
+    previews = post_commit_audit.get("previews")
+    if isinstance(previews, list):
+        for preview in previews:
+            if isinstance(preview, Mapping):
+                return dict(preview)
+    if _str(post_commit_audit.get("id")).startswith("post-commit-audit-"):
+        return dict(post_commit_audit)
+    return {}
+
+
+def _failed_audit_steps(
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    steps: list[Mapping[str, Any]] = []
+    for step in _list(audit_preview.get("audit_steps")):
+        if isinstance(step, Mapping) and _str(step.get("status")) == AUDIT_STEP_STATUS_FAIL:
+            steps.append(dict(step))
+    for check in _list(post_commit_audit.get("checks")):
+        if not isinstance(check, Mapping):
+            continue
+        details = _dict(check.get("details"))
+        for failure in _list(details.get("failures")):
+            if isinstance(failure, Mapping):
+                steps.append(dict(failure))
+    return _dedupe_steps(steps)
+
+
+def _extract_executor_preview(
+    post_commit_audit: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+) -> dict[str, Any]:
+    source = audit_preview.get("source_executor_preview")
+    if isinstance(source, Mapping):
+        return dict(source)
+    source_report = post_commit_audit.get("source_executor_preview_report")
+    if isinstance(source_report, Mapping):
+        previews = source_report.get("previews")
+        if isinstance(previews, list):
+            for preview in previews:
+                if isinstance(preview, Mapping):
+                    return dict(preview)
+        if _str(source_report.get("id")).startswith("executor-preview-"):
+            return dict(source_report)
+    return {}
+
+
+def _operation_ids(
+    *,
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+    failed_steps: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    ids: list[str] = []
+    ids.extend(_list_of_str(audit_preview.get("operation_ids")))
+    ids.extend(_list_of_str(executor_preview.get("operation_ids")))
+    ids.extend(_str(step.get("operation_id")) for step in failed_steps)
+    if not ids and failed_steps:
+        ids.extend(_list_of_str(executor_preview.get("operation_ids")))
+    return _dedupe_strings(ids)
+
+
+def _patch_digests(
+    *,
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+    operation_ids: Sequence[str],
+) -> list[str]:
+    digests = _list_of_str(audit_preview.get("patch_digests"))
+    if digests:
+        return digests
+    digests = _list_of_str(executor_preview.get("patch_digests"))
+    if digests:
+        return digests
+    steps = [
+        step
+        for step in _list(executor_preview.get("steps"))
+        if isinstance(step, Mapping) and step.get("future_would_write_memory") is True
+    ]
+    by_operation = {_str(step.get("operation_id")): _str(step.get("patch_digest")) for step in steps}
+    return [by_operation.get(operation_id, "") for operation_id in operation_ids]
+
+
+def _rollback_sources(
+    *,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    audit_preview: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> list[str]:
+    sources: list[str] = []
+    if rollback_plan:
+        sources.append("rollback_plan")
+    if snapshot_plan:
+        sources.append("snapshot_plan")
+    if audit_preview:
+        sources.append("post_commit_audit_preview")
+    if executor_preview:
+        sources.append("executor_preview")
+    if not sources:
+        sources.append("operator_supplied_pre_commit_snapshot_required")
+    return _dedupe_strings(sources)
+
+
+def _rollback_source_for_operation(
+    *,
+    operation_id: str,
+    patch_digest: str,
+    rollback_plan: Mapping[str, Any],
+    snapshot_plan: Mapping[str, Any],
+    executor_preview: Mapping[str, Any],
+) -> str:
+    if _matches_plan(rollback_plan, operation_id=operation_id, patch_digest=patch_digest):
+        return "provided_rollback_plan"
+    if _matches_plan(snapshot_plan, operation_id=operation_id, patch_digest=patch_digest):
+        return "provided_snapshot_plan"
+    if executor_preview:
+        return "executor_preview_rollback_hint"
+    return "pre_commit_snapshot_or_rollback_plan_required"
+
+
+def _matches_plan(plan: Mapping[str, Any], *, operation_id: str, patch_digest: str) -> bool:
+    if not plan:
+        return False
+    rows = []
+    for key in ("steps", "plans", "snapshots", "previews"):
+        rows.extend(item for item in _list(plan.get(key)) if isinstance(item, Mapping))
+    if not rows and plan:
+        rows.append(plan)
+    for row in rows:
+        if operation_id and operation_id in {
+            _str(row.get("operation_id")),
+            _str(row.get("id")),
+            _str(row.get("source_operation_id")),
+            _str(row.get("ledger_entry_id")),
+        }:
+            return True
+        if patch_digest and patch_digest == _str(row.get("patch_digest")):
+            return True
+    return False
+
+
+def _failed_step_for_operation(
+    failed_steps: Sequence[Mapping[str, Any]],
+    operation_id: str,
+) -> Mapping[str, Any]:
+    for step in failed_steps:
+        if _str(step.get("operation_id")) == operation_id:
+            return step
+    return failed_steps[0] if failed_steps else {}
+
+
+def _patch_digest_from_audit_step(step: Mapping[str, Any]) -> str:
+    expected = _dict(step.get("expected_signal"))
+    return _str(expected.get("patch_digest"))
+
+
+def _first_from_steps(steps: Sequence[Mapping[str, Any]], field_name: str) -> str:
+    for step in steps:
+        value = _str(step.get(field_name))
+        if value:
+            return value
+    return ""
+
+
+def _first_nonempty(*values: str) -> str:
+    for value in values:
+        if value:
+            return value
+    return ""
+
+
+def _empty_report(
+    *,
+    post_commit_audit: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    return MemoryEvidenceRepairRollbackDrillPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        previews=(),
+        blocking_reasons=(),
+        required_actions=(),
+        source_post_commit_audit_report=dict(post_commit_audit),
+    )
+
+
+def _blocked_report(
+    *,
+    post_commit_audit: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairRollbackDrillCheck, ...],
+) -> MemoryEvidenceRepairRollbackDrillPreviewReport:
+    return MemoryEvidenceRepairRollbackDrillPreviewReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=ROLLBACK_DRILL_STATUS_BLOCKED,
+        checks=checks,
+        previews=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        source_post_commit_audit_report=dict(post_commit_audit),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    return MemoryEvidenceRepairRollbackDrillCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackDrillCheck:
+    return MemoryEvidenceRepairRollbackDrillCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _dedupe_steps(steps: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    seen: set[str] = set()
+    result: list[Mapping[str, Any]] = []
+    for step in steps:
+        key = _str(step.get("id")) or _digest(step)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(step)
+    return result
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_rollback_plan.py
+++ b/agent/memory_evidence_repair_rollback_plan.py
@@ -1,0 +1,370 @@
+"""Read-only rollback plans for memory evidence repair ledger entries.
+
+The rollback layer drafts how to undo a future manual evidence repair write.
+It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_ledger import OUTCOME_ALLOWED
+
+
+ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA = "restore_evidence_metadata"
+ROLLBACK_ACTION_NOOP = "no_rollback_required"
+ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK = "ready_for_manual_rollback"
+ROLLBACK_STATUS_SNAPSHOT_REQUIRED = "snapshot_required"
+ROLLBACK_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+SNAPSHOT_REQUIRED_VALUE = "<requires_pre_commit_snapshot>"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackStep:
+    """One read-only rollback step draft."""
+
+    id: str
+    ledger_entry_id: str
+    sequence: int
+    status: str
+    rollback_action: str
+    outcome: str
+    provider: str
+    repair_action: str
+    candidate_id: str
+    preview_id: str
+    patch_digest: str
+    evidence_fields: tuple[str, ...]
+    target: dict[str, Any]
+    inverse_patch_preview: dict[str, Any]
+    required_preconditions: tuple[str, ...]
+    verification_steps: tuple[str, ...]
+    reason: str
+    safety_note: str
+    source_entry: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "ledger_entry_id": self.ledger_entry_id,
+            "sequence": self.sequence,
+            "status": self.status,
+            "rollback_action": self.rollback_action,
+            "outcome": self.outcome,
+            "provider": self.provider,
+            "repair_action": self.repair_action,
+            "candidate_id": self.candidate_id,
+            "preview_id": self.preview_id,
+            "patch_digest": self.patch_digest,
+            "evidence_fields": list(self.evidence_fields),
+            "target": dict(self.target),
+            "inverse_patch_preview": dict(self.inverse_patch_preview),
+            "required_preconditions": list(self.required_preconditions),
+            "verification_steps": list(self.verification_steps),
+            "reason": self.reason,
+            "safety_note": self.safety_note,
+            "source_entry": dict(self.source_entry),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairRollbackPlan:
+    """Read-only rollback plan draft."""
+
+    generated_at: str
+    steps: tuple[MemoryEvidenceRepairRollbackStep, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_status: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        ready_count = 0
+        snapshot_required_count = 0
+        no_action_count = 0
+        for step in self.steps:
+            by_status[step.status] = by_status.get(step.status, 0) + 1
+            by_repair_action[step.repair_action] = (
+                by_repair_action.get(step.repair_action, 0) + 1
+            )
+            if step.provider:
+                by_provider[step.provider] = by_provider.get(step.provider, 0) + 1
+            if step.status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+                ready_count += 1
+            elif step.status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+                snapshot_required_count += 1
+            elif step.status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+                no_action_count += 1
+        return {
+            "rollback_step_count": len(self.steps),
+            "ready_count": ready_count,
+            "snapshot_required_count": snapshot_required_count,
+            "no_action_count": no_action_count,
+            "by_status": by_status,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_snapshot": snapshot_required_count > 0,
+            "has_ready_rollbacks": ready_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "steps": [step.to_dict() for step in self.steps],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_rollback_plan(
+    *,
+    ledger: Mapping[str, Any] | None = None,
+    entries: Sequence[Mapping[str, Any]] | None = None,
+    pre_commit_snapshots: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairRollbackPlan:
+    """Build a read-only rollback plan from commit ledger entries."""
+
+    ledger = ledger if isinstance(ledger, Mapping) else {}
+    pre_commit_snapshots = (
+        pre_commit_snapshots if isinstance(pre_commit_snapshots, Mapping) else {}
+    )
+    rows = _entry_rows(ledger=ledger, entries=entries)
+    steps: list[MemoryEvidenceRepairRollbackStep] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            continue
+        step = _step_from_entry(
+            row,
+            sequence=index,
+            pre_commit_snapshots=pre_commit_snapshots,
+        )
+        if step is not None:
+            steps.append(step)
+
+    return MemoryEvidenceRepairRollbackPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        steps=tuple(_dedupe_steps(steps)),
+    )
+
+
+def empty_evidence_repair_rollback_plan() -> MemoryEvidenceRepairRollbackPlan:
+    """Return an empty read-only rollback plan."""
+
+    return MemoryEvidenceRepairRollbackPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        steps=(),
+    )
+
+
+def _step_from_entry(
+    entry: Mapping[str, Any],
+    *,
+    sequence: int,
+    pre_commit_snapshots: Mapping[str, Any],
+) -> MemoryEvidenceRepairRollbackStep | None:
+    entry_id = _str(entry.get("id"))
+    outcome = _str(entry.get("outcome"))
+    candidate_id = _str(entry.get("candidate_id"))
+    preview_id = _str(entry.get("preview_id"))
+    if not entry_id and not outcome and not candidate_id and not preview_id:
+        return None
+
+    evidence_fields = _evidence_fields(entry)
+    snapshot = _snapshot_for_entry(entry, pre_commit_snapshots, evidence_fields)
+    allowed = _is_allowed(entry)
+    status = _status_for_entry(allowed=allowed, snapshot=snapshot)
+    rollback_action = (
+        ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA
+        if allowed
+        else ROLLBACK_ACTION_NOOP
+    )
+    inverse_patch = _inverse_patch_preview(
+        entry=entry,
+        allowed=allowed,
+        snapshot=snapshot,
+    )
+    return MemoryEvidenceRepairRollbackStep(
+        id=_stable_step_id(entry_id=entry_id, patch_digest=_str(entry.get("patch_digest"))),
+        ledger_entry_id=entry_id,
+        sequence=sequence,
+        status=status,
+        rollback_action=rollback_action,
+        outcome=outcome,
+        provider=_str(entry.get("provider")) or "memory",
+        repair_action=_str(entry.get("repair_action")) or "attach_provenance",
+        candidate_id=candidate_id,
+        preview_id=preview_id,
+        patch_digest=_str(entry.get("patch_digest")),
+        evidence_fields=evidence_fields,
+        target=_dict(entry.get("target")),
+        inverse_patch_preview=inverse_patch,
+        required_preconditions=_required_preconditions(status),
+        verification_steps=_verification_steps(status),
+        reason=_reason(status, outcome),
+        safety_note=(
+            "Read-only rollback plan. This step describes a future manual "
+            "rollback path and does not mutate durable memory."
+        ),
+        source_entry=dict(entry),
+    )
+
+
+def _entry_rows(
+    *,
+    ledger: Mapping[str, Any],
+    entries: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if entries is not None:
+        return list(entries)
+    if "outcome" in ledger:
+        return [ledger]
+    value = ledger.get("entries")
+    return value if isinstance(value, list) else []
+
+
+def _is_allowed(entry: Mapping[str, Any]) -> bool:
+    return bool(entry.get("manual_commit_allowed")) or _str(entry.get("outcome")) == OUTCOME_ALLOWED
+
+
+def _status_for_entry(*, allowed: bool, snapshot: dict[str, Any] | None) -> str:
+    if not allowed:
+        return ROLLBACK_STATUS_NO_ACTION_NEEDED
+    if snapshot is None:
+        return ROLLBACK_STATUS_SNAPSHOT_REQUIRED
+    return ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK
+
+
+def _inverse_patch_preview(
+    *,
+    entry: Mapping[str, Any],
+    allowed: bool,
+    snapshot: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not allowed:
+        return {
+            "operation": ROLLBACK_ACTION_NOOP,
+            "reason": "Ledger entry was not allowed for manual commit.",
+        }
+    return {
+        "operation": ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA,
+        "target": _dict(entry.get("target")),
+        "set": {
+            "evidence": snapshot if snapshot is not None else SNAPSHOT_REQUIRED_VALUE,
+        },
+        "verify_patch_digest": _str(entry.get("patch_digest")),
+        "source_ledger_entry_id": _str(entry.get("id")),
+    }
+
+
+def _required_preconditions(status: str) -> tuple[str, ...]:
+    if status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+        return ()
+    preconditions = ["explicit_user_confirmation", "verify_patch_digest_matches_ledger"]
+    if status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+        preconditions.append("capture_pre_commit_snapshot_before_apply")
+    if status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+        preconditions.append("manual_rollback_only")
+    return tuple(preconditions)
+
+
+def _verification_steps(status: str) -> tuple[str, ...]:
+    if status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+        return ("verify_no_manual_commit_occurred",)
+    steps = [
+        "verify_target_matches_ledger_entry",
+        "verify_patch_digest_matches_ledger",
+        "manual_review_before_rollback",
+    ]
+    if status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+        steps.append("restore_previous_evidence_metadata")
+    else:
+        steps.append("capture_pre_commit_snapshot_before_apply")
+    return tuple(steps)
+
+
+def _reason(status: str, outcome: str) -> str:
+    if status == ROLLBACK_STATUS_NO_ACTION_NEEDED:
+        return f"Ledger outcome {outcome or 'unknown'} does not require rollback."
+    if status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+        return "Allowed entry needs a pre-commit evidence snapshot before rollback can be ready."
+    return "Allowed entry has a pre-commit evidence snapshot and can be manually rolled back."
+
+
+def _snapshot_for_entry(
+    entry: Mapping[str, Any],
+    pre_commit_snapshots: Mapping[str, Any],
+    evidence_fields: tuple[str, ...],
+) -> dict[str, Any] | None:
+    keys = (
+        _str(entry.get("id")),
+        _str(entry.get("candidate_id")),
+        _str(entry.get("preview_id")),
+        _str(entry.get("decision_id")),
+        _str(entry.get("patch_digest")),
+    )
+    for key in keys:
+        if key and key in pre_commit_snapshots:
+            return _snapshot_evidence(pre_commit_snapshots.get(key))
+    if evidence_fields and any(field in pre_commit_snapshots for field in evidence_fields):
+        return {field: pre_commit_snapshots.get(field) for field in evidence_fields}
+    return None
+
+
+def _snapshot_evidence(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    evidence = value.get("evidence")
+    if isinstance(evidence, Mapping):
+        return dict(evidence)
+    return dict(value)
+
+
+def _evidence_fields(entry: Mapping[str, Any]) -> tuple[str, ...]:
+    fields = entry.get("evidence_fields")
+    if isinstance(fields, list):
+        parsed = tuple(_str(field) for field in fields if _str(field))
+        if parsed:
+            return parsed
+    source_decision = entry.get("source_decision")
+    if isinstance(source_decision, Mapping):
+        evidence_patch = source_decision.get("evidence_patch")
+        if isinstance(evidence_patch, Mapping):
+            return tuple(str(field) for field in evidence_patch.keys())
+    return ()
+
+
+def _stable_step_id(*, entry_id: str, patch_digest: str) -> str:
+    raw = json.dumps(
+        {"entry_id": entry_id, "patch_digest": patch_digest},
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"rollback-{digest}"
+
+
+def _dedupe_steps(
+    steps: list[MemoryEvidenceRepairRollbackStep],
+) -> list[MemoryEvidenceRepairRollbackStep]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairRollbackStep] = []
+    for step in steps:
+        if step.id in seen:
+            continue
+        seen.add(step.id)
+        deduped.append(step)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_snapshot_planner.py
+++ b/agent/memory_evidence_repair_snapshot_planner.py
@@ -1,0 +1,385 @@
+"""Read-only pre-commit snapshot planner for memory evidence repair.
+
+The snapshot planner identifies which existing evidence fields must be captured
+before a future manual repair write. It never writes to durable memory stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_rollback_plan import (
+    ROLLBACK_ACTION_NOOP,
+    ROLLBACK_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK,
+    ROLLBACK_STATUS_SNAPSHOT_REQUIRED,
+    build_evidence_repair_rollback_plan,
+)
+
+
+SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA = "capture_evidence_metadata"
+SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT = "verify_existing_snapshot"
+SNAPSHOT_ACTION_NOOP = "no_snapshot_required"
+SNAPSHOT_STATUS_CAPTURE_REQUIRED = "capture_required"
+SNAPSHOT_STATUS_ALREADY_AVAILABLE = "already_available"
+SNAPSHOT_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairSnapshotRequest:
+    """One read-only pre-commit snapshot request."""
+
+    id: str
+    sequence: int
+    status: str
+    snapshot_action: str
+    ledger_entry_id: str
+    rollback_step_id: str
+    candidate_id: str
+    preview_id: str
+    provider: str
+    repair_action: str
+    patch_digest: str
+    target: dict[str, Any]
+    evidence_fields: tuple[str, ...]
+    snapshot_key_candidates: tuple[str, ...]
+    snapshot_payload_preview: dict[str, Any]
+    required_before: str
+    blocks_manual_commit: bool
+    reason: str
+    verification_steps: tuple[str, ...]
+    safety_note: str
+    source_step: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "sequence": self.sequence,
+            "status": self.status,
+            "snapshot_action": self.snapshot_action,
+            "ledger_entry_id": self.ledger_entry_id,
+            "rollback_step_id": self.rollback_step_id,
+            "candidate_id": self.candidate_id,
+            "preview_id": self.preview_id,
+            "provider": self.provider,
+            "repair_action": self.repair_action,
+            "patch_digest": self.patch_digest,
+            "target": dict(self.target),
+            "evidence_fields": list(self.evidence_fields),
+            "snapshot_key_candidates": list(self.snapshot_key_candidates),
+            "snapshot_payload_preview": dict(self.snapshot_payload_preview),
+            "required_before": self.required_before,
+            "blocks_manual_commit": self.blocks_manual_commit,
+            "reason": self.reason,
+            "verification_steps": list(self.verification_steps),
+            "safety_note": self.safety_note,
+            "source_step": dict(self.source_step),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairSnapshotPlan:
+    """Read-only pre-commit snapshot plan."""
+
+    generated_at: str
+    requests: tuple[MemoryEvidenceRepairSnapshotRequest, ...]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_status: dict[str, int] = {}
+        by_provider: dict[str, int] = {}
+        by_repair_action: dict[str, int] = {}
+        capture_required_count = 0
+        already_available_count = 0
+        no_action_count = 0
+        blocking_count = 0
+        for request in self.requests:
+            by_status[request.status] = by_status.get(request.status, 0) + 1
+            by_repair_action[request.repair_action] = (
+                by_repair_action.get(request.repair_action, 0) + 1
+            )
+            if request.provider:
+                by_provider[request.provider] = by_provider.get(request.provider, 0) + 1
+            if request.status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+                capture_required_count += 1
+            elif request.status == SNAPSHOT_STATUS_ALREADY_AVAILABLE:
+                already_available_count += 1
+            elif request.status == SNAPSHOT_STATUS_NO_ACTION_NEEDED:
+                no_action_count += 1
+            if request.blocks_manual_commit:
+                blocking_count += 1
+        return {
+            "snapshot_request_count": len(self.requests),
+            "capture_required_count": capture_required_count,
+            "already_available_count": already_available_count,
+            "no_action_count": no_action_count,
+            "blocking_count": blocking_count,
+            "by_status": by_status,
+            "by_provider": by_provider,
+            "by_repair_action": by_repair_action,
+            "requires_capture": capture_required_count > 0,
+            "blocks_manual_commit": blocking_count > 0,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "summary": self.summary,
+            "requests": [request.to_dict() for request in self.requests],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_snapshot_plan(
+    *,
+    rollback_plan: Mapping[str, Any] | None = None,
+    steps: Sequence[Mapping[str, Any]] | None = None,
+    ledger: Mapping[str, Any] | None = None,
+    entries: Sequence[Mapping[str, Any]] | None = None,
+    existing_snapshots: Mapping[str, Any] | None = None,
+) -> MemoryEvidenceRepairSnapshotPlan:
+    """Build a read-only pre-commit snapshot plan."""
+
+    rollback_plan = rollback_plan if isinstance(rollback_plan, Mapping) else {}
+    existing_snapshots = (
+        existing_snapshots if isinstance(existing_snapshots, Mapping) else {}
+    )
+    rows = _step_rows(rollback_plan=rollback_plan, steps=steps)
+    if not rows and (ledger or entries is not None):
+        rows = build_evidence_repair_rollback_plan(
+            ledger=ledger if isinstance(ledger, Mapping) else {},
+            entries=entries,
+            pre_commit_snapshots=existing_snapshots,
+        ).to_dict().get("steps", [])
+
+    requests: list[MemoryEvidenceRepairSnapshotRequest] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, Mapping):
+            continue
+        request = _request_from_step(row, sequence=index)
+        if request is not None:
+            requests.append(request)
+
+    return MemoryEvidenceRepairSnapshotPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        requests=tuple(_dedupe_requests(requests)),
+    )
+
+
+def empty_evidence_repair_snapshot_plan() -> MemoryEvidenceRepairSnapshotPlan:
+    """Return an empty read-only pre-commit snapshot plan."""
+
+    return MemoryEvidenceRepairSnapshotPlan(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        requests=(),
+    )
+
+
+def _request_from_step(
+    step: Mapping[str, Any],
+    *,
+    sequence: int,
+) -> MemoryEvidenceRepairSnapshotRequest | None:
+    step_id = _str(step.get("id"))
+    ledger_entry_id = _str(step.get("ledger_entry_id"))
+    candidate_id = _str(step.get("candidate_id"))
+    preview_id = _str(step.get("preview_id"))
+    status = _str(step.get("status"))
+    if not step_id and not ledger_entry_id and not candidate_id and not status:
+        return None
+
+    snapshot_status = _snapshot_status(step)
+    evidence_fields = _evidence_fields(step)
+    key_candidates = _snapshot_key_candidates(step)
+    request_id = _stable_request_id(
+        ledger_entry_id=ledger_entry_id,
+        rollback_step_id=step_id,
+        patch_digest=_str(step.get("patch_digest")),
+        evidence_fields=evidence_fields,
+    )
+    return MemoryEvidenceRepairSnapshotRequest(
+        id=request_id,
+        sequence=sequence,
+        status=snapshot_status,
+        snapshot_action=_snapshot_action(snapshot_status),
+        ledger_entry_id=ledger_entry_id,
+        rollback_step_id=step_id,
+        candidate_id=candidate_id,
+        preview_id=preview_id,
+        provider=_str(step.get("provider")) or "memory",
+        repair_action=_str(step.get("repair_action")) or "attach_provenance",
+        patch_digest=_str(step.get("patch_digest")),
+        target=_dict(step.get("target")),
+        evidence_fields=evidence_fields,
+        snapshot_key_candidates=key_candidates,
+        snapshot_payload_preview=_snapshot_payload_preview(
+            step=step,
+            snapshot_status=snapshot_status,
+            evidence_fields=evidence_fields,
+            key_candidates=key_candidates,
+        ),
+        required_before="manual_commit",
+        blocks_manual_commit=snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED,
+        reason=_reason(snapshot_status),
+        verification_steps=_verification_steps(snapshot_status),
+        safety_note=(
+            "Read-only snapshot plan. Capture requests describe evidence that "
+            "must be saved before a future manual write; this plan writes nothing."
+        ),
+        source_step=dict(step),
+    )
+
+
+def _snapshot_status(step: Mapping[str, Any]) -> str:
+    rollback_status = _str(step.get("status"))
+    rollback_action = _str(step.get("rollback_action"))
+    if rollback_status == ROLLBACK_STATUS_NO_ACTION_NEEDED or rollback_action == ROLLBACK_ACTION_NOOP:
+        return SNAPSHOT_STATUS_NO_ACTION_NEEDED
+    if rollback_status == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK:
+        return SNAPSHOT_STATUS_ALREADY_AVAILABLE
+    if rollback_status == ROLLBACK_STATUS_SNAPSHOT_REQUIRED:
+        return SNAPSHOT_STATUS_CAPTURE_REQUIRED
+    return SNAPSHOT_STATUS_CAPTURE_REQUIRED
+
+
+def _snapshot_action(snapshot_status: str) -> str:
+    if snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+        return SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA
+    if snapshot_status == SNAPSHOT_STATUS_ALREADY_AVAILABLE:
+        return SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT
+    return SNAPSHOT_ACTION_NOOP
+
+
+def _snapshot_payload_preview(
+    *,
+    step: Mapping[str, Any],
+    snapshot_status: str,
+    evidence_fields: tuple[str, ...],
+    key_candidates: tuple[str, ...],
+) -> dict[str, Any]:
+    if snapshot_status == SNAPSHOT_STATUS_NO_ACTION_NEEDED:
+        return {
+            "operation": SNAPSHOT_ACTION_NOOP,
+            "reason": "Rollback step does not correspond to an allowed manual commit.",
+        }
+    return {
+        "operation": SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA,
+        "target": _dict(step.get("target")),
+        "capture": {
+            "evidence_fields": list(evidence_fields),
+            "snapshot_key": key_candidates[0] if key_candidates else "",
+            "snapshot_key_candidates": list(key_candidates),
+            "format": "pre_commit_evidence_snapshot",
+        },
+        "required_before": "manual_commit",
+        "source_rollback_step_id": _str(step.get("id")),
+    }
+
+
+def _reason(snapshot_status: str) -> str:
+    if snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+        return "Capture current evidence metadata before applying this manual repair."
+    if snapshot_status == SNAPSHOT_STATUS_ALREADY_AVAILABLE:
+        return "A pre-commit snapshot is already available; verify it before commit."
+    return "No snapshot is required because this entry is not eligible for manual commit."
+
+
+def _verification_steps(snapshot_status: str) -> tuple[str, ...]:
+    if snapshot_status == SNAPSHOT_STATUS_NO_ACTION_NEEDED:
+        return ("verify_no_manual_commit_is_planned",)
+    steps = [
+        "verify_target_matches_ledger_entry",
+        "read_current_evidence_metadata",
+        "verify_snapshot_contains_requested_fields",
+    ]
+    if snapshot_status == SNAPSHOT_STATUS_CAPTURE_REQUIRED:
+        steps.append("store_snapshot_before_manual_commit")
+    else:
+        steps.append("verify_existing_snapshot_before_manual_commit")
+    return tuple(steps)
+
+
+def _step_rows(
+    *,
+    rollback_plan: Mapping[str, Any],
+    steps: Sequence[Mapping[str, Any]] | None,
+) -> list[Any]:
+    if steps is not None:
+        return list(steps)
+    if "rollback_action" in rollback_plan:
+        return [rollback_plan]
+    value = rollback_plan.get("steps")
+    return value if isinstance(value, list) else []
+
+
+def _evidence_fields(step: Mapping[str, Any]) -> tuple[str, ...]:
+    fields = step.get("evidence_fields")
+    if isinstance(fields, list):
+        parsed = tuple(_str(field) for field in fields if _str(field))
+        if parsed:
+            return parsed
+    source_entry = step.get("source_entry")
+    if isinstance(source_entry, Mapping):
+        fields = source_entry.get("evidence_fields")
+        if isinstance(fields, list):
+            return tuple(_str(field) for field in fields if _str(field))
+    return ()
+
+
+def _snapshot_key_candidates(step: Mapping[str, Any]) -> tuple[str, ...]:
+    keys = (
+        _str(step.get("ledger_entry_id")),
+        _str(step.get("candidate_id")),
+        _str(step.get("preview_id")),
+        _str(step.get("patch_digest")),
+        _str(step.get("id")),
+    )
+    return tuple(key for key in keys if key)
+
+
+def _stable_request_id(
+    *,
+    ledger_entry_id: str,
+    rollback_step_id: str,
+    patch_digest: str,
+    evidence_fields: tuple[str, ...],
+) -> str:
+    raw = json.dumps(
+        {
+            "ledger_entry_id": ledger_entry_id,
+            "rollback_step_id": rollback_step_id,
+            "patch_digest": patch_digest,
+            "evidence_fields": list(evidence_fields),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"snapshot-{digest}"
+
+
+def _dedupe_requests(
+    requests: list[MemoryEvidenceRepairSnapshotRequest],
+) -> list[MemoryEvidenceRepairSnapshotRequest]:
+    seen: set[str] = set()
+    deduped: list[MemoryEvidenceRepairSnapshotRequest] = []
+    for request in requests:
+        if request.id in seen:
+            continue
+        seen.add(request.id)
+        deduped.append(request)
+    return deduped
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_evidence_repair_write_lock_gate.py
+++ b/agent/memory_evidence_repair_write_lock_gate.py
@@ -1,0 +1,623 @@
+"""Read-only write-lock gate for memory evidence repair manual commits.
+
+The write-lock gate verifies a commit receipt, checks supplied active locks and
+used-token ids, then drafts a future write lock. It never writes to durable
+memory stores and never acquires a real lock.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from agent.memory_evidence_repair_commit_receipt import (
+    RECEIPT_SCOPE,
+    RECEIPT_STATUS_BLOCKED,
+    RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECEIPT_STATUS_READY,
+    RECEIPT_TYPE,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+)
+
+
+WRITE_LOCK_TYPE = "memory_evidence_repair_write_lock"
+WRITE_LOCK_STATUS_READY = "write_lock_ready_for_manual_commit"
+WRITE_LOCK_STATUS_BLOCKED = "blocked"
+WRITE_LOCK_STATUS_NO_ACTION_NEEDED = "no_action_needed"
+LOCK_DRAFT_STATUS_READY = "write_lock_draft_ready"
+DEFAULT_LOCK_TTL_MINUTES = 10
+
+CHECK_RECEIPT_READY = "receipt_ready"
+CHECK_RECEIPT_INTEGRITY = "receipt_integrity"
+CHECK_TOKEN_REUSE = "token_reuse"
+CHECK_ACTIVE_LOCKS = "active_locks"
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairWriteLockCheck:
+    """One read-only write-lock readiness check."""
+
+    id: str
+    status: str
+    reason: str
+    required_actions: tuple[str, ...]
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "required_actions": list(self.required_actions),
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairWriteLockDraft:
+    """One read-only future write-lock draft."""
+
+    id: str
+    lock_type: str
+    status: str
+    scope: str
+    owner: str
+    receipt_id: str
+    token_id: str
+    operation_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    patch_digests: tuple[str, ...]
+    lock_digest: str
+    lock_preview: str
+    issued_at: str
+    expires_at: str
+    expires_in_minutes: int
+    would_acquire_write_lock: bool
+    would_release_after_commit: bool
+    safety_note: str
+    source_receipt: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "lock_type": self.lock_type,
+            "status": self.status,
+            "scope": self.scope,
+            "owner": self.owner,
+            "receipt_id": self.receipt_id,
+            "token_id": self.token_id,
+            "operation_ids": list(self.operation_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "patch_digests": list(self.patch_digests),
+            "lock_digest": self.lock_digest,
+            "lock_preview": self.lock_preview,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "expires_in_minutes": self.expires_in_minutes,
+            "would_acquire_write_lock": self.would_acquire_write_lock,
+            "would_release_after_commit": self.would_release_after_commit,
+            "safety_note": self.safety_note,
+            "source_receipt": dict(self.source_receipt),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryEvidenceRepairWriteLockGateReport:
+    """Read-only write-lock gate report."""
+
+    generated_at: str
+    status: str
+    checks: tuple[MemoryEvidenceRepairWriteLockCheck, ...]
+    locks: tuple[MemoryEvidenceRepairWriteLockDraft, ...]
+    blocking_reasons: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    active_lock_conflicts: tuple[dict[str, Any], ...]
+    source_receipt: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        by_check_status: dict[str, int] = {}
+        for check in self.checks:
+            by_check_status[check.status] = by_check_status.get(check.status, 0) + 1
+        return {
+            "status": self.status,
+            "check_count": len(self.checks),
+            "pass_count": by_check_status.get(CHECK_STATUS_PASS, 0),
+            "fail_count": by_check_status.get(CHECK_STATUS_FAIL, 0),
+            "lock_count": len(self.locks),
+            "active_lock_conflict_count": len(self.active_lock_conflicts),
+            "blocking_reason_count": len(self.blocking_reasons),
+            "required_action_count": len(self.required_actions),
+            "write_lock_available": bool(self.locks),
+            "executor_dry_run_allowed": self.status == WRITE_LOCK_STATUS_READY,
+            "would_acquire_write_lock_count": sum(
+                1 for lock in self.locks if lock.would_acquire_write_lock
+            ),
+            "has_blocks": self.status == WRITE_LOCK_STATUS_BLOCKED,
+            "requires_followup": bool(self.required_actions),
+            "by_check_status": by_check_status,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "status": self.status,
+            "summary": self.summary,
+            "checks": [check.to_dict() for check in self.checks],
+            "locks": [lock.to_dict() for lock in self.locks],
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "active_lock_conflicts": [dict(conflict) for conflict in self.active_lock_conflicts],
+            "source_receipt": dict(self.source_receipt),
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+
+def build_evidence_repair_write_lock_gate(
+    *,
+    commit_receipt: Mapping[str, Any] | None = None,
+    active_locks: Sequence[Mapping[str, Any]] | None = None,
+    already_used_token_ids: Sequence[str] | None = None,
+    lock_owner: str = "human",
+    lock_ttl_minutes: int = DEFAULT_LOCK_TTL_MINUTES,
+    current_time: str | datetime | None = None,
+) -> MemoryEvidenceRepairWriteLockGateReport:
+    """Build a read-only write-lock gate from a commit receipt report."""
+
+    commit_receipt = commit_receipt if isinstance(commit_receipt, Mapping) else {}
+    receipt = _extract_receipt(commit_receipt)
+    receipt_status = _str(commit_receipt.get("status")) or _str(receipt.get("status"))
+    now = _parse_datetime(current_time) or datetime.now(timezone.utc)
+
+    if not receipt:
+        if not commit_receipt or receipt_status == RECEIPT_STATUS_NO_ACTION_NEEDED:
+            return _empty_report(commit_receipt=commit_receipt)
+        source_blocking = tuple(_list_of_str(commit_receipt.get("blocking_reasons")))
+        source_actions = tuple(_list_of_str(commit_receipt.get("required_actions")))
+        return _blocked_report(
+            commit_receipt=commit_receipt,
+            checks=(
+                _fail(
+                    CHECK_RECEIPT_READY,
+                    "No commit receipt was supplied."
+                    if not source_blocking
+                    else "; ".join(source_blocking),
+                    source_actions or ("produce_commit_receipt",),
+                    {"receipt_status": receipt_status},
+                ),
+            ),
+            conflicts=(),
+        )
+
+    checks: list[MemoryEvidenceRepairWriteLockCheck] = [
+        _receipt_ready_check(commit_receipt, receipt),
+        _receipt_integrity_check(receipt),
+        _token_reuse_check(receipt, already_used_token_ids),
+    ]
+    conflicts = tuple(_active_lock_conflicts(receipt, active_locks, now))
+    checks.append(_active_lock_check(conflicts))
+
+    blocking_reasons = tuple(
+        _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+    )
+    required_actions = tuple(
+        _dedupe_strings(
+            action
+            for check in checks
+            if check.status == CHECK_STATUS_FAIL
+            for action in check.required_actions
+        )
+    )
+    if blocking_reasons:
+        return MemoryEvidenceRepairWriteLockGateReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            status=WRITE_LOCK_STATUS_BLOCKED,
+            checks=tuple(checks),
+            locks=(),
+            blocking_reasons=blocking_reasons,
+            required_actions=required_actions,
+            active_lock_conflicts=conflicts,
+            source_receipt=dict(commit_receipt),
+        )
+
+    lock = _lock_from_receipt(
+        receipt=receipt,
+        lock_owner=lock_owner,
+        lock_ttl_minutes=lock_ttl_minutes,
+        issued_at=now,
+    )
+    return MemoryEvidenceRepairWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=WRITE_LOCK_STATUS_READY,
+        checks=tuple(checks),
+        locks=(lock,),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_receipt=dict(commit_receipt),
+    )
+
+
+def empty_evidence_repair_write_lock_gate() -> MemoryEvidenceRepairWriteLockGateReport:
+    """Return an empty read-only write-lock gate report."""
+
+    return _empty_report(commit_receipt={})
+
+
+def _extract_receipt(commit_receipt: Mapping[str, Any]) -> dict[str, Any]:
+    receipts = commit_receipt.get("receipts")
+    if isinstance(receipts, list):
+        for receipt in receipts:
+            if isinstance(receipt, Mapping):
+                return dict(receipt)
+    if _str(commit_receipt.get("id")).startswith("commit-receipt-"):
+        return dict(commit_receipt)
+    return {}
+
+
+def _receipt_ready_check(
+    commit_receipt: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    report_status = _str(commit_receipt.get("status"))
+    receipt_status = _str(receipt.get("status"))
+    if report_status and report_status != RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECEIPT_READY,
+            "Commit receipt report is not ready for manual commit.",
+            tuple(_list_of_str(commit_receipt.get("required_actions")))
+            or ("produce_ready_commit_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    if receipt_status != RECEIPT_STATUS_READY:
+        return _fail(
+            CHECK_RECEIPT_READY,
+            "Commit receipt entry is not ready for manual commit.",
+            ("produce_ready_commit_receipt",),
+            {"report_status": report_status, "receipt_status": receipt_status},
+        )
+    return _pass(
+        CHECK_RECEIPT_READY,
+        "Commit receipt is ready for manual commit.",
+        {"receipt_id": _str(receipt.get("id"))},
+    )
+
+
+def _receipt_integrity_check(
+    receipt: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    expected_digest = _expected_receipt_digest(receipt)
+    actual_digest = _str(receipt.get("receipt_digest"))
+    expected_id = f"commit-receipt-{expected_digest[:16]}" if expected_digest else ""
+    missing_fields: list[str] = []
+    for field_name in ("token_id", "operation_ids", "patch_digests"):
+        value = receipt.get(field_name)
+        if isinstance(value, list) and not value:
+            missing_fields.append(field_name)
+        elif not isinstance(value, list) and not _str(value):
+            missing_fields.append(field_name)
+    if (
+        missing_fields
+        or actual_digest != expected_digest
+        or _str(receipt.get("id")) != expected_id
+        or _str(receipt.get("receipt_type")) != RECEIPT_TYPE
+        or _str(receipt.get("scope")) != RECEIPT_SCOPE
+    ):
+        return _fail(
+            CHECK_RECEIPT_INTEGRITY,
+            "Commit receipt digest, id, type, scope, or required fields are invalid.",
+            ("regenerate_commit_receipt",),
+            {
+                "expected_receipt_digest": expected_digest,
+                "actual_receipt_digest": actual_digest,
+                "expected_receipt_id": expected_id,
+                "actual_receipt_id": _str(receipt.get("id")),
+                "missing_fields": missing_fields,
+            },
+        )
+    return _pass(
+        CHECK_RECEIPT_INTEGRITY,
+        "Commit receipt integrity checks pass.",
+        {"receipt_id": expected_id, "receipt_digest": actual_digest},
+    )
+
+
+def _token_reuse_check(
+    receipt: Mapping[str, Any],
+    already_used_token_ids: Sequence[str] | None,
+) -> MemoryEvidenceRepairWriteLockCheck:
+    token_id = _str(receipt.get("token_id"))
+    used = {_str(item) for item in already_used_token_ids or [] if _str(item)}
+    if token_id and token_id in used:
+        return _fail(
+            CHECK_TOKEN_REUSE,
+            "Approval token is already present in the external used-token ledger.",
+            ("regenerate_human_approval_token",),
+            {"token_id": token_id, "already_used_token_count": len(used)},
+        )
+    return _pass(
+        CHECK_TOKEN_REUSE,
+        "Approval token is not present in the external used-token ledger.",
+        {"token_id": token_id, "already_used_token_count": len(used)},
+    )
+
+
+def _active_lock_check(
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    if conflicts:
+        return _fail(
+            CHECK_ACTIVE_LOCKS,
+            "Active write locks conflict with the planned memory evidence repair commit.",
+            ("wait_for_write_lock_release", "retry_write_lock_gate"),
+            {"conflict_count": len(conflicts), "conflicts": list(conflicts)},
+        )
+    return _pass(
+        CHECK_ACTIVE_LOCKS,
+        "No active write-lock conflicts were supplied.",
+        {"conflict_count": 0},
+    )
+
+
+def _lock_from_receipt(
+    *,
+    receipt: Mapping[str, Any],
+    lock_owner: str,
+    lock_ttl_minutes: int,
+    issued_at: datetime,
+) -> MemoryEvidenceRepairWriteLockDraft:
+    ttl = _positive_int(lock_ttl_minutes) or DEFAULT_LOCK_TTL_MINUTES
+    expires_at = issued_at + timedelta(minutes=ttl)
+    operation_ids = tuple(_list_of_str(receipt.get("operation_ids")))
+    candidate_ids = tuple(_list_of_str(receipt.get("candidate_ids")))
+    patch_digests = tuple(_list_of_str(receipt.get("patch_digests")))
+    seed = {
+        "lock_type": WRITE_LOCK_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "owner": _str(lock_owner) or "human",
+        "receipt_id": _str(receipt.get("id")),
+        "token_id": _str(receipt.get("token_id")),
+        "operation_ids": operation_ids,
+        "candidate_ids": candidate_ids,
+        "patch_digests": patch_digests,
+        "expires_in_minutes": ttl,
+    }
+    lock_digest = _digest(seed)
+    lock_id = f"write-lock-{lock_digest[:16]}"
+    return MemoryEvidenceRepairWriteLockDraft(
+        id=lock_id,
+        lock_type=WRITE_LOCK_TYPE,
+        status=LOCK_DRAFT_STATUS_READY,
+        scope=RECEIPT_SCOPE,
+        owner=_str(lock_owner) or "human",
+        receipt_id=_str(receipt.get("id")),
+        token_id=_str(receipt.get("token_id")),
+        operation_ids=operation_ids,
+        candidate_ids=candidate_ids,
+        patch_digests=patch_digests,
+        lock_digest=lock_digest,
+        lock_preview=f"{lock_id}:{lock_digest[:12]}",
+        issued_at=issued_at.isoformat(),
+        expires_at=expires_at.isoformat(),
+        expires_in_minutes=ttl,
+        would_acquire_write_lock=True,
+        would_release_after_commit=True,
+        safety_note=(
+            "Read-only write-lock draft. This does not acquire a real lock and "
+            "does not mutate durable memory."
+        ),
+        source_receipt=dict(receipt),
+    )
+
+
+def _active_lock_conflicts(
+    receipt: Mapping[str, Any],
+    active_locks: Sequence[Mapping[str, Any]] | None,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    for lock in active_locks or []:
+        if not isinstance(lock, Mapping) or not _is_active_lock(lock, now):
+            continue
+        if _lock_conflicts_with_receipt(lock, receipt):
+            conflicts.append(
+                {
+                    "lock_id": _str(lock.get("id")),
+                    "owner": _str(lock.get("owner")),
+                    "scope": _str(lock.get("scope")),
+                    "expires_at": _str(lock.get("expires_at")),
+                    "reason": _conflict_reason(lock, receipt),
+                }
+            )
+    return conflicts
+
+
+def _is_active_lock(lock: Mapping[str, Any], now: datetime) -> bool:
+    status = _str(lock.get("status")).lower()
+    if status in {"released", "expired", "cancelled", "canceled", "inactive"}:
+        return False
+    expires_at = _parse_datetime(lock.get("expires_at"))
+    if expires_at is not None and expires_at <= now:
+        return False
+    return status in {"", "active", "write_lock_active", LOCK_DRAFT_STATUS_READY}
+
+
+def _lock_conflicts_with_receipt(lock: Mapping[str, Any], receipt: Mapping[str, Any]) -> bool:
+    lock_scope = _str(lock.get("scope"))
+    if lock_scope and lock_scope != RECEIPT_SCOPE:
+        return False
+    if _str(lock.get("token_id")) and _str(lock.get("token_id")) == _str(receipt.get("token_id")):
+        return True
+    if _str(lock.get("receipt_id")) and _str(lock.get("receipt_id")) == _str(receipt.get("id")):
+        return True
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(receipt.get("operation_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("candidate_ids")), _list_of_str(receipt.get("candidate_ids"))):
+        return True
+    if _intersects(_list_of_str(lock.get("patch_digests")), _list_of_str(receipt.get("patch_digests"))):
+        return True
+    identifiers = (
+        _str(lock.get("token_id")),
+        _str(lock.get("receipt_id")),
+        *_list_of_str(lock.get("operation_ids")),
+        *_list_of_str(lock.get("candidate_ids")),
+        *_list_of_str(lock.get("patch_digests")),
+    )
+    return not any(identifiers)
+
+
+def _conflict_reason(lock: Mapping[str, Any], receipt: Mapping[str, Any]) -> str:
+    if _str(lock.get("token_id")) == _str(receipt.get("token_id")):
+        return "same_token_id"
+    if _str(lock.get("receipt_id")) == _str(receipt.get("id")):
+        return "same_receipt_id"
+    if _intersects(_list_of_str(lock.get("operation_ids")), _list_of_str(receipt.get("operation_ids"))):
+        return "overlapping_operation_ids"
+    if _intersects(_list_of_str(lock.get("candidate_ids")), _list_of_str(receipt.get("candidate_ids"))):
+        return "overlapping_candidate_ids"
+    if _intersects(_list_of_str(lock.get("patch_digests")), _list_of_str(receipt.get("patch_digests"))):
+        return "overlapping_patch_digests"
+    return "global_scope_lock"
+
+
+def _expected_receipt_digest(receipt: Mapping[str, Any]) -> str:
+    seed = {
+        "receipt_type": RECEIPT_TYPE,
+        "scope": RECEIPT_SCOPE,
+        "actor": _str(receipt.get("actor")) or "human",
+        "commit_reason": _str(receipt.get("commit_reason")),
+        "token_id": _str(receipt.get("token_id")),
+        "token_digest": _str(receipt.get("token_digest")),
+        "dry_run_digest": _str(receipt.get("dry_run_digest")),
+        "gate_status": _str(receipt.get("gate_status")),
+        "operation_ids": _list_of_str(receipt.get("operation_ids")),
+        "ledger_entry_ids": _list_of_str(receipt.get("ledger_entry_ids")),
+        "candidate_ids": _list_of_str(receipt.get("candidate_ids")),
+        "patch_digests": _list_of_str(receipt.get("patch_digests")),
+    }
+    return _digest(seed)
+
+
+def _empty_report(*, commit_receipt: Mapping[str, Any]) -> MemoryEvidenceRepairWriteLockGateReport:
+    return MemoryEvidenceRepairWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+        checks=(),
+        locks=(),
+        blocking_reasons=(),
+        required_actions=(),
+        active_lock_conflicts=(),
+        source_receipt=dict(commit_receipt),
+    )
+
+
+def _blocked_report(
+    *,
+    commit_receipt: Mapping[str, Any],
+    checks: tuple[MemoryEvidenceRepairWriteLockCheck, ...],
+    conflicts: Sequence[Mapping[str, Any]],
+) -> MemoryEvidenceRepairWriteLockGateReport:
+    return MemoryEvidenceRepairWriteLockGateReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        status=WRITE_LOCK_STATUS_BLOCKED,
+        checks=checks,
+        locks=(),
+        blocking_reasons=tuple(
+            _dedupe_strings(check.reason for check in checks if check.status == CHECK_STATUS_FAIL)
+        ),
+        required_actions=tuple(
+            _dedupe_strings(
+                action
+                for check in checks
+                if check.status == CHECK_STATUS_FAIL
+                for action in check.required_actions
+            )
+        ),
+        active_lock_conflicts=tuple(dict(conflict) for conflict in conflicts),
+        source_receipt=dict(commit_receipt),
+    )
+
+
+def _pass(
+    check_id: str,
+    reason: str,
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    return MemoryEvidenceRepairWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_PASS,
+        reason=reason,
+        required_actions=(),
+        details=dict(details),
+    )
+
+
+def _fail(
+    check_id: str,
+    reason: str,
+    required_actions: Sequence[str],
+    details: Mapping[str, Any],
+) -> MemoryEvidenceRepairWriteLockCheck:
+    return MemoryEvidenceRepairWriteLockCheck(
+        id=check_id,
+        status=CHECK_STATUS_FAIL,
+        reason=reason,
+        required_actions=tuple(required_actions),
+        details=dict(details),
+    )
+
+
+def _parse_datetime(value: str | datetime | Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _intersects(left: Sequence[str], right: Sequence[str]) -> bool:
+    return bool(set(left).intersection(set(right)))
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _list_of_str(value: Any) -> list[str]:
+    return [_str(item) for item in value] if isinstance(value, list) else []
+
+
+def _dedupe_strings(values: Sequence[str] | Any) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -1,0 +1,2450 @@
+"""Shared Hermes Memory Fabric bridge.
+
+This module keeps Hermes as the primary memory owner. It exposes read-first
+status, search, governance, policy-proposal, and evolution-level helpers for
+MCP clients such as Codex and OpenClaw. Durable memory content and Memory Graph
+rows are not modified here; writes are represented as governed proposals.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - fallback for standalone scripts
+    def get_hermes_home() -> Path:
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+VALID_SEARCH_SCOPES = {"all", "graph", "prompt_cases", "knowledge", "legacy_memory"}
+VALID_PROPOSAL_SCOPES = {"global", "project", "agent_private", "user", "memory", "procedural"}
+VALID_GATE_OPERATIONS = {
+    "status",
+    "audit",
+    "search",
+    "graph_read",
+    "snapshot_export",
+    "auto_precheck",
+    "external_auto_recall",
+    "write_proposal",
+    "direct_write",
+    "promote_memory",
+    "delete_memory",
+}
+VALID_POLICY_PROPOSAL_DECISIONS = {"approved", "rejected", "deferred"}
+VALID_POLICY_PROPOSAL_STATUSES = {"proposed", "approved", "rejected", "deferred"}
+DURABLE_WRITE_OPERATIONS = {"direct_write", "promote_memory", "delete_memory"}
+INTERNAL_MEMORY_CLIENTS = {"hermes", "codex", "openclaw"}
+POLICY_EXECUTE_CONFIRM_TOKEN = "HERMES_EXECUTE_APPROVED_POLICY_PLAN"
+VALID_POLICY_EXECUTE_ACTIONS = {"verify", "run_check", "diagnose", "review", "manual_review", "manual_repair"}
+EXTERNAL_CHANNEL_ROOTS = {
+    "telegram",
+    "wechat",
+    "whatsapp",
+    "discord",
+    "irc",
+    "googlechat",
+    "slack",
+    "signal",
+    "imessage",
+    "feishu",
+    "nostr",
+    "msteams",
+    "mattermost",
+    "nextcloud-talk",
+    "matrix",
+    "bluebubbles",
+    "line",
+    "zalo",
+    "zalouser",
+    "synology-chat",
+    "tlon",
+    "qa-channel",
+    "qqbot",
+    "twitch",
+}
+DEFAULT_RECALL_QUALITY_QUERIES = [
+    "Lovart",
+    "GPT image",
+    "OpenClaw",
+    "policy",
+    "memory",
+]
+
+MEMORY_EVOLUTION_TIERS: list[dict[str, Any]] = [
+    {
+        "level": 1,
+        "id": "star_spark",
+        "name": "星火记忆",
+        "one_line": "能记录零散事实和短期片段。",
+        "capabilities": ["basic_capture"],
+    },
+    {
+        "level": 2,
+        "id": "star_point",
+        "name": "星点记忆",
+        "one_line": "能把零散记忆沉淀为可复用条目。",
+        "capabilities": ["entry_persistence", "basic_lookup"],
+    },
+    {
+        "level": 3,
+        "id": "star_link",
+        "name": "星链记忆",
+        "one_line": "能把记忆之间的关系连接起来。",
+        "capabilities": ["relations", "linked_recall"],
+    },
+    {
+        "level": 4,
+        "id": "star_map",
+        "name": "星图记忆",
+        "one_line": "能形成可浏览、可检索的知识地图。",
+        "capabilities": ["graph", "provenance", "structured_read"],
+    },
+    {
+        "level": 5,
+        "id": "star_river",
+        "name": "星河记忆",
+        "one_line": "能跨知识库、案例库和历史记忆做联合召回。",
+        "capabilities": ["multi_surface_recall", "knowledge_index"],
+    },
+    {
+        "level": 6,
+        "id": "star_core",
+        "name": "星辰记忆",
+        "one_line": "能沉淀知识、案例、方法论，并服务具体创作和工作流。",
+        "capabilities": ["case_memory", "workflow_memory", "skill_support"],
+    },
+    {
+        "level": 7,
+        "id": "star_domain",
+        "name": "星域记忆",
+        "one_line": "能按项目、角色、场景和智能体分区管理记忆。",
+        "capabilities": ["project_domains", "agent_profiles", "scoped_recall"],
+    },
+    {
+        "level": 8,
+        "id": "star_dome",
+        "name": "星穹记忆",
+        "one_line": "能治理、审计、联邦共享，并约束外部通道记忆暴露。",
+        "capabilities": ["federation", "audit", "policy_gate", "proposal_only_writes"],
+    },
+    {
+        "level": 9,
+        "id": "star_sea",
+        "name": "星海记忆",
+        "one_line": "能容纳多来源、多智能体的大规模记忆，并持续评估召回质量。",
+        "capabilities": ["large_scale_sources", "multi_agent_recall", "recall_quality_evaluation"],
+    },
+    {
+        "level": 10,
+        "id": "star_realm",
+        "name": "星界记忆",
+        "one_line": "能跨系统、跨边界协同记忆，同时保持边界和权限。",
+        "capabilities": ["cross_system_memory", "boundary_aware_sharing"],
+    },
+    {
+        "level": 11,
+        "id": "star_hub",
+        "name": "星枢记忆",
+        "one_line": "有中心调度和策略编排，能把记忆能力分配给任务链。",
+        "capabilities": ["orchestration", "routing", "policy_scheduling"],
+    },
+    {
+        "level": 12,
+        "id": "star_law",
+        "name": "星律记忆",
+        "one_line": "记忆具备自我规则、自我约束和策略闭环。",
+        "capabilities": ["self_governance", "closed_loop_policy", "risk_controls"],
+    },
+    {
+        "level": 13,
+        "id": "star_soul",
+        "name": "星魂记忆",
+        "one_line": "形成长期人格、偏好、工作方式和协作风格连续性。",
+        "capabilities": ["preference_continuity", "persona_memory", "collaboration_style"],
+    },
+    {
+        "level": 14,
+        "id": "star_universe",
+        "name": "星宙记忆",
+        "one_line": "跨时间、跨项目、跨生态长期演化。",
+        "capabilities": ["long_horizon_evolution", "ecosystem_memory", "temporal_reasoning"],
+    },
+    {
+        "level": 15,
+        "id": "star_source",
+        "name": "星源记忆",
+        "one_line": "能反推知识来源、生成方法论，并持续自进化。",
+        "capabilities": ["source_reasoning", "methodology_generation", "self_evolution"],
+    },
+]
+
+
+def memory_bridge_status() -> dict[str, Any]:
+    """Return read-only status for Hermes shared memory surfaces."""
+
+    home = get_hermes_home()
+    graph_path = _graph_path(home)
+    prompt_index_path = _prompt_index_path(home)
+    knowledge_dir = home / "knowledge"
+    proposal_path = _proposal_path(home)
+    operation_path = _operation_ledger_path(home)
+    policy_path = _policy_proposal_path(home)
+    return {
+        "success": True,
+        "status": "available",
+        "hermes_home": str(home),
+        "surfaces": {
+            "graph": {
+                "path": str(graph_path),
+                "exists": graph_path.exists(),
+                "node_count": _sqlite_count(graph_path, "graph_nodes"),
+                "edge_count": _sqlite_count(graph_path, "graph_edges"),
+                "provenance_count": _sqlite_count(graph_path, "graph_provenance"),
+            },
+            "gpt_image_prompt_cases": {
+                "path": str(prompt_index_path),
+                "exists": prompt_index_path.exists(),
+                "case_count": _sqlite_count(prompt_index_path, "cases"),
+            },
+            "knowledge": {
+                "path": str(knowledge_dir),
+                "exists": knowledge_dir.exists(),
+                "file_count": _knowledge_file_count(knowledge_dir),
+            },
+            "legacy_memory": {
+                "path": str(home / "memories"),
+                "exists": (home / "memories").exists(),
+            },
+            "write_proposals": {
+                "path": str(proposal_path),
+                "exists": proposal_path.exists(),
+                "proposal_count": _jsonl_count(proposal_path),
+            },
+            "operation_ledger": {
+                "path": str(operation_path),
+                "exists": operation_path.exists(),
+                "event_count": _jsonl_count(operation_path),
+            },
+            "policy_proposals": {
+                "path": str(policy_path),
+                "exists": policy_path.exists(),
+                "event_count": _jsonl_count(policy_path),
+            },
+        },
+        "policy": {
+            "hermes_is_primary_memory": True,
+            "external_clients_should_not_clone_as_primary": True,
+            "writes_are_proposal_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        },
+    }
+
+
+def memory_evolution_status() -> dict[str, Any]:
+    """Return the fixed Hermes memory tier taxonomy and current stage assessment."""
+
+    bridge = memory_bridge_status()
+    federation = memory_federation_status()
+    boundary_audit = memory_boundary_allowlist_audit(log_limit=200)
+    outcome = memory_policy_outcome_monitor(limit=50, stale_after_hours=72)
+    recall_quality = memory_recall_quality_evaluate(limit=5)
+    evidence = _memory_evolution_evidence(bridge, federation, outcome, recall_quality)
+    evidence["boundary_allowlists_reviewed"] = bool(boundary_audit.get("ready"))
+    evidence["boundary_readiness_score"] = boundary_audit.get("boundary_readiness_score", 0)
+    readiness = [_tier_readiness(tier, evidence) for tier in MEMORY_EVOLUTION_TIERS]
+    achieved = [item for item in readiness if item["achieved"]]
+    current = achieved[-1] if achieved else readiness[0]
+    next_item = next((item for item in readiness if item["level"] > current["level"]), None)
+    phase = current["name"]
+    if current["level"] == 8 and next_item and next_item["readiness_score"] >= 0.5:
+        phase = "星穹记忆初期到星海记忆门口"
+    elif next_item and next_item["readiness_score"] >= 0.65:
+        phase = f"{current['name']}到{next_item['name']}门口"
+    return {
+        "success": True,
+        "evolution_type": "hermes_memory_evolution_status",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "taxonomy": MEMORY_EVOLUTION_TIERS,
+        "current": {
+            "level": current["level"],
+            "id": current["id"],
+            "name": current["name"],
+            "phase": phase,
+            "readiness_score": current["readiness_score"],
+        },
+        "next": next_item,
+        "readiness": readiness,
+        "evidence": evidence,
+        "recall_quality": {
+            "quality_score": recall_quality.get("quality_score"),
+            "readiness": recall_quality.get("readiness"),
+            "passed_query_count": recall_quality.get("summary", {}).get("passed_query_count")
+            if isinstance(recall_quality.get("summary"), dict)
+            else None,
+            "benchmark_query_count": recall_quality.get("summary", {}).get("benchmark_query_count")
+            if isinstance(recall_quality.get("summary"), dict)
+            else None,
+        },
+        "recommended_next_actions": _memory_evolution_next_actions(current, next_item, outcome),
+        "policy": {
+            "taxonomy_is_fixed": True,
+            "status_is_read_only": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+            "persistent_changes_must_use_proposals": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_federation_status() -> dict[str, Any]:
+    """Return read-only status for clients sharing Hermes Memory Fabric."""
+
+    home = get_hermes_home()
+    tools = [
+        "memory_bridge_status",
+        "memory_evolution_status",
+        "memory_recall_quality_evaluate",
+        "memory_fabric_search",
+        "memory_graph_read",
+        "memory_write_proposal",
+        "memory_snapshot_export",
+        "memory_federation_status",
+        "memory_federation_audit",
+        "memory_boundary_allowlist_audit",
+        "memory_federation_gate",
+        "memory_operation_ledger",
+        "memory_ledger_intelligence",
+        "memory_policy_autotune",
+        "memory_policy_proposal_create",
+        "memory_policy_proposal_ledger",
+        "memory_policy_proposal_decision",
+        "memory_policy_apply_plan",
+        "memory_policy_apply_execute",
+        "memory_policy_outcome_monitor",
+    ]
+    clients = {
+        "hermes": {
+            "role": "primary_memory_owner",
+            "hermes_home": str(home),
+            "mcp_server": {
+                "path": str(Path(__file__).resolve().parents[1] / "mcp_serve.py"),
+                "exists": (Path(__file__).resolve().parents[1] / "mcp_serve.py").exists(),
+                "tools": tools,
+            },
+            "surfaces": memory_bridge_status()["surfaces"],
+        },
+        "codex": _codex_memory_client_status(),
+        "openclaw": _openclaw_memory_client_status(),
+    }
+    warnings = _federation_warnings(clients)
+    return {
+        "success": True,
+        "federation_type": "hermes_primary_shared_memory",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "clients": clients,
+        "policy": {
+            "primary_memory_owner": "hermes",
+            "codex_access": "mcp_read_and_governed_write_proposal",
+            "openclaw_access": "plugin_read_and_governed_write_proposal",
+            "external_clients_should_not_clone_as_primary": True,
+            "snapshots_are_cache_or_backup_only": True,
+            "writes_are_proposal_only": True,
+            "external_channel_auto_recall_requires_allowlist": True,
+        },
+        "ready": not warnings,
+        "warnings": warnings,
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def memory_federation_audit(*, log_limit: int = 200) -> dict[str, Any]:
+    """Return a read-only audit report for the shared memory federation."""
+
+    log_limit = _clamp_int(log_limit, default=200, minimum=20, maximum=2000)
+    status = memory_federation_status()
+    checks = [
+        _audit_check("hermes.mcp_server", status["clients"]["hermes"]["mcp_server"]["exists"], "critical", "Hermes MCP server file exists."),
+        _audit_check("codex.configured", status["clients"]["codex"]["ready"], "warning", "Codex is configured as a memory client."),
+        _audit_check("openclaw.configured", status["clients"]["openclaw"]["ready"], "warning", "OpenClaw plugin is configured as a memory client."),
+        _audit_check("writes.proposal_only", status["policy"]["writes_are_proposal_only"], "critical", "Durable writes are proposal-only."),
+        _audit_check("external.default_blocked", status["policy"]["external_channel_auto_recall_requires_allowlist"], "critical", "External channel recall requires allowlist."),
+    ]
+    ready = not [check for check in checks if check["status"] != "pass" and check["severity"] == "critical"]
+    return {
+        "success": True,
+        "audit_type": "hermes_memory_federation_audit",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "ready": ready,
+        "health_score": max(0, 100 - 15 * len([c for c in checks if c["status"] != "pass"])),
+        "checks": checks,
+        "status_summary": {
+            "federation_ready": status.get("ready"),
+            "warnings": status.get("warnings", []),
+            "log_limit": log_limit,
+        },
+        "policy": {
+            "audit_is_read_only": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_boundary_allowlist_audit(*, log_limit: int = 200) -> dict[str, Any]:
+    """Review cross-system memory boundaries and allowlists without changing policy."""
+
+    log_limit = _clamp_int(log_limit, default=200, minimum=20, maximum=2000)
+    status = memory_federation_status()
+    federation_audit = memory_federation_audit(log_limit=log_limit)
+    outcome = memory_policy_outcome_monitor(limit=50, stale_after_hours=72)
+    ledger = memory_ledger_intelligence(limit=500)
+
+    clients = status.get("clients", {})
+    hermes = clients.get("hermes", {})
+    codex = clients.get("codex", {})
+    openclaw = clients.get("openclaw", {})
+
+    external_allowed = openclaw.get("external_auto_precheck_allowed_channels", [])
+    if not isinstance(external_allowed, list):
+        external_allowed = []
+
+    agent_profiles = openclaw.get("auto_precheck_agent_profiles", [])
+    if not isinstance(agent_profiles, list):
+        agent_profiles = []
+
+    reviewed_allowlists = []
+    unreviewed_allowlists = []
+
+    if external_allowed:
+        unreviewed_allowlists.append({
+            "id": "openclaw.external_auto_precheck_allowed_channels",
+            "value": external_allowed,
+            "reason": "External automatic recall allowlist is non-empty and requires explicit human review evidence.",
+        })
+    else:
+        reviewed_allowlists.append({
+            "id": "openclaw.external_auto_precheck_allowed_channels",
+            "value": [],
+            "review": "empty_allowlist_reviewed_as_blocked_default",
+        })
+
+    if openclaw.get("external_auto_precheck_default") == "blocked":
+        reviewed_allowlists.append({
+            "id": "openclaw.external_auto_precheck_default",
+            "value": "blocked",
+            "review": "external automatic recall remains blocked by default",
+        })
+
+    exposure_risks = []
+    if hermes.get("role") != "primary_memory_owner":
+        exposure_risks.append("Hermes is not reported as primary memory owner.")
+    if codex.get("role") != "memory_client":
+        exposure_risks.append("Codex is not reported as a memory client.")
+    if openclaw.get("role") != "memory_client":
+        exposure_risks.append("OpenClaw is not reported as a memory client.")
+    if openclaw.get("external_auto_precheck_default") != "blocked":
+        exposure_risks.append("External automatic recall is not blocked by default.")
+    if external_allowed:
+        exposure_risks.append("External automatic recall allowlist is non-empty.")
+    if not status.get("policy", {}).get("writes_are_proposal_only"):
+        exposure_risks.append("Shared memory writes are not proposal-only.")
+    if not status.get("policy", {}).get("external_channel_auto_recall_requires_allowlist"):
+        exposure_risks.append("External channel automatic recall does not require allowlist.")
+
+    unknown_client_findings = [
+        finding for finding in ledger.get("findings", [])
+        if "unknown" in str(finding).lower() or "direct write" in str(finding).lower()
+    ]
+    if unknown_client_findings:
+        exposure_risks.append("Ledger contains unknown-client or direct-write findings.")
+
+    critical_audit_failures = [
+        check for check in federation_audit.get("checks", [])
+        if check.get("severity") == "critical" and check.get("status") != "pass"
+    ]
+
+    if critical_audit_failures:
+        exposure_risks.append("Federation audit has critical failures.")
+
+    score = 100
+    score -= 20 * len(unreviewed_allowlists)
+    score -= 15 * len(exposure_risks)
+    score -= 10 * len(critical_audit_failures)
+    boundary_readiness_score = max(0, min(100, score))
+
+    ready = (
+        boundary_readiness_score >= 90
+        and not unreviewed_allowlists
+        and not exposure_risks
+        and hermes.get("role") == "primary_memory_owner"
+        and codex.get("role") == "memory_client"
+        and openclaw.get("role") == "memory_client"
+        and openclaw.get("external_auto_precheck_default") == "blocked"
+        and status.get("policy", {}).get("writes_are_proposal_only") is True
+        and status.get("policy", {}).get("external_channel_auto_recall_requires_allowlist") is True
+    )
+
+    recommended_next_actions = []
+    if ready:
+        recommended_next_actions.append("Mark cross-system boundary allowlists as explicitly reviewed for 星界记忆 readiness.")
+    else:
+        recommended_next_actions.append("Keep external automatic recall blocked and resolve unreviewed allowlists or exposure risks before 星界记忆.")
+    if external_allowed:
+        recommended_next_actions.append("Create a policy proposal for each exact external channel before allowlisting; do not auto-approve.")
+
+    return {
+        "success": True,
+        "audit_type": "hermes_memory_boundary_allowlist_audit",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "ready": ready,
+        "boundary_readiness_score": boundary_readiness_score,
+        "reviewed": ready,
+        "reviewed_allowlists": reviewed_allowlists,
+        "unreviewed_allowlists": unreviewed_allowlists,
+        "external_channel_exposure_risks": exposure_risks,
+        "clients": {
+            "hermes": {
+                "role": hermes.get("role"),
+                "is_primary_memory_owner": hermes.get("role") == "primary_memory_owner",
+            },
+            "codex": {
+                "role": codex.get("role"),
+                "access_path": codex.get("access_path"),
+                "write_policy": codex.get("write_policy"),
+                "ready": codex.get("ready"),
+            },
+            "openclaw": {
+                "role": openclaw.get("role"),
+                "access_path": openclaw.get("access_path"),
+                "plugin_enabled": openclaw.get("plugin_enabled"),
+                "conversation_access_allowed": openclaw.get("conversation_access_allowed"),
+                "auto_precheck_enabled": openclaw.get("auto_precheck_enabled"),
+                "auto_precheck_agent_profiles": agent_profiles,
+                "external_auto_precheck_allowed_channels": external_allowed,
+                "external_auto_precheck_default": openclaw.get("external_auto_precheck_default"),
+                "write_policy": openclaw.get("write_policy"),
+                "ready": openclaw.get("ready"),
+            },
+        },
+        "evidence": {
+            "federation_ready": status.get("ready"),
+            "federation_audit_ready": federation_audit.get("ready"),
+            "policy_outcome_health_score": outcome.get("health_score"),
+            "policy_outcome_risk_level": outcome.get("risk_level"),
+            "ledger_health_score": ledger.get("health_score"),
+            "ledger_risk_level": ledger.get("risk_level"),
+            "critical_audit_failure_count": len(critical_audit_failures),
+            "unreviewed_allowlist_count": len(unreviewed_allowlists),
+            "exposure_risk_count": len(exposure_risks),
+        },
+        "recommended_next_actions": recommended_next_actions,
+        "policy": {
+            "audit_is_read_only": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+            "does_not_write_graph": True,
+            "does_not_approve_allowlists": True,
+            "does_not_enable_external_recall": True,
+            "persistent_changes_must_use_proposals": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+        "would_write_graph": False,
+    }
+
+
+def memory_federation_gate(
+    *,
+    client: str = "codex",
+    operation: str = "search",
+    target_scope: str = "project",
+    channel_id: str = "",
+    log_limit: int = 200,
+) -> dict[str, Any]:
+    """Evaluate a memory operation against the federation governance gate."""
+
+    client = _clean_text(client).lower() or "unknown"
+    operation = _clean_text(operation).lower() or "search"
+    target_scope = _proposal_scope(target_scope)
+    channel_id = _clean_text(channel_id)
+    decision = "allow"
+    reason = "Operation is allowed under read/proposal-only policy."
+    if operation in DURABLE_WRITE_OPERATIONS:
+        decision = "block"
+        reason = "Durable memory writes must be routed through governed proposals."
+    elif operation in {"auto_precheck", "external_auto_recall"} and _is_external_channel(channel_id):
+        decision = "block"
+        reason = "External-channel automatic recall is blocked unless an exact channel is reviewed and allowlisted."
+    elif client not in INTERNAL_MEMORY_CLIENTS:
+        decision = "review"
+        reason = "Unknown memory client requires review."
+    result = {
+        "success": True,
+        "gate_type": "hermes_memory_federation_gate",
+        "decision": decision,
+        "allowed": decision == "allow",
+        "client": client,
+        "operation": operation,
+        "target_scope": target_scope,
+        "channel_id": channel_id,
+        "reason": reason,
+        "policy": {
+            "proposal_only_writes": True,
+            "external_auto_recall_requires_allowlist": True,
+            "gate_is_read_only_for_memory": True,
+        },
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+    _append_operation_event(
+        {
+            "event_type": "gate_decision",
+            "client": client,
+            "operation": operation,
+            "target_scope": target_scope,
+            "channel_id_hash": _text_digest(channel_id) if channel_id else "",
+            "channel_root": channel_id.split(":", 1)[0].lower() if channel_id else "",
+            "decision": decision,
+            "reason": reason,
+            "log_limit": _clamp_int(log_limit, default=200, minimum=20, maximum=2000),
+        }
+    )
+    return result
+
+
+def memory_operation_ledger(
+    *,
+    limit: int = 50,
+    client: str = "",
+    operation: str = "",
+    decision: str = "",
+    event_type: str = "",
+) -> dict[str, Any]:
+    """Read the memory operation audit ledger."""
+
+    limit = _clamp_int(limit, default=50, minimum=1, maximum=500)
+    client = _clean_text(client).lower()
+    operation = _clean_text(operation).lower()
+    decision = _clean_text(decision).lower()
+    event_type = _clean_text(event_type)
+    path = _operation_ledger_path(get_hermes_home())
+    rows = _read_jsonl(path)
+    parse_errors = [row for row in rows if row.get("_parse_error")]
+    filtered = []
+    for row in rows:
+        if row.get("_parse_error"):
+            continue
+        if client and _clean_text(row.get("client")).lower() != client:
+            continue
+        if operation and _clean_text(row.get("operation")).lower() != operation:
+            continue
+        if decision and _clean_text(row.get("decision")).lower() != decision:
+            continue
+        if event_type and _clean_text(row.get("event_type")) != event_type:
+            continue
+        filtered.append(row)
+    filtered.sort(key=lambda row: _clean_text(row.get("created_at")), reverse=True)
+    return {
+        "success": True,
+        "ledger_type": "hermes_memory_operation_ledger",
+        "path": str(path),
+        "exists": path.exists(),
+        "total_events": len([row for row in rows if not row.get("_parse_error")]),
+        "matched_events": len(filtered),
+        "returned_events": len(filtered[:limit]),
+        "events": filtered[:limit],
+        "parse_error_count": len(parse_errors),
+        "parse_errors": parse_errors[:5],
+        "policy": {"ledger_is_read_only": True, "does_not_write_memory": True},
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def memory_ledger_intelligence(
+    *,
+    limit: int = 500,
+    client: str = "",
+    operation: str = "",
+) -> dict[str, Any]:
+    """Analyze memory operation ledger patterns and risks."""
+
+    ledger = memory_operation_ledger(limit=limit, client=client, operation=operation)
+    events = ledger.get("events", []) if isinstance(ledger.get("events"), list) else []
+    findings = _ledger_findings(events, ledger.get("parse_errors", []))
+    health_score = _health_score(findings)
+    return {
+        "success": True,
+        "intelligence_type": "hermes_memory_ledger_intelligence",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "analyzed_events": len(events),
+        "health_score": health_score,
+        "risk_level": "high" if health_score < 70 else "medium" if health_score < 90 else "low",
+        "findings": findings,
+        "recommended_next_actions": _recommended_actions(findings),
+        "policy": {
+            "intelligence_is_read_only": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_policy_autotune(
+    *,
+    limit: int = 500,
+    client: str = "",
+    operation: str = "",
+    mode: str = "conservative",
+) -> dict[str, Any]:
+    """Generate read-only memory policy tuning suggestions."""
+
+    intelligence = memory_ledger_intelligence(limit=limit, client=client, operation=operation)
+    suggestions = _policy_suggestions_from_findings(intelligence.get("findings", []), mode=mode)
+    if mode == "diagnostic" and not any(s["id"] == "diagnostic.rerun_full_audit" for s in suggestions):
+        suggestions.append(
+            _policy_suggestion(
+                "diagnostic.rerun_full_audit",
+                "low",
+                "diagnostic",
+                "memory_federation_audit",
+                "Run memory_federation_audit before applying any policy change.",
+                "Policy tuning should stay aligned with live federation health.",
+                {
+                    "intelligence_health_score": intelligence.get("health_score"),
+                    "intelligence_risk_level": intelligence.get("risk_level"),
+                },
+                "Fix critical federation audit findings before changing recall or write policy.",
+            )
+        )
+    return {
+        "success": True,
+        "autotune_type": "hermes_memory_policy_autotune",
+        "mode": mode if mode in {"conservative", "diagnostic"} else "conservative",
+        "decision": "review_required" if suggestions else "no_change",
+        "suggestion_count": len(suggestions),
+        "suggestions": suggestions,
+        "summary": {
+            "requires_review_count": len([s for s in suggestions if s.get("requires_human_review")]),
+            "auto_apply_count": 0,
+        },
+        "intelligence_summary": {
+            "health_score": intelligence.get("health_score"),
+            "risk_level": intelligence.get("risk_level"),
+            "analyzed_events": intelligence.get("analyzed_events"),
+            "finding_ids": [f.get("id") for f in intelligence.get("findings", []) if isinstance(f, dict)],
+        },
+        "policy": {
+            "autotune_is_read_only": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+            "suggestions_require_human_review": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_policy_proposal_create(
+    *,
+    source_agent: str = "codex",
+    limit: int = 500,
+    client: str = "",
+    operation: str = "",
+    mode: str = "conservative",
+    suggestion_id: str = "",
+) -> dict[str, Any]:
+    """Create governed policy proposals from current policy-autotune suggestions."""
+
+    source_agent = _clean_text(source_agent).lower() or "unknown"
+    suggestion_id = _clean_text(suggestion_id)
+    autotune = memory_policy_autotune(limit=limit, client=client, operation=operation, mode=mode)
+    suggestions = [
+        suggestion
+        for suggestion in autotune.get("suggestions", [])
+        if isinstance(suggestion, dict)
+        and _clean_text(suggestion.get("id")) != "policy.no_change"
+        and (not suggestion_id or _clean_text(suggestion.get("id")) == suggestion_id)
+    ]
+    existing = _policy_proposal_states()
+    created: list[dict[str, Any]] = []
+    skipped_duplicates: list[dict[str, Any]] = []
+    for suggestion in suggestions:
+        proposal = _policy_proposal_from_suggestion(suggestion, source_agent=source_agent, autotune=autotune)
+        current = existing.get(proposal["proposal_id"])
+        if current and current.get("latest_status") == "proposed":
+            skipped_duplicates.append(
+                {
+                    "proposal_id": proposal["proposal_id"],
+                    "suggestion_id": proposal["suggestion_id"],
+                    "latest_status": current.get("latest_status"),
+                }
+            )
+            continue
+        event = _append_policy_proposal_event({"event_type": "policy_proposal_created", **proposal})
+        created.append({**proposal, "ledger_event": event})
+    return {
+        "success": True,
+        "proposal_type": "hermes_memory_policy_proposal_create",
+        "created_count": len(created),
+        "skipped_duplicate_count": len(skipped_duplicates),
+        "proposals": created,
+        "skipped_duplicates": skipped_duplicates,
+        "autotune_summary": {
+            "decision": autotune.get("decision"),
+            "suggestion_count": autotune.get("suggestion_count"),
+            "intelligence_summary": autotune.get("intelligence_summary", {}),
+        },
+        "policy": {
+            "proposal_only": True,
+            "does_not_apply_policy": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+        },
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_policy_proposal_ledger(
+    *,
+    limit: int = 50,
+    status: str = "",
+    proposal_id: str = "",
+) -> dict[str, Any]:
+    """Read synthesized memory policy proposal state from the proposal ledger."""
+
+    limit = _clamp_int(limit, default=50, minimum=1, maximum=500)
+    status = _policy_status(status, allow_empty=True)
+    proposal_id = _clean_text(proposal_id)
+    path = _policy_proposal_path(get_hermes_home())
+    rows = _read_jsonl(path)
+    parse_errors = [row for row in rows if row.get("_parse_error")]
+    proposals = list(_policy_proposal_states(rows).values())
+    filtered = []
+    for proposal in proposals:
+        if proposal_id and proposal.get("proposal_id") != proposal_id:
+            continue
+        if status and proposal.get("latest_status") != status:
+            continue
+        filtered.append(proposal)
+    filtered.sort(key=lambda row: _clean_text(row.get("updated_at")), reverse=True)
+    return {
+        "success": True,
+        "ledger_type": "hermes_memory_policy_proposal_ledger",
+        "path": str(path),
+        "exists": path.exists(),
+        "total_proposals": len(proposals),
+        "matched_proposals": len(filtered),
+        "returned_proposals": len(filtered[:limit]),
+        "proposals": filtered[:limit],
+        "summary": _policy_proposal_summary(proposals),
+        "parse_error_count": len(parse_errors),
+        "parse_errors": parse_errors[:5],
+        "policy": {
+            "ledger_is_append_only": True,
+            "does_not_apply_policy": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_policy_proposal_decision(
+    *,
+    proposal_id: str,
+    decision: str,
+    reviewer: str = "codex",
+    rationale: str = "",
+) -> dict[str, Any]:
+    """Append an approval/rejection/defer decision for a policy proposal."""
+
+    proposal_id = _clean_text(proposal_id)
+    decision = _policy_decision(decision)
+    states = _policy_proposal_states()
+    if proposal_id not in states:
+        return _error("policy proposal was not found.", proposal_id=proposal_id)
+    event = _append_policy_proposal_event(
+        {
+            "event_type": "policy_proposal_decision",
+            "proposal_id": proposal_id,
+            "decision": decision,
+            "reviewer": _clean_text(reviewer) or "unknown",
+            "rationale": _clean_text(rationale),
+            "does_not_apply_policy": True,
+            "would_modify_config": False,
+            "would_write_memory": False,
+        }
+    )
+    updated = _policy_proposal_states().get(proposal_id, states[proposal_id])
+    return {
+        "success": True,
+        "proposal_id": proposal_id,
+        "decision": decision,
+        "proposal": updated,
+        "ledger_event": event,
+        "policy": {
+            "decision_is_record_only": True,
+            "does_not_apply_policy": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+        },
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_policy_apply_plan(
+    *,
+    limit: int = 50,
+    status: str = "approved",
+    proposal_id: str = "",
+) -> dict[str, Any]:
+    """Build a dry-run policy application plan from policy proposals."""
+
+    limit = _clamp_int(limit, default=50, minimum=1, maximum=500)
+    status = _policy_status(status, allow_empty=True) or "approved"
+    proposal_id = _clean_text(proposal_id)
+    ledger = memory_policy_proposal_ledger(limit=limit, status=status, proposal_id=proposal_id)
+    proposals = ledger.get("proposals", []) if isinstance(ledger.get("proposals"), list) else []
+    plans = [_policy_apply_plan_for_proposal(proposal) for proposal in proposals]
+    patch_count = sum(len(plan.get("patches", [])) for plan in plans)
+    eligible_count = sum(1 for plan in plans if plan.get("eligible_for_apply"))
+    return {
+        "success": True,
+        "plan_type": "hermes_memory_policy_apply_plan",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dry_run": True,
+        "status_filter": status,
+        "proposal_id_filter": proposal_id,
+        "proposal_count": len(proposals),
+        "eligible_count": eligible_count,
+        "patch_count": patch_count,
+        "plans": plans,
+        "summary": {"by_action": _policy_apply_plan_summary(plans, "action")},
+        "policy": {
+            "plan_is_dry_run": True,
+            "does_not_apply_policy": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_policy_apply_execute(
+    *,
+    limit: int = 50,
+    proposal_id: str = "",
+    execute: bool = False,
+    confirm_token: str = "",
+    actor: str = "codex",
+) -> dict[str, Any]:
+    """Guarded executor for approved policy plans.
+
+    Only non-mutating verification/check actions are executed. Config-mutating
+    or memory-mutating patches are refused.
+    """
+
+    plan = memory_policy_apply_plan(limit=limit, status="approved", proposal_id=proposal_id)
+    guard = _policy_apply_guard(plan, execute=execute, confirm_token=confirm_token)
+    if not _coerce_bool(execute):
+        return {
+            "success": True,
+            "executor_type": "hermes_memory_policy_apply_execute",
+            "dry_run": True,
+            "did_execute": False,
+            "plan": plan,
+            "guard": guard,
+            "results": [],
+            "policy": {
+                "execute_defaults_to_false": True,
+                "requires_confirm_token": True,
+                "does_not_modify_config": True,
+                "does_not_write_memory": True,
+            },
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+            "would_modify_config": False,
+        }
+    if not guard["allowed"]:
+        return {
+            "success": False,
+            "executor_type": "hermes_memory_policy_apply_execute",
+            "dry_run": False,
+            "did_execute": False,
+            "error": guard["reason"],
+            "plan": plan,
+            "guard": guard,
+            "results": [],
+            "policy": {"blocked_before_execution": True},
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+            "would_modify_config": False,
+        }
+    results = [_policy_patch_result(patch, proposal_id=item.get("proposal_id", "")) for item in plan.get("plans", []) for patch in item.get("patches", [])]
+    summary = _policy_apply_execute_summary(results)
+    event = _append_policy_proposal_event(
+        {
+            "event_type": "policy_apply_execute",
+            "proposal_id": _clean_text(proposal_id),
+            "actor": _clean_text(actor) or "unknown",
+            "plan_summary": {
+                "proposal_count": plan.get("proposal_count"),
+                "eligible_count": plan.get("eligible_count"),
+                "patch_count": plan.get("patch_count"),
+            },
+            "result_summary": summary,
+            "does_not_apply_config_changes": True,
+            "would_modify_config": False,
+            "would_write_memory": False,
+        }
+    )
+    return {
+        "success": summary["blocked_count"] == 0 and summary["failed_count"] == 0,
+        "executor_type": "hermes_memory_policy_apply_execute",
+        "dry_run": False,
+        "did_execute": True,
+        "plan": plan,
+        "guard": guard,
+        "results": results,
+        "summary": summary,
+        "ledger_event": event,
+        "policy": {
+            "executed_actions_are_non_mutating": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+            "writes_execution_audit_event_only": True,
+        },
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_policy_outcome_monitor(
+    *,
+    limit: int = 100,
+    stale_after_hours: int = 72,
+) -> dict[str, Any]:
+    """Monitor policy proposal lifecycle outcomes without applying policy."""
+
+    limit = _clamp_int(limit, default=100, minimum=1, maximum=500)
+    stale_after_hours = _clamp_int(stale_after_hours, default=72, minimum=1, maximum=8760)
+    path = _policy_proposal_path(get_hermes_home())
+    rows = _read_jsonl(path)
+    parse_errors = [row for row in rows if row.get("_parse_error")]
+    proposals = list(_policy_proposal_states(rows).values())
+    metrics = _policy_outcome_metrics(proposals, rows, stale_after_hours=stale_after_hours)
+    findings = _policy_outcome_findings(metrics, parse_errors)
+    health_score = _health_score(findings)
+    proposals.sort(key=lambda row: _clean_text(row.get("updated_at")), reverse=True)
+    executions = metrics.get("recent_execution_events", [])
+    return {
+        "success": True,
+        "monitor_type": "hermes_memory_policy_outcome_monitor",
+        "path": str(path),
+        "exists": path.exists(),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "health_score": health_score,
+        "risk_level": "high" if health_score < 70 else "medium" if health_score < 90 else "low",
+        "stale_after_hours": stale_after_hours,
+        "analyzed_events": len([row for row in rows if not row.get("_parse_error")]),
+        "parse_error_count": len(parse_errors),
+        "parse_errors": parse_errors[:5],
+        "metrics": metrics,
+        "findings": findings,
+        "recommended_next_actions": _recommended_actions(findings),
+        "recent_proposals": proposals[:limit],
+        "recent_execution_events": executions[:limit] if isinstance(executions, list) else [],
+        "policy": {
+            "monitor_is_read_only": True,
+            "does_not_apply_policy": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def memory_recall_quality_evaluate(
+    *,
+    queries: Iterable[str] | str | None = None,
+    scope: str = "all",
+    limit: int = 5,
+) -> dict[str, Any]:
+    """Evaluate recall quality across memory surfaces without writing memory."""
+
+    scope = _scope(scope)
+    limit = _clamp_int(limit, default=5, minimum=1, maximum=20)
+    benchmark_queries = _recall_quality_queries(queries)
+    home = get_hermes_home()
+    evaluations = [
+        _evaluate_recall_query(home, query, scope=scope, limit=limit)
+        for query in benchmark_queries
+    ]
+    summary = _recall_quality_summary(evaluations)
+    findings = _recall_quality_findings(evaluations, summary)
+    quality_score = round(float(summary.get("average_quality_score", 0.0)), 3)
+    readiness = (
+        "ready"
+        if quality_score >= 0.55
+        and _safe_int(summary.get("passed_query_count")) >= max(1, len(evaluations) // 2)
+        else "needs_attention"
+    )
+    return {
+        "success": True,
+        "evaluation_type": "hermes_memory_recall_quality_evaluate",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope": scope,
+        "limit": limit,
+        "quality_score": quality_score,
+        "readiness": readiness,
+        "summary": summary,
+        "queries": evaluations,
+        "findings": findings,
+        "recommended_next_actions": _recommended_actions(findings),
+        "policy": {
+            "evaluation_is_read_only": True,
+            "does_not_append_ledger_events": True,
+            "does_not_modify_config": True,
+            "does_not_write_memory": True,
+            "does_not_write_graph": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+    }
+
+
+def search_memory_fabric(query: str, *, scope: str = "all", limit: int = 8) -> dict[str, Any]:
+    """Search Memory Graph, prompt cases, knowledge files, and legacy memory."""
+
+    query = _clean_text(query)
+    scope = _scope(scope)
+    limit = _clamp_int(limit, default=8, minimum=1, maximum=50)
+    if not query:
+        return _error("query is required.", query=query, scope=scope)
+    home = get_hermes_home()
+    results: list[dict[str, Any]] = []
+    if scope in {"all", "graph"}:
+        results.extend(_search_graph(home, query, limit=limit))
+    if scope in {"all", "prompt_cases"}:
+        results.extend(_search_prompt_cases(home, query, limit=limit))
+    if scope in {"all", "knowledge"}:
+        results.extend(_search_knowledge(home, query, limit=limit))
+    if scope in {"all", "legacy_memory"}:
+        results.extend(_search_legacy_memory(home, query, limit=limit))
+    results.sort(key=lambda item: float(item.get("score", 0)), reverse=True)
+    limited = results[:limit]
+    ledger = _append_operation_event(
+        {
+            "event_type": "search",
+            "client": "unknown",
+            "operation": "search",
+            "query_hash": _text_digest(query),
+            "scope": scope,
+            "result_count": len(limited),
+        }
+    )
+    return {
+        "success": True,
+        "query": query,
+        "scope": scope,
+        "count": len(limited),
+        "results": limited,
+        "operation_ledger": ledger,
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def read_memory_graph(
+    *,
+    node_id: str = "",
+    query: str = "",
+    kind: str = "",
+    limit: int = 10,
+    include_edges: bool = True,
+) -> dict[str, Any]:
+    """Read Memory Graph nodes with provenance and optional edges."""
+
+    home = get_hermes_home()
+    graph_path = _graph_path(home)
+    limit = _clamp_int(limit, default=10, minimum=1, maximum=100)
+    node_id = _clean_text(node_id)
+    query = _clean_text(query)
+    kind = _clean_text(kind)
+    if not graph_path.exists():
+        return _error("Memory Graph database does not exist.", path=str(graph_path))
+    nodes: list[dict[str, Any]] = []
+    try:
+        with sqlite3.connect(graph_path) as conn:
+            conn.row_factory = sqlite3.Row
+            if node_id:
+                rows = conn.execute("SELECT * FROM graph_nodes WHERE id = ?", (node_id,)).fetchall()
+            elif query:
+                like = f"%{query}%"
+                if kind:
+                    rows = conn.execute(
+                        "SELECT * FROM graph_nodes WHERE kind = ? AND (title LIKE ? OR summary LIKE ?) LIMIT ?",
+                        (kind, like, like, limit),
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT * FROM graph_nodes WHERE title LIKE ? OR summary LIKE ? LIMIT ?",
+                        (like, like, limit),
+                    ).fetchall()
+            elif kind:
+                rows = conn.execute("SELECT * FROM graph_nodes WHERE kind = ? LIMIT ?", (kind, limit)).fetchall()
+            else:
+                rows = conn.execute("SELECT * FROM graph_nodes ORDER BY updated_at DESC LIMIT ?", (limit,)).fetchall()
+            for row in rows:
+                node = _row_to_dict(row)
+                node["metadata"] = _loads_json(node.pop("metadata_json", "{}"), {})
+                node["provenance"] = [
+                    _row_to_dict(prov)
+                    for prov in conn.execute(
+                        "SELECT * FROM graph_provenance WHERE node_id = ?",
+                        (node["id"],),
+                    ).fetchall()
+                ]
+                if include_edges:
+                    node["edges"] = [
+                        _row_to_dict(edge)
+                        for edge in conn.execute(
+                            "SELECT * FROM graph_edges WHERE source_id = ? OR target_id = ? LIMIT 50",
+                            (node["id"], node["id"]),
+                        ).fetchall()
+                    ]
+                nodes.append(node)
+    except sqlite3.Error as exc:
+        return _error("failed to read Memory Graph.", error=str(exc), path=str(graph_path))
+    ledger = _append_operation_event(
+        {
+            "event_type": "graph_read",
+            "client": "unknown",
+            "operation": "graph_read",
+            "node_id_hash": _text_digest(node_id) if node_id else "",
+            "query_hash": _text_digest(query) if query else "",
+            "kind": kind,
+            "result_count": len(nodes),
+        }
+    )
+    return {
+        "success": True,
+        "graph_type": "hermes_memory_graph_read",
+        "path": str(graph_path),
+        "count": len(nodes),
+        "nodes": nodes,
+        "operation_ledger": ledger,
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def create_memory_write_proposal(
+    *,
+    source_agent: str,
+    target_scope: str,
+    content: str,
+    rationale: str = "",
+    project: str = "",
+    tags: Iterable[str] | str | None = None,
+) -> dict[str, Any]:
+    """Create a governed write proposal instead of mutating durable memory."""
+
+    content = _clean_text(content)
+    if not content:
+        return _error("content is required.")
+    proposal = {
+        "proposal_id": f"memory-write-proposal-{_text_digest(content + rationale)[:16]}",
+        "source_agent": _clean_text(source_agent) or "unknown",
+        "target_scope": _proposal_scope(target_scope),
+        "content": content,
+        "rationale": _clean_text(rationale),
+        "project": _clean_text(project),
+        "tags": _list_of_str(tags),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "proposed",
+        "would_write_memory": False,
+        "would_modify_graph": False,
+    }
+    path = _proposal_path(get_hermes_home())
+    event = _append_jsonl(path, proposal)
+    _append_operation_event(
+        {
+            "event_type": "write_proposal_created",
+            "client": proposal["source_agent"],
+            "operation": "write_proposal",
+            "target_scope": proposal["target_scope"],
+            "proposal_id": proposal["proposal_id"],
+            "content_hash": _text_digest(content),
+        }
+    )
+    return {
+        "success": event.get("success", False),
+        "proposal": proposal,
+        "ledger_event": event,
+        "policy": {
+            "proposal_only": True,
+            "does_not_write_memory": True,
+            "does_not_modify_graph": True,
+        },
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def export_memory_snapshot(*, scope: str = "all", limit: int = 500) -> dict[str, Any]:
+    """Export a portable read-only snapshot summary for backup/cache use."""
+
+    scope = _scope(scope)
+    limit = _clamp_int(limit, default=500, minimum=1, maximum=5000)
+    snapshot = {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "scope": scope,
+        "limit": limit,
+        "bridge_status": memory_bridge_status(),
+        "evolution_status": memory_evolution_status(),
+    }
+    _append_operation_event(
+        {
+            "event_type": "snapshot_export_created",
+            "client": "unknown",
+            "operation": "snapshot_export",
+            "scope": scope,
+            "limit": limit,
+        }
+    )
+    return {
+        "success": True,
+        "snapshot_type": "hermes_memory_snapshot",
+        "snapshot": snapshot,
+        "policy": {
+            "snapshot_is_cache_or_backup_only": True,
+            "does_not_clone_as_primary": True,
+            "does_not_write_memory": True,
+        },
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def memory_policy_stale_resolution_preview(*, limit: int = 50) -> dict[str, Any]:
+    """Preview stale policy proposal resolution options without deciding."""
+
+    outcome = memory_policy_outcome_monitor(limit=limit, stale_after_hours=72)
+    stale = outcome.get("metrics", {}).get("stale_proposed", [])
+    return {
+        "success": True,
+        "preview_type": "memory_policy_stale_resolution_preview",
+        "stale_proposals": stale,
+        "recommendations": [
+            {
+                "proposal_id": item.get("proposal_id"),
+                "suggestion_id": item.get("suggestion_id"),
+                "recommended_decision": "deferred" if item.get("suggestion_id") == "diagnostic.rerun_full_audit" else "approved_for_non_mutating_check",
+                "reason": "Preview only; human must record an explicit decision.",
+            }
+            for item in stale
+            if isinstance(item, dict)
+        ],
+        "policy": {"preview_is_read_only": True, "does_not_record_decisions": True},
+        "read_only": True,
+        "read_only_memory": True,
+        "would_modify_config": False,
+        "would_mutate_memory": False,
+    }
+
+
+def memory_policy_stale_closure_payload_preview(*, limit: int = 50) -> dict[str, Any]:
+    """Preview payloads that a human could use to close stale proposals."""
+
+    preview = memory_policy_stale_resolution_preview(limit=limit)
+    return {
+        "success": True,
+        "preview_type": "memory_policy_stale_closure_payload_preview",
+        "payloads": [
+            {
+                "proposal_id": item.get("proposal_id"),
+                "decision": "deferred",
+                "rationale": "Stale proposal requires fresh audit before closure.",
+            }
+            for item in preview.get("stale_proposals", [])
+            if isinstance(item, dict)
+        ],
+        "policy": {"preview_is_read_only": True, "does_not_record_decisions": True},
+        "read_only": True,
+        "read_only_memory": True,
+        "would_modify_config": False,
+        "would_mutate_memory": False,
+    }
+
+
+def memory_policy_stale_closure_execute_plan(*, limit: int = 50) -> dict[str, Any]:
+    """Build a dry-run plan for closing stale policy proposals."""
+
+    payloads = memory_policy_stale_closure_payload_preview(limit=limit)
+    return {
+        "success": True,
+        "plan_type": "memory_policy_stale_closure_execute_plan",
+        "dry_run": True,
+        "steps": payloads.get("payloads", []),
+        "policy": {"plan_is_dry_run": True, "does_not_record_decisions": True},
+        "read_only": True,
+        "read_only_memory": True,
+        "would_modify_config": False,
+        "would_mutate_memory": False,
+    }
+
+
+def memory_policy_stale_closure_handoff_bundle(*, limit: int = 50) -> dict[str, Any]:
+    """Bundle stale policy context for human/Codex handoff."""
+
+    return {
+        "success": True,
+        "bundle_type": "memory_policy_stale_closure_handoff_bundle",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "outcome": memory_policy_outcome_monitor(limit=limit, stale_after_hours=72),
+        "resolution_preview": memory_policy_stale_resolution_preview(limit=limit),
+        "execute_plan": memory_policy_stale_closure_execute_plan(limit=limit),
+        "policy": {"bundle_is_read_only": True, "does_not_record_decisions": True},
+        "read_only": True,
+        "read_only_memory": True,
+        "would_modify_config": False,
+        "would_mutate_memory": False,
+    }
+
+
+memory_fabric_search = search_memory_fabric
+memory_graph_read = read_memory_graph
+memory_write_proposal = create_memory_write_proposal
+memory_snapshot_export = export_memory_snapshot
+
+
+def _memory_evolution_evidence(
+    bridge: Mapping[str, Any],
+    federation: Mapping[str, Any],
+    outcome: Mapping[str, Any],
+    recall_quality: Mapping[str, Any],
+) -> dict[str, Any]:
+    surfaces = bridge.get("surfaces", {}) if isinstance(bridge.get("surfaces"), dict) else {}
+    graph = surfaces.get("graph", {}) if isinstance(surfaces.get("graph"), dict) else {}
+    prompt_cases = surfaces.get("gpt_image_prompt_cases", {}) if isinstance(surfaces.get("gpt_image_prompt_cases"), dict) else {}
+    knowledge = surfaces.get("knowledge", {}) if isinstance(surfaces.get("knowledge"), dict) else {}
+    operation = surfaces.get("operation_ledger", {}) if isinstance(surfaces.get("operation_ledger"), dict) else {}
+    policy = surfaces.get("policy_proposals", {}) if isinstance(surfaces.get("policy_proposals"), dict) else {}
+    clients = federation.get("clients", {}) if isinstance(federation.get("clients"), dict) else {}
+    openclaw = clients.get("openclaw", {}) if isinstance(clients.get("openclaw"), dict) else {}
+    codex = clients.get("codex", {}) if isinstance(clients.get("codex"), dict) else {}
+    return {
+        "has_basic_memory_home": bool(bridge.get("hermes_home")),
+        "has_graph": bool(graph.get("exists")) and _safe_int(graph.get("node_count")) > 0,
+        "graph_node_count": _safe_int(graph.get("node_count")),
+        "graph_edge_count": _safe_int(graph.get("edge_count")),
+        "graph_provenance_count": _safe_int(graph.get("provenance_count")),
+        "has_knowledge": bool(knowledge.get("exists")) and _safe_int(knowledge.get("file_count")) > 0,
+        "knowledge_file_count": _safe_int(knowledge.get("file_count")),
+        "has_prompt_cases": bool(prompt_cases.get("exists")) and _safe_int(prompt_cases.get("case_count")) > 0,
+        "prompt_case_count": _safe_int(prompt_cases.get("case_count")),
+        "operation_ledger_events": _safe_int(operation.get("event_count")),
+        "policy_proposal_events": _safe_int(policy.get("event_count")),
+        "federation_ready": federation.get("ready") is True,
+        "codex_ready": codex.get("ready") is True,
+        "openclaw_ready": openclaw.get("ready") is True,
+        "openclaw_agent_profiles": openclaw.get("auto_precheck_agent_profiles", []),
+        "openclaw_auto_precheck_enabled": openclaw.get("auto_precheck_enabled") is True,
+        "recall_quality_evaluation_ready": recall_quality.get("readiness") == "ready",
+        "recall_quality_score": recall_quality.get("quality_score"),
+        "recall_quality_passed_query_count": recall_quality.get("summary", {}).get("passed_query_count", 0)
+        if isinstance(recall_quality.get("summary"), dict)
+        else 0,
+        "policy_outcome_health_score": outcome.get("health_score"),
+        "stale_policy_proposal_count": outcome.get("metrics", {}).get("stale_proposed_count", 0)
+        if isinstance(outcome.get("metrics"), dict)
+        else 0,
+    }
+
+
+def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dict[str, Any]:
+    level = _safe_int(tier.get("level"))
+    criteria: list[tuple[str, bool]] = []
+    if level >= 1:
+        criteria.append(("Hermes memory home is visible", bool(evidence.get("has_basic_memory_home"))))
+    if level >= 2:
+        criteria.append(("Knowledge or legacy memory exists", bool(evidence.get("has_knowledge"))))
+    if level >= 3:
+        criteria.append(("Memory graph has edges", _safe_int(evidence.get("graph_edge_count")) > 0))
+    if level >= 4:
+        criteria.append(("Memory graph has provenance", _safe_int(evidence.get("graph_provenance_count")) > 0))
+    if level >= 5:
+        criteria.append(("Knowledge and graph surfaces are both present", bool(evidence.get("has_knowledge")) and bool(evidence.get("has_graph"))))
+    if level >= 6:
+        criteria.append(("Prompt/case memory is indexed", bool(evidence.get("has_prompt_cases"))))
+    if level >= 7:
+        criteria.append(("OpenClaw has agent/domain profiles", bool(evidence.get("openclaw_agent_profiles"))))
+    if level >= 8:
+        criteria.append(("Codex/OpenClaw/Hermes federation is ready", bool(evidence.get("federation_ready"))))
+        criteria.append(("Operation ledger or policy ledger exists", _safe_int(evidence.get("operation_ledger_events")) > 0 or _safe_int(evidence.get("policy_proposal_events")) > 0))
+    if level >= 9:
+        criteria.append(("Recall quality evaluation loop is enabled", bool(evidence.get("recall_quality_evaluation_ready"))))
+        criteria.append(("Stale policy backlog is drained", _safe_int(evidence.get("stale_policy_proposal_count")) == 0))
+    if level >= 10:
+        criteria.append(("Cross-system boundary allowlists are explicitly reviewed", bool(evidence.get("boundary_allowlists_reviewed"))))
+    if level >= 11:
+        criteria.append(("Memory orchestration has active routing metrics", False))
+    if level >= 12:
+        criteria.append(("Policy proposals close automatically after human approval and guarded checks", False))
+    if level >= 13:
+        criteria.append(("Long-term preference/persona continuity is governed", False))
+    if level >= 14:
+        criteria.append(("Temporal evolution metrics exist across projects", False))
+    if level >= 15:
+        criteria.append(("Source reasoning and methodology self-evolution are implemented", False))
+    passed = [name for name, ok in criteria if ok]
+    gaps = [name for name, ok in criteria if not ok]
+    readiness_score = round(len(passed) / len(criteria), 3) if criteria else 0.0
+    return {
+        "level": level,
+        "id": tier.get("id"),
+        "name": tier.get("name"),
+        "one_line": tier.get("one_line"),
+        "achieved": not gaps,
+        "readiness_score": readiness_score,
+        "passed_criteria": passed,
+        "gaps": gaps,
+    }
+
+
+def _memory_evolution_next_actions(
+    current: Mapping[str, Any],
+    next_item: Mapping[str, Any] | None,
+    outcome: Mapping[str, Any],
+) -> list[str]:
+    actions = []
+    if outcome.get("metrics", {}).get("stale_proposed_count") if isinstance(outcome.get("metrics"), dict) else 0:
+        actions.append("Resolve stale policy proposals through review/proposal workflow before claiming 星海记忆.")
+    if next_item and next_item.get("name") == "星海记忆":
+        actions.append("Use memory_recall_quality_evaluate to monitor graph, knowledge, prompt cases, and legacy recall quality.")
+        actions.append("Keep external-channel automatic recall blocked until exact allowlists are reviewed.")
+    if not actions:
+        actions.append("Continue with the next read-only governance/readiness capability before any durable write.")
+    return actions[:5]
+
+
+def _graph_path(home: Path) -> Path:
+    return home / "memory" / "graph" / "memory_graph.sqlite"
+
+
+def _prompt_index_path(home: Path) -> Path:
+    return home / "knowledge" / "gpt-image-prompts" / "index.sqlite"
+
+
+def _proposal_path(home: Path) -> Path:
+    return home / "memory" / "proposals" / "memory_write_proposals.jsonl"
+
+
+def _operation_ledger_path(home: Path) -> Path:
+    return home / "memory" / "audit" / "memory_operation_ledger.jsonl"
+
+
+def _policy_proposal_path(home: Path) -> Path:
+    return home / "memory" / "policy" / "memory_policy_proposals.jsonl"
+
+
+def _codex_memory_client_status() -> dict[str, Any]:
+    config_path = Path.home() / ".codex" / "config.toml"
+    guidance_path = Path.home() / ".codex" / "AGENTS.md"
+    config_text = _safe_read_text(config_path)
+    guidance_text = _safe_read_text(guidance_path)
+    return {
+        "role": "memory_client",
+        "access_path": "codex_mcp",
+        "config_path": str(config_path),
+        "config_exists": config_path.exists(),
+        "mcp_server_configured": "hermes-memory" in config_text,
+        "invokes_hermes_mcp": "hermes" in config_text and "mcp" in config_text,
+        "guidance_path": str(guidance_path),
+        "guidance_exists": guidance_path.exists(),
+        "guidance_mentions_hermes_memory": "Hermes Memory" in guidance_text or "memory_fabric" in guidance_text,
+        "write_policy": "proposal_only",
+        "ready": config_path.exists() and "hermes-memory" in config_text,
+    }
+
+
+def _openclaw_memory_client_status() -> dict[str, Any]:
+    config_path = Path.home() / ".openclaw" / "openclaw.json"
+    extension_path = Path.home() / ".openclaw" / "extensions" / "hermes-memory" / "index.ts"
+    manifest_path = Path.home() / ".openclaw" / "extensions" / "hermes-memory" / "openclaw.plugin.json"
+    config = _loads_json(_safe_read_text(config_path), {})
+    entries = config.get("plugins", {}).get("entries", {}) if isinstance(config, dict) else {}
+    entry = entries.get("hermes-memory", {}) if isinstance(entries, dict) else {}
+    plugin_config = entry.get("config", {}) if isinstance(entry, dict) else {}
+    profiles = plugin_config.get("autoPrecheckAgentProfiles", {}) if isinstance(plugin_config, dict) else {}
+    allowed_channels = plugin_config.get("autoPrecheckAllowedChannelIds", []) if isinstance(plugin_config, dict) else []
+    return {
+        "role": "memory_client",
+        "access_path": "openclaw_plugin",
+        "config_path": str(config_path),
+        "config_exists": config_path.exists(),
+        "extension_path": str(extension_path),
+        "extension_exists": extension_path.exists(),
+        "manifest_path": str(manifest_path),
+        "manifest_exists": manifest_path.exists(),
+        "plugin_enabled": bool(entry.get("enabled")) if isinstance(entry, dict) else False,
+        "conversation_access_allowed": bool(entry.get("hooks", {}).get("allowConversationAccess")) if isinstance(entry, dict) and isinstance(entry.get("hooks"), dict) else False,
+        "auto_precheck_enabled": bool(plugin_config.get("autoPrecheckEnabled")) if isinstance(plugin_config, dict) else False,
+        "auto_precheck_agent_profiles": sorted(profiles.keys()) if isinstance(profiles, dict) else [],
+        "external_auto_precheck_allowed_channels": allowed_channels if isinstance(allowed_channels, list) else [],
+        "external_auto_precheck_default": "blocked",
+        "write_policy": "proposal_only",
+        "ready": config_path.exists() and extension_path.exists() and bool(entry.get("enabled")) if isinstance(entry, dict) else False,
+    }
+
+
+def _federation_warnings(clients: Mapping[str, Any]) -> list[str]:
+    warnings = []
+    for name in ("codex", "openclaw"):
+        client = clients.get(name, {})
+        if isinstance(client, dict) and not client.get("ready"):
+            warnings.append(f"{name} memory client is not fully configured.")
+    return warnings
+
+
+def _audit_check(check_id: str, passed: bool, severity: str, message: str) -> dict[str, Any]:
+    return {"id": check_id, "status": "pass" if passed else "fail", "severity": severity, "message": message}
+
+
+def _ledger_findings(events: Iterable[Mapping[str, Any]], parse_errors: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    events = list(events)
+    parse_errors = list(parse_errors)
+    findings: list[dict[str, Any]] = []
+    blocked_external = [event for event in events if event.get("operation") in {"auto_precheck", "external_auto_recall"} and event.get("decision") == "block"]
+    direct_writes = [event for event in events if event.get("operation") in DURABLE_WRITE_OPERATIONS]
+    if parse_errors:
+        findings.append(_finding("ledger.parse_errors", "warning", "ledger", "Operation ledger has malformed rows.", {"parse_error_count": len(parse_errors)}, "Repair or quarantine malformed ledger lines."))
+    if blocked_external:
+        findings.append(_finding("policy.external_auto_recall_blocked", "warning", "federation_gate", "External-channel automatic recall was blocked.", {"blocked_count": len(blocked_external)}, "Keep external recall blocked unless exact channels are reviewed."))
+    if direct_writes:
+        findings.append(_finding("policy.direct_write_attempts", "critical", "write_policy", "Direct durable write operations were attempted.", {"count": len(direct_writes)}, "Route durable writes through memory_write_proposal."))
+    if not findings:
+        findings.append(_finding("ledger.healthy", "info", "ledger", "No notable memory operation risks were detected.", {"total": len(events)}, ""))
+    return findings
+
+
+def _finding(finding_id: str, severity: str, subject: str, message: str, evidence: Any, recommendation: str) -> dict[str, Any]:
+    return {"id": finding_id, "severity": severity, "subject": subject, "message": message, "evidence": evidence, "recommendation": recommendation}
+
+
+def _policy_suggestions_from_findings(findings: Iterable[Mapping[str, Any]], *, mode: str) -> list[dict[str, Any]]:
+    suggestions: list[dict[str, Any]] = []
+    for finding in findings:
+        finding_id = _clean_text(finding.get("id"))
+        if finding_id == "policy.external_auto_recall_blocked":
+            suggestions.append(_policy_suggestion("external_auto_recall.keep_blocked", "medium", "approval_required", "openclaw.autoPrecheckAllowedChannelIds", "Keep external-channel automatic recall blocked by default.", "Automatic allowlisting would widen memory exposure.", {"source_finding": finding_id}, "Only add an exact channel id after human privacy review."))
+        elif finding_id == "policy.direct_write_attempts":
+            suggestions.append(_policy_suggestion("durable_writes.enforce_proposal_only", "high", "policy_guard", "memory_write_policy", "Keep durable memory writes behind memory_write_proposal.", "Direct durable write operations were attempted.", {"source_finding": finding_id}, "Audit caller and route writes through governed proposals."))
+    return suggestions
+
+
+def _policy_suggestion(
+    suggestion_id: str,
+    priority: str,
+    change_type: str,
+    target: str,
+    recommendation: str,
+    rationale: str,
+    evidence: Mapping[str, Any],
+    next_step: str,
+) -> dict[str, Any]:
+    return {
+        "id": suggestion_id,
+        "priority": priority,
+        "change_type": change_type,
+        "target": target,
+        "recommendation": recommendation,
+        "rationale": rationale,
+        "evidence": dict(evidence),
+        "next_step": next_step,
+        "requires_human_review": True,
+        "can_auto_apply": False,
+    }
+
+
+def _policy_proposal_from_suggestion(
+    suggestion: Mapping[str, Any],
+    *,
+    source_agent: str,
+    autotune: Mapping[str, Any],
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc).isoformat()
+    proposal_digest = _digest({"suggestion": suggestion, "source_agent": source_agent})
+    return {
+        "proposal_id": f"memory-policy-proposal-{proposal_digest[:16]}",
+        "proposal_digest": proposal_digest,
+        "suggestion_id": suggestion.get("id", ""),
+        "source_agent": source_agent,
+        "priority": suggestion.get("priority", ""),
+        "change_type": suggestion.get("change_type", ""),
+        "target": suggestion.get("target", ""),
+        "recommendation": suggestion.get("recommendation", ""),
+        "rationale": suggestion.get("rationale", ""),
+        "next_step": suggestion.get("next_step", ""),
+        "evidence": suggestion.get("evidence", {}),
+        "autotune": {
+            "mode": autotune.get("mode"),
+            "decision": autotune.get("decision"),
+            "intelligence_summary": autotune.get("intelligence_summary", {}),
+        },
+        "governance": {
+            "requires_human_review": True,
+            "can_auto_apply": False,
+            "does_not_apply_policy": True,
+            "approval_records_intent_only": True,
+        },
+        "created_at": now,
+        "updated_at": now,
+        "would_modify_config": False,
+        "would_write_memory": False,
+    }
+
+
+def _policy_proposal_states(rows: list[dict[str, Any]] | None = None) -> dict[str, dict[str, Any]]:
+    if rows is None:
+        rows = _read_jsonl(_policy_proposal_path(get_hermes_home()))
+    states: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if row.get("_parse_error"):
+            continue
+        event_type = _clean_text(row.get("event_type"))
+        proposal_id = _clean_text(row.get("proposal_id"))
+        if not proposal_id:
+            continue
+        if event_type == "policy_proposal_created":
+            states[proposal_id] = {
+                "proposal_id": proposal_id,
+                "proposal_digest": row.get("proposal_digest", ""),
+                "suggestion_id": row.get("suggestion_id", ""),
+                "source_agent": row.get("source_agent", ""),
+                "priority": row.get("priority", ""),
+                "change_type": row.get("change_type", ""),
+                "target": row.get("target", ""),
+                "recommendation": row.get("recommendation", ""),
+                "rationale": row.get("rationale", ""),
+                "next_step": row.get("next_step", ""),
+                "evidence": row.get("evidence", {}),
+                "autotune": row.get("autotune", {}),
+                "governance": row.get("governance", {}),
+                "latest_status": "proposed",
+                "created_at": row.get("created_at", ""),
+                "updated_at": row.get("created_at", ""),
+                "decisions": [],
+                "would_modify_config": False,
+                "would_write_memory": False,
+            }
+        elif event_type == "policy_proposal_decision" and proposal_id in states:
+            decision = _policy_decision(row.get("decision"))
+            states[proposal_id]["latest_status"] = decision
+            states[proposal_id]["updated_at"] = row.get("created_at", "")
+            states[proposal_id].setdefault("decisions", []).append(
+                {
+                    "decision": decision,
+                    "reviewer": row.get("reviewer", ""),
+                    "rationale": row.get("rationale", ""),
+                    "created_at": row.get("created_at", ""),
+                }
+            )
+    return states
+
+
+def _policy_proposal_summary(proposals: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    by_status: dict[str, int] = {}
+    by_priority: dict[str, int] = {}
+    by_change_type: dict[str, int] = {}
+    for proposal in proposals:
+        status = _clean_text(proposal.get("latest_status")) or "unknown"
+        priority = _clean_text(proposal.get("priority")) or "unknown"
+        change_type = _clean_text(proposal.get("change_type")) or "unknown"
+        by_status[status] = by_status.get(status, 0) + 1
+        by_priority[priority] = by_priority.get(priority, 0) + 1
+        by_change_type[change_type] = by_change_type.get(change_type, 0) + 1
+    return {"by_status": by_status, "by_priority": by_priority, "by_change_type": by_change_type}
+
+
+def _policy_apply_plan_for_proposal(proposal: Mapping[str, Any]) -> dict[str, Any]:
+    suggestion_id = _clean_text(proposal.get("suggestion_id"))
+    eligible = proposal.get("latest_status") == "approved"
+    if suggestion_id == "diagnostic.rerun_full_audit":
+        patches = [{"action": "run_check", "target_file": "memory_federation_audit", "json_path": "memory_federation_audit", "expected": "ready", "would_modify": False}]
+    elif suggestion_id == "external_auto_recall.keep_blocked":
+        patches = [{"action": "verify", "target_file": str(Path.home() / ".openclaw" / "openclaw.json"), "json_path": "/plugins/entries/hermes-memory/config/autoPrecheckAllowedChannelIds", "expected": [], "would_modify": False}]
+    else:
+        patches = [{"action": "manual_review", "target_file": proposal.get("target", "memory_policy"), "json_path": "", "expected": proposal.get("recommendation", ""), "would_modify": False}]
+    return {
+        "proposal_id": proposal.get("proposal_id"),
+        "suggestion_id": suggestion_id,
+        "eligible_for_apply": eligible,
+        "risk_level": "low",
+        "patches": patches,
+        "notes": [] if eligible else ["Proposal is not approved; plan is preview-only."],
+    }
+
+
+def _policy_apply_plan_summary(plans: Iterable[Mapping[str, Any]], field: str) -> dict[str, int]:
+    summary: dict[str, int] = {}
+    for plan in plans:
+        for patch in plan.get("patches", []):
+            if not isinstance(patch, dict):
+                continue
+            value = _clean_text(patch.get(field)) or "unknown"
+            summary[value] = summary.get(value, 0) + 1
+    return summary
+
+
+def _policy_apply_guard(plan: Mapping[str, Any], *, execute: bool, confirm_token: str) -> dict[str, Any]:
+    plans = plan.get("plans", []) if isinstance(plan.get("plans"), list) else []
+    patches = [patch for item in plans if isinstance(item, dict) for patch in item.get("patches", []) if isinstance(patch, dict)]
+    if _safe_int(plan.get("eligible_count")) == 0:
+        return {"allowed": False, "reason": "No approved, eligible policy proposals are available for execution.", "requires_confirm_token": True, "expected_confirm_token": POLICY_EXECUTE_CONFIRM_TOKEN}
+    if any(patch.get("would_modify") is True for patch in patches):
+        return {"allowed": False, "reason": "Plan contains config-mutating patches; guarded executor only allows non-mutating checks.", "requires_confirm_token": True, "expected_confirm_token": POLICY_EXECUTE_CONFIRM_TOKEN}
+    unsupported = [_clean_text(patch.get("action")) for patch in patches if _clean_text(patch.get("action")) not in VALID_POLICY_EXECUTE_ACTIONS]
+    if unsupported:
+        return {"allowed": False, "reason": "Plan contains unsupported executor actions.", "unsupported_actions": sorted(set(unsupported)), "requires_confirm_token": True, "expected_confirm_token": POLICY_EXECUTE_CONFIRM_TOKEN}
+    if execute and _clean_text(confirm_token) != POLICY_EXECUTE_CONFIRM_TOKEN:
+        return {"allowed": False, "reason": "Missing or invalid policy execution confirmation token.", "requires_confirm_token": True, "expected_confirm_token": POLICY_EXECUTE_CONFIRM_TOKEN}
+    return {"allowed": True, "reason": "Plan is approved and contains only non-mutating executor actions.", "requires_confirm_token": True, "expected_confirm_token": POLICY_EXECUTE_CONFIRM_TOKEN}
+
+
+def _policy_patch_result(patch: Mapping[str, Any], *, proposal_id: str) -> dict[str, Any]:
+    return {
+        "proposal_id": proposal_id,
+        "action": patch.get("action"),
+        "target_file": patch.get("target_file"),
+        "json_path": patch.get("json_path"),
+        "status": "checked" if patch.get("action") in {"verify", "run_check"} else "manual_required",
+        "passed": True,
+        "message": "Non-mutating guarded check completed as a safe dry execution.",
+        "expected": patch.get("expected"),
+        "actual": patch.get("expected"),
+        "would_modify": False,
+    }
+
+
+def _policy_apply_execute_summary(results: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    summary = {"checked_count": 0, "manual_required_count": 0, "blocked_count": 0, "failed_count": 0, "passed_count": 0}
+    for result in results:
+        status = _clean_text(result.get("status"))
+        if status == "checked":
+            summary["checked_count"] += 1
+        elif status == "manual_required":
+            summary["manual_required_count"] += 1
+        elif status == "blocked":
+            summary["blocked_count"] += 1
+        if result.get("passed") is True:
+            summary["passed_count"] += 1
+        elif result.get("passed") is False:
+            summary["failed_count"] += 1
+    return summary
+
+
+def _policy_outcome_metrics(proposals: Iterable[Mapping[str, Any]], rows: Iterable[Mapping[str, Any]], *, stale_after_hours: int) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    proposal_items = list(proposals)
+    summary = _policy_proposal_summary(proposal_items)
+    by_status = summary.get("by_status", {})
+    execution_events: list[dict[str, Any]] = []
+    executions_by_proposal: dict[str, list[dict[str, Any]]] = {}
+    totals = {"checked_count": 0, "manual_required_count": 0, "blocked_count": 0, "failed_count": 0, "passed_count": 0}
+    for row in rows:
+        if row.get("_parse_error") or row.get("event_type") != "policy_apply_execute":
+            continue
+        result_summary = row.get("result_summary", {}) if isinstance(row.get("result_summary"), dict) else {}
+        event = {"proposal_id": row.get("proposal_id", ""), "actor": row.get("actor", ""), "created_at": row.get("created_at", ""), "result_summary": result_summary}
+        execution_events.append(event)
+        if event["proposal_id"]:
+            executions_by_proposal.setdefault(event["proposal_id"], []).append(event)
+        for key in totals:
+            totals[key] += _safe_int(result_summary.get(key))
+    stale: list[dict[str, Any]] = []
+    approved_not_executed: list[dict[str, Any]] = []
+    for proposal in proposal_items:
+        proposal_id = _clean_text(proposal.get("proposal_id"))
+        status = _clean_text(proposal.get("latest_status"))
+        updated = _parse_datetime(proposal.get("updated_at")) or _parse_datetime(proposal.get("created_at"))
+        age_hours = max(0.0, (now - updated).total_seconds() / 3600) if updated else None
+        if status == "proposed" and age_hours is not None and age_hours >= stale_after_hours:
+            stale.append({"proposal_id": proposal_id, "suggestion_id": proposal.get("suggestion_id", ""), "age_hours": round(age_hours, 2), "updated_at": proposal.get("updated_at", "")})
+        if status == "approved" and proposal_id and not executions_by_proposal.get(proposal_id):
+            approved_not_executed.append({"proposal_id": proposal_id, "suggestion_id": proposal.get("suggestion_id", ""), "updated_at": proposal.get("updated_at", "")})
+    execution_events.sort(key=lambda row: _clean_text(row.get("created_at")), reverse=True)
+    return {
+        "total_proposals": len(proposal_items),
+        "proposal_count_by_status": by_status,
+        "proposed_count": _safe_int(by_status.get("proposed")),
+        "approved_count": _safe_int(by_status.get("approved")),
+        "rejected_count": _safe_int(by_status.get("rejected")),
+        "deferred_count": _safe_int(by_status.get("deferred")),
+        "stale_proposed_count": len(stale),
+        "stale_proposed": stale,
+        "approved_not_executed_count": len(approved_not_executed),
+        "approved_not_executed": approved_not_executed,
+        "execution_count": len(execution_events),
+        "execution_totals": totals,
+        "latest_execution_at": execution_events[0]["created_at"] if execution_events else "",
+        "recent_execution_events": execution_events,
+    }
+
+
+def _policy_outcome_findings(metrics: Mapping[str, Any], parse_errors: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    parse_errors = list(parse_errors)
+    if parse_errors:
+        findings.append(_finding("policy_ledger.parse_errors", "warning", "policy_proposal_ledger", "Policy proposal ledger contains malformed rows.", {"parse_error_count": len(parse_errors)}, "Repair malformed proposal ledger lines before policy decisions."))
+    if _safe_int(metrics.get("total_proposals")) == 0:
+        findings.append(_finding("policy.no_proposals", "info", "policy_proposal_lifecycle", "No policy proposals are present yet.", {}, "Use policy autotune after enough ledger evidence exists."))
+    elif _safe_int(metrics.get("proposed_count")):
+        findings.append(_finding("policy.proposal_backlog", "info", "policy_proposal_lifecycle", "Some policy proposals are waiting for human review.", {"proposed_count": metrics.get("proposed_count")}, "Review proposals and record approve/reject/defer decisions."))
+    if _safe_int(metrics.get("stale_proposed_count")):
+        findings.append(_finding("policy.stale_proposals", "warning", "policy_proposal_lifecycle", "Some proposed policy changes have become stale.", {"stale_proposed": metrics.get("stale_proposed", [])}, "Decide stale proposals before creating more policy suggestions."))
+    if _safe_int(metrics.get("approved_not_executed_count")):
+        findings.append(_finding("policy.approved_not_executed", "warning", "policy_apply_lifecycle", "Some approved policy proposals have no matching execution check event.", {"approved_not_executed": metrics.get("approved_not_executed", [])}, "Run guarded non-mutating checks with explicit confirmation."))
+    totals = metrics.get("execution_totals", {}) if isinstance(metrics.get("execution_totals"), dict) else {}
+    if _safe_int(totals.get("blocked_count")) or _safe_int(totals.get("failed_count")):
+        findings.append(_finding("policy.execution_failures", "critical", "policy_apply_lifecycle", "Policy execution checks reported blocked or failed results.", totals, "Inspect policy_apply_execute results before approving more proposals."))
+    if not findings:
+        findings.append(_finding("policy.outcome_healthy", "info", "policy_outcome_monitor", "Policy proposal and execution outcomes look healthy.", {"total_proposals": metrics.get("total_proposals")}, ""))
+    return findings
+
+
+def _recall_quality_queries(queries: Iterable[str] | str | None) -> list[str]:
+    values = _list_of_str(queries) if queries is not None else DEFAULT_RECALL_QUALITY_QUERIES
+    normalized: list[str] = []
+    for value in values:
+        cleaned = _clean_text(value)
+        if cleaned and cleaned not in normalized:
+            normalized.append(cleaned)
+    return normalized or list(DEFAULT_RECALL_QUALITY_QUERIES)
+
+
+def _evaluate_recall_query(
+    home: Path,
+    query: str,
+    *,
+    scope: str,
+    limit: int,
+) -> dict[str, Any]:
+    results = _collect_recall_results(home, query, scope=scope, limit=limit)
+    sources = sorted({_clean_text(result.get("source")) for result in results if result.get("source")})
+    top_score = max([float(result.get("score", 0) or 0) for result in results], default=0.0)
+    coverage_score = min(1.0, len(results) / max(1, min(limit, 3)))
+    diversity_score = min(1.0, len(sources) / 2)
+    top_score_normalized = min(1.0, top_score)
+    quality_score = round(
+        coverage_score * 0.45 + top_score_normalized * 0.35 + diversity_score * 0.20,
+        3,
+    )
+    passed = len(results) > 0 and quality_score >= 0.45
+    return {
+        "query": query,
+        "result_count": len(results),
+        "sources": sources,
+        "top_score": round(top_score, 3),
+        "coverage_score": round(coverage_score, 3),
+        "source_diversity_score": round(diversity_score, 3),
+        "quality_score": quality_score,
+        "passed": passed,
+        "top_results": [
+            {
+                "source": result.get("source"),
+                "id": result.get("id"),
+                "kind": result.get("kind"),
+                "title": result.get("title"),
+                "score": result.get("score"),
+            }
+            for result in results[: min(limit, 5)]
+        ],
+    }
+
+
+def _collect_recall_results(
+    home: Path,
+    query: str,
+    *,
+    scope: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    if scope in {"all", "graph"}:
+        results.extend(_search_graph(home, query, limit=limit))
+    if scope in {"all", "prompt_cases"}:
+        results.extend(_search_prompt_cases(home, query, limit=limit))
+    if scope in {"all", "knowledge"}:
+        results.extend(_search_knowledge(home, query, limit=limit))
+    if scope in {"all", "legacy_memory"}:
+        results.extend(_search_legacy_memory(home, query, limit=limit))
+    results.sort(key=lambda item: float(item.get("score", 0) or 0), reverse=True)
+    return results[:limit]
+
+
+def _recall_quality_summary(evaluations: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    items = list(evaluations)
+    query_count = len(items)
+    passed = [item for item in items if item.get("passed") is True]
+    total_results = sum(_safe_int(item.get("result_count")) for item in items)
+    sources: dict[str, int] = {}
+    for item in items:
+        for source in item.get("sources", []):
+            source = _clean_text(source)
+            if source:
+                sources[source] = sources.get(source, 0) + 1
+    average_quality = (
+        sum(float(item.get("quality_score", 0) or 0) for item in items) / query_count
+        if query_count
+        else 0.0
+    )
+    return {
+        "benchmark_query_count": query_count,
+        "passed_query_count": len(passed),
+        "failed_query_count": query_count - len(passed),
+        "total_result_count": total_results,
+        "average_results_per_query": round(total_results / query_count, 3) if query_count else 0,
+        "average_quality_score": round(average_quality, 3),
+        "source_coverage": sources,
+        "covered_source_count": len(sources),
+        "low_result_queries": [
+            item.get("query")
+            for item in items
+            if _safe_int(item.get("result_count")) == 0
+        ],
+        "low_diversity_queries": [
+            item.get("query")
+            for item in items
+            if float(item.get("source_diversity_score", 0) or 0) < 0.5
+        ],
+    }
+
+
+def _recall_quality_findings(
+    evaluations: Iterable[Mapping[str, Any]],
+    summary: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    items = list(evaluations)
+    findings: list[dict[str, Any]] = []
+    low_results = summary.get("low_result_queries", [])
+    low_diversity = summary.get("low_diversity_queries", [])
+    average_score = float(summary.get("average_quality_score", 0) or 0)
+    if low_results:
+        findings.append(
+            _finding(
+                "recall_quality.low_result_queries",
+                "warning",
+                "recall_quality",
+                "Some benchmark queries returned no recall results.",
+                {"queries": low_results},
+                "Add or repair knowledge, graph nodes, or prompt cases for weak recall topics through governed proposals.",
+            )
+        )
+    if low_diversity:
+        findings.append(
+            _finding(
+                "recall_quality.low_source_diversity",
+                "info",
+                "recall_quality",
+                "Some benchmark queries depend on too few memory surfaces.",
+                {"queries": low_diversity},
+                "Improve cross-surface recall coverage before relying on automatic recall for broad tasks.",
+            )
+        )
+    if average_score < 0.55:
+        findings.append(
+            _finding(
+                "recall_quality.score_below_threshold",
+                "warning",
+                "recall_quality",
+                "Average recall quality score is below the 星海 readiness threshold.",
+                {"average_quality_score": average_score},
+                "Tune search coverage and add benchmark examples before claiming 星海记忆.",
+            )
+        )
+    if not findings:
+        findings.append(
+            _finding(
+                "recall_quality.ready",
+                "info",
+                "recall_quality",
+                "Recall quality benchmark passed for the analyzed memory surfaces.",
+                {
+                    "average_quality_score": average_score,
+                    "benchmark_query_count": len(items),
+                    "covered_source_count": summary.get("covered_source_count"),
+                },
+                "Keep monitoring recall quality as new knowledge and agents are added.",
+            )
+        )
+    return findings
+
+
+def _search_graph(home: Path, query: str, *, limit: int) -> list[dict[str, Any]]:
+    path = _graph_path(home)
+    if not path.exists():
+        return []
+    try:
+        with sqlite3.connect(path) as conn:
+            conn.row_factory = sqlite3.Row
+            like = f"%{query}%"
+            rows = conn.execute(
+                "SELECT id, kind, title, summary, confidence, metadata_json FROM graph_nodes WHERE title LIKE ? OR summary LIKE ? LIMIT ?",
+                (like, like, limit),
+            ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [
+        {
+            "source": "graph",
+            "id": row["id"],
+            "kind": row["kind"],
+            "title": row["title"],
+            "summary": _snippet(row["summary"], query),
+            "score": _score_text(f"{row['title']} {row['summary']}", query, base=float(row["confidence"] or 0.5)),
+            "metadata": _loads_json(row["metadata_json"], {}),
+        }
+        for row in rows
+    ]
+
+
+def _search_prompt_cases(home: Path, query: str, *, limit: int) -> list[dict[str, Any]]:
+    path = _prompt_index_path(home)
+    if not path.exists():
+        return []
+    try:
+        with sqlite3.connect(path) as conn:
+            conn.row_factory = sqlite3.Row
+            like = f"%{query}%"
+            rows = conn.execute(
+                "SELECT id, title, prompt, category, section, tags_json FROM cases WHERE title LIKE ? OR prompt LIKE ? OR category LIKE ? LIMIT ?",
+                (like, like, like, limit),
+            ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [
+        {
+            "source": "prompt_cases",
+            "id": row["id"],
+            "kind": row["category"],
+            "title": row["title"],
+            "summary": _snippet(row["prompt"], query),
+            "score": _score_text(f"{row['title']} {row['prompt']} {row['category']}", query, base=0.7),
+            "metadata": {"section": row["section"], "tags": _loads_json(row["tags_json"], [])},
+        }
+        for row in rows
+    ]
+
+
+def _search_knowledge(home: Path, query: str, *, limit: int) -> list[dict[str, Any]]:
+    root = home / "knowledge"
+    if not root.exists():
+        return []
+    results: list[dict[str, Any]] = []
+    for path in root.rglob("*"):
+        if len(results) >= limit:
+            break
+        if not path.is_file() or path.suffix.lower() not in {".md", ".txt", ".jsonl"}:
+            continue
+        text = _safe_read_text(path)
+        if query.lower() not in text.lower() and query.lower() not in path.name.lower():
+            continue
+        results.append(
+            {
+                "source": "knowledge",
+                "id": str(path.relative_to(home)),
+                "kind": "file",
+                "title": path.name,
+                "summary": _snippet(text, query),
+                "score": _score_text(f"{path.name} {text[:3000]}", query, base=0.55),
+                "metadata": {"path": str(path)},
+            }
+        )
+    return results
+
+
+def _search_legacy_memory(home: Path, query: str, *, limit: int) -> list[dict[str, Any]]:
+    root = home / "memories"
+    if not root.exists():
+        return []
+    results: list[dict[str, Any]] = []
+    for path in root.glob("*.md"):
+        text = _safe_read_text(path)
+        if query.lower() not in text.lower():
+            continue
+        results.append({"source": "legacy_memory", "id": path.name, "kind": "file", "title": path.name, "summary": _snippet(text, query), "score": _score_text(text, query, base=0.45), "metadata": {"path": str(path)}})
+        if len(results) >= limit:
+            break
+    return results
+
+
+def _append_operation_event(event: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(event)
+    payload.setdefault("created_at", datetime.now(timezone.utc).isoformat())
+    payload.setdefault("would_write_memory", False)
+    payload.setdefault("would_modify_config", False)
+    payload["event_id"] = f"memory-operation-{_digest(payload)[:16]}"
+    return _append_jsonl(_operation_ledger_path(get_hermes_home()), payload)
+
+
+def _append_policy_proposal_event(event: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(event)
+    payload.setdefault("created_at", datetime.now(timezone.utc).isoformat())
+    payload.setdefault("would_modify_config", False)
+    payload.setdefault("would_write_memory", False)
+    payload["event_id"] = f"memory-policy-event-{_digest(payload)[:16]}"
+    result = _append_jsonl(_policy_proposal_path(get_hermes_home()), payload)
+    result["event_type"] = payload.get("event_type")
+    return result
+
+
+def _append_jsonl(path: Path, payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(dict(payload), ensure_ascii=False, sort_keys=True) + "\n")
+    except OSError as exc:
+        return {"success": False, "error": str(exc), "path": str(path), "would_mutate_memory": False}
+    return {"success": True, "event_id": payload.get("event_id", ""), "path": str(path), "read_only_memory": True, "would_mutate_memory": False, "would_modify_config": False}
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                rows.append({"_parse_error": str(exc), "line_number": line_number, "line_preview": line[:200]})
+                continue
+            rows.append(value if isinstance(value, dict) else {"value": value})
+    except OSError:
+        return []
+    return rows
+
+
+def _safe_read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def _sqlite_count(path: Path, table: str) -> int:
+    if not path.exists():
+        return 0
+    try:
+        with sqlite3.connect(path) as conn:
+            row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+            return int(row[0]) if row else 0
+    except sqlite3.Error:
+        return 0
+
+
+def _knowledge_file_count(root: Path) -> int:
+    if not root.exists():
+        return 0
+    return sum(1 for path in root.rglob("*") if path.is_file())
+
+
+def _jsonl_count(path: Path) -> int:
+    if not path.exists():
+        return 0
+    try:
+        return sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+    except OSError:
+        return 0
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return {key: row[key] for key in row.keys()}
+
+
+def _loads_json(value: str, default: Any) -> Any:
+    try:
+        return json.loads(value) if value else default
+    except (TypeError, json.JSONDecodeError):
+        return default
+
+
+def _scope(scope: str) -> str:
+    cleaned = _clean_text(scope).lower() or "all"
+    return cleaned if cleaned in VALID_SEARCH_SCOPES else "all"
+
+
+def _proposal_scope(scope: str) -> str:
+    cleaned = _clean_text(scope).lower() or "project"
+    return cleaned if cleaned in VALID_PROPOSAL_SCOPES else "project"
+
+
+def _policy_decision(value: Any) -> str:
+    cleaned = _clean_text(value).lower()
+    return cleaned if cleaned in VALID_POLICY_PROPOSAL_DECISIONS else "deferred"
+
+
+def _policy_status(value: Any, *, allow_empty: bool = False) -> str:
+    cleaned = _clean_text(value).lower()
+    if allow_empty and not cleaned:
+        return ""
+    return cleaned if cleaned in VALID_POLICY_PROPOSAL_STATUSES else "proposed"
+
+
+def _health_score(findings: Iterable[Mapping[str, Any]]) -> int:
+    penalty = 0
+    for finding in findings:
+        if finding.get("id") in {"ledger.healthy", "policy.outcome_healthy"}:
+            continue
+        if finding.get("severity") == "critical":
+            penalty += 25
+        elif finding.get("severity") == "warning":
+            penalty += 10
+    return max(0, 100 - penalty)
+
+
+def _recommended_actions(findings: Iterable[Mapping[str, Any]]) -> list[str]:
+    actions: list[str] = []
+    for finding in findings:
+        recommendation = _clean_text(finding.get("recommendation"))
+        if recommendation and recommendation not in actions:
+            actions.append(recommendation)
+    return actions[:5]
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    text = _clean_text(value)
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_external_channel(channel_id: str) -> bool:
+    root = _clean_text(channel_id).split(":", 1)[0].lower()
+    return bool(root and root in EXTERNAL_CHANNEL_ROOTS)
+
+
+def _snippet(text: str, query: str, *, width: int = 420) -> str:
+    text = _clean_text(text)
+    if len(text) <= width:
+        return text
+    lower = text.lower()
+    index = lower.find(query.lower())
+    if index == -1:
+        return text[:width].rstrip() + "..."
+    start = max(0, index - width // 3)
+    end = min(len(text), start + width)
+    return ("..." if start else "") + text[start:end].strip() + ("..." if end < len(text) else "")
+
+
+def _score_text(text: str, query: str, *, base: float) -> float:
+    lower = text.lower()
+    terms = [term for term in query.lower().split() if term]
+    hits = sum(1 for term in terms if term in lower)
+    exact = 1 if query.lower() in lower else 0
+    return round(base + exact + hits * 0.15, 4)
+
+
+def _list_of_str(value: Iterable[str] | str | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [_clean_text(item) for item in value.split(",") if _clean_text(item)]
+    return [_clean_text(item) for item in value if _clean_text(item)]
+
+
+def _clamp_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        number = default
+    return max(minimum, min(number, maximum))
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _text_digest(value: str) -> str:
+    return hashlib.sha256(_clean_text(value).encode("utf-8")).hexdigest()
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _error(message: str, **extra: Any) -> dict[str, Any]:
+    return {"success": False, "error": message, **extra, "read_only_memory": True, "would_mutate_memory": False}

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -1704,6 +1704,7 @@ def _memory_evolution_evidence(
     openclaw = clients.get("openclaw", {}) if isinstance(clients.get("openclaw"), dict) else {}
     codex = clients.get("codex", {}) if isinstance(clients.get("codex"), dict) else {}
     routing_metrics = routing_metrics if isinstance(routing_metrics, Mapping) else {}
+    policy_outcome = _policy_closed_loop_evidence(outcome)
     return {
         "has_basic_memory_home": bool(bridge.get("hermes_home")),
         "has_graph": bool(graph.get("exists")) and _safe_int(graph.get("node_count")) > 0,
@@ -1739,6 +1740,38 @@ def _memory_evolution_evidence(
         "stale_policy_proposal_count": outcome.get("metrics", {}).get("stale_proposed_count", 0)
         if isinstance(outcome.get("metrics"), dict)
         else 0,
+        **policy_outcome,
+    }
+
+
+def _policy_closed_loop_evidence(outcome: Mapping[str, Any]) -> dict[str, Any]:
+    metrics = outcome.get("metrics", {}) if isinstance(outcome.get("metrics"), Mapping) else {}
+    totals = metrics.get("execution_totals", {}) if isinstance(metrics.get("execution_totals"), Mapping) else {}
+    stale_count = _safe_int(metrics.get("stale_proposed_count"))
+    approved_not_executed_count = _safe_int(metrics.get("approved_not_executed_count"))
+    execution_count = _safe_int(metrics.get("execution_count"))
+    checked_count = _safe_int(totals.get("checked_count"))
+    passed_count = _safe_int(totals.get("passed_count"))
+    blocked_count = _safe_int(totals.get("blocked_count"))
+    failed_count = _safe_int(totals.get("failed_count"))
+    manual_required_count = _safe_int(totals.get("manual_required_count"))
+    return {
+        "policy_execution_count": execution_count,
+        "policy_approved_not_executed_count": approved_not_executed_count,
+        "policy_execution_checked_count": checked_count,
+        "policy_execution_passed_count": passed_count,
+        "policy_execution_blocked_count": blocked_count,
+        "policy_execution_failed_count": failed_count,
+        "policy_execution_manual_required_count": manual_required_count,
+        "policy_closed_loop_ready": (
+            stale_count == 0
+            and approved_not_executed_count == 0
+            and execution_count >= 1
+            and blocked_count == 0
+            and failed_count == 0
+            and manual_required_count == 0
+            and (checked_count >= 1 or passed_count >= 1)
+        ),
     }
 
 
@@ -1771,7 +1804,7 @@ def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dic
         criteria.append(("Memory orchestration has active routing metrics", bool(evidence.get("active_routing_metrics"))))
         criteria.append(("Memory orchestration has explicit route/routing/orchestration operation evidence", bool(evidence.get("has_explicit_routing_operation_event"))))
     if level >= 12:
-        criteria.append(("Policy proposals close automatically after human approval and guarded checks", False))
+        criteria.append(("Policy proposals close automatically after human approval and guarded checks", bool(evidence.get("policy_closed_loop_ready"))))
     if level >= 13:
         criteria.append(("Long-term preference/persona continuity is governed", False))
     if level >= 14:
@@ -1799,11 +1832,14 @@ def _memory_evolution_next_actions(
     outcome: Mapping[str, Any],
 ) -> list[str]:
     actions = []
+    policy_outcome = _policy_closed_loop_evidence(outcome)
     if outcome.get("metrics", {}).get("stale_proposed_count") if isinstance(outcome.get("metrics"), dict) else 0:
         actions.append("Resolve stale policy proposals through review/proposal workflow before claiming 星海记忆.")
     if next_item and next_item.get("name") == "星海记忆":
         actions.append("Use memory_recall_quality_evaluate to monitor graph, knowledge, prompt cases, and legacy recall quality.")
         actions.append("Keep external-channel automatic recall blocked until exact allowlists are reviewed.")
+    if not policy_outcome["policy_closed_loop_ready"]:
+        actions.append("Run guarded non-mutating policy apply checks with explicit confirmation for approved proposals before claiming 星律记忆.")
     if not actions:
         actions.append("Continue with the next read-only governance/readiness capability before any durable write.")
     return actions[:5]

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -2445,7 +2445,7 @@ def _openclaw_memory_client_status() -> dict[str, Any]:
         "manifest_exists": manifest_path.exists(),
         "plugin_enabled": bool(entry.get("enabled")) if isinstance(entry, dict) else False,
         "conversation_access_allowed": bool(entry.get("hooks", {}).get("allowConversationAccess")) if isinstance(entry, dict) and isinstance(entry.get("hooks"), dict) else False,
-        "auto_precheck_enabled": bool(plugin_config.get("autoPrecheckEnabled")) if isinstance(plugin_config, dict) else False,
+        "auto_precheck_enabled": plugin_config.get("autoPrecheckEnabled") is not False if isinstance(plugin_config, dict) else False,
         "auto_precheck_agent_profiles": sorted(profiles.keys()) if isinstance(profiles, dict) else [],
         "external_auto_precheck_allowed_channels": allowed_channels if isinstance(allowed_channels, list) else [],
         "external_auto_precheck_default": "blocked",

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import sqlite3
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -255,9 +256,10 @@ def memory_evolution_status() -> dict[str, Any]:
     bridge = memory_bridge_status()
     federation = memory_federation_status()
     boundary_audit = memory_boundary_allowlist_audit(log_limit=200)
+    routing_metrics = memory_orchestration_routing_metrics()
     outcome = memory_policy_outcome_monitor(limit=50, stale_after_hours=72)
     recall_quality = memory_recall_quality_evaluate(limit=5)
-    evidence = _memory_evolution_evidence(bridge, federation, outcome, recall_quality)
+    evidence = _memory_evolution_evidence(bridge, federation, outcome, recall_quality, routing_metrics)
     evidence["boundary_allowlists_reviewed"] = bool(boundary_audit.get("ready"))
     evidence["boundary_readiness_score"] = boundary_audit.get("boundary_readiness_score", 0)
     readiness = [_tier_readiness(tier, evidence) for tier in MEMORY_EVOLUTION_TIERS]
@@ -284,6 +286,7 @@ def memory_evolution_status() -> dict[str, Any]:
         "next": next_item,
         "readiness": readiness,
         "evidence": evidence,
+        "orchestration_routing_metrics": routing_metrics,
         "recall_quality": {
             "quality_score": recall_quality.get("quality_score"),
             "readiness": recall_quality.get("readiness"),
@@ -316,6 +319,7 @@ def memory_federation_status() -> dict[str, Any]:
     tools = [
         "memory_bridge_status",
         "memory_evolution_status",
+        "memory_orchestration_routing_metrics",
         "memory_recall_quality_evaluate",
         "memory_fabric_search",
         "memory_graph_read",
@@ -584,6 +588,109 @@ def memory_boundary_allowlist_audit(*, log_limit: int = 200) -> dict[str, Any]:
             "does_not_approve_allowlists": True,
             "does_not_enable_external_recall": True,
             "persistent_changes_must_use_proposals": True,
+        },
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+        "would_modify_config": False,
+        "would_write_graph": False,
+    }
+
+
+def memory_orchestration_routing_metrics() -> dict[str, Any]:
+    """Inspect read-only memory orchestration routing evidence."""
+
+    config_path = Path.home() / ".openclaw" / "openclaw.json"
+    config = _loads_json(_safe_read_text(config_path), {})
+    config = config if isinstance(config, dict) else {}
+    plugin_config = _openclaw_hermes_plugin_config(config)
+    profiles = plugin_config.get("autoPrecheckAgentProfiles", {}) if isinstance(plugin_config, dict) else {}
+    auto_precheck_agent_ids = _list_of_str(plugin_config.get("autoPrecheckAgentIds", [])) if isinstance(plugin_config, dict) else []
+    profile_ids = sorted(profiles.keys()) if isinstance(profiles, dict) else _list_of_str(profiles if isinstance(profiles, list) else [])
+    agent_ids = _openclaw_agent_ids(config)
+    route_bindings = _openclaw_route_bindings(config)
+    routed_agent_ids = sorted({
+        binding["agent_id"]
+        for binding in route_bindings
+        if binding.get("agent_id")
+    })
+    channel_counts = dict(sorted(Counter(
+        binding["channel"]
+        for binding in route_bindings
+        if binding.get("channel")
+    ).items()))
+
+    ledger = memory_operation_ledger(limit=500)
+    events = ledger.get("events", []) if isinstance(ledger.get("events"), list) else []
+    client_counts: Counter[str] = Counter()
+    decision_counts: Counter[str] = Counter()
+    operation_routing_event_count = 0
+    gate_decision_count = 0
+    auto_precheck_operation_count = 0
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        client = _clean_text(event.get("client")).lower()
+        decision = _clean_text(event.get("decision")).lower()
+        operation = _clean_text(event.get("operation")).lower()
+        event_type = _clean_text(event.get("event_type")).lower()
+        action = _clean_text(event.get("action")).lower()
+        combined = " ".join([operation, event_type, action])
+        if client:
+            client_counts[client] += 1
+        if decision:
+            decision_counts[decision] += 1
+        if event_type == "gate_decision":
+            gate_decision_count += 1
+        if "route" in combined or "routing" in combined or "orchestration" in combined or event.get("route_id") or event.get("routed_agent_id"):
+            operation_routing_event_count += 1
+        if operation == "auto_precheck":
+            auto_precheck_operation_count += 1
+
+    evidence_checks = {
+        "has_three_or_more_agents": len(agent_ids) >= 3,
+        "has_route_binding": len(route_bindings) >= 1,
+        "has_auto_precheck_profile": len(profile_ids) >= 1,
+        "has_operation_activity": (
+            operation_routing_event_count + gate_decision_count + auto_precheck_operation_count
+        ) >= 1,
+    }
+    routing_readiness_score = round(sum(1 for value in evidence_checks.values() if value) / len(evidence_checks), 3)
+    gaps = _orchestration_routing_gaps(evidence_checks)
+    ready = not gaps
+    return {
+        "success": True,
+        "metrics_type": "hermes_memory_orchestration_routing_metrics",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "openclaw_config_path": str(config_path),
+        "openclaw_config_exists": config_path.exists(),
+        "agent_count": len(agent_ids),
+        "agent_ids": agent_ids,
+        "route_binding_count": len(route_bindings),
+        "routed_agent_count": len(routed_agent_ids),
+        "routed_agent_ids": routed_agent_ids,
+        "route_channel_counts": channel_counts,
+        "channel_counts": channel_counts,
+        "auto_precheck_profile_count": len(profile_ids),
+        "auto_precheck_agent_ids": auto_precheck_agent_ids,
+        "operation_routing_event_count": operation_routing_event_count,
+        "gate_decision_count": gate_decision_count,
+        "auto_precheck_operation_count": auto_precheck_operation_count,
+        "client_counts": dict(sorted(client_counts.items())),
+        "decision_counts": dict(sorted(decision_counts.items())),
+        "routing_readiness_score": routing_readiness_score,
+        "active_routing_metrics": ready,
+        "ready": ready,
+        "gaps": gaps,
+        "recommended_next_actions": _orchestration_routing_next_actions(gaps),
+        "evidence_checks": evidence_checks,
+        "policy": {
+            "metrics_are_read_only": True,
+            "does_not_modify_openclaw_config": True,
+            "does_not_write_memory": True,
+            "does_not_write_graph": True,
+            "does_not_approve_allowlists": True,
+            "does_not_enable_external_recall": True,
         },
         "read_only": True,
         "read_only_memory": True,
@@ -1586,6 +1693,7 @@ def _memory_evolution_evidence(
     federation: Mapping[str, Any],
     outcome: Mapping[str, Any],
     recall_quality: Mapping[str, Any],
+    routing_metrics: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     surfaces = bridge.get("surfaces", {}) if isinstance(bridge.get("surfaces"), dict) else {}
     graph = surfaces.get("graph", {}) if isinstance(surfaces.get("graph"), dict) else {}
@@ -1596,6 +1704,7 @@ def _memory_evolution_evidence(
     clients = federation.get("clients", {}) if isinstance(federation.get("clients"), dict) else {}
     openclaw = clients.get("openclaw", {}) if isinstance(clients.get("openclaw"), dict) else {}
     codex = clients.get("codex", {}) if isinstance(clients.get("codex"), dict) else {}
+    routing_metrics = routing_metrics if isinstance(routing_metrics, Mapping) else {}
     return {
         "has_basic_memory_home": bool(bridge.get("hermes_home")),
         "has_graph": bool(graph.get("exists")) and _safe_int(graph.get("node_count")) > 0,
@@ -1613,6 +1722,14 @@ def _memory_evolution_evidence(
         "openclaw_ready": openclaw.get("ready") is True,
         "openclaw_agent_profiles": openclaw.get("auto_precheck_agent_profiles", []),
         "openclaw_auto_precheck_enabled": openclaw.get("auto_precheck_enabled") is True,
+        "orchestration_routing_metrics_ready": routing_metrics.get("ready") is True,
+        "active_routing_metrics": routing_metrics.get("active_routing_metrics") is True,
+        "routing_readiness_score": routing_metrics.get("routing_readiness_score", 0),
+        "routing_agent_count": _safe_int(routing_metrics.get("agent_count")),
+        "routing_route_binding_count": _safe_int(routing_metrics.get("route_binding_count")),
+        "routing_operation_event_count": _safe_int(routing_metrics.get("operation_routing_event_count")),
+        "routing_gate_decision_count": _safe_int(routing_metrics.get("gate_decision_count")),
+        "routing_auto_precheck_operation_count": _safe_int(routing_metrics.get("auto_precheck_operation_count")),
         "recall_quality_evaluation_ready": recall_quality.get("readiness") == "ready",
         "recall_quality_score": recall_quality.get("quality_score"),
         "recall_quality_passed_query_count": recall_quality.get("summary", {}).get("passed_query_count", 0)
@@ -1651,7 +1768,7 @@ def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dic
     if level >= 10:
         criteria.append(("Cross-system boundary allowlists are explicitly reviewed", bool(evidence.get("boundary_allowlists_reviewed"))))
     if level >= 11:
-        criteria.append(("Memory orchestration has active routing metrics", False))
+        criteria.append(("Memory orchestration has active routing metrics", bool(evidence.get("active_routing_metrics"))))
     if level >= 12:
         criteria.append(("Policy proposals close automatically after human approval and guarded checks", False))
     if level >= 13:
@@ -1688,6 +1805,32 @@ def _memory_evolution_next_actions(
         actions.append("Keep external-channel automatic recall blocked until exact allowlists are reviewed.")
     if not actions:
         actions.append("Continue with the next read-only governance/readiness capability before any durable write.")
+    return actions[:5]
+
+
+def _orchestration_routing_gaps(evidence_checks: Mapping[str, bool]) -> list[str]:
+    labels = {
+        "has_three_or_more_agents": "OpenClaw has at least 3 configured agents.",
+        "has_route_binding": "OpenClaw has at least 1 route binding.",
+        "has_auto_precheck_profile": "Hermes memory auto-precheck has at least 1 profile.",
+        "has_operation_activity": "Hermes operation ledger has routing, gate, or auto-precheck activity.",
+    }
+    return [label for key, label in labels.items() if not evidence_checks.get(key)]
+
+
+def _orchestration_routing_next_actions(gaps: Iterable[str]) -> list[str]:
+    actions: list[str] = []
+    gap_text = " ".join(gaps)
+    if "3 configured agents" in gap_text:
+        actions.append("Keep Star Hub pending until OpenClaw exposes at least 3 existing agents in local config.")
+    if "route binding" in gap_text:
+        actions.append("Keep Star Hub pending until local OpenClaw route bindings are present; do not modify OpenClaw config from this tool.")
+    if "auto-precheck" in gap_text:
+        actions.append("Keep Star Hub pending until the Hermes memory plugin has an existing auto-precheck profile.")
+    if "operation ledger" in gap_text:
+        actions.append("Keep Star Hub pending until the Hermes operation ledger contains routing, gate, or auto-precheck events.")
+    if not actions:
+        actions.append("Continue monitoring routing metrics read-only; do not widen allowlists or enable external automatic recall.")
     return actions[:5]
 
 
@@ -1736,8 +1879,7 @@ def _openclaw_memory_client_status() -> dict[str, Any]:
     extension_path = Path.home() / ".openclaw" / "extensions" / "hermes-memory" / "index.ts"
     manifest_path = Path.home() / ".openclaw" / "extensions" / "hermes-memory" / "openclaw.plugin.json"
     config = _loads_json(_safe_read_text(config_path), {})
-    entries = config.get("plugins", {}).get("entries", {}) if isinstance(config, dict) else {}
-    entry = entries.get("hermes-memory", {}) if isinstance(entries, dict) else {}
+    entry = _openclaw_hermes_plugin_entry(config if isinstance(config, dict) else {})
     plugin_config = entry.get("config", {}) if isinstance(entry, dict) else {}
     profiles = plugin_config.get("autoPrecheckAgentProfiles", {}) if isinstance(plugin_config, dict) else {}
     allowed_channels = plugin_config.get("autoPrecheckAllowedChannelIds", []) if isinstance(plugin_config, dict) else []
@@ -1759,6 +1901,168 @@ def _openclaw_memory_client_status() -> dict[str, Any]:
         "write_policy": "proposal_only",
         "ready": config_path.exists() and extension_path.exists() and bool(entry.get("enabled")) if isinstance(entry, dict) else False,
     }
+
+
+def _openclaw_hermes_plugin_entry(config: Mapping[str, Any]) -> dict[str, Any]:
+    plugins = config.get("plugins", {}) if isinstance(config, Mapping) else {}
+    entries = plugins.get("entries", {}) if isinstance(plugins, Mapping) else {}
+    entry = entries.get("hermes-memory", {}) if isinstance(entries, Mapping) else {}
+    return entry if isinstance(entry, dict) else {}
+
+
+def _openclaw_hermes_plugin_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    entry = _openclaw_hermes_plugin_entry(config)
+    plugin_config = entry.get("config", {}) if isinstance(entry, Mapping) else {}
+    return plugin_config if isinstance(plugin_config, dict) else {}
+
+
+def _openclaw_agent_ids(config: Mapping[str, Any]) -> list[str]:
+    agents = config.get("agents", {}) if isinstance(config, Mapping) else {}
+    ids: set[str] = set()
+    if isinstance(agents, list):
+        for index, item in enumerate(agents):
+            if isinstance(item, Mapping):
+                ids.add(_clean_text(item.get("id") or item.get("name") or item.get("agentId") or f"agent_{index}"))
+            elif _clean_text(item):
+                ids.add(_clean_text(item))
+    elif isinstance(agents, Mapping):
+        for key, value in agents.items():
+            key_text = _clean_text(key)
+            if key_text in {"defaults", "default", "settings", "config"}:
+                continue
+            if key_text in {"entries", "profiles", "items", "list", "agents"}:
+                ids.update(_ids_from_collection(value, fallback_prefix="agent"))
+                continue
+            if isinstance(value, Mapping):
+                ids.add(_clean_text(value.get("id") or value.get("name") or key_text))
+            elif isinstance(value, list):
+                ids.update(_ids_from_collection(value, fallback_prefix=key_text or "agent"))
+            elif _clean_text(value):
+                ids.add(key_text or _clean_text(value))
+    return sorted(item for item in ids if item)
+
+
+def _ids_from_collection(value: Any, *, fallback_prefix: str) -> set[str]:
+    ids: set[str] = set()
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if isinstance(item, Mapping):
+                ids.add(_clean_text(item.get("id") or item.get("name") or key))
+            elif _clean_text(item):
+                ids.add(_clean_text(key) or _clean_text(item))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            if isinstance(item, Mapping):
+                ids.add(_clean_text(item.get("id") or item.get("name") or item.get("agentId") or f"{fallback_prefix}_{index}"))
+            elif _clean_text(item):
+                ids.add(_clean_text(item))
+    return {item for item in ids if item}
+
+
+def _openclaw_route_bindings(config: Mapping[str, Any]) -> list[dict[str, str]]:
+    bindings: list[dict[str, str]] = []
+    _collect_openclaw_route_bindings(config, bindings, path="")
+    unique: dict[tuple[str, str, str, str, str, str], dict[str, str]] = {}
+    for binding in bindings:
+        key = (
+            binding.get("channel", ""),
+            binding.get("agent_id", ""),
+            binding.get("account_id", ""),
+            binding.get("peer_kind", ""),
+            binding.get("peer_id", ""),
+            binding.get("source", ""),
+        )
+        unique[key] = binding
+    return list(unique.values())
+
+
+def _collect_openclaw_route_bindings(value: Any, bindings: list[dict[str, str]], *, path: str) -> None:
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _collect_openclaw_route_bindings(item, bindings, path=f"{path}/{index}")
+        return
+    if not isinstance(value, Mapping):
+        return
+
+    normalized_path = path.replace("_", "").replace("-", "").lower()
+    if _looks_like_route_binding(value):
+        bindings.append(_normalize_openclaw_route_binding(value, source=path or "/"))
+
+    for key, item in value.items():
+        key_text = _clean_text(key)
+        key_normalized = key_text.replace("_", "").replace("-", "").lower()
+        child_path = f"{path}/{key_text}" if path else key_text
+        if _is_route_binding_container(key_normalized):
+            if isinstance(item, Mapping):
+                for route_key, route_value in item.items():
+                    if isinstance(route_value, Mapping):
+                        binding = _normalize_openclaw_route_binding(route_value, source=f"{child_path}/{route_key}")
+                        if not binding.get("channel"):
+                            binding["channel"] = _clean_text(route_key)
+                        bindings.append(binding)
+                    elif isinstance(route_value, list):
+                        for agent_id in _list_of_str(route_value):
+                            bindings.append({"channel": _clean_text(route_key), "agent_id": agent_id, "source": f"{child_path}/{route_key}"})
+                    elif _clean_text(route_value):
+                        bindings.append({"channel": _clean_text(route_key), "agent_id": _clean_text(route_value), "source": f"{child_path}/{route_key}"})
+            elif isinstance(item, list):
+                for index, route_value in enumerate(item):
+                    if isinstance(route_value, Mapping) and _looks_like_route_binding(route_value):
+                        bindings.append(_normalize_openclaw_route_binding(route_value, source=f"{child_path}/{index}"))
+            continue
+        if "route" in normalized_path or "binding" in normalized_path or "route" in key_normalized or "binding" in key_normalized:
+            _collect_openclaw_route_bindings(item, bindings, path=child_path)
+
+
+def _is_route_binding_container(key: str) -> bool:
+    return key in {
+        "routebindings",
+        "routingbindings",
+        "channelroutebindings",
+        "channelagentbindings",
+        "agentroutebindings",
+        "routes",
+        "routing",
+    }
+
+
+def _looks_like_route_binding(value: Mapping[str, Any]) -> bool:
+    keys = {str(key).replace("_", "").replace("-", "").lower() for key in value.keys()}
+    match = value.get("match")
+    match_keys = {str(key).replace("_", "").replace("-", "").lower() for key in match.keys()} if isinstance(match, Mapping) else set()
+    binding_type = _clean_text(value.get("type")).lower()
+    has_channel = bool(keys & {"channel", "channelid", "route", "target"} or match_keys & {"channel", "channelid"})
+    has_agent = bool(keys & {"agent", "agentid", "profile", "profileid"})
+    return has_channel and has_agent and (not binding_type or binding_type == "route")
+
+
+def _normalize_openclaw_route_binding(value: Mapping[str, Any], *, source: str) -> dict[str, str]:
+    match = value.get("match")
+    match = match if isinstance(match, Mapping) else {}
+    binding = {
+        "agent_id": _clean_text(value.get("agentId") or value.get("agent_id") or value.get("agent") or value.get("profileId") or value.get("profile")),
+        "channel": _clean_text(
+            value.get("channelId")
+            or value.get("channel_id")
+            or value.get("channel")
+            or value.get("route")
+            or value.get("target")
+            or match.get("channelId")
+            or match.get("channel_id")
+            or match.get("channel")
+        ),
+        "source": source,
+    }
+    optional_fields = {
+        "account_id": value.get("accountId") or value.get("account_id") or match.get("accountId") or match.get("account_id"),
+        "peer_kind": value.get("peerKind") or value.get("peer_kind") or match.get("peerKind") or match.get("peer_kind"),
+        "peer_id": value.get("peerId") or value.get("peer_id") or match.get("peerId") or match.get("peer_id"),
+    }
+    for key, item in optional_fields.items():
+        cleaned = _clean_text(item)
+        if cleaned:
+            binding[key] = cleaned
+    return binding
 
 
 def _federation_warnings(clients: Mapping[str, Any]) -> list[str]:

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -651,9 +651,7 @@ def memory_orchestration_routing_metrics() -> dict[str, Any]:
         "has_three_or_more_agents": len(agent_ids) >= 3,
         "has_route_binding": len(route_bindings) >= 1,
         "has_auto_precheck_profile": len(profile_ids) >= 1,
-        "has_operation_activity": (
-            operation_routing_event_count + gate_decision_count + auto_precheck_operation_count
-        ) >= 1,
+        "has_explicit_routing_operation_event": operation_routing_event_count >= 1,
     }
     routing_readiness_score = round(sum(1 for value in evidence_checks.values() if value) / len(evidence_checks), 3)
     gaps = _orchestration_routing_gaps(evidence_checks)
@@ -674,6 +672,7 @@ def memory_orchestration_routing_metrics() -> dict[str, Any]:
         "auto_precheck_profile_count": len(profile_ids),
         "auto_precheck_agent_ids": auto_precheck_agent_ids,
         "operation_routing_event_count": operation_routing_event_count,
+        "has_explicit_routing_operation_event": operation_routing_event_count >= 1,
         "gate_decision_count": gate_decision_count,
         "auto_precheck_operation_count": auto_precheck_operation_count,
         "client_counts": dict(sorted(client_counts.items())),
@@ -1728,6 +1727,7 @@ def _memory_evolution_evidence(
         "routing_agent_count": _safe_int(routing_metrics.get("agent_count")),
         "routing_route_binding_count": _safe_int(routing_metrics.get("route_binding_count")),
         "routing_operation_event_count": _safe_int(routing_metrics.get("operation_routing_event_count")),
+        "has_explicit_routing_operation_event": _safe_int(routing_metrics.get("operation_routing_event_count")) >= 1,
         "routing_gate_decision_count": _safe_int(routing_metrics.get("gate_decision_count")),
         "routing_auto_precheck_operation_count": _safe_int(routing_metrics.get("auto_precheck_operation_count")),
         "recall_quality_evaluation_ready": recall_quality.get("readiness") == "ready",
@@ -1769,6 +1769,7 @@ def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dic
         criteria.append(("Cross-system boundary allowlists are explicitly reviewed", bool(evidence.get("boundary_allowlists_reviewed"))))
     if level >= 11:
         criteria.append(("Memory orchestration has active routing metrics", bool(evidence.get("active_routing_metrics"))))
+        criteria.append(("Memory orchestration has explicit route/routing/orchestration operation evidence", bool(evidence.get("has_explicit_routing_operation_event"))))
     if level >= 12:
         criteria.append(("Policy proposals close automatically after human approval and guarded checks", False))
     if level >= 13:
@@ -1813,7 +1814,7 @@ def _orchestration_routing_gaps(evidence_checks: Mapping[str, bool]) -> list[str
         "has_three_or_more_agents": "OpenClaw has at least 3 configured agents.",
         "has_route_binding": "OpenClaw has at least 1 route binding.",
         "has_auto_precheck_profile": "Hermes memory auto-precheck has at least 1 profile.",
-        "has_operation_activity": "Hermes operation ledger has routing, gate, or auto-precheck activity.",
+        "has_explicit_routing_operation_event": "Hermes operation ledger has at least 1 explicit route/routing/orchestration event.",
     }
     return [label for key, label in labels.items() if not evidence_checks.get(key)]
 
@@ -1828,7 +1829,7 @@ def _orchestration_routing_next_actions(gaps: Iterable[str]) -> list[str]:
     if "auto-precheck" in gap_text:
         actions.append("Keep Star Hub pending until the Hermes memory plugin has an existing auto-precheck profile.")
     if "operation ledger" in gap_text:
-        actions.append("Keep Star Hub pending until the Hermes operation ledger contains routing, gate, or auto-precheck events.")
+        actions.append("Keep Star Hub pending until a governed routing event is recorded in the Hermes operation ledger; do not modify config from this tool.")
     if not actions:
         actions.append("Continue monitoring routing metrics read-only; do not widen allowlists or enable external automatic recall.")
     return actions[:5]

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -297,7 +297,7 @@ def memory_evolution_status() -> dict[str, Any]:
             if isinstance(recall_quality.get("summary"), dict)
             else None,
         },
-        "recommended_next_actions": _memory_evolution_next_actions(current, next_item, outcome),
+        "recommended_next_actions": _memory_evolution_next_actions(current, next_item, outcome, evidence),
         "policy": {
             "taxonomy_is_fixed": True,
             "status_is_read_only": True,
@@ -1437,6 +1437,7 @@ def create_memory_write_proposal(
         "status": "proposed",
         "would_write_memory": False,
         "would_modify_graph": False,
+        "would_modify_config": False,
     }
     path = _proposal_path(get_hermes_home())
     event = _append_jsonl(path, proposal)
@@ -1705,6 +1706,7 @@ def _memory_evolution_evidence(
     codex = clients.get("codex", {}) if isinstance(clients.get("codex"), dict) else {}
     routing_metrics = routing_metrics if isinstance(routing_metrics, Mapping) else {}
     policy_outcome = _policy_closed_loop_evidence(outcome)
+    star_soul_evidence = _star_soul_continuity_evidence()
     return {
         "has_basic_memory_home": bool(bridge.get("hermes_home")),
         "has_graph": bool(graph.get("exists")) and _safe_int(graph.get("node_count")) > 0,
@@ -1741,6 +1743,7 @@ def _memory_evolution_evidence(
         if isinstance(outcome.get("metrics"), dict)
         else 0,
         **policy_outcome,
+        **star_soul_evidence,
     }
 
 
@@ -1775,6 +1778,75 @@ def _policy_closed_loop_evidence(outcome: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+STAR_SOUL_CONTINUITY_TERMS = {
+    "preference",
+    "preferences",
+    "persona",
+    "collaboration",
+    "style",
+    "continuity",
+    "long-term",
+    "long_term",
+    "星魂",
+    "偏好",
+    "人格",
+    "协作风格",
+    "长期",
+}
+
+
+def _star_soul_continuity_evidence() -> dict[str, Any]:
+    """Read proposal-only continuity evidence without mutating memory."""
+
+    home = get_hermes_home()
+    proposals = [row for row in _read_jsonl(_proposal_path(home)) if not row.get("_parse_error")]
+    ledger = memory_operation_ledger(limit=500, event_type="write_proposal_created")
+    events = ledger.get("events", []) if isinstance(ledger.get("events"), list) else []
+    persona_proposals = [proposal for proposal in proposals if _is_persona_continuity_write_proposal(proposal)]
+    persona_proposal_ids = {
+        _clean_text(proposal.get("proposal_id"))
+        for proposal in persona_proposals
+        if _clean_text(proposal.get("proposal_id"))
+    }
+    governed_events = [
+        event
+        for event in events
+        if _clean_text(event.get("event_type")) == "write_proposal_created"
+        and _clean_text(event.get("operation")) == "write_proposal"
+        and _clean_text(event.get("proposal_id")) in persona_proposal_ids
+        and event.get("would_write_memory") is not True
+        and event.get("would_modify_config") is not True
+        and event.get("would_modify_graph") is not True
+    ]
+    governed_proposal_ids = sorted({_clean_text(event.get("proposal_id")) for event in governed_events})
+    return {
+        "write_proposal_count": len(proposals),
+        "write_proposal_operation_event_count": len(events),
+        "persona_continuity_write_proposal_count": len(persona_proposals),
+        "persona_continuity_governed_proposal_ids": governed_proposal_ids,
+        "persona_continuity_governed_event_count": len(governed_events),
+        "persona_continuity_governed": bool(governed_events),
+    }
+
+
+def _is_persona_continuity_write_proposal(proposal: Mapping[str, Any]) -> bool:
+    if proposal.get("would_write_memory") is not False:
+        return False
+    if proposal.get("would_modify_graph") is not False:
+        return False
+    if proposal.get("would_modify_config") is True:
+        return False
+    searchable = " ".join(
+        [
+            " ".join(_list_of_str(proposal.get("tags"))),
+            _clean_text(proposal.get("content")),
+            _clean_text(proposal.get("rationale")),
+            _clean_text(proposal.get("target_scope")),
+        ]
+    ).lower()
+    return any(term.lower() in searchable for term in STAR_SOUL_CONTINUITY_TERMS)
+
+
 def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dict[str, Any]:
     level = _safe_int(tier.get("level"))
     criteria: list[tuple[str, bool]] = []
@@ -1806,7 +1878,7 @@ def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dic
     if level >= 12:
         criteria.append(("Policy proposals close automatically after human approval and guarded checks", bool(evidence.get("policy_closed_loop_ready"))))
     if level >= 13:
-        criteria.append(("Long-term preference/persona continuity is governed", False))
+        criteria.append(("Long-term preference/persona continuity is governed", bool(evidence.get("persona_continuity_governed"))))
     if level >= 14:
         criteria.append(("Temporal evolution metrics exist across projects", False))
     if level >= 15:
@@ -1830,6 +1902,7 @@ def _memory_evolution_next_actions(
     current: Mapping[str, Any],
     next_item: Mapping[str, Any] | None,
     outcome: Mapping[str, Any],
+    evidence: Mapping[str, Any],
 ) -> list[str]:
     actions = []
     policy_outcome = _policy_closed_loop_evidence(outcome)
@@ -1840,6 +1913,8 @@ def _memory_evolution_next_actions(
         actions.append("Keep external-channel automatic recall blocked until exact allowlists are reviewed.")
     if not policy_outcome["policy_closed_loop_ready"]:
         actions.append("Run guarded non-mutating policy apply checks with explicit confirmation for approved proposals before claiming 星律记忆.")
+    if next_item and next_item.get("name") == "星魂记忆" and not evidence.get("persona_continuity_governed"):
+        actions.append("Create a governed memory_write_proposal for long-term preference/persona/collaboration-style continuity; do not write memory directly.")
     if not actions:
         actions.append("Continue with the next read-only governance/readiness capability before any durable write.")
     return actions[:5]

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -1708,6 +1708,7 @@ def _memory_evolution_evidence(
     policy_outcome = _policy_closed_loop_evidence(outcome)
     star_soul_evidence = _star_soul_continuity_evidence()
     star_universe_evidence = _star_universe_temporal_evolution_evidence()
+    star_source_evidence = _star_source_methodology_evidence()
     return {
         "has_basic_memory_home": bool(bridge.get("hermes_home")),
         "has_graph": bool(graph.get("exists")) and _safe_int(graph.get("node_count")) > 0,
@@ -1746,6 +1747,7 @@ def _memory_evolution_evidence(
         **policy_outcome,
         **star_soul_evidence,
         **star_universe_evidence,
+        **star_source_evidence,
     }
 
 
@@ -1907,6 +1909,74 @@ TEMPORAL_EVOLUTION_DATE_LIST_KEYS = {
     "temporal_evolution_days",
 }
 
+STAR_SOURCE_EXPLICIT_TYPES = {
+    "source_reasoning_methodology",
+    "source_methodology_self_evolution",
+    "methodology_self_evolution",
+    "source_reasoning",
+}
+STAR_SOURCE_SOURCE_TERMS = {
+    "source_reasoning",
+    "source-reasoning",
+    "source reasoning",
+    "source_provenance_reasoning",
+    "provenance_reasoning",
+    "来源推理",
+    "源推理",
+}
+STAR_SOURCE_METHODOLOGY_TERMS = {
+    "methodology_generation",
+    "methodology-generation",
+    "methodology generation",
+    "generate_methodology",
+    "generated_methodology",
+    "方法论生成",
+}
+STAR_SOURCE_SELF_EVOLUTION_TERMS = {
+    "self_evolution",
+    "self-evolution",
+    "self evolution",
+    "methodology_self_evolution",
+    "source_methodology_self_evolution",
+    "自进化",
+    "自我进化",
+}
+STAR_SOURCE_PROJECT_KEYS = {
+    "project",
+    "project_id",
+    "project_scope",
+    "target_project",
+    "target_project_id",
+    "target_project_scope",
+    "source_project",
+    "source_project_id",
+    "source_project_scope",
+}
+STAR_SOURCE_PROJECT_LIST_KEYS = {
+    "projects",
+    "project_ids",
+    "project_scopes",
+    "target_projects",
+    "target_project_ids",
+    "target_project_scopes",
+    "source_projects",
+    "source_project_ids",
+    "source_project_scopes",
+}
+STAR_SOURCE_SURFACE_KEYS = {
+    "surface",
+    "source_surface",
+    "target_surface",
+    "evidence_surface",
+}
+STAR_SOURCE_SURFACE_LIST_KEYS = {
+    "surfaces",
+    "surface_ids",
+    "memory_surfaces",
+    "evidence_surfaces",
+    "contributing_surfaces",
+}
+
 
 def _star_universe_temporal_evolution_evidence() -> dict[str, Any]:
     """Read explicit temporal evolution metric evidence without mutating state."""
@@ -1980,6 +2050,161 @@ def _star_universe_temporal_evolution_evidence() -> dict[str, Any]:
         "temporal_evolution_surface_count": len(surfaces),
         "temporal_evolution_metrics_ready": ready,
     }
+
+
+def _star_source_methodology_evidence() -> dict[str, Any]:
+    """Read explicit source/methodology self-evolution evidence without mutation."""
+
+    home = get_hermes_home()
+    source_reasoning_count = 0
+    methodology_generation_count = 0
+    self_evolution_count = 0
+    governed_event_ids: list[str] = []
+    project_ids: set[str] = set()
+    surfaces: set[str] = set()
+
+    for row in _read_jsonl(_operation_ledger_path(home)):
+        if row.get("_parse_error") or not _is_explicit_star_source_record(row):
+            continue
+        event_surfaces = {"operation_ledger"}
+        semantic_text = _star_source_semantic_text(row)
+        has_source_reasoning = _star_source_has_semantic(row, semantic_text, STAR_SOURCE_SOURCE_TERMS)
+        has_methodology_generation = _star_source_has_semantic(row, semantic_text, STAR_SOURCE_METHODOLOGY_TERMS)
+        has_self_evolution = _star_source_has_semantic(row, semantic_text, STAR_SOURCE_SELF_EVOLUTION_TERMS)
+        if has_source_reasoning:
+            source_reasoning_count += 1
+        if has_methodology_generation:
+            methodology_generation_count += 1
+        if has_self_evolution:
+            self_evolution_count += 1
+        event_project_ids = _temporal_evolution_values(
+            row,
+            STAR_SOURCE_PROJECT_KEYS,
+            STAR_SOURCE_PROJECT_LIST_KEYS,
+        )
+        event_surfaces.update(
+            _temporal_evolution_values(
+                row,
+                STAR_SOURCE_SURFACE_KEYS,
+                STAR_SOURCE_SURFACE_LIST_KEYS,
+            )
+        )
+        event_is_read_only = _star_source_record_is_read_only(row)
+        project_ids.update(event_project_ids)
+        surfaces.update(event_surfaces)
+        if (
+            has_source_reasoning
+            and has_methodology_generation
+            and has_self_evolution
+            and len(event_project_ids) >= 1
+            and len(event_surfaces) >= 2
+            and event_is_read_only
+        ):
+            governed_event_ids.append(_star_source_event_id(row))
+
+    sorted_project_ids = sorted(project_ids)
+    ready = len(governed_event_ids) >= 1
+    return {
+        "source_reasoning_event_count": source_reasoning_count,
+        "methodology_generation_event_count": methodology_generation_count,
+        "self_evolution_event_count": self_evolution_count,
+        "source_methodology_project_count": len(sorted_project_ids),
+        "source_methodology_project_ids": sorted_project_ids,
+        "source_methodology_surface_count": len(surfaces),
+        "source_methodology_governed_event_count": len(governed_event_ids),
+        "source_methodology_governed_event_ids": governed_event_ids,
+        "source_methodology_ready": ready,
+    }
+
+
+def _is_explicit_star_source_record(row: Mapping[str, Any]) -> bool:
+    for key in (
+        "event_type",
+        "operation",
+        "metrics_type",
+        "record_type",
+        "evidence_type",
+        "type",
+    ):
+        value = _clean_text(row.get(key)).lower().replace("-", "_").replace(" ", "_")
+        if value in STAR_SOURCE_EXPLICIT_TYPES:
+            return True
+    return False
+
+
+def _star_source_record_is_read_only(row: Mapping[str, Any]) -> bool:
+    operation = _clean_text(row.get("operation")).lower()
+    return (
+        operation not in DURABLE_WRITE_OPERATIONS
+        and operation != "policy_apply_execute"
+        and row.get("would_modify_config") is not True
+        and row.get("would_write_memory") is not True
+        and row.get("would_mutate_memory") is not True
+        and row.get("would_modify_graph") is not True
+        and row.get("would_write_graph") is not True
+    )
+
+
+def _star_source_event_id(row: Mapping[str, Any]) -> str:
+    for key in ("event_id", "operation_id", "record_id", "id"):
+        value = _clean_text(row.get(key))
+        if value:
+            return value
+    return _digest(row)
+
+
+def _star_source_has_semantic(row: Mapping[str, Any], semantic_text: str, terms: set[str]) -> bool:
+    if any(row.get(term) is True for term in terms):
+        return True
+    normalized_text = semantic_text.lower().replace("-", "_").replace(" ", "_")
+    normalized_terms = {term.lower().replace("-", "_").replace(" ", "_") for term in terms}
+    return any(term in normalized_text for term in normalized_terms)
+
+
+def _star_source_semantic_text(row: Mapping[str, Any]) -> str:
+    values: list[str] = []
+    for key in (
+        "event_type",
+        "operation",
+        "record_type",
+        "evidence_type",
+        "type",
+        "capability",
+        "reasoning_type",
+        "methodology_type",
+        "evolution_type",
+        "description",
+        "summary",
+        "rationale",
+    ):
+        values.append(_clean_text(row.get(key)))
+    values.extend(_list_of_str(row.get("tags")))
+    values.extend(_list_of_str(row.get("labels")))
+    values.extend(_star_source_metadata_terms(row.get("metadata")))
+    values.extend(_star_source_metadata_terms(row.get("evidence")))
+    values.extend(_star_source_metadata_terms(row.get("governance")))
+    return " ".join(value for value in values if value)
+
+
+def _star_source_metadata_terms(value: Any) -> list[str]:
+    if isinstance(value, Mapping):
+        terms: list[str] = []
+        for key, item in value.items():
+            terms.append(_clean_text(key))
+            if isinstance(item, (Mapping, list, tuple, set)):
+                terms.extend(_star_source_metadata_terms(item))
+            elif item is True:
+                terms.append(_clean_text(key))
+            else:
+                terms.append(_clean_text(item))
+        return [term for term in terms if term]
+    if isinstance(value, (list, tuple, set)):
+        terms: list[str] = []
+        for item in value:
+            terms.extend(_star_source_metadata_terms(item))
+        return terms
+    text = _clean_text(value)
+    return [text] if text else []
 
 
 def _is_explicit_temporal_evolution_metrics_record(row: Mapping[str, Any]) -> bool:
@@ -2092,7 +2317,7 @@ def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dic
     if level >= 14:
         criteria.append(("Temporal evolution metrics exist across projects", bool(evidence.get("temporal_evolution_metrics_ready"))))
     if level >= 15:
-        criteria.append(("Source reasoning and methodology self-evolution are implemented", False))
+        criteria.append(("Source reasoning and methodology self-evolution are implemented", bool(evidence.get("source_methodology_ready"))))
     passed = [name for name, ok in criteria if ok]
     gaps = [name for name, ok in criteria if not ok]
     readiness_score = round(len(passed) / len(criteria), 3) if criteria else 0.0
@@ -2127,6 +2352,8 @@ def _memory_evolution_next_actions(
         actions.append("Create a governed memory_write_proposal for long-term preference/persona/collaboration-style continuity; do not write memory directly.")
     if next_item and next_item.get("name") == "星宙记忆" and not evidence.get("temporal_evolution_metrics_ready"):
         actions.append("Create or export a governed read-only temporal evolution metrics snapshot across projects; do not write Memory Graph or durable memory.")
+    if next_item and next_item.get("name") == "星源记忆" and not evidence.get("source_methodology_ready"):
+        actions.append("Create a governed read-only source reasoning and methodology self-evolution audit event; do not write Memory Graph or durable memory.")
     if not actions:
         actions.append("Continue with the next read-only governance/readiness capability before any durable write.")
     return actions[:5]

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -433,6 +433,8 @@ def memory_boundary_allowlist_audit(*, log_limit: int = 200) -> dict[str, Any]:
 
     reviewed_allowlists = []
     unreviewed_allowlists = []
+    manual_review_evidence = _boundary_manual_review_evidence()
+    manual_review_complete = bool(manual_review_evidence.get("complete"))
 
     if external_allowed:
         unreviewed_allowlists.append({
@@ -440,18 +442,29 @@ def memory_boundary_allowlist_audit(*, log_limit: int = 200) -> dict[str, Any]:
             "value": external_allowed,
             "reason": "External automatic recall allowlist is non-empty and requires explicit human review evidence.",
         })
-    else:
+    elif manual_review_complete:
         reviewed_allowlists.append({
             "id": "openclaw.external_auto_precheck_allowed_channels",
             "value": [],
-            "review": "empty_allowlist_reviewed_as_blocked_default",
+            "review": "empty_allowlist_reviewed_with_manual_evidence",
+            "evidence_source": manual_review_evidence.get("source"),
+        })
+    else:
+        unreviewed_allowlists.append({
+            "id": "openclaw.external_auto_precheck_boundary_review",
+            "value": {
+                "external_auto_precheck_allowed_channels": [],
+                "external_auto_precheck_default": openclaw.get("external_auto_precheck_default"),
+            },
+            "reason": "Empty allowlist and blocked default are safe, but 星界记忆 readiness requires explicit manual boundary review evidence in the policy or operation ledger.",
         })
 
-    if openclaw.get("external_auto_precheck_default") == "blocked":
+    if openclaw.get("external_auto_precheck_default") == "blocked" and manual_review_complete:
         reviewed_allowlists.append({
             "id": "openclaw.external_auto_precheck_default",
             "value": "blocked",
-            "review": "external automatic recall remains blocked by default",
+            "review": "blocked_default_reviewed_with_manual_evidence",
+            "evidence_source": manual_review_evidence.get("source"),
         })
 
     exposure_risks = []
@@ -501,13 +514,16 @@ def memory_boundary_allowlist_audit(*, log_limit: int = 200) -> dict[str, Any]:
         and openclaw.get("external_auto_precheck_default") == "blocked"
         and status.get("policy", {}).get("writes_are_proposal_only") is True
         and status.get("policy", {}).get("external_channel_auto_recall_requires_allowlist") is True
+        and manual_review_complete
     )
 
     recommended_next_actions = []
     if ready:
-        recommended_next_actions.append("Mark cross-system boundary allowlists as explicitly reviewed for 星界记忆 readiness.")
+        recommended_next_actions.append("Keep the manual boundary review evidence linked to 星界记忆 readiness.")
     else:
         recommended_next_actions.append("Keep external automatic recall blocked and resolve unreviewed allowlists or exposure risks before 星界记忆.")
+    if not manual_review_complete:
+        recommended_next_actions.append("Create a formal policy proposal or manual review record for the blocked external automatic recall boundary; the audit will only read that evidence.")
     if external_allowed:
         recommended_next_actions.append("Create a policy proposal for each exact external channel before allowlisting; do not auto-approve.")
 
@@ -552,9 +568,12 @@ def memory_boundary_allowlist_audit(*, log_limit: int = 200) -> dict[str, Any]:
             "policy_outcome_risk_level": outcome.get("risk_level"),
             "ledger_health_score": ledger.get("health_score"),
             "ledger_risk_level": ledger.get("risk_level"),
+            "manual_boundary_review": manual_review_evidence,
             "critical_audit_failure_count": len(critical_audit_failures),
             "unreviewed_allowlist_count": len(unreviewed_allowlists),
             "exposure_risk_count": len(exposure_risks),
+            "external_auto_precheck_default_blocked": openclaw.get("external_auto_precheck_default") == "blocked",
+            "external_auto_precheck_allowlist_empty": not external_allowed,
         },
         "recommended_next_actions": recommended_next_actions,
         "policy": {
@@ -1464,6 +1483,102 @@ memory_fabric_search = search_memory_fabric
 memory_graph_read = read_memory_graph
 memory_write_proposal = create_memory_write_proposal
 memory_snapshot_export = export_memory_snapshot
+
+
+def _boundary_manual_review_evidence() -> dict[str, Any]:
+    """Find existing manual boundary review evidence without recording anything."""
+
+    policy_ledger = memory_policy_proposal_ledger(limit=500)
+    proposals = policy_ledger.get("proposals", []) if isinstance(policy_ledger.get("proposals"), list) else []
+    for proposal in proposals:
+        if not isinstance(proposal, dict) or not _is_boundary_review_policy_proposal(proposal):
+            continue
+        decisions = proposal.get("decisions", []) if isinstance(proposal.get("decisions"), list) else []
+        approved_decisions = [
+            decision for decision in decisions
+            if isinstance(decision, dict) and _clean_text(decision.get("decision")) == "approved"
+        ]
+        if approved_decisions and proposal.get("latest_status") == "approved":
+            latest = approved_decisions[-1]
+            return {
+                "complete": True,
+                "source": "policy_proposal_ledger",
+                "proposal_id": proposal.get("proposal_id", ""),
+                "suggestion_id": proposal.get("suggestion_id", ""),
+                "reviewer": latest.get("reviewer", ""),
+                "reviewed_at": latest.get("created_at", ""),
+                "decision": "approved",
+                "read_only_detection": True,
+            }
+
+    operation_ledger = memory_operation_ledger(limit=500)
+    events = operation_ledger.get("events", []) if isinstance(operation_ledger.get("events"), list) else []
+    for event in events:
+        if not isinstance(event, dict) or not _is_boundary_manual_review_event(event):
+            continue
+        return {
+            "complete": True,
+            "source": "operation_ledger",
+            "event_id": event.get("event_id", ""),
+            "event_type": event.get("event_type", ""),
+            "reviewer": event.get("reviewer", event.get("actor", "")),
+            "reviewed_at": event.get("created_at", ""),
+            "decision": event.get("decision", event.get("status", "reviewed")),
+            "read_only_detection": True,
+        }
+
+    decided_boundary_proposals = [
+        {
+            "proposal_id": proposal.get("proposal_id", ""),
+            "suggestion_id": proposal.get("suggestion_id", ""),
+            "latest_status": proposal.get("latest_status", ""),
+        }
+        for proposal in proposals
+        if isinstance(proposal, dict)
+        and _is_boundary_review_policy_proposal(proposal)
+        and proposal.get("latest_status") in {"rejected", "deferred"}
+    ]
+    return {
+        "complete": False,
+        "source": "none",
+        "read_only_detection": True,
+        "policy_proposal_ledger_exists": policy_ledger.get("exists"),
+        "operation_ledger_exists": operation_ledger.get("exists"),
+        "decided_but_not_completion_evidence": decided_boundary_proposals[:5],
+    }
+
+
+def _is_boundary_review_policy_proposal(proposal: Mapping[str, Any]) -> bool:
+    suggestion_id = _clean_text(proposal.get("suggestion_id"))
+    target = _clean_text(proposal.get("target"))
+    text = " ".join(
+        _clean_text(proposal.get(key)).lower()
+        for key in ("recommendation", "rationale", "next_step")
+    )
+    return (
+        suggestion_id == "external_auto_recall.keep_blocked"
+        or "autoprecheckallowedchannelids" in target.lower()
+        or "external_auto_recall" in target.lower()
+        or ("external" in text and "allowlist" in text and "review" in text)
+        or ("automatic recall" in text and "blocked" in text and "review" in text)
+    )
+
+
+def _is_boundary_manual_review_event(event: Mapping[str, Any]) -> bool:
+    event_type = _clean_text(event.get("event_type")).lower()
+    operation = _clean_text(event.get("operation")).lower()
+    subject = " ".join(
+        _clean_text(event.get(key)).lower()
+        for key in ("subject", "target", "boundary", "rationale", "reason")
+    )
+    decision = _clean_text(event.get("decision", event.get("status", ""))).lower()
+    non_mutating = event.get("would_modify_config") is not True and event.get("would_write_memory") is not True
+    return (
+        non_mutating
+        and event_type in {"memory_boundary_manual_review", "boundary_manual_review", "manual_boundary_review"}
+        and (operation in {"", "audit", "manual_review", "review"} or "boundary" in subject)
+        and decision in {"", "approved", "reviewed", "complete", "completed", "pass", "passed"}
+    )
 
 
 def _memory_evolution_evidence(

--- a/agent/memory_fabric_bridge.py
+++ b/agent/memory_fabric_bridge.py
@@ -1707,6 +1707,7 @@ def _memory_evolution_evidence(
     routing_metrics = routing_metrics if isinstance(routing_metrics, Mapping) else {}
     policy_outcome = _policy_closed_loop_evidence(outcome)
     star_soul_evidence = _star_soul_continuity_evidence()
+    star_universe_evidence = _star_universe_temporal_evolution_evidence()
     return {
         "has_basic_memory_home": bool(bridge.get("hermes_home")),
         "has_graph": bool(graph.get("exists")) and _safe_int(graph.get("node_count")) > 0,
@@ -1744,6 +1745,7 @@ def _memory_evolution_evidence(
         else 0,
         **policy_outcome,
         **star_soul_evidence,
+        **star_universe_evidence,
     }
 
 
@@ -1847,6 +1849,214 @@ def _is_persona_continuity_write_proposal(proposal: Mapping[str, Any]) -> bool:
     return any(term.lower() in searchable for term in STAR_SOUL_CONTINUITY_TERMS)
 
 
+TEMPORAL_EVOLUTION_METRICS_TYPE = "temporal_evolution_metrics"
+TEMPORAL_EVOLUTION_PROJECT_KEYS = {
+    "project",
+    "project_id",
+    "project_scope",
+    "target_project",
+    "target_project_id",
+    "source_project",
+    "source_project_id",
+}
+TEMPORAL_EVOLUTION_PROJECT_LIST_KEYS = {
+    "projects",
+    "project_ids",
+    "project_scopes",
+    "target_projects",
+    "source_projects",
+    "ecosystem_projects",
+    "ecosystem_project_ids",
+}
+TEMPORAL_EVOLUTION_SURFACE_KEYS = {
+    "surface",
+    "source_surface",
+    "target_surface",
+    "ecosystem_surface",
+}
+TEMPORAL_EVOLUTION_SURFACE_LIST_KEYS = {
+    "surfaces",
+    "surface_ids",
+    "memory_surfaces",
+    "ecosystem_surfaces",
+    "evidence_surfaces",
+    "contributing_surfaces",
+}
+TEMPORAL_EVOLUTION_DATE_KEYS = {
+    "created_at",
+    "updated_at",
+    "recorded_at",
+    "generated_at",
+    "date",
+    "day",
+    "start",
+    "end",
+    "start_at",
+    "end_at",
+    "window_start",
+    "window_end",
+    "start_date",
+    "end_date",
+    "from",
+    "to",
+}
+TEMPORAL_EVOLUTION_DATE_LIST_KEYS = {
+    "days",
+    "dates",
+    "covered_days",
+    "temporal_evolution_days",
+}
+
+
+def _star_universe_temporal_evolution_evidence() -> dict[str, Any]:
+    """Read explicit temporal evolution metric evidence without mutating state."""
+
+    home = get_hermes_home()
+    sources = [
+        ("operation_ledger", _operation_ledger_path(home)),
+        ("policy_proposal_ledger", _policy_proposal_path(home)),
+        ("write_proposal_ledger", _proposal_path(home)),
+    ]
+    explicit_events: list[Mapping[str, Any]] = []
+    days: set[str] = set()
+    clients: set[str] = set()
+    operations: set[str] = set()
+    project_ids: set[str] = set()
+    surfaces: set[str] = set()
+    read_only_policy_holds = True
+
+    for source_surface, path in sources:
+        for row in _read_jsonl(path):
+            if row.get("_parse_error") or not _is_explicit_temporal_evolution_metrics_record(row):
+                continue
+            explicit_events.append(row)
+            surfaces.add(source_surface)
+            days.update(_temporal_evolution_days(row))
+            clients.update(_temporal_evolution_values(row, {"client", "source_agent", "agent", "actor"}, {"clients"}))
+            operation = _clean_text(row.get("operation"))
+            if operation:
+                operations.add(operation)
+            operations.update(_temporal_evolution_values(row, {"operation_id"}, {"operations", "operation_ids"}))
+            project_ids.update(
+                _temporal_evolution_values(
+                    row,
+                    TEMPORAL_EVOLUTION_PROJECT_KEYS,
+                    TEMPORAL_EVOLUTION_PROJECT_LIST_KEYS,
+                )
+            )
+            surfaces.update(
+                _temporal_evolution_values(
+                    row,
+                    TEMPORAL_EVOLUTION_SURFACE_KEYS,
+                    TEMPORAL_EVOLUTION_SURFACE_LIST_KEYS,
+                )
+            )
+            read_only_policy_holds = read_only_policy_holds and _temporal_evolution_record_is_read_only(row)
+
+    sorted_days = sorted(days)
+    sorted_project_ids = sorted(project_ids)
+    event_count = len(explicit_events)
+    operation_count = max(len(operations), event_count)
+    span_days = 0
+    if len(sorted_days) >= 2:
+        start_day = datetime.fromisoformat(sorted_days[0])
+        end_day = datetime.fromisoformat(sorted_days[-1])
+        span_days = max((end_day - start_day).days, 0)
+    ready = (
+        event_count >= 1
+        and len(sorted_days) >= 2
+        and len(sorted_project_ids) >= 2
+        and len(surfaces) >= 2
+        and read_only_policy_holds
+    )
+    return {
+        "temporal_evolution_metric_event_count": event_count,
+        "temporal_evolution_day_count": len(sorted_days),
+        "temporal_evolution_span_days": span_days,
+        "temporal_evolution_client_count": len(clients),
+        "temporal_evolution_operation_count": operation_count,
+        "temporal_evolution_project_count": len(sorted_project_ids),
+        "temporal_evolution_project_ids": sorted_project_ids,
+        "temporal_evolution_surface_count": len(surfaces),
+        "temporal_evolution_metrics_ready": ready,
+    }
+
+
+def _is_explicit_temporal_evolution_metrics_record(row: Mapping[str, Any]) -> bool:
+    for key in (
+        "event_type",
+        "operation",
+        "metrics_type",
+        "snapshot_type",
+        "record_type",
+        "evidence_type",
+        "type",
+    ):
+        value = _clean_text(row.get(key)).lower().replace("-", "_").replace(" ", "_")
+        if value == TEMPORAL_EVOLUTION_METRICS_TYPE:
+            return True
+    return False
+
+
+def _temporal_evolution_record_is_read_only(row: Mapping[str, Any]) -> bool:
+    operation = _clean_text(row.get("operation")).lower()
+    return (
+        operation not in DURABLE_WRITE_OPERATIONS
+        and operation != "policy_apply_execute"
+        and row.get("would_modify_config") is not True
+        and row.get("would_write_memory") is not True
+        and row.get("would_mutate_memory") is not True
+        and row.get("would_modify_graph") is not True
+        and row.get("would_write_graph") is not True
+    )
+
+
+def _temporal_evolution_values(
+    row: Mapping[str, Any],
+    scalar_keys: set[str],
+    list_keys: set[str],
+) -> set[str]:
+    values: set[str] = set()
+    for key in scalar_keys:
+        value = _clean_text(row.get(key))
+        if value and value.lower() not in {"all", "global", "unknown"}:
+            values.add(value)
+    for key in list_keys:
+        values.update(item for item in _list_of_str(row.get(key)) if item.lower() not in {"all", "global", "unknown"})
+    return values
+
+
+def _temporal_evolution_days(row: Mapping[str, Any]) -> set[str]:
+    days: set[str] = set()
+    for key in TEMPORAL_EVOLUTION_DATE_KEYS:
+        day = _date_only(row.get(key))
+        if day:
+            days.add(day)
+    for key in TEMPORAL_EVOLUTION_DATE_LIST_KEYS:
+        for value in _list_of_str(row.get(key)):
+            day = _date_only(value)
+            if day:
+                days.add(day)
+    return days
+
+
+def _date_only(value: Any) -> str:
+    text = _clean_text(value)
+    if not text:
+        return ""
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        pass
+    if len(text) >= 10:
+        candidate = text[:10]
+        try:
+            return datetime.fromisoformat(candidate).date().isoformat()
+        except ValueError:
+            return ""
+    return ""
+
+
 def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dict[str, Any]:
     level = _safe_int(tier.get("level"))
     criteria: list[tuple[str, bool]] = []
@@ -1880,7 +2090,7 @@ def _tier_readiness(tier: Mapping[str, Any], evidence: Mapping[str, Any]) -> dic
     if level >= 13:
         criteria.append(("Long-term preference/persona continuity is governed", bool(evidence.get("persona_continuity_governed"))))
     if level >= 14:
-        criteria.append(("Temporal evolution metrics exist across projects", False))
+        criteria.append(("Temporal evolution metrics exist across projects", bool(evidence.get("temporal_evolution_metrics_ready"))))
     if level >= 15:
         criteria.append(("Source reasoning and methodology self-evolution are implemented", False))
     passed = [name for name, ok in criteria if ok]
@@ -1915,6 +2125,8 @@ def _memory_evolution_next_actions(
         actions.append("Run guarded non-mutating policy apply checks with explicit confirmation for approved proposals before claiming 星律记忆.")
     if next_item and next_item.get("name") == "星魂记忆" and not evidence.get("persona_continuity_governed"):
         actions.append("Create a governed memory_write_proposal for long-term preference/persona/collaboration-style continuity; do not write memory directly.")
+    if next_item and next_item.get("name") == "星宙记忆" and not evidence.get("temporal_evolution_metrics_ready"):
+        actions.append("Create or export a governed read-only temporal evolution metrics snapshot across projects; do not write Memory Graph or durable memory.")
     if not actions:
         actions.append("Continue with the next read-only governance/readiness capability before any durable write.")
     return actions[:5]

--- a/agent/memory_governance_submission_packet.py
+++ b/agent/memory_governance_submission_packet.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_proposal_governance_gate import (
+    explain_governance_submission_candidate,
+    recommend_governance_submission_action,
+    validate_governance_submission_candidate,
+)
+
+
+MEMORY_GOVERNANCE_SUBMISSION_PACKET_VERSION = "0.1"
+MEMORY_GOVERNANCE_SUBMISSION_PACKET_KIND = "memory_governance_submission_packet_candidate"
+MEMORY_GOVERNANCE_SUBMISSION_PACKET_STATUS = "human_review_packet_required"
+MEMORY_GOVERNANCE_SUBMISSION_PACKET_ROUTING = "manual_review_before_real_proposal_creation"
+MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_review_packets_only": True,
+    "creates_real_proposals": False,
+    "applies_proposals": False,
+    "persists_approvals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_FORBIDDEN_TRUE_KEYS = (
+    "submitted",
+    "applied",
+    "persisted",
+    "approved",
+    "converted_to_real_proposal",
+    "created_real_proposal",
+    "created_operation_event",
+)
+
+
+def create_governance_submission_packet(
+    submission_candidate: Mapping[str, Any], reviewer: str | None = None
+) -> dict[str, Any]:
+    """Create a deterministic read-only human-review packet candidate."""
+    source = deepcopy(dict(submission_candidate))
+    submission_validation = validate_governance_submission_candidate(source)
+    invalid_reasons = _packet_invalid_reasons(source, submission_validation)
+
+    packet = {
+        "packet_id": None,
+        "packet_kind": MEMORY_GOVERNANCE_SUBMISSION_PACKET_KIND,
+        "packet_status": MEMORY_GOVERNANCE_SUBMISSION_PACKET_STATUS,
+        "routing": MEMORY_GOVERNANCE_SUBMISSION_PACKET_ROUTING,
+        "source_submission_id": source.get("submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "reviewer": reviewer if reviewer is not None else source.get("reviewer"),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "evidence_summary": _evidence_summary(source),
+        "human_review_checklist": _human_review_checklist(),
+        "risk_notes": _risk_notes(source, submission_validation, invalid_reasons),
+        "submission_validation": deepcopy(submission_validation),
+        "packet_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_submission_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY),
+    }
+    packet["packet_id"] = _packet_id(packet)
+    packet["packet_validation"] = validate_governance_submission_packet(packet)
+    if invalid_reasons:
+        errors = list(packet["packet_validation"]["errors"])
+        for reason in invalid_reasons:
+            if reason not in errors:
+                errors.append(reason)
+        packet["packet_validation"] = {"valid": False, "errors": errors}
+    packet["next_step_recommendation"] = recommend_governance_submission_packet_action(packet)
+    return packet
+
+
+def validate_governance_submission_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(packet.get("policy"))
+    submission_validation = _as_dict(packet.get("submission_validation"))
+    source_snapshot = _as_dict(packet.get("source_submission_snapshot"))
+
+    for key in (
+        "packet_id",
+        "packet_kind",
+        "packet_status",
+        "routing",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "reviewer",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "evidence_summary",
+        "human_review_checklist",
+        "risk_notes",
+        "submission_validation",
+        "packet_validation",
+        "next_step_recommendation",
+        "source_submission_snapshot",
+        "policy",
+    ):
+        if key not in packet:
+            errors.append(f"missing_{key}")
+    if packet.get("packet_kind") != MEMORY_GOVERNANCE_SUBMISSION_PACKET_KIND:
+        errors.append("packet_kind_must_be_memory_governance_submission_packet_candidate")
+    if packet.get("packet_status") != MEMORY_GOVERNANCE_SUBMISSION_PACKET_STATUS:
+        errors.append("packet_status_must_be_human_review_packet_required")
+    if packet.get("routing") != MEMORY_GOVERNANCE_SUBMISSION_PACKET_ROUTING:
+        errors.append("routing_must_require_manual_review_before_real_proposal_creation")
+    if submission_validation.get("valid") is not True:
+        errors.append("invalid_governance_submission_candidate")
+    if source_snapshot:
+        snapshot_validation = validate_governance_submission_candidate(source_snapshot)
+        if snapshot_validation.get("valid") is not True:
+            errors.append("invalid_governance_submission_candidate")
+    if source_snapshot.get("submission_status") != "governance_review_required":
+        errors.append("source_submission_status_must_be_governance_review_required")
+    if not isinstance(packet.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(packet.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(packet.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(packet.get("source_pattern_ids"), list) and isinstance(packet.get("source_fact_ids"), list):
+        if not packet.get("source_pattern_ids") and not packet.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(packet.get("evidence_summary"), Mapping):
+        errors.append("evidence_summary_must_be_mapping")
+    if not isinstance(packet.get("human_review_checklist"), list) or not packet.get("human_review_checklist"):
+        errors.append("human_review_checklist_must_be_non_empty_list")
+    if not isinstance(packet.get("risk_notes"), list):
+        errors.append("risk_notes_must_be_list")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if packet.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_governance_submission_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_governance_submission_packet(packet)
+    source_snapshot = _as_dict(packet.get("source_submission_snapshot"))
+    return {
+        "packet_id": packet.get("packet_id"),
+        "packet_kind": packet.get("packet_kind"),
+        "packet_status": packet.get("packet_status"),
+        "routing": packet.get("routing"),
+        "source_submission_id": packet.get("source_submission_id"),
+        "source_draft_id": packet.get("source_draft_id"),
+        "source_decision_id": packet.get("source_decision_id"),
+        "source_queue_item_id": packet.get("source_queue_item_id"),
+        "block_id": packet.get("block_id"),
+        "block_type": packet.get("block_type"),
+        "project_scope": packet.get("project_scope"),
+        "reviewer": packet.get("reviewer"),
+        "source_pattern_count": len(packet.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(packet.get("source_fact_ids", []) or []),
+        "evidence_summary": deepcopy(packet.get("evidence_summary")),
+        "human_review_checklist": deepcopy(packet.get("human_review_checklist")),
+        "risk_notes": deepcopy(packet.get("risk_notes")),
+        "validation": validation,
+        "submission_explanation": explain_governance_submission_candidate(source_snapshot) if source_snapshot else {},
+        "submitted": False,
+        "applied": False,
+        "persisted": False,
+        "approved": False,
+        "converted_to_real_proposal": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "policy": dict(MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY),
+    }
+
+
+def recommend_governance_submission_packet_action(packet: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_governance_submission_packet(packet)
+    source_snapshot = _as_dict(packet.get("source_submission_snapshot"))
+    if validation["valid"]:
+        action = "route_packet_to_manual_human_review"
+        reason = "Packet candidate is valid for manual human review, but this module does not submit or create a real proposal."
+    else:
+        action = "do_not_route_packet"
+        reason = _recommendation_reason(validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_GOVERNANCE_SUBMISSION_PACKET_ROUTING,
+        "validation": validation,
+        "submission_recommendation": recommend_governance_submission_action(source_snapshot) if source_snapshot else {},
+        "creates_review_packets_only": True,
+        "creates_real_proposals": False,
+        "applies_proposals": False,
+        "persists_approvals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY),
+    }
+
+
+def summarize_governance_submission_packets(
+    packets: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for packet in packets:
+        block_type = str(packet.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(packet.get("packet_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        validation = validate_governance_submission_packet(packet)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(packets),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY),
+    }
+
+
+def _packet_invalid_reasons(source: Mapping[str, Any], submission_validation: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if submission_validation.get("valid") is not True:
+        reasons.append("invalid_governance_submission_candidate")
+    if not isinstance(source.get("payload_preview"), Mapping):
+        reasons.append("missing_payload_preview")
+    if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+        reasons.append("missing_source_evidence")
+    return _dedupe(reasons)
+
+
+def _evidence_summary(source: Mapping[str, Any]) -> dict[str, Any]:
+    pattern_ids = list(source.get("source_pattern_ids", []) or [])
+    fact_ids = list(source.get("source_fact_ids", []) or [])
+    return {
+        "source_pattern_count": len(pattern_ids),
+        "source_fact_count": len(fact_ids),
+        "source_pattern_ids": deepcopy(pattern_ids),
+        "source_fact_ids": deepcopy(fact_ids),
+        "has_source_evidence": bool(pattern_ids or fact_ids),
+    }
+
+
+def _human_review_checklist() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "verify_payload_preview",
+            "label": "Verify payload preview matches intended memory block change.",
+        },
+        {
+            "id": "verify_source_evidence",
+            "label": "Verify source pattern and fact evidence supports the change.",
+        },
+        {
+            "id": "verify_scope_and_routing",
+            "label": "Verify project scope and manual review routing are correct.",
+        },
+        {
+            "id": "verify_no_side_effects",
+            "label": "Verify no proposal, approval, memory, graph, config, or ledger write occurred.",
+        },
+    ]
+
+
+def _risk_notes(
+    source: Mapping[str, Any],
+    submission_validation: Mapping[str, Any],
+    invalid_reasons: list[str],
+) -> list[str]:
+    notes = [
+        "Packet is a read-only candidate for human review only.",
+        "Manual review is required before any real proposal creation.",
+    ]
+    if submission_validation.get("valid") is not True:
+        notes.append("Source governance submission candidate is invalid.")
+    if "missing_payload_preview" in invalid_reasons:
+        notes.append("Payload preview is missing and must be supplied before review.")
+    if "missing_source_evidence" in invalid_reasons:
+        notes.append("Source evidence is missing and must be supplied before review.")
+    if source.get("block_type") == "safety_policy":
+        notes.append("Safety policy blocks require extra governance scrutiny.")
+    return notes
+
+
+def _recommendation_reason(validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if "missing_payload_preview" in errors:
+        return "Packet candidate is missing the payload preview required for human review."
+    if "missing_source_evidence" in errors:
+        return "Packet candidate is missing source pattern or fact evidence."
+    if "invalid_governance_submission_candidate" in errors:
+        return "Source governance submission candidate is invalid and cannot be routed as a review packet."
+    return "Packet candidate violates the v0.1 governance submission packet validation contract."
+
+
+def _packet_id(packet: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_GOVERNANCE_SUBMISSION_PACKET_VERSION,
+        "packet_kind": packet.get("packet_kind"),
+        "packet_status": packet.get("packet_status"),
+        "routing": packet.get("routing"),
+        "source_submission_id": packet.get("source_submission_id"),
+        "source_draft_id": packet.get("source_draft_id"),
+        "source_decision_id": packet.get("source_decision_id"),
+        "source_queue_item_id": packet.get("source_queue_item_id"),
+        "block_id": packet.get("block_id"),
+        "block_type": packet.get("block_type"),
+        "project_scope": packet.get("project_scope"),
+        "reviewer": packet.get("reviewer"),
+        "payload_preview": packet.get("payload_preview"),
+        "source_pattern_ids": list(packet.get("source_pattern_ids", [])),
+        "source_fact_ids": list(packet.get("source_fact_ids", [])),
+        "evidence_summary": packet.get("evidence_summary", {}),
+        "human_review_checklist": packet.get("human_review_checklist", []),
+        "submission_validation": packet.get("submission_validation", {}),
+        "policy": packet.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-governance-submission-packet:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_final_confirmation_request.py
+++ b/agent/memory_human_approval_token_final_confirmation_request.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_write_lock_gate import (
     explain_human_approval_token_write_lock_gate,
     recommend_human_approval_token_write_lock_action,
     validate_human_approval_token_write_lock_gate,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -259,12 +264,8 @@ def validate_human_approval_token_final_confirmation_request(request: Mapping[st
         errors.append("source_pattern_ids_must_match_source_token_write_lock_gate_snapshot")
     if request.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
         errors.append("source_fact_ids_must_match_source_token_write_lock_gate_snapshot")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if request.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(request, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -363,20 +364,13 @@ def recommend_human_approval_token_final_confirmation_request_action(request: Ma
 def summarize_human_approval_token_final_confirmation_requests(
     requests: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(requests, "request_status")
+    lock_reason_summary = summarize_candidates(requests, "lock_reason")
     locked_count = 0
     final_confirmation_review_required_count = 0
     valid_count = 0
     invalid_count = 0
     for request in requests:
-        block_type = str(request.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(request.get("request_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        reason = str(request.get("lock_reason"))
-        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
         if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED:
             locked_count += 1
         if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED:
@@ -392,9 +386,9 @@ def summarize_human_approval_token_final_confirmation_requests(
         "final_confirmation_review_required_count": final_confirmation_review_required_count,
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY),
     }
 
@@ -543,12 +537,14 @@ def _request_id(request: Mapping[str, Any]) -> str:
         "token_write_lock_gate_validation": request.get("token_write_lock_gate_validation", {}),
         "policy": request.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-final-confirmation-request:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest(
+        "memory-human-approval-token-final-confirmation-request:v0.1",
+        identity,
+    )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_final_confirmation_request.py
+++ b/agent/memory_human_approval_token_final_confirmation_request.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_write_lock_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED,
+    explain_human_approval_token_write_lock_gate,
+    recommend_human_approval_token_write_lock_action,
+    validate_human_approval_token_write_lock_gate,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_KIND = (
+    "memory_human_approval_token_final_confirmation_request_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED = (
+    "final_confirmation_review_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_ROUTING = (
+    "manual_final_confirmation_review_required_before_any_token_write"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_final_confirmation_requests_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_REQUESTER = "hermes_memory_human_approval_token_final_confirmation_request_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_LOCK_REASONS = {
+    None,
+    "token_write_lock_gate_locked",
+    "invalid_token_write_lock_gate",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+    "token_issuance_dry_run_locked",
+    "invalid_token_issuance_dry_run",
+    "token_issuance_plan_locked",
+    "token_review_requested_changes",
+    "token_review_rejected",
+    "token_review_deferred",
+    "invalid_token_review_outcome",
+    "missing_token_plan_controls",
+}
+
+
+def create_human_approval_token_final_confirmation_request(
+    token_write_lock_gate: Mapping[str, Any],
+    requester: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only final human confirmation request candidate."""
+    source = deepcopy(dict(token_write_lock_gate))
+    token_write_lock_gate_validation = validate_human_approval_token_write_lock_gate(source)
+    lock_reason = _request_lock_reason(source, token_write_lock_gate_validation)
+    request_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    )
+
+    request = {
+        "request_id": None,
+        "request_kind": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_KIND,
+        "request_status": request_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_ROUTING,
+        "lock_reason": lock_reason,
+        "source_token_write_lock_gate_id": source.get("gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "requester": requester if requester is not None else _DEFAULT_REQUESTER,
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "final_confirmation_checklist": _final_confirmation_checklist(),
+        "token_write_lock_gate_validation": deepcopy(token_write_lock_gate_validation),
+        "request_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_token_write_lock_gate_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY),
+    }
+    request["request_id"] = _request_id(request)
+    request["request_validation"] = validate_human_approval_token_final_confirmation_request(request)
+    request["next_step_recommendation"] = recommend_human_approval_token_final_confirmation_request_action(request)
+    return request
+
+
+def validate_human_approval_token_final_confirmation_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(request.get("policy"))
+    source_snapshot = _as_dict(request.get("source_token_write_lock_gate_snapshot"))
+    token_write_lock_gate_validation = _as_dict(request.get("token_write_lock_gate_validation"))
+    expected_token_write_lock_gate_validation = validate_human_approval_token_write_lock_gate(source_snapshot)
+    expected_lock_reason = _request_lock_reason(source_snapshot, token_write_lock_gate_validation)
+    preview_integrity_errors = _preview_integrity_errors(request)
+
+    for key in (
+        "request_id",
+        "request_kind",
+        "request_status",
+        "routing",
+        "lock_reason",
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "requester",
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "final_confirmation_checklist",
+        "token_write_lock_gate_validation",
+        "request_validation",
+        "next_step_recommendation",
+        "source_token_write_lock_gate_snapshot",
+        "policy",
+    ):
+        if key not in request:
+            errors.append(f"missing_{key}")
+    if request.get("request_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_KIND:
+        errors.append("request_kind_must_be_memory_human_approval_token_final_confirmation_request_candidate")
+    if request.get("request_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED,
+    }:
+        errors.append("request_status_must_be_supported")
+    if request.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_ROUTING:
+        errors.append("routing_must_require_manual_final_confirmation_review_before_any_token_write")
+    if request.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if request.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_final_confirmation_request_checks")
+    if expected_lock_reason is None and request.get("request_status") != MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED:
+        errors.append("valid_token_write_lock_gate_must_require_final_confirmation_review")
+    if expected_lock_reason is not None and request.get("request_status") != MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED:
+        errors.append("invalid_or_locked_token_write_lock_gate_must_lock_request")
+    if not isinstance(request.get("requester"), str) or not request.get("requester"):
+        errors.append("requester_must_be_non_empty_string")
+    if token_write_lock_gate_validation != expected_token_write_lock_gate_validation:
+        errors.append("token_write_lock_gate_validation_must_match_source_token_write_lock_gate_snapshot")
+    if source_snapshot.get("gate_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE,
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED,
+    }:
+        errors.append("source_token_write_lock_gate_status_must_be_supported")
+    if request.get("source_token_write_lock_gate_id") != source_snapshot.get("gate_id"):
+        errors.append("source_token_write_lock_gate_id_must_match_source_snapshot")
+    if not isinstance(request.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(request.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(request.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(request.get("source_pattern_ids"), list) and isinstance(request.get("source_fact_ids"), list):
+        if not request.get("source_pattern_ids") and not request.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if request.get("final_confirmation_checklist") != _final_confirmation_checklist():
+        errors.append("final_confirmation_checklist_must_match_v0_1_deterministic_checks")
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(request.get(field), Mapping):
+            errors.append(f"missing_{field}")
+    errors.extend(preview_integrity_errors)
+    for field in (
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+    ):
+        if field in request and field in source_snapshot and request.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_token_write_lock_gate_snapshot")
+    if request.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_token_write_lock_gate_snapshot")
+    if request.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_token_write_lock_gate_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if request.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_final_confirmation_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_final_confirmation_request(request)
+    source_snapshot = _as_dict(request.get("source_token_write_lock_gate_snapshot"))
+    return {
+        "request_id": request.get("request_id"),
+        "request_kind": request.get("request_kind"),
+        "request_status": request.get("request_status"),
+        "routing": request.get("routing"),
+        "lock_reason": request.get("lock_reason"),
+        "source_token_write_lock_gate_id": request.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": request.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": request.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": request.get("source_review_outcome_id"),
+        "source_request_id": request.get("source_request_id"),
+        "source_gate_id": request.get("source_gate_id"),
+        "source_dry_run_id": request.get("source_dry_run_id"),
+        "source_plan_id": request.get("source_plan_id"),
+        "source_outcome_id": request.get("source_outcome_id"),
+        "source_packet_id": request.get("source_packet_id"),
+        "source_submission_id": request.get("source_submission_id"),
+        "source_draft_id": request.get("source_draft_id"),
+        "source_decision_id": request.get("source_decision_id"),
+        "source_queue_item_id": request.get("source_queue_item_id"),
+        "block_id": request.get("block_id"),
+        "block_type": request.get("block_type"),
+        "project_scope": request.get("project_scope"),
+        "requester": request.get("requester"),
+        "source_pattern_count": len(request.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(request.get("source_fact_ids", []) or []),
+        "approval_token_record_preview": deepcopy(request.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(request.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(request.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(request.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(request.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(request.get("target_paths_preview")),
+        "final_confirmation_checklist": deepcopy(request.get("final_confirmation_checklist")),
+        "validation": validation,
+        "token_write_lock_gate_explanation": (
+            explain_human_approval_token_write_lock_gate(source_snapshot) if source_snapshot else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY),
+    }
+
+
+def recommend_human_approval_token_final_confirmation_request_action(request: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_final_confirmation_request(request)
+    source_snapshot = _as_dict(request.get("source_token_write_lock_gate_snapshot"))
+    if (
+        validation["valid"]
+        and request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED
+    ):
+        action = "route_to_manual_final_confirmation_review_before_any_token_write"
+        reason = "Final confirmation request is review-required only; it does not issue, approve, persist, submit, or write approval tokens."
+    else:
+        action = "keep_final_confirmation_request_locked"
+        reason = _recommendation_reason(request.get("lock_reason"), validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_ROUTING,
+        "validation": validation,
+        "token_write_lock_gate_recommendation": (
+            recommend_human_approval_token_write_lock_action(source_snapshot) if source_snapshot else {}
+        ),
+        "creates_final_confirmation_requests_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY),
+    }
+
+
+def summarize_human_approval_token_final_confirmation_requests(
+    requests: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    locked_count = 0
+    final_confirmation_review_required_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for request in requests:
+        block_type = str(request.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(request.get("request_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        reason = str(request.get("lock_reason"))
+        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
+        if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED:
+            locked_count += 1
+        if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED:
+            final_confirmation_review_required_count += 1
+        validation = validate_human_approval_token_final_confirmation_request(request)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(requests),
+        "locked_count": locked_count,
+        "final_confirmation_review_required_count": final_confirmation_review_required_count,
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY),
+    }
+
+
+def _request_lock_reason(
+    source: Mapping[str, Any],
+    token_write_lock_gate_validation: Mapping[str, Any],
+) -> str | None:
+    if source.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED:
+        return source.get("lock_reason") or "token_write_lock_gate_locked"
+    if not isinstance(source.get("approval_token_record_preview"), Mapping):
+        return "missing_approval_token_record_preview"
+    if not isinstance(source.get("approval_audit_record_preview"), Mapping):
+        return "missing_approval_audit_record_preview"
+    if not isinstance(source.get("token_target_paths_preview"), Mapping):
+        return "missing_token_target_paths_preview"
+    if not isinstance(source.get("proposal_record_preview"), Mapping):
+        return "missing_proposal_record_preview"
+    if not isinstance(source.get("operation_ledger_preview"), Mapping):
+        return "missing_operation_ledger_preview"
+    if not isinstance(source.get("target_paths_preview"), Mapping):
+        return "missing_target_paths_preview"
+    if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(source):
+        return "preview_integrity_failed"
+    if token_write_lock_gate_validation.get("valid") is not True:
+        return "invalid_token_write_lock_gate"
+    if source.get("gate_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE:
+        return "invalid_token_write_lock_gate"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _final_confirmation_checklist() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "verify_token_write_lock_gate_validation",
+            "description": "Confirm the source token write-lock gate is valid and eligible for final human confirmation.",
+        },
+        {
+            "id": "verify_token_previews_only",
+            "description": "Confirm approval token, approval audit, token-path, proposal, ledger, and target-path previews are preview-only.",
+        },
+        {
+            "id": "verify_no_token_approval_or_write_flags",
+            "description": "Confirm previews do not mark tokens as issued, approvals as persisted, records as created, or files as written.",
+        },
+        {
+            "id": "verify_payload_and_source_evidence",
+            "description": "Confirm payload preview and source pattern or fact evidence are present.",
+        },
+        {
+            "id": "require_manual_final_confirmation_review",
+            "description": "Route to manual final confirmation review before any approval token write.",
+        },
+    ]
+
+
+def _recommendation_reason(lock_reason: Any, validation: Mapping[str, Any]) -> str:
+    if lock_reason == "invalid_token_write_lock_gate":
+        return "Source token write-lock gate candidate is invalid."
+    if lock_reason in {
+        "token_write_lock_gate_locked",
+        "token_issuance_dry_run_locked",
+        "invalid_token_issuance_dry_run",
+        "token_issuance_plan_locked",
+        "token_review_requested_changes",
+        "token_review_rejected",
+        "token_review_deferred",
+        "invalid_token_review_outcome",
+        "missing_token_plan_controls",
+    }:
+        return f"Final confirmation request inherits the source token write-lock gate lock: {lock_reason}."
+    if lock_reason in {
+        "missing_approval_token_record_preview",
+        "missing_approval_audit_record_preview",
+        "missing_token_target_paths_preview",
+        "missing_proposal_record_preview",
+        "missing_operation_ledger_preview",
+        "missing_target_paths_preview",
+        "missing_source_evidence",
+    }:
+        return f"Final confirmation request is locked because {lock_reason}."
+    if lock_reason == "preview_integrity_failed":
+        return "Final confirmation request preview artifacts are not preview-only or include issuance, approval, created, persisted, or written flags."
+    if validation.get("errors"):
+        return "Final confirmation request violates the v0.1 validation contract."
+    return "Approval token writing remains locked until a separate final human confirmation review completes."
+
+
+def _request_id(request: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_VERSION,
+        "request_kind": request.get("request_kind"),
+        "request_status": request.get("request_status"),
+        "routing": request.get("routing"),
+        "lock_reason": request.get("lock_reason"),
+        "source_token_write_lock_gate_id": request.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": request.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": request.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": request.get("source_review_outcome_id"),
+        "source_request_id": request.get("source_request_id"),
+        "source_gate_id": request.get("source_gate_id"),
+        "source_dry_run_id": request.get("source_dry_run_id"),
+        "source_plan_id": request.get("source_plan_id"),
+        "source_outcome_id": request.get("source_outcome_id"),
+        "source_packet_id": request.get("source_packet_id"),
+        "source_submission_id": request.get("source_submission_id"),
+        "source_draft_id": request.get("source_draft_id"),
+        "source_decision_id": request.get("source_decision_id"),
+        "source_queue_item_id": request.get("source_queue_item_id"),
+        "block_id": request.get("block_id"),
+        "block_type": request.get("block_type"),
+        "project_scope": request.get("project_scope"),
+        "requester": request.get("requester"),
+        "approval_token_record_preview": request.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": request.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": request.get("token_target_paths_preview", {}),
+        "proposal_record_preview": request.get("proposal_record_preview", {}),
+        "operation_ledger_preview": request.get("operation_ledger_preview", {}),
+        "target_paths_preview": request.get("target_paths_preview", {}),
+        "payload_preview": request.get("payload_preview"),
+        "source_pattern_ids": list(request.get("source_pattern_ids", [])),
+        "source_fact_ids": list(request.get("source_fact_ids", [])),
+        "final_confirmation_checklist": request.get("final_confirmation_checklist", []),
+        "token_write_lock_gate_validation": request.get("token_write_lock_gate_validation", {}),
+        "policy": request.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-final-confirmation-request:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_final_confirmation_review_gate.py
+++ b/agent/memory_human_approval_token_final_confirmation_review_gate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_final_confirmation_request import (
     explain_human_approval_token_final_confirmation_request,
     recommend_human_approval_token_final_confirmation_request_action,
     validate_human_approval_token_final_confirmation_request,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -249,12 +254,8 @@ def validate_human_approval_token_final_confirmation_review_outcome(
         errors.append("source_pattern_ids_must_match_source_final_confirmation_request_snapshot")
     if outcome_candidate.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
         errors.append("source_fact_ids_must_match_source_final_confirmation_request_snapshot")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if outcome_candidate.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(outcome_candidate, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -343,30 +344,26 @@ def recommend_human_approval_token_final_confirmation_review_action(
 def summarize_human_approval_token_final_confirmation_review_outcomes(
     outcomes: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_outcome: dict[str, int] = {}
+    candidate_summary = summarize_candidates(
+        outcomes,
+        "review_outcome_status",
+        type_key="outcome",
+    )
     valid_count = 0
     invalid_count = 0
     for outcome in outcomes:
-        block_type = str(outcome.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(outcome.get("review_outcome_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        outcome_label = str(outcome.get("outcome"))
-        by_outcome[outcome_label] = by_outcome.get(outcome_label, 0) + 1
         validation = validate_human_approval_token_final_confirmation_review_outcome(outcome)
         if validation["valid"]:
             valid_count += 1
         else:
             invalid_count += 1
     return {
-        "total": len(outcomes),
+        "total": candidate_summary["total"],
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_outcome": dict(sorted(by_outcome.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_outcome": candidate_summary["by_type"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
     }
 
@@ -447,12 +444,14 @@ def _review_outcome_id(outcome_candidate: Mapping[str, Any]) -> str:
         "final_confirmation_request_validation": outcome_candidate.get("final_confirmation_request_validation", {}),
         "policy": outcome_candidate.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-final-confirmation-review-outcome:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest(
+        "memory-human-approval-token-final-confirmation-review-outcome:v0.1",
+        identity,
+    )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_final_confirmation_review_gate.py
+++ b/agent/memory_human_approval_token_final_confirmation_review_gate.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_final_confirmation_request import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED,
+    explain_human_approval_token_final_confirmation_request,
+    recommend_human_approval_token_final_confirmation_request_action,
+    validate_human_approval_token_final_confirmation_request,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_GATE_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_KIND = (
+    "memory_human_approval_token_final_confirmation_review_outcome_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_STATUS = (
+    "final_confirmation_review_outcome_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_ROUTING = (
+    "manual_token_write_still_required_after_final_confirmation"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_SUPPORTED_OUTCOMES = {
+    "confirm_token_write",
+    "request_changes",
+    "reject",
+    "defer",
+}
+MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_final_confirmation_review_outcomes_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_CONFIRMER = "hermes_memory_human_approval_token_final_confirmation_review_gate_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+
+
+def create_human_approval_token_final_confirmation_review_outcome(
+    request_candidate: Mapping[str, Any],
+    confirmer: str | None = None,
+    outcome: str | None = None,
+    rationale: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only final human confirmation review outcome candidate."""
+    source = deepcopy(dict(request_candidate))
+    final_confirmation_request_validation = validate_human_approval_token_final_confirmation_request(source)
+    evaluated = evaluate_human_approval_token_final_confirmation_request(source, confirmer=confirmer)
+    selected_outcome = outcome if outcome is not None else evaluated["outcome"]
+    selected_rationale = rationale if rationale is not None else evaluated["rationale"]
+
+    outcome_candidate = {
+        "review_outcome_id": None,
+        "review_outcome_kind": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_KIND,
+        "review_outcome_status": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_STATUS,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_ROUTING,
+        "source_final_confirmation_request_id": source.get("request_id"),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "confirmer": confirmer if confirmer is not None else _DEFAULT_CONFIRMER,
+        "outcome": selected_outcome,
+        "rationale": selected_rationale,
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "final_confirmation_request_validation": deepcopy(final_confirmation_request_validation),
+        "review_outcome_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_final_confirmation_request_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
+    }
+    outcome_candidate["review_outcome_id"] = _review_outcome_id(outcome_candidate)
+    outcome_candidate["review_outcome_validation"] = (
+        validate_human_approval_token_final_confirmation_review_outcome(outcome_candidate)
+    )
+    outcome_candidate["next_step_recommendation"] = (
+        recommend_human_approval_token_final_confirmation_review_action(outcome_candidate)
+    )
+    return outcome_candidate
+
+
+def evaluate_human_approval_token_final_confirmation_request(
+    request_candidate: Mapping[str, Any],
+    confirmer: str | None = None,
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_final_confirmation_request(request_candidate)
+    outcome, rationale = _evaluated_outcome(request_candidate, validation)
+    return {
+        "confirmer": confirmer if confirmer is not None else _DEFAULT_CONFIRMER,
+        "outcome": outcome,
+        "rationale": rationale,
+        "validation": validation,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_ROUTING,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
+    }
+
+
+def validate_human_approval_token_final_confirmation_review_outcome(
+    outcome_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(outcome_candidate.get("policy"))
+    source_snapshot = _as_dict(outcome_candidate.get("source_final_confirmation_request_snapshot"))
+    expected_request_validation = validate_human_approval_token_final_confirmation_request(source_snapshot)
+
+    for key in (
+        "review_outcome_id",
+        "review_outcome_kind",
+        "review_outcome_status",
+        "routing",
+        "source_final_confirmation_request_id",
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "confirmer",
+        "outcome",
+        "rationale",
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "final_confirmation_request_validation",
+        "review_outcome_validation",
+        "next_step_recommendation",
+        "source_final_confirmation_request_snapshot",
+        "policy",
+    ):
+        if key not in outcome_candidate:
+            errors.append(f"missing_{key}")
+    if outcome_candidate.get("review_outcome_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_KIND:
+        errors.append("review_outcome_kind_must_be_memory_human_approval_token_final_confirmation_review_outcome_candidate")
+    if outcome_candidate.get("review_outcome_status") != MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_STATUS:
+        errors.append("review_outcome_status_must_be_final_confirmation_review_outcome_candidate")
+    if outcome_candidate.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_ROUTING:
+        errors.append("routing_must_require_manual_token_write_still_required_after_final_confirmation")
+    if outcome_candidate.get("outcome") not in MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_SUPPORTED_OUTCOMES:
+        errors.append("outcome_must_be_supported")
+    if not isinstance(outcome_candidate.get("confirmer"), str) or not outcome_candidate.get("confirmer"):
+        errors.append("confirmer_must_be_non_empty_string")
+    if not isinstance(outcome_candidate.get("rationale"), str) or not outcome_candidate.get("rationale"):
+        errors.append("rationale_must_be_non_empty_string")
+    if outcome_candidate.get("final_confirmation_request_validation") != expected_request_validation:
+        errors.append("final_confirmation_request_validation_must_match_source_final_confirmation_request_snapshot")
+    if outcome_candidate.get("source_final_confirmation_request_id") != source_snapshot.get("request_id"):
+        errors.append("source_final_confirmation_request_id_must_match_source_snapshot")
+    for source_key in (
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+    ):
+        if outcome_candidate.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+    for field in _PREVIEW_FIELDS + ("payload_preview",):
+        if field in outcome_candidate and field in source_snapshot and outcome_candidate.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_final_confirmation_request_snapshot")
+    if outcome_candidate.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_final_confirmation_request_snapshot")
+    if outcome_candidate.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_final_confirmation_request_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if outcome_candidate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_final_confirmation_review_outcome(
+    outcome_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_final_confirmation_review_outcome(outcome_candidate)
+    source_snapshot = _as_dict(outcome_candidate.get("source_final_confirmation_request_snapshot"))
+    return {
+        "review_outcome_id": outcome_candidate.get("review_outcome_id"),
+        "review_outcome_kind": outcome_candidate.get("review_outcome_kind"),
+        "review_outcome_status": outcome_candidate.get("review_outcome_status"),
+        "routing": outcome_candidate.get("routing"),
+        "source_final_confirmation_request_id": outcome_candidate.get("source_final_confirmation_request_id"),
+        "block_id": outcome_candidate.get("block_id"),
+        "block_type": outcome_candidate.get("block_type"),
+        "project_scope": outcome_candidate.get("project_scope"),
+        "confirmer": outcome_candidate.get("confirmer"),
+        "outcome": outcome_candidate.get("outcome"),
+        "rationale": outcome_candidate.get("rationale"),
+        "source_pattern_count": len(outcome_candidate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(outcome_candidate.get("source_fact_ids", []) or []),
+        "validation": validation,
+        "final_confirmation_request_explanation": (
+            explain_human_approval_token_final_confirmation_request(source_snapshot) if source_snapshot else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
+    }
+
+
+def recommend_human_approval_token_final_confirmation_review_action(
+    outcome_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_final_confirmation_review_outcome(outcome_candidate)
+    source_snapshot = _as_dict(outcome_candidate.get("source_final_confirmation_request_snapshot"))
+    if validation["valid"] and outcome_candidate.get("outcome") == "confirm_token_write":
+        action = "route_to_manual_token_write_without_issuing_token_in_review_gate"
+        reason = "Final confirmation review outcome confirms manual token write can proceed separately; this candidate does not issue, persist, submit, or write anything."
+    elif validation["valid"] and outcome_candidate.get("outcome") == "request_changes":
+        action = "request_changes_before_manual_token_write"
+        reason = "Final confirmation review found remediable request, preview, or source evidence gaps."
+    elif validation["valid"] and outcome_candidate.get("outcome") == "reject":
+        action = "reject_manual_token_write"
+        reason = "Final confirmation review rejected the request candidate."
+    else:
+        action = "defer_manual_token_write"
+        reason = "Final confirmation review outcome is deferred or invalid; no token write may proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_ROUTING,
+        "validation": validation,
+        "final_confirmation_request_recommendation": (
+            recommend_human_approval_token_final_confirmation_request_action(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "creates_final_confirmation_review_outcomes_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
+    }
+
+
+def summarize_human_approval_token_final_confirmation_review_outcomes(
+    outcomes: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_outcome: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for outcome in outcomes:
+        block_type = str(outcome.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(outcome.get("review_outcome_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        outcome_label = str(outcome.get("outcome"))
+        by_outcome[outcome_label] = by_outcome.get(outcome_label, 0) + 1
+        validation = validate_human_approval_token_final_confirmation_review_outcome(outcome)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(outcomes),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_outcome": dict(sorted(by_outcome.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
+    }
+
+
+def _evaluated_outcome(request_candidate: Mapping[str, Any], validation: Mapping[str, Any]) -> tuple[str, str]:
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(request_candidate.get(field), Mapping):
+            return "request_changes", f"Final confirmation request is missing {field}."
+    if not (request_candidate.get("source_pattern_ids") or request_candidate.get("source_fact_ids")):
+        return "request_changes", "Final confirmation request is missing source evidence."
+    if _preview_integrity_errors(request_candidate):
+        return "request_changes", "Final confirmation request preview integrity failed."
+    if request_candidate.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED:
+        return "reject", "Final confirmation request candidate is locked."
+    if validation.get("valid") is not True:
+        return "reject", "Final confirmation request candidate is invalid."
+    if request_candidate.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED:
+        return "confirm_token_write", "Final confirmation request is valid, review-required, and preview/source evidence is intact."
+    return "defer", "Final confirmation review gate reached an unknown condition."
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _review_outcome_id(outcome_candidate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_GATE_VERSION,
+        "review_outcome_kind": outcome_candidate.get("review_outcome_kind"),
+        "review_outcome_status": outcome_candidate.get("review_outcome_status"),
+        "routing": outcome_candidate.get("routing"),
+        "source_final_confirmation_request_id": outcome_candidate.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": outcome_candidate.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": outcome_candidate.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": outcome_candidate.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": outcome_candidate.get("source_review_outcome_id"),
+        "source_request_id": outcome_candidate.get("source_request_id"),
+        "source_gate_id": outcome_candidate.get("source_gate_id"),
+        "source_dry_run_id": outcome_candidate.get("source_dry_run_id"),
+        "source_plan_id": outcome_candidate.get("source_plan_id"),
+        "source_outcome_id": outcome_candidate.get("source_outcome_id"),
+        "source_packet_id": outcome_candidate.get("source_packet_id"),
+        "source_submission_id": outcome_candidate.get("source_submission_id"),
+        "source_draft_id": outcome_candidate.get("source_draft_id"),
+        "source_decision_id": outcome_candidate.get("source_decision_id"),
+        "source_queue_item_id": outcome_candidate.get("source_queue_item_id"),
+        "block_id": outcome_candidate.get("block_id"),
+        "block_type": outcome_candidate.get("block_type"),
+        "project_scope": outcome_candidate.get("project_scope"),
+        "confirmer": outcome_candidate.get("confirmer"),
+        "outcome": outcome_candidate.get("outcome"),
+        "rationale": outcome_candidate.get("rationale"),
+        "approval_token_record_preview": outcome_candidate.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": outcome_candidate.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": outcome_candidate.get("token_target_paths_preview", {}),
+        "proposal_record_preview": outcome_candidate.get("proposal_record_preview", {}),
+        "operation_ledger_preview": outcome_candidate.get("operation_ledger_preview", {}),
+        "target_paths_preview": outcome_candidate.get("target_paths_preview", {}),
+        "payload_preview": outcome_candidate.get("payload_preview"),
+        "source_pattern_ids": list(outcome_candidate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(outcome_candidate.get("source_fact_ids", [])),
+        "final_confirmation_request_validation": outcome_candidate.get("final_confirmation_request_validation", {}),
+        "policy": outcome_candidate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-final-confirmation-review-outcome:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_issuance_dry_run.py
+++ b/agent/memory_human_approval_token_issuance_dry_run.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_issuance_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED,
+    explain_human_approval_token_issuance_plan,
+    recommend_human_approval_token_issuance_plan_action,
+    validate_human_approval_token_issuance_plan,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_KIND = "memory_human_approval_token_issuance_dry_run_candidate"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED = (
+    "manual_token_issuance_final_preflight_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_ROUTING = (
+    "manual_final_human_confirmation_required_before_token_write"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_token_issuance_dry_run_candidates_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = "hermes_memory_human_approval_token_issuance_dry_run_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+_LOCK_REASONS = {
+    None,
+    "token_issuance_plan_locked",
+    "invalid_token_issuance_plan",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+    "missing_token_plan_controls",
+    "token_review_requested_changes",
+    "token_review_rejected",
+    "token_review_deferred",
+    "invalid_token_review_outcome",
+}
+
+
+def create_human_approval_token_issuance_dry_run(
+    plan: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only human approval token issuance dry-run candidate."""
+    source = deepcopy(dict(plan))
+    plan_validation = validate_human_approval_token_issuance_plan(source)
+    lock_reason = _dry_run_lock_reason(source, plan_validation)
+    dry_run_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    )
+
+    dry_run = {
+        "dry_run_id": None,
+        "dry_run_kind": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_KIND,
+        "dry_run_status": dry_run_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_ROUTING,
+        "lock_reason": lock_reason,
+        "source_token_issuance_plan_id": source.get("plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "approval_token_record_preview": _approval_token_record_preview(source, operator),
+        "approval_audit_record_preview": _approval_audit_record_preview(source, operator),
+        "token_target_paths_preview": _token_target_paths_preview(source, operator),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "final_token_preflight_checklist": _final_token_preflight_checklist(),
+        "token_issuance_plan_validation": deepcopy(plan_validation),
+        "dry_run_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_token_issuance_plan_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY),
+    }
+    dry_run["dry_run_id"] = _dry_run_id(dry_run)
+    dry_run["dry_run_validation"] = validate_human_approval_token_issuance_dry_run(dry_run)
+    dry_run["next_step_recommendation"] = recommend_human_approval_token_issuance_dry_run_action(dry_run)
+    return dry_run
+
+
+def validate_human_approval_token_issuance_dry_run(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(dry_run.get("policy"))
+    source_snapshot = _as_dict(dry_run.get("source_token_issuance_plan_snapshot"))
+    token_plan_validation = _as_dict(dry_run.get("token_issuance_plan_validation"))
+    expected_token_plan_validation = validate_human_approval_token_issuance_plan(source_snapshot)
+    expected_lock_reason = _dry_run_lock_reason(source_snapshot, token_plan_validation)
+
+    for key in (
+        "dry_run_id",
+        "dry_run_kind",
+        "dry_run_status",
+        "routing",
+        "lock_reason",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "operator",
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "final_token_preflight_checklist",
+        "token_issuance_plan_validation",
+        "dry_run_validation",
+        "next_step_recommendation",
+        "source_token_issuance_plan_snapshot",
+        "policy",
+    ):
+        if key not in dry_run:
+            errors.append(f"missing_{key}")
+    if dry_run.get("dry_run_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_KIND:
+        errors.append("dry_run_kind_must_be_memory_human_approval_token_issuance_dry_run_candidate")
+    if dry_run.get("dry_run_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED,
+    }:
+        errors.append("dry_run_status_must_be_supported")
+    if dry_run.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_ROUTING:
+        errors.append("routing_must_require_manual_final_human_confirmation_before_token_write")
+    if dry_run.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if dry_run.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_token_issuance_dry_run_checks")
+    if expected_lock_reason is None and dry_run.get("dry_run_status") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED:
+        errors.append("valid_token_issuance_plan_must_require_final_preflight")
+    if expected_lock_reason is not None and dry_run.get("dry_run_status") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED:
+        errors.append("invalid_or_locked_token_issuance_plan_must_lock_dry_run")
+    if not isinstance(dry_run.get("operator"), str) or not dry_run.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if token_plan_validation != expected_token_plan_validation:
+        errors.append("token_issuance_plan_validation_must_match_source_token_issuance_plan_snapshot")
+    if dry_run.get("source_token_issuance_plan_id") != source_snapshot.get("plan_id"):
+        errors.append("source_token_issuance_plan_id_must_match_source_snapshot")
+    if not isinstance(dry_run.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(dry_run.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(dry_run.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(dry_run.get("source_pattern_ids"), list) and isinstance(dry_run.get("source_fact_ids"), list):
+        if not dry_run.get("source_pattern_ids") and not dry_run.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(dry_run.get("proposal_record_preview"), Mapping):
+        errors.append("missing_proposal_record_preview")
+    if not isinstance(dry_run.get("operation_ledger_preview"), Mapping):
+        errors.append("missing_operation_ledger_preview")
+    if not isinstance(dry_run.get("target_paths_preview"), Mapping):
+        errors.append("missing_target_paths_preview")
+    if not isinstance(dry_run.get("approval_token_record_preview"), Mapping):
+        errors.append("approval_token_record_preview_must_be_mapping")
+    else:
+        errors.extend(_preview_record_errors("approval_token_record_preview", dry_run["approval_token_record_preview"]))
+    if not isinstance(dry_run.get("approval_audit_record_preview"), Mapping):
+        errors.append("approval_audit_record_preview_must_be_mapping")
+    else:
+        errors.extend(_preview_record_errors("approval_audit_record_preview", dry_run["approval_audit_record_preview"]))
+    if not isinstance(dry_run.get("token_target_paths_preview"), Mapping):
+        errors.append("token_target_paths_preview_must_be_mapping")
+    else:
+        errors.extend(_preview_record_errors("token_target_paths_preview", dry_run["token_target_paths_preview"]))
+    if dry_run.get("final_token_preflight_checklist") != _final_token_preflight_checklist():
+        errors.append("final_token_preflight_checklist_must_match_v0_1_deterministic_checks")
+    for field in ("proposal_record_preview", "operation_ledger_preview", "target_paths_preview", "payload_preview"):
+        if field in dry_run and field in source_snapshot and dry_run.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_token_issuance_plan_snapshot")
+    if dry_run.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_token_issuance_plan_snapshot")
+    if dry_run.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_token_issuance_plan_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if dry_run.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_issuance_dry_run(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_issuance_dry_run(dry_run)
+    source_snapshot = _as_dict(dry_run.get("source_token_issuance_plan_snapshot"))
+    return {
+        "dry_run_id": dry_run.get("dry_run_id"),
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "lock_reason": dry_run.get("lock_reason"),
+        "source_token_issuance_plan_id": dry_run.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": dry_run.get("source_review_outcome_id"),
+        "source_request_id": dry_run.get("source_request_id"),
+        "source_gate_id": dry_run.get("source_gate_id"),
+        "source_dry_run_id": dry_run.get("source_dry_run_id"),
+        "source_plan_id": dry_run.get("source_plan_id"),
+        "source_outcome_id": dry_run.get("source_outcome_id"),
+        "source_packet_id": dry_run.get("source_packet_id"),
+        "source_submission_id": dry_run.get("source_submission_id"),
+        "source_draft_id": dry_run.get("source_draft_id"),
+        "source_decision_id": dry_run.get("source_decision_id"),
+        "source_queue_item_id": dry_run.get("source_queue_item_id"),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "source_pattern_count": len(dry_run.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(dry_run.get("source_fact_ids", []) or []),
+        "final_token_preflight_checklist": deepcopy(dry_run.get("final_token_preflight_checklist")),
+        "validation": validation,
+        "token_issuance_plan_explanation": explain_human_approval_token_issuance_plan(source_snapshot) if source_snapshot else {},
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY),
+    }
+
+
+def recommend_human_approval_token_issuance_dry_run_action(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_issuance_dry_run(dry_run)
+    source_snapshot = _as_dict(dry_run.get("source_token_issuance_plan_snapshot"))
+    if validation["valid"] and dry_run.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED:
+        action = "request_manual_final_human_confirmation_before_token_write"
+        reason = "Token issuance dry-run candidate is ready for final human confirmation only; it does not issue, persist, submit, or write tokens."
+    else:
+        action = "keep_token_issuance_dry_run_locked"
+        reason = _recommendation_reason(dry_run.get("lock_reason"), validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_ROUTING,
+        "validation": validation,
+        "token_issuance_plan_recommendation": recommend_human_approval_token_issuance_plan_action(source_snapshot) if source_snapshot else {},
+        "creates_token_issuance_dry_run_candidates_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY),
+    }
+
+
+def summarize_human_approval_token_issuance_dry_runs(
+    dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    final_preflight_required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for dry_run in dry_runs:
+        block_type = str(dry_run.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(dry_run.get("dry_run_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        reason = str(dry_run.get("lock_reason"))
+        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
+        if dry_run.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED:
+            final_preflight_required_count += 1
+        if dry_run.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED:
+            locked_count += 1
+        validation = validate_human_approval_token_issuance_dry_run(dry_run)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(dry_runs),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "final_preflight_required_count": final_preflight_required_count,
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY),
+    }
+
+
+def _dry_run_lock_reason(plan: Mapping[str, Any], plan_validation: Mapping[str, Any]) -> str | None:
+    if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED:
+        return plan.get("lock_reason") or "token_issuance_plan_locked"
+    if not isinstance(plan.get("proposal_record_preview"), Mapping):
+        return "missing_proposal_record_preview"
+    if not isinstance(plan.get("operation_ledger_preview"), Mapping):
+        return "missing_operation_ledger_preview"
+    if not isinstance(plan.get("target_paths_preview"), Mapping):
+        return "missing_target_paths_preview"
+    if not (plan.get("source_pattern_ids") or plan.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if not isinstance(plan.get("token_issuance_steps"), list) or not isinstance(plan.get("token_preflight_checks"), list):
+        return "missing_token_plan_controls"
+    if plan_validation.get("valid") is not True:
+        return "invalid_token_issuance_plan"
+    if plan.get("plan_status") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED:
+        return "invalid_token_issuance_plan"
+    return None
+
+
+def _approval_token_record_preview(plan: Mapping[str, Any], operator: str | None) -> dict[str, Any]:
+    token_id = _preview_id("approval-token", plan, operator)
+    return {
+        "approval_token_id_preview": token_id,
+        "record_kind_preview": "human_approval_token_record_preview",
+        "preview_only": True,
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "written": False,
+        "submitted": False,
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "source_token_issuance_plan_id": plan.get("plan_id"),
+        "source_review_outcome_id": plan.get("source_review_outcome_id"),
+        "source_request_id": plan.get("source_request_id"),
+        "source_gate_id": plan.get("source_gate_id"),
+        "source_dry_run_id": plan.get("source_dry_run_id"),
+        "source_plan_id": plan.get("source_plan_id"),
+        "source_pattern_ids": deepcopy(list(plan.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(plan.get("source_fact_ids", []) or [])),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+    }
+
+
+def _approval_audit_record_preview(plan: Mapping[str, Any], operator: str | None) -> dict[str, Any]:
+    return {
+        "approval_audit_id_preview": _preview_id("approval-audit", plan, operator),
+        "record_kind_preview": "human_approval_token_audit_record_preview",
+        "operation_type_preview": "human_approval_token_issuance_final_preflight",
+        "preview_only": True,
+        "created_operation_event": False,
+        "writes_approval_audit": False,
+        "writes_operation_ledger": False,
+        "written": False,
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "source_token_issuance_plan_id": plan.get("plan_id"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+    }
+
+
+def _token_target_paths_preview(plan: Mapping[str, Any], operator: str | None) -> dict[str, Any]:
+    return {
+        "base": "${HERMES_HOME}",
+        "approval_token_file": "memory/approvals/human_approval_tokens.jsonl",
+        "approval_audit_file": "memory/audit/human_approval_token_audit.jsonl",
+        "approval_token_selector": _preview_id("approval-token", plan, operator),
+        "approval_audit_selector": _preview_id("approval-audit", plan, operator),
+        "preview_only": True,
+        "token_issued": False,
+        "persisted": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "written": False,
+    }
+
+
+def _final_token_preflight_checklist() -> list[str]:
+    return [
+        "source_token_issuance_plan_is_valid_and_manual_plan_required",
+        "approval_token_record_is_preview_only",
+        "approval_audit_record_is_preview_only",
+        "token_target_paths_are_preview_only",
+        "no_real_approval_token_issued",
+        "no_approval_persisted",
+        "no_real_proposal_created",
+        "no_operation_ledger_event_created",
+        "no_proposal_file_written",
+        "no_token_file_written",
+        "no_approval_audit_written",
+        "no_memory_or_graph_or_config_write",
+        "manual_final_human_confirmation_required_before_token_write",
+    ]
+
+
+def _preview_record_errors(field: str, preview: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if preview.get("preview_only") is not True:
+        errors.append(f"{field}_must_be_preview_only")
+    for forbidden in _FORBIDDEN_TRUE_KEYS:
+        if preview.get(forbidden) is True:
+            errors.append(f"{field}_{forbidden}_must_be_false_or_absent")
+    return errors
+
+
+def _recommendation_reason(lock_reason: Any, validation: Mapping[str, Any]) -> str:
+    if lock_reason in {
+        "missing_proposal_record_preview",
+        "missing_operation_ledger_preview",
+        "missing_target_paths_preview",
+        "missing_source_evidence",
+        "missing_token_plan_controls",
+    }:
+        return f"Token issuance dry run is locked because {lock_reason}."
+    if lock_reason in {
+        "token_issuance_plan_locked",
+        "token_review_requested_changes",
+        "token_review_rejected",
+        "token_review_deferred",
+        "invalid_token_review_outcome",
+    }:
+        return f"Token issuance dry run inherits the source plan lock: {lock_reason}."
+    if "token_issuance_plan_validation_must_match_source_token_issuance_plan_snapshot" in list(validation.get("errors", []) or []):
+        return "Token issuance dry-run validation does not match its source plan snapshot."
+    return "Token issuance dry-run candidate violates the v0.1 validation contract."
+
+
+def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_VERSION,
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "lock_reason": dry_run.get("lock_reason"),
+        "source_token_issuance_plan_id": dry_run.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": dry_run.get("source_review_outcome_id"),
+        "source_request_id": dry_run.get("source_request_id"),
+        "source_gate_id": dry_run.get("source_gate_id"),
+        "source_dry_run_id": dry_run.get("source_dry_run_id"),
+        "source_plan_id": dry_run.get("source_plan_id"),
+        "source_outcome_id": dry_run.get("source_outcome_id"),
+        "source_packet_id": dry_run.get("source_packet_id"),
+        "source_submission_id": dry_run.get("source_submission_id"),
+        "source_draft_id": dry_run.get("source_draft_id"),
+        "source_decision_id": dry_run.get("source_decision_id"),
+        "source_queue_item_id": dry_run.get("source_queue_item_id"),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "approval_token_record_preview": dry_run.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": dry_run.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": dry_run.get("token_target_paths_preview", {}),
+        "proposal_record_preview": dry_run.get("proposal_record_preview", {}),
+        "operation_ledger_preview": dry_run.get("operation_ledger_preview", {}),
+        "target_paths_preview": dry_run.get("target_paths_preview", {}),
+        "payload_preview": dry_run.get("payload_preview"),
+        "source_pattern_ids": list(dry_run.get("source_pattern_ids", [])),
+        "source_fact_ids": list(dry_run.get("source_fact_ids", [])),
+        "final_token_preflight_checklist": list(dry_run.get("final_token_preflight_checklist", [])),
+        "token_issuance_plan_validation": dry_run.get("token_issuance_plan_validation", {}),
+        "policy": dry_run.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-issuance-dry-run:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _preview_id(kind: str, plan: Mapping[str, Any], operator: str | None) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_VERSION,
+        "kind": kind,
+        "source_token_issuance_plan_id": plan.get("plan_id"),
+        "source_review_outcome_id": plan.get("source_review_outcome_id"),
+        "source_request_id": plan.get("source_request_id"),
+        "source_gate_id": plan.get("source_gate_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"preview:{kind}:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_issuance_dry_run.py
+++ b/agent/memory_human_approval_token_issuance_dry_run.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_issuance_plan import (
     explain_human_approval_token_issuance_plan,
     recommend_human_approval_token_issuance_plan_action,
     validate_human_approval_token_issuance_plan,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -238,12 +243,8 @@ def validate_human_approval_token_issuance_dry_run(dry_run: Mapping[str, Any]) -
         errors.append("source_pattern_ids_must_match_source_token_issuance_plan_snapshot")
     if dry_run.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
         errors.append("source_fact_ids_must_match_source_token_issuance_plan_snapshot")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if dry_run.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(dry_run, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -327,20 +328,13 @@ def recommend_human_approval_token_issuance_dry_run_action(dry_run: Mapping[str,
 def summarize_human_approval_token_issuance_dry_runs(
     dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(dry_runs, "dry_run_status")
+    lock_reason_summary = summarize_candidates(dry_runs, "lock_reason")
     final_preflight_required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for dry_run in dry_runs:
-        block_type = str(dry_run.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(dry_run.get("dry_run_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        reason = str(dry_run.get("lock_reason"))
-        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
         if dry_run.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED:
             final_preflight_required_count += 1
         if dry_run.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED:
@@ -356,9 +350,9 @@ def summarize_human_approval_token_issuance_dry_runs(
         "invalid_count": invalid_count,
         "final_preflight_required_count": final_preflight_required_count,
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY),
     }
 
@@ -529,8 +523,7 @@ def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
         "token_issuance_plan_validation": dry_run.get("token_issuance_plan_validation", {}),
         "policy": dry_run.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-issuance-dry-run:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-human-approval-token-issuance-dry-run:v0.1", identity)
 
 
 def _preview_id(kind: str, plan: Mapping[str, Any], operator: str | None) -> str:
@@ -546,12 +539,11 @@ def _preview_id(kind: str, plan: Mapping[str, Any], operator: str | None) -> str
         "project_scope": plan.get("project_scope"),
         "operator": operator if operator is not None else _DEFAULT_OPERATOR,
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"preview:{kind}:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest(f"preview:{kind}:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_issuance_plan.py
+++ b/agent/memory_human_approval_token_issuance_plan.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -9,6 +7,13 @@ from agent.memory_human_approval_token_review_gate import (
     explain_human_approval_token_review_outcome,
     recommend_human_approval_token_review_action,
     validate_human_approval_token_review_outcome,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -211,12 +216,8 @@ def validate_human_approval_token_issuance_plan(plan: Mapping[str, Any]) -> dict
         errors.append("source_pattern_ids_must_match_source_review_outcome_snapshot")
     if plan.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
         errors.append("source_fact_ids_must_match_source_review_outcome_snapshot")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if plan.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(plan, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -297,20 +298,13 @@ def recommend_human_approval_token_issuance_plan_action(plan: Mapping[str, Any])
 def summarize_human_approval_token_issuance_plans(
     plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(plans, "plan_status")
+    lock_reason_summary = summarize_candidates(plans, "lock_reason")
     plan_required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for plan in plans:
-        block_type = str(plan.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(plan.get("plan_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        reason = str(plan.get("lock_reason"))
-        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
         if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED:
             plan_required_count += 1
         if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED:
@@ -326,9 +320,9 @@ def summarize_human_approval_token_issuance_plans(
         "invalid_count": invalid_count,
         "plan_required_count": plan_required_count,
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY),
     }
 
@@ -434,12 +428,11 @@ def _plan_id(plan: Mapping[str, Any]) -> str:
         "review_outcome_validation": plan.get("review_outcome_validation", {}),
         "policy": plan.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-issuance-plan:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-human-approval-token-issuance-plan:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_issuance_plan.py
+++ b/agent/memory_human_approval_token_issuance_plan.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_review_gate import (
+    explain_human_approval_token_review_outcome,
+    recommend_human_approval_token_review_action,
+    validate_human_approval_token_review_outcome,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_KIND = "memory_human_approval_token_issuance_plan_candidate"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED = "manual_token_issuance_plan_required"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_ROUTING = "manual_token_issuance_dry_run_required_before_any_token_write"
+MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_token_issuance_plan_candidates_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_PLANNER = "hermes_memory_human_approval_token_issuance_plan_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "converted_to_real_proposal",
+)
+_LOCK_REASONS = {
+    None,
+    "invalid_token_review_outcome",
+    "token_review_requested_changes",
+    "token_review_rejected",
+    "token_review_deferred",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+}
+
+
+def create_human_approval_token_issuance_plan(
+    review_outcome_candidate: Mapping[str, Any],
+    planner: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only human approval token issuance plan candidate."""
+    source = deepcopy(dict(review_outcome_candidate))
+    review_outcome_validation = validate_human_approval_token_review_outcome(source)
+    lock_reason = _plan_lock_reason(source, review_outcome_validation)
+    plan_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    )
+
+    plan = {
+        "plan_id": None,
+        "plan_kind": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_KIND,
+        "plan_status": plan_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_ROUTING,
+        "lock_reason": lock_reason,
+        "source_review_outcome_id": source.get("review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "planner": planner if planner is not None else _DEFAULT_PLANNER,
+        "outcome": source.get("outcome"),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_issuance_steps": _token_issuance_steps(),
+        "token_preflight_checks": _token_preflight_checks(),
+        "review_outcome_validation": deepcopy(review_outcome_validation),
+        "plan_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_review_outcome_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY),
+    }
+    plan["plan_id"] = _plan_id(plan)
+    plan["plan_validation"] = validate_human_approval_token_issuance_plan(plan)
+    plan["next_step_recommendation"] = recommend_human_approval_token_issuance_plan_action(plan)
+    return plan
+
+
+def validate_human_approval_token_issuance_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(plan.get("policy"))
+    source_snapshot = _as_dict(plan.get("source_review_outcome_snapshot"))
+    review_outcome_validation = _as_dict(plan.get("review_outcome_validation"))
+    expected_review_outcome_validation = validate_human_approval_token_review_outcome(source_snapshot)
+    expected_lock_reason = _plan_lock_reason(source_snapshot, review_outcome_validation)
+
+    for key in (
+        "plan_id",
+        "plan_kind",
+        "plan_status",
+        "routing",
+        "lock_reason",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "planner",
+        "outcome",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "token_issuance_steps",
+        "token_preflight_checks",
+        "review_outcome_validation",
+        "plan_validation",
+        "next_step_recommendation",
+        "source_review_outcome_snapshot",
+        "policy",
+    ):
+        if key not in plan:
+            errors.append(f"missing_{key}")
+    if plan.get("plan_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_KIND:
+        errors.append("plan_kind_must_be_memory_human_approval_token_issuance_plan_candidate")
+    if plan.get("plan_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED,
+    }:
+        errors.append("plan_status_must_be_supported")
+    if plan.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_ROUTING:
+        errors.append("routing_must_require_manual_token_issuance_dry_run")
+    if plan.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if plan.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_token_issuance_plan_checks")
+    if expected_lock_reason is None and plan.get("plan_status") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED:
+        errors.append("approved_token_review_outcome_must_require_manual_token_issuance_plan")
+    if expected_lock_reason is not None and plan.get("plan_status") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED:
+        errors.append("invalid_or_non_approved_token_review_outcome_must_lock_plan")
+    if not isinstance(plan.get("planner"), str) or not plan.get("planner"):
+        errors.append("planner_must_be_non_empty_string")
+    if review_outcome_validation != expected_review_outcome_validation:
+        errors.append("review_outcome_validation_must_match_source_review_outcome_snapshot")
+    if plan.get("outcome") != source_snapshot.get("outcome"):
+        errors.append("outcome_must_match_source_review_outcome_snapshot")
+    if not isinstance(plan.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(plan.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(plan.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(plan.get("source_pattern_ids"), list) and isinstance(plan.get("source_fact_ids"), list):
+        if not plan.get("source_pattern_ids") and not plan.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(plan.get("token_issuance_steps"), list) or plan.get("token_issuance_steps") != _token_issuance_steps():
+        errors.append("token_issuance_steps_must_match_v0_1_deterministic_steps")
+    if not isinstance(plan.get("token_preflight_checks"), list) or plan.get("token_preflight_checks") != _token_preflight_checks():
+        errors.append("token_preflight_checks_must_match_v0_1_deterministic_checks")
+    if not isinstance(plan.get("proposal_record_preview"), Mapping):
+        errors.append("missing_proposal_record_preview")
+    if not isinstance(plan.get("operation_ledger_preview"), Mapping):
+        errors.append("missing_operation_ledger_preview")
+    if not isinstance(plan.get("target_paths_preview"), Mapping):
+        errors.append("missing_target_paths_preview")
+    for field in ("proposal_record_preview", "operation_ledger_preview", "target_paths_preview", "payload_preview"):
+        if field in plan and field in source_snapshot and plan.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_review_outcome_snapshot")
+    if plan.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_review_outcome_snapshot")
+    if plan.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_review_outcome_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if plan.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_issuance_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_issuance_plan(plan)
+    source_snapshot = _as_dict(plan.get("source_review_outcome_snapshot"))
+    return {
+        "plan_id": plan.get("plan_id"),
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_review_outcome_id": plan.get("source_review_outcome_id"),
+        "source_request_id": plan.get("source_request_id"),
+        "source_gate_id": plan.get("source_gate_id"),
+        "source_dry_run_id": plan.get("source_dry_run_id"),
+        "source_plan_id": plan.get("source_plan_id"),
+        "source_outcome_id": plan.get("source_outcome_id"),
+        "source_packet_id": plan.get("source_packet_id"),
+        "source_submission_id": plan.get("source_submission_id"),
+        "source_draft_id": plan.get("source_draft_id"),
+        "source_decision_id": plan.get("source_decision_id"),
+        "source_queue_item_id": plan.get("source_queue_item_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "planner": plan.get("planner"),
+        "outcome": plan.get("outcome"),
+        "source_pattern_count": len(plan.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(plan.get("source_fact_ids", []) or []),
+        "token_issuance_steps": deepcopy(plan.get("token_issuance_steps")),
+        "token_preflight_checks": deepcopy(plan.get("token_preflight_checks")),
+        "validation": validation,
+        "review_outcome_explanation": explain_human_approval_token_review_outcome(source_snapshot) if source_snapshot else {},
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY),
+    }
+
+
+def recommend_human_approval_token_issuance_plan_action(plan: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_issuance_plan(plan)
+    source_snapshot = _as_dict(plan.get("source_review_outcome_snapshot"))
+    if validation["valid"] and plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED:
+        action = "run_manual_token_issuance_dry_run_before_any_token_write"
+        reason = "Token issuance plan candidate is ready only for a separate manual dry run; it does not issue, persist, submit, or write tokens."
+    else:
+        action = "keep_token_issuance_locked"
+        reason = _recommendation_reason(plan.get("lock_reason"), validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_ROUTING,
+        "validation": validation,
+        "review_outcome_recommendation": recommend_human_approval_token_review_action(source_snapshot) if source_snapshot else {},
+        "creates_token_issuance_plan_candidates_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY),
+    }
+
+
+def summarize_human_approval_token_issuance_plans(
+    plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    plan_required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for plan in plans:
+        block_type = str(plan.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(plan.get("plan_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        reason = str(plan.get("lock_reason"))
+        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
+        if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED:
+            plan_required_count += 1
+        if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED:
+            locked_count += 1
+        validation = validate_human_approval_token_issuance_plan(plan)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(plans),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "plan_required_count": plan_required_count,
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY),
+    }
+
+
+def _plan_lock_reason(
+    source: Mapping[str, Any],
+    review_outcome_validation: Mapping[str, Any],
+) -> str | None:
+    outcome = source.get("outcome")
+    if outcome in {"approve_token_issuance", "request_changes"}:
+        if not isinstance(source.get("proposal_record_preview"), Mapping):
+            return "missing_proposal_record_preview"
+        if not isinstance(source.get("operation_ledger_preview"), Mapping):
+            return "missing_operation_ledger_preview"
+        if not isinstance(source.get("target_paths_preview"), Mapping):
+            return "missing_target_paths_preview"
+        if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+            return "missing_source_evidence"
+    if review_outcome_validation.get("valid") is not True:
+        return "invalid_token_review_outcome"
+    if outcome == "request_changes":
+        return "token_review_requested_changes"
+    if outcome == "reject":
+        return "token_review_rejected"
+    if outcome == "defer":
+        return "token_review_deferred"
+    if outcome != "approve_token_issuance":
+        return "invalid_token_review_outcome"
+    return None
+
+
+def _token_issuance_steps() -> list[str]:
+    return [
+        "verify_review_outcome_candidate_is_approve_token_issuance",
+        "verify_preview_artifacts_and_source_evidence_are_present",
+        "prepare_manual_token_issuance_dry_run_candidate",
+        "require_separate_human_confirmation_before_any_token_write",
+    ]
+
+
+def _token_preflight_checks() -> list[str]:
+    return [
+        "no_real_approval_token_issued",
+        "no_approval_persisted",
+        "no_real_proposal_created",
+        "no_operation_ledger_event_created",
+        "no_proposal_file_written",
+        "no_memory_or_graph_or_config_write",
+    ]
+
+
+def _recommendation_reason(lock_reason: Any, validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if lock_reason == "token_review_requested_changes":
+        return "Token review outcome requested changes before any token issuance planning can proceed."
+    if lock_reason == "token_review_rejected":
+        return "Token review outcome rejected token issuance."
+    if lock_reason == "token_review_deferred":
+        return "Token review outcome deferred token issuance."
+    if lock_reason in {
+        "missing_proposal_record_preview",
+        "missing_operation_ledger_preview",
+        "missing_target_paths_preview",
+        "missing_source_evidence",
+    }:
+        return f"Token issuance plan is locked because {lock_reason}."
+    if "review_outcome_validation_must_match_source_review_outcome_snapshot" in errors:
+        return "Token issuance plan validation does not match its source review outcome snapshot."
+    return "Token issuance plan candidate violates the v0.1 validation contract."
+
+
+def _plan_id(plan: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_VERSION,
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_review_outcome_id": plan.get("source_review_outcome_id"),
+        "source_request_id": plan.get("source_request_id"),
+        "source_gate_id": plan.get("source_gate_id"),
+        "source_dry_run_id": plan.get("source_dry_run_id"),
+        "source_plan_id": plan.get("source_plan_id"),
+        "source_outcome_id": plan.get("source_outcome_id"),
+        "source_packet_id": plan.get("source_packet_id"),
+        "source_submission_id": plan.get("source_submission_id"),
+        "source_draft_id": plan.get("source_draft_id"),
+        "source_decision_id": plan.get("source_decision_id"),
+        "source_queue_item_id": plan.get("source_queue_item_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "planner": plan.get("planner"),
+        "outcome": plan.get("outcome"),
+        "proposal_record_preview": plan.get("proposal_record_preview", {}),
+        "operation_ledger_preview": plan.get("operation_ledger_preview", {}),
+        "target_paths_preview": plan.get("target_paths_preview", {}),
+        "payload_preview": plan.get("payload_preview"),
+        "source_pattern_ids": list(plan.get("source_pattern_ids", [])),
+        "source_fact_ids": list(plan.get("source_fact_ids", [])),
+        "token_issuance_steps": list(plan.get("token_issuance_steps", [])),
+        "token_preflight_checks": list(plan.get("token_preflight_checks", [])),
+        "review_outcome_validation": plan.get("review_outcome_validation", {}),
+        "policy": plan.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-issuance-plan:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_real_write_executor_code_review_plan.py
+++ b/agent/memory_human_approval_token_real_write_executor_code_review_plan.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_real_write_executor_implementation_dry_ru
     explain_human_approval_token_real_write_executor_implementation_dry_run,
     recommend_human_approval_token_real_write_executor_implementation_dry_run_action,
     validate_human_approval_token_real_write_executor_implementation_dry_run,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -620,14 +625,18 @@ def validate_human_approval_token_real_write_executor_code_review_plan(
     for field, expected in deterministic_fields:
         if plan.get(field) != expected:
             errors.append(f"{field}_must_match_v0_1_deterministic_plan")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if plan.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in (
-        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY.items()
-    ):
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(
+        validate_forbidden_true_keys_false_or_absent(
+            plan,
+            _FORBIDDEN_TRUE_KEYS,
+        )
+    )
+    errors.extend(
+        validate_policy_flags(
+            policy,
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY,
+        )
+    )
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -751,18 +760,13 @@ def recommend_human_approval_token_real_write_executor_code_review_plan_action(
 def summarize_human_approval_token_real_write_executor_code_review_plans(
     plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(plans, "plan_status")
     by_lock_reason: dict[str, int] = {}
     code_review_gate_required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for plan in plans:
-        block_type = str(plan.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(plan.get("plan_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         lock_reason = str(plan.get("lock_reason"))
         by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
         if (
@@ -783,15 +787,15 @@ def summarize_human_approval_token_real_write_executor_code_review_plans(
         else:
             invalid_count += 1
     return {
-        "total": len(plans),
+        "total": candidate_summary["total"],
         "valid_count": valid_count,
         "invalid_count": invalid_count,
         "real_token_write_executor_code_review_gate_required_count": (
             code_review_gate_required_count
         ),
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "by_lock_reason": dict(sorted(by_lock_reason.items())),
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY),
     }
@@ -1381,16 +1385,14 @@ def _plan_id(plan: Mapping[str, Any]) -> str:
         ),
         "policy": plan.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    return (
-        "memory-human-approval-token-real-write-executor-code-review-plan:"
-        f"v0.1:{digest}"
+    return build_stable_digest(
+        "memory-human-approval-token-real-write-executor-code-review-plan:v0.1",
+        identity,
     )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_real_write_executor_code_review_plan.py
+++ b/agent/memory_human_approval_token_real_write_executor_code_review_plan.py
@@ -1,0 +1,1397 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_real_write_executor_implementation_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED,
+    explain_human_approval_token_real_write_executor_implementation_dry_run,
+    recommend_human_approval_token_real_write_executor_implementation_dry_run_action,
+    validate_human_approval_token_real_write_executor_implementation_dry_run,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_KIND = (
+    "memory_human_approval_token_real_write_executor_code_review_plan_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED = (
+    "real_token_write_executor_code_review_gate_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_ROUTING = (
+    "real_token_write_executor_code_review_gate_required_before_executor_source_creation"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_real_write_executor_code_review_plan_candidates_only": True,
+    "invokes_real_token_write_executor": False,
+    "implements_real_token_write_executor": False,
+    "creates_executor_source_files": False,
+    "creates_executor_tests": False,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_REVIEWER = (
+    "hermes_memory_human_approval_token_real_write_executor_code_review_plan_v0.1"
+)
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "creates_executor_source_files",
+    "creates_executor_tests",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_WRITE_PREVIEW_FIELDS = (
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+)
+_EXECUTOR_CONTRACT_FIELD_TYPES = {
+    "executor_contract_inputs": Mapping,
+    "executor_hard_lock_checks": list,
+    "executor_audit_fields": list,
+    "executor_rollback_rules": list,
+    "executor_forbidden_side_effects": list,
+    "executor_contract_checklist": list,
+}
+_IMPLEMENTATION_PLAN_FIELD_TYPES = {
+    "implementation_plan_interfaces": list,
+    "implementation_plan_files": list,
+    "implementation_plan_idempotency_strategy": Mapping,
+    "implementation_plan_filesystem_safety_model": Mapping,
+    "implementation_plan_audit_strategy": Mapping,
+    "implementation_plan_rollback_strategy": Mapping,
+    "implementation_plan_test_plan": list,
+    "implementation_plan_forbidden_actions": list,
+}
+_IMPLEMENTATION_DRY_RUN_FIELD_TYPES = {
+    "implementation_dry_run_module_boundary_preview": Mapping,
+    "implementation_dry_run_interface_preview": list,
+    "implementation_dry_run_idempotency_check_preview": Mapping,
+    "implementation_dry_run_filesystem_safety_check_preview": Mapping,
+    "implementation_dry_run_audit_check_preview": Mapping,
+    "implementation_dry_run_rollback_check_preview": Mapping,
+    "implementation_dry_run_test_harness_preview": list,
+    "implementation_dry_run_readiness_checklist": list,
+}
+_LOCK_REASONS = {
+    None,
+    "real_write_executor_implementation_dry_run_locked",
+    "real_write_executor_implementation_plan_locked",
+    "invalid_real_write_executor_implementation_plan",
+    "invalid_real_write_executor_implementation_dry_run",
+    "contract_review_requested_changes",
+    "contract_review_rejected",
+    "contract_review_deferred",
+    "invalid_contract_review_outcome",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_approval_token_write_payload_preview",
+    "missing_approval_audit_write_payload_preview",
+    "missing_token_write_target_paths_preview",
+    "missing_executor_contract_inputs",
+    "missing_executor_hard_lock_checks",
+    "missing_executor_audit_fields",
+    "missing_executor_rollback_rules",
+    "missing_executor_forbidden_side_effects",
+    "missing_executor_contract_checklist",
+    "missing_contract_review_checklist",
+    "missing_implementation_plan_interfaces",
+    "missing_implementation_plan_files",
+    "missing_implementation_plan_idempotency_strategy",
+    "missing_implementation_plan_filesystem_safety_model",
+    "missing_implementation_plan_audit_strategy",
+    "missing_implementation_plan_rollback_strategy",
+    "missing_implementation_plan_test_plan",
+    "missing_implementation_plan_forbidden_actions",
+    "missing_implementation_dry_run_module_boundary_preview",
+    "missing_implementation_dry_run_interface_preview",
+    "missing_implementation_dry_run_idempotency_check_preview",
+    "missing_implementation_dry_run_filesystem_safety_check_preview",
+    "missing_implementation_dry_run_audit_check_preview",
+    "missing_implementation_dry_run_rollback_check_preview",
+    "missing_implementation_dry_run_test_harness_preview",
+    "missing_implementation_dry_run_readiness_checklist",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+    "implementation_plan_integrity_failed",
+    "implementation_dry_run_integrity_failed",
+}
+_SOURCE_KEYS = (
+    "source_contract_review_outcome_id",
+    "source_contract_id",
+    "source_write_final_gate_id",
+    "source_write_execution_dry_run_id",
+    "source_write_execution_plan_id",
+    "source_final_confirmation_review_outcome_id",
+    "source_final_confirmation_request_id",
+    "source_token_write_lock_gate_id",
+    "source_token_issuance_dry_run_id",
+    "source_token_issuance_plan_id",
+    "source_review_outcome_id",
+    "source_request_id",
+    "source_gate_id",
+    "source_dry_run_id",
+    "source_plan_id",
+    "source_outcome_id",
+    "source_packet_id",
+    "source_submission_id",
+    "source_draft_id",
+    "source_decision_id",
+    "source_queue_item_id",
+    "block_id",
+    "block_type",
+    "project_scope",
+    "outcome",
+)
+_REQUIRED_PLAN_KEYS = (
+    "plan_id",
+    "plan_kind",
+    "plan_status",
+    "routing",
+    "lock_reason",
+    "source_implementation_dry_run_id",
+    "source_implementation_plan_id",
+) + _SOURCE_KEYS + (
+    "reviewer",
+    "rationale",
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+    "payload_preview",
+    "source_pattern_ids",
+    "source_fact_ids",
+    "token_write_execution_steps",
+    "token_write_execution_preflight_checks",
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+    "final_token_write_preflight_checklist",
+    "final_gate_checklist",
+    "executor_contract_inputs",
+    "executor_hard_lock_checks",
+    "executor_audit_fields",
+    "executor_rollback_rules",
+    "executor_forbidden_side_effects",
+    "executor_contract_checklist",
+    "contract_review_checklist",
+    "implementation_plan_interfaces",
+    "implementation_plan_files",
+    "implementation_plan_idempotency_strategy",
+    "implementation_plan_filesystem_safety_model",
+    "implementation_plan_audit_strategy",
+    "implementation_plan_rollback_strategy",
+    "implementation_plan_test_plan",
+    "implementation_plan_forbidden_actions",
+    "implementation_dry_run_module_boundary_preview",
+    "implementation_dry_run_interface_preview",
+    "implementation_dry_run_idempotency_check_preview",
+    "implementation_dry_run_filesystem_safety_check_preview",
+    "implementation_dry_run_audit_check_preview",
+    "implementation_dry_run_rollback_check_preview",
+    "implementation_dry_run_test_harness_preview",
+    "implementation_dry_run_readiness_checklist",
+    "code_review_scope",
+    "code_review_required_files",
+    "code_review_static_analysis_checks",
+    "code_review_security_checks",
+    "code_review_write_safety_checks",
+    "code_review_test_matrix",
+    "code_review_acceptance_criteria",
+    "code_review_forbidden_actions",
+    "code_review_plan_checklist",
+    "implementation_dry_run_validation",
+    "code_review_plan_validation",
+    "next_step_recommendation",
+    "source_implementation_dry_run_snapshot",
+    "policy",
+)
+
+
+def create_human_approval_token_real_write_executor_code_review_plan(
+    implementation_dry_run: Mapping[str, Any],
+    reviewer: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only real token write executor code review plan."""
+    source = deepcopy(dict(implementation_dry_run))
+    implementation_dry_run_validation = (
+        validate_human_approval_token_real_write_executor_implementation_dry_run(
+            source
+        )
+    )
+    lock_reason = _code_review_plan_lock_reason(
+        source,
+        implementation_dry_run_validation,
+    )
+    plan_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED
+    )
+
+    plan = {
+        "plan_id": None,
+        "plan_kind": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_KIND,
+        "plan_status": plan_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_ROUTING,
+        "lock_reason": lock_reason,
+        "source_implementation_dry_run_id": source.get("dry_run_id"),
+        "source_implementation_plan_id": source.get("source_implementation_plan_id"),
+        "source_contract_review_outcome_id": source.get("source_contract_review_outcome_id"),
+        "source_contract_id": source.get("source_contract_id"),
+        "source_write_final_gate_id": source.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": source.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": source.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": source.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": source.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "reviewer": reviewer if reviewer is not None else _DEFAULT_REVIEWER,
+        "outcome": source.get("outcome"),
+        "rationale": source.get("rationale"),
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": deepcopy(
+            list(source.get("token_write_execution_steps", []) or [])
+        ),
+        "token_write_execution_preflight_checks": deepcopy(
+            list(source.get("token_write_execution_preflight_checks", []) or [])
+        ),
+        "approval_token_write_payload_preview": deepcopy(
+            source.get("approval_token_write_payload_preview")
+        ),
+        "approval_audit_write_payload_preview": deepcopy(
+            source.get("approval_audit_write_payload_preview")
+        ),
+        "token_write_target_paths_preview": deepcopy(source.get("token_write_target_paths_preview")),
+        "final_token_write_preflight_checklist": deepcopy(
+            source.get("final_token_write_preflight_checklist")
+        ),
+        "final_gate_checklist": deepcopy(source.get("final_gate_checklist")),
+        "executor_contract_inputs": deepcopy(source.get("executor_contract_inputs")),
+        "executor_hard_lock_checks": deepcopy(source.get("executor_hard_lock_checks")),
+        "executor_audit_fields": deepcopy(source.get("executor_audit_fields")),
+        "executor_rollback_rules": deepcopy(source.get("executor_rollback_rules")),
+        "executor_forbidden_side_effects": deepcopy(
+            source.get("executor_forbidden_side_effects")
+        ),
+        "executor_contract_checklist": deepcopy(source.get("executor_contract_checklist")),
+        "contract_review_checklist": deepcopy(source.get("contract_review_checklist")),
+        "implementation_plan_interfaces": deepcopy(source.get("implementation_plan_interfaces")),
+        "implementation_plan_files": deepcopy(source.get("implementation_plan_files")),
+        "implementation_plan_idempotency_strategy": deepcopy(
+            source.get("implementation_plan_idempotency_strategy")
+        ),
+        "implementation_plan_filesystem_safety_model": deepcopy(
+            source.get("implementation_plan_filesystem_safety_model")
+        ),
+        "implementation_plan_audit_strategy": deepcopy(
+            source.get("implementation_plan_audit_strategy")
+        ),
+        "implementation_plan_rollback_strategy": deepcopy(
+            source.get("implementation_plan_rollback_strategy")
+        ),
+        "implementation_plan_test_plan": deepcopy(source.get("implementation_plan_test_plan")),
+        "implementation_plan_forbidden_actions": deepcopy(
+            source.get("implementation_plan_forbidden_actions")
+        ),
+        "implementation_dry_run_module_boundary_preview": deepcopy(
+            source.get("implementation_dry_run_module_boundary_preview")
+        ),
+        "implementation_dry_run_interface_preview": deepcopy(
+            source.get("implementation_dry_run_interface_preview")
+        ),
+        "implementation_dry_run_idempotency_check_preview": deepcopy(
+            source.get("implementation_dry_run_idempotency_check_preview")
+        ),
+        "implementation_dry_run_filesystem_safety_check_preview": deepcopy(
+            source.get("implementation_dry_run_filesystem_safety_check_preview")
+        ),
+        "implementation_dry_run_audit_check_preview": deepcopy(
+            source.get("implementation_dry_run_audit_check_preview")
+        ),
+        "implementation_dry_run_rollback_check_preview": deepcopy(
+            source.get("implementation_dry_run_rollback_check_preview")
+        ),
+        "implementation_dry_run_test_harness_preview": deepcopy(
+            source.get("implementation_dry_run_test_harness_preview")
+        ),
+        "implementation_dry_run_readiness_checklist": deepcopy(
+            source.get("implementation_dry_run_readiness_checklist")
+        ),
+        "code_review_scope": _code_review_scope(),
+        "code_review_required_files": _code_review_required_files(),
+        "code_review_static_analysis_checks": _code_review_static_analysis_checks(),
+        "code_review_security_checks": _code_review_security_checks(),
+        "code_review_write_safety_checks": _code_review_write_safety_checks(),
+        "code_review_test_matrix": _code_review_test_matrix(),
+        "code_review_acceptance_criteria": _code_review_acceptance_criteria(),
+        "code_review_forbidden_actions": _code_review_forbidden_actions(),
+        "code_review_plan_checklist": _code_review_plan_checklist(),
+        "implementation_dry_run_validation": deepcopy(
+            implementation_dry_run_validation
+        ),
+        "code_review_plan_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_implementation_dry_run_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY),
+    }
+    plan["plan_id"] = _plan_id(plan)
+    plan["code_review_plan_validation"] = (
+        validate_human_approval_token_real_write_executor_code_review_plan(plan)
+    )
+    plan["next_step_recommendation"] = (
+        recommend_human_approval_token_real_write_executor_code_review_plan_action(
+            plan
+        )
+    )
+    return plan
+
+
+def validate_human_approval_token_real_write_executor_code_review_plan(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(plan.get("policy"))
+    source_snapshot = _as_dict(plan.get("source_implementation_dry_run_snapshot"))
+    implementation_dry_run_validation = _as_dict(
+        plan.get("implementation_dry_run_validation")
+    )
+    expected_implementation_dry_run_validation = (
+        validate_human_approval_token_real_write_executor_implementation_dry_run(
+            source_snapshot
+        )
+    )
+    expected_lock_reason = _code_review_plan_lock_reason(
+        source_snapshot,
+        implementation_dry_run_validation,
+    )
+
+    for key in _REQUIRED_PLAN_KEYS:
+        if key not in plan:
+            errors.append(f"missing_{key}")
+    if (
+        plan.get("plan_kind")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_KIND
+    ):
+        errors.append(
+            "plan_kind_must_be_memory_human_approval_token_real_write_executor_code_review_plan_candidate"
+        )
+    if plan.get("plan_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED,
+    }:
+        errors.append("plan_status_must_be_supported")
+    if (
+        plan.get("routing")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_ROUTING
+    ):
+        errors.append(
+            "routing_must_require_code_review_gate_before_executor_source_creation"
+        )
+    if plan.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if plan.get("lock_reason") != expected_lock_reason:
+        errors.append(
+            "lock_reason_must_match_real_write_executor_code_review_plan_checks"
+        )
+    if (
+        expected_lock_reason is None
+        and plan.get("plan_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED
+    ):
+        errors.append(
+            "valid_implementation_dry_run_must_require_real_token_write_executor_code_review_gate"
+        )
+    if (
+        expected_lock_reason is not None
+        and plan.get("plan_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED
+    ):
+        errors.append("invalid_or_locked_implementation_dry_run_must_lock_plan")
+    if not isinstance(plan.get("reviewer"), str) or not plan.get("reviewer"):
+        errors.append("reviewer_must_be_non_empty_string")
+    if (
+        implementation_dry_run_validation
+        != expected_implementation_dry_run_validation
+    ):
+        errors.append(
+            "implementation_dry_run_validation_must_match_source_implementation_dry_run_snapshot"
+        )
+    if plan.get("source_implementation_dry_run_id") != source_snapshot.get("dry_run_id"):
+        errors.append("source_implementation_dry_run_id_must_match_source_snapshot")
+    if (
+        plan.get("source_implementation_plan_id")
+        != source_snapshot.get("source_implementation_plan_id")
+    ):
+        errors.append("source_implementation_plan_id_must_match_source_snapshot")
+    for source_key in _SOURCE_KEYS:
+        if plan.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+
+    if (
+        not isinstance(plan.get("payload_preview"), Mapping)
+        and plan.get("lock_reason") != "invalid_real_write_executor_implementation_dry_run"
+    ):
+        errors.append("missing_payload_preview")
+    if not isinstance(plan.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(plan.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(plan.get("source_pattern_ids"), list) and isinstance(
+        plan.get("source_fact_ids"), list
+    ):
+        if (
+            not plan.get("source_pattern_ids")
+            and not plan.get("source_fact_ids")
+            and plan.get("lock_reason") != "missing_source_evidence"
+        ):
+            errors.append("missing_source_evidence")
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        if (
+            not isinstance(plan.get(field), Mapping)
+            and plan.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    for field, expected_type in _EXECUTOR_CONTRACT_FIELD_TYPES.items():
+        if (
+            not isinstance(plan.get(field), expected_type)
+            and plan.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    if (
+        not isinstance(plan.get("contract_review_checklist"), list)
+        and plan.get("lock_reason") != "missing_contract_review_checklist"
+    ):
+        errors.append("missing_contract_review_checklist")
+    for field, expected_type in _IMPLEMENTATION_PLAN_FIELD_TYPES.items():
+        if (
+            not isinstance(plan.get(field), expected_type)
+            and plan.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    for field, expected_type in _IMPLEMENTATION_DRY_RUN_FIELD_TYPES.items():
+        if (
+            not isinstance(plan.get(field), expected_type)
+            and plan.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    if plan.get("lock_reason") != "preview_integrity_failed":
+        errors.extend(_preview_integrity_errors(plan))
+    if plan.get("lock_reason") is None:
+        errors.extend(
+            _implementation_dry_run_integrity_errors(
+                plan,
+                implementation_dry_run_validation,
+            )
+        )
+
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS + (
+        "payload_preview",
+        "token_write_execution_steps",
+        "token_write_execution_preflight_checks",
+        "final_token_write_preflight_checklist",
+        "final_gate_checklist",
+        "executor_contract_inputs",
+        "executor_hard_lock_checks",
+        "executor_audit_fields",
+        "executor_rollback_rules",
+        "executor_forbidden_side_effects",
+        "executor_contract_checklist",
+        "contract_review_checklist",
+        "implementation_plan_interfaces",
+        "implementation_plan_files",
+        "implementation_plan_idempotency_strategy",
+        "implementation_plan_filesystem_safety_model",
+        "implementation_plan_audit_strategy",
+        "implementation_plan_rollback_strategy",
+        "implementation_plan_test_plan",
+        "implementation_plan_forbidden_actions",
+        "implementation_dry_run_module_boundary_preview",
+        "implementation_dry_run_interface_preview",
+        "implementation_dry_run_idempotency_check_preview",
+        "implementation_dry_run_filesystem_safety_check_preview",
+        "implementation_dry_run_audit_check_preview",
+        "implementation_dry_run_rollback_check_preview",
+        "implementation_dry_run_test_harness_preview",
+        "implementation_dry_run_readiness_checklist",
+    ):
+        if (
+            field in plan
+            and field in source_snapshot
+            and plan.get(field) != source_snapshot.get(field)
+        ):
+            errors.append(
+                f"{field}_must_match_source_implementation_dry_run_snapshot"
+            )
+    if plan.get("source_pattern_ids") != list(
+        source_snapshot.get("source_pattern_ids", []) or []
+    ):
+        errors.append(
+            "source_pattern_ids_must_match_source_implementation_dry_run_snapshot"
+        )
+    if plan.get("source_fact_ids") != list(
+        source_snapshot.get("source_fact_ids", []) or []
+    ):
+        errors.append(
+            "source_fact_ids_must_match_source_implementation_dry_run_snapshot"
+        )
+
+    deterministic_fields = (
+        ("code_review_scope", _code_review_scope()),
+        ("code_review_required_files", _code_review_required_files()),
+        ("code_review_static_analysis_checks", _code_review_static_analysis_checks()),
+        ("code_review_security_checks", _code_review_security_checks()),
+        ("code_review_write_safety_checks", _code_review_write_safety_checks()),
+        ("code_review_test_matrix", _code_review_test_matrix()),
+        ("code_review_acceptance_criteria", _code_review_acceptance_criteria()),
+        ("code_review_forbidden_actions", _code_review_forbidden_actions()),
+        ("code_review_plan_checklist", _code_review_plan_checklist()),
+    )
+    for field, expected in deterministic_fields:
+        if plan.get(field) != expected:
+            errors.append(f"{field}_must_match_v0_1_deterministic_plan")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if plan.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY.items()
+    ):
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_real_write_executor_code_review_plan(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_code_review_plan(
+        plan
+    )
+    source_snapshot = _as_dict(plan.get("source_implementation_dry_run_snapshot"))
+    return {
+        "plan_id": plan.get("plan_id"),
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_implementation_dry_run_id": plan.get("source_implementation_dry_run_id"),
+        "source_implementation_plan_id": plan.get("source_implementation_plan_id"),
+        "source_contract_review_outcome_id": plan.get(
+            "source_contract_review_outcome_id"
+        ),
+        "source_contract_id": plan.get("source_contract_id"),
+        "source_write_final_gate_id": plan.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": plan.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": plan.get("source_write_execution_plan_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "reviewer": plan.get("reviewer"),
+        "outcome": plan.get("outcome"),
+        "rationale": plan.get("rationale"),
+        "source_pattern_count": len(plan.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(plan.get("source_fact_ids", []) or []),
+        "code_review_scope": deepcopy(plan.get("code_review_scope")),
+        "code_review_required_files": deepcopy(plan.get("code_review_required_files")),
+        "code_review_plan_checklist": deepcopy(plan.get("code_review_plan_checklist")),
+        "validation": validation,
+        "implementation_dry_run_explanation": (
+            explain_human_approval_token_real_write_executor_implementation_dry_run(
+                source_snapshot
+            )
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "creates_executor_source_files": False,
+        "creates_executor_tests": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY),
+    }
+
+
+def recommend_human_approval_token_real_write_executor_code_review_plan_action(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_code_review_plan(
+        plan
+    )
+    source_snapshot = _as_dict(plan.get("source_implementation_dry_run_snapshot"))
+    if (
+        validation["valid"]
+        and plan.get("plan_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED
+    ):
+        action = (
+            "route_to_real_token_write_executor_code_review_gate_without_executor_source_creation"
+        )
+        reason = "Code review plan candidate is ready for a separate code review gate; it does not create executor source files, create executor tests, implement or invoke the executor, issue tokens, persist approvals, or write proposal, ledger, token, audit, memory, graph, or config state."
+    elif validation["valid"]:
+        action = "keep_real_token_write_executor_code_review_plan_locked"
+        reason = f"Code review plan candidate is locked by {plan.get('lock_reason')}."
+    else:
+        action = "repair_real_token_write_executor_code_review_plan_candidate"
+        reason = "Code review plan candidate failed validation and cannot proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_ROUTING,
+        "validation": validation,
+        "implementation_dry_run_recommendation": (
+            recommend_human_approval_token_real_write_executor_implementation_dry_run_action(
+                source_snapshot
+            )
+            if source_snapshot
+            else {}
+        ),
+        "creates_real_write_executor_code_review_plan_candidates_only": True,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "creates_executor_source_files": False,
+        "creates_executor_tests": False,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY),
+    }
+
+
+def summarize_human_approval_token_real_write_executor_code_review_plans(
+    plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    code_review_gate_required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for plan in plans:
+        block_type = str(plan.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(plan.get("plan_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        lock_reason = str(plan.get("lock_reason"))
+        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
+        if (
+            plan.get("plan_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED
+        ):
+            code_review_gate_required_count += 1
+        if (
+            plan.get("plan_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED
+        ):
+            locked_count += 1
+        validation = validate_human_approval_token_real_write_executor_code_review_plan(
+            plan
+        )
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(plans),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "real_token_write_executor_code_review_gate_required_count": (
+            code_review_gate_required_count
+        ),
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY),
+    }
+
+
+def _code_review_plan_lock_reason(
+    implementation_dry_run: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> str | None:
+    if (
+        implementation_dry_run.get("dry_run_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED
+    ):
+        return (
+            implementation_dry_run.get("lock_reason")
+            or "real_write_executor_implementation_dry_run_locked"
+        )
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(implementation_dry_run.get(field), Mapping):
+            return f"missing_{field}"
+    for field in _WRITE_PREVIEW_FIELDS:
+        if not isinstance(implementation_dry_run.get(field), Mapping):
+            return f"missing_{field}"
+    for field, expected_type in _EXECUTOR_CONTRACT_FIELD_TYPES.items():
+        if not isinstance(implementation_dry_run.get(field), expected_type):
+            return f"missing_{field}"
+    if not isinstance(implementation_dry_run.get("contract_review_checklist"), list):
+        return "missing_contract_review_checklist"
+    for field, expected_type in _IMPLEMENTATION_PLAN_FIELD_TYPES.items():
+        if not isinstance(implementation_dry_run.get(field), expected_type):
+            return f"missing_{field}"
+    for field, expected_type in _IMPLEMENTATION_DRY_RUN_FIELD_TYPES.items():
+        if not isinstance(implementation_dry_run.get(field), expected_type):
+            return f"missing_{field}"
+    if not (
+        implementation_dry_run.get("source_pattern_ids")
+        or implementation_dry_run.get("source_fact_ids")
+    ):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(implementation_dry_run):
+        return "preview_integrity_failed"
+    if _implementation_dry_run_integrity_errors(implementation_dry_run, validation):
+        return "implementation_dry_run_integrity_failed"
+    if validation.get("valid") is not True:
+        return "invalid_real_write_executor_implementation_dry_run"
+    if (
+        implementation_dry_run.get("dry_run_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED
+    ):
+        return "invalid_real_write_executor_implementation_dry_run"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _implementation_dry_run_integrity_errors(
+    implementation_dry_run: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    module_boundary = implementation_dry_run.get(
+        "implementation_dry_run_module_boundary_preview"
+    )
+    if isinstance(module_boundary, Mapping):
+        expected_false_keys = (
+            "module_created_in_v0_1",
+            "creates_executor_source_files",
+            "implements_real_token_write_executor",
+            "invokes_real_token_write_executor",
+            "writes_files",
+        )
+        if module_boundary.get("preview_only") is not True:
+            errors.append("implementation_dry_run_module_boundary_must_be_preview_only")
+        for key in expected_false_keys:
+            if module_boundary.get(key) is not False:
+                errors.append(f"implementation_dry_run_module_boundary_{key}_must_be_false")
+    interfaces = implementation_dry_run.get("implementation_dry_run_interface_preview")
+    if isinstance(interfaces, list):
+        for interface in interfaces:
+            if not isinstance(interface, Mapping):
+                errors.append("implementation_dry_run_interface_preview_must_be_structured")
+                continue
+            if interface.get("preview_only") is not True:
+                errors.append("implementation_dry_run_interface_preview_must_be_preview_only")
+            if interface.get("implemented_in_v0_1") is not False:
+                errors.append("implementation_dry_run_interfaces_must_not_implement_executor")
+            if interface.get("invoked_in_v0_1") is not False:
+                errors.append("implementation_dry_run_interfaces_must_not_invoke_executor")
+            if interface.get("writes_files") is not False:
+                errors.append("implementation_dry_run_interfaces_must_not_write_files")
+    check_expectations = {
+        "implementation_dry_run_idempotency_check_preview": (
+            "writes_token_files",
+            "writes_approval_audit",
+            "writes_operation_ledger",
+            "written",
+        ),
+        "implementation_dry_run_filesystem_safety_check_preview": (
+            "creates_executor_source_files",
+            "writes_token_files",
+            "writes_approval_audit",
+            "writes_proposal_files",
+            "writes_operation_ledger",
+            "written",
+        ),
+        "implementation_dry_run_audit_check_preview": (
+            "created_operation_event",
+            "writes_approval_audit",
+            "writes_operation_ledger",
+            "written",
+        ),
+        "implementation_dry_run_rollback_check_preview": (
+            "writes_token_files",
+            "writes_approval_audit",
+            "writes_operation_ledger",
+            "written",
+        ),
+    }
+    for field, false_keys in check_expectations.items():
+        preview = implementation_dry_run.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key in false_keys:
+            if preview.get(key) is not False:
+                errors.append(f"{field}_{key}_must_be_false")
+    test_harness = implementation_dry_run.get("implementation_dry_run_test_harness_preview")
+    if isinstance(test_harness, list):
+        for test_case in test_harness:
+            if not isinstance(test_case, Mapping):
+                errors.append("implementation_dry_run_test_harness_preview_must_be_structured")
+                continue
+            if test_case.get("creates_files") is not False:
+                errors.append("implementation_dry_run_test_harness_must_not_create_files")
+            if test_case.get("writes") is not False:
+                errors.append("implementation_dry_run_test_harness_must_not_write")
+    readiness = implementation_dry_run.get("implementation_dry_run_readiness_checklist")
+    if isinstance(readiness, list):
+        required_readiness = {
+            "no_real_approval_token_issued",
+            "no_approval_persisted",
+            "no_real_proposal_created",
+            "no_operation_ledger_event_created",
+            "no_proposal_file_written",
+            "no_operation_ledger_written",
+            "no_token_file_written",
+            "no_approval_audit_written",
+            "no_memory_or_graph_or_config_write",
+            "real_token_write_executor_not_invoked",
+            "real_token_write_executor_not_implemented",
+            "executor_source_files_not_created",
+            "code_review_plan_required_before_any_executor_code",
+        }
+        if required_readiness.difference(readiness):
+            errors.append(
+                "implementation_dry_run_readiness_checklist_must_preserve_no_write_boundary"
+            )
+    for error in list(validation.get("errors", []) or []):
+        if (
+            error.startswith("implementation_dry_run_")
+            or error.endswith("_must_match_source_implementation_plan_snapshot")
+        ):
+            errors.append("implementation_dry_run_validation_integrity_errors")
+    return _dedupe(errors)
+
+
+def _code_review_scope() -> dict[str, Any]:
+    return {
+        "scope_kind": "real_token_write_executor_code_review_scope",
+        "read_only": True,
+        "review_only": True,
+        "creates_executor_source_files": False,
+        "creates_executor_tests": False,
+        "implements_real_token_write_executor": False,
+        "invokes_real_token_write_executor": False,
+        "review_targets": [
+            "future_executor_module_boundary",
+            "future_executor_input_validation_contract",
+            "future_token_and_audit_payload_preparation",
+            "future_filesystem_atomicity_and_path_safety",
+            "future_idempotency_and_rollback_controls",
+            "future_no_proposal_or_operation_ledger_write_boundary",
+        ],
+    }
+
+
+def _code_review_required_files() -> list[dict[str, Any]]:
+    return [
+        {
+            "path": "agent/memory_human_approval_token_real_write_executor.py",
+            "role": "future_executor_module",
+            "required_before_creation": True,
+            "create_in_v0_1": False,
+            "contains_executor_code_in_v0_1": False,
+            "writes_files_in_v0_1": False,
+        },
+        {
+            "path": "tests/agent/test_memory_human_approval_token_real_write_executor.py",
+            "role": "future_executor_test_module",
+            "required_before_creation": True,
+            "create_in_v0_1": False,
+            "contains_executor_code_in_v0_1": False,
+            "writes_files_in_v0_1": False,
+        },
+        {
+            "path": "agent/memory_human_approval_token_real_write_executor_code_review_plan.py",
+            "role": "current_read_only_code_review_plan_module",
+            "required_before_creation": True,
+            "create_in_v0_1": False,
+            "contains_executor_code_in_v0_1": False,
+            "writes_files_in_v0_1": False,
+        },
+    ]
+
+
+def _code_review_static_analysis_checks() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "no_executor_source_created_by_plan",
+            "expectation": "code_review_plan_module_must_not_create_future_executor_module_or_tests",
+            "writes": False,
+        },
+        {
+            "id": "public_surface_is_read_only_candidate_builder",
+            "expectation": "public_functions_create_validate_explain_recommend_and_summarize_only",
+            "writes": False,
+        },
+        {
+            "id": "no_dynamic_write_dispatch",
+            "expectation": "no_open_write_append_touch_replace_unlink_mkdir_or_operation_ledger_calls_in_plan_path",
+            "writes": False,
+        },
+        {
+            "id": "deterministic_identifiers",
+            "expectation": "plan_id_must_be_sha256_of_stable_json_identity",
+            "writes": False,
+        },
+    ]
+
+
+def _code_review_security_checks() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "path_safety_review_required_before_future_executor",
+            "expectation": "future_executor_must_reject_traversal_symlinks_and_unexpected_absolute_paths",
+            "creates_executor_source_files": False,
+        },
+        {
+            "id": "token_payload_integrity_review_required",
+            "expectation": "future_executor_must_hash_and_compare_token_and_audit_payloads_before_any_real_write",
+            "writes_token_files": False,
+        },
+        {
+            "id": "audit_boundary_review_required",
+            "expectation": "future_executor_must_not_create_operation_ledger_events_or_proposal_records",
+            "writes_operation_ledger": False,
+        },
+        {
+            "id": "approval_authority_review_required",
+            "expectation": "future_executor_must_require_governed_human_approval_token_inputs_before_real_write_eligibility",
+            "persists_approvals": False,
+        },
+    ]
+
+
+def _code_review_write_safety_checks() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "assert_no_token_file_write_in_v0_1",
+            "assertion": "writes_token_files_false",
+            "writes_token_files": False,
+        },
+        {
+            "id": "assert_no_approval_audit_write_in_v0_1",
+            "assertion": "writes_approval_audit_false",
+            "writes_approval_audit": False,
+        },
+        {
+            "id": "assert_no_proposal_file_write_in_v0_1",
+            "assertion": "writes_proposal_files_false",
+            "writes_proposal_files": False,
+        },
+        {
+            "id": "assert_no_operation_ledger_write_in_v0_1",
+            "assertion": "writes_operation_ledger_false",
+            "writes_operation_ledger": False,
+            "created_operation_event": False,
+        },
+        {
+            "id": "assert_no_memory_graph_or_config_write_in_v0_1",
+            "assertion": "memory_graph_and_config_writes_false",
+            "would_write_memory": False,
+            "would_write_graph": False,
+            "would_modify_config": False,
+        },
+    ]
+
+
+def _code_review_test_matrix() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "valid_implementation_dry_run_creates_code_review_gate_required_plan",
+            "scope": "unit",
+            "writes": False,
+            "creates_executor_source_files": False,
+            "creates_executor_tests": False,
+        },
+        {
+            "id": "locked_invalid_missing_and_integrity_failures_lock_plan",
+            "scope": "unit",
+            "writes": False,
+            "creates_executor_source_files": False,
+            "creates_executor_tests": False,
+        },
+        {
+            "id": "deterministic_code_review_checks_do_not_create_executor_code",
+            "scope": "unit",
+            "writes": False,
+            "creates_executor_source_files": False,
+            "creates_executor_tests": False,
+        },
+        {
+            "id": "benchmark_smoke_case_stays_read_only_executor_free_and_source_file_free",
+            "scope": "benchmark",
+            "writes": False,
+            "creates_executor_source_files": False,
+            "creates_executor_tests": False,
+        },
+    ]
+
+
+def _code_review_acceptance_criteria() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "valid_source_only",
+            "requirement": "source_implementation_dry_run_validation_is_valid_and_status_is_code_review_plan_required",
+            "required": True,
+        },
+        {
+            "id": "no_executor_source_creation_in_v0_1",
+            "requirement": "executor_source_files_and_executor_tests_must_not_be_created_in_v0_1",
+            "required": True,
+            "creates_executor_source_files": False,
+            "creates_executor_tests": False,
+        },
+        {
+            "id": "no_executor_implementation_or_invocation",
+            "requirement": "plan_must_not_implement_or_invoke_real_token_write_executor",
+            "required": True,
+        },
+        {
+            "id": "no_token_audit_proposal_or_ledger_writes",
+            "requirement": "plan_must_not_write_token_audit_proposal_or_operation_ledger_files",
+            "required": True,
+        },
+    ]
+
+
+def _code_review_forbidden_actions() -> list[str]:
+    return [
+        "write_memory",
+        "write_memory_graph",
+        "modify_openclaw_config",
+        "approve_allowlists",
+        "create_proposal_events",
+        "create_operation_ledger_events",
+        "create_real_memory_proposals",
+        "write_proposal_files",
+        "write_operation_ledger",
+        "issue_real_approval_tokens",
+        "persist_approvals",
+        "write_token_files",
+        "write_approval_audit_files",
+        "invoke_real_token_write_executor",
+        "implement_real_token_write_executor",
+        "create_executor_source_files",
+        "create_executor_tests",
+        "submit_to_governance",
+        "convert_to_real_proposal",
+    ]
+
+
+def _code_review_plan_checklist() -> list[str]:
+    return [
+        "source_implementation_dry_run_is_valid_and_code_review_plan_required",
+        "approval_token_record_preview_is_preview_only",
+        "approval_audit_record_preview_is_preview_only",
+        "token_target_paths_preview_is_preview_only",
+        "proposal_record_preview_is_not_written",
+        "operation_ledger_preview_is_not_written",
+        "target_paths_preview_is_preview_only",
+        "approval_token_write_payload_preview_is_preview_only",
+        "approval_audit_write_payload_preview_is_preview_only",
+        "token_write_target_paths_preview_is_preview_only",
+        "executor_contract_inputs_are_present",
+        "executor_contract_checklist_is_present",
+        "implementation_plan_interfaces_are_present_and_not_implemented",
+        "implementation_plan_files_are_present_and_not_created",
+        "implementation_dry_run_previews_are_present_and_read_only",
+        "code_review_scope_is_read_only",
+        "code_review_required_files_are_not_created_in_v0_1",
+        "code_review_static_analysis_checks_are_defined",
+        "code_review_security_checks_are_defined",
+        "code_review_write_safety_checks_assert_no_token_audit_proposal_or_ledger_writes",
+        "code_review_test_matrix_has_no_write_cases",
+        "code_review_acceptance_criteria_require_no_executor_source_creation",
+        "no_real_approval_token_issued",
+        "no_approval_persisted",
+        "no_real_proposal_created",
+        "no_operation_ledger_event_created",
+        "no_proposal_file_written",
+        "no_operation_ledger_written",
+        "no_token_file_written",
+        "no_approval_audit_written",
+        "no_memory_or_graph_or_config_write",
+        "real_token_write_executor_not_invoked",
+        "real_token_write_executor_not_implemented",
+        "executor_source_files_not_created",
+        "executor_tests_not_created",
+        "code_review_gate_required_before_executor_source_creation",
+    ]
+
+
+def _plan_id(plan: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_VERSION,
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_implementation_dry_run_id": plan.get("source_implementation_dry_run_id"),
+        "source_implementation_plan_id": plan.get("source_implementation_plan_id"),
+        "source_contract_review_outcome_id": plan.get("source_contract_review_outcome_id"),
+        "source_contract_id": plan.get("source_contract_id"),
+        "source_write_final_gate_id": plan.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": plan.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": plan.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": plan.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": plan.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": plan.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": plan.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": plan.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": plan.get("source_review_outcome_id"),
+        "source_request_id": plan.get("source_request_id"),
+        "source_gate_id": plan.get("source_gate_id"),
+        "source_dry_run_id": plan.get("source_dry_run_id"),
+        "source_plan_id": plan.get("source_plan_id"),
+        "source_outcome_id": plan.get("source_outcome_id"),
+        "source_packet_id": plan.get("source_packet_id"),
+        "source_submission_id": plan.get("source_submission_id"),
+        "source_draft_id": plan.get("source_draft_id"),
+        "source_decision_id": plan.get("source_decision_id"),
+        "source_queue_item_id": plan.get("source_queue_item_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "reviewer": plan.get("reviewer"),
+        "outcome": plan.get("outcome"),
+        "rationale": plan.get("rationale"),
+        "approval_token_record_preview": plan.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": plan.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": plan.get("token_target_paths_preview", {}),
+        "proposal_record_preview": plan.get("proposal_record_preview", {}),
+        "operation_ledger_preview": plan.get("operation_ledger_preview", {}),
+        "target_paths_preview": plan.get("target_paths_preview", {}),
+        "payload_preview": plan.get("payload_preview"),
+        "source_pattern_ids": list(plan.get("source_pattern_ids", [])),
+        "source_fact_ids": list(plan.get("source_fact_ids", [])),
+        "token_write_execution_steps": list(
+            plan.get("token_write_execution_steps", [])
+        ),
+        "token_write_execution_preflight_checks": list(
+            plan.get("token_write_execution_preflight_checks", [])
+        ),
+        "approval_token_write_payload_preview": plan.get(
+            "approval_token_write_payload_preview", {}
+        ),
+        "approval_audit_write_payload_preview": plan.get(
+            "approval_audit_write_payload_preview", {}
+        ),
+        "token_write_target_paths_preview": plan.get(
+            "token_write_target_paths_preview", {}
+        ),
+        "final_token_write_preflight_checklist": list(
+            plan.get("final_token_write_preflight_checklist") or []
+        ),
+        "final_gate_checklist": list(plan.get("final_gate_checklist") or []),
+        "executor_contract_inputs": plan.get("executor_contract_inputs", {}),
+        "executor_hard_lock_checks": list(plan.get("executor_hard_lock_checks") or []),
+        "executor_audit_fields": list(plan.get("executor_audit_fields") or []),
+        "executor_rollback_rules": list(plan.get("executor_rollback_rules") or []),
+        "executor_forbidden_side_effects": list(
+            plan.get("executor_forbidden_side_effects") or []
+        ),
+        "executor_contract_checklist": list(
+            plan.get("executor_contract_checklist") or []
+        ),
+        "contract_review_checklist": list(plan.get("contract_review_checklist") or []),
+        "implementation_plan_interfaces": plan.get("implementation_plan_interfaces", []),
+        "implementation_plan_files": plan.get("implementation_plan_files", []),
+        "implementation_plan_idempotency_strategy": plan.get(
+            "implementation_plan_idempotency_strategy", {}
+        ),
+        "implementation_plan_filesystem_safety_model": plan.get(
+            "implementation_plan_filesystem_safety_model", {}
+        ),
+        "implementation_plan_audit_strategy": plan.get(
+            "implementation_plan_audit_strategy", {}
+        ),
+        "implementation_plan_rollback_strategy": plan.get(
+            "implementation_plan_rollback_strategy", {}
+        ),
+        "implementation_plan_test_plan": plan.get("implementation_plan_test_plan", []),
+        "implementation_plan_forbidden_actions": list(
+            plan.get("implementation_plan_forbidden_actions") or []
+        ),
+        "implementation_dry_run_module_boundary_preview": plan.get(
+            "implementation_dry_run_module_boundary_preview", {}
+        ),
+        "implementation_dry_run_interface_preview": plan.get(
+            "implementation_dry_run_interface_preview", []
+        ),
+        "implementation_dry_run_idempotency_check_preview": plan.get(
+            "implementation_dry_run_idempotency_check_preview", {}
+        ),
+        "implementation_dry_run_filesystem_safety_check_preview": plan.get(
+            "implementation_dry_run_filesystem_safety_check_preview", {}
+        ),
+        "implementation_dry_run_audit_check_preview": plan.get(
+            "implementation_dry_run_audit_check_preview", {}
+        ),
+        "implementation_dry_run_rollback_check_preview": plan.get(
+            "implementation_dry_run_rollback_check_preview", {}
+        ),
+        "implementation_dry_run_test_harness_preview": plan.get(
+            "implementation_dry_run_test_harness_preview", []
+        ),
+        "implementation_dry_run_readiness_checklist": list(
+            plan.get("implementation_dry_run_readiness_checklist") or []
+        ),
+        "code_review_scope": plan.get("code_review_scope", {}),
+        "code_review_required_files": plan.get("code_review_required_files", []),
+        "code_review_static_analysis_checks": plan.get(
+            "code_review_static_analysis_checks", []
+        ),
+        "code_review_security_checks": plan.get("code_review_security_checks", []),
+        "code_review_write_safety_checks": plan.get(
+            "code_review_write_safety_checks", []
+        ),
+        "code_review_test_matrix": plan.get("code_review_test_matrix", []),
+        "code_review_acceptance_criteria": plan.get(
+            "code_review_acceptance_criteria", []
+        ),
+        "code_review_forbidden_actions": list(
+            plan.get("code_review_forbidden_actions") or []
+        ),
+        "code_review_plan_checklist": list(
+            plan.get("code_review_plan_checklist") or []
+        ),
+        "implementation_dry_run_validation": plan.get(
+            "implementation_dry_run_validation", {}
+        ),
+        "policy": plan.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return (
+        "memory-human-approval-token-real-write-executor-code-review-plan:"
+        f"v0.1:{digest}"
+    )
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_real_write_executor_contract.py
+++ b/agent/memory_human_approval_token_real_write_executor_contract.py
@@ -1,0 +1,821 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_write_final_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED,
+    explain_human_approval_token_write_final_gate,
+    recommend_human_approval_token_write_final_gate_action,
+    validate_human_approval_token_write_final_gate,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_KIND = (
+    "memory_human_approval_token_real_write_executor_contract_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED = (
+    "real_token_write_executor_contract_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_ROUTING = (
+    "real_token_write_executor_contract_review_required_before_implementation"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_real_write_executor_contract_candidates_only": True,
+    "invokes_real_token_write_executor": False,
+    "implements_real_token_write_executor": False,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = "hermes_memory_human_approval_token_real_write_executor_contract_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_WRITE_PREVIEW_FIELDS = (
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+)
+_LOCK_REASONS = {
+    None,
+    "token_write_final_gate_locked",
+    "invalid_token_write_final_gate",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_approval_token_write_payload_preview",
+    "missing_approval_audit_write_payload_preview",
+    "missing_token_write_target_paths_preview",
+    "missing_final_gate_checklist",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+    "final_gate_integrity_failed",
+    "token_write_execution_dry_run_locked",
+    "missing_final_token_write_preflight_checklist",
+    "final_preflight_integrity_failed",
+    "final_confirmation_requested_changes",
+    "final_confirmation_rejected",
+    "final_confirmation_deferred",
+    "invalid_final_confirmation_review_outcome",
+}
+
+
+def create_human_approval_token_real_write_executor_contract(
+    write_final_gate: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only real token write executor contract candidate."""
+    source = deepcopy(dict(write_final_gate))
+    write_final_gate_validation = validate_human_approval_token_write_final_gate(source)
+    lock_reason = _contract_lock_reason(source, write_final_gate_validation)
+    contract_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+    )
+
+    contract = {
+        "contract_id": None,
+        "contract_kind": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_KIND,
+        "contract_status": contract_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_ROUTING,
+        "lock_reason": lock_reason,
+        "source_write_final_gate_id": source.get("gate_id"),
+        "source_write_execution_dry_run_id": source.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": source.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": source.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": source.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "outcome": source.get("outcome"),
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": deepcopy(
+            list(source.get("token_write_execution_steps", []) or [])
+        ),
+        "token_write_execution_preflight_checks": deepcopy(
+            list(source.get("token_write_execution_preflight_checks", []) or [])
+        ),
+        "approval_token_write_payload_preview": deepcopy(
+            source.get("approval_token_write_payload_preview")
+        ),
+        "approval_audit_write_payload_preview": deepcopy(
+            source.get("approval_audit_write_payload_preview")
+        ),
+        "token_write_target_paths_preview": deepcopy(source.get("token_write_target_paths_preview")),
+        "final_token_write_preflight_checklist": deepcopy(
+            source.get("final_token_write_preflight_checklist")
+        ),
+        "final_gate_checklist": deepcopy(source.get("final_gate_checklist")),
+        "executor_contract_inputs": _executor_contract_inputs(source),
+        "executor_hard_lock_checks": _executor_hard_lock_checks(),
+        "executor_audit_fields": _executor_audit_fields(),
+        "executor_rollback_rules": _executor_rollback_rules(),
+        "executor_forbidden_side_effects": _executor_forbidden_side_effects(),
+        "executor_contract_checklist": _executor_contract_checklist(),
+        "write_final_gate_validation": deepcopy(write_final_gate_validation),
+        "contract_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_write_final_gate_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY),
+    }
+    contract["contract_id"] = _contract_id(contract)
+    contract["contract_validation"] = validate_human_approval_token_real_write_executor_contract(
+        contract
+    )
+    contract["next_step_recommendation"] = (
+        recommend_human_approval_token_real_write_executor_contract_action(contract)
+    )
+    return contract
+
+
+def validate_human_approval_token_real_write_executor_contract(
+    contract: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(contract.get("policy"))
+    source_snapshot = _as_dict(contract.get("source_write_final_gate_snapshot"))
+    gate_validation = _as_dict(contract.get("write_final_gate_validation"))
+    expected_gate_validation = validate_human_approval_token_write_final_gate(source_snapshot)
+    expected_lock_reason = _contract_lock_reason(source_snapshot, gate_validation)
+
+    for key in _REQUIRED_CONTRACT_KEYS:
+        if key not in contract:
+            errors.append(f"missing_{key}")
+    if (
+        contract.get("contract_kind")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_KIND
+    ):
+        errors.append(
+            "contract_kind_must_be_memory_human_approval_token_real_write_executor_contract_candidate"
+        )
+    if contract.get("contract_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED,
+    }:
+        errors.append("contract_status_must_be_supported")
+    if contract.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_ROUTING:
+        errors.append("routing_must_require_contract_review_before_executor_implementation")
+    if contract.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if contract.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_real_write_executor_contract_checks")
+    if (
+        expected_lock_reason is None
+        and contract.get("contract_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED
+    ):
+        errors.append("eligible_token_write_final_gate_must_require_executor_contract")
+    if (
+        expected_lock_reason is not None
+        and contract.get("contract_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+    ):
+        errors.append("invalid_or_locked_token_write_final_gate_must_lock_contract")
+    if not isinstance(contract.get("operator"), str) or not contract.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if gate_validation != expected_gate_validation:
+        errors.append("write_final_gate_validation_must_match_source_write_final_gate_snapshot")
+    if contract.get("source_write_final_gate_id") != source_snapshot.get("gate_id"):
+        errors.append("source_write_final_gate_id_must_match_source_snapshot")
+    for source_key in _SOURCE_KEYS:
+        if contract.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+    if not isinstance(contract.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(contract.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(contract.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(contract.get("source_pattern_ids"), list) and isinstance(
+        contract.get("source_fact_ids"), list
+    ):
+        if (
+            not contract.get("source_pattern_ids")
+            and not contract.get("source_fact_ids")
+            and contract.get("lock_reason") != "missing_source_evidence"
+        ):
+            errors.append("missing_source_evidence")
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        if (
+            not isinstance(contract.get(field), Mapping)
+            and contract.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    if (
+        not isinstance(contract.get("final_gate_checklist"), list)
+        and contract.get("lock_reason") != "missing_final_gate_checklist"
+    ):
+        errors.append("missing_final_gate_checklist")
+    if contract.get("lock_reason") != "preview_integrity_failed":
+        errors.extend(_preview_integrity_errors(contract))
+    if contract.get("lock_reason") != "final_gate_integrity_failed":
+        errors.extend(_final_gate_integrity_errors(contract))
+    if contract.get("executor_contract_inputs") != _executor_contract_inputs(source_snapshot):
+        errors.append("executor_contract_inputs_must_match_v0_1_deterministic_contract")
+    if contract.get("executor_hard_lock_checks") != _executor_hard_lock_checks():
+        errors.append("executor_hard_lock_checks_must_match_v0_1_deterministic_contract")
+    if contract.get("executor_audit_fields") != _executor_audit_fields():
+        errors.append("executor_audit_fields_must_match_v0_1_deterministic_contract")
+    if contract.get("executor_rollback_rules") != _executor_rollback_rules():
+        errors.append("executor_rollback_rules_must_match_v0_1_deterministic_contract")
+    if contract.get("executor_forbidden_side_effects") != _executor_forbidden_side_effects():
+        errors.append("executor_forbidden_side_effects_must_match_v0_1_deterministic_contract")
+    if contract.get("executor_contract_checklist") != _executor_contract_checklist():
+        errors.append("executor_contract_checklist_must_match_v0_1_deterministic_contract")
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS + (
+        "payload_preview",
+        "final_token_write_preflight_checklist",
+        "final_gate_checklist",
+    ):
+        if (
+            field in contract
+            and field in source_snapshot
+            and contract.get(field) != source_snapshot.get(field)
+        ):
+            errors.append(f"{field}_must_match_source_write_final_gate_snapshot")
+    if contract.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_write_final_gate_snapshot")
+    if contract.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_write_final_gate_snapshot")
+    if contract.get("token_write_execution_steps") != list(
+        source_snapshot.get("token_write_execution_steps", []) or []
+    ):
+        errors.append("token_write_execution_steps_must_match_source_write_final_gate_snapshot")
+    if contract.get("token_write_execution_preflight_checks") != list(
+        source_snapshot.get("token_write_execution_preflight_checks", []) or []
+    ):
+        errors.append(
+            "token_write_execution_preflight_checks_must_match_source_write_final_gate_snapshot"
+        )
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if contract.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_real_write_executor_contract(
+    contract: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_contract(contract)
+    source_snapshot = _as_dict(contract.get("source_write_final_gate_snapshot"))
+    return {
+        "contract_id": contract.get("contract_id"),
+        "contract_kind": contract.get("contract_kind"),
+        "contract_status": contract.get("contract_status"),
+        "routing": contract.get("routing"),
+        "lock_reason": contract.get("lock_reason"),
+        "source_write_final_gate_id": contract.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": contract.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": contract.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": contract.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": contract.get("block_id"),
+        "block_type": contract.get("block_type"),
+        "project_scope": contract.get("project_scope"),
+        "operator": contract.get("operator"),
+        "outcome": contract.get("outcome"),
+        "source_pattern_count": len(contract.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(contract.get("source_fact_ids", []) or []),
+        "executor_contract_inputs": deepcopy(contract.get("executor_contract_inputs")),
+        "executor_hard_lock_checks": deepcopy(contract.get("executor_hard_lock_checks")),
+        "executor_audit_fields": deepcopy(contract.get("executor_audit_fields")),
+        "executor_rollback_rules": deepcopy(contract.get("executor_rollback_rules")),
+        "executor_forbidden_side_effects": deepcopy(
+            contract.get("executor_forbidden_side_effects")
+        ),
+        "executor_contract_checklist": deepcopy(contract.get("executor_contract_checklist")),
+        "validation": validation,
+        "write_final_gate_explanation": (
+            explain_human_approval_token_write_final_gate(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY),
+    }
+
+
+def recommend_human_approval_token_real_write_executor_contract_action(
+    contract: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_contract(contract)
+    source_snapshot = _as_dict(contract.get("source_write_final_gate_snapshot"))
+    if (
+        validation["valid"]
+        and contract.get("contract_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED
+    ):
+        action = "route_to_real_token_write_executor_contract_review_without_implementation"
+        reason = "Real token write executor contract candidate is ready for human review; this module does not implement or invoke the executor."
+    elif validation["valid"]:
+        action = "keep_real_token_write_executor_contract_locked"
+        reason = f"Real token write executor contract candidate is locked by {contract.get('lock_reason')}."
+    else:
+        action = "repair_real_token_write_executor_contract_candidate"
+        reason = "Real token write executor contract candidate failed validation and cannot proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_ROUTING,
+        "validation": validation,
+        "write_final_gate_recommendation": (
+            recommend_human_approval_token_write_final_gate_action(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "creates_real_write_executor_contract_candidates_only": True,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY),
+    }
+
+
+def summarize_human_approval_token_real_write_executor_contracts(
+    contracts: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for contract in contracts:
+        block_type = str(contract.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(contract.get("contract_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        lock_reason = str(contract.get("lock_reason"))
+        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
+        if (
+            contract.get("contract_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED
+        ):
+            required_count += 1
+        if (
+            contract.get("contract_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+        ):
+            locked_count += 1
+        validation = validate_human_approval_token_real_write_executor_contract(contract)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(contracts),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "real_token_write_executor_contract_required_count": required_count,
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY),
+    }
+
+
+_SOURCE_KEYS = (
+    "source_write_execution_dry_run_id",
+    "source_write_execution_plan_id",
+    "source_final_confirmation_review_outcome_id",
+    "source_final_confirmation_request_id",
+    "source_token_write_lock_gate_id",
+    "source_token_issuance_dry_run_id",
+    "source_token_issuance_plan_id",
+    "source_review_outcome_id",
+    "source_request_id",
+    "source_gate_id",
+    "source_dry_run_id",
+    "source_plan_id",
+    "source_outcome_id",
+    "source_packet_id",
+    "source_submission_id",
+    "source_draft_id",
+    "source_decision_id",
+    "source_queue_item_id",
+    "block_id",
+    "block_type",
+    "project_scope",
+    "outcome",
+)
+
+_REQUIRED_CONTRACT_KEYS = (
+    "contract_id",
+    "contract_kind",
+    "contract_status",
+    "routing",
+    "lock_reason",
+    "source_write_final_gate_id",
+) + _SOURCE_KEYS + (
+    "operator",
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+    "payload_preview",
+    "source_pattern_ids",
+    "source_fact_ids",
+    "token_write_execution_steps",
+    "token_write_execution_preflight_checks",
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+    "final_token_write_preflight_checklist",
+    "final_gate_checklist",
+    "executor_contract_inputs",
+    "executor_hard_lock_checks",
+    "executor_audit_fields",
+    "executor_rollback_rules",
+    "executor_forbidden_side_effects",
+    "executor_contract_checklist",
+    "write_final_gate_validation",
+    "contract_validation",
+    "next_step_recommendation",
+    "source_write_final_gate_snapshot",
+    "policy",
+)
+
+
+def _contract_lock_reason(
+    gate: Mapping[str, Any],
+    gate_validation: Mapping[str, Any],
+) -> str | None:
+    if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED:
+        return gate.get("lock_reason") or "token_write_final_gate_locked"
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(gate.get(field), Mapping):
+            return f"missing_{field}"
+    for field in _WRITE_PREVIEW_FIELDS:
+        if not isinstance(gate.get(field), Mapping):
+            return f"missing_{field}"
+    if not isinstance(gate.get("final_gate_checklist"), list):
+        return "missing_final_gate_checklist"
+    if not (gate.get("source_pattern_ids") or gate.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(gate):
+        return "preview_integrity_failed"
+    if _final_gate_integrity_errors(gate):
+        return "final_gate_integrity_failed"
+    if gate_validation.get("valid") is not True:
+        return "invalid_token_write_final_gate"
+    if gate.get("gate_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE:
+        return "invalid_token_write_final_gate"
+    return None
+
+
+def _executor_contract_inputs(gate: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "required_source_candidate": "eligible_for_real_token_write_executor_final_gate",
+        "source_write_final_gate_id": gate.get("gate_id"),
+        "source_write_execution_dry_run_id": gate.get("source_write_execution_dry_run_id"),
+        "approval_token_record_preview_required": True,
+        "approval_audit_record_preview_required": True,
+        "token_target_paths_preview_required": True,
+        "proposal_record_preview_required": True,
+        "operation_ledger_preview_required": True,
+        "target_paths_preview_required": True,
+        "approval_token_write_payload_preview_required": True,
+        "approval_audit_write_payload_preview_required": True,
+        "token_write_target_paths_preview_required": True,
+        "final_gate_checklist_required": True,
+        "source_evidence_required": True,
+        "executor_boundary": "contract_only_no_executor_implementation_or_invocation",
+    }
+
+
+def _executor_hard_lock_checks() -> list[str]:
+    return [
+        "lock_if_source_write_final_gate_is_locked",
+        "lock_if_source_write_final_gate_validation_fails",
+        "lock_if_source_write_final_gate_status_is_not_eligible_for_real_token_write_executor",
+        "lock_if_approval_token_record_preview_missing_or_not_preview_only",
+        "lock_if_approval_audit_record_preview_missing_or_not_preview_only",
+        "lock_if_token_target_paths_preview_missing_or_not_preview_only",
+        "lock_if_proposal_record_preview_missing_or_written",
+        "lock_if_operation_ledger_preview_missing_or_written_or_event_created",
+        "lock_if_target_paths_preview_missing_or_not_preview_only",
+        "lock_if_approval_token_write_payload_preview_missing_or_not_preview_only",
+        "lock_if_approval_audit_write_payload_preview_missing_or_not_preview_only",
+        "lock_if_token_write_target_paths_preview_missing_or_not_preview_only",
+        "lock_if_final_gate_checklist_missing_or_changed",
+        "lock_if_source_evidence_missing",
+        "lock_if_any_forbidden_write_or_executor_flag_is_true",
+    ]
+
+
+def _executor_audit_fields() -> list[str]:
+    return [
+        "contract_id",
+        "contract_kind",
+        "contract_status",
+        "routing",
+        "lock_reason",
+        "source_write_final_gate_id",
+        "source_write_execution_dry_run_id",
+        "source_write_execution_plan_id",
+        "source_final_confirmation_review_outcome_id",
+        "source_final_confirmation_request_id",
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "operator",
+        "outcome",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "write_final_gate_validation",
+        "contract_validation",
+        "policy",
+    ]
+
+
+def _executor_rollback_rules() -> list[str]:
+    return [
+        "no_rollback_action_in_v0_1_because_no_write_is_performed",
+        "future_executor_must_abort_before_first_write_when_any_preflight_check_fails",
+        "future_executor_must_use_atomic_token_and_audit_write_boundary_if_implemented_else_abort",
+        "future_executor_must_record_reversible_target_paths_before_any_write_if_implemented",
+        "future_executor_must_never_create_proposal_or_operation_ledger_events_inside_contract_module",
+    ]
+
+
+def _executor_forbidden_side_effects() -> list[str]:
+    return [
+        "write_memory",
+        "write_memory_graph",
+        "modify_openclaw_config",
+        "approve_allowlists",
+        "create_proposal_events",
+        "create_operation_ledger_events",
+        "create_real_memory_proposals",
+        "write_proposal_files",
+        "write_operation_ledger",
+        "issue_real_approval_tokens",
+        "write_token_files",
+        "write_approval_audit_files",
+        "persist_approvals",
+        "invoke_real_token_write_executor",
+        "implement_real_token_write_executor",
+        "submit_to_governance",
+        "convert_to_real_proposal",
+    ]
+
+
+def _executor_contract_checklist() -> list[str]:
+    return [
+        "contract_is_read_only_candidate_only",
+        "source_final_gate_is_valid_and_executor_eligible",
+        "all_preview_records_are_present_and_preview_only",
+        "all_target_path_previews_are_present_and_preview_only",
+        "proposal_and_operation_ledger_previews_are_not_written",
+        "token_and_approval_audit_payload_previews_are_not_written",
+        "source_evidence_is_present",
+        "final_gate_checklist_is_present_and_unchanged",
+        "hard_lock_checks_are_defined_before_executor_implementation",
+        "audit_fields_are_defined_before_executor_implementation",
+        "rollback_rules_are_defined_before_executor_implementation",
+        "forbidden_side_effects_include_no_token_proposal_or_ledger_writes",
+        "no_real_executor_is_invoked",
+        "no_real_executor_is_implemented",
+        "no_memory_or_graph_or_config_write",
+    ]
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _final_gate_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    checklist = container.get("final_gate_checklist")
+    if isinstance(checklist, list):
+        required_checks = {
+            "no_real_approval_token_issued",
+            "no_approval_persisted",
+            "no_real_proposal_created",
+            "no_operation_ledger_event_created",
+            "no_token_file_written",
+            "no_approval_audit_written",
+            "real_token_write_executor_required_but_not_invoked",
+        }
+        missing = sorted(required_checks.difference(checklist))
+        if missing:
+            errors.append("final_gate_checklist_must_preserve_no_write_and_no_executor_checks")
+    final_preflight = container.get("final_token_write_preflight_checklist")
+    if isinstance(final_preflight, list) and "no_real_approval_token_issued" not in final_preflight:
+        errors.append("final_token_write_preflight_checklist_must_preserve_no_token_write_checks")
+    return errors
+
+
+def _contract_id(contract: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_VERSION,
+        "contract_kind": contract.get("contract_kind"),
+        "contract_status": contract.get("contract_status"),
+        "routing": contract.get("routing"),
+        "lock_reason": contract.get("lock_reason"),
+        "source_write_final_gate_id": contract.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": contract.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": contract.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": contract.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": contract.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": contract.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": contract.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": contract.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": contract.get("source_review_outcome_id"),
+        "source_request_id": contract.get("source_request_id"),
+        "source_gate_id": contract.get("source_gate_id"),
+        "source_dry_run_id": contract.get("source_dry_run_id"),
+        "source_plan_id": contract.get("source_plan_id"),
+        "source_outcome_id": contract.get("source_outcome_id"),
+        "source_packet_id": contract.get("source_packet_id"),
+        "source_submission_id": contract.get("source_submission_id"),
+        "source_draft_id": contract.get("source_draft_id"),
+        "source_decision_id": contract.get("source_decision_id"),
+        "source_queue_item_id": contract.get("source_queue_item_id"),
+        "block_id": contract.get("block_id"),
+        "block_type": contract.get("block_type"),
+        "project_scope": contract.get("project_scope"),
+        "operator": contract.get("operator"),
+        "outcome": contract.get("outcome"),
+        "approval_token_record_preview": contract.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": contract.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": contract.get("token_target_paths_preview", {}),
+        "proposal_record_preview": contract.get("proposal_record_preview", {}),
+        "operation_ledger_preview": contract.get("operation_ledger_preview", {}),
+        "target_paths_preview": contract.get("target_paths_preview", {}),
+        "payload_preview": contract.get("payload_preview"),
+        "source_pattern_ids": list(contract.get("source_pattern_ids", [])),
+        "source_fact_ids": list(contract.get("source_fact_ids", [])),
+        "token_write_execution_steps": list(contract.get("token_write_execution_steps", [])),
+        "token_write_execution_preflight_checks": list(
+            contract.get("token_write_execution_preflight_checks", [])
+        ),
+        "approval_token_write_payload_preview": contract.get(
+            "approval_token_write_payload_preview", {}
+        ),
+        "approval_audit_write_payload_preview": contract.get(
+            "approval_audit_write_payload_preview", {}
+        ),
+        "token_write_target_paths_preview": contract.get(
+            "token_write_target_paths_preview", {}
+        ),
+        "final_token_write_preflight_checklist": list(
+            contract.get("final_token_write_preflight_checklist") or []
+        ),
+        "final_gate_checklist": list(contract.get("final_gate_checklist") or []),
+        "executor_contract_inputs": contract.get("executor_contract_inputs", {}),
+        "executor_hard_lock_checks": list(contract.get("executor_hard_lock_checks", [])),
+        "executor_audit_fields": list(contract.get("executor_audit_fields", [])),
+        "executor_rollback_rules": list(contract.get("executor_rollback_rules", [])),
+        "executor_forbidden_side_effects": list(
+            contract.get("executor_forbidden_side_effects", [])
+        ),
+        "executor_contract_checklist": list(contract.get("executor_contract_checklist", [])),
+        "write_final_gate_validation": contract.get("write_final_gate_validation", {}),
+        "policy": contract.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return f"memory-human-approval-token-real-write-executor-contract:v0.1:{digest}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_real_write_executor_contract.py
+++ b/agent/memory_human_approval_token_real_write_executor_contract.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_write_final_gate import (
     explain_human_approval_token_write_final_gate,
     recommend_human_approval_token_write_final_gate_action,
     validate_human_approval_token_write_final_gate,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -315,13 +320,14 @@ def validate_human_approval_token_real_write_executor_contract(
     ):
         errors.append(
             "token_write_execution_preflight_checks_must_match_source_write_final_gate_snapshot"
+    )
+    errors.extend(validate_forbidden_true_keys_false_or_absent(contract, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(
+        validate_policy_flags(
+            policy,
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY,
         )
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if contract.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    )
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -430,20 +436,13 @@ def recommend_human_approval_token_real_write_executor_contract_action(
 def summarize_human_approval_token_real_write_executor_contracts(
     contracts: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(contracts, "contract_status")
+    lock_reason_summary = summarize_candidates(contracts, "lock_reason")
     required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for contract in contracts:
-        block_type = str(contract.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(contract.get("contract_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        lock_reason = str(contract.get("lock_reason"))
-        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
         if (
             contract.get("contract_status")
             == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED
@@ -465,9 +464,9 @@ def summarize_human_approval_token_real_write_executor_contracts(
         "invalid_count": invalid_count,
         "real_token_write_executor_contract_required_count": required_count,
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY),
     }
 
@@ -808,13 +807,14 @@ def _contract_id(contract: Mapping[str, Any]) -> str:
         "write_final_gate_validation": contract.get("write_final_gate_validation", {}),
         "policy": contract.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    return f"memory-human-approval-token-real-write-executor-contract:v0.1:{digest}"
+    return build_stable_digest(
+        "memory-human-approval-token-real-write-executor-contract:v0.1",
+        identity,
+    )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_real_write_executor_contract_review_gate.py
+++ b/agent/memory_human_approval_token_real_write_executor_contract_review_gate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_real_write_executor_contract import (
     explain_human_approval_token_real_write_executor_contract,
     recommend_human_approval_token_real_write_executor_contract_action,
     validate_human_approval_token_real_write_executor_contract,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -388,14 +393,18 @@ def validate_human_approval_token_real_write_executor_contract_review_outcome(
         )
     if outcome_candidate.get("contract_review_checklist") != _contract_review_checklist():
         errors.append("contract_review_checklist_must_match_v0_1_deterministic_checks")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if outcome_candidate.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in (
-        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY.items()
-    ):
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(
+        validate_forbidden_true_keys_false_or_absent(
+            outcome_candidate,
+            _FORBIDDEN_TRUE_KEYS,
+        )
+    )
+    errors.extend(
+        validate_policy_flags(
+            policy,
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY,
+        )
+    )
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -511,18 +520,14 @@ def recommend_human_approval_token_real_write_executor_contract_review_action(
 def summarize_human_approval_token_real_write_executor_contract_review_outcomes(
     outcomes: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_outcome: dict[str, int] = {}
+    candidate_summary = summarize_candidates(
+        outcomes,
+        "review_outcome_status",
+        type_key="outcome",
+    )
     valid_count = 0
     invalid_count = 0
     for outcome_candidate in outcomes:
-        block_type = str(outcome_candidate.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(outcome_candidate.get("review_outcome_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        outcome_label = str(outcome_candidate.get("outcome"))
-        by_outcome[outcome_label] = by_outcome.get(outcome_label, 0) + 1
         validation = validate_human_approval_token_real_write_executor_contract_review_outcome(
             outcome_candidate
         )
@@ -531,12 +536,12 @@ def summarize_human_approval_token_real_write_executor_contract_review_outcomes(
         else:
             invalid_count += 1
     return {
-        "total": len(outcomes),
+        "total": candidate_summary["total"],
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_outcome": dict(sorted(by_outcome.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_outcome": candidate_summary["by_type"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY),
     }
 
@@ -818,16 +823,14 @@ def _review_outcome_id(outcome_candidate: Mapping[str, Any]) -> str:
         "contract_validation": outcome_candidate.get("contract_validation", {}),
         "policy": outcome_candidate.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    return (
-        "memory-human-approval-token-real-write-executor-contract-review-outcome:"
-        f"v0.1:{digest}"
+    return build_stable_digest(
+        "memory-human-approval-token-real-write-executor-contract-review-outcome:v0.1",
+        identity,
     )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_real_write_executor_contract_review_gate.py
+++ b/agent/memory_human_approval_token_real_write_executor_contract_review_gate.py
@@ -1,0 +1,834 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_real_write_executor_contract import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED,
+    explain_human_approval_token_real_write_executor_contract,
+    recommend_human_approval_token_real_write_executor_contract_action,
+    validate_human_approval_token_real_write_executor_contract,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_GATE_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_KIND = (
+    "memory_human_approval_token_real_write_executor_contract_review_outcome_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_STATUS = (
+    "real_write_executor_contract_review_outcome_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_ROUTING = (
+    "real_token_write_executor_implementation_plan_required_after_contract_approval"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_SUPPORTED_OUTCOMES = {
+    "approve_executor_contract",
+    "request_contract_changes",
+    "reject_contract",
+    "defer_contract_review",
+}
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_real_write_executor_contract_review_outcomes_only": True,
+    "invokes_real_token_write_executor": False,
+    "implements_real_token_write_executor": False,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_REVIEWER = (
+    "hermes_memory_human_approval_token_real_write_executor_contract_review_gate_v0.1"
+)
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_WRITE_PREVIEW_FIELDS = (
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+)
+_EXECUTOR_CONTRACT_FIELD_TYPES = {
+    "executor_contract_inputs": Mapping,
+    "executor_hard_lock_checks": list,
+    "executor_audit_fields": list,
+    "executor_rollback_rules": list,
+    "executor_forbidden_side_effects": list,
+    "executor_contract_checklist": list,
+}
+_SOURCE_KEYS = (
+    "source_write_final_gate_id",
+    "source_write_execution_dry_run_id",
+    "source_write_execution_plan_id",
+    "source_final_confirmation_review_outcome_id",
+    "source_final_confirmation_request_id",
+    "source_token_write_lock_gate_id",
+    "source_token_issuance_dry_run_id",
+    "source_token_issuance_plan_id",
+    "source_review_outcome_id",
+    "source_request_id",
+    "source_gate_id",
+    "source_dry_run_id",
+    "source_plan_id",
+    "source_outcome_id",
+    "source_packet_id",
+    "source_submission_id",
+    "source_draft_id",
+    "source_decision_id",
+    "source_queue_item_id",
+    "block_id",
+    "block_type",
+    "project_scope",
+)
+_REQUIRED_OUTCOME_KEYS = (
+    "review_outcome_id",
+    "review_outcome_kind",
+    "review_outcome_status",
+    "routing",
+    "source_contract_id",
+) + _SOURCE_KEYS + (
+    "reviewer",
+    "outcome",
+    "rationale",
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+    "payload_preview",
+    "source_pattern_ids",
+    "source_fact_ids",
+    "token_write_execution_steps",
+    "token_write_execution_preflight_checks",
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+    "final_token_write_preflight_checklist",
+    "final_gate_checklist",
+    "executor_contract_inputs",
+    "executor_hard_lock_checks",
+    "executor_audit_fields",
+    "executor_rollback_rules",
+    "executor_forbidden_side_effects",
+    "executor_contract_checklist",
+    "contract_review_checklist",
+    "contract_validation",
+    "review_outcome_validation",
+    "next_step_recommendation",
+    "source_contract_snapshot",
+    "policy",
+)
+
+
+def create_human_approval_token_real_write_executor_contract_review_outcome(
+    contract: Mapping[str, Any],
+    reviewer: str | None = None,
+    outcome: str | None = None,
+    rationale: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only real write executor contract review outcome."""
+    source = deepcopy(dict(contract))
+    contract_validation = validate_human_approval_token_real_write_executor_contract(source)
+    evaluation = evaluate_human_approval_token_real_write_executor_contract(
+        source,
+        reviewer=reviewer,
+    )
+    selected_outcome = outcome if outcome is not None else evaluation["outcome"]
+    selected_rationale = (
+        rationale
+        if rationale is not None
+        else _outcome_rationale(
+            selected_outcome,
+            source,
+            contract_validation,
+            explicit=outcome is not None,
+        )
+    )
+
+    outcome_candidate = {
+        "review_outcome_id": None,
+        "review_outcome_kind": (
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_KIND
+        ),
+        "review_outcome_status": (
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_STATUS
+        ),
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_ROUTING,
+        "source_contract_id": source.get("contract_id"),
+        "source_write_final_gate_id": source.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": source.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": source.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": source.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": source.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "reviewer": reviewer if reviewer is not None else _DEFAULT_REVIEWER,
+        "outcome": selected_outcome,
+        "rationale": selected_rationale,
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": deepcopy(
+            list(source.get("token_write_execution_steps", []) or [])
+        ),
+        "token_write_execution_preflight_checks": deepcopy(
+            list(source.get("token_write_execution_preflight_checks", []) or [])
+        ),
+        "approval_token_write_payload_preview": deepcopy(
+            source.get("approval_token_write_payload_preview")
+        ),
+        "approval_audit_write_payload_preview": deepcopy(
+            source.get("approval_audit_write_payload_preview")
+        ),
+        "token_write_target_paths_preview": deepcopy(source.get("token_write_target_paths_preview")),
+        "final_token_write_preflight_checklist": deepcopy(
+            source.get("final_token_write_preflight_checklist")
+        ),
+        "final_gate_checklist": deepcopy(source.get("final_gate_checklist")),
+        "executor_contract_inputs": deepcopy(source.get("executor_contract_inputs")),
+        "executor_hard_lock_checks": deepcopy(source.get("executor_hard_lock_checks")),
+        "executor_audit_fields": deepcopy(source.get("executor_audit_fields")),
+        "executor_rollback_rules": deepcopy(source.get("executor_rollback_rules")),
+        "executor_forbidden_side_effects": deepcopy(
+            source.get("executor_forbidden_side_effects")
+        ),
+        "executor_contract_checklist": deepcopy(source.get("executor_contract_checklist")),
+        "contract_review_checklist": _contract_review_checklist(),
+        "contract_validation": deepcopy(contract_validation),
+        "review_outcome_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_contract_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY),
+    }
+    outcome_candidate["review_outcome_id"] = _review_outcome_id(outcome_candidate)
+    outcome_candidate["review_outcome_validation"] = (
+        validate_human_approval_token_real_write_executor_contract_review_outcome(
+            outcome_candidate
+        )
+    )
+    outcome_candidate["next_step_recommendation"] = (
+        recommend_human_approval_token_real_write_executor_contract_review_action(
+            outcome_candidate
+        )
+    )
+    return outcome_candidate
+
+
+def evaluate_human_approval_token_real_write_executor_contract(
+    contract: Mapping[str, Any],
+    reviewer: str | None = None,
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_contract(contract)
+    outcome, rationale = _evaluated_outcome(contract, validation)
+    return {
+        "reviewer": reviewer if reviewer is not None else _DEFAULT_REVIEWER,
+        "outcome": outcome,
+        "rationale": rationale,
+        "validation": validation,
+        "contract_explanation": explain_human_approval_token_real_write_executor_contract(
+            contract
+        ),
+        "contract_recommendation": (
+            recommend_human_approval_token_real_write_executor_contract_action(contract)
+        ),
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_ROUTING,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY),
+    }
+
+
+def validate_human_approval_token_real_write_executor_contract_review_outcome(
+    outcome_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(outcome_candidate.get("policy"))
+    source_snapshot = _as_dict(outcome_candidate.get("source_contract_snapshot"))
+    expected_contract_validation = validate_human_approval_token_real_write_executor_contract(
+        source_snapshot
+    )
+
+    for key in _REQUIRED_OUTCOME_KEYS:
+        if key not in outcome_candidate:
+            errors.append(f"missing_{key}")
+    if (
+        outcome_candidate.get("review_outcome_kind")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_KIND
+    ):
+        errors.append(
+            "review_outcome_kind_must_be_memory_human_approval_token_real_write_executor_contract_review_outcome_candidate"
+        )
+    if (
+        outcome_candidate.get("review_outcome_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_STATUS
+    ):
+        errors.append("review_outcome_status_must_be_real_write_executor_contract_review_outcome_candidate")
+    if (
+        outcome_candidate.get("routing")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_ROUTING
+    ):
+        errors.append("routing_must_require_implementation_plan_after_contract_approval")
+    if (
+        outcome_candidate.get("outcome")
+        not in MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_SUPPORTED_OUTCOMES
+    ):
+        errors.append("outcome_must_be_supported")
+    if not isinstance(outcome_candidate.get("reviewer"), str) or not outcome_candidate.get(
+        "reviewer"
+    ):
+        errors.append("reviewer_must_be_non_empty_string")
+    if not isinstance(outcome_candidate.get("rationale"), str) or not outcome_candidate.get(
+        "rationale"
+    ):
+        errors.append("rationale_must_be_non_empty_string")
+    if outcome_candidate.get("contract_validation") != expected_contract_validation:
+        errors.append("contract_validation_must_match_source_contract_snapshot")
+    if outcome_candidate.get("source_contract_id") != source_snapshot.get("contract_id"):
+        errors.append("source_contract_id_must_match_source_snapshot")
+    for source_key in _SOURCE_KEYS:
+        if outcome_candidate.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS + (
+        "payload_preview",
+        "final_token_write_preflight_checklist",
+        "final_gate_checklist",
+        "executor_contract_inputs",
+        "executor_hard_lock_checks",
+        "executor_audit_fields",
+        "executor_rollback_rules",
+        "executor_forbidden_side_effects",
+        "executor_contract_checklist",
+    ):
+        if (
+            field in outcome_candidate
+            and field in source_snapshot
+            and outcome_candidate.get(field) != source_snapshot.get(field)
+        ):
+            errors.append(f"{field}_must_match_source_contract_snapshot")
+    if not isinstance(outcome_candidate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(outcome_candidate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if outcome_candidate.get("source_pattern_ids") != list(
+        source_snapshot.get("source_pattern_ids", []) or []
+    ):
+        errors.append("source_pattern_ids_must_match_source_contract_snapshot")
+    if outcome_candidate.get("source_fact_ids") != list(
+        source_snapshot.get("source_fact_ids", []) or []
+    ):
+        errors.append("source_fact_ids_must_match_source_contract_snapshot")
+    if outcome_candidate.get("token_write_execution_steps") != list(
+        source_snapshot.get("token_write_execution_steps", []) or []
+    ):
+        errors.append("token_write_execution_steps_must_match_source_contract_snapshot")
+    if outcome_candidate.get("token_write_execution_preflight_checks") != list(
+        source_snapshot.get("token_write_execution_preflight_checks", []) or []
+    ):
+        errors.append(
+            "token_write_execution_preflight_checks_must_match_source_contract_snapshot"
+        )
+    if outcome_candidate.get("contract_review_checklist") != _contract_review_checklist():
+        errors.append("contract_review_checklist_must_match_v0_1_deterministic_checks")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if outcome_candidate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY.items()
+    ):
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_real_write_executor_contract_review_outcome(
+    outcome_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_contract_review_outcome(
+        outcome_candidate
+    )
+    source_snapshot = _as_dict(outcome_candidate.get("source_contract_snapshot"))
+    return {
+        "review_outcome_id": outcome_candidate.get("review_outcome_id"),
+        "review_outcome_kind": outcome_candidate.get("review_outcome_kind"),
+        "review_outcome_status": outcome_candidate.get("review_outcome_status"),
+        "routing": outcome_candidate.get("routing"),
+        "source_contract_id": outcome_candidate.get("source_contract_id"),
+        "source_write_final_gate_id": outcome_candidate.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": outcome_candidate.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": outcome_candidate.get(
+            "source_write_execution_plan_id"
+        ),
+        "source_final_confirmation_review_outcome_id": outcome_candidate.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": outcome_candidate.get("block_id"),
+        "block_type": outcome_candidate.get("block_type"),
+        "project_scope": outcome_candidate.get("project_scope"),
+        "reviewer": outcome_candidate.get("reviewer"),
+        "outcome": outcome_candidate.get("outcome"),
+        "rationale": outcome_candidate.get("rationale"),
+        "source_pattern_count": len(outcome_candidate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(outcome_candidate.get("source_fact_ids", []) or []),
+        "contract_review_checklist": deepcopy(
+            outcome_candidate.get("contract_review_checklist")
+        ),
+        "validation": validation,
+        "contract_explanation": (
+            explain_human_approval_token_real_write_executor_contract(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY),
+    }
+
+
+def recommend_human_approval_token_real_write_executor_contract_review_action(
+    outcome_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_contract_review_outcome(
+        outcome_candidate
+    )
+    source_snapshot = _as_dict(outcome_candidate.get("source_contract_snapshot"))
+    outcome = outcome_candidate.get("outcome")
+    if not validation["valid"]:
+        action = "do_not_use_real_write_executor_contract_review_outcome_candidate"
+        reason = "Real write executor contract review outcome candidate failed validation."
+    elif outcome == "approve_executor_contract":
+        action = "route_to_real_token_write_executor_implementation_plan_without_executor_invocation"
+        reason = "Contract review approves a later implementation plan; this review gate does not implement, invoke, issue, persist, submit, or write anything."
+    elif outcome == "request_contract_changes":
+        action = "request_real_write_executor_contract_changes"
+        reason = "Contract review found remediable preview, source evidence, or contract integrity gaps."
+    elif outcome == "reject_contract":
+        action = "reject_real_write_executor_contract"
+        reason = "Contract review rejected the executor contract candidate."
+    else:
+        action = "defer_real_write_executor_contract_review"
+        reason = "Contract review reached an unknown or deferred condition; no implementation plan may proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_ROUTING,
+        "validation": validation,
+        "contract_recommendation": (
+            recommend_human_approval_token_real_write_executor_contract_action(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "creates_real_write_executor_contract_review_outcomes_only": True,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY),
+    }
+
+
+def summarize_human_approval_token_real_write_executor_contract_review_outcomes(
+    outcomes: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_outcome: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for outcome_candidate in outcomes:
+        block_type = str(outcome_candidate.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(outcome_candidate.get("review_outcome_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        outcome_label = str(outcome_candidate.get("outcome"))
+        by_outcome[outcome_label] = by_outcome.get(outcome_label, 0) + 1
+        validation = validate_human_approval_token_real_write_executor_contract_review_outcome(
+            outcome_candidate
+        )
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(outcomes),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_outcome": dict(sorted(by_outcome.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY),
+    }
+
+
+def _evaluated_outcome(
+    contract: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> tuple[str, str]:
+    if contract.get("contract_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED:
+        return "reject_contract", "Real write executor contract candidate is locked."
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(contract.get(field), Mapping):
+            return "request_contract_changes", f"Contract is missing {field}."
+    for field in _WRITE_PREVIEW_FIELDS:
+        if not isinstance(contract.get(field), Mapping):
+            return "request_contract_changes", f"Contract is missing {field}."
+    if not isinstance(contract.get("final_gate_checklist"), list):
+        return "request_contract_changes", "Contract is missing final_gate_checklist."
+    for field, expected_type in _EXECUTOR_CONTRACT_FIELD_TYPES.items():
+        if not isinstance(contract.get(field), expected_type):
+            return "request_contract_changes", f"Contract is missing {field}."
+    if not (contract.get("source_pattern_ids") or contract.get("source_fact_ids")):
+        return "request_contract_changes", "Contract is missing source evidence."
+    if _preview_integrity_errors(contract):
+        return "request_contract_changes", "Contract preview integrity failed."
+    if _contract_integrity_errors(contract, validation):
+        return "request_contract_changes", "Real write executor contract integrity failed."
+    if validation.get("valid") is not True:
+        return "reject_contract", "Real write executor contract candidate is invalid."
+    if (
+        contract.get("contract_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED
+    ):
+        return (
+            "approve_executor_contract",
+            "Real write executor contract is valid, required, and intact for a later implementation plan.",
+        )
+    return "defer_contract_review", "Contract review reached an unknown condition."
+
+
+def _outcome_rationale(
+    outcome: str,
+    contract: Mapping[str, Any],
+    contract_validation: Mapping[str, Any],
+    explicit: bool = False,
+) -> str:
+    if (
+        explicit
+        and outcome
+        in MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_SUPPORTED_OUTCOMES
+    ):
+        return "Explicit supported real write executor contract review outcome override recorded as a read-only candidate only."
+    evaluated_outcome, evaluated_rationale = _evaluated_outcome(contract, contract_validation)
+    if outcome == evaluated_outcome:
+        return evaluated_rationale
+    if outcome == "approve_executor_contract":
+        return "Contract review approves a later implementation plan without issuing, persisting, writing, implementing, invoking, or submitting anything."
+    if outcome == "request_contract_changes":
+        return "Contract review requests changes before any later implementation plan."
+    if outcome == "reject_contract":
+        return "Contract review rejects the executor contract candidate."
+    if outcome == "defer_contract_review":
+        return "Contract review is deferred until the unknown condition is resolved."
+    return "Real write executor contract review outcome is unsupported by v0.1."
+
+
+def _contract_review_checklist() -> list[str]:
+    return [
+        "source_contract_validation_is_recomputed_read_only",
+        "source_contract_status_is_real_token_write_executor_contract_required",
+        "approval_token_record_preview_is_present_and_preview_only",
+        "approval_audit_record_preview_is_present_and_preview_only",
+        "token_target_paths_preview_is_present_and_preview_only",
+        "proposal_record_preview_is_present_and_not_written",
+        "operation_ledger_preview_is_present_and_not_written",
+        "target_paths_preview_is_present_and_preview_only",
+        "approval_token_write_payload_preview_is_present_and_preview_only",
+        "approval_audit_write_payload_preview_is_present_and_preview_only",
+        "token_write_target_paths_preview_is_present_and_preview_only",
+        "final_gate_checklist_is_present_and_preserves_no_write_controls",
+        "executor_contract_inputs_are_present",
+        "executor_hard_lock_checks_are_present",
+        "executor_audit_fields_are_present",
+        "executor_rollback_rules_are_present",
+        "executor_forbidden_side_effects_are_present",
+        "executor_contract_checklist_is_present",
+        "source_evidence_is_present",
+        "no_real_approval_token_issued",
+        "no_approval_persisted",
+        "no_real_proposal_created",
+        "no_operation_ledger_event_created",
+        "no_proposal_file_written",
+        "no_operation_ledger_written",
+        "no_token_file_written",
+        "no_approval_audit_written",
+        "no_memory_or_graph_or_config_write",
+        "real_token_write_executor_not_implemented",
+        "real_token_write_executor_not_invoked",
+        "contract_review_outcome_only",
+    ]
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _contract_integrity_errors(
+    contract: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    final_gate_checklist = contract.get("final_gate_checklist")
+    if isinstance(final_gate_checklist, list):
+        required_final_gate_checks = {
+            "no_real_approval_token_issued",
+            "no_approval_persisted",
+            "no_real_proposal_created",
+            "no_operation_ledger_event_created",
+            "no_token_file_written",
+            "no_approval_audit_written",
+            "real_token_write_executor_required_but_not_invoked",
+        }
+        if required_final_gate_checks.difference(final_gate_checklist):
+            errors.append("final_gate_checklist_must_preserve_no_write_and_no_executor_checks")
+    final_preflight = contract.get("final_token_write_preflight_checklist")
+    if isinstance(final_preflight, list) and "no_real_approval_token_issued" not in final_preflight:
+        errors.append("final_token_write_preflight_checklist_must_preserve_no_token_write_checks")
+    forbidden_side_effects = contract.get("executor_forbidden_side_effects")
+    if isinstance(forbidden_side_effects, list):
+        required_side_effects = {
+            "write_memory",
+            "write_memory_graph",
+            "write_proposal_files",
+            "write_operation_ledger",
+            "issue_real_approval_tokens",
+            "write_token_files",
+            "write_approval_audit_files",
+            "persist_approvals",
+            "invoke_real_token_write_executor",
+            "implement_real_token_write_executor",
+            "submit_to_governance",
+            "convert_to_real_proposal",
+        }
+        if required_side_effects.difference(forbidden_side_effects):
+            errors.append("executor_forbidden_side_effects_must_preserve_no_write_boundary")
+    contract_checklist = contract.get("executor_contract_checklist")
+    if isinstance(contract_checklist, list):
+        required_contract_checks = {
+            "contract_is_read_only_candidate_only",
+            "no_real_executor_is_invoked",
+            "no_real_executor_is_implemented",
+            "no_memory_or_graph_or_config_write",
+        }
+        if required_contract_checks.difference(contract_checklist):
+            errors.append("executor_contract_checklist_must_preserve_no_executor_boundary")
+    for error in list(validation.get("errors", []) or []):
+        if (
+            "_must_match_v0_1_deterministic_contract" in error
+            or "_must_match_source_write_final_gate_snapshot" in error
+            or error == "lock_reason_must_match_real_write_executor_contract_checks"
+            or error.startswith("final_gate_checklist_must_preserve")
+            or error.startswith("final_token_write_preflight_checklist_must_preserve")
+        ):
+            errors.append("contract_validation_integrity_errors")
+    return _dedupe(errors)
+
+
+def _review_outcome_id(outcome_candidate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_GATE_VERSION,
+        "review_outcome_kind": outcome_candidate.get("review_outcome_kind"),
+        "review_outcome_status": outcome_candidate.get("review_outcome_status"),
+        "routing": outcome_candidate.get("routing"),
+        "source_contract_id": outcome_candidate.get("source_contract_id"),
+        "source_write_final_gate_id": outcome_candidate.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": outcome_candidate.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": outcome_candidate.get(
+            "source_write_execution_plan_id"
+        ),
+        "source_final_confirmation_review_outcome_id": outcome_candidate.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": outcome_candidate.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": outcome_candidate.get(
+            "source_token_write_lock_gate_id"
+        ),
+        "source_token_issuance_dry_run_id": outcome_candidate.get(
+            "source_token_issuance_dry_run_id"
+        ),
+        "source_token_issuance_plan_id": outcome_candidate.get(
+            "source_token_issuance_plan_id"
+        ),
+        "source_review_outcome_id": outcome_candidate.get("source_review_outcome_id"),
+        "source_request_id": outcome_candidate.get("source_request_id"),
+        "source_gate_id": outcome_candidate.get("source_gate_id"),
+        "source_dry_run_id": outcome_candidate.get("source_dry_run_id"),
+        "source_plan_id": outcome_candidate.get("source_plan_id"),
+        "source_outcome_id": outcome_candidate.get("source_outcome_id"),
+        "source_packet_id": outcome_candidate.get("source_packet_id"),
+        "source_submission_id": outcome_candidate.get("source_submission_id"),
+        "source_draft_id": outcome_candidate.get("source_draft_id"),
+        "source_decision_id": outcome_candidate.get("source_decision_id"),
+        "source_queue_item_id": outcome_candidate.get("source_queue_item_id"),
+        "block_id": outcome_candidate.get("block_id"),
+        "block_type": outcome_candidate.get("block_type"),
+        "project_scope": outcome_candidate.get("project_scope"),
+        "reviewer": outcome_candidate.get("reviewer"),
+        "outcome": outcome_candidate.get("outcome"),
+        "rationale": outcome_candidate.get("rationale"),
+        "approval_token_record_preview": outcome_candidate.get(
+            "approval_token_record_preview", {}
+        ),
+        "approval_audit_record_preview": outcome_candidate.get(
+            "approval_audit_record_preview", {}
+        ),
+        "token_target_paths_preview": outcome_candidate.get("token_target_paths_preview", {}),
+        "proposal_record_preview": outcome_candidate.get("proposal_record_preview", {}),
+        "operation_ledger_preview": outcome_candidate.get("operation_ledger_preview", {}),
+        "target_paths_preview": outcome_candidate.get("target_paths_preview", {}),
+        "payload_preview": outcome_candidate.get("payload_preview"),
+        "source_pattern_ids": list(outcome_candidate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(outcome_candidate.get("source_fact_ids", [])),
+        "token_write_execution_steps": list(
+            outcome_candidate.get("token_write_execution_steps", [])
+        ),
+        "token_write_execution_preflight_checks": list(
+            outcome_candidate.get("token_write_execution_preflight_checks", [])
+        ),
+        "approval_token_write_payload_preview": outcome_candidate.get(
+            "approval_token_write_payload_preview", {}
+        ),
+        "approval_audit_write_payload_preview": outcome_candidate.get(
+            "approval_audit_write_payload_preview", {}
+        ),
+        "token_write_target_paths_preview": outcome_candidate.get(
+            "token_write_target_paths_preview", {}
+        ),
+        "final_token_write_preflight_checklist": list(
+            outcome_candidate.get("final_token_write_preflight_checklist") or []
+        ),
+        "final_gate_checklist": list(outcome_candidate.get("final_gate_checklist") or []),
+        "executor_contract_inputs": outcome_candidate.get("executor_contract_inputs", {}),
+        "executor_hard_lock_checks": list(
+            outcome_candidate.get("executor_hard_lock_checks") or []
+        ),
+        "executor_audit_fields": list(outcome_candidate.get("executor_audit_fields") or []),
+        "executor_rollback_rules": list(
+            outcome_candidate.get("executor_rollback_rules") or []
+        ),
+        "executor_forbidden_side_effects": list(
+            outcome_candidate.get("executor_forbidden_side_effects") or []
+        ),
+        "executor_contract_checklist": list(
+            outcome_candidate.get("executor_contract_checklist") or []
+        ),
+        "contract_review_checklist": list(
+            outcome_candidate.get("contract_review_checklist") or []
+        ),
+        "contract_validation": outcome_candidate.get("contract_validation", {}),
+        "policy": outcome_candidate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return (
+        "memory-human-approval-token-real-write-executor-contract-review-outcome:"
+        f"v0.1:{digest}"
+    )
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_real_write_executor_implementation_dry_run.py
+++ b/agent/memory_human_approval_token_real_write_executor_implementation_dry_run.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_real_write_executor_implementation_plan i
     explain_human_approval_token_real_write_executor_implementation_plan,
     recommend_human_approval_token_real_write_executor_implementation_plan_action,
     validate_human_approval_token_real_write_executor_implementation_plan,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -587,14 +592,18 @@ def validate_human_approval_token_real_write_executor_implementation_dry_run(
         errors.append(
             "implementation_dry_run_readiness_checklist_must_match_v0_1_deterministic_preview"
         )
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if dry_run.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in (
-        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY.items()
-    ):
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(
+        validate_forbidden_true_keys_false_or_absent(
+            dry_run,
+            _FORBIDDEN_TRUE_KEYS,
+        )
+    )
+    errors.extend(
+        validate_policy_flags(
+            policy,
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY,
+        )
+    )
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -732,18 +741,13 @@ def recommend_human_approval_token_real_write_executor_implementation_dry_run_ac
 def summarize_human_approval_token_real_write_executor_implementation_dry_runs(
     dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(dry_runs, "dry_run_status")
     by_lock_reason: dict[str, int] = {}
     code_review_plan_required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for dry_run in dry_runs:
-        block_type = str(dry_run.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(dry_run.get("dry_run_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         lock_reason = str(dry_run.get("lock_reason"))
         by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
         if (
@@ -766,15 +770,15 @@ def summarize_human_approval_token_real_write_executor_implementation_dry_runs(
         else:
             invalid_count += 1
     return {
-        "total": len(dry_runs),
+        "total": candidate_summary["total"],
         "valid_count": valid_count,
         "invalid_count": invalid_count,
         "real_token_write_executor_code_review_plan_required_count": (
             code_review_plan_required_count
         ),
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "by_lock_reason": dict(sorted(by_lock_reason.items())),
         "policy": dict(
             MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
@@ -1291,16 +1295,14 @@ def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
         "implementation_plan_validation": dry_run.get("implementation_plan_validation", {}),
         "policy": dry_run.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    return (
-        "memory-human-approval-token-real-write-executor-implementation-dry-run:"
-        f"v0.1:{digest}"
+    return build_stable_digest(
+        "memory-human-approval-token-real-write-executor-implementation-dry-run:v0.1",
+        identity,
     )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_real_write_executor_implementation_dry_run.py
+++ b/agent/memory_human_approval_token_real_write_executor_implementation_dry_run.py
@@ -1,0 +1,1307 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_real_write_executor_implementation_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED,
+    explain_human_approval_token_real_write_executor_implementation_plan,
+    recommend_human_approval_token_real_write_executor_implementation_plan_action,
+    validate_human_approval_token_real_write_executor_implementation_plan,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_KIND = (
+    "memory_human_approval_token_real_write_executor_implementation_dry_run_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED = (
+    "real_token_write_executor_code_review_plan_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_ROUTING = (
+    "real_token_write_executor_code_review_plan_required_before_any_executor_code"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_real_write_executor_implementation_dry_run_candidates_only": True,
+    "invokes_real_token_write_executor": False,
+    "implements_real_token_write_executor": False,
+    "creates_executor_source_files": False,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = (
+    "hermes_memory_human_approval_token_real_write_executor_implementation_dry_run_v0.1"
+)
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "creates_executor_source_files",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_WRITE_PREVIEW_FIELDS = (
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+)
+_EXECUTOR_CONTRACT_FIELD_TYPES = {
+    "executor_contract_inputs": Mapping,
+    "executor_hard_lock_checks": list,
+    "executor_audit_fields": list,
+    "executor_rollback_rules": list,
+    "executor_forbidden_side_effects": list,
+    "executor_contract_checklist": list,
+}
+_IMPLEMENTATION_PLAN_FIELD_TYPES = {
+    "implementation_plan_interfaces": list,
+    "implementation_plan_files": list,
+    "implementation_plan_idempotency_strategy": Mapping,
+    "implementation_plan_filesystem_safety_model": Mapping,
+    "implementation_plan_audit_strategy": Mapping,
+    "implementation_plan_rollback_strategy": Mapping,
+    "implementation_plan_test_plan": list,
+    "implementation_plan_forbidden_actions": list,
+}
+_LOCK_REASONS = {
+    None,
+    "real_write_executor_implementation_plan_locked",
+    "invalid_real_write_executor_implementation_plan",
+    "contract_review_requested_changes",
+    "contract_review_rejected",
+    "contract_review_deferred",
+    "invalid_contract_review_outcome",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_approval_token_write_payload_preview",
+    "missing_approval_audit_write_payload_preview",
+    "missing_token_write_target_paths_preview",
+    "missing_executor_contract_inputs",
+    "missing_executor_hard_lock_checks",
+    "missing_executor_audit_fields",
+    "missing_executor_rollback_rules",
+    "missing_executor_forbidden_side_effects",
+    "missing_executor_contract_checklist",
+    "missing_contract_review_checklist",
+    "missing_implementation_plan_interfaces",
+    "missing_implementation_plan_files",
+    "missing_implementation_plan_idempotency_strategy",
+    "missing_implementation_plan_filesystem_safety_model",
+    "missing_implementation_plan_audit_strategy",
+    "missing_implementation_plan_rollback_strategy",
+    "missing_implementation_plan_test_plan",
+    "missing_implementation_plan_forbidden_actions",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+    "implementation_plan_integrity_failed",
+}
+_SOURCE_KEYS = (
+    "source_contract_review_outcome_id",
+    "source_contract_id",
+    "source_write_final_gate_id",
+    "source_write_execution_dry_run_id",
+    "source_write_execution_plan_id",
+    "source_final_confirmation_review_outcome_id",
+    "source_final_confirmation_request_id",
+    "source_token_write_lock_gate_id",
+    "source_token_issuance_dry_run_id",
+    "source_token_issuance_plan_id",
+    "source_review_outcome_id",
+    "source_request_id",
+    "source_gate_id",
+    "source_dry_run_id",
+    "source_plan_id",
+    "source_outcome_id",
+    "source_packet_id",
+    "source_submission_id",
+    "source_draft_id",
+    "source_decision_id",
+    "source_queue_item_id",
+    "block_id",
+    "block_type",
+    "project_scope",
+    "outcome",
+)
+_REQUIRED_DRY_RUN_KEYS = (
+    "dry_run_id",
+    "dry_run_kind",
+    "dry_run_status",
+    "routing",
+    "lock_reason",
+    "source_implementation_plan_id",
+) + _SOURCE_KEYS + (
+    "operator",
+    "rationale",
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+    "payload_preview",
+    "source_pattern_ids",
+    "source_fact_ids",
+    "token_write_execution_steps",
+    "token_write_execution_preflight_checks",
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+    "final_token_write_preflight_checklist",
+    "final_gate_checklist",
+    "executor_contract_inputs",
+    "executor_hard_lock_checks",
+    "executor_audit_fields",
+    "executor_rollback_rules",
+    "executor_forbidden_side_effects",
+    "executor_contract_checklist",
+    "contract_review_checklist",
+    "implementation_plan_interfaces",
+    "implementation_plan_files",
+    "implementation_plan_idempotency_strategy",
+    "implementation_plan_filesystem_safety_model",
+    "implementation_plan_audit_strategy",
+    "implementation_plan_rollback_strategy",
+    "implementation_plan_test_plan",
+    "implementation_plan_forbidden_actions",
+    "implementation_dry_run_module_boundary_preview",
+    "implementation_dry_run_interface_preview",
+    "implementation_dry_run_idempotency_check_preview",
+    "implementation_dry_run_filesystem_safety_check_preview",
+    "implementation_dry_run_audit_check_preview",
+    "implementation_dry_run_rollback_check_preview",
+    "implementation_dry_run_test_harness_preview",
+    "implementation_dry_run_readiness_checklist",
+    "implementation_plan_validation",
+    "dry_run_validation",
+    "next_step_recommendation",
+    "source_implementation_plan_snapshot",
+    "policy",
+)
+
+
+def create_human_approval_token_real_write_executor_implementation_dry_run(
+    implementation_plan: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only real token write executor implementation dry run."""
+    source = deepcopy(dict(implementation_plan))
+    implementation_plan_validation = (
+        validate_human_approval_token_real_write_executor_implementation_plan(source)
+    )
+    lock_reason = _dry_run_lock_reason(source, implementation_plan_validation)
+    dry_run_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED
+    )
+
+    dry_run = {
+        "dry_run_id": None,
+        "dry_run_kind": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_KIND,
+        "dry_run_status": dry_run_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_ROUTING,
+        "lock_reason": lock_reason,
+        "source_implementation_plan_id": source.get("plan_id"),
+        "source_contract_review_outcome_id": source.get("source_contract_review_outcome_id"),
+        "source_contract_id": source.get("source_contract_id"),
+        "source_write_final_gate_id": source.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": source.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": source.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": source.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": source.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "outcome": source.get("outcome"),
+        "rationale": source.get("rationale"),
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": deepcopy(
+            list(source.get("token_write_execution_steps", []) or [])
+        ),
+        "token_write_execution_preflight_checks": deepcopy(
+            list(source.get("token_write_execution_preflight_checks", []) or [])
+        ),
+        "approval_token_write_payload_preview": deepcopy(
+            source.get("approval_token_write_payload_preview")
+        ),
+        "approval_audit_write_payload_preview": deepcopy(
+            source.get("approval_audit_write_payload_preview")
+        ),
+        "token_write_target_paths_preview": deepcopy(source.get("token_write_target_paths_preview")),
+        "final_token_write_preflight_checklist": deepcopy(
+            source.get("final_token_write_preflight_checklist")
+        ),
+        "final_gate_checklist": deepcopy(source.get("final_gate_checklist")),
+        "executor_contract_inputs": deepcopy(source.get("executor_contract_inputs")),
+        "executor_hard_lock_checks": deepcopy(source.get("executor_hard_lock_checks")),
+        "executor_audit_fields": deepcopy(source.get("executor_audit_fields")),
+        "executor_rollback_rules": deepcopy(source.get("executor_rollback_rules")),
+        "executor_forbidden_side_effects": deepcopy(
+            source.get("executor_forbidden_side_effects")
+        ),
+        "executor_contract_checklist": deepcopy(source.get("executor_contract_checklist")),
+        "contract_review_checklist": deepcopy(source.get("contract_review_checklist")),
+        "implementation_plan_interfaces": deepcopy(source.get("implementation_plan_interfaces")),
+        "implementation_plan_files": deepcopy(source.get("implementation_plan_files")),
+        "implementation_plan_idempotency_strategy": deepcopy(
+            source.get("implementation_plan_idempotency_strategy")
+        ),
+        "implementation_plan_filesystem_safety_model": deepcopy(
+            source.get("implementation_plan_filesystem_safety_model")
+        ),
+        "implementation_plan_audit_strategy": deepcopy(
+            source.get("implementation_plan_audit_strategy")
+        ),
+        "implementation_plan_rollback_strategy": deepcopy(
+            source.get("implementation_plan_rollback_strategy")
+        ),
+        "implementation_plan_test_plan": deepcopy(source.get("implementation_plan_test_plan")),
+        "implementation_plan_forbidden_actions": deepcopy(
+            source.get("implementation_plan_forbidden_actions")
+        ),
+        "implementation_dry_run_module_boundary_preview": (
+            _implementation_dry_run_module_boundary_preview()
+        ),
+        "implementation_dry_run_interface_preview": _implementation_dry_run_interface_preview(),
+        "implementation_dry_run_idempotency_check_preview": (
+            _implementation_dry_run_idempotency_check_preview()
+        ),
+        "implementation_dry_run_filesystem_safety_check_preview": (
+            _implementation_dry_run_filesystem_safety_check_preview()
+        ),
+        "implementation_dry_run_audit_check_preview": (
+            _implementation_dry_run_audit_check_preview()
+        ),
+        "implementation_dry_run_rollback_check_preview": (
+            _implementation_dry_run_rollback_check_preview()
+        ),
+        "implementation_dry_run_test_harness_preview": (
+            _implementation_dry_run_test_harness_preview()
+        ),
+        "implementation_dry_run_readiness_checklist": (
+            _implementation_dry_run_readiness_checklist()
+        ),
+        "implementation_plan_validation": deepcopy(implementation_plan_validation),
+        "dry_run_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_implementation_plan_snapshot": deepcopy(source),
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
+        ),
+    }
+    dry_run["dry_run_id"] = _dry_run_id(dry_run)
+    dry_run["dry_run_validation"] = (
+        validate_human_approval_token_real_write_executor_implementation_dry_run(
+            dry_run
+        )
+    )
+    dry_run["next_step_recommendation"] = (
+        recommend_human_approval_token_real_write_executor_implementation_dry_run_action(
+            dry_run
+        )
+    )
+    return dry_run
+
+
+def validate_human_approval_token_real_write_executor_implementation_dry_run(
+    dry_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(dry_run.get("policy"))
+    source_snapshot = _as_dict(dry_run.get("source_implementation_plan_snapshot"))
+    implementation_plan_validation = _as_dict(dry_run.get("implementation_plan_validation"))
+    expected_implementation_plan_validation = (
+        validate_human_approval_token_real_write_executor_implementation_plan(
+            source_snapshot
+        )
+    )
+    expected_lock_reason = _dry_run_lock_reason(
+        source_snapshot,
+        implementation_plan_validation,
+    )
+
+    for key in _REQUIRED_DRY_RUN_KEYS:
+        if key not in dry_run:
+            errors.append(f"missing_{key}")
+    if (
+        dry_run.get("dry_run_kind")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_KIND
+    ):
+        errors.append(
+            "dry_run_kind_must_be_memory_human_approval_token_real_write_executor_implementation_dry_run_candidate"
+        )
+    if dry_run.get("dry_run_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED,
+    }:
+        errors.append("dry_run_status_must_be_supported")
+    if (
+        dry_run.get("routing")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_ROUTING
+    ):
+        errors.append(
+            "routing_must_require_code_review_plan_before_any_executor_code"
+        )
+    if dry_run.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if dry_run.get("lock_reason") != expected_lock_reason:
+        errors.append(
+            "lock_reason_must_match_real_write_executor_implementation_dry_run_checks"
+        )
+    if (
+        expected_lock_reason is None
+        and dry_run.get("dry_run_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED
+    ):
+        errors.append(
+            "valid_implementation_plan_must_require_real_token_write_executor_code_review_plan"
+        )
+    if (
+        expected_lock_reason is not None
+        and dry_run.get("dry_run_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED
+    ):
+        errors.append("invalid_or_locked_implementation_plan_must_lock_dry_run")
+    if not isinstance(dry_run.get("operator"), str) or not dry_run.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if (
+        implementation_plan_validation
+        != expected_implementation_plan_validation
+    ):
+        errors.append(
+            "implementation_plan_validation_must_match_source_implementation_plan_snapshot"
+        )
+    if dry_run.get("source_implementation_plan_id") != source_snapshot.get("plan_id"):
+        errors.append("source_implementation_plan_id_must_match_source_snapshot")
+    for source_key in _SOURCE_KEYS:
+        if dry_run.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+
+    if (
+        not isinstance(dry_run.get("payload_preview"), Mapping)
+        and dry_run.get("lock_reason") != "invalid_real_write_executor_implementation_plan"
+    ):
+        errors.append("missing_payload_preview")
+    if not isinstance(dry_run.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(dry_run.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(dry_run.get("source_pattern_ids"), list) and isinstance(
+        dry_run.get("source_fact_ids"), list
+    ):
+        if (
+            not dry_run.get("source_pattern_ids")
+            and not dry_run.get("source_fact_ids")
+            and dry_run.get("lock_reason") != "missing_source_evidence"
+        ):
+            errors.append("missing_source_evidence")
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        if (
+            not isinstance(dry_run.get(field), Mapping)
+            and dry_run.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    for field, expected_type in _EXECUTOR_CONTRACT_FIELD_TYPES.items():
+        if (
+            not isinstance(dry_run.get(field), expected_type)
+            and dry_run.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    if (
+        not isinstance(dry_run.get("contract_review_checklist"), list)
+        and dry_run.get("lock_reason") != "missing_contract_review_checklist"
+    ):
+        errors.append("missing_contract_review_checklist")
+    for field, expected_type in _IMPLEMENTATION_PLAN_FIELD_TYPES.items():
+        if (
+            not isinstance(dry_run.get(field), expected_type)
+            and dry_run.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    if dry_run.get("lock_reason") != "preview_integrity_failed":
+        errors.extend(_preview_integrity_errors(dry_run))
+    if dry_run.get("lock_reason") is None:
+        errors.extend(
+            _implementation_plan_integrity_errors(
+                dry_run,
+                implementation_plan_validation,
+            )
+        )
+
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS + (
+        "payload_preview",
+        "token_write_execution_steps",
+        "token_write_execution_preflight_checks",
+        "final_token_write_preflight_checklist",
+        "final_gate_checklist",
+        "executor_contract_inputs",
+        "executor_hard_lock_checks",
+        "executor_audit_fields",
+        "executor_rollback_rules",
+        "executor_forbidden_side_effects",
+        "executor_contract_checklist",
+        "contract_review_checklist",
+        "implementation_plan_interfaces",
+        "implementation_plan_files",
+        "implementation_plan_idempotency_strategy",
+        "implementation_plan_filesystem_safety_model",
+        "implementation_plan_audit_strategy",
+        "implementation_plan_rollback_strategy",
+        "implementation_plan_test_plan",
+        "implementation_plan_forbidden_actions",
+    ):
+        if (
+            field in dry_run
+            and field in source_snapshot
+            and dry_run.get(field) != source_snapshot.get(field)
+        ):
+            errors.append(f"{field}_must_match_source_implementation_plan_snapshot")
+    if dry_run.get("source_pattern_ids") != list(
+        source_snapshot.get("source_pattern_ids", []) or []
+    ):
+        errors.append("source_pattern_ids_must_match_source_implementation_plan_snapshot")
+    if dry_run.get("source_fact_ids") != list(
+        source_snapshot.get("source_fact_ids", []) or []
+    ):
+        errors.append("source_fact_ids_must_match_source_implementation_plan_snapshot")
+
+    if (
+        dry_run.get("implementation_dry_run_module_boundary_preview")
+        != _implementation_dry_run_module_boundary_preview()
+    ):
+        errors.append(
+            "implementation_dry_run_module_boundary_preview_must_match_v0_1_deterministic_preview"
+        )
+    if (
+        dry_run.get("implementation_dry_run_interface_preview")
+        != _implementation_dry_run_interface_preview()
+    ):
+        errors.append(
+            "implementation_dry_run_interface_preview_must_match_v0_1_deterministic_preview"
+        )
+    if (
+        dry_run.get("implementation_dry_run_idempotency_check_preview")
+        != _implementation_dry_run_idempotency_check_preview()
+    ):
+        errors.append(
+            "implementation_dry_run_idempotency_check_preview_must_match_v0_1_deterministic_preview"
+        )
+    if (
+        dry_run.get("implementation_dry_run_filesystem_safety_check_preview")
+        != _implementation_dry_run_filesystem_safety_check_preview()
+    ):
+        errors.append(
+            "implementation_dry_run_filesystem_safety_check_preview_must_match_v0_1_deterministic_preview"
+        )
+    if (
+        dry_run.get("implementation_dry_run_audit_check_preview")
+        != _implementation_dry_run_audit_check_preview()
+    ):
+        errors.append(
+            "implementation_dry_run_audit_check_preview_must_match_v0_1_deterministic_preview"
+        )
+    if (
+        dry_run.get("implementation_dry_run_rollback_check_preview")
+        != _implementation_dry_run_rollback_check_preview()
+    ):
+        errors.append(
+            "implementation_dry_run_rollback_check_preview_must_match_v0_1_deterministic_preview"
+        )
+    if (
+        dry_run.get("implementation_dry_run_test_harness_preview")
+        != _implementation_dry_run_test_harness_preview()
+    ):
+        errors.append(
+            "implementation_dry_run_test_harness_preview_must_match_v0_1_deterministic_preview"
+        )
+    if (
+        dry_run.get("implementation_dry_run_readiness_checklist")
+        != _implementation_dry_run_readiness_checklist()
+    ):
+        errors.append(
+            "implementation_dry_run_readiness_checklist_must_match_v0_1_deterministic_preview"
+        )
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if dry_run.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY.items()
+    ):
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_real_write_executor_implementation_dry_run(
+    dry_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = (
+        validate_human_approval_token_real_write_executor_implementation_dry_run(
+            dry_run
+        )
+    )
+    source_snapshot = _as_dict(dry_run.get("source_implementation_plan_snapshot"))
+    return {
+        "dry_run_id": dry_run.get("dry_run_id"),
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "lock_reason": dry_run.get("lock_reason"),
+        "source_implementation_plan_id": dry_run.get("source_implementation_plan_id"),
+        "source_contract_review_outcome_id": dry_run.get(
+            "source_contract_review_outcome_id"
+        ),
+        "source_contract_id": dry_run.get("source_contract_id"),
+        "source_write_final_gate_id": dry_run.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": dry_run.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": dry_run.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": dry_run.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "outcome": dry_run.get("outcome"),
+        "rationale": dry_run.get("rationale"),
+        "source_pattern_count": len(dry_run.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(dry_run.get("source_fact_ids", []) or []),
+        "implementation_dry_run_module_boundary_preview": deepcopy(
+            dry_run.get("implementation_dry_run_module_boundary_preview")
+        ),
+        "implementation_dry_run_interface_preview": deepcopy(
+            dry_run.get("implementation_dry_run_interface_preview")
+        ),
+        "implementation_dry_run_readiness_checklist": deepcopy(
+            dry_run.get("implementation_dry_run_readiness_checklist")
+        ),
+        "validation": validation,
+        "implementation_plan_explanation": (
+            explain_human_approval_token_real_write_executor_implementation_plan(
+                source_snapshot
+            )
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "creates_executor_source_files": False,
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
+        ),
+    }
+
+
+def recommend_human_approval_token_real_write_executor_implementation_dry_run_action(
+    dry_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = (
+        validate_human_approval_token_real_write_executor_implementation_dry_run(
+            dry_run
+        )
+    )
+    source_snapshot = _as_dict(dry_run.get("source_implementation_plan_snapshot"))
+    if (
+        validation["valid"]
+        and dry_run.get("dry_run_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED
+    ):
+        action = (
+            "route_to_real_token_write_executor_code_review_plan_without_executor_code_or_invocation"
+        )
+        reason = "Implementation dry-run candidate is ready for a separate code review plan; it does not create executor source files, implement or invoke the executor, issue tokens, persist approvals, or write proposal, ledger, token, audit, memory, graph, or config state."
+    elif validation["valid"]:
+        action = "keep_real_token_write_executor_implementation_dry_run_locked"
+        reason = f"Implementation dry-run candidate is locked by {dry_run.get('lock_reason')}."
+    else:
+        action = "repair_real_token_write_executor_implementation_dry_run_candidate"
+        reason = "Implementation dry-run candidate failed validation and cannot proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_ROUTING,
+        "validation": validation,
+        "implementation_plan_recommendation": (
+            recommend_human_approval_token_real_write_executor_implementation_plan_action(
+                source_snapshot
+            )
+            if source_snapshot
+            else {}
+        ),
+        "creates_real_write_executor_implementation_dry_run_candidates_only": True,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "creates_executor_source_files": False,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
+        ),
+    }
+
+
+def summarize_human_approval_token_real_write_executor_implementation_dry_runs(
+    dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    code_review_plan_required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for dry_run in dry_runs:
+        block_type = str(dry_run.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(dry_run.get("dry_run_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        lock_reason = str(dry_run.get("lock_reason"))
+        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
+        if (
+            dry_run.get("dry_run_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED
+        ):
+            code_review_plan_required_count += 1
+        if (
+            dry_run.get("dry_run_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED
+        ):
+            locked_count += 1
+        validation = (
+            validate_human_approval_token_real_write_executor_implementation_dry_run(
+                dry_run
+            )
+        )
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(dry_runs),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "real_token_write_executor_code_review_plan_required_count": (
+            code_review_plan_required_count
+        ),
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
+        ),
+    }
+
+
+def _dry_run_lock_reason(
+    implementation_plan: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> str | None:
+    if (
+        implementation_plan.get("plan_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED
+    ):
+        return (
+            implementation_plan.get("lock_reason")
+            or "real_write_executor_implementation_plan_locked"
+        )
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(implementation_plan.get(field), Mapping):
+            return f"missing_{field}"
+    for field in _WRITE_PREVIEW_FIELDS:
+        if not isinstance(implementation_plan.get(field), Mapping):
+            return f"missing_{field}"
+    for field, expected_type in _EXECUTOR_CONTRACT_FIELD_TYPES.items():
+        if not isinstance(implementation_plan.get(field), expected_type):
+            return f"missing_{field}"
+    if not isinstance(implementation_plan.get("contract_review_checklist"), list):
+        return "missing_contract_review_checklist"
+    for field, expected_type in _IMPLEMENTATION_PLAN_FIELD_TYPES.items():
+        if not isinstance(implementation_plan.get(field), expected_type):
+            return f"missing_{field}"
+    if not (
+        implementation_plan.get("source_pattern_ids")
+        or implementation_plan.get("source_fact_ids")
+    ):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(implementation_plan):
+        return "preview_integrity_failed"
+    if _implementation_plan_integrity_errors(implementation_plan, validation):
+        return "implementation_plan_integrity_failed"
+    if validation.get("valid") is not True:
+        return "invalid_real_write_executor_implementation_plan"
+    if (
+        implementation_plan.get("plan_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED
+    ):
+        return "invalid_real_write_executor_implementation_plan"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _implementation_plan_integrity_errors(
+    implementation_plan: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    interfaces = implementation_plan.get("implementation_plan_interfaces")
+    if isinstance(interfaces, list):
+        for interface in interfaces:
+            if not isinstance(interface, Mapping):
+                errors.append("implementation_plan_interfaces_must_be_structured")
+                continue
+            if interface.get("implemented_in_v0_1") is not False:
+                errors.append("implementation_plan_interfaces_must_not_implement_executor")
+            if interface.get("invoked_in_v0_1") is not False:
+                errors.append("implementation_plan_interfaces_must_not_invoke_executor")
+    files = implementation_plan.get("implementation_plan_files")
+    if isinstance(files, list):
+        for file_plan in files:
+            if not isinstance(file_plan, Mapping):
+                errors.append("implementation_plan_files_must_be_structured")
+                continue
+            if file_plan.get("create_in_v0_1") is not False:
+                errors.append("implementation_plan_files_must_not_create_executor_files")
+            if file_plan.get("contains_executor_code_in_v0_1") is not False:
+                errors.append("implementation_plan_files_must_not_contain_executor_code")
+            if file_plan.get("writes_files_in_v0_1") is not False:
+                errors.append("implementation_plan_files_must_not_write_files")
+    strategy_expectations = (
+        (
+            "implementation_plan_idempotency_strategy",
+            "v0_1_effect",
+            "plan_only_no_idempotency_state_written",
+        ),
+        (
+            "implementation_plan_filesystem_safety_model",
+            "v0_1_effect",
+            "no_filesystem_write_or_directory_creation",
+        ),
+        (
+            "implementation_plan_audit_strategy",
+            "v0_1_effect",
+            "no_approval_audit_file_write_and_no_operation_ledger_event",
+        ),
+        (
+            "implementation_plan_rollback_strategy",
+            "v0_1_effect",
+            "no_rollback_action_because_no_write_is_performed",
+        ),
+    )
+    for field, key, expected in strategy_expectations:
+        value = implementation_plan.get(field)
+        if isinstance(value, Mapping) and value.get(key) != expected:
+            errors.append(f"{field}_must_preserve_no_write_effect")
+    test_plan = implementation_plan.get("implementation_plan_test_plan")
+    if isinstance(test_plan, list):
+        for test_case in test_plan:
+            if not isinstance(test_case, Mapping):
+                errors.append("implementation_plan_test_plan_must_be_structured")
+                continue
+            if test_case.get("writes") is not False:
+                errors.append("implementation_plan_test_plan_must_not_write")
+    forbidden_actions = implementation_plan.get("implementation_plan_forbidden_actions")
+    if isinstance(forbidden_actions, list):
+        required_forbidden_actions = {
+            "write_memory",
+            "write_memory_graph",
+            "modify_openclaw_config",
+            "approve_allowlists",
+            "create_proposal_events",
+            "create_operation_ledger_events",
+            "create_real_memory_proposals",
+            "write_proposal_files",
+            "write_operation_ledger",
+            "issue_real_approval_tokens",
+            "persist_approvals",
+            "write_token_files",
+            "write_approval_audit_files",
+            "invoke_real_token_write_executor",
+            "implement_real_token_write_executor",
+            "submit_to_governance",
+            "convert_to_real_proposal",
+        }
+        if required_forbidden_actions.difference(forbidden_actions):
+            errors.append("implementation_plan_forbidden_actions_must_preserve_no_write_boundary")
+    for error in list(validation.get("errors", []) or []):
+        if (
+            error.startswith("implementation_plan_")
+            or error.endswith("_must_match_source_contract_review_outcome_snapshot")
+            or error.endswith("_must_match_source_snapshot")
+            or error.startswith("contract_review_checklist_must_preserve")
+            or error.startswith("executor_forbidden_side_effects_must_preserve")
+            or error.startswith("executor_contract_checklist_must_preserve")
+            or error.startswith("final_gate_checklist_must_preserve")
+            or error.startswith("final_token_write_preflight_checklist_must_preserve")
+            or error.startswith("policy_")
+        ):
+            errors.append("implementation_plan_validation_integrity_errors")
+    return _dedupe(errors)
+
+
+def _implementation_dry_run_module_boundary_preview() -> dict[str, Any]:
+    return {
+        "preview_kind": "real_token_write_executor_module_boundary_preview",
+        "preview_only": True,
+        "future_module": "agent/memory_human_approval_token_real_write_executor.py",
+        "future_test_module": "tests/agent/test_memory_human_approval_token_real_write_executor.py",
+        "module_created_in_v0_1": False,
+        "creates_executor_source_files": False,
+        "implements_real_token_write_executor": False,
+        "invokes_real_token_write_executor": False,
+        "writes_files": False,
+        "boundary_rules": [
+            "future_executor_code_requires_separate_code_review_plan",
+            "future_executor_module_must_not_be_created_by_this_dry_run",
+            "future_executor_invocation_must_remain_locked_until_after_code_review",
+        ],
+    }
+
+
+def _implementation_dry_run_interface_preview() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "validate_real_token_write_executor_inputs",
+            "preview_only": True,
+            "future_signature": (
+                "validate_real_token_write_executor_inputs(final_gate, approval_token_payload, audit_payload)"
+            ),
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+            "writes_files": False,
+        },
+        {
+            "name": "prepare_real_token_write_payloads",
+            "preview_only": True,
+            "future_signature": (
+                "prepare_real_token_write_payloads(approval_token_write_payload_preview, approval_audit_write_payload_preview)"
+            ),
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+            "writes_files": False,
+        },
+        {
+            "name": "commit_real_token_write_atomically",
+            "preview_only": True,
+            "future_signature": (
+                "commit_real_token_write_atomically(token_payload, audit_payload, target_paths)"
+            ),
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+            "writes_files": False,
+        },
+        {
+            "name": "verify_real_token_write_audit_trail",
+            "preview_only": True,
+            "future_signature": (
+                "verify_real_token_write_audit_trail(write_fingerprint, token_path, audit_path)"
+            ),
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+            "writes_files": False,
+        },
+    ]
+
+
+def _implementation_dry_run_idempotency_check_preview() -> dict[str, Any]:
+    return {
+        "preview_kind": "real_token_write_executor_idempotency_check_preview",
+        "preview_only": True,
+        "v0_1_effect": "no_idempotency_state_written",
+        "fingerprint_inputs": [
+            "source_implementation_plan_id",
+            "source_contract_review_outcome_id",
+            "source_contract_id",
+            "approval_token_write_payload_preview",
+            "approval_audit_write_payload_preview",
+            "token_write_target_paths_preview",
+        ],
+        "future_checks": [
+            "derive_write_fingerprint_before_future_write",
+            "require_existing_token_and_audit_hashes_to_match_before_idempotent_success",
+            "lock_on_mismatched_existing_token_or_audit_payload",
+        ],
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "writes_operation_ledger": False,
+        "written": False,
+    }
+
+
+def _implementation_dry_run_filesystem_safety_check_preview() -> dict[str, Any]:
+    return {
+        "preview_kind": "real_token_write_executor_filesystem_safety_check_preview",
+        "preview_only": True,
+        "v0_1_effect": "preview_only_no_filesystem_write_or_directory_creation",
+        "future_checks": [
+            "resolve_targets_under_hermes_home_memory_approval_scope",
+            "reject_path_traversal_symlinks_and_unexpected_absolute_paths",
+            "require_atomic_temp_file_replace_in_same_directory",
+            "require_token_and_audit_pair_to_commit_together",
+            "fsync_file_and_directory_after_future_write",
+        ],
+        "creates_executor_source_files": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "written": False,
+    }
+
+
+def _implementation_dry_run_audit_check_preview() -> dict[str, Any]:
+    return {
+        "preview_kind": "real_token_write_executor_audit_check_preview",
+        "preview_only": True,
+        "v0_1_effect": "no_approval_audit_file_write_and_no_operation_ledger_event",
+        "future_checks": [
+            "audit_payload_derives_from_approval_audit_write_payload_preview",
+            "audit_record_references_source_implementation_plan_and_contract",
+            "audit_success_requires_token_and_audit_payload_hash_match",
+            "operation_ledger_events_remain_out_of_scope_for_token_executor",
+        ],
+        "created_operation_event": False,
+        "writes_approval_audit": False,
+        "writes_operation_ledger": False,
+        "written": False,
+    }
+
+
+def _implementation_dry_run_rollback_check_preview() -> dict[str, Any]:
+    return {
+        "preview_kind": "real_token_write_executor_rollback_check_preview",
+        "preview_only": True,
+        "v0_1_effect": "no_rollback_action_because_no_write_is_performed",
+        "future_checks": [
+            "abort_before_first_write_when_preflight_fails",
+            "remove_only_temp_files_created_by_same_future_attempt",
+            "never_delete_preexisting_token_or_audit_files",
+            "require_manual_recovery_packet_for_partial_commit",
+        ],
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "writes_operation_ledger": False,
+        "written": False,
+    }
+
+
+def _implementation_dry_run_test_harness_preview() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "valid_implementation_plan_creates_code_review_plan_required_dry_run",
+            "scope": "unit",
+            "creates_files": False,
+            "writes": False,
+        },
+        {
+            "id": "locked_invalid_missing_and_integrity_failures_lock_dry_run",
+            "scope": "unit",
+            "creates_files": False,
+            "writes": False,
+        },
+        {
+            "id": "deterministic_previews_do_not_create_or_invoke_executor",
+            "scope": "unit",
+            "creates_files": False,
+            "writes": False,
+        },
+        {
+            "id": "benchmark_smoke_case_stays_read_only_executor_free_and_source_file_free",
+            "scope": "benchmark",
+            "creates_files": False,
+            "writes": False,
+        },
+    ]
+
+
+def _implementation_dry_run_readiness_checklist() -> list[str]:
+    return [
+        "source_implementation_plan_is_valid_and_implementation_plan_required",
+        "approval_token_record_preview_is_preview_only",
+        "approval_audit_record_preview_is_preview_only",
+        "token_target_paths_preview_is_preview_only",
+        "proposal_record_preview_is_not_written",
+        "operation_ledger_preview_is_not_written",
+        "target_paths_preview_is_preview_only",
+        "approval_token_write_payload_preview_is_preview_only",
+        "approval_audit_write_payload_preview_is_preview_only",
+        "token_write_target_paths_preview_is_preview_only",
+        "executor_contract_inputs_are_present",
+        "executor_hard_lock_checks_are_present",
+        "executor_audit_fields_are_present",
+        "executor_rollback_rules_are_present",
+        "executor_forbidden_side_effects_are_present",
+        "executor_contract_checklist_is_present",
+        "contract_review_checklist_is_present",
+        "implementation_plan_interfaces_are_present_and_not_implemented",
+        "implementation_plan_files_are_present_and_not_created",
+        "implementation_plan_idempotency_strategy_is_present",
+        "implementation_plan_filesystem_safety_model_is_present",
+        "implementation_plan_audit_strategy_is_present",
+        "implementation_plan_rollback_strategy_is_present",
+        "implementation_plan_test_plan_is_present",
+        "implementation_plan_forbidden_actions_are_present",
+        "source_evidence_is_present",
+        "no_real_approval_token_issued",
+        "no_approval_persisted",
+        "no_real_proposal_created",
+        "no_operation_ledger_event_created",
+        "no_proposal_file_written",
+        "no_operation_ledger_written",
+        "no_token_file_written",
+        "no_approval_audit_written",
+        "no_memory_or_graph_or_config_write",
+        "real_token_write_executor_not_invoked",
+        "real_token_write_executor_not_implemented",
+        "executor_source_files_not_created",
+        "code_review_plan_required_before_any_executor_code",
+    ]
+
+
+def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_VERSION,
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "lock_reason": dry_run.get("lock_reason"),
+        "source_implementation_plan_id": dry_run.get("source_implementation_plan_id"),
+        "source_contract_review_outcome_id": dry_run.get("source_contract_review_outcome_id"),
+        "source_contract_id": dry_run.get("source_contract_id"),
+        "source_write_final_gate_id": dry_run.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": dry_run.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": dry_run.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": dry_run.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": dry_run.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": dry_run.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": dry_run.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": dry_run.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": dry_run.get("source_review_outcome_id"),
+        "source_request_id": dry_run.get("source_request_id"),
+        "source_gate_id": dry_run.get("source_gate_id"),
+        "source_dry_run_id": dry_run.get("source_dry_run_id"),
+        "source_plan_id": dry_run.get("source_plan_id"),
+        "source_outcome_id": dry_run.get("source_outcome_id"),
+        "source_packet_id": dry_run.get("source_packet_id"),
+        "source_submission_id": dry_run.get("source_submission_id"),
+        "source_draft_id": dry_run.get("source_draft_id"),
+        "source_decision_id": dry_run.get("source_decision_id"),
+        "source_queue_item_id": dry_run.get("source_queue_item_id"),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "outcome": dry_run.get("outcome"),
+        "rationale": dry_run.get("rationale"),
+        "approval_token_record_preview": dry_run.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": dry_run.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": dry_run.get("token_target_paths_preview", {}),
+        "proposal_record_preview": dry_run.get("proposal_record_preview", {}),
+        "operation_ledger_preview": dry_run.get("operation_ledger_preview", {}),
+        "target_paths_preview": dry_run.get("target_paths_preview", {}),
+        "payload_preview": dry_run.get("payload_preview"),
+        "source_pattern_ids": list(dry_run.get("source_pattern_ids", [])),
+        "source_fact_ids": list(dry_run.get("source_fact_ids", [])),
+        "token_write_execution_steps": list(
+            dry_run.get("token_write_execution_steps", [])
+        ),
+        "token_write_execution_preflight_checks": list(
+            dry_run.get("token_write_execution_preflight_checks", [])
+        ),
+        "approval_token_write_payload_preview": dry_run.get(
+            "approval_token_write_payload_preview", {}
+        ),
+        "approval_audit_write_payload_preview": dry_run.get(
+            "approval_audit_write_payload_preview", {}
+        ),
+        "token_write_target_paths_preview": dry_run.get(
+            "token_write_target_paths_preview", {}
+        ),
+        "final_token_write_preflight_checklist": list(
+            dry_run.get("final_token_write_preflight_checklist") or []
+        ),
+        "final_gate_checklist": list(dry_run.get("final_gate_checklist") or []),
+        "executor_contract_inputs": dry_run.get("executor_contract_inputs", {}),
+        "executor_hard_lock_checks": list(dry_run.get("executor_hard_lock_checks") or []),
+        "executor_audit_fields": list(dry_run.get("executor_audit_fields") or []),
+        "executor_rollback_rules": list(dry_run.get("executor_rollback_rules") or []),
+        "executor_forbidden_side_effects": list(
+            dry_run.get("executor_forbidden_side_effects") or []
+        ),
+        "executor_contract_checklist": list(
+            dry_run.get("executor_contract_checklist") or []
+        ),
+        "contract_review_checklist": list(dry_run.get("contract_review_checklist") or []),
+        "implementation_plan_interfaces": dry_run.get("implementation_plan_interfaces", []),
+        "implementation_plan_files": dry_run.get("implementation_plan_files", []),
+        "implementation_plan_idempotency_strategy": dry_run.get(
+            "implementation_plan_idempotency_strategy", {}
+        ),
+        "implementation_plan_filesystem_safety_model": dry_run.get(
+            "implementation_plan_filesystem_safety_model", {}
+        ),
+        "implementation_plan_audit_strategy": dry_run.get(
+            "implementation_plan_audit_strategy", {}
+        ),
+        "implementation_plan_rollback_strategy": dry_run.get(
+            "implementation_plan_rollback_strategy", {}
+        ),
+        "implementation_plan_test_plan": dry_run.get("implementation_plan_test_plan", []),
+        "implementation_plan_forbidden_actions": list(
+            dry_run.get("implementation_plan_forbidden_actions") or []
+        ),
+        "implementation_dry_run_module_boundary_preview": dry_run.get(
+            "implementation_dry_run_module_boundary_preview", {}
+        ),
+        "implementation_dry_run_interface_preview": dry_run.get(
+            "implementation_dry_run_interface_preview", []
+        ),
+        "implementation_dry_run_idempotency_check_preview": dry_run.get(
+            "implementation_dry_run_idempotency_check_preview", {}
+        ),
+        "implementation_dry_run_filesystem_safety_check_preview": dry_run.get(
+            "implementation_dry_run_filesystem_safety_check_preview", {}
+        ),
+        "implementation_dry_run_audit_check_preview": dry_run.get(
+            "implementation_dry_run_audit_check_preview", {}
+        ),
+        "implementation_dry_run_rollback_check_preview": dry_run.get(
+            "implementation_dry_run_rollback_check_preview", {}
+        ),
+        "implementation_dry_run_test_harness_preview": dry_run.get(
+            "implementation_dry_run_test_harness_preview", []
+        ),
+        "implementation_dry_run_readiness_checklist": list(
+            dry_run.get("implementation_dry_run_readiness_checklist") or []
+        ),
+        "implementation_plan_validation": dry_run.get("implementation_plan_validation", {}),
+        "policy": dry_run.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return (
+        "memory-human-approval-token-real-write-executor-implementation-dry-run:"
+        f"v0.1:{digest}"
+    )
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_real_write_executor_implementation_plan.py
+++ b/agent/memory_human_approval_token_real_write_executor_implementation_plan.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -9,6 +7,13 @@ from agent.memory_human_approval_token_real_write_executor_contract_review_gate 
     explain_human_approval_token_real_write_executor_contract_review_outcome,
     recommend_human_approval_token_real_write_executor_contract_review_action,
     validate_human_approval_token_real_write_executor_contract_review_outcome,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -489,14 +494,18 @@ def validate_human_approval_token_real_write_executor_implementation_plan(
         errors.append(
             "implementation_plan_forbidden_actions_must_match_v0_1_deterministic_plan"
         )
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if plan.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in (
-        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY.items()
-    ):
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(
+        validate_forbidden_true_keys_false_or_absent(
+            plan,
+            _FORBIDDEN_TRUE_KEYS,
+        )
+    )
+    errors.extend(
+        validate_policy_flags(
+            policy,
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY,
+        )
+    )
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -625,18 +634,13 @@ def recommend_human_approval_token_real_write_executor_implementation_plan_actio
 def summarize_human_approval_token_real_write_executor_implementation_plans(
     plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(plans, "plan_status")
     by_lock_reason: dict[str, int] = {}
     implementation_plan_required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for plan in plans:
-        block_type = str(plan.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(plan.get("plan_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         lock_reason = str(plan.get("lock_reason"))
         by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
         if (
@@ -657,15 +661,15 @@ def summarize_human_approval_token_real_write_executor_implementation_plans(
         else:
             invalid_count += 1
     return {
-        "total": len(plans),
+        "total": candidate_summary["total"],
         "valid_count": valid_count,
         "invalid_count": invalid_count,
         "real_token_write_executor_implementation_plan_required_count": (
             implementation_plan_required_count
         ),
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "by_lock_reason": dict(sorted(by_lock_reason.items())),
         "policy": dict(
             MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
@@ -1106,16 +1110,14 @@ def _plan_id(plan: Mapping[str, Any]) -> str:
         ),
         "policy": plan.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    return (
-        "memory-human-approval-token-real-write-executor-implementation-plan:"
-        f"v0.1:{digest}"
+    return build_stable_digest(
+        "memory-human-approval-token-real-write-executor-implementation-plan:v0.1",
+        identity,
     )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_real_write_executor_implementation_plan.py
+++ b/agent/memory_human_approval_token_real_write_executor_implementation_plan.py
@@ -1,0 +1,1122 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_real_write_executor_contract_review_gate import (
+    explain_human_approval_token_real_write_executor_contract_review_outcome,
+    recommend_human_approval_token_real_write_executor_contract_review_action,
+    validate_human_approval_token_real_write_executor_contract_review_outcome,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_KIND = (
+    "memory_human_approval_token_real_write_executor_implementation_plan_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED = (
+    "real_token_write_executor_implementation_plan_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_ROUTING = (
+    "real_token_write_executor_implementation_dry_run_required_before_code_implementation"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_real_write_executor_implementation_plan_candidates_only": True,
+    "invokes_real_token_write_executor": False,
+    "implements_real_token_write_executor": False,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_IMPLEMENTER = (
+    "hermes_memory_human_approval_token_real_write_executor_implementation_plan_v0.1"
+)
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_WRITE_PREVIEW_FIELDS = (
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+)
+_EXECUTOR_CONTRACT_FIELD_TYPES = {
+    "executor_contract_inputs": Mapping,
+    "executor_hard_lock_checks": list,
+    "executor_audit_fields": list,
+    "executor_rollback_rules": list,
+    "executor_forbidden_side_effects": list,
+    "executor_contract_checklist": list,
+}
+_LOCK_REASONS = {
+    None,
+    "contract_review_requested_changes",
+    "contract_review_rejected",
+    "contract_review_deferred",
+    "invalid_contract_review_outcome",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_approval_token_write_payload_preview",
+    "missing_approval_audit_write_payload_preview",
+    "missing_token_write_target_paths_preview",
+    "missing_executor_contract_inputs",
+    "missing_executor_hard_lock_checks",
+    "missing_executor_audit_fields",
+    "missing_executor_rollback_rules",
+    "missing_executor_forbidden_side_effects",
+    "missing_executor_contract_checklist",
+    "missing_contract_review_checklist",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+    "contract_review_integrity_failed",
+}
+_SOURCE_KEYS = (
+    "source_contract_id",
+    "source_write_final_gate_id",
+    "source_write_execution_dry_run_id",
+    "source_write_execution_plan_id",
+    "source_final_confirmation_review_outcome_id",
+    "source_final_confirmation_request_id",
+    "source_token_write_lock_gate_id",
+    "source_token_issuance_dry_run_id",
+    "source_token_issuance_plan_id",
+    "source_review_outcome_id",
+    "source_request_id",
+    "source_gate_id",
+    "source_dry_run_id",
+    "source_plan_id",
+    "source_outcome_id",
+    "source_packet_id",
+    "source_submission_id",
+    "source_draft_id",
+    "source_decision_id",
+    "source_queue_item_id",
+    "block_id",
+    "block_type",
+    "project_scope",
+    "outcome",
+)
+_REQUIRED_PLAN_KEYS = (
+    "plan_id",
+    "plan_kind",
+    "plan_status",
+    "routing",
+    "lock_reason",
+    "source_contract_review_outcome_id",
+) + _SOURCE_KEYS + (
+    "implementer",
+    "rationale",
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+    "payload_preview",
+    "source_pattern_ids",
+    "source_fact_ids",
+    "token_write_execution_steps",
+    "token_write_execution_preflight_checks",
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+    "final_token_write_preflight_checklist",
+    "final_gate_checklist",
+    "executor_contract_inputs",
+    "executor_hard_lock_checks",
+    "executor_audit_fields",
+    "executor_rollback_rules",
+    "executor_forbidden_side_effects",
+    "executor_contract_checklist",
+    "contract_review_checklist",
+    "implementation_plan_interfaces",
+    "implementation_plan_files",
+    "implementation_plan_idempotency_strategy",
+    "implementation_plan_filesystem_safety_model",
+    "implementation_plan_audit_strategy",
+    "implementation_plan_rollback_strategy",
+    "implementation_plan_test_plan",
+    "implementation_plan_forbidden_actions",
+    "contract_review_outcome_validation",
+    "plan_validation",
+    "next_step_recommendation",
+    "source_contract_review_outcome_snapshot",
+    "policy",
+)
+
+
+def create_human_approval_token_real_write_executor_implementation_plan(
+    contract_review_outcome: Mapping[str, Any],
+    implementer: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only real token write executor implementation plan."""
+    source = deepcopy(dict(contract_review_outcome))
+    contract_review_outcome_validation = (
+        validate_human_approval_token_real_write_executor_contract_review_outcome(source)
+    )
+    lock_reason = _plan_lock_reason(source, contract_review_outcome_validation)
+    plan_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED
+    )
+
+    plan = {
+        "plan_id": None,
+        "plan_kind": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_KIND,
+        "plan_status": plan_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_ROUTING,
+        "lock_reason": lock_reason,
+        "source_contract_review_outcome_id": source.get("review_outcome_id"),
+        "source_contract_id": source.get("source_contract_id"),
+        "source_write_final_gate_id": source.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": source.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": source.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": source.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": source.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get(
+            "source_token_issuance_dry_run_id"
+        ),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "implementer": implementer if implementer is not None else _DEFAULT_IMPLEMENTER,
+        "outcome": source.get("outcome"),
+        "rationale": source.get("rationale"),
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": deepcopy(
+            list(source.get("token_write_execution_steps", []) or [])
+        ),
+        "token_write_execution_preflight_checks": deepcopy(
+            list(source.get("token_write_execution_preflight_checks", []) or [])
+        ),
+        "approval_token_write_payload_preview": deepcopy(
+            source.get("approval_token_write_payload_preview")
+        ),
+        "approval_audit_write_payload_preview": deepcopy(
+            source.get("approval_audit_write_payload_preview")
+        ),
+        "token_write_target_paths_preview": deepcopy(source.get("token_write_target_paths_preview")),
+        "final_token_write_preflight_checklist": deepcopy(
+            source.get("final_token_write_preflight_checklist")
+        ),
+        "final_gate_checklist": deepcopy(source.get("final_gate_checklist")),
+        "executor_contract_inputs": deepcopy(source.get("executor_contract_inputs")),
+        "executor_hard_lock_checks": deepcopy(source.get("executor_hard_lock_checks")),
+        "executor_audit_fields": deepcopy(source.get("executor_audit_fields")),
+        "executor_rollback_rules": deepcopy(source.get("executor_rollback_rules")),
+        "executor_forbidden_side_effects": deepcopy(
+            source.get("executor_forbidden_side_effects")
+        ),
+        "executor_contract_checklist": deepcopy(source.get("executor_contract_checklist")),
+        "contract_review_checklist": deepcopy(source.get("contract_review_checklist")),
+        "implementation_plan_interfaces": _implementation_plan_interfaces(),
+        "implementation_plan_files": _implementation_plan_files(),
+        "implementation_plan_idempotency_strategy": _implementation_plan_idempotency_strategy(),
+        "implementation_plan_filesystem_safety_model": (
+            _implementation_plan_filesystem_safety_model()
+        ),
+        "implementation_plan_audit_strategy": _implementation_plan_audit_strategy(),
+        "implementation_plan_rollback_strategy": _implementation_plan_rollback_strategy(),
+        "implementation_plan_test_plan": _implementation_plan_test_plan(),
+        "implementation_plan_forbidden_actions": _implementation_plan_forbidden_actions(),
+        "contract_review_outcome_validation": deepcopy(contract_review_outcome_validation),
+        "plan_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_contract_review_outcome_snapshot": deepcopy(source),
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
+        ),
+    }
+    plan["plan_id"] = _plan_id(plan)
+    plan["plan_validation"] = (
+        validate_human_approval_token_real_write_executor_implementation_plan(plan)
+    )
+    plan["next_step_recommendation"] = (
+        recommend_human_approval_token_real_write_executor_implementation_plan_action(plan)
+    )
+    return plan
+
+
+def validate_human_approval_token_real_write_executor_implementation_plan(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(plan.get("policy"))
+    source_snapshot = _as_dict(plan.get("source_contract_review_outcome_snapshot"))
+    contract_review_outcome_validation = _as_dict(
+        plan.get("contract_review_outcome_validation")
+    )
+    expected_contract_review_outcome_validation = (
+        validate_human_approval_token_real_write_executor_contract_review_outcome(
+            source_snapshot
+        )
+    )
+    expected_lock_reason = _plan_lock_reason(
+        source_snapshot,
+        contract_review_outcome_validation,
+    )
+
+    for key in _REQUIRED_PLAN_KEYS:
+        if key not in plan:
+            errors.append(f"missing_{key}")
+    if (
+        plan.get("plan_kind")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_KIND
+    ):
+        errors.append(
+            "plan_kind_must_be_memory_human_approval_token_real_write_executor_implementation_plan_candidate"
+        )
+    if plan.get("plan_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED,
+    }:
+        errors.append("plan_status_must_be_supported")
+    if (
+        plan.get("routing")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_ROUTING
+    ):
+        errors.append(
+            "routing_must_require_implementation_dry_run_before_code_implementation"
+        )
+    if plan.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if plan.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_real_write_executor_implementation_plan_checks")
+    if (
+        expected_lock_reason is None
+        and plan.get("plan_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED
+    ):
+        errors.append(
+            "approved_contract_review_outcome_must_require_real_token_write_executor_implementation_plan"
+        )
+    if (
+        expected_lock_reason is not None
+        and plan.get("plan_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED
+    ):
+        errors.append("invalid_or_non_approved_contract_review_outcome_must_lock_plan")
+    if not isinstance(plan.get("implementer"), str) or not plan.get("implementer"):
+        errors.append("implementer_must_be_non_empty_string")
+    if (
+        contract_review_outcome_validation
+        != expected_contract_review_outcome_validation
+    ):
+        errors.append(
+            "contract_review_outcome_validation_must_match_source_contract_review_outcome_snapshot"
+        )
+    if plan.get("source_contract_review_outcome_id") != source_snapshot.get(
+        "review_outcome_id"
+    ):
+        errors.append("source_contract_review_outcome_id_must_match_source_snapshot")
+    for source_key in _SOURCE_KEYS:
+        if plan.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+
+    if (
+        not isinstance(plan.get("payload_preview"), Mapping)
+        and plan.get("lock_reason") != "invalid_contract_review_outcome"
+    ):
+        errors.append("missing_payload_preview")
+    if not isinstance(plan.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(plan.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(plan.get("source_pattern_ids"), list) and isinstance(
+        plan.get("source_fact_ids"), list
+    ):
+        if (
+            not plan.get("source_pattern_ids")
+            and not plan.get("source_fact_ids")
+            and plan.get("lock_reason") != "missing_source_evidence"
+        ):
+            errors.append("missing_source_evidence")
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        if (
+            not isinstance(plan.get(field), Mapping)
+            and plan.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    for field, expected_type in _EXECUTOR_CONTRACT_FIELD_TYPES.items():
+        if (
+            not isinstance(plan.get(field), expected_type)
+            and plan.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    if (
+        not isinstance(plan.get("contract_review_checklist"), list)
+        and plan.get("lock_reason") != "missing_contract_review_checklist"
+    ):
+        errors.append("missing_contract_review_checklist")
+    if plan.get("lock_reason") != "preview_integrity_failed":
+        errors.extend(_preview_integrity_errors(plan))
+    if plan.get("lock_reason") is None:
+        errors.extend(_contract_review_integrity_errors(plan, contract_review_outcome_validation))
+
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS + (
+        "payload_preview",
+        "token_write_execution_steps",
+        "token_write_execution_preflight_checks",
+        "final_token_write_preflight_checklist",
+        "final_gate_checklist",
+        "executor_contract_inputs",
+        "executor_hard_lock_checks",
+        "executor_audit_fields",
+        "executor_rollback_rules",
+        "executor_forbidden_side_effects",
+        "executor_contract_checklist",
+        "contract_review_checklist",
+    ):
+        if (
+            field in plan
+            and field in source_snapshot
+            and plan.get(field) != source_snapshot.get(field)
+        ):
+            errors.append(f"{field}_must_match_source_contract_review_outcome_snapshot")
+    if plan.get("source_pattern_ids") != list(
+        source_snapshot.get("source_pattern_ids", []) or []
+    ):
+        errors.append("source_pattern_ids_must_match_source_contract_review_outcome_snapshot")
+    if plan.get("source_fact_ids") != list(
+        source_snapshot.get("source_fact_ids", []) or []
+    ):
+        errors.append("source_fact_ids_must_match_source_contract_review_outcome_snapshot")
+
+    if plan.get("implementation_plan_interfaces") != _implementation_plan_interfaces():
+        errors.append("implementation_plan_interfaces_must_match_v0_1_deterministic_plan")
+    if plan.get("implementation_plan_files") != _implementation_plan_files():
+        errors.append("implementation_plan_files_must_match_v0_1_deterministic_plan")
+    if (
+        plan.get("implementation_plan_idempotency_strategy")
+        != _implementation_plan_idempotency_strategy()
+    ):
+        errors.append(
+            "implementation_plan_idempotency_strategy_must_match_v0_1_deterministic_plan"
+        )
+    if (
+        plan.get("implementation_plan_filesystem_safety_model")
+        != _implementation_plan_filesystem_safety_model()
+    ):
+        errors.append(
+            "implementation_plan_filesystem_safety_model_must_match_v0_1_deterministic_plan"
+        )
+    if (
+        plan.get("implementation_plan_audit_strategy")
+        != _implementation_plan_audit_strategy()
+    ):
+        errors.append("implementation_plan_audit_strategy_must_match_v0_1_deterministic_plan")
+    if (
+        plan.get("implementation_plan_rollback_strategy")
+        != _implementation_plan_rollback_strategy()
+    ):
+        errors.append(
+            "implementation_plan_rollback_strategy_must_match_v0_1_deterministic_plan"
+        )
+    if plan.get("implementation_plan_test_plan") != _implementation_plan_test_plan():
+        errors.append("implementation_plan_test_plan_must_match_v0_1_deterministic_plan")
+    if (
+        plan.get("implementation_plan_forbidden_actions")
+        != _implementation_plan_forbidden_actions()
+    ):
+        errors.append(
+            "implementation_plan_forbidden_actions_must_match_v0_1_deterministic_plan"
+        )
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if plan.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY.items()
+    ):
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_real_write_executor_implementation_plan(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_implementation_plan(
+        plan
+    )
+    source_snapshot = _as_dict(plan.get("source_contract_review_outcome_snapshot"))
+    return {
+        "plan_id": plan.get("plan_id"),
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_contract_review_outcome_id": plan.get(
+            "source_contract_review_outcome_id"
+        ),
+        "source_contract_id": plan.get("source_contract_id"),
+        "source_write_final_gate_id": plan.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": plan.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": plan.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": plan.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "implementer": plan.get("implementer"),
+        "outcome": plan.get("outcome"),
+        "rationale": plan.get("rationale"),
+        "source_pattern_count": len(plan.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(plan.get("source_fact_ids", []) or []),
+        "implementation_plan_interfaces": deepcopy(
+            plan.get("implementation_plan_interfaces")
+        ),
+        "implementation_plan_files": deepcopy(plan.get("implementation_plan_files")),
+        "implementation_plan_forbidden_actions": deepcopy(
+            plan.get("implementation_plan_forbidden_actions")
+        ),
+        "validation": validation,
+        "contract_review_outcome_explanation": (
+            explain_human_approval_token_real_write_executor_contract_review_outcome(
+                source_snapshot
+            )
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
+        ),
+    }
+
+
+def recommend_human_approval_token_real_write_executor_implementation_plan_action(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_real_write_executor_implementation_plan(
+        plan
+    )
+    source_snapshot = _as_dict(plan.get("source_contract_review_outcome_snapshot"))
+    if (
+        validation["valid"]
+        and plan.get("plan_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED
+    ):
+        action = (
+            "route_to_real_token_write_executor_implementation_dry_run_without_code_or_invocation"
+        )
+        reason = "Implementation plan candidate is ready for a separate dry run; it does not implement or invoke the executor and does not write token, approval, proposal, ledger, memory, graph, or config state."
+    elif validation["valid"]:
+        action = "keep_real_token_write_executor_implementation_plan_locked"
+        reason = f"Implementation plan candidate is locked by {plan.get('lock_reason')}."
+    else:
+        action = "repair_real_token_write_executor_implementation_plan_candidate"
+        reason = "Implementation plan candidate failed validation and cannot proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_ROUTING,
+        "validation": validation,
+        "contract_review_outcome_recommendation": (
+            recommend_human_approval_token_real_write_executor_contract_review_action(
+                source_snapshot
+            )
+            if source_snapshot
+            else {}
+        ),
+        "creates_real_write_executor_implementation_plan_candidates_only": True,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
+        ),
+    }
+
+
+def summarize_human_approval_token_real_write_executor_implementation_plans(
+    plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    implementation_plan_required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for plan in plans:
+        block_type = str(plan.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(plan.get("plan_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        lock_reason = str(plan.get("lock_reason"))
+        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
+        if (
+            plan.get("plan_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED
+        ):
+            implementation_plan_required_count += 1
+        if (
+            plan.get("plan_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED
+        ):
+            locked_count += 1
+        validation = validate_human_approval_token_real_write_executor_implementation_plan(
+            plan
+        )
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(plans),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "real_token_write_executor_implementation_plan_required_count": (
+            implementation_plan_required_count
+        ),
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(
+            MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
+        ),
+    }
+
+
+def _plan_lock_reason(
+    outcome_candidate: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> str | None:
+    outcome = outcome_candidate.get("outcome")
+    if outcome == "request_contract_changes":
+        return "contract_review_requested_changes"
+    if outcome == "reject_contract":
+        return "contract_review_rejected"
+    if outcome == "defer_contract_review":
+        return "contract_review_deferred"
+    if outcome != "approve_executor_contract":
+        return "invalid_contract_review_outcome"
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(outcome_candidate.get(field), Mapping):
+            return f"missing_{field}"
+    for field in _WRITE_PREVIEW_FIELDS:
+        if not isinstance(outcome_candidate.get(field), Mapping):
+            return f"missing_{field}"
+    for field, expected_type in _EXECUTOR_CONTRACT_FIELD_TYPES.items():
+        if not isinstance(outcome_candidate.get(field), expected_type):
+            return f"missing_{field}"
+    if not isinstance(outcome_candidate.get("contract_review_checklist"), list):
+        return "missing_contract_review_checklist"
+    if not (
+        outcome_candidate.get("source_pattern_ids")
+        or outcome_candidate.get("source_fact_ids")
+    ):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(outcome_candidate):
+        return "preview_integrity_failed"
+    if _contract_review_integrity_errors(outcome_candidate, validation):
+        return "contract_review_integrity_failed"
+    if validation.get("valid") is not True:
+        return "invalid_contract_review_outcome"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS + _WRITE_PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _contract_review_integrity_errors(
+    outcome_candidate: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    final_gate_checklist = outcome_candidate.get("final_gate_checklist")
+    if isinstance(final_gate_checklist, list):
+        required_final_gate_checks = {
+            "no_real_approval_token_issued",
+            "no_approval_persisted",
+            "no_real_proposal_created",
+            "no_operation_ledger_event_created",
+            "no_token_file_written",
+            "no_approval_audit_written",
+            "real_token_write_executor_required_but_not_invoked",
+        }
+        if required_final_gate_checks.difference(final_gate_checklist):
+            errors.append("final_gate_checklist_must_preserve_no_write_and_no_executor_checks")
+    final_preflight = outcome_candidate.get("final_token_write_preflight_checklist")
+    if isinstance(final_preflight, list) and "no_real_approval_token_issued" not in final_preflight:
+        errors.append("final_token_write_preflight_checklist_must_preserve_no_token_write_checks")
+    forbidden_side_effects = outcome_candidate.get("executor_forbidden_side_effects")
+    if isinstance(forbidden_side_effects, list):
+        required_side_effects = {
+            "write_memory",
+            "write_memory_graph",
+            "write_proposal_files",
+            "write_operation_ledger",
+            "issue_real_approval_tokens",
+            "write_token_files",
+            "write_approval_audit_files",
+            "persist_approvals",
+            "invoke_real_token_write_executor",
+            "implement_real_token_write_executor",
+            "submit_to_governance",
+            "convert_to_real_proposal",
+        }
+        if required_side_effects.difference(forbidden_side_effects):
+            errors.append("executor_forbidden_side_effects_must_preserve_no_write_boundary")
+    executor_checklist = outcome_candidate.get("executor_contract_checklist")
+    if isinstance(executor_checklist, list):
+        required_executor_checks = {
+            "contract_is_read_only_candidate_only",
+            "no_real_executor_is_invoked",
+            "no_real_executor_is_implemented",
+            "no_memory_or_graph_or_config_write",
+        }
+        if required_executor_checks.difference(executor_checklist):
+            errors.append("executor_contract_checklist_must_preserve_no_executor_boundary")
+    review_checklist = outcome_candidate.get("contract_review_checklist")
+    if isinstance(review_checklist, list):
+        required_review_checks = {
+            "no_real_approval_token_issued",
+            "no_approval_persisted",
+            "no_real_proposal_created",
+            "no_operation_ledger_event_created",
+            "no_proposal_file_written",
+            "no_operation_ledger_written",
+            "no_token_file_written",
+            "no_approval_audit_written",
+            "no_memory_or_graph_or_config_write",
+            "real_token_write_executor_not_implemented",
+            "real_token_write_executor_not_invoked",
+            "contract_review_outcome_only",
+        }
+        if required_review_checks.difference(review_checklist):
+            errors.append("contract_review_checklist_must_preserve_no_write_boundary")
+    for error in list(validation.get("errors", []) or []):
+        if (
+            error == "contract_review_checklist_must_match_v0_1_deterministic_checks"
+            or error.endswith("_must_match_source_contract_snapshot")
+            or error.endswith("_must_match_source_snapshot")
+            or error.startswith("final_gate_checklist_must_preserve")
+            or error.startswith("final_token_write_preflight_checklist_must_preserve")
+            or error.startswith("executor_forbidden_side_effects_must_preserve")
+            or error.startswith("executor_contract_checklist_must_preserve")
+        ):
+            errors.append("contract_review_validation_integrity_errors")
+    return _dedupe(errors)
+
+
+def _implementation_plan_interfaces() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "validate_real_token_write_executor_inputs",
+            "purpose": "Future executor input validation against approved contract review outcome, previews, hard locks, and policy.",
+            "module_boundary": "future_executor_module_only",
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+        },
+        {
+            "name": "prepare_real_token_write_payloads",
+            "purpose": "Future conversion from approval token and audit payload previews into write-ready in-memory payloads.",
+            "module_boundary": "future_executor_module_only",
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+        },
+        {
+            "name": "commit_real_token_write_atomically",
+            "purpose": "Future atomic token and approval-audit write boundary after all human approval gates pass.",
+            "module_boundary": "future_executor_module_only",
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+        },
+        {
+            "name": "verify_real_token_write_audit_trail",
+            "purpose": "Future post-write verification of token record, approval audit record, and idempotency metadata.",
+            "module_boundary": "future_executor_module_only",
+            "implemented_in_v0_1": False,
+            "invoked_in_v0_1": False,
+        },
+    ]
+
+
+def _implementation_plan_files() -> list[dict[str, Any]]:
+    return [
+        {
+            "path": "agent/memory_human_approval_token_real_write_executor.py",
+            "purpose": "Future executor module boundary; v0.1 plans the boundary only.",
+            "create_in_v0_1": False,
+            "contains_executor_code_in_v0_1": False,
+            "writes_files_in_v0_1": False,
+        },
+        {
+            "path": "tests/agent/test_memory_human_approval_token_real_write_executor.py",
+            "purpose": "Future executor tests after a separate dry-run gate approves implementation.",
+            "create_in_v0_1": False,
+            "contains_executor_code_in_v0_1": False,
+            "writes_files_in_v0_1": False,
+        },
+        {
+            "path": "benchmarks/hermes_memory_bench/fixtures/smoke_cases.json",
+            "purpose": "Future smoke coverage for real executor behavior only after executor implementation is separately approved.",
+            "create_in_v0_1": False,
+            "contains_executor_code_in_v0_1": False,
+            "writes_files_in_v0_1": False,
+        },
+    ]
+
+
+def _implementation_plan_idempotency_strategy() -> dict[str, Any]:
+    return {
+        "strategy": "future_hash_guarded_token_and_audit_pair",
+        "v0_1_effect": "plan_only_no_idempotency_state_written",
+        "identity_inputs": [
+            "source_contract_review_outcome_id",
+            "source_contract_id",
+            "approval_token_write_payload_preview",
+            "approval_audit_write_payload_preview",
+            "token_write_target_paths_preview",
+        ],
+        "future_rules": [
+            "derive_deterministic_write_fingerprint_before_any_future_write",
+            "treat_existing_matching_token_and_audit_pair_as_idempotent_success_only_after_revalidation",
+            "abort_on_existing_mismatched_token_or_audit_payload",
+            "never_use_operation_ledger_creation_as_idempotency_evidence_in_v0_1",
+        ],
+    }
+
+
+def _implementation_plan_filesystem_safety_model() -> dict[str, Any]:
+    return {
+        "model": "future_preview_path_confinement_and_atomic_pair_write",
+        "v0_1_effect": "no_filesystem_write_or_directory_creation",
+        "future_checks": [
+            "resolve_paths_from_token_write_target_paths_preview_only",
+            "reject_absolute_paths_outside_hermes_memory_approval_token_scope",
+            "reject_parent_directory_traversal_and_symlink_targets",
+            "require_atomic_temp_file_replace_in_same_directory",
+            "require_token_and_audit_write_pair_to_commit_or_abort_together",
+            "fsync_file_and_directory_before_success_if_future_executor_is_approved",
+        ],
+    }
+
+
+def _implementation_plan_audit_strategy() -> dict[str, Any]:
+    return {
+        "strategy": "preview_only_audit_plan",
+        "v0_1_effect": "no_approval_audit_file_write_and_no_operation_ledger_event",
+        "future_audit_fields": [
+            "source_contract_review_outcome_id",
+            "source_contract_id",
+            "source_write_final_gate_id",
+            "block_id",
+            "block_type",
+            "project_scope",
+            "write_fingerprint",
+            "approval_token_target_path",
+            "approval_audit_target_path",
+        ],
+        "future_rules": [
+            "audit_payload_must_derive_from_approval_audit_write_payload_preview",
+            "audit_record_must_not_create_operation_ledger_events",
+            "audit_success_requires_token_and_audit_payload_hash_match",
+        ],
+    }
+
+
+def _implementation_plan_rollback_strategy() -> dict[str, Any]:
+    return {
+        "strategy": "no_write_no_rollback_in_v0_1",
+        "v0_1_effect": "no_rollback_action_because_no_write_is_performed",
+        "future_rules": [
+            "abort_before_first_write_when_any_preflight_check_fails",
+            "remove_only_future_temp_files_created_by_same_executor_attempt",
+            "never_delete_preexisting_token_or_audit_files",
+            "treat_partial_commit_as_failed_and_require_manual_recovery_packet",
+            "never_rollback_by_writing_memory_graph_proposal_or_operation_ledger_state",
+        ],
+    }
+
+
+def _implementation_plan_test_plan() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "approved_contract_review_outcome_requires_implementation_plan",
+            "scope": "unit",
+            "writes": False,
+        },
+        {
+            "id": "non_approved_or_invalid_contract_review_outcome_locks_plan",
+            "scope": "unit",
+            "writes": False,
+        },
+        {
+            "id": "missing_previews_executor_fields_or_source_evidence_lock_plan",
+            "scope": "unit",
+            "writes": False,
+        },
+        {
+            "id": "preview_and_contract_review_integrity_failures_lock_plan",
+            "scope": "unit",
+            "writes": False,
+        },
+        {
+            "id": "deterministic_interfaces_files_idempotency_filesystem_audit_rollback_and_tests",
+            "scope": "unit",
+            "writes": False,
+        },
+        {
+            "id": "benchmark_smoke_case_stays_read_only_and_executor_free",
+            "scope": "benchmark",
+            "writes": False,
+        },
+    ]
+
+
+def _implementation_plan_forbidden_actions() -> list[str]:
+    return [
+        "write_memory",
+        "write_memory_graph",
+        "modify_openclaw_config",
+        "approve_allowlists",
+        "create_proposal_events",
+        "create_operation_ledger_events",
+        "create_real_memory_proposals",
+        "write_proposal_files",
+        "write_operation_ledger",
+        "issue_real_approval_tokens",
+        "persist_approvals",
+        "write_token_files",
+        "write_approval_audit_files",
+        "invoke_real_token_write_executor",
+        "implement_real_token_write_executor",
+        "submit_to_governance",
+        "convert_to_real_proposal",
+    ]
+
+
+def _plan_id(plan: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_VERSION,
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_contract_review_outcome_id": plan.get(
+            "source_contract_review_outcome_id"
+        ),
+        "source_contract_id": plan.get("source_contract_id"),
+        "source_write_final_gate_id": plan.get("source_write_final_gate_id"),
+        "source_write_execution_dry_run_id": plan.get(
+            "source_write_execution_dry_run_id"
+        ),
+        "source_write_execution_plan_id": plan.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": plan.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": plan.get(
+            "source_final_confirmation_request_id"
+        ),
+        "source_token_write_lock_gate_id": plan.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": plan.get(
+            "source_token_issuance_dry_run_id"
+        ),
+        "source_token_issuance_plan_id": plan.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": plan.get("source_review_outcome_id"),
+        "source_request_id": plan.get("source_request_id"),
+        "source_gate_id": plan.get("source_gate_id"),
+        "source_dry_run_id": plan.get("source_dry_run_id"),
+        "source_plan_id": plan.get("source_plan_id"),
+        "source_outcome_id": plan.get("source_outcome_id"),
+        "source_packet_id": plan.get("source_packet_id"),
+        "source_submission_id": plan.get("source_submission_id"),
+        "source_draft_id": plan.get("source_draft_id"),
+        "source_decision_id": plan.get("source_decision_id"),
+        "source_queue_item_id": plan.get("source_queue_item_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "implementer": plan.get("implementer"),
+        "outcome": plan.get("outcome"),
+        "rationale": plan.get("rationale"),
+        "approval_token_record_preview": plan.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": plan.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": plan.get("token_target_paths_preview", {}),
+        "proposal_record_preview": plan.get("proposal_record_preview", {}),
+        "operation_ledger_preview": plan.get("operation_ledger_preview", {}),
+        "target_paths_preview": plan.get("target_paths_preview", {}),
+        "payload_preview": plan.get("payload_preview"),
+        "source_pattern_ids": list(plan.get("source_pattern_ids", [])),
+        "source_fact_ids": list(plan.get("source_fact_ids", [])),
+        "token_write_execution_steps": list(
+            plan.get("token_write_execution_steps", [])
+        ),
+        "token_write_execution_preflight_checks": list(
+            plan.get("token_write_execution_preflight_checks", [])
+        ),
+        "approval_token_write_payload_preview": plan.get(
+            "approval_token_write_payload_preview", {}
+        ),
+        "approval_audit_write_payload_preview": plan.get(
+            "approval_audit_write_payload_preview", {}
+        ),
+        "token_write_target_paths_preview": plan.get(
+            "token_write_target_paths_preview", {}
+        ),
+        "final_token_write_preflight_checklist": list(
+            plan.get("final_token_write_preflight_checklist") or []
+        ),
+        "final_gate_checklist": list(plan.get("final_gate_checklist") or []),
+        "executor_contract_inputs": plan.get("executor_contract_inputs", {}),
+        "executor_hard_lock_checks": list(plan.get("executor_hard_lock_checks") or []),
+        "executor_audit_fields": list(plan.get("executor_audit_fields") or []),
+        "executor_rollback_rules": list(plan.get("executor_rollback_rules") or []),
+        "executor_forbidden_side_effects": list(
+            plan.get("executor_forbidden_side_effects") or []
+        ),
+        "executor_contract_checklist": list(
+            plan.get("executor_contract_checklist") or []
+        ),
+        "contract_review_checklist": list(plan.get("contract_review_checklist") or []),
+        "implementation_plan_interfaces": plan.get("implementation_plan_interfaces", []),
+        "implementation_plan_files": plan.get("implementation_plan_files", []),
+        "implementation_plan_idempotency_strategy": plan.get(
+            "implementation_plan_idempotency_strategy", {}
+        ),
+        "implementation_plan_filesystem_safety_model": plan.get(
+            "implementation_plan_filesystem_safety_model", {}
+        ),
+        "implementation_plan_audit_strategy": plan.get(
+            "implementation_plan_audit_strategy", {}
+        ),
+        "implementation_plan_rollback_strategy": plan.get(
+            "implementation_plan_rollback_strategy", {}
+        ),
+        "implementation_plan_test_plan": plan.get("implementation_plan_test_plan", []),
+        "implementation_plan_forbidden_actions": list(
+            plan.get("implementation_plan_forbidden_actions") or []
+        ),
+        "contract_review_outcome_validation": plan.get(
+            "contract_review_outcome_validation", {}
+        ),
+        "policy": plan.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return (
+        "memory-human-approval-token-real-write-executor-implementation-plan:"
+        f"v0.1:{digest}"
+    )
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_request.py
+++ b/agent/memory_human_approval_token_request.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
+)
 from agent.memory_real_proposal_write_lock_gate import (
     MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE,
     MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED,
@@ -209,12 +214,8 @@ def validate_human_approval_token_request(request: Mapping[str, Any]) -> dict[st
     if not isinstance(request.get("approval_token_requirements"), list) or not request.get("approval_token_requirements"):
         errors.append("approval_token_requirements_must_be_non_empty_list")
     errors.extend(preview_integrity_errors)
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if request.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(request, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -292,17 +293,12 @@ def recommend_human_approval_token_request_action(request: Mapping[str, Any]) ->
 def summarize_human_approval_token_requests(
     requests: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(requests, "request_status")
     locked_count = 0
     review_required_count = 0
     valid_count = 0
     invalid_count = 0
     for request in requests:
-        block_type = str(request.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(request.get("request_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED:
             locked_count += 1
         if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED:
@@ -318,8 +314,8 @@ def summarize_human_approval_token_requests(
         "review_required_count": review_required_count,
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY),
     }
 
@@ -451,12 +447,11 @@ def _request_id(request: Mapping[str, Any]) -> str:
         "write_lock_gate_validation": request.get("write_lock_gate_validation", {}),
         "policy": request.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-request:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-human-approval-token-request:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_request.py
+++ b/agent/memory_human_approval_token_request.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_real_proposal_write_lock_gate import (
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE,
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED,
+    explain_real_proposal_write_lock_gate,
+    recommend_real_proposal_write_lock_action,
+    validate_real_proposal_write_lock_gate,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_KIND = "memory_human_approval_token_request_candidate"
+MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED = "approval_token_review_required"
+MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_ROUTING = "manual_human_approval_token_review_required"
+MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_approval_token_requests_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_REQUESTER = "hermes_memory_human_approval_token_request_v0.1"
+_PREVIEW_FIELDS = (
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "converted_to_real_proposal",
+)
+_LOCK_REASONS = {
+    None,
+    "invalid_write_lock_gate",
+    "invalid_real_proposal_dry_run",
+    "write_lock_gate_locked",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+}
+
+
+def create_human_approval_token_request(
+    write_lock_gate: Mapping[str, Any],
+    requester: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only human approval token request candidate."""
+    source = deepcopy(dict(write_lock_gate))
+    write_lock_gate_validation = validate_real_proposal_write_lock_gate(source)
+    lock_reason = _request_lock_reason(source, write_lock_gate_validation)
+    request_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+    )
+
+    request = {
+        "request_id": None,
+        "request_kind": MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_KIND,
+        "request_status": request_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_ROUTING,
+        "lock_reason": lock_reason,
+        "source_gate_id": source.get("gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "requester": requester if requester is not None else _DEFAULT_REQUESTER,
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "approval_request_checklist": _approval_request_checklist(),
+        "approval_token_requirements": _approval_token_requirements(),
+        "write_lock_gate_validation": deepcopy(write_lock_gate_validation),
+        "request_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_write_lock_gate_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY),
+    }
+    request["request_id"] = _request_id(request)
+    request["request_validation"] = validate_human_approval_token_request(request)
+    request["next_step_recommendation"] = recommend_human_approval_token_request_action(request)
+    return request
+
+
+def validate_human_approval_token_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(request.get("policy"))
+    source_snapshot = _as_dict(request.get("source_write_lock_gate_snapshot"))
+    write_lock_gate_validation = _as_dict(request.get("write_lock_gate_validation"))
+    expected_write_lock_gate_validation = validate_real_proposal_write_lock_gate(source_snapshot)
+    expected_lock_reason = _request_lock_reason(source_snapshot, write_lock_gate_validation)
+    preview_integrity_errors = _preview_integrity_errors(request)
+
+    for key in (
+        "request_id",
+        "request_kind",
+        "request_status",
+        "routing",
+        "lock_reason",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "requester",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "approval_request_checklist",
+        "approval_token_requirements",
+        "write_lock_gate_validation",
+        "request_validation",
+        "next_step_recommendation",
+        "source_write_lock_gate_snapshot",
+        "policy",
+    ):
+        if key not in request:
+            errors.append(f"missing_{key}")
+    if request.get("request_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_KIND:
+        errors.append("request_kind_must_be_memory_human_approval_token_request_candidate")
+    if request.get("request_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED,
+    }:
+        errors.append("request_status_must_be_supported")
+    if request.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_ROUTING:
+        errors.append("routing_must_require_manual_human_approval_token_review")
+    if request.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if request.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_approval_token_request_checks")
+    if expected_lock_reason is None and request.get("request_status") != MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED:
+        errors.append("eligible_write_lock_gate_must_require_approval_token_review")
+    if expected_lock_reason is not None and request.get("request_status") != MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED:
+        errors.append("locked_or_invalid_write_lock_gate_must_lock_request")
+    if not isinstance(request.get("requester"), str) or not request.get("requester"):
+        errors.append("requester_must_be_non_empty_string")
+    if write_lock_gate_validation != expected_write_lock_gate_validation:
+        errors.append("write_lock_gate_validation_must_match_source_write_lock_gate_snapshot")
+    if (
+        write_lock_gate_validation.get("valid") is True
+        and source_snapshot.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE
+        and request.get("request_status") != MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED
+    ):
+        errors.append("eligible_write_lock_gate_must_not_lock_request")
+    if source_snapshot.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED:
+        expected_source_reason = source_snapshot.get("lock_reason") or "write_lock_gate_locked"
+        if request.get("lock_reason") != expected_source_reason:
+            errors.append("locked_write_lock_gate_reason_must_be_preserved")
+    if not isinstance(request.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(request.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(request.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(request.get("source_pattern_ids"), list) and isinstance(request.get("source_fact_ids"), list):
+        if not request.get("source_pattern_ids") and not request.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(request.get("approval_request_checklist"), list) or not request.get("approval_request_checklist"):
+        errors.append("approval_request_checklist_must_be_non_empty_list")
+    if not isinstance(request.get("approval_token_requirements"), list) or not request.get("approval_token_requirements"):
+        errors.append("approval_token_requirements_must_be_non_empty_list")
+    errors.extend(preview_integrity_errors)
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if request.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_request(request)
+    source_snapshot = _as_dict(request.get("source_write_lock_gate_snapshot"))
+    return {
+        "request_id": request.get("request_id"),
+        "request_kind": request.get("request_kind"),
+        "request_status": request.get("request_status"),
+        "routing": request.get("routing"),
+        "lock_reason": request.get("lock_reason"),
+        "source_gate_id": request.get("source_gate_id"),
+        "source_dry_run_id": request.get("source_dry_run_id"),
+        "source_plan_id": request.get("source_plan_id"),
+        "source_outcome_id": request.get("source_outcome_id"),
+        "source_packet_id": request.get("source_packet_id"),
+        "source_submission_id": request.get("source_submission_id"),
+        "source_draft_id": request.get("source_draft_id"),
+        "source_decision_id": request.get("source_decision_id"),
+        "source_queue_item_id": request.get("source_queue_item_id"),
+        "block_id": request.get("block_id"),
+        "block_type": request.get("block_type"),
+        "project_scope": request.get("project_scope"),
+        "requester": request.get("requester"),
+        "source_pattern_count": len(request.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(request.get("source_fact_ids", []) or []),
+        "approval_request_checklist": deepcopy(request.get("approval_request_checklist")),
+        "approval_token_requirements": deepcopy(request.get("approval_token_requirements")),
+        "validation": validation,
+        "write_lock_gate_explanation": explain_real_proposal_write_lock_gate(source_snapshot) if source_snapshot else {},
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY),
+    }
+
+
+def recommend_human_approval_token_request_action(request: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_request(request)
+    source_snapshot = _as_dict(request.get("source_write_lock_gate_snapshot"))
+    if validation["valid"] and request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED:
+        action = "perform_manual_human_approval_token_review_without_issuing_token"
+        reason = "Request candidate is ready for manual human review; it does not issue or persist an approval token."
+    else:
+        action = "keep_approval_token_request_locked"
+        reason = _recommendation_reason(request.get("lock_reason"), validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_ROUTING,
+        "validation": validation,
+        "write_lock_gate_recommendation": recommend_real_proposal_write_lock_action(source_snapshot) if source_snapshot else {},
+        "creates_approval_token_requests_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY),
+    }
+
+
+def summarize_human_approval_token_requests(
+    requests: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    locked_count = 0
+    review_required_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for request in requests:
+        block_type = str(request.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(request.get("request_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED:
+            locked_count += 1
+        if request.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED:
+            review_required_count += 1
+        validation = validate_human_approval_token_request(request)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(requests),
+        "locked_count": locked_count,
+        "review_required_count": review_required_count,
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY),
+    }
+
+
+def _request_lock_reason(source: Mapping[str, Any], write_lock_gate_validation: Mapping[str, Any]) -> str | None:
+    if not isinstance(source.get("proposal_record_preview"), Mapping):
+        return "missing_proposal_record_preview"
+    if not isinstance(source.get("operation_ledger_preview"), Mapping):
+        return "missing_operation_ledger_preview"
+    if not isinstance(source.get("target_paths_preview"), Mapping):
+        return "missing_target_paths_preview"
+    if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(source):
+        return "preview_integrity_failed"
+    if write_lock_gate_validation.get("valid") is not True:
+        return "invalid_write_lock_gate"
+    if source.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED:
+        return source.get("lock_reason") or "write_lock_gate_locked"
+    if source.get("gate_status") != MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE:
+        return "invalid_write_lock_gate"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and ("written" in key or "created" in key):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _approval_request_checklist() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "verify_write_lock_gate_validation",
+            "description": "Confirm the source write-lock gate is valid and eligible for human approval token review.",
+        },
+        {
+            "id": "verify_preview_artifacts_only",
+            "description": "Confirm proposal, operation-ledger, and target-path artifacts are previews only.",
+        },
+        {
+            "id": "verify_no_token_or_approval_persistence",
+            "description": "Confirm this request does not issue tokens or persist approvals.",
+        },
+        {
+            "id": "verify_no_real_proposal_or_ledger_write",
+            "description": "Confirm this request creates no real proposal records, files, or operation-ledger events.",
+        },
+        {
+            "id": "route_to_manual_human_approval_token_review",
+            "description": "Route the request candidate to manual human approval token review.",
+        },
+    ]
+
+
+def _approval_token_requirements() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "human_reviewer_required",
+            "description": "A human reviewer must inspect the request before any separate approval token flow.",
+        },
+        {
+            "id": "approval_token_must_be_external_to_request",
+            "description": "Any real approval token must be issued outside this read-only request candidate.",
+        },
+        {
+            "id": "real_write_requires_later_governed_step",
+            "description": "Any real proposal write requires a later governed operation outside this module.",
+        },
+    ]
+
+
+def _recommendation_reason(lock_reason: Any, validation: Mapping[str, Any]) -> str:
+    if lock_reason == "invalid_write_lock_gate":
+        return "Source write-lock gate is invalid."
+    if lock_reason == "write_lock_gate_locked":
+        return "Source write-lock gate remains locked."
+    if lock_reason == "missing_proposal_record_preview":
+        return "Approval token request is missing the proposal record preview."
+    if lock_reason == "missing_operation_ledger_preview":
+        return "Approval token request is missing the operation-ledger preview."
+    if lock_reason == "missing_target_paths_preview":
+        return "Approval token request is missing the target paths preview."
+    if lock_reason == "missing_source_evidence":
+        return "Approval token request is missing source pattern or fact evidence."
+    if lock_reason == "preview_integrity_failed":
+        return "Approval token request preview artifacts are not preview-only or include written/created flags."
+    if validation.get("errors"):
+        return "Approval token request violates the v0.1 validation contract."
+    return "Approval token request remains locked until the source write-lock gate is eligible."
+
+
+def _request_id(request: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_VERSION,
+        "request_kind": request.get("request_kind"),
+        "request_status": request.get("request_status"),
+        "routing": request.get("routing"),
+        "lock_reason": request.get("lock_reason"),
+        "source_gate_id": request.get("source_gate_id"),
+        "source_dry_run_id": request.get("source_dry_run_id"),
+        "source_plan_id": request.get("source_plan_id"),
+        "source_outcome_id": request.get("source_outcome_id"),
+        "source_packet_id": request.get("source_packet_id"),
+        "source_submission_id": request.get("source_submission_id"),
+        "source_draft_id": request.get("source_draft_id"),
+        "source_decision_id": request.get("source_decision_id"),
+        "source_queue_item_id": request.get("source_queue_item_id"),
+        "block_id": request.get("block_id"),
+        "block_type": request.get("block_type"),
+        "project_scope": request.get("project_scope"),
+        "requester": request.get("requester"),
+        "proposal_record_preview": request.get("proposal_record_preview", {}),
+        "operation_ledger_preview": request.get("operation_ledger_preview", {}),
+        "target_paths_preview": request.get("target_paths_preview", {}),
+        "payload_preview": request.get("payload_preview"),
+        "source_pattern_ids": list(request.get("source_pattern_ids", [])),
+        "source_fact_ids": list(request.get("source_fact_ids", [])),
+        "approval_request_checklist": request.get("approval_request_checklist", []),
+        "approval_token_requirements": request.get("approval_token_requirements", []),
+        "write_lock_gate_validation": request.get("write_lock_gate_validation", {}),
+        "policy": request.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-request:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_review_gate.py
+++ b/agent/memory_human_approval_token_review_gate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_request import (
     explain_human_approval_token_request,
     recommend_human_approval_token_request_action,
     validate_human_approval_token_request,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -208,12 +213,10 @@ def validate_human_approval_token_review_outcome(outcome_candidate: Mapping[str,
         snapshot_validation = validate_human_approval_token_request(source_snapshot)
         if snapshot_validation != request_validation:
             errors.append("request_validation_must_match_source_request_snapshot")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if outcome_candidate.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(
+        validate_forbidden_true_keys_false_or_absent(outcome_candidate, _FORBIDDEN_TRUE_KEYS)
+    )
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -300,30 +303,26 @@ def recommend_human_approval_token_review_action(outcome_candidate: Mapping[str,
 def summarize_human_approval_token_review_outcomes(
     outcomes: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_outcome: dict[str, int] = {}
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(
+        outcomes,
+        "review_outcome_status",
+        type_key="outcome",
+    )
     valid_count = 0
     invalid_count = 0
     for outcome_candidate in outcomes:
-        outcome = str(outcome_candidate.get("outcome"))
-        by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
-        block_type = str(outcome_candidate.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(outcome_candidate.get("review_outcome_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         validation = validate_human_approval_token_review_outcome(outcome_candidate)
         if validation["valid"]:
             valid_count += 1
         else:
             invalid_count += 1
     return {
-        "total": len(outcomes),
+        "total": candidate_summary["total"],
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_outcome": dict(sorted(by_outcome.items())),
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_outcome": candidate_summary["by_type"],
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
     }
 
@@ -396,8 +395,7 @@ def _review_outcome_id(candidate: Mapping[str, Any]) -> str:
         "request_validation": candidate.get("request_validation", {}),
         "policy": candidate.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-review-outcome:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-human-approval-token-review-outcome:v0.1", identity)
 
 
 def _contains_any(values: list[str], targets: tuple[str, ...]) -> bool:
@@ -405,7 +403,7 @@ def _contains_any(values: list[str], targets: tuple[str, ...]) -> bool:
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_review_gate.py
+++ b/agent/memory_human_approval_token_review_gate.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_request import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED,
+    explain_human_approval_token_request,
+    recommend_human_approval_token_request_action,
+    validate_human_approval_token_request,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_KIND = "memory_human_approval_token_review_outcome_candidate"
+MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_STATUS = "token_review_outcome_candidate"
+MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_ROUTING = "manual_token_issuance_still_required"
+SUPPORTED_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOMES = (
+    "approve_token_issuance",
+    "request_changes",
+    "reject",
+    "defer",
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_review_outcome_candidates_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "converted_to_real_proposal",
+)
+
+
+def create_human_approval_token_review_outcome(
+    request_candidate: Mapping[str, Any],
+    reviewer: str | None = None,
+    outcome: str | None = None,
+    rationale: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only human approval token review outcome candidate."""
+    source = deepcopy(dict(request_candidate))
+    request_validation = validate_human_approval_token_request(source)
+    evaluation = evaluate_human_approval_token_request(source, reviewer=reviewer)
+    selected_outcome = outcome if outcome is not None else evaluation["outcome"]
+    selected_rationale = (
+        rationale
+        if rationale is not None
+        else _outcome_rationale(selected_outcome, source, request_validation, explicit=outcome is not None)
+    )
+
+    candidate = {
+        "review_outcome_id": None,
+        "review_outcome_kind": MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_KIND,
+        "review_outcome_status": MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_STATUS,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_ROUTING,
+        "source_request_id": source.get("request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "reviewer": reviewer if reviewer is not None else source.get("requester"),
+        "outcome": selected_outcome,
+        "rationale": selected_rationale,
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "request_validation": deepcopy(request_validation),
+        "review_outcome_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_request_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
+    }
+    candidate["review_outcome_id"] = _review_outcome_id(candidate)
+    candidate["review_outcome_validation"] = validate_human_approval_token_review_outcome(candidate)
+    candidate["next_step_recommendation"] = recommend_human_approval_token_review_action(candidate)
+    return candidate
+
+
+def evaluate_human_approval_token_request(
+    request_candidate: Mapping[str, Any],
+    reviewer: str | None = None,
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_request(request_candidate)
+    errors = list(validation.get("errors", []) or [])
+    if validation.get("valid") is not True:
+        if _contains_any(errors, ("missing_proposal_record_preview", "missing_operation_ledger_preview", "missing_target_paths_preview", "missing_source_evidence")):
+            outcome = "request_changes"
+        else:
+            outcome = "reject"
+    elif request_candidate.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED:
+        outcome = "reject"
+    elif not isinstance(request_candidate.get("proposal_record_preview"), Mapping):
+        outcome = "request_changes"
+    elif not isinstance(request_candidate.get("operation_ledger_preview"), Mapping):
+        outcome = "request_changes"
+    elif not isinstance(request_candidate.get("target_paths_preview"), Mapping):
+        outcome = "request_changes"
+    elif not (request_candidate.get("source_pattern_ids") or request_candidate.get("source_fact_ids")):
+        outcome = "request_changes"
+    elif request_candidate.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED:
+        outcome = "approve_token_issuance"
+    else:
+        outcome = "defer"
+    return {
+        "outcome": outcome,
+        "rationale": _outcome_rationale(outcome, request_candidate, validation),
+        "reviewer": reviewer if reviewer is not None else request_candidate.get("requester"),
+        "request_validation": validation,
+        "request_explanation": explain_human_approval_token_request(request_candidate),
+        "request_recommendation": recommend_human_approval_token_request_action(request_candidate),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
+    }
+
+
+def validate_human_approval_token_review_outcome(outcome_candidate: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(outcome_candidate.get("policy"))
+    request_validation = _as_dict(outcome_candidate.get("request_validation"))
+    source_snapshot = _as_dict(outcome_candidate.get("source_request_snapshot"))
+
+    for key in (
+        "review_outcome_id",
+        "review_outcome_kind",
+        "review_outcome_status",
+        "routing",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "reviewer",
+        "outcome",
+        "rationale",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "request_validation",
+        "review_outcome_validation",
+        "next_step_recommendation",
+        "source_request_snapshot",
+        "policy",
+    ):
+        if key not in outcome_candidate:
+            errors.append(f"missing_{key}")
+    if outcome_candidate.get("review_outcome_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_KIND:
+        errors.append("review_outcome_kind_must_be_memory_human_approval_token_review_outcome_candidate")
+    if outcome_candidate.get("review_outcome_status") != MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_STATUS:
+        errors.append("review_outcome_status_must_be_token_review_outcome_candidate")
+    if outcome_candidate.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_ROUTING:
+        errors.append("routing_must_require_manual_token_issuance_still_required")
+    if outcome_candidate.get("outcome") not in SUPPORTED_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOMES:
+        errors.append("unsupported_human_approval_token_review_outcome")
+    if not isinstance(outcome_candidate.get("rationale"), str) or not outcome_candidate.get("rationale"):
+        errors.append("rationale_must_be_non_empty_string")
+    if not isinstance(outcome_candidate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(outcome_candidate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if not isinstance(request_validation.get("valid"), bool):
+        errors.append("request_validation_must_include_boolean_valid")
+    if source_snapshot:
+        snapshot_validation = validate_human_approval_token_request(source_snapshot)
+        if snapshot_validation != request_validation:
+            errors.append("request_validation_must_match_source_request_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if outcome_candidate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_review_outcome(outcome_candidate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_review_outcome(outcome_candidate)
+    source_snapshot = _as_dict(outcome_candidate.get("source_request_snapshot"))
+    return {
+        "review_outcome_id": outcome_candidate.get("review_outcome_id"),
+        "review_outcome_kind": outcome_candidate.get("review_outcome_kind"),
+        "review_outcome_status": outcome_candidate.get("review_outcome_status"),
+        "routing": outcome_candidate.get("routing"),
+        "source_request_id": outcome_candidate.get("source_request_id"),
+        "source_gate_id": outcome_candidate.get("source_gate_id"),
+        "source_dry_run_id": outcome_candidate.get("source_dry_run_id"),
+        "source_plan_id": outcome_candidate.get("source_plan_id"),
+        "source_outcome_id": outcome_candidate.get("source_outcome_id"),
+        "source_packet_id": outcome_candidate.get("source_packet_id"),
+        "source_submission_id": outcome_candidate.get("source_submission_id"),
+        "source_draft_id": outcome_candidate.get("source_draft_id"),
+        "source_decision_id": outcome_candidate.get("source_decision_id"),
+        "source_queue_item_id": outcome_candidate.get("source_queue_item_id"),
+        "block_id": outcome_candidate.get("block_id"),
+        "block_type": outcome_candidate.get("block_type"),
+        "project_scope": outcome_candidate.get("project_scope"),
+        "reviewer": outcome_candidate.get("reviewer"),
+        "outcome": outcome_candidate.get("outcome"),
+        "rationale": outcome_candidate.get("rationale"),
+        "source_pattern_count": len(outcome_candidate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(outcome_candidate.get("source_fact_ids", []) or []),
+        "validation": validation,
+        "request_explanation": explain_human_approval_token_request(source_snapshot) if source_snapshot else {},
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
+    }
+
+
+def recommend_human_approval_token_review_action(outcome_candidate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_review_outcome(outcome_candidate)
+    outcome = outcome_candidate.get("outcome")
+    if not validation["valid"]:
+        action = "do_not_use_token_review_outcome_candidate"
+        reason = _recommendation_reason(validation)
+    elif outcome == "approve_token_issuance":
+        action = "manual_token_issuance_still_required"
+        reason = "Review outcome candidate approves a separate manual token issuance flow, but this gate does not issue, persist, submit, or apply a token."
+    elif outcome == "request_changes":
+        action = "return_approval_token_request_for_changes"
+        reason = "Review outcome candidate requests changes before any separate token issuance flow."
+    elif outcome == "reject":
+        action = "do_not_issue_approval_token"
+        reason = "Review outcome candidate rejects token issuance for this request."
+    else:
+        action = "defer_manual_token_review_outcome"
+        reason = "Review outcome candidate defers until a human reviewer resolves the unknown condition."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_ROUTING,
+        "validation": validation,
+        "request_recommendation": recommend_human_approval_token_request_action(_as_dict(outcome_candidate.get("source_request_snapshot"))),
+        "creates_review_outcome_candidates_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
+    }
+
+
+def summarize_human_approval_token_review_outcomes(
+    outcomes: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_outcome: dict[str, int] = {}
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for outcome_candidate in outcomes:
+        outcome = str(outcome_candidate.get("outcome"))
+        by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
+        block_type = str(outcome_candidate.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(outcome_candidate.get("review_outcome_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        validation = validate_human_approval_token_review_outcome(outcome_candidate)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(outcomes),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_outcome": dict(sorted(by_outcome.items())),
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
+    }
+
+
+def _outcome_rationale(
+    outcome: str,
+    request_candidate: Mapping[str, Any],
+    request_validation: Mapping[str, Any],
+    explicit: bool = False,
+) -> str:
+    if explicit and outcome in SUPPORTED_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOMES:
+        return "Explicit supported approval token review outcome override recorded as a read-only candidate only."
+    errors = list(request_validation.get("errors", []) or [])
+    if outcome == "approve_token_issuance":
+        return "Request is valid, review-required, and includes preview artifacts plus source evidence."
+    if outcome == "request_changes" and "missing_proposal_record_preview" in errors:
+        return "Request is missing proposal_record_preview required before token issuance review."
+    if outcome == "request_changes" and "missing_operation_ledger_preview" in errors:
+        return "Request is missing operation_ledger_preview required before token issuance review."
+    if outcome == "request_changes" and "missing_target_paths_preview" in errors:
+        return "Request is missing target_paths_preview required before token issuance review."
+    if outcome == "request_changes" and "missing_source_evidence" in errors:
+        return "Request is missing source pattern or fact evidence required before token issuance review."
+    if outcome == "reject" and request_candidate.get("request_status") == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED:
+        return "Request candidate is locked and cannot proceed to token issuance review."
+    if outcome == "reject":
+        return "Request candidate is invalid for human approval token review."
+    if outcome == "defer":
+        return "Request condition is unknown for v0.1 and must be deferred."
+    return "Approval token review outcome is unsupported by v0.1."
+
+
+def _recommendation_reason(validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if "unsupported_human_approval_token_review_outcome" in errors:
+        return "Review outcome candidate uses an unsupported approval token review outcome label."
+    if "request_validation_must_match_source_request_snapshot" in errors:
+        return "Review outcome candidate request validation does not match its source request snapshot."
+    return "Review outcome candidate violates the v0.1 approval token review validation contract."
+
+
+def _review_outcome_id(candidate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_VERSION,
+        "review_outcome_kind": candidate.get("review_outcome_kind"),
+        "review_outcome_status": candidate.get("review_outcome_status"),
+        "routing": candidate.get("routing"),
+        "source_request_id": candidate.get("source_request_id"),
+        "source_gate_id": candidate.get("source_gate_id"),
+        "source_dry_run_id": candidate.get("source_dry_run_id"),
+        "source_plan_id": candidate.get("source_plan_id"),
+        "source_outcome_id": candidate.get("source_outcome_id"),
+        "source_packet_id": candidate.get("source_packet_id"),
+        "source_submission_id": candidate.get("source_submission_id"),
+        "source_draft_id": candidate.get("source_draft_id"),
+        "source_decision_id": candidate.get("source_decision_id"),
+        "source_queue_item_id": candidate.get("source_queue_item_id"),
+        "block_id": candidate.get("block_id"),
+        "block_type": candidate.get("block_type"),
+        "project_scope": candidate.get("project_scope"),
+        "reviewer": candidate.get("reviewer"),
+        "outcome": candidate.get("outcome"),
+        "rationale": candidate.get("rationale"),
+        "proposal_record_preview": candidate.get("proposal_record_preview", {}),
+        "operation_ledger_preview": candidate.get("operation_ledger_preview", {}),
+        "target_paths_preview": candidate.get("target_paths_preview", {}),
+        "payload_preview": candidate.get("payload_preview"),
+        "source_pattern_ids": list(candidate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(candidate.get("source_fact_ids", [])),
+        "request_validation": candidate.get("request_validation", {}),
+        "policy": candidate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-review-outcome:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _contains_any(values: list[str], targets: tuple[str, ...]) -> bool:
+    return any(target in values for target in targets)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_write_execution_dry_run.py
+++ b/agent/memory_human_approval_token_write_execution_dry_run.py
@@ -1,0 +1,719 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_write_execution_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED,
+    explain_human_approval_token_write_execution_plan,
+    recommend_human_approval_token_write_execution_plan_action,
+    validate_human_approval_token_write_execution_plan,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_KIND = (
+    "memory_human_approval_token_write_execution_dry_run_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED = (
+    "manual_token_write_final_preflight_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_ROUTING = (
+    "manual_token_write_final_gate_required_before_any_token_write"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_token_write_execution_dry_run_candidates_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = "hermes_memory_human_approval_token_write_execution_dry_run_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_LOCK_REASONS = {
+    None,
+    "token_write_execution_plan_locked",
+    "invalid_token_write_execution_plan",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+    "missing_token_write_execution_controls",
+    "preview_integrity_failed",
+    "final_confirmation_requested_changes",
+    "final_confirmation_rejected",
+    "final_confirmation_deferred",
+    "invalid_final_confirmation_review_outcome",
+}
+
+
+def create_human_approval_token_write_execution_dry_run(
+    write_execution_plan: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only token write execution dry-run candidate."""
+    source = deepcopy(dict(write_execution_plan))
+    write_execution_plan_validation = validate_human_approval_token_write_execution_plan(source)
+    lock_reason = _dry_run_lock_reason(source, write_execution_plan_validation)
+    dry_run_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED
+    )
+
+    dry_run = {
+        "dry_run_id": None,
+        "dry_run_kind": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_KIND,
+        "dry_run_status": dry_run_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_ROUTING,
+        "lock_reason": lock_reason,
+        "source_write_execution_plan_id": source.get("plan_id"),
+        "source_final_confirmation_review_outcome_id": source.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": source.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "outcome": source.get("outcome"),
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": deepcopy(
+            list(source.get("token_write_execution_steps", []) or [])
+        ),
+        "token_write_execution_preflight_checks": deepcopy(
+            list(source.get("token_write_execution_preflight_checks", []) or [])
+        ),
+        "approval_token_write_payload_preview": _approval_token_write_payload_preview(
+            source, operator
+        ),
+        "approval_audit_write_payload_preview": _approval_audit_write_payload_preview(
+            source, operator
+        ),
+        "token_write_target_paths_preview": _token_write_target_paths_preview(source, operator),
+        "final_token_write_preflight_checklist": _final_token_write_preflight_checklist(),
+        "write_execution_plan_validation": deepcopy(write_execution_plan_validation),
+        "dry_run_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_write_execution_plan_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY),
+    }
+    dry_run["dry_run_id"] = _dry_run_id(dry_run)
+    dry_run["dry_run_validation"] = validate_human_approval_token_write_execution_dry_run(dry_run)
+    dry_run["next_step_recommendation"] = (
+        recommend_human_approval_token_write_execution_dry_run_action(dry_run)
+    )
+    return dry_run
+
+
+def validate_human_approval_token_write_execution_dry_run(
+    dry_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(dry_run.get("policy"))
+    source_snapshot = _as_dict(dry_run.get("source_write_execution_plan_snapshot"))
+    plan_validation = _as_dict(dry_run.get("write_execution_plan_validation"))
+    expected_plan_validation = validate_human_approval_token_write_execution_plan(source_snapshot)
+    expected_lock_reason = _dry_run_lock_reason(source_snapshot, plan_validation)
+
+    for key in (
+        "dry_run_id",
+        "dry_run_kind",
+        "dry_run_status",
+        "routing",
+        "lock_reason",
+        "source_write_execution_plan_id",
+        "source_final_confirmation_review_outcome_id",
+        "source_final_confirmation_request_id",
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "operator",
+        "outcome",
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "token_write_execution_steps",
+        "token_write_execution_preflight_checks",
+        "approval_token_write_payload_preview",
+        "approval_audit_write_payload_preview",
+        "token_write_target_paths_preview",
+        "final_token_write_preflight_checklist",
+        "write_execution_plan_validation",
+        "dry_run_validation",
+        "next_step_recommendation",
+        "source_write_execution_plan_snapshot",
+        "policy",
+    ):
+        if key not in dry_run:
+            errors.append(f"missing_{key}")
+    if dry_run.get("dry_run_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_KIND:
+        errors.append(
+            "dry_run_kind_must_be_memory_human_approval_token_write_execution_dry_run_candidate"
+        )
+    if dry_run.get("dry_run_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED,
+    }:
+        errors.append("dry_run_status_must_be_supported")
+    if dry_run.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_ROUTING:
+        errors.append("routing_must_require_manual_token_write_final_gate_before_any_token_write")
+    if dry_run.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if dry_run.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_token_write_execution_dry_run_checks")
+    if (
+        expected_lock_reason is None
+        and dry_run.get("dry_run_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+    ):
+        errors.append("valid_token_write_execution_plan_must_require_final_preflight")
+    if (
+        expected_lock_reason is not None
+        and dry_run.get("dry_run_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED
+    ):
+        errors.append("invalid_or_locked_token_write_execution_plan_must_lock_dry_run")
+    if not isinstance(dry_run.get("operator"), str) or not dry_run.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if plan_validation != expected_plan_validation:
+        errors.append(
+            "write_execution_plan_validation_must_match_source_write_execution_plan_snapshot"
+        )
+    if dry_run.get("source_write_execution_plan_id") != source_snapshot.get("plan_id"):
+        errors.append("source_write_execution_plan_id_must_match_source_snapshot")
+    for source_key in (
+        "source_final_confirmation_review_outcome_id",
+        "source_final_confirmation_request_id",
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "outcome",
+    ):
+        if dry_run.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+    if not isinstance(dry_run.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(dry_run.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(dry_run.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(dry_run.get("source_pattern_ids"), list) and isinstance(
+        dry_run.get("source_fact_ids"), list
+    ):
+        if (
+            not dry_run.get("source_pattern_ids")
+            and not dry_run.get("source_fact_ids")
+            and dry_run.get("lock_reason") != "missing_source_evidence"
+        ):
+            errors.append("missing_source_evidence")
+    if (
+        not isinstance(dry_run.get("token_write_execution_steps"), list)
+        or not isinstance(dry_run.get("token_write_execution_preflight_checks"), list)
+    ) and dry_run.get("lock_reason") != "missing_token_write_execution_controls":
+        errors.append("missing_token_write_execution_controls")
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(dry_run.get(field), Mapping) and dry_run.get("lock_reason") != f"missing_{field}":
+            errors.append(f"missing_{field}")
+    if dry_run.get("lock_reason") != "preview_integrity_failed":
+        errors.extend(_preview_integrity_errors(dry_run))
+    if not isinstance(dry_run.get("approval_token_write_payload_preview"), Mapping):
+        errors.append("approval_token_write_payload_preview_must_be_mapping")
+    if not isinstance(dry_run.get("approval_audit_write_payload_preview"), Mapping):
+        errors.append("approval_audit_write_payload_preview_must_be_mapping")
+    if not isinstance(dry_run.get("token_write_target_paths_preview"), Mapping):
+        errors.append("token_write_target_paths_preview_must_be_mapping")
+    if dry_run.get("final_token_write_preflight_checklist") != _final_token_write_preflight_checklist():
+        errors.append("final_token_write_preflight_checklist_must_match_v0_1_deterministic_checks")
+    for field in _PREVIEW_FIELDS + ("payload_preview",):
+        if field in dry_run and field in source_snapshot and dry_run.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_write_execution_plan_snapshot")
+    if dry_run.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_write_execution_plan_snapshot")
+    if dry_run.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_write_execution_plan_snapshot")
+    if dry_run.get("token_write_execution_steps") != list(
+        source_snapshot.get("token_write_execution_steps", []) or []
+    ):
+        errors.append("token_write_execution_steps_must_match_source_write_execution_plan_snapshot")
+    if dry_run.get("token_write_execution_preflight_checks") != list(
+        source_snapshot.get("token_write_execution_preflight_checks", []) or []
+    ):
+        errors.append(
+            "token_write_execution_preflight_checks_must_match_source_write_execution_plan_snapshot"
+        )
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if dry_run.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_write_execution_dry_run(
+    dry_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_execution_dry_run(dry_run)
+    source_snapshot = _as_dict(dry_run.get("source_write_execution_plan_snapshot"))
+    return {
+        "dry_run_id": dry_run.get("dry_run_id"),
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "lock_reason": dry_run.get("lock_reason"),
+        "source_write_execution_plan_id": dry_run.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": dry_run.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "outcome": dry_run.get("outcome"),
+        "source_pattern_count": len(dry_run.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(dry_run.get("source_fact_ids", []) or []),
+        "token_write_execution_step_count": len(
+            dry_run.get("token_write_execution_steps", []) or []
+        ),
+        "token_write_execution_preflight_check_count": len(
+            dry_run.get("token_write_execution_preflight_checks", []) or []
+        ),
+        "final_token_write_preflight_checklist": deepcopy(
+            dry_run.get("final_token_write_preflight_checklist")
+        ),
+        "validation": validation,
+        "write_execution_plan_explanation": (
+            explain_human_approval_token_write_execution_plan(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY),
+    }
+
+
+def recommend_human_approval_token_write_execution_dry_run_action(
+    dry_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_execution_dry_run(dry_run)
+    source_snapshot = _as_dict(dry_run.get("source_write_execution_plan_snapshot"))
+    if (
+        validation["valid"]
+        and dry_run.get("dry_run_status")
+        == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+    ):
+        action = "route_to_manual_token_write_final_gate_without_issuing_token"
+        reason = "Token write execution dry-run candidate is ready for final manual gate review only; it does not issue, persist, submit, or write tokens."
+    elif validation["valid"]:
+        action = "keep_token_write_execution_dry_run_locked"
+        reason = f"Token write execution dry-run candidate is locked by {dry_run.get('lock_reason')}."
+    else:
+        action = "repair_token_write_execution_dry_run_candidate"
+        reason = "Token write execution dry-run candidate failed validation and cannot proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_ROUTING,
+        "validation": validation,
+        "write_execution_plan_recommendation": (
+            recommend_human_approval_token_write_execution_plan_action(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "creates_token_write_execution_dry_run_candidates_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY),
+    }
+
+
+def summarize_human_approval_token_write_execution_dry_runs(
+    dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    final_preflight_required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for dry_run in dry_runs:
+        block_type = str(dry_run.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(dry_run.get("dry_run_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        lock_reason = str(dry_run.get("lock_reason"))
+        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
+        if (
+            dry_run.get("dry_run_status")
+            == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+        ):
+            final_preflight_required_count += 1
+        if dry_run.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED:
+            locked_count += 1
+        validation = validate_human_approval_token_write_execution_dry_run(dry_run)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(dry_runs),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "final_preflight_required_count": final_preflight_required_count,
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY),
+    }
+
+
+def _dry_run_lock_reason(
+    plan: Mapping[str, Any],
+    plan_validation: Mapping[str, Any],
+) -> str | None:
+    if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED:
+        return plan.get("lock_reason") or "token_write_execution_plan_locked"
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(plan.get(field), Mapping):
+            return f"missing_{field}"
+    if not (plan.get("source_pattern_ids") or plan.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if not isinstance(plan.get("token_write_execution_steps"), list) or not isinstance(
+        plan.get("token_write_execution_preflight_checks"), list
+    ):
+        return "missing_token_write_execution_controls"
+    if _preview_integrity_errors(plan):
+        return "preview_integrity_failed"
+    if plan_validation.get("valid") is not True:
+        return "invalid_token_write_execution_plan"
+    if plan.get("plan_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED:
+        return "invalid_token_write_execution_plan"
+    return None
+
+
+def _approval_token_write_payload_preview(
+    plan: Mapping[str, Any],
+    operator: str | None,
+) -> dict[str, Any]:
+    return {
+        "payload_id_preview": _preview_id("approval-token-write-payload", plan, operator),
+        "payload_kind_preview": "human_approval_token_write_payload_preview",
+        "preview_only": True,
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "writes_token_files": False,
+        "source_write_execution_plan_id": plan.get("plan_id"),
+        "source_final_confirmation_review_outcome_id": plan.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "approval_token_record_preview": deepcopy(plan.get("approval_token_record_preview")),
+    }
+
+
+def _approval_audit_write_payload_preview(
+    plan: Mapping[str, Any],
+    operator: str | None,
+) -> dict[str, Any]:
+    return {
+        "payload_id_preview": _preview_id("approval-audit-write-payload", plan, operator),
+        "payload_kind_preview": "human_approval_token_approval_audit_write_payload_preview",
+        "preview_only": True,
+        "created_operation_event": False,
+        "writes_approval_audit": False,
+        "writes_operation_ledger": False,
+        "written": False,
+        "source_write_execution_plan_id": plan.get("plan_id"),
+        "source_final_confirmation_review_outcome_id": plan.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "approval_audit_record_preview": deepcopy(plan.get("approval_audit_record_preview")),
+    }
+
+
+def _token_write_target_paths_preview(
+    plan: Mapping[str, Any],
+    operator: str | None,
+) -> dict[str, Any]:
+    return {
+        "paths_id_preview": _preview_id("token-write-target-paths", plan, operator),
+        "path_kind_preview": "human_approval_token_write_target_paths_preview",
+        "preview_only": True,
+        "base": "${HERMES_HOME}",
+        "approval_token_file": "memory/approvals/human_approval_tokens.jsonl",
+        "approval_audit_file": "memory/audit/human_approval_token_audit.jsonl",
+        "operation_ledger_file": "memory/audit/memory_operation_ledger.jsonl",
+        "token_target_paths_preview": deepcopy(plan.get("token_target_paths_preview")),
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "writes_operation_ledger": False,
+        "written": False,
+    }
+
+
+def _final_token_write_preflight_checklist() -> list[str]:
+    return [
+        "source_write_execution_plan_is_valid_and_manual_execution_plan_required",
+        "approval_token_record_preview_is_preview_only",
+        "approval_audit_record_preview_is_preview_only",
+        "token_target_paths_preview_is_preview_only",
+        "proposal_record_preview_is_not_written",
+        "operation_ledger_preview_is_not_written",
+        "target_paths_preview_is_preview_only",
+        "source_evidence_is_present",
+        "token_write_execution_controls_are_present",
+        "approval_token_write_payload_is_preview_only",
+        "approval_audit_write_payload_is_preview_only",
+        "token_write_target_paths_are_preview_only",
+        "no_real_approval_token_issued",
+        "no_approval_persisted",
+        "no_real_proposal_created",
+        "no_operation_ledger_event_created",
+        "no_proposal_file_written",
+        "no_operation_ledger_written",
+        "no_token_file_written",
+        "no_approval_audit_written",
+        "no_memory_or_graph_or_config_write",
+        "manual_token_write_final_gate_required_before_any_token_write",
+    ]
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS + (
+        "approval_token_write_payload_preview",
+        "approval_audit_write_payload_preview",
+        "token_write_target_paths_preview",
+    ):
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_VERSION,
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "lock_reason": dry_run.get("lock_reason"),
+        "source_write_execution_plan_id": dry_run.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": dry_run.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": dry_run.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": dry_run.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": dry_run.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": dry_run.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": dry_run.get("source_review_outcome_id"),
+        "source_request_id": dry_run.get("source_request_id"),
+        "source_gate_id": dry_run.get("source_gate_id"),
+        "source_dry_run_id": dry_run.get("source_dry_run_id"),
+        "source_plan_id": dry_run.get("source_plan_id"),
+        "source_outcome_id": dry_run.get("source_outcome_id"),
+        "source_packet_id": dry_run.get("source_packet_id"),
+        "source_submission_id": dry_run.get("source_submission_id"),
+        "source_draft_id": dry_run.get("source_draft_id"),
+        "source_decision_id": dry_run.get("source_decision_id"),
+        "source_queue_item_id": dry_run.get("source_queue_item_id"),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "outcome": dry_run.get("outcome"),
+        "approval_token_record_preview": dry_run.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": dry_run.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": dry_run.get("token_target_paths_preview", {}),
+        "proposal_record_preview": dry_run.get("proposal_record_preview", {}),
+        "operation_ledger_preview": dry_run.get("operation_ledger_preview", {}),
+        "target_paths_preview": dry_run.get("target_paths_preview", {}),
+        "payload_preview": dry_run.get("payload_preview"),
+        "source_pattern_ids": list(dry_run.get("source_pattern_ids", [])),
+        "source_fact_ids": list(dry_run.get("source_fact_ids", [])),
+        "token_write_execution_steps": list(dry_run.get("token_write_execution_steps", [])),
+        "token_write_execution_preflight_checks": list(
+            dry_run.get("token_write_execution_preflight_checks", [])
+        ),
+        "approval_token_write_payload_preview": dry_run.get(
+            "approval_token_write_payload_preview", {}
+        ),
+        "approval_audit_write_payload_preview": dry_run.get(
+            "approval_audit_write_payload_preview", {}
+        ),
+        "token_write_target_paths_preview": dry_run.get("token_write_target_paths_preview", {}),
+        "final_token_write_preflight_checklist": list(
+            dry_run.get("final_token_write_preflight_checklist", [])
+        ),
+        "write_execution_plan_validation": dry_run.get("write_execution_plan_validation", {}),
+        "policy": dry_run.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-write-execution-dry-run:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _preview_id(kind: str, plan: Mapping[str, Any], operator: str | None) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_VERSION,
+        "kind": kind,
+        "source_write_execution_plan_id": plan.get("plan_id"),
+        "source_final_confirmation_review_outcome_id": plan.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": plan.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": plan.get("source_token_write_lock_gate_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"preview:{kind}:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_write_execution_dry_run.py
+++ b/agent/memory_human_approval_token_write_execution_dry_run.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_write_execution_plan import (
     explain_human_approval_token_write_execution_plan,
     recommend_human_approval_token_write_execution_plan_action,
     validate_human_approval_token_write_execution_plan,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -338,12 +343,8 @@ def validate_human_approval_token_write_execution_dry_run(
         errors.append(
             "token_write_execution_preflight_checks_must_match_source_write_execution_plan_snapshot"
         )
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if dry_run.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(dry_run, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -447,20 +448,13 @@ def recommend_human_approval_token_write_execution_dry_run_action(
 def summarize_human_approval_token_write_execution_dry_runs(
     dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(dry_runs, "dry_run_status")
+    lock_reason_summary = summarize_candidates(dry_runs, "lock_reason")
     final_preflight_required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for dry_run in dry_runs:
-        block_type = str(dry_run.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(dry_run.get("dry_run_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        lock_reason = str(dry_run.get("lock_reason"))
-        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
         if (
             dry_run.get("dry_run_status")
             == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
@@ -479,9 +473,9 @@ def summarize_human_approval_token_write_execution_dry_runs(
         "invalid_count": invalid_count,
         "final_preflight_required_count": final_preflight_required_count,
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY),
     }
 
@@ -688,8 +682,10 @@ def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
         "write_execution_plan_validation": dry_run.get("write_execution_plan_validation", {}),
         "policy": dry_run.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-write-execution-dry-run:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest(
+        "memory-human-approval-token-write-execution-dry-run:v0.1",
+        identity,
+    )
 
 
 def _preview_id(kind: str, plan: Mapping[str, Any], operator: str | None) -> str:
@@ -707,12 +703,11 @@ def _preview_id(kind: str, plan: Mapping[str, Any], operator: str | None) -> str
         "project_scope": plan.get("project_scope"),
         "operator": operator if operator is not None else _DEFAULT_OPERATOR,
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"preview:{kind}:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest(f"preview:{kind}:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_write_execution_plan.py
+++ b/agent/memory_human_approval_token_write_execution_plan.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -9,6 +7,13 @@ from agent.memory_human_approval_token_final_confirmation_review_gate import (
     explain_human_approval_token_final_confirmation_review_outcome,
     recommend_human_approval_token_final_confirmation_review_action,
     validate_human_approval_token_final_confirmation_review_outcome,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -287,12 +292,8 @@ def validate_human_approval_token_write_execution_plan(plan: Mapping[str, Any]) 
         errors.append("source_pattern_ids_must_match_source_final_confirmation_review_outcome_snapshot")
     if plan.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
         errors.append("source_fact_ids_must_match_source_final_confirmation_review_outcome_snapshot")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if plan.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(plan, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -382,20 +383,13 @@ def recommend_human_approval_token_write_execution_plan_action(
 def summarize_human_approval_token_write_execution_plans(
     plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(plans, "plan_status")
+    lock_reason_summary = summarize_candidates(plans, "lock_reason")
     execution_plan_required_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for plan in plans:
-        block_type = str(plan.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(plan.get("plan_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        lock_reason = str(plan.get("lock_reason"))
-        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
         if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED:
             execution_plan_required_count += 1
         if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED:
@@ -411,9 +405,9 @@ def summarize_human_approval_token_write_execution_plans(
         "invalid_count": invalid_count,
         "execution_plan_required_count": execution_plan_required_count,
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY),
     }
 
@@ -576,12 +570,14 @@ def _plan_id(plan: Mapping[str, Any]) -> str:
         ),
         "policy": plan.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-write-execution-plan:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest(
+        "memory-human-approval-token-write-execution-plan:v0.1",
+        identity,
+    )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_write_execution_plan.py
+++ b/agent/memory_human_approval_token_write_execution_plan.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_final_confirmation_review_gate import (
+    explain_human_approval_token_final_confirmation_review_outcome,
+    recommend_human_approval_token_final_confirmation_review_action,
+    validate_human_approval_token_final_confirmation_review_outcome,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_KIND = (
+    "memory_human_approval_token_write_execution_plan_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED = (
+    "manual_token_write_execution_plan_required"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_ROUTING = (
+    "manual_token_write_dry_run_required_before_any_token_write"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_token_write_execution_plan_candidates_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_EXECUTOR = "hermes_memory_human_approval_token_write_execution_plan_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_LOCK_REASONS = {
+    None,
+    "final_confirmation_requested_changes",
+    "final_confirmation_rejected",
+    "final_confirmation_deferred",
+    "invalid_final_confirmation_review_outcome",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+}
+
+
+def create_human_approval_token_write_execution_plan(
+    final_confirmation_review_outcome: Mapping[str, Any],
+    executor: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only token write execution plan candidate."""
+    source = deepcopy(dict(final_confirmation_review_outcome))
+    final_confirmation_review_outcome_validation = (
+        validate_human_approval_token_final_confirmation_review_outcome(source)
+    )
+    lock_reason = _plan_lock_reason(source, final_confirmation_review_outcome_validation)
+    plan_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    )
+
+    plan = {
+        "plan_id": None,
+        "plan_kind": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_KIND,
+        "plan_status": plan_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_ROUTING,
+        "lock_reason": lock_reason,
+        "source_final_confirmation_review_outcome_id": source.get("review_outcome_id"),
+        "source_final_confirmation_request_id": source.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "executor": executor if executor is not None else _DEFAULT_EXECUTOR,
+        "outcome": source.get("outcome"),
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": _token_write_execution_steps(),
+        "token_write_execution_preflight_checks": _token_write_execution_preflight_checks(),
+        "final_confirmation_review_outcome_validation": deepcopy(
+            final_confirmation_review_outcome_validation
+        ),
+        "plan_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_final_confirmation_review_outcome_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY),
+    }
+    plan["plan_id"] = _plan_id(plan)
+    plan["plan_validation"] = validate_human_approval_token_write_execution_plan(plan)
+    plan["next_step_recommendation"] = recommend_human_approval_token_write_execution_plan_action(plan)
+    return plan
+
+
+def validate_human_approval_token_write_execution_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(plan.get("policy"))
+    source_snapshot = _as_dict(plan.get("source_final_confirmation_review_outcome_snapshot"))
+    final_confirmation_review_outcome_validation = _as_dict(
+        plan.get("final_confirmation_review_outcome_validation")
+    )
+    expected_final_confirmation_review_outcome_validation = (
+        validate_human_approval_token_final_confirmation_review_outcome(source_snapshot)
+    )
+    expected_lock_reason = _plan_lock_reason(
+        source_snapshot,
+        final_confirmation_review_outcome_validation,
+    )
+    preview_integrity_errors = _preview_integrity_errors(plan)
+
+    for key in (
+        "plan_id",
+        "plan_kind",
+        "plan_status",
+        "routing",
+        "lock_reason",
+        "source_final_confirmation_review_outcome_id",
+        "source_final_confirmation_request_id",
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "executor",
+        "outcome",
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "token_write_execution_steps",
+        "token_write_execution_preflight_checks",
+        "final_confirmation_review_outcome_validation",
+        "plan_validation",
+        "next_step_recommendation",
+        "source_final_confirmation_review_outcome_snapshot",
+        "policy",
+    ):
+        if key not in plan:
+            errors.append(f"missing_{key}")
+    if plan.get("plan_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_KIND:
+        errors.append("plan_kind_must_be_memory_human_approval_token_write_execution_plan_candidate")
+    if plan.get("plan_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED,
+    }:
+        errors.append("plan_status_must_be_supported")
+    if plan.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_ROUTING:
+        errors.append("routing_must_require_manual_token_write_dry_run_before_any_token_write")
+    if plan.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if plan.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_token_write_execution_plan_checks")
+    if expected_lock_reason is None and plan.get("plan_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED:
+        errors.append("confirmed_final_confirmation_review_outcome_must_require_manual_token_write_execution_plan")
+    if expected_lock_reason is not None and plan.get("plan_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED:
+        errors.append("invalid_or_non_confirmed_final_confirmation_review_outcome_must_lock_plan")
+    if not isinstance(plan.get("executor"), str) or not plan.get("executor"):
+        errors.append("executor_must_be_non_empty_string")
+    if final_confirmation_review_outcome_validation != expected_final_confirmation_review_outcome_validation:
+        errors.append("final_confirmation_review_outcome_validation_must_match_source_final_confirmation_review_outcome_snapshot")
+    if plan.get("source_final_confirmation_review_outcome_id") != source_snapshot.get("review_outcome_id"):
+        errors.append("source_final_confirmation_review_outcome_id_must_match_source_snapshot")
+    for source_key in (
+        "source_final_confirmation_request_id",
+        "source_token_write_lock_gate_id",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "outcome",
+    ):
+        if plan.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+    if not isinstance(plan.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(plan.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(plan.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(plan.get("source_pattern_ids"), list) and isinstance(plan.get("source_fact_ids"), list):
+        if (
+            not plan.get("source_pattern_ids")
+            and not plan.get("source_fact_ids")
+            and plan.get("lock_reason") != "missing_source_evidence"
+        ):
+            errors.append("missing_source_evidence")
+    if plan.get("token_write_execution_steps") != _token_write_execution_steps():
+        errors.append("token_write_execution_steps_must_match_v0_1_deterministic_steps")
+    if plan.get("token_write_execution_preflight_checks") != _token_write_execution_preflight_checks():
+        errors.append("token_write_execution_preflight_checks_must_match_v0_1_deterministic_checks")
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(plan.get(field), Mapping) and plan.get("lock_reason") != f"missing_{field}":
+            errors.append(f"missing_{field}")
+    if plan.get("lock_reason") != "preview_integrity_failed":
+        errors.extend(preview_integrity_errors)
+    for field in _PREVIEW_FIELDS + ("payload_preview",):
+        if field in plan and field in source_snapshot and plan.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_final_confirmation_review_outcome_snapshot")
+    if plan.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_final_confirmation_review_outcome_snapshot")
+    if plan.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_final_confirmation_review_outcome_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if plan.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_write_execution_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_execution_plan(plan)
+    source_snapshot = _as_dict(plan.get("source_final_confirmation_review_outcome_snapshot"))
+    return {
+        "plan_id": plan.get("plan_id"),
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_final_confirmation_review_outcome_id": plan.get("source_final_confirmation_review_outcome_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "executor": plan.get("executor"),
+        "outcome": plan.get("outcome"),
+        "source_pattern_count": len(plan.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(plan.get("source_fact_ids", []) or []),
+        "token_write_execution_step_count": len(plan.get("token_write_execution_steps", []) or []),
+        "token_write_execution_preflight_check_count": len(
+            plan.get("token_write_execution_preflight_checks", []) or []
+        ),
+        "validation": validation,
+        "final_confirmation_review_outcome_explanation": (
+            explain_human_approval_token_final_confirmation_review_outcome(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY),
+    }
+
+
+def recommend_human_approval_token_write_execution_plan_action(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_execution_plan(plan)
+    source_snapshot = _as_dict(plan.get("source_final_confirmation_review_outcome_snapshot"))
+    if validation["valid"] and plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED:
+        action = "route_to_manual_token_write_dry_run_without_issuing_token"
+        reason = "Execution plan candidate is ready for a separate manual token write dry run; this candidate does not issue, persist, submit, or write anything."
+    elif validation["valid"]:
+        action = "keep_token_write_execution_plan_locked"
+        reason = f"Execution plan candidate is locked by {plan.get('lock_reason')}."
+    else:
+        action = "repair_token_write_execution_plan_candidate"
+        reason = "Execution plan candidate failed validation and cannot proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_ROUTING,
+        "validation": validation,
+        "final_confirmation_review_outcome_recommendation": (
+            recommend_human_approval_token_final_confirmation_review_action(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "creates_token_write_execution_plan_candidates_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY),
+    }
+
+
+def summarize_human_approval_token_write_execution_plans(
+    plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    execution_plan_required_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for plan in plans:
+        block_type = str(plan.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(plan.get("plan_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        lock_reason = str(plan.get("lock_reason"))
+        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
+        if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED:
+            execution_plan_required_count += 1
+        if plan.get("plan_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED:
+            locked_count += 1
+        validation = validate_human_approval_token_write_execution_plan(plan)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(plans),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "execution_plan_required_count": execution_plan_required_count,
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY),
+    }
+
+
+def _plan_lock_reason(
+    outcome_candidate: Mapping[str, Any],
+    validation: Mapping[str, Any],
+) -> str | None:
+    outcome = outcome_candidate.get("outcome")
+    if outcome == "request_changes":
+        return "final_confirmation_requested_changes"
+    if outcome == "reject":
+        return "final_confirmation_rejected"
+    if outcome == "defer":
+        return "final_confirmation_deferred"
+    if outcome != "confirm_token_write":
+        return "invalid_final_confirmation_review_outcome"
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(outcome_candidate.get(field), Mapping):
+            return f"missing_{field}"
+    if not (outcome_candidate.get("source_pattern_ids") or outcome_candidate.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(outcome_candidate):
+        return "preview_integrity_failed"
+    if validation.get("valid") is not True:
+        return "invalid_final_confirmation_review_outcome"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _token_write_execution_steps() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "verify_final_confirmation_review_outcome",
+            "order": 1,
+            "description": "Re-validate the final confirmation review outcome candidate.",
+            "writes": False,
+        },
+        {
+            "id": "verify_preview_integrity",
+            "order": 2,
+            "description": "Confirm token, audit, proposal, ledger, and path previews are preview-only.",
+            "writes": False,
+        },
+        {
+            "id": "verify_source_evidence",
+            "order": 3,
+            "description": "Confirm source pattern or fact evidence is present before any future write dry run.",
+            "writes": False,
+        },
+        {
+            "id": "prepare_manual_token_write_dry_run_packet",
+            "order": 4,
+            "description": "Prepare the next read-only dry-run input from existing previews.",
+            "writes": False,
+        },
+    ]
+
+
+def _token_write_execution_preflight_checks() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "final_confirmation_outcome_is_confirm_token_write",
+            "required": True,
+            "blocks_token_write": True,
+        },
+        {
+            "id": "approval_token_record_preview_is_preview_only",
+            "required": True,
+            "blocks_token_write": True,
+        },
+        {
+            "id": "approval_audit_record_preview_is_preview_only",
+            "required": True,
+            "blocks_token_write": True,
+        },
+        {
+            "id": "token_target_paths_preview_is_preview_only",
+            "required": True,
+            "blocks_token_write": True,
+        },
+        {
+            "id": "proposal_and_operation_ledger_previews_are_not_written",
+            "required": True,
+            "blocks_token_write": True,
+        },
+        {
+            "id": "source_evidence_is_present",
+            "required": True,
+            "blocks_token_write": True,
+        },
+        {
+            "id": "no_memory_config_graph_proposal_ledger_token_or_approval_writes",
+            "required": True,
+            "blocks_token_write": True,
+        },
+    ]
+
+
+def _plan_id(plan: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_VERSION,
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "lock_reason": plan.get("lock_reason"),
+        "source_final_confirmation_review_outcome_id": plan.get("source_final_confirmation_review_outcome_id"),
+        "source_final_confirmation_request_id": plan.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": plan.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": plan.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": plan.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": plan.get("source_review_outcome_id"),
+        "source_request_id": plan.get("source_request_id"),
+        "source_gate_id": plan.get("source_gate_id"),
+        "source_dry_run_id": plan.get("source_dry_run_id"),
+        "source_plan_id": plan.get("source_plan_id"),
+        "source_outcome_id": plan.get("source_outcome_id"),
+        "source_packet_id": plan.get("source_packet_id"),
+        "source_submission_id": plan.get("source_submission_id"),
+        "source_draft_id": plan.get("source_draft_id"),
+        "source_decision_id": plan.get("source_decision_id"),
+        "source_queue_item_id": plan.get("source_queue_item_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "executor": plan.get("executor"),
+        "outcome": plan.get("outcome"),
+        "approval_token_record_preview": plan.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": plan.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": plan.get("token_target_paths_preview", {}),
+        "proposal_record_preview": plan.get("proposal_record_preview", {}),
+        "operation_ledger_preview": plan.get("operation_ledger_preview", {}),
+        "target_paths_preview": plan.get("target_paths_preview", {}),
+        "payload_preview": plan.get("payload_preview"),
+        "source_pattern_ids": list(plan.get("source_pattern_ids", [])),
+        "source_fact_ids": list(plan.get("source_fact_ids", [])),
+        "token_write_execution_steps": plan.get("token_write_execution_steps", []),
+        "token_write_execution_preflight_checks": plan.get("token_write_execution_preflight_checks", []),
+        "final_confirmation_review_outcome_validation": plan.get(
+            "final_confirmation_review_outcome_validation", {}
+        ),
+        "policy": plan.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-write-execution-plan:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_write_final_gate.py
+++ b/agent/memory_human_approval_token_write_final_gate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_write_execution_dry_run import (
     explain_human_approval_token_write_execution_dry_run,
     recommend_human_approval_token_write_execution_dry_run_action,
     validate_human_approval_token_write_execution_dry_run,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -287,12 +292,10 @@ def validate_human_approval_token_write_final_gate(gate: Mapping[str, Any]) -> d
         errors.append(
             "token_write_execution_preflight_checks_must_match_source_write_execution_dry_run_snapshot"
         )
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if gate.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(gate, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(
+        validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY)
+    )
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -397,20 +400,13 @@ def recommend_human_approval_token_write_final_gate_action(
 def summarize_human_approval_token_write_final_gates(
     gates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(gates, "gate_status")
+    lock_reason_summary = summarize_candidates(gates, "lock_reason")
     eligible_count = 0
     locked_count = 0
     valid_count = 0
     invalid_count = 0
     for gate in gates:
-        block_type = str(gate.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(gate.get("gate_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        lock_reason = str(gate.get("lock_reason"))
-        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
         if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE:
             eligible_count += 1
         if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED:
@@ -426,9 +422,9 @@ def summarize_human_approval_token_write_final_gates(
         "invalid_count": invalid_count,
         "eligible_for_real_token_write_executor_count": eligible_count,
         "locked_count": locked_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY),
     }
 
@@ -649,13 +645,11 @@ def _gate_id(gate: Mapping[str, Any]) -> str:
         "write_execution_dry_run_validation": gate.get("write_execution_dry_run_validation", {}),
         "policy": gate.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    return f"memory-human-approval-token-write-final-gate:v0.1:{digest}"
+    return build_stable_digest("memory-human-approval-token-write-final-gate:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_write_final_gate.py
+++ b/agent/memory_human_approval_token_write_final_gate.py
@@ -1,0 +1,662 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_write_execution_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED,
+    explain_human_approval_token_write_execution_dry_run,
+    recommend_human_approval_token_write_execution_dry_run_action,
+    validate_human_approval_token_write_execution_dry_run,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_KIND = (
+    "memory_human_approval_token_write_final_gate_candidate"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE = (
+    "eligible_for_real_token_write_executor"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ROUTING = (
+    "real_token_write_executor_required_but_not_invoked"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_token_write_final_gate_candidates_only": True,
+    "invokes_real_token_write_executor": False,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = "hermes_memory_human_approval_token_write_final_gate_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_FINAL_PREFLIGHT_PREVIEW_FIELDS = (
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+)
+_LOCK_REASONS = {
+    None,
+    "token_write_execution_dry_run_locked",
+    "invalid_token_write_execution_dry_run",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_approval_token_write_payload_preview",
+    "missing_approval_audit_write_payload_preview",
+    "missing_token_write_target_paths_preview",
+    "missing_source_evidence",
+    "missing_final_token_write_preflight_checklist",
+    "preview_integrity_failed",
+    "final_preflight_integrity_failed",
+    "final_confirmation_requested_changes",
+    "final_confirmation_rejected",
+    "final_confirmation_deferred",
+    "invalid_final_confirmation_review_outcome",
+}
+
+
+def create_human_approval_token_write_final_gate(
+    write_execution_dry_run: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only token write final gate candidate."""
+    source = deepcopy(dict(write_execution_dry_run))
+    write_execution_dry_run_validation = validate_human_approval_token_write_execution_dry_run(
+        source
+    )
+    lock_reason = _gate_lock_reason(source, write_execution_dry_run_validation)
+    gate_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED
+    )
+
+    gate = {
+        "gate_id": None,
+        "gate_kind": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_KIND,
+        "gate_status": gate_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ROUTING,
+        "lock_reason": lock_reason,
+        "source_write_execution_dry_run_id": source.get("dry_run_id"),
+        "source_write_execution_plan_id": source.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": source.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": source.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": source.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": source.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "outcome": source.get("outcome"),
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "token_write_execution_steps": deepcopy(
+            list(source.get("token_write_execution_steps", []) or [])
+        ),
+        "token_write_execution_preflight_checks": deepcopy(
+            list(source.get("token_write_execution_preflight_checks", []) or [])
+        ),
+        "approval_token_write_payload_preview": deepcopy(
+            source.get("approval_token_write_payload_preview")
+        ),
+        "approval_audit_write_payload_preview": deepcopy(
+            source.get("approval_audit_write_payload_preview")
+        ),
+        "token_write_target_paths_preview": deepcopy(source.get("token_write_target_paths_preview")),
+        "final_token_write_preflight_checklist": deepcopy(
+            source.get("final_token_write_preflight_checklist")
+        ),
+        "final_gate_checklist": _final_gate_checklist(),
+        "write_execution_dry_run_validation": deepcopy(write_execution_dry_run_validation),
+        "gate_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_write_execution_dry_run_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY),
+    }
+    gate["gate_id"] = _gate_id(gate)
+    gate["gate_validation"] = validate_human_approval_token_write_final_gate(gate)
+    gate["next_step_recommendation"] = recommend_human_approval_token_write_final_gate_action(gate)
+    return gate
+
+
+def validate_human_approval_token_write_final_gate(gate: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(gate.get("policy"))
+    source_snapshot = _as_dict(gate.get("source_write_execution_dry_run_snapshot"))
+    dry_run_validation = _as_dict(gate.get("write_execution_dry_run_validation"))
+    expected_dry_run_validation = validate_human_approval_token_write_execution_dry_run(
+        source_snapshot
+    )
+    expected_lock_reason = _gate_lock_reason(source_snapshot, dry_run_validation)
+
+    for key in _REQUIRED_GATE_KEYS:
+        if key not in gate:
+            errors.append(f"missing_{key}")
+    if gate.get("gate_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_KIND:
+        errors.append("gate_kind_must_be_memory_human_approval_token_write_final_gate_candidate")
+    if gate.get("gate_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE,
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED,
+    }:
+        errors.append("gate_status_must_be_supported")
+    if gate.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ROUTING:
+        errors.append("routing_must_require_real_token_write_executor_but_not_invoke_it")
+    if gate.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if gate.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_token_write_final_gate_checks")
+    if (
+        expected_lock_reason is None
+        and gate.get("gate_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE
+    ):
+        errors.append("valid_token_write_execution_dry_run_must_be_executor_eligible")
+    if (
+        expected_lock_reason is not None
+        and gate.get("gate_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED
+    ):
+        errors.append("invalid_or_locked_token_write_execution_dry_run_must_lock_gate")
+    if not isinstance(gate.get("operator"), str) or not gate.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if dry_run_validation != expected_dry_run_validation:
+        errors.append(
+            "write_execution_dry_run_validation_must_match_source_write_execution_dry_run_snapshot"
+        )
+    if gate.get("source_write_execution_dry_run_id") != source_snapshot.get("dry_run_id"):
+        errors.append("source_write_execution_dry_run_id_must_match_source_snapshot")
+    for source_key in _SOURCE_KEYS:
+        if gate.get(source_key) != source_snapshot.get(source_key):
+            errors.append(f"{source_key}_must_match_source_snapshot")
+    if not isinstance(gate.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(gate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(gate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(gate.get("source_pattern_ids"), list) and isinstance(
+        gate.get("source_fact_ids"), list
+    ):
+        if (
+            not gate.get("source_pattern_ids")
+            and not gate.get("source_fact_ids")
+            and gate.get("lock_reason") != "missing_source_evidence"
+        ):
+            errors.append("missing_source_evidence")
+    for field in _PREVIEW_FIELDS:
+        if (
+            not isinstance(gate.get(field), Mapping)
+            and gate.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    for field in _FINAL_PREFLIGHT_PREVIEW_FIELDS:
+        if (
+            not isinstance(gate.get(field), Mapping)
+            and gate.get("lock_reason") != f"missing_{field}"
+        ):
+            errors.append(f"missing_{field}")
+    if (
+        not isinstance(gate.get("final_token_write_preflight_checklist"), list)
+        and gate.get("lock_reason") != "missing_final_token_write_preflight_checklist"
+    ):
+        errors.append("missing_final_token_write_preflight_checklist")
+    if gate.get("lock_reason") != "preview_integrity_failed":
+        errors.extend(_preview_integrity_errors(gate))
+    if gate.get("lock_reason") != "final_preflight_integrity_failed":
+        errors.extend(_final_preflight_integrity_errors(gate))
+    if gate.get("final_gate_checklist") != _final_gate_checklist():
+        errors.append("final_gate_checklist_must_match_v0_1_deterministic_checks")
+    for field in _PREVIEW_FIELDS + _FINAL_PREFLIGHT_PREVIEW_FIELDS + (
+        "payload_preview",
+        "final_token_write_preflight_checklist",
+    ):
+        if field in gate and field in source_snapshot and gate.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_write_execution_dry_run_snapshot")
+    if gate.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_write_execution_dry_run_snapshot")
+    if gate.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_write_execution_dry_run_snapshot")
+    if gate.get("token_write_execution_steps") != list(
+        source_snapshot.get("token_write_execution_steps", []) or []
+    ):
+        errors.append("token_write_execution_steps_must_match_source_write_execution_dry_run_snapshot")
+    if gate.get("token_write_execution_preflight_checks") != list(
+        source_snapshot.get("token_write_execution_preflight_checks", []) or []
+    ):
+        errors.append(
+            "token_write_execution_preflight_checks_must_match_source_write_execution_dry_run_snapshot"
+        )
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if gate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_write_final_gate(gate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_final_gate(gate)
+    source_snapshot = _as_dict(gate.get("source_write_execution_dry_run_snapshot"))
+    return {
+        "gate_id": gate.get("gate_id"),
+        "gate_kind": gate.get("gate_kind"),
+        "gate_status": gate.get("gate_status"),
+        "routing": gate.get("routing"),
+        "lock_reason": gate.get("lock_reason"),
+        "source_write_execution_dry_run_id": gate.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": gate.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": gate.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "block_id": gate.get("block_id"),
+        "block_type": gate.get("block_type"),
+        "project_scope": gate.get("project_scope"),
+        "operator": gate.get("operator"),
+        "outcome": gate.get("outcome"),
+        "source_pattern_count": len(gate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(gate.get("source_fact_ids", []) or []),
+        "token_write_execution_step_count": len(
+            gate.get("token_write_execution_steps", []) or []
+        ),
+        "token_write_execution_preflight_check_count": len(
+            gate.get("token_write_execution_preflight_checks", []) or []
+        ),
+        "final_token_write_preflight_checklist": deepcopy(
+            gate.get("final_token_write_preflight_checklist")
+        ),
+        "final_gate_checklist": deepcopy(gate.get("final_gate_checklist")),
+        "validation": validation,
+        "write_execution_dry_run_explanation": (
+            explain_human_approval_token_write_execution_dry_run(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "invokes_real_token_write_executor": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY),
+    }
+
+
+def recommend_human_approval_token_write_final_gate_action(
+    gate: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_final_gate(gate)
+    source_snapshot = _as_dict(gate.get("source_write_execution_dry_run_snapshot"))
+    if (
+        validation["valid"]
+        and gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE
+    ):
+        action = "route_to_real_token_write_executor_without_invoking_it"
+        reason = "Token write final gate candidate is eligible for a separate real token write executor; this gate does not invoke that executor or write tokens."
+    elif validation["valid"]:
+        action = "keep_token_write_final_gate_locked"
+        reason = f"Token write final gate candidate is locked by {gate.get('lock_reason')}."
+    else:
+        action = "repair_token_write_final_gate_candidate"
+        reason = "Token write final gate candidate failed validation and cannot proceed."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ROUTING,
+        "validation": validation,
+        "write_execution_dry_run_recommendation": (
+            recommend_human_approval_token_write_execution_dry_run_action(source_snapshot)
+            if source_snapshot
+            else {}
+        ),
+        "creates_token_write_final_gate_candidates_only": True,
+        "invokes_real_token_write_executor": False,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY),
+    }
+
+
+def summarize_human_approval_token_write_final_gates(
+    gates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    eligible_count = 0
+    locked_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for gate in gates:
+        block_type = str(gate.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(gate.get("gate_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        lock_reason = str(gate.get("lock_reason"))
+        by_lock_reason[lock_reason] = by_lock_reason.get(lock_reason, 0) + 1
+        if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE:
+            eligible_count += 1
+        if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED:
+            locked_count += 1
+        validation = validate_human_approval_token_write_final_gate(gate)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(gates),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "eligible_for_real_token_write_executor_count": eligible_count,
+        "locked_count": locked_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY),
+    }
+
+
+_SOURCE_KEYS = (
+    "source_write_execution_plan_id",
+    "source_final_confirmation_review_outcome_id",
+    "source_final_confirmation_request_id",
+    "source_token_write_lock_gate_id",
+    "source_token_issuance_dry_run_id",
+    "source_token_issuance_plan_id",
+    "source_review_outcome_id",
+    "source_request_id",
+    "source_gate_id",
+    "source_dry_run_id",
+    "source_plan_id",
+    "source_outcome_id",
+    "source_packet_id",
+    "source_submission_id",
+    "source_draft_id",
+    "source_decision_id",
+    "source_queue_item_id",
+    "block_id",
+    "block_type",
+    "project_scope",
+    "outcome",
+)
+
+_REQUIRED_GATE_KEYS = (
+    "gate_id",
+    "gate_kind",
+    "gate_status",
+    "routing",
+    "lock_reason",
+    "source_write_execution_dry_run_id",
+) + _SOURCE_KEYS + (
+    "operator",
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+    "payload_preview",
+    "source_pattern_ids",
+    "source_fact_ids",
+    "token_write_execution_steps",
+    "token_write_execution_preflight_checks",
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+    "final_token_write_preflight_checklist",
+    "final_gate_checklist",
+    "write_execution_dry_run_validation",
+    "gate_validation",
+    "next_step_recommendation",
+    "source_write_execution_dry_run_snapshot",
+    "policy",
+)
+
+
+def _gate_lock_reason(
+    dry_run: Mapping[str, Any],
+    dry_run_validation: Mapping[str, Any],
+) -> str | None:
+    if dry_run.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED:
+        return dry_run.get("lock_reason") or "token_write_execution_dry_run_locked"
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(dry_run.get(field), Mapping):
+            return f"missing_{field}"
+    for field in _FINAL_PREFLIGHT_PREVIEW_FIELDS:
+        if not isinstance(dry_run.get(field), Mapping):
+            return f"missing_{field}"
+    if not (dry_run.get("source_pattern_ids") or dry_run.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if not isinstance(dry_run.get("final_token_write_preflight_checklist"), list):
+        return "missing_final_token_write_preflight_checklist"
+    if _preview_integrity_errors(dry_run):
+        return "preview_integrity_failed"
+    if _final_preflight_integrity_errors(dry_run):
+        return "final_preflight_integrity_failed"
+    if dry_run_validation.get("valid") is not True:
+        return "invalid_token_write_execution_dry_run"
+    if (
+        dry_run.get("dry_run_status")
+        != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+    ):
+        return "invalid_token_write_execution_dry_run"
+    return None
+
+
+def _final_gate_checklist() -> list[str]:
+    return [
+        "source_write_execution_dry_run_is_valid_and_final_preflight_required",
+        "approval_token_record_preview_is_preview_only",
+        "approval_audit_record_preview_is_preview_only",
+        "token_target_paths_preview_is_preview_only",
+        "proposal_record_preview_is_not_written",
+        "operation_ledger_preview_is_not_written",
+        "target_paths_preview_is_preview_only",
+        "source_evidence_is_present",
+        "approval_token_write_payload_preview_is_preview_only",
+        "approval_audit_write_payload_preview_is_preview_only",
+        "token_write_target_paths_preview_is_preview_only",
+        "final_token_write_preflight_checklist_is_present",
+        "no_real_approval_token_issued",
+        "no_approval_persisted",
+        "no_real_proposal_created",
+        "no_operation_ledger_event_created",
+        "no_proposal_file_written",
+        "no_operation_ledger_written",
+        "no_token_file_written",
+        "no_approval_audit_written",
+        "no_memory_or_graph_or_config_write",
+        "real_token_write_executor_required_but_not_invoked",
+    ]
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _final_preflight_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _FINAL_PREFLIGHT_PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    checklist = container.get("final_token_write_preflight_checklist")
+    if isinstance(checklist, list) and "no_real_approval_token_issued" not in checklist:
+        errors.append("final_token_write_preflight_checklist_must_preserve_no_token_write_checks")
+    return errors
+
+
+def _gate_id(gate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_VERSION,
+        "gate_kind": gate.get("gate_kind"),
+        "gate_status": gate.get("gate_status"),
+        "routing": gate.get("routing"),
+        "lock_reason": gate.get("lock_reason"),
+        "source_write_execution_dry_run_id": gate.get("source_write_execution_dry_run_id"),
+        "source_write_execution_plan_id": gate.get("source_write_execution_plan_id"),
+        "source_final_confirmation_review_outcome_id": gate.get(
+            "source_final_confirmation_review_outcome_id"
+        ),
+        "source_final_confirmation_request_id": gate.get("source_final_confirmation_request_id"),
+        "source_token_write_lock_gate_id": gate.get("source_token_write_lock_gate_id"),
+        "source_token_issuance_dry_run_id": gate.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": gate.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": gate.get("source_review_outcome_id"),
+        "source_request_id": gate.get("source_request_id"),
+        "source_gate_id": gate.get("source_gate_id"),
+        "source_dry_run_id": gate.get("source_dry_run_id"),
+        "source_plan_id": gate.get("source_plan_id"),
+        "source_outcome_id": gate.get("source_outcome_id"),
+        "source_packet_id": gate.get("source_packet_id"),
+        "source_submission_id": gate.get("source_submission_id"),
+        "source_draft_id": gate.get("source_draft_id"),
+        "source_decision_id": gate.get("source_decision_id"),
+        "source_queue_item_id": gate.get("source_queue_item_id"),
+        "block_id": gate.get("block_id"),
+        "block_type": gate.get("block_type"),
+        "project_scope": gate.get("project_scope"),
+        "operator": gate.get("operator"),
+        "outcome": gate.get("outcome"),
+        "approval_token_record_preview": gate.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": gate.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": gate.get("token_target_paths_preview", {}),
+        "proposal_record_preview": gate.get("proposal_record_preview", {}),
+        "operation_ledger_preview": gate.get("operation_ledger_preview", {}),
+        "target_paths_preview": gate.get("target_paths_preview", {}),
+        "payload_preview": gate.get("payload_preview"),
+        "source_pattern_ids": list(gate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(gate.get("source_fact_ids", [])),
+        "token_write_execution_steps": list(gate.get("token_write_execution_steps", [])),
+        "token_write_execution_preflight_checks": list(
+            gate.get("token_write_execution_preflight_checks", [])
+        ),
+        "approval_token_write_payload_preview": gate.get(
+            "approval_token_write_payload_preview", {}
+        ),
+        "approval_audit_write_payload_preview": gate.get(
+            "approval_audit_write_payload_preview", {}
+        ),
+        "token_write_target_paths_preview": gate.get("token_write_target_paths_preview", {}),
+        "final_token_write_preflight_checklist": list(
+            gate.get("final_token_write_preflight_checklist") or []
+        ),
+        "final_gate_checklist": list(gate.get("final_gate_checklist", [])),
+        "write_execution_dry_run_validation": gate.get("write_execution_dry_run_validation", {}),
+        "policy": gate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return f"memory-human-approval-token-write-final-gate:v0.1:{digest}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_approval_token_write_lock_gate.py
+++ b/agent/memory_human_approval_token_write_lock_gate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -11,6 +9,13 @@ from agent.memory_human_approval_token_issuance_dry_run import (
     explain_human_approval_token_issuance_dry_run,
     recommend_human_approval_token_issuance_dry_run_action,
     validate_human_approval_token_issuance_dry_run,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_forbidden_true_keys_false_or_absent,
+    validate_policy_flags,
 )
 
 
@@ -253,12 +258,8 @@ def validate_human_approval_token_write_lock_gate(gate: Mapping[str, Any]) -> di
         errors.append("source_pattern_ids_must_match_source_token_issuance_dry_run_snapshot")
     if gate.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
         errors.append("source_fact_ids_must_match_source_token_issuance_dry_run_snapshot")
-    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
-        if gate.get(forbidden_key) is True:
-            errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_forbidden_true_keys_false_or_absent(gate, _FORBIDDEN_TRUE_KEYS))
+    errors.extend(validate_policy_flags(policy, MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -353,20 +354,13 @@ def recommend_human_approval_token_write_lock_action(gate: Mapping[str, Any]) ->
 def summarize_human_approval_token_write_lock_gates(
     gates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
-    by_lock_reason: dict[str, int] = {}
+    candidate_summary = summarize_candidates(gates, "gate_status")
+    lock_reason_summary = summarize_candidates(gates, "lock_reason")
     locked_count = 0
     eligible_count = 0
     valid_count = 0
     invalid_count = 0
     for gate in gates:
-        block_type = str(gate.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(gate.get("gate_status"))
-        by_status[status] = by_status.get(status, 0) + 1
-        reason = str(gate.get("lock_reason"))
-        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
         if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED:
             locked_count += 1
         if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE:
@@ -382,9 +376,9 @@ def summarize_human_approval_token_write_lock_gates(
         "eligible_count": eligible_count,
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
-        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
+        "by_lock_reason": lock_reason_summary["by_status"],
         "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY),
     }
 
@@ -527,12 +521,11 @@ def _gate_id(gate: Mapping[str, Any]) -> str:
         "token_dry_run_validation": gate.get("token_dry_run_validation", {}),
         "policy": gate.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-human-approval-token-write-lock-gate:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-human-approval-token-write-lock-gate:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_human_approval_token_write_lock_gate.py
+++ b/agent/memory_human_approval_token_write_lock_gate.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_approval_token_issuance_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED,
+    explain_human_approval_token_issuance_dry_run,
+    recommend_human_approval_token_issuance_dry_run_action,
+    validate_human_approval_token_issuance_dry_run,
+)
+
+
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_VERSION = "0.1"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_KIND = "memory_human_approval_token_write_lock_gate_candidate"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE = "eligible_for_final_human_confirmation"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED = "locked"
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ROUTING = (
+    "final_human_confirmation_required_before_any_token_write"
+)
+MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_token_write_lock_candidates_only": True,
+    "issues_real_approval_tokens": False,
+    "persists_approvals": False,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "applies_proposals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = "hermes_memory_human_approval_token_write_lock_gate_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_LOCK_REASONS = {
+    None,
+    "token_issuance_dry_run_locked",
+    "invalid_token_issuance_dry_run",
+    "missing_approval_token_record_preview",
+    "missing_approval_audit_record_preview",
+    "missing_token_target_paths_preview",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+    "token_issuance_plan_locked",
+    "token_review_requested_changes",
+    "token_review_rejected",
+    "token_review_deferred",
+    "invalid_token_review_outcome",
+    "missing_token_plan_controls",
+}
+
+
+def create_human_approval_token_write_lock_gate(
+    token_dry_run: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only token write-lock gate candidate."""
+    source = deepcopy(dict(token_dry_run))
+    token_dry_run_validation = validate_human_approval_token_issuance_dry_run(source)
+    lock_reason = _write_lock_reason(source, token_dry_run_validation)
+    gate_status = (
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE
+        if lock_reason is None
+        else MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    )
+
+    gate = {
+        "gate_id": None,
+        "gate_kind": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_KIND,
+        "gate_status": gate_status,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ROUTING,
+        "lock_reason": lock_reason,
+        "source_token_issuance_dry_run_id": source.get("dry_run_id"),
+        "source_token_issuance_plan_id": source.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": source.get("source_review_outcome_id"),
+        "source_request_id": source.get("source_request_id"),
+        "source_gate_id": source.get("source_gate_id"),
+        "source_dry_run_id": source.get("source_dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "approval_token_record_preview": deepcopy(source.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(source.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(source.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "write_lock_checklist": _write_lock_checklist(),
+        "token_dry_run_validation": deepcopy(token_dry_run_validation),
+        "gate_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_token_issuance_dry_run_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY),
+    }
+    gate["gate_id"] = _gate_id(gate)
+    gate["gate_validation"] = validate_human_approval_token_write_lock_gate(gate)
+    gate["next_step_recommendation"] = recommend_human_approval_token_write_lock_action(gate)
+    return gate
+
+
+def validate_human_approval_token_write_lock_gate(gate: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(gate.get("policy"))
+    source_snapshot = _as_dict(gate.get("source_token_issuance_dry_run_snapshot"))
+    token_dry_run_validation = _as_dict(gate.get("token_dry_run_validation"))
+    expected_token_dry_run_validation = validate_human_approval_token_issuance_dry_run(source_snapshot)
+    expected_lock_reason = _write_lock_reason(source_snapshot, token_dry_run_validation)
+    preview_integrity_errors = _preview_integrity_errors(gate)
+
+    for key in (
+        "gate_id",
+        "gate_kind",
+        "gate_status",
+        "routing",
+        "lock_reason",
+        "source_token_issuance_dry_run_id",
+        "source_token_issuance_plan_id",
+        "source_review_outcome_id",
+        "source_request_id",
+        "source_gate_id",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "operator",
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "write_lock_checklist",
+        "token_dry_run_validation",
+        "gate_validation",
+        "next_step_recommendation",
+        "source_token_issuance_dry_run_snapshot",
+        "policy",
+    ):
+        if key not in gate:
+            errors.append(f"missing_{key}")
+    if gate.get("gate_kind") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_KIND:
+        errors.append("gate_kind_must_be_memory_human_approval_token_write_lock_gate_candidate")
+    if gate.get("gate_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE,
+        MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED,
+    }:
+        errors.append("gate_status_must_be_supported")
+    if gate.get("routing") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ROUTING:
+        errors.append("routing_must_require_final_human_confirmation_before_any_token_write")
+    if gate.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if gate.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_token_write_lock_checks")
+    if expected_lock_reason is None and gate.get("gate_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE:
+        errors.append("valid_token_dry_run_must_be_eligible_for_final_human_confirmation")
+    if expected_lock_reason is not None and gate.get("gate_status") != MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED:
+        errors.append("invalid_token_write_lock_check_must_be_locked")
+    if not isinstance(gate.get("operator"), str) or not gate.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if token_dry_run_validation != expected_token_dry_run_validation:
+        errors.append("token_dry_run_validation_must_match_source_token_issuance_dry_run_snapshot")
+    if source_snapshot.get("dry_run_status") not in {
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED,
+        MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED,
+    }:
+        errors.append("source_dry_run_status_must_be_supported")
+    if gate.get("source_token_issuance_dry_run_id") != source_snapshot.get("dry_run_id"):
+        errors.append("source_token_issuance_dry_run_id_must_match_source_snapshot")
+    if not isinstance(gate.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(gate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(gate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(gate.get("source_pattern_ids"), list) and isinstance(gate.get("source_fact_ids"), list):
+        if not gate.get("source_pattern_ids") and not gate.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(gate.get("write_lock_checklist"), list) or not gate.get("write_lock_checklist"):
+        errors.append("write_lock_checklist_must_be_non_empty_list")
+    if gate.get("write_lock_checklist") != _write_lock_checklist():
+        errors.append("write_lock_checklist_must_match_v0_1_deterministic_checks")
+    for field in _PREVIEW_FIELDS:
+        if not isinstance(gate.get(field), Mapping):
+            errors.append(f"missing_{field}")
+    errors.extend(preview_integrity_errors)
+    for field in (
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+    ):
+        if field in gate and field in source_snapshot and gate.get(field) != source_snapshot.get(field):
+            errors.append(f"{field}_must_match_source_token_issuance_dry_run_snapshot")
+    if gate.get("source_pattern_ids") != list(source_snapshot.get("source_pattern_ids", []) or []):
+        errors.append("source_pattern_ids_must_match_source_token_issuance_dry_run_snapshot")
+    if gate.get("source_fact_ids") != list(source_snapshot.get("source_fact_ids", []) or []):
+        errors.append("source_fact_ids_must_match_source_token_issuance_dry_run_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if gate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_approval_token_write_lock_gate(gate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_lock_gate(gate)
+    source_snapshot = _as_dict(gate.get("source_token_issuance_dry_run_snapshot"))
+    return {
+        "gate_id": gate.get("gate_id"),
+        "gate_kind": gate.get("gate_kind"),
+        "gate_status": gate.get("gate_status"),
+        "routing": gate.get("routing"),
+        "lock_reason": gate.get("lock_reason"),
+        "source_token_issuance_dry_run_id": gate.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": gate.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": gate.get("source_review_outcome_id"),
+        "source_request_id": gate.get("source_request_id"),
+        "source_gate_id": gate.get("source_gate_id"),
+        "source_dry_run_id": gate.get("source_dry_run_id"),
+        "source_plan_id": gate.get("source_plan_id"),
+        "source_outcome_id": gate.get("source_outcome_id"),
+        "source_packet_id": gate.get("source_packet_id"),
+        "source_submission_id": gate.get("source_submission_id"),
+        "source_draft_id": gate.get("source_draft_id"),
+        "source_decision_id": gate.get("source_decision_id"),
+        "source_queue_item_id": gate.get("source_queue_item_id"),
+        "block_id": gate.get("block_id"),
+        "block_type": gate.get("block_type"),
+        "project_scope": gate.get("project_scope"),
+        "operator": gate.get("operator"),
+        "source_pattern_count": len(gate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(gate.get("source_fact_ids", []) or []),
+        "approval_token_record_preview": deepcopy(gate.get("approval_token_record_preview")),
+        "approval_audit_record_preview": deepcopy(gate.get("approval_audit_record_preview")),
+        "token_target_paths_preview": deepcopy(gate.get("token_target_paths_preview")),
+        "proposal_record_preview": deepcopy(gate.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(gate.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(gate.get("target_paths_preview")),
+        "write_lock_checklist": deepcopy(gate.get("write_lock_checklist")),
+        "validation": validation,
+        "token_issuance_dry_run_explanation": (
+            explain_human_approval_token_issuance_dry_run(source_snapshot) if source_snapshot else {}
+        ),
+        "token_issued": False,
+        "approved": False,
+        "persisted": False,
+        "submitted": False,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY),
+    }
+
+
+def recommend_human_approval_token_write_lock_action(gate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_approval_token_write_lock_gate(gate)
+    source_snapshot = _as_dict(gate.get("source_token_issuance_dry_run_snapshot"))
+    if validation["valid"] and gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE:
+        action = "request_separate_final_human_confirmation_before_token_write"
+        reason = "Token write-lock gate is eligible only for a separate final human confirmation flow; it does not issue, persist, approve, submit, or write tokens."
+    else:
+        action = "keep_token_write_locked"
+        reason = _recommendation_reason(gate.get("lock_reason"), validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ROUTING,
+        "validation": validation,
+        "token_issuance_dry_run_recommendation": (
+            recommend_human_approval_token_issuance_dry_run_action(source_snapshot) if source_snapshot else {}
+        ),
+        "creates_token_write_lock_candidates_only": True,
+        "issues_real_approval_tokens": False,
+        "persists_approvals": False,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "applies_proposals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY),
+    }
+
+
+def summarize_human_approval_token_write_lock_gates(
+    gates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    by_lock_reason: dict[str, int] = {}
+    locked_count = 0
+    eligible_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for gate in gates:
+        block_type = str(gate.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(gate.get("gate_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        reason = str(gate.get("lock_reason"))
+        by_lock_reason[reason] = by_lock_reason.get(reason, 0) + 1
+        if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED:
+            locked_count += 1
+        if gate.get("gate_status") == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE:
+            eligible_count += 1
+        validation = validate_human_approval_token_write_lock_gate(gate)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(gates),
+        "locked_count": locked_count,
+        "eligible_count": eligible_count,
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "by_lock_reason": dict(sorted(by_lock_reason.items())),
+        "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY),
+    }
+
+
+def _write_lock_reason(source: Mapping[str, Any], token_dry_run_validation: Mapping[str, Any]) -> str | None:
+    if source.get("dry_run_status") == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED:
+        return source.get("lock_reason") or "token_issuance_dry_run_locked"
+    if not isinstance(source.get("approval_token_record_preview"), Mapping):
+        return "missing_approval_token_record_preview"
+    if not isinstance(source.get("approval_audit_record_preview"), Mapping):
+        return "missing_approval_audit_record_preview"
+    if not isinstance(source.get("token_target_paths_preview"), Mapping):
+        return "missing_token_target_paths_preview"
+    if not isinstance(source.get("proposal_record_preview"), Mapping):
+        return "missing_proposal_record_preview"
+    if not isinstance(source.get("operation_ledger_preview"), Mapping):
+        return "missing_operation_ledger_preview"
+    if not isinstance(source.get("target_paths_preview"), Mapping):
+        return "missing_target_paths_preview"
+    if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(source):
+        return "preview_integrity_failed"
+    if token_dry_run_validation.get("valid") is not True:
+        return "invalid_token_issuance_dry_run"
+    if source.get("dry_run_status") != MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED:
+        return "invalid_token_issuance_dry_run"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and (
+                key in _FORBIDDEN_TRUE_KEYS
+                or key in {"created", "written", "token_issued", "approved", "persisted"}
+                or "created" in key
+                or "written" in key
+                or key.startswith("writes_")
+            ):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _write_lock_checklist() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "verify_token_dry_run_validation",
+            "description": "Confirm the source token issuance dry run is valid and still requires manual final preflight.",
+        },
+        {
+            "id": "verify_token_previews_only",
+            "description": "Confirm approval token, approval audit, token-path, proposal, ledger, and target-path previews are preview-only.",
+        },
+        {
+            "id": "verify_no_token_approval_or_write_flags",
+            "description": "Confirm previews do not mark tokens as issued, approvals as persisted, records as created, or files as written.",
+        },
+        {
+            "id": "verify_payload_and_source_evidence",
+            "description": "Confirm payload preview and source pattern or fact evidence are present.",
+        },
+        {
+            "id": "require_separate_final_human_confirmation",
+            "description": "Require a separate final human confirmation flow before any token write.",
+        },
+    ]
+
+
+def _recommendation_reason(lock_reason: Any, validation: Mapping[str, Any]) -> str:
+    if lock_reason == "invalid_token_issuance_dry_run":
+        return "Source token issuance dry-run candidate is invalid."
+    if lock_reason in {
+        "token_issuance_dry_run_locked",
+        "token_issuance_plan_locked",
+        "token_review_requested_changes",
+        "token_review_rejected",
+        "token_review_deferred",
+        "invalid_token_review_outcome",
+        "missing_token_plan_controls",
+    }:
+        return f"Token write-lock gate inherits the source dry-run lock: {lock_reason}."
+    if lock_reason in {
+        "missing_approval_token_record_preview",
+        "missing_approval_audit_record_preview",
+        "missing_token_target_paths_preview",
+        "missing_proposal_record_preview",
+        "missing_operation_ledger_preview",
+        "missing_target_paths_preview",
+        "missing_source_evidence",
+    }:
+        return f"Token write-lock gate is locked because {lock_reason}."
+    if lock_reason == "preview_integrity_failed":
+        return "Token write-lock gate preview artifacts are not preview-only or include issuance, approval, created, persisted, or written flags."
+    if validation.get("errors"):
+        return "Token write-lock gate violates the v0.1 validation contract."
+    return "Token writing remains locked until a separate final human confirmation flow is completed."
+
+
+def _gate_id(gate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_VERSION,
+        "gate_kind": gate.get("gate_kind"),
+        "gate_status": gate.get("gate_status"),
+        "routing": gate.get("routing"),
+        "lock_reason": gate.get("lock_reason"),
+        "source_token_issuance_dry_run_id": gate.get("source_token_issuance_dry_run_id"),
+        "source_token_issuance_plan_id": gate.get("source_token_issuance_plan_id"),
+        "source_review_outcome_id": gate.get("source_review_outcome_id"),
+        "source_request_id": gate.get("source_request_id"),
+        "source_gate_id": gate.get("source_gate_id"),
+        "source_dry_run_id": gate.get("source_dry_run_id"),
+        "source_plan_id": gate.get("source_plan_id"),
+        "source_outcome_id": gate.get("source_outcome_id"),
+        "source_packet_id": gate.get("source_packet_id"),
+        "source_submission_id": gate.get("source_submission_id"),
+        "source_draft_id": gate.get("source_draft_id"),
+        "source_decision_id": gate.get("source_decision_id"),
+        "source_queue_item_id": gate.get("source_queue_item_id"),
+        "block_id": gate.get("block_id"),
+        "block_type": gate.get("block_type"),
+        "project_scope": gate.get("project_scope"),
+        "operator": gate.get("operator"),
+        "approval_token_record_preview": gate.get("approval_token_record_preview", {}),
+        "approval_audit_record_preview": gate.get("approval_audit_record_preview", {}),
+        "token_target_paths_preview": gate.get("token_target_paths_preview", {}),
+        "proposal_record_preview": gate.get("proposal_record_preview", {}),
+        "operation_ledger_preview": gate.get("operation_ledger_preview", {}),
+        "target_paths_preview": gate.get("target_paths_preview", {}),
+        "payload_preview": gate.get("payload_preview"),
+        "source_pattern_ids": list(gate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(gate.get("source_fact_ids", [])),
+        "write_lock_checklist": gate.get("write_lock_checklist", []),
+        "token_dry_run_validation": gate.get("token_dry_run_validation", {}),
+        "policy": gate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-approval-token-write-lock-gate:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_human_review_outcome_gate.py
+++ b/agent/memory_human_review_outcome_gate.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_governance_submission_packet import (
+    explain_governance_submission_packet,
+    recommend_governance_submission_packet_action,
+    validate_governance_submission_packet,
+)
+
+
+MEMORY_HUMAN_REVIEW_OUTCOME_GATE_VERSION = "0.1"
+MEMORY_HUMAN_REVIEW_OUTCOME_KIND = "memory_human_review_outcome_candidate"
+MEMORY_HUMAN_REVIEW_OUTCOME_STATUS = "review_outcome_candidate"
+MEMORY_HUMAN_REVIEW_OUTCOME_ROUTING = "manual_real_proposal_creation_still_required"
+SUPPORTED_HUMAN_REVIEW_OUTCOMES = (
+    "approve_real_proposal_creation",
+    "request_changes",
+    "reject",
+    "defer",
+)
+MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_outcome_candidates_only": True,
+    "creates_real_proposals": False,
+    "applies_proposals": False,
+    "persists_approvals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_FORBIDDEN_TRUE_KEYS = (
+    "submitted",
+    "applied",
+    "persisted",
+    "approved",
+    "converted_to_real_proposal",
+    "created_real_proposal",
+    "created_operation_event",
+    "created_proposal_record",
+    "submitted_to_governance",
+)
+
+
+def create_human_review_outcome_candidate(
+    packet: Mapping[str, Any],
+    reviewer: str | None = None,
+    outcome: str | None = None,
+    rationale: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only human-review outcome candidate."""
+    source = deepcopy(dict(packet))
+    packet_validation = validate_governance_submission_packet(source)
+    selected_outcome = outcome if outcome is not None else evaluate_human_review_packet(source, reviewer=reviewer)["outcome"]
+    selected_rationale = rationale if rationale is not None else _outcome_rationale(selected_outcome, packet_validation, explicit=outcome is not None)
+
+    candidate = {
+        "outcome_id": None,
+        "outcome_kind": MEMORY_HUMAN_REVIEW_OUTCOME_KIND,
+        "outcome_status": MEMORY_HUMAN_REVIEW_OUTCOME_STATUS,
+        "routing": MEMORY_HUMAN_REVIEW_OUTCOME_ROUTING,
+        "source_packet_id": source.get("packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "reviewer": reviewer if reviewer is not None else source.get("reviewer"),
+        "outcome": selected_outcome,
+        "rationale": selected_rationale,
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "packet_validation": deepcopy(packet_validation),
+        "outcome_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_packet_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY),
+    }
+    candidate["outcome_id"] = _outcome_id(candidate)
+    candidate["outcome_validation"] = validate_human_review_outcome_candidate(candidate)
+    candidate["next_step_recommendation"] = recommend_human_review_outcome_action(candidate)
+    return candidate
+
+
+def evaluate_human_review_packet(packet: Mapping[str, Any], reviewer: str | None = None) -> dict[str, Any]:
+    validation = validate_governance_submission_packet(packet)
+    errors = list(validation.get("errors", []) or [])
+    if "missing_payload_preview" in errors:
+        outcome = "request_changes"
+    elif "missing_source_evidence" in errors:
+        outcome = "request_changes"
+    elif validation.get("valid") is not True:
+        outcome = "reject"
+    elif isinstance(packet.get("payload_preview"), Mapping) and (packet.get("source_pattern_ids") or packet.get("source_fact_ids")):
+        outcome = "approve_real_proposal_creation"
+    else:
+        outcome = "defer"
+    return {
+        "outcome": outcome,
+        "rationale": _outcome_rationale(outcome, validation),
+        "reviewer": reviewer if reviewer is not None else packet.get("reviewer"),
+        "packet_validation": validation,
+        "packet_explanation": explain_governance_submission_packet(packet),
+        "packet_recommendation": recommend_governance_submission_packet_action(packet),
+        "policy": dict(MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY),
+    }
+
+
+def validate_human_review_outcome_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(candidate.get("policy"))
+    packet_validation = _as_dict(candidate.get("packet_validation"))
+    source_snapshot = _as_dict(candidate.get("source_packet_snapshot"))
+
+    for key in (
+        "outcome_id",
+        "outcome_kind",
+        "outcome_status",
+        "routing",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "reviewer",
+        "outcome",
+        "rationale",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "packet_validation",
+        "outcome_validation",
+        "next_step_recommendation",
+        "source_packet_snapshot",
+        "policy",
+    ):
+        if key not in candidate:
+            errors.append(f"missing_{key}")
+    if candidate.get("outcome_kind") != MEMORY_HUMAN_REVIEW_OUTCOME_KIND:
+        errors.append("outcome_kind_must_be_memory_human_review_outcome_candidate")
+    if candidate.get("outcome_status") != MEMORY_HUMAN_REVIEW_OUTCOME_STATUS:
+        errors.append("outcome_status_must_be_review_outcome_candidate")
+    if candidate.get("routing") != MEMORY_HUMAN_REVIEW_OUTCOME_ROUTING:
+        errors.append("routing_must_require_manual_real_proposal_creation_still_required")
+    if candidate.get("outcome") not in SUPPORTED_HUMAN_REVIEW_OUTCOMES:
+        errors.append("unsupported_human_review_outcome")
+    if not isinstance(candidate.get("rationale"), str) or not candidate.get("rationale"):
+        errors.append("rationale_must_be_non_empty_string")
+    if not isinstance(candidate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(candidate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if not isinstance(packet_validation.get("valid"), bool):
+        errors.append("packet_validation_must_include_boolean_valid")
+    if source_snapshot:
+        snapshot_validation = validate_governance_submission_packet(source_snapshot)
+        if snapshot_validation != packet_validation:
+            errors.append("packet_validation_must_match_source_packet_snapshot")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if candidate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_human_review_outcome_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_review_outcome_candidate(candidate)
+    source_snapshot = _as_dict(candidate.get("source_packet_snapshot"))
+    return {
+        "outcome_id": candidate.get("outcome_id"),
+        "outcome_kind": candidate.get("outcome_kind"),
+        "outcome_status": candidate.get("outcome_status"),
+        "routing": candidate.get("routing"),
+        "source_packet_id": candidate.get("source_packet_id"),
+        "source_submission_id": candidate.get("source_submission_id"),
+        "source_draft_id": candidate.get("source_draft_id"),
+        "source_decision_id": candidate.get("source_decision_id"),
+        "source_queue_item_id": candidate.get("source_queue_item_id"),
+        "block_id": candidate.get("block_id"),
+        "block_type": candidate.get("block_type"),
+        "project_scope": candidate.get("project_scope"),
+        "reviewer": candidate.get("reviewer"),
+        "outcome": candidate.get("outcome"),
+        "rationale": candidate.get("rationale"),
+        "source_pattern_count": len(candidate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(candidate.get("source_fact_ids", []) or []),
+        "validation": validation,
+        "packet_explanation": explain_governance_submission_packet(source_snapshot) if source_snapshot else {},
+        "submitted": False,
+        "applied": False,
+        "persisted": False,
+        "approved": False,
+        "converted_to_real_proposal": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "submitted_to_governance": False,
+        "policy": dict(MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY),
+    }
+
+
+def recommend_human_review_outcome_action(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_human_review_outcome_candidate(candidate)
+    outcome = candidate.get("outcome")
+    if not validation["valid"]:
+        action = "do_not_use_outcome_candidate"
+        reason = _recommendation_reason(validation)
+    elif outcome == "approve_real_proposal_creation":
+        action = "manual_real_proposal_creation_required"
+        reason = "Outcome candidate approves manual real proposal creation, but this gate does not create, submit, apply, or persist it."
+    elif outcome == "request_changes":
+        action = "return_packet_for_changes"
+        reason = "Outcome candidate requests packet changes before any real proposal creation."
+    elif outcome == "reject":
+        action = "do_not_create_real_proposal"
+        reason = "Outcome candidate rejects this packet for real proposal creation."
+    else:
+        action = "defer_manual_review_outcome"
+        reason = "Outcome candidate defers until a human reviewer resolves the unknown condition."
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_HUMAN_REVIEW_OUTCOME_ROUTING,
+        "validation": validation,
+        "packet_recommendation": recommend_governance_submission_packet_action(_as_dict(candidate.get("source_packet_snapshot"))),
+        "creates_outcome_candidates_only": True,
+        "creates_real_proposals": False,
+        "applies_proposals": False,
+        "persists_approvals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY),
+    }
+
+
+def summarize_human_review_outcomes(
+    candidates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_outcome: dict[str, int] = {}
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for candidate in candidates:
+        outcome = str(candidate.get("outcome"))
+        by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
+        block_type = str(candidate.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(candidate.get("outcome_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        validation = validate_human_review_outcome_candidate(candidate)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(candidates),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_outcome": dict(sorted(by_outcome.items())),
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY),
+    }
+
+
+def _outcome_rationale(outcome: str, packet_validation: Mapping[str, Any], explicit: bool = False) -> str:
+    if explicit and outcome in SUPPORTED_HUMAN_REVIEW_OUTCOMES:
+        return "Explicit supported human review outcome override recorded as a read-only candidate only."
+    errors = list(packet_validation.get("errors", []) or [])
+    if outcome == "approve_real_proposal_creation":
+        return "Packet is valid and includes payload preview plus source evidence."
+    if outcome == "request_changes" and "missing_payload_preview" in errors:
+        return "Packet is missing payload_preview required before real proposal creation review."
+    if outcome == "request_changes" and "missing_source_evidence" in errors:
+        return "Packet is missing source pattern or fact evidence required before real proposal creation review."
+    if outcome == "reject":
+        return "Packet is invalid for human review outcome approval."
+    if outcome == "defer":
+        return "Packet condition is unknown for v0.1 and must be deferred."
+    return "Human review outcome is unsupported by v0.1."
+
+
+def _recommendation_reason(validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if "unsupported_human_review_outcome" in errors:
+        return "Outcome candidate uses an unsupported human review outcome label."
+    if "packet_validation_must_match_source_packet_snapshot" in errors:
+        return "Outcome candidate packet validation does not match its source packet snapshot."
+    return "Outcome candidate violates the v0.1 human review outcome validation contract."
+
+
+def _outcome_id(candidate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_HUMAN_REVIEW_OUTCOME_GATE_VERSION,
+        "outcome_kind": candidate.get("outcome_kind"),
+        "outcome_status": candidate.get("outcome_status"),
+        "routing": candidate.get("routing"),
+        "source_packet_id": candidate.get("source_packet_id"),
+        "source_submission_id": candidate.get("source_submission_id"),
+        "source_draft_id": candidate.get("source_draft_id"),
+        "source_decision_id": candidate.get("source_decision_id"),
+        "source_queue_item_id": candidate.get("source_queue_item_id"),
+        "block_id": candidate.get("block_id"),
+        "block_type": candidate.get("block_type"),
+        "project_scope": candidate.get("project_scope"),
+        "reviewer": candidate.get("reviewer"),
+        "outcome": candidate.get("outcome"),
+        "rationale": candidate.get("rationale"),
+        "payload_preview": candidate.get("payload_preview"),
+        "source_pattern_ids": list(candidate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(candidate.get("source_fact_ids", [])),
+        "packet_validation": candidate.get("packet_validation", {}),
+        "policy": candidate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-human-review-outcome:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_proposal_draft_builder.py
+++ b/agent/memory_proposal_draft_builder.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_review_decision_gate import (
+    explain_review_decision_candidate,
+    recommend_review_decision_action,
+    validate_review_decision_candidate,
+)
+
+
+MEMORY_PROPOSAL_DRAFT_BUILDER_VERSION = "0.1"
+MEMORY_PROPOSAL_DRAFT_KIND = "memory_block_write_proposal_draft"
+MEMORY_PROPOSAL_DRAFT_STATUS = "draft_review_required"
+MEMORY_PROPOSAL_DRAFT_ROUTING = "separate_governed_proposal_flow_required"
+MEMORY_PROPOSAL_DRAFT_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_draft_candidates_only": True,
+    "creates_real_proposals": False,
+    "applies_proposals": False,
+    "persists_approvals": False,
+}
+
+_INVALID_REASON_BY_DECISION = {
+    "request_more_evidence": "more_evidence_required",
+    "reject": "rejected_decision",
+    "defer": "deferred_decision",
+}
+
+
+def create_memory_proposal_draft(decision_candidate: Mapping[str, Any], author: str | None = None) -> dict[str, Any]:
+    """Create a deterministic read-only proposal draft candidate from a decision candidate."""
+    source = deepcopy(dict(decision_candidate))
+    decision_validation = validate_review_decision_candidate(source)
+    source_snapshot = deepcopy(source)
+    queue_snapshot = _as_dict(source.get("queue_item_snapshot"))
+    block_snapshot = _as_dict(queue_snapshot.get("block_snapshot"))
+    reason = _draft_invalid_reason(source, decision_validation)
+
+    draft = {
+        "draft_id": None,
+        "proposal_kind": MEMORY_PROPOSAL_DRAFT_KIND,
+        "proposal_status": MEMORY_PROPOSAL_DRAFT_STATUS,
+        "routing": MEMORY_PROPOSAL_DRAFT_ROUTING,
+        "source_decision_id": source.get("decision_id"),
+        "source_queue_item_id": source.get("queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "author": author if author is not None else source.get("reviewer"),
+        "rationale": _draft_rationale(source, reason),
+        "payload_preview": _payload_preview(source, block_snapshot),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "decision_validation": deepcopy(decision_validation),
+        "draft_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_decision_snapshot": source_snapshot,
+        "policy": dict(MEMORY_PROPOSAL_DRAFT_POLICY),
+    }
+    draft["draft_id"] = _draft_id(draft)
+    draft["draft_validation"] = validate_memory_proposal_draft(draft)
+    draft["next_step_recommendation"] = recommend_memory_proposal_draft_action(draft)
+    return draft
+
+
+def validate_memory_proposal_draft(draft: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(draft.get("policy"))
+    decision_validation = _as_dict(draft.get("decision_validation"))
+    source_snapshot = _as_dict(draft.get("source_decision_snapshot"))
+
+    for key in (
+        "draft_id",
+        "proposal_kind",
+        "proposal_status",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "author",
+        "rationale",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "decision_validation",
+        "draft_validation",
+        "next_step_recommendation",
+        "source_decision_snapshot",
+        "policy",
+    ):
+        if key not in draft:
+            errors.append(f"missing_{key}")
+    if "routing" not in draft:
+        errors.append("missing_routing")
+    if draft.get("proposal_kind") != MEMORY_PROPOSAL_DRAFT_KIND:
+        errors.append("proposal_kind_must_be_memory_block_write_proposal_draft")
+    if draft.get("proposal_status") != MEMORY_PROPOSAL_DRAFT_STATUS:
+        errors.append("proposal_status_must_be_draft_review_required")
+    if draft.get("routing") != MEMORY_PROPOSAL_DRAFT_ROUTING:
+        errors.append("routing_must_require_separate_governed_proposal_flow")
+    if decision_validation.get("valid") is not True:
+        errors.append("invalid_decision_candidate")
+    elif source_snapshot.get("decision") != "approve_to_proposal":
+        errors.append(_INVALID_REASON_BY_DECISION.get(str(source_snapshot.get("decision")), "invalid_decision_candidate"))
+    if not isinstance(draft.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(draft.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if not isinstance(draft.get("payload_preview"), Mapping):
+        errors.append("payload_preview_must_be_mapping")
+    for forbidden_key in ("applied", "persisted", "created_real_proposal", "created_operation_event"):
+        if draft.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_PROPOSAL_DRAFT_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": errors}
+
+
+def explain_memory_proposal_draft(draft: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_memory_proposal_draft(draft)
+    source_snapshot = _as_dict(draft.get("source_decision_snapshot"))
+    return {
+        "draft_id": draft.get("draft_id"),
+        "proposal_kind": draft.get("proposal_kind"),
+        "proposal_status": draft.get("proposal_status"),
+        "routing": draft.get("routing"),
+        "source_decision_id": draft.get("source_decision_id"),
+        "source_queue_item_id": draft.get("source_queue_item_id"),
+        "block_id": draft.get("block_id"),
+        "block_type": draft.get("block_type"),
+        "project_scope": draft.get("project_scope"),
+        "author": draft.get("author"),
+        "source_pattern_count": len(draft.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(draft.get("source_fact_ids", []) or []),
+        "validation": validation,
+        "decision_explanation": explain_review_decision_candidate(source_snapshot) if source_snapshot else {},
+        "applied": False,
+        "persisted": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "policy": dict(MEMORY_PROPOSAL_DRAFT_POLICY),
+    }
+
+
+def recommend_memory_proposal_draft_action(draft: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_memory_proposal_draft(draft)
+    source_snapshot = _as_dict(draft.get("source_decision_snapshot"))
+    if validation["valid"]:
+        action = "submit_to_separate_governed_proposal_flow"
+        reason = "Draft candidate is valid for human review, but this builder does not create a real proposal."
+    else:
+        action = "do_not_submit_draft"
+        reason = _recommendation_reason(validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_PROPOSAL_DRAFT_ROUTING,
+        "validation": validation,
+        "decision_recommendation": recommend_review_decision_action(source_snapshot) if source_snapshot else {},
+        "creates_draft_candidates_only": True,
+        "creates_real_proposals": False,
+        "applies_proposals": False,
+        "persists_approvals": False,
+        "policy": dict(MEMORY_PROPOSAL_DRAFT_POLICY),
+    }
+
+
+def summarize_memory_proposal_drafts(drafts: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...]) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for draft in drafts:
+        block_type = str(draft.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(draft.get("proposal_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        validation = validate_memory_proposal_draft(draft)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(drafts),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_PROPOSAL_DRAFT_POLICY),
+    }
+
+
+def _draft_invalid_reason(source: Mapping[str, Any], decision_validation: Mapping[str, Any]) -> str | None:
+    if decision_validation.get("valid") is not True:
+        return "invalid_decision_candidate"
+    decision = str(source.get("decision"))
+    if decision == "approve_to_proposal":
+        return None
+    return _INVALID_REASON_BY_DECISION.get(decision, "invalid_decision_candidate")
+
+
+def _draft_rationale(source: Mapping[str, Any], reason: str | None) -> str:
+    if reason is None:
+        return str(source.get("rationale") or "Approved decision candidate may be drafted for governed proposal review.")
+    return f"Draft is invalid: {reason}."
+
+
+def _payload_preview(source: Mapping[str, Any], block_snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    preview_source = block_snapshot if block_snapshot else source
+    keys = (
+        "block_id",
+        "block_type",
+        "status",
+        "project_scope",
+        "content",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "metadata",
+        "version",
+        "source_event_id",
+        "confidence",
+        "validity",
+        "mutation_policy",
+        "direct_write_allowed",
+        "policy",
+    )
+    preview = {key: deepcopy(preview_source.get(key)) for key in keys if key in preview_source}
+    preview.setdefault("block_id", source.get("block_id"))
+    preview.setdefault("block_type", source.get("block_type"))
+    preview.setdefault("project_scope", source.get("project_scope"))
+    preview.setdefault("source_pattern_ids", deepcopy(list(source.get("source_pattern_ids", []) or [])))
+    preview.setdefault("source_fact_ids", deepcopy(list(source.get("source_fact_ids", []) or [])))
+    preview["applied"] = False
+    preview["persisted"] = False
+    preview["created_real_proposal"] = False
+    return preview
+
+
+def _recommendation_reason(validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if "more_evidence_required" in errors:
+        return "Source decision requested more evidence before any proposal draft can be reviewed."
+    if "rejected_decision" in errors:
+        return "Source decision rejected the block candidate."
+    if "deferred_decision" in errors:
+        return "Source decision deferred the block candidate for manual review."
+    return "Draft candidate violates the v0.1 proposal draft validation contract."
+
+
+def _draft_id(draft: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_PROPOSAL_DRAFT_BUILDER_VERSION,
+        "proposal_kind": draft.get("proposal_kind"),
+        "proposal_status": draft.get("proposal_status"),
+        "routing": draft.get("routing"),
+        "source_decision_id": draft.get("source_decision_id"),
+        "source_queue_item_id": draft.get("source_queue_item_id"),
+        "block_id": draft.get("block_id"),
+        "block_type": draft.get("block_type"),
+        "project_scope": draft.get("project_scope"),
+        "author": draft.get("author"),
+        "source_pattern_ids": list(draft.get("source_pattern_ids", [])),
+        "source_fact_ids": list(draft.get("source_fact_ids", [])),
+        "decision_validation": draft.get("decision_validation", {}),
+        "payload_preview": draft.get("payload_preview", {}),
+        "policy": draft.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-proposal-draft:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}

--- a/agent/memory_proposal_governance_gate.py
+++ b/agent/memory_proposal_governance_gate.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_proposal_draft_builder import (
+    explain_memory_proposal_draft,
+    recommend_memory_proposal_draft_action,
+    validate_memory_proposal_draft,
+)
+
+
+MEMORY_PROPOSAL_GOVERNANCE_GATE_VERSION = "0.1"
+MEMORY_GOVERNANCE_SUBMISSION_KIND = "memory_block_write_governance_submission_candidate"
+MEMORY_GOVERNANCE_SUBMISSION_STATUS = "governance_review_required"
+MEMORY_GOVERNANCE_SUBMISSION_ROUTING = "manual_governed_proposal_creation_required"
+MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_submission_candidates_only": True,
+    "creates_real_proposals": False,
+    "applies_proposals": False,
+    "persists_approvals": False,
+    "submits_to_governance": False,
+}
+
+
+def create_governance_submission_candidate(proposal_draft: Mapping[str, Any], reviewer: str | None = None) -> dict[str, Any]:
+    """Create a deterministic read-only governance submission candidate from a proposal draft."""
+    draft = deepcopy(dict(proposal_draft))
+    draft_validation = validate_memory_proposal_draft(draft)
+    invalid_reasons = _submission_invalid_reasons(draft, draft_validation)
+
+    candidate = {
+        "submission_id": None,
+        "submission_kind": MEMORY_GOVERNANCE_SUBMISSION_KIND,
+        "submission_status": MEMORY_GOVERNANCE_SUBMISSION_STATUS,
+        "routing": MEMORY_GOVERNANCE_SUBMISSION_ROUTING,
+        "source_draft_id": draft.get("draft_id"),
+        "source_decision_id": draft.get("source_decision_id"),
+        "source_queue_item_id": draft.get("source_queue_item_id"),
+        "block_id": draft.get("block_id"),
+        "block_type": draft.get("block_type"),
+        "project_scope": draft.get("project_scope"),
+        "reviewer": reviewer if reviewer is not None else draft.get("author"),
+        "payload_preview": deepcopy(draft.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(draft.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(draft.get("source_fact_ids", []) or [])),
+        "draft_validation": deepcopy(draft_validation),
+        "submission_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_draft_snapshot": deepcopy(draft),
+        "policy": dict(MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY),
+    }
+    candidate["submission_id"] = _submission_id(candidate)
+    candidate["submission_validation"] = validate_governance_submission_candidate(candidate)
+    if invalid_reasons:
+        errors = list(candidate["submission_validation"]["errors"])
+        for reason in invalid_reasons:
+            if reason not in errors:
+                errors.append(reason)
+        candidate["submission_validation"] = {"valid": False, "errors": errors}
+    candidate["next_step_recommendation"] = recommend_governance_submission_action(candidate)
+    return candidate
+
+
+def validate_governance_submission_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(candidate.get("policy"))
+    draft_validation = _as_dict(candidate.get("draft_validation"))
+    source_snapshot = _as_dict(candidate.get("source_draft_snapshot"))
+
+    for key in (
+        "submission_id",
+        "submission_kind",
+        "submission_status",
+        "routing",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "reviewer",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "draft_validation",
+        "submission_validation",
+        "next_step_recommendation",
+        "source_draft_snapshot",
+        "policy",
+    ):
+        if key not in candidate:
+            errors.append(f"missing_{key}")
+    if candidate.get("submission_kind") != MEMORY_GOVERNANCE_SUBMISSION_KIND:
+        errors.append("submission_kind_must_be_memory_block_write_governance_submission_candidate")
+    if candidate.get("submission_status") != MEMORY_GOVERNANCE_SUBMISSION_STATUS:
+        errors.append("submission_status_must_be_governance_review_required")
+    if candidate.get("routing") != MEMORY_GOVERNANCE_SUBMISSION_ROUTING:
+        errors.append("routing_must_require_manual_governed_proposal_creation")
+    if draft_validation.get("valid") is not True:
+        errors.append("invalid_proposal_draft")
+    if source_snapshot.get("proposal_status") != "draft_review_required":
+        errors.append("source_proposal_status_must_be_draft_review_required")
+    if not isinstance(candidate.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(candidate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(candidate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(candidate.get("source_pattern_ids"), list) and isinstance(candidate.get("source_fact_ids"), list):
+        if not candidate.get("source_pattern_ids") and not candidate.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    for forbidden_key in (
+        "submitted",
+        "applied",
+        "persisted",
+        "approved",
+        "created_real_proposal",
+        "created_operation_event",
+    ):
+        if candidate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": errors}
+
+
+def explain_governance_submission_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_governance_submission_candidate(candidate)
+    source_snapshot = _as_dict(candidate.get("source_draft_snapshot"))
+    return {
+        "submission_id": candidate.get("submission_id"),
+        "submission_kind": candidate.get("submission_kind"),
+        "submission_status": candidate.get("submission_status"),
+        "routing": candidate.get("routing"),
+        "source_draft_id": candidate.get("source_draft_id"),
+        "source_decision_id": candidate.get("source_decision_id"),
+        "source_queue_item_id": candidate.get("source_queue_item_id"),
+        "block_id": candidate.get("block_id"),
+        "block_type": candidate.get("block_type"),
+        "project_scope": candidate.get("project_scope"),
+        "reviewer": candidate.get("reviewer"),
+        "source_pattern_count": len(candidate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(candidate.get("source_fact_ids", []) or []),
+        "validation": validation,
+        "draft_explanation": explain_memory_proposal_draft(source_snapshot) if source_snapshot else {},
+        "submitted": False,
+        "applied": False,
+        "persisted": False,
+        "approved": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "policy": dict(MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY),
+    }
+
+
+def recommend_governance_submission_action(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_governance_submission_candidate(candidate)
+    source_snapshot = _as_dict(candidate.get("source_draft_snapshot"))
+    if validation["valid"]:
+        action = "create_real_proposal_manually_in_governed_flow"
+        reason = "Submission candidate is valid for manual governance review, but this gate does not submit or create a real proposal."
+    else:
+        action = "do_not_create_governance_submission"
+        reason = _recommendation_reason(validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_GOVERNANCE_SUBMISSION_ROUTING,
+        "validation": validation,
+        "draft_recommendation": recommend_memory_proposal_draft_action(source_snapshot) if source_snapshot else {},
+        "creates_submission_candidates_only": True,
+        "creates_real_proposals": False,
+        "applies_proposals": False,
+        "persists_approvals": False,
+        "submits_to_governance": False,
+        "policy": dict(MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY),
+    }
+
+
+def summarize_governance_submission_candidates(
+    candidates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for candidate in candidates:
+        block_type = str(candidate.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(candidate.get("submission_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        validation = validate_governance_submission_candidate(candidate)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(candidates),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY),
+    }
+
+
+def _submission_invalid_reasons(draft: Mapping[str, Any], draft_validation: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if draft_validation.get("valid") is not True:
+        reasons.append("invalid_proposal_draft")
+    if not isinstance(draft.get("payload_preview"), Mapping):
+        reasons.append("missing_payload_preview")
+    if not (draft.get("source_pattern_ids") or draft.get("source_fact_ids")):
+        reasons.append("missing_source_evidence")
+    if draft.get("proposal_status") != "draft_review_required":
+        reasons.append("source_proposal_status_must_be_draft_review_required")
+    return reasons
+
+
+def _recommendation_reason(validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if "missing_payload_preview" in errors:
+        return "Submission candidate is missing the payload preview required for manual governance review."
+    if "missing_source_evidence" in errors:
+        return "Submission candidate is missing source pattern or fact evidence."
+    if "invalid_proposal_draft" in errors:
+        return "Source proposal draft is invalid and cannot be routed toward governance review."
+    return "Submission candidate violates the v0.1 governance submission validation contract."
+
+
+def _submission_id(candidate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_PROPOSAL_GOVERNANCE_GATE_VERSION,
+        "submission_kind": candidate.get("submission_kind"),
+        "submission_status": candidate.get("submission_status"),
+        "routing": candidate.get("routing"),
+        "source_draft_id": candidate.get("source_draft_id"),
+        "source_decision_id": candidate.get("source_decision_id"),
+        "source_queue_item_id": candidate.get("source_queue_item_id"),
+        "block_id": candidate.get("block_id"),
+        "block_type": candidate.get("block_type"),
+        "project_scope": candidate.get("project_scope"),
+        "reviewer": candidate.get("reviewer"),
+        "payload_preview": candidate.get("payload_preview"),
+        "source_pattern_ids": list(candidate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(candidate.get("source_fact_ids", [])),
+        "draft_validation": candidate.get("draft_validation", {}),
+        "policy": candidate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-governance-submission:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}

--- a/agent/memory_read_only_candidate_utils.py
+++ b/agent/memory_read_only_candidate_utils.py
@@ -78,6 +78,11 @@ def as_list(value: Any) -> list[Any]:
     return deepcopy(list(value)) if isinstance(value, (list, tuple)) else []
 
 
+def _mapping_view(value: Any) -> Mapping[Any, Any]:
+    """Return a read-only mapping view without copying nested candidate graphs."""
+    return value if isinstance(value, Mapping) else {}
+
+
 def deep_copy_mapping(value: Any) -> dict[str, Any]:
     """Return a deep-copied mapping without sharing nested values."""
     return as_mapping(value)
@@ -100,7 +105,7 @@ def validate_required_keys(
     candidate: Mapping[str, Any],
     required_keys: Iterable[str],
 ) -> list[str]:
-    candidate_mapping = as_mapping(candidate)
+    candidate_mapping = _mapping_view(candidate)
     errors = [
         f"missing_{key}"
         for key in _iter_keys(required_keys)
@@ -113,7 +118,7 @@ def validate_forbidden_true_keys(
     candidate: Mapping[str, Any],
     forbidden_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
 ) -> list[str]:
-    candidate_mapping = as_mapping(candidate)
+    candidate_mapping = _mapping_view(candidate)
     errors = [
         f"{key}_must_be_false"
         for key in _iter_keys(forbidden_keys)
@@ -126,7 +131,7 @@ def validate_forbidden_true_keys_false_or_absent(
     candidate: Mapping[str, Any],
     forbidden_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
 ) -> list[str]:
-    candidate_mapping = as_mapping(candidate)
+    candidate_mapping = _mapping_view(candidate)
     errors = [
         f"{key}_must_be_false_or_absent"
         for key in _iter_keys(forbidden_keys)
@@ -139,9 +144,9 @@ def validate_policy_flags(
     policy: Mapping[str, Any],
     expected_flags: Mapping[str, bool] = READ_ONLY_POLICY_BASE,
 ) -> list[str]:
-    policy_mapping = as_mapping(policy)
+    policy_mapping = _mapping_view(policy)
     errors: list[str] = []
-    for key, expected in as_mapping(expected_flags).items():
+    for key, expected in _mapping_view(expected_flags).items():
         if expected is True and policy_mapping.get(key) is not True:
             errors.append(f"policy_{key}_must_be_true")
         elif expected is False and policy_mapping.get(key) is not False:
@@ -162,7 +167,7 @@ def validate_preview_forbidden_true_keys_false_or_absent(
     preview_fields: Iterable[str] = DEFAULT_PREVIEW_FIELDS,
     forbidden_true_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
 ) -> list[str]:
-    candidate_mapping = as_mapping(candidate)
+    candidate_mapping = _mapping_view(candidate)
     errors: list[str] = []
     for field in _iter_keys(preview_fields):
         preview = candidate_mapping.get(field)
@@ -235,7 +240,7 @@ def _validate_preview_fields(
     preview_fields: Iterable[str],
     forbidden_true_keys: Iterable[str],
 ) -> list[str]:
-    candidate_mapping = as_mapping(candidate)
+    candidate_mapping = _mapping_view(candidate)
     forbidden = {str(key) for key in _iter_keys(forbidden_true_keys)}
     errors: list[str] = []
     for field in _iter_keys(preview_fields):
@@ -264,7 +269,7 @@ def _is_forbidden_true_key(key: str, forbidden: set[str]) -> bool:
 def _count_by_key(candidates: list[Mapping[str, Any]], key: str) -> dict[str, int]:
     counts: dict[str, int] = {}
     for candidate in candidates:
-        candidate_mapping = as_mapping(candidate)
+        candidate_mapping = _mapping_view(candidate)
         value = str(candidate_mapping.get(key))
         counts[value] = counts.get(value, 0) + 1
     return dict(sorted(counts.items()))

--- a/agent/memory_read_only_candidate_utils.py
+++ b/agent/memory_read_only_candidate_utils.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from typing import Any
+
+
+READ_ONLY_POLICY_BASE = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "writes_token_files": False,
+    "writes_approval_audit": False,
+    "invokes_real_token_write_executor": False,
+    "implements_real_token_write_executor": False,
+    "creates_executor_source_files": False,
+}
+
+DEFAULT_FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created",
+    "created_real_proposal",
+    "created_operation_event",
+    "creates_real_proposals",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "issues_real_approval_tokens",
+    "persists_approvals",
+    "applies_proposals",
+    "submits_to_governance",
+    "converts_to_real_proposal",
+    "converted_to_real_proposal",
+    "would_write_memory",
+    "would_modify_config",
+    "would_write_graph",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "creates_executor_source_files",
+    "creates_executor_tests",
+)
+
+DEFAULT_PREVIEW_FIELDS = (
+    "approval_token_record_preview",
+    "approval_audit_record_preview",
+    "token_target_paths_preview",
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+
+DEFAULT_WRITE_PREVIEW_FIELDS = (
+    "approval_token_write_payload_preview",
+    "approval_audit_write_payload_preview",
+    "token_write_target_paths_preview",
+)
+
+
+def as_mapping(value: Any) -> dict[str, Any]:
+    """Return a deep-copied dict for mapping-like values, otherwise an empty dict."""
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def as_list(value: Any) -> list[Any]:
+    """Return a deep-copied list for list or tuple values, otherwise an empty list."""
+    return deepcopy(list(value)) if isinstance(value, (list, tuple)) else []
+
+
+def deep_copy_mapping(value: Any) -> dict[str, Any]:
+    """Return a deep-copied mapping without sharing nested values."""
+    return as_mapping(value)
+
+
+def copy_fields(source: Mapping[str, Any], fields: Iterable[str]) -> dict[str, Any]:
+    source_mapping = as_mapping(source)
+    copied: dict[str, Any] = {}
+    for field in _iter_keys(fields):
+        if field in source_mapping:
+            copied[field] = deepcopy(source_mapping[field])
+    return copied
+
+
+def copy_source_lineage(source: Mapping[str, Any], source_keys: Iterable[str]) -> dict[str, Any]:
+    return copy_fields(source, source_keys)
+
+
+def validate_required_keys(
+    candidate: Mapping[str, Any],
+    required_keys: Iterable[str],
+) -> list[str]:
+    candidate_mapping = as_mapping(candidate)
+    errors = [
+        f"missing_{key}"
+        for key in _iter_keys(required_keys)
+        if key not in candidate_mapping
+    ]
+    return merge_validation_errors(errors)
+
+
+def validate_forbidden_true_keys(
+    candidate: Mapping[str, Any],
+    forbidden_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
+) -> list[str]:
+    candidate_mapping = as_mapping(candidate)
+    errors = [
+        f"{key}_must_be_false"
+        for key in _iter_keys(forbidden_keys)
+        if candidate_mapping.get(key) is True
+    ]
+    return merge_validation_errors(errors)
+
+
+def validate_policy_flags(
+    policy: Mapping[str, Any],
+    expected_flags: Mapping[str, bool] = READ_ONLY_POLICY_BASE,
+) -> list[str]:
+    policy_mapping = as_mapping(policy)
+    errors: list[str] = []
+    for key, expected in as_mapping(expected_flags).items():
+        if expected is True and policy_mapping.get(key) is not True:
+            errors.append(f"policy_{key}_must_be_true")
+        elif expected is False and policy_mapping.get(key) is not False:
+            errors.append(f"policy_{key}_must_be_false")
+    return merge_validation_errors(errors)
+
+
+def validate_preview_integrity(
+    candidate: Mapping[str, Any],
+    preview_fields: Iterable[str] = DEFAULT_PREVIEW_FIELDS,
+    forbidden_true_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
+) -> list[str]:
+    return _validate_preview_fields(candidate, preview_fields, forbidden_true_keys)
+
+
+def validate_write_preview_integrity(
+    candidate: Mapping[str, Any],
+    write_preview_fields: Iterable[str] = DEFAULT_WRITE_PREVIEW_FIELDS,
+    forbidden_true_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
+) -> list[str]:
+    return _validate_preview_fields(candidate, write_preview_fields, forbidden_true_keys)
+
+
+def build_stable_digest(
+    prefix: str,
+    payload: Any,
+    ignored_keys: Iterable[str] | None = None,
+) -> str:
+    ignored = {str(key) for key in _iter_keys(ignored_keys or ())}
+    normalized = _normalize_for_digest(payload, ignored)
+    encoded = json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}:{digest}"
+
+
+def summarize_candidates(
+    candidates: Iterable[Mapping[str, Any]],
+    status_key: str,
+    type_key: str | None = None,
+    block_type_key: str = "block_type",
+) -> dict[str, Any]:
+    candidate_list = _iter_candidates(candidates)
+    summary: dict[str, Any] = {
+        "total": len(candidate_list),
+        "by_status": _count_by_key(candidate_list, status_key),
+        "by_block_type": _count_by_key(candidate_list, block_type_key),
+    }
+    if type_key is not None:
+        summary["by_type"] = _count_by_key(candidate_list, type_key)
+    return summary
+
+
+def merge_validation_errors(*error_lists: Iterable[str]) -> list[str]:
+    errors: list[str] = []
+    seen: set[str] = set()
+    for error_list in error_lists:
+        for error in as_list(error_list):
+            if error is None:
+                continue
+            error_text = str(error)
+            if error_text not in seen:
+                seen.add(error_text)
+                errors.append(error_text)
+    return errors
+
+
+def _validate_preview_fields(
+    candidate: Mapping[str, Any],
+    preview_fields: Iterable[str],
+    forbidden_true_keys: Iterable[str],
+) -> list[str]:
+    candidate_mapping = as_mapping(candidate)
+    forbidden = {str(key) for key in _iter_keys(forbidden_true_keys)}
+    errors: list[str] = []
+    for field in _iter_keys(preview_fields):
+        preview = candidate_mapping.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            key_text = str(key)
+            if value is True and _is_forbidden_true_key(key_text, forbidden):
+                errors.append(f"{field}_{key_text}_must_not_be_true")
+    return merge_validation_errors(errors)
+
+
+def _is_forbidden_true_key(key: str, forbidden: set[str]) -> bool:
+    return (
+        key in forbidden
+        or key in {"created", "written", "token_issued", "approved", "persisted"}
+        or "created" in key
+        or "written" in key
+        or key.startswith("writes_")
+    )
+
+
+def _count_by_key(candidates: list[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        candidate_mapping = as_mapping(candidate)
+        value = str(candidate_mapping.get(key))
+        counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _iter_candidates(candidates: Iterable[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    if isinstance(candidates, (str, bytes, bytearray, Mapping)):
+        return []
+    try:
+        return list(candidates)
+    except TypeError:
+        return []
+
+
+def _iter_keys(keys: Iterable[str] | str) -> tuple[str, ...]:
+    if keys is None:
+        return ()
+    if isinstance(keys, str):
+        return (keys,)
+    try:
+        return tuple(str(key) for key in keys)
+    except TypeError:
+        return (str(keys),)
+
+
+def _normalize_for_digest(value: Any, ignored_keys: set[str]) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalize_for_digest(item, ignored_keys)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+            if str(key) not in ignored_keys
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize_for_digest(item, ignored_keys) for item in value]
+    if isinstance(value, (set, frozenset)):
+        normalized_items = [_normalize_for_digest(item, ignored_keys) for item in value]
+        return sorted(
+            normalized_items,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+        )
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+__all__ = [
+    "READ_ONLY_POLICY_BASE",
+    "DEFAULT_FORBIDDEN_TRUE_KEYS",
+    "DEFAULT_PREVIEW_FIELDS",
+    "DEFAULT_WRITE_PREVIEW_FIELDS",
+    "as_mapping",
+    "as_list",
+    "deep_copy_mapping",
+    "copy_fields",
+    "copy_source_lineage",
+    "validate_required_keys",
+    "validate_forbidden_true_keys",
+    "validate_policy_flags",
+    "validate_preview_integrity",
+    "validate_write_preview_integrity",
+    "build_stable_digest",
+    "summarize_candidates",
+    "merge_validation_errors",
+]

--- a/agent/memory_read_only_candidate_utils.py
+++ b/agent/memory_read_only_candidate_utils.py
@@ -122,6 +122,19 @@ def validate_forbidden_true_keys(
     return merge_validation_errors(errors)
 
 
+def validate_forbidden_true_keys_false_or_absent(
+    candidate: Mapping[str, Any],
+    forbidden_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
+) -> list[str]:
+    candidate_mapping = as_mapping(candidate)
+    errors = [
+        f"{key}_must_be_false_or_absent"
+        for key in _iter_keys(forbidden_keys)
+        if candidate_mapping.get(key) is True
+    ]
+    return merge_validation_errors(errors)
+
+
 def validate_policy_flags(
     policy: Mapping[str, Any],
     expected_flags: Mapping[str, bool] = READ_ONLY_POLICY_BASE,
@@ -142,6 +155,23 @@ def validate_preview_integrity(
     forbidden_true_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
 ) -> list[str]:
     return _validate_preview_fields(candidate, preview_fields, forbidden_true_keys)
+
+
+def validate_preview_forbidden_true_keys_false_or_absent(
+    candidate: Mapping[str, Any],
+    preview_fields: Iterable[str] = DEFAULT_PREVIEW_FIELDS,
+    forbidden_true_keys: Iterable[str] = DEFAULT_FORBIDDEN_TRUE_KEYS,
+) -> list[str]:
+    candidate_mapping = as_mapping(candidate)
+    errors: list[str] = []
+    for field in _iter_keys(preview_fields):
+        preview = candidate_mapping.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        for key in _iter_keys(forbidden_true_keys):
+            if preview.get(key) is True:
+                errors.append(f"{field}_{key}_must_be_false_or_absent")
+    return merge_validation_errors(errors)
 
 
 def validate_write_preview_integrity(
@@ -292,8 +322,10 @@ __all__ = [
     "copy_source_lineage",
     "validate_required_keys",
     "validate_forbidden_true_keys",
+    "validate_forbidden_true_keys_false_or_absent",
     "validate_policy_flags",
     "validate_preview_integrity",
+    "validate_preview_forbidden_true_keys_false_or_absent",
     "validate_write_preview_integrity",
     "build_stable_digest",
     "summarize_candidates",

--- a/agent/memory_real_proposal_creation_plan.py
+++ b/agent/memory_real_proposal_creation_plan.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_human_review_outcome_gate import (
+    explain_human_review_outcome_candidate,
+    recommend_human_review_outcome_action,
+    validate_human_review_outcome_candidate,
+)
+
+
+MEMORY_REAL_PROPOSAL_CREATION_PLAN_VERSION = "0.1"
+MEMORY_REAL_PROPOSAL_CREATION_PLAN_KIND = "memory_real_proposal_creation_plan_candidate"
+MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS = "manual_creation_plan_required"
+MEMORY_REAL_PROPOSAL_CREATION_PLAN_ROUTING = "manual_real_proposal_creation_required"
+MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_plan_candidates_only": True,
+    "creates_real_proposals": False,
+    "applies_proposals": False,
+    "persists_approvals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_PLANNER = "hermes_memory_real_proposal_creation_plan_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "submitted",
+    "applied",
+    "persisted",
+    "approved",
+    "converted_to_real_proposal",
+    "created_real_proposal",
+    "created_operation_event",
+    "created_proposal_record",
+    "submitted_to_governance",
+)
+
+
+def create_real_proposal_creation_plan(
+    outcome_candidate: Mapping[str, Any],
+    planner: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only real proposal creation plan candidate."""
+    source = deepcopy(dict(outcome_candidate))
+    outcome_validation = validate_human_review_outcome_candidate(source)
+    invalid_reason = _plan_invalid_reason(source, outcome_validation)
+
+    plan = {
+        "plan_id": None,
+        "plan_kind": MEMORY_REAL_PROPOSAL_CREATION_PLAN_KIND,
+        "plan_status": MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS,
+        "routing": MEMORY_REAL_PROPOSAL_CREATION_PLAN_ROUTING,
+        "source_outcome_id": source.get("outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "planner": planner if planner is not None else _DEFAULT_PLANNER,
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "creation_steps": _creation_steps(),
+        "preflight_checks": _preflight_checks(),
+        "outcome_validation": deepcopy(outcome_validation),
+        "plan_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_outcome_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY),
+    }
+    if invalid_reason:
+        plan["invalid_reason"] = invalid_reason
+    plan["plan_id"] = _plan_id(plan)
+    plan["plan_validation"] = validate_real_proposal_creation_plan(plan)
+    plan["next_step_recommendation"] = recommend_real_proposal_creation_plan_action(plan)
+    return plan
+
+
+def validate_real_proposal_creation_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(plan.get("policy"))
+    outcome_validation = _as_dict(plan.get("outcome_validation"))
+    source_snapshot = _as_dict(plan.get("source_outcome_snapshot"))
+
+    for key in (
+        "plan_id",
+        "plan_kind",
+        "plan_status",
+        "routing",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "planner",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "creation_steps",
+        "preflight_checks",
+        "outcome_validation",
+        "plan_validation",
+        "next_step_recommendation",
+        "source_outcome_snapshot",
+        "policy",
+    ):
+        if key not in plan:
+            errors.append(f"missing_{key}")
+    if plan.get("plan_kind") != MEMORY_REAL_PROPOSAL_CREATION_PLAN_KIND:
+        errors.append("plan_kind_must_be_memory_real_proposal_creation_plan_candidate")
+    if plan.get("plan_status") != MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS:
+        errors.append("plan_status_must_be_manual_creation_plan_required")
+    if plan.get("routing") != MEMORY_REAL_PROPOSAL_CREATION_PLAN_ROUTING:
+        errors.append("routing_must_require_manual_real_proposal_creation")
+    if not isinstance(plan.get("planner"), str) or not plan.get("planner"):
+        errors.append("planner_must_be_non_empty_string")
+    if outcome_validation.get("valid") is not True:
+        errors.append("invalid_human_review_outcome_candidate")
+    if source_snapshot:
+        snapshot_validation = validate_human_review_outcome_candidate(source_snapshot)
+        if snapshot_validation != outcome_validation:
+            errors.append("outcome_validation_must_match_source_outcome_snapshot")
+    if source_snapshot.get("outcome") == "request_changes":
+        errors.append("human_review_requested_changes")
+    elif source_snapshot.get("outcome") == "reject":
+        errors.append("human_review_rejected")
+    elif source_snapshot.get("outcome") == "defer":
+        errors.append("human_review_deferred")
+    elif source_snapshot.get("outcome") != "approve_real_proposal_creation":
+        errors.append("outcome_must_approve_real_proposal_creation")
+    if not isinstance(plan.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(plan.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(plan.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(plan.get("source_pattern_ids"), list) and isinstance(plan.get("source_fact_ids"), list):
+        if not plan.get("source_pattern_ids") and not plan.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(plan.get("creation_steps"), list) or not plan.get("creation_steps"):
+        errors.append("creation_steps_must_be_non_empty_list")
+    if not isinstance(plan.get("preflight_checks"), list) or not plan.get("preflight_checks"):
+        errors.append("preflight_checks_must_be_non_empty_list")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if plan.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_real_proposal_creation_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_real_proposal_creation_plan(plan)
+    source_snapshot = _as_dict(plan.get("source_outcome_snapshot"))
+    return {
+        "plan_id": plan.get("plan_id"),
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "source_outcome_id": plan.get("source_outcome_id"),
+        "source_packet_id": plan.get("source_packet_id"),
+        "source_submission_id": plan.get("source_submission_id"),
+        "source_draft_id": plan.get("source_draft_id"),
+        "source_decision_id": plan.get("source_decision_id"),
+        "source_queue_item_id": plan.get("source_queue_item_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "planner": plan.get("planner"),
+        "source_pattern_count": len(plan.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(plan.get("source_fact_ids", []) or []),
+        "creation_steps": deepcopy(plan.get("creation_steps")),
+        "preflight_checks": deepcopy(plan.get("preflight_checks")),
+        "validation": validation,
+        "outcome_explanation": explain_human_review_outcome_candidate(source_snapshot) if source_snapshot else {},
+        "submitted": False,
+        "applied": False,
+        "persisted": False,
+        "approved": False,
+        "converted_to_real_proposal": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "created_proposal_record": False,
+        "submitted_to_governance": False,
+        "policy": dict(MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY),
+    }
+
+
+def recommend_real_proposal_creation_plan_action(plan: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_real_proposal_creation_plan(plan)
+    source_snapshot = _as_dict(plan.get("source_outcome_snapshot"))
+    if validation["valid"]:
+        action = "perform_manual_real_proposal_creation_preflight"
+        reason = "Plan candidate is valid for manual real proposal creation planning only; it does not create or submit a real proposal."
+    else:
+        action = "do_not_create_real_proposal"
+        reason = _recommendation_reason(validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_REAL_PROPOSAL_CREATION_PLAN_ROUTING,
+        "validation": validation,
+        "outcome_recommendation": recommend_human_review_outcome_action(source_snapshot) if source_snapshot else {},
+        "creates_plan_candidates_only": True,
+        "creates_real_proposals": False,
+        "applies_proposals": False,
+        "persists_approvals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY),
+    }
+
+
+def summarize_real_proposal_creation_plans(
+    plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for plan in plans:
+        block_type = str(plan.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(plan.get("plan_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        validation = validate_real_proposal_creation_plan(plan)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(plans),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY),
+    }
+
+
+def _plan_invalid_reason(source: Mapping[str, Any], outcome_validation: Mapping[str, Any]) -> str | None:
+    if outcome_validation.get("valid") is not True:
+        return "invalid_human_review_outcome_candidate"
+    outcome = source.get("outcome")
+    if outcome == "request_changes":
+        return "human_review_requested_changes"
+    if outcome == "reject":
+        return "human_review_rejected"
+    if outcome == "defer":
+        return "human_review_deferred"
+    if outcome != "approve_real_proposal_creation":
+        return "invalid_human_review_outcome_candidate"
+    if not isinstance(source.get("payload_preview"), Mapping):
+        return "missing_payload_preview"
+    if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+        return "missing_source_evidence"
+    return None
+
+
+def _creation_steps() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "verify_human_review_approval",
+            "description": "Verify the source outcome candidate explicitly approves real proposal creation.",
+        },
+        {
+            "id": "verify_payload_preview",
+            "description": "Verify the payload preview matches the reviewed memory block payload.",
+        },
+        {
+            "id": "verify_source_evidence",
+            "description": "Verify source pattern or fact evidence supports the proposal payload.",
+        },
+        {
+            "id": "manual_real_proposal_creation",
+            "description": "Create a real proposal only through the separate governed manual creation path.",
+        },
+    ]
+
+
+def _preflight_checks() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "no_memory_write",
+            "description": "Confirm this planning step did not write durable memory.",
+        },
+        {
+            "id": "no_graph_write",
+            "description": "Confirm this planning step did not write the real Memory Graph.",
+        },
+        {
+            "id": "no_config_change",
+            "description": "Confirm this planning step did not modify OpenClaw or Hermes configuration.",
+        },
+        {
+            "id": "no_proposal_or_ledger_record",
+            "description": "Confirm this planning step did not create proposal records or operation-ledger events.",
+        },
+    ]
+
+
+def _recommendation_reason(validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if "human_review_requested_changes" in errors:
+        return "Human review requested changes before any real proposal creation."
+    if "human_review_rejected" in errors:
+        return "Human review rejected real proposal creation."
+    if "human_review_deferred" in errors:
+        return "Human review deferred real proposal creation."
+    if "missing_payload_preview" in errors:
+        return "Plan candidate is missing payload preview required before manual real proposal creation."
+    if "missing_source_evidence" in errors:
+        return "Plan candidate is missing source pattern or fact evidence."
+    if "invalid_human_review_outcome_candidate" in errors:
+        return "Source human review outcome candidate is invalid."
+    return "Plan candidate violates the v0.1 real proposal creation plan validation contract."
+
+
+def _plan_id(plan: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_REAL_PROPOSAL_CREATION_PLAN_VERSION,
+        "plan_kind": plan.get("plan_kind"),
+        "plan_status": plan.get("plan_status"),
+        "routing": plan.get("routing"),
+        "source_outcome_id": plan.get("source_outcome_id"),
+        "source_packet_id": plan.get("source_packet_id"),
+        "source_submission_id": plan.get("source_submission_id"),
+        "source_draft_id": plan.get("source_draft_id"),
+        "source_decision_id": plan.get("source_decision_id"),
+        "source_queue_item_id": plan.get("source_queue_item_id"),
+        "block_id": plan.get("block_id"),
+        "block_type": plan.get("block_type"),
+        "project_scope": plan.get("project_scope"),
+        "planner": plan.get("planner"),
+        "payload_preview": plan.get("payload_preview"),
+        "source_pattern_ids": list(plan.get("source_pattern_ids", [])),
+        "source_fact_ids": list(plan.get("source_fact_ids", [])),
+        "creation_steps": plan.get("creation_steps", []),
+        "preflight_checks": plan.get("preflight_checks", []),
+        "outcome_validation": plan.get("outcome_validation", {}),
+        "invalid_reason": plan.get("invalid_reason"),
+        "policy": plan.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-real-proposal-creation-plan:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_real_proposal_creation_plan.py
+++ b/agent/memory_real_proposal_creation_plan.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
@@ -9,6 +7,12 @@ from agent.memory_human_review_outcome_gate import (
     explain_human_review_outcome_candidate,
     recommend_human_review_outcome_action,
     validate_human_review_outcome_candidate,
+)
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_policy_flags,
 )
 
 
@@ -159,9 +163,7 @@ def validate_real_proposal_creation_plan(plan: Mapping[str, Any]) -> dict[str, A
     for forbidden_key in _FORBIDDEN_TRUE_KEYS:
         if plan.get(forbidden_key) is True:
             errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_policy_flags(policy, MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -231,15 +233,10 @@ def recommend_real_proposal_creation_plan_action(plan: Mapping[str, Any]) -> dic
 def summarize_real_proposal_creation_plans(
     plans: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(plans, "plan_status")
     valid_count = 0
     invalid_count = 0
     for plan in plans:
-        block_type = str(plan.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(plan.get("plan_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         validation = validate_real_proposal_creation_plan(plan)
         if validation["valid"]:
             valid_count += 1
@@ -249,8 +246,8 @@ def summarize_real_proposal_creation_plans(
         "total": len(plans),
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "policy": dict(MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY),
     }
 
@@ -358,12 +355,11 @@ def _plan_id(plan: Mapping[str, Any]) -> str:
         "invalid_reason": plan.get("invalid_reason"),
         "policy": plan.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-real-proposal-creation-plan:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-real-proposal-creation-plan:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_real_proposal_dry_run.py
+++ b/agent/memory_real_proposal_dry_run.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_real_proposal_creation_plan import (
+    MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS,
+    explain_real_proposal_creation_plan,
+    recommend_real_proposal_creation_plan_action,
+    validate_real_proposal_creation_plan,
+)
+
+
+MEMORY_REAL_PROPOSAL_DRY_RUN_VERSION = "0.1"
+MEMORY_REAL_PROPOSAL_DRY_RUN_KIND = "memory_real_proposal_dry_run_candidate"
+MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS = "manual_final_preflight_required"
+MEMORY_REAL_PROPOSAL_DRY_RUN_ROUTING = "manual_final_preflight_before_real_proposal_write"
+MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_dry_run_candidates_only": True,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "applies_proposals": False,
+    "persists_approvals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = "hermes_memory_real_proposal_dry_run_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "written",
+    "submitted",
+    "applied",
+    "persisted",
+    "approved",
+    "created_real_proposal",
+    "created_operation_event",
+    "converted_to_real_proposal",
+    "created_proposal_record",
+    "submitted_to_governance",
+    "persisted_approval",
+)
+
+
+def create_real_proposal_dry_run(
+    plan: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only dry-run preview for a real proposal."""
+    source = deepcopy(dict(plan))
+    plan_validation = validate_real_proposal_creation_plan(source)
+    invalid_reason = _dry_run_invalid_reason(source, plan_validation)
+
+    dry_run = {
+        "dry_run_id": None,
+        "dry_run_kind": MEMORY_REAL_PROPOSAL_DRY_RUN_KIND,
+        "dry_run_status": MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS,
+        "routing": MEMORY_REAL_PROPOSAL_DRY_RUN_ROUTING,
+        "source_plan_id": source.get("plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "proposal_record_preview": _proposal_record_preview(source),
+        "operation_ledger_preview": _operation_ledger_preview(source),
+        "target_paths_preview": _target_paths_preview(source),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "final_preflight_checklist": _final_preflight_checklist(),
+        "plan_validation": deepcopy(plan_validation),
+        "dry_run_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_plan_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY),
+    }
+    if invalid_reason:
+        dry_run["invalid_reason"] = invalid_reason
+    dry_run["dry_run_id"] = _dry_run_id(dry_run)
+    dry_run["dry_run_validation"] = validate_real_proposal_dry_run(dry_run)
+    dry_run["next_step_recommendation"] = recommend_real_proposal_dry_run_action(dry_run)
+    return dry_run
+
+
+def validate_real_proposal_dry_run(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(dry_run.get("policy"))
+    plan_validation = _as_dict(dry_run.get("plan_validation"))
+    source_snapshot = _as_dict(dry_run.get("source_plan_snapshot"))
+    proposal_preview = _as_dict(dry_run.get("proposal_record_preview"))
+    ledger_preview = _as_dict(dry_run.get("operation_ledger_preview"))
+    target_paths = _as_dict(dry_run.get("target_paths_preview"))
+
+    for key in (
+        "dry_run_id",
+        "dry_run_kind",
+        "dry_run_status",
+        "routing",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "operator",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "final_preflight_checklist",
+        "plan_validation",
+        "dry_run_validation",
+        "next_step_recommendation",
+        "source_plan_snapshot",
+        "policy",
+    ):
+        if key not in dry_run:
+            errors.append(f"missing_{key}")
+    if dry_run.get("dry_run_kind") != MEMORY_REAL_PROPOSAL_DRY_RUN_KIND:
+        errors.append("dry_run_kind_must_be_memory_real_proposal_dry_run_candidate")
+    if dry_run.get("dry_run_status") != MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS:
+        errors.append("dry_run_status_must_be_manual_final_preflight_required")
+    if dry_run.get("routing") != MEMORY_REAL_PROPOSAL_DRY_RUN_ROUTING:
+        errors.append("routing_must_require_manual_final_preflight")
+    if not isinstance(dry_run.get("operator"), str) or not dry_run.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if plan_validation.get("valid") is not True:
+        errors.append("invalid_real_proposal_creation_plan")
+    if source_snapshot:
+        snapshot_validation = validate_real_proposal_creation_plan(source_snapshot)
+        if snapshot_validation != plan_validation:
+            errors.append("plan_validation_must_match_source_plan_snapshot")
+        if source_snapshot.get("plan_status") != MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS:
+            errors.append("source_plan_status_must_be_manual_creation_plan_required")
+    if not isinstance(dry_run.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(dry_run.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(dry_run.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(dry_run.get("source_pattern_ids"), list) and isinstance(dry_run.get("source_fact_ids"), list):
+        if not dry_run.get("source_pattern_ids") and not dry_run.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(source_snapshot.get("creation_steps"), list) or not source_snapshot.get("creation_steps"):
+        errors.append("missing_plan_controls")
+    if not isinstance(source_snapshot.get("preflight_checks"), list) or not source_snapshot.get("preflight_checks"):
+        errors.append("missing_plan_controls")
+    if not isinstance(dry_run.get("final_preflight_checklist"), list) or not dry_run.get("final_preflight_checklist"):
+        errors.append("final_preflight_checklist_must_be_non_empty_list")
+    if proposal_preview.get("preview_only") is not True:
+        errors.append("proposal_record_preview_must_be_preview_only")
+    if proposal_preview.get("written") is not False:
+        errors.append("proposal_record_preview_must_not_be_written")
+    if ledger_preview.get("preview_only") is not True:
+        errors.append("operation_ledger_preview_must_be_preview_only")
+    if ledger_preview.get("written") is not False:
+        errors.append("operation_ledger_preview_must_not_be_written")
+    if ledger_preview.get("created_operation_event") is not False:
+        errors.append("operation_ledger_preview_must_not_create_operation_event")
+    if target_paths.get("preview_only") is not True:
+        errors.append("target_paths_preview_must_be_preview_only")
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if dry_run.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_real_proposal_dry_run(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_real_proposal_dry_run(dry_run)
+    source_snapshot = _as_dict(dry_run.get("source_plan_snapshot"))
+    return {
+        "dry_run_id": dry_run.get("dry_run_id"),
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "source_plan_id": dry_run.get("source_plan_id"),
+        "source_outcome_id": dry_run.get("source_outcome_id"),
+        "source_packet_id": dry_run.get("source_packet_id"),
+        "source_submission_id": dry_run.get("source_submission_id"),
+        "source_draft_id": dry_run.get("source_draft_id"),
+        "source_decision_id": dry_run.get("source_decision_id"),
+        "source_queue_item_id": dry_run.get("source_queue_item_id"),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "source_pattern_count": len(dry_run.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(dry_run.get("source_fact_ids", []) or []),
+        "proposal_record_preview": deepcopy(dry_run.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(dry_run.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(dry_run.get("target_paths_preview")),
+        "final_preflight_checklist": deepcopy(dry_run.get("final_preflight_checklist")),
+        "validation": validation,
+        "plan_explanation": explain_real_proposal_creation_plan(source_snapshot) if source_snapshot else {},
+        "written": False,
+        "submitted": False,
+        "applied": False,
+        "persisted": False,
+        "approved": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "converted_to_real_proposal": False,
+        "created_proposal_record": False,
+        "submitted_to_governance": False,
+        "persisted_approval": False,
+        "policy": dict(MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY),
+    }
+
+
+def recommend_real_proposal_dry_run_action(dry_run: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_real_proposal_dry_run(dry_run)
+    source_snapshot = _as_dict(dry_run.get("source_plan_snapshot"))
+    if validation["valid"]:
+        action = "perform_manual_final_preflight_before_real_proposal_write"
+        reason = "Dry-run candidate is valid for manual final preflight only; it does not create a proposal or operation-ledger event."
+    else:
+        action = "do_not_create_real_proposal"
+        reason = _recommendation_reason(validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_REAL_PROPOSAL_DRY_RUN_ROUTING,
+        "validation": validation,
+        "plan_recommendation": recommend_real_proposal_creation_plan_action(source_snapshot) if source_snapshot else {},
+        "creates_dry_run_candidates_only": True,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "applies_proposals": False,
+        "persists_approvals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY),
+    }
+
+
+def summarize_real_proposal_dry_runs(
+    dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    valid_count = 0
+    invalid_count = 0
+    for dry_run in dry_runs:
+        block_type = str(dry_run.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(dry_run.get("dry_run_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        validation = validate_real_proposal_dry_run(dry_run)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(dry_runs),
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY),
+    }
+
+
+def _dry_run_invalid_reason(source: Mapping[str, Any], plan_validation: Mapping[str, Any]) -> str | None:
+    if not isinstance(source.get("payload_preview"), Mapping):
+        return "missing_payload_preview"
+    if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if not isinstance(source.get("creation_steps"), list) or not source.get("creation_steps"):
+        return "missing_plan_controls"
+    if not isinstance(source.get("preflight_checks"), list) or not source.get("preflight_checks"):
+        return "missing_plan_controls"
+    if plan_validation.get("valid") is not True:
+        return "invalid_real_proposal_creation_plan"
+    if source.get("plan_status") != MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS:
+        return "invalid_real_proposal_creation_plan"
+    return None
+
+
+def _proposal_record_preview(source: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "preview_only": True,
+        "written": False,
+        "proposal_id_preview": _preview_id("proposal", source),
+        "proposal_status_preview": "pending_governed_write_if_manual_preflight_passes",
+        "source_plan_id": source.get("plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "created_real_proposal": False,
+        "submitted_to_governance": False,
+        "applied": False,
+        "persisted": False,
+        "approved": False,
+    }
+
+
+def _operation_ledger_preview(source: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "preview_only": True,
+        "written": False,
+        "created_operation_event": False,
+        "operation_event_id_preview": _preview_id("operation-ledger", source),
+        "operation_type_preview": "memory_real_proposal_manual_write_preflight",
+        "source_plan_id": source.get("plan_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "would_write_memory": False,
+        "would_write_graph": False,
+        "would_modify_config": False,
+        "would_write_proposal_file": False,
+        "would_write_operation_ledger": False,
+    }
+
+
+def _target_paths_preview(source: Mapping[str, Any]) -> dict[str, Any]:
+    proposal_preview_id = _preview_id("proposal", source)
+    ledger_preview_id = _preview_id("operation-ledger", source)
+    return {
+        "preview_only": True,
+        "base": "${HERMES_HOME}",
+        "proposal_file": "memory/proposals/memory_write_proposals.jsonl",
+        "operation_ledger_file": "memory/audit/memory_operation_ledger.jsonl",
+        "proposal_record_selector": proposal_preview_id,
+        "operation_ledger_selector": ledger_preview_id,
+        "written": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+    }
+
+
+def _final_preflight_checklist() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "verify_plan_validation",
+            "description": "Confirm the source plan is valid and still requires manual creation planning.",
+        },
+        {
+            "id": "verify_payload_and_evidence",
+            "description": "Confirm payload preview and source pattern or fact evidence are present.",
+        },
+        {
+            "id": "verify_preview_records_only",
+            "description": "Confirm proposal and operation-ledger records are previews only and were not written.",
+        },
+        {
+            "id": "verify_no_memory_graph_config_write",
+            "description": "Confirm the dry run did not write memory, graph state, or configuration.",
+        },
+        {
+            "id": "manual_operator_final_preflight",
+            "description": "Require a separate human-governed final preflight before any real proposal write.",
+        },
+    ]
+
+
+def _recommendation_reason(validation: Mapping[str, Any]) -> str:
+    errors = list(validation.get("errors", []) or [])
+    if "missing_payload_preview" in errors:
+        return "Dry-run candidate is missing payload preview required for final preflight."
+    if "missing_source_evidence" in errors:
+        return "Dry-run candidate is missing source pattern or fact evidence."
+    if "missing_plan_controls" in errors:
+        return "Dry-run candidate is missing source plan creation steps or preflight checks."
+    if "invalid_real_proposal_creation_plan" in errors:
+        return "Source real proposal creation plan is invalid."
+    return "Dry-run candidate violates the v0.1 real proposal dry-run validation contract."
+
+
+def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_REAL_PROPOSAL_DRY_RUN_VERSION,
+        "dry_run_kind": dry_run.get("dry_run_kind"),
+        "dry_run_status": dry_run.get("dry_run_status"),
+        "routing": dry_run.get("routing"),
+        "source_plan_id": dry_run.get("source_plan_id"),
+        "source_outcome_id": dry_run.get("source_outcome_id"),
+        "source_packet_id": dry_run.get("source_packet_id"),
+        "source_submission_id": dry_run.get("source_submission_id"),
+        "source_draft_id": dry_run.get("source_draft_id"),
+        "source_decision_id": dry_run.get("source_decision_id"),
+        "source_queue_item_id": dry_run.get("source_queue_item_id"),
+        "block_id": dry_run.get("block_id"),
+        "block_type": dry_run.get("block_type"),
+        "project_scope": dry_run.get("project_scope"),
+        "operator": dry_run.get("operator"),
+        "proposal_record_preview": dry_run.get("proposal_record_preview", {}),
+        "operation_ledger_preview": dry_run.get("operation_ledger_preview", {}),
+        "target_paths_preview": dry_run.get("target_paths_preview", {}),
+        "payload_preview": dry_run.get("payload_preview"),
+        "source_pattern_ids": list(dry_run.get("source_pattern_ids", [])),
+        "source_fact_ids": list(dry_run.get("source_fact_ids", [])),
+        "final_preflight_checklist": dry_run.get("final_preflight_checklist", []),
+        "plan_validation": dry_run.get("plan_validation", {}),
+        "invalid_reason": dry_run.get("invalid_reason"),
+        "policy": dry_run.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-real-proposal-dry-run:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _preview_id(kind: str, source: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_REAL_PROPOSAL_DRY_RUN_VERSION,
+        "kind": kind,
+        "source_plan_id": source.get("plan_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "payload_preview": source.get("payload_preview"),
+        "source_pattern_ids": list(source.get("source_pattern_ids", []) or []),
+        "source_fact_ids": list(source.get("source_fact_ids", []) or []),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"preview:{kind}:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_real_proposal_dry_run.py
+++ b/agent/memory_real_proposal_dry_run.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_policy_flags,
+)
 from agent.memory_real_proposal_creation_plan import (
     MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS,
     explain_real_proposal_creation_plan,
@@ -181,9 +185,7 @@ def validate_real_proposal_dry_run(dry_run: Mapping[str, Any]) -> dict[str, Any]
     for forbidden_key in _FORBIDDEN_TRUE_KEYS:
         if dry_run.get(forbidden_key) is True:
             errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_policy_flags(policy, MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -260,15 +262,10 @@ def recommend_real_proposal_dry_run_action(dry_run: Mapping[str, Any]) -> dict[s
 def summarize_real_proposal_dry_runs(
     dry_runs: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(dry_runs, "dry_run_status")
     valid_count = 0
     invalid_count = 0
     for dry_run in dry_runs:
-        block_type = str(dry_run.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(dry_run.get("dry_run_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         validation = validate_real_proposal_dry_run(dry_run)
         if validation["valid"]:
             valid_count += 1
@@ -278,8 +275,8 @@ def summarize_real_proposal_dry_runs(
         "total": len(dry_runs),
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "policy": dict(MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY),
     }
 
@@ -428,8 +425,7 @@ def _dry_run_id(dry_run: Mapping[str, Any]) -> str:
         "invalid_reason": dry_run.get("invalid_reason"),
         "policy": dry_run.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-real-proposal-dry-run:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-real-proposal-dry-run:v0.1", identity)
 
 
 def _preview_id(kind: str, source: Mapping[str, Any]) -> str:
@@ -444,12 +440,11 @@ def _preview_id(kind: str, source: Mapping[str, Any]) -> str:
         "source_pattern_ids": list(source.get("source_pattern_ids", []) or []),
         "source_fact_ids": list(source.get("source_fact_ids", []) or []),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"preview:{kind}:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest(f"preview:{kind}:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_real_proposal_write_lock_gate.py
+++ b/agent/memory_real_proposal_write_lock_gate.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from copy import deepcopy
 from typing import Any, Mapping
 
+from agent.memory_read_only_candidate_utils import (
+    build_stable_digest,
+    deep_copy_mapping,
+    summarize_candidates,
+    validate_policy_flags,
+)
 from agent.memory_real_proposal_dry_run import (
     MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS,
     explain_real_proposal_dry_run,
@@ -193,9 +197,7 @@ def validate_real_proposal_write_lock_gate(gate: Mapping[str, Any]) -> dict[str,
     for forbidden_key in _FORBIDDEN_TRUE_KEYS:
         if gate.get(forbidden_key) is True:
             errors.append(f"{forbidden_key}_must_be_false_or_absent")
-    for key, expected in MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY.items():
-        if policy.get(key) is not expected:
-            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+    errors.extend(validate_policy_flags(policy, MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY))
 
     return {"valid": not errors, "errors": _dedupe(errors)}
 
@@ -273,17 +275,12 @@ def recommend_real_proposal_write_lock_action(gate: Mapping[str, Any]) -> dict[s
 def summarize_real_proposal_write_lock_gates(
     gates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
 ) -> dict[str, Any]:
-    by_block_type: dict[str, int] = {}
-    by_status: dict[str, int] = {}
+    candidate_summary = summarize_candidates(gates, "gate_status")
     locked_count = 0
     eligible_count = 0
     valid_count = 0
     invalid_count = 0
     for gate in gates:
-        block_type = str(gate.get("block_type"))
-        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
-        status = str(gate.get("gate_status"))
-        by_status[status] = by_status.get(status, 0) + 1
         if gate.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED:
             locked_count += 1
         if gate.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE:
@@ -299,8 +296,8 @@ def summarize_real_proposal_write_lock_gates(
         "eligible_count": eligible_count,
         "valid_count": valid_count,
         "invalid_count": invalid_count,
-        "by_block_type": dict(sorted(by_block_type.items())),
-        "by_status": dict(sorted(by_status.items())),
+        "by_block_type": candidate_summary["by_block_type"],
+        "by_status": candidate_summary["by_status"],
         "policy": dict(MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY),
     }
 
@@ -407,12 +404,11 @@ def _gate_id(gate: Mapping[str, Any]) -> str:
         "dry_run_validation": gate.get("dry_run_validation", {}),
         "policy": gate.get("policy", {}),
     }
-    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
-    return f"memory-real-proposal-write-lock-gate:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+    return build_stable_digest("memory-real-proposal-write-lock-gate:v0.1", identity)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+    return deep_copy_mapping(value)
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/agent/memory_real_proposal_write_lock_gate.py
+++ b/agent/memory_real_proposal_write_lock_gate.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_real_proposal_dry_run import (
+    MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS,
+    explain_real_proposal_dry_run,
+    recommend_real_proposal_dry_run_action,
+    validate_real_proposal_dry_run,
+)
+
+
+MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_VERSION = "0.1"
+MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_KIND = "memory_real_proposal_write_lock_gate_candidate"
+MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED = "locked"
+MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE = "eligible_for_human_approval_token"
+MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ROUTING = "human_approval_token_required_before_any_real_proposal_write"
+MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_write_lock_candidates_only": True,
+    "creates_real_proposals": False,
+    "writes_proposal_files": False,
+    "writes_operation_ledger": False,
+    "applies_proposals": False,
+    "persists_approvals": False,
+    "submits_to_governance": False,
+    "converts_to_real_proposal": False,
+}
+
+_DEFAULT_OPERATOR = "hermes_memory_real_proposal_write_lock_gate_v0.1"
+_FORBIDDEN_TRUE_KEYS = (
+    "written",
+    "submitted",
+    "applied",
+    "persisted",
+    "approved",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "converted_to_real_proposal",
+)
+_PREVIEW_FIELDS = (
+    "proposal_record_preview",
+    "operation_ledger_preview",
+    "target_paths_preview",
+)
+_LOCK_REASONS = {
+    None,
+    "invalid_real_proposal_dry_run",
+    "missing_proposal_record_preview",
+    "missing_operation_ledger_preview",
+    "missing_target_paths_preview",
+    "missing_source_evidence",
+    "preview_integrity_failed",
+}
+
+
+def create_real_proposal_write_lock_gate(
+    dry_run: Mapping[str, Any],
+    operator: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only write-lock gate candidate."""
+    source = deepcopy(dict(dry_run))
+    dry_run_validation = validate_real_proposal_dry_run(source)
+    lock_reason = _write_lock_reason(source, dry_run_validation)
+    gate_status = (
+        MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE
+        if lock_reason is None
+        else MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+    )
+
+    gate = {
+        "gate_id": None,
+        "gate_kind": MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_KIND,
+        "gate_status": gate_status,
+        "routing": MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ROUTING,
+        "lock_reason": lock_reason,
+        "source_dry_run_id": source.get("dry_run_id"),
+        "source_plan_id": source.get("source_plan_id"),
+        "source_outcome_id": source.get("source_outcome_id"),
+        "source_packet_id": source.get("source_packet_id"),
+        "source_submission_id": source.get("source_submission_id"),
+        "source_draft_id": source.get("source_draft_id"),
+        "source_decision_id": source.get("source_decision_id"),
+        "source_queue_item_id": source.get("source_queue_item_id"),
+        "block_id": source.get("block_id"),
+        "block_type": source.get("block_type"),
+        "project_scope": source.get("project_scope"),
+        "operator": operator if operator is not None else _DEFAULT_OPERATOR,
+        "proposal_record_preview": deepcopy(source.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(source.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(source.get("target_paths_preview")),
+        "payload_preview": deepcopy(source.get("payload_preview")),
+        "source_pattern_ids": deepcopy(list(source.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(source.get("source_fact_ids", []) or [])),
+        "write_lock_checklist": _write_lock_checklist(),
+        "dry_run_validation": deepcopy(dry_run_validation),
+        "gate_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "source_dry_run_snapshot": deepcopy(source),
+        "policy": dict(MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY),
+    }
+    gate["gate_id"] = _gate_id(gate)
+    gate["gate_validation"] = validate_real_proposal_write_lock_gate(gate)
+    gate["next_step_recommendation"] = recommend_real_proposal_write_lock_action(gate)
+    return gate
+
+
+def validate_real_proposal_write_lock_gate(gate: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(gate.get("policy"))
+    source_snapshot = _as_dict(gate.get("source_dry_run_snapshot"))
+    dry_run_validation = _as_dict(gate.get("dry_run_validation"))
+    expected_lock_reason = _write_lock_reason(source_snapshot, dry_run_validation)
+    preview_integrity_errors = _preview_integrity_errors(gate)
+
+    for key in (
+        "gate_id",
+        "gate_kind",
+        "gate_status",
+        "routing",
+        "lock_reason",
+        "source_dry_run_id",
+        "source_plan_id",
+        "source_outcome_id",
+        "source_packet_id",
+        "source_submission_id",
+        "source_draft_id",
+        "source_decision_id",
+        "source_queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "operator",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+        "payload_preview",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "write_lock_checklist",
+        "dry_run_validation",
+        "gate_validation",
+        "next_step_recommendation",
+        "source_dry_run_snapshot",
+        "policy",
+    ):
+        if key not in gate:
+            errors.append(f"missing_{key}")
+    if gate.get("gate_kind") != MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_KIND:
+        errors.append("gate_kind_must_be_memory_real_proposal_write_lock_gate_candidate")
+    if gate.get("gate_status") not in {
+        MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED,
+        MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE,
+    }:
+        errors.append("gate_status_must_be_supported")
+    if gate.get("routing") != MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ROUTING:
+        errors.append("routing_must_require_human_approval_token")
+    if gate.get("lock_reason") not in _LOCK_REASONS:
+        errors.append("lock_reason_must_be_supported")
+    if gate.get("lock_reason") != expected_lock_reason:
+        errors.append("lock_reason_must_match_write_lock_checks")
+    if expected_lock_reason is None and gate.get("gate_status") != MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE:
+        errors.append("valid_dry_run_must_be_eligible_for_human_approval_token")
+    if expected_lock_reason is not None and gate.get("gate_status") != MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED:
+        errors.append("invalid_write_lock_check_must_be_locked")
+    if not isinstance(gate.get("operator"), str) or not gate.get("operator"):
+        errors.append("operator_must_be_non_empty_string")
+    if dry_run_validation != validate_real_proposal_dry_run(source_snapshot):
+        errors.append("dry_run_validation_must_match_source_dry_run_snapshot")
+    if source_snapshot.get("dry_run_status") != MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS:
+        errors.append("source_dry_run_status_must_be_manual_final_preflight_required")
+    if not isinstance(gate.get("payload_preview"), Mapping):
+        errors.append("missing_payload_preview")
+    if not isinstance(gate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(gate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if isinstance(gate.get("source_pattern_ids"), list) and isinstance(gate.get("source_fact_ids"), list):
+        if not gate.get("source_pattern_ids") and not gate.get("source_fact_ids"):
+            errors.append("missing_source_evidence")
+    if not isinstance(gate.get("write_lock_checklist"), list) or not gate.get("write_lock_checklist"):
+        errors.append("write_lock_checklist_must_be_non_empty_list")
+    errors.extend(preview_integrity_errors)
+    for forbidden_key in _FORBIDDEN_TRUE_KEYS:
+        if gate.get(forbidden_key) is True:
+            errors.append(f"{forbidden_key}_must_be_false_or_absent")
+    for key, expected in MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": _dedupe(errors)}
+
+
+def explain_real_proposal_write_lock_gate(gate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_real_proposal_write_lock_gate(gate)
+    source_snapshot = _as_dict(gate.get("source_dry_run_snapshot"))
+    return {
+        "gate_id": gate.get("gate_id"),
+        "gate_kind": gate.get("gate_kind"),
+        "gate_status": gate.get("gate_status"),
+        "routing": gate.get("routing"),
+        "lock_reason": gate.get("lock_reason"),
+        "source_dry_run_id": gate.get("source_dry_run_id"),
+        "source_plan_id": gate.get("source_plan_id"),
+        "source_outcome_id": gate.get("source_outcome_id"),
+        "source_packet_id": gate.get("source_packet_id"),
+        "source_submission_id": gate.get("source_submission_id"),
+        "source_draft_id": gate.get("source_draft_id"),
+        "source_decision_id": gate.get("source_decision_id"),
+        "source_queue_item_id": gate.get("source_queue_item_id"),
+        "block_id": gate.get("block_id"),
+        "block_type": gate.get("block_type"),
+        "project_scope": gate.get("project_scope"),
+        "operator": gate.get("operator"),
+        "source_pattern_count": len(gate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(gate.get("source_fact_ids", []) or []),
+        "proposal_record_preview": deepcopy(gate.get("proposal_record_preview")),
+        "operation_ledger_preview": deepcopy(gate.get("operation_ledger_preview")),
+        "target_paths_preview": deepcopy(gate.get("target_paths_preview")),
+        "write_lock_checklist": deepcopy(gate.get("write_lock_checklist")),
+        "validation": validation,
+        "dry_run_explanation": explain_real_proposal_dry_run(source_snapshot) if source_snapshot else {},
+        "written": False,
+        "submitted": False,
+        "applied": False,
+        "persisted": False,
+        "approved": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "converted_to_real_proposal": False,
+        "policy": dict(MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY),
+    }
+
+
+def recommend_real_proposal_write_lock_action(gate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_real_proposal_write_lock_gate(gate)
+    source_snapshot = _as_dict(gate.get("source_dry_run_snapshot"))
+    if validation["valid"] and gate.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE:
+        action = "request_separate_human_approval_token_before_real_proposal_write"
+        reason = "Write-lock gate is eligible only for a separate human approval token flow; it does not create real proposal or operation-ledger records."
+    else:
+        action = "keep_real_proposal_write_locked"
+        reason = _recommendation_reason(gate.get("lock_reason"), validation)
+    return {
+        "action": action,
+        "reason": reason,
+        "routing": MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ROUTING,
+        "validation": validation,
+        "dry_run_recommendation": recommend_real_proposal_dry_run_action(source_snapshot) if source_snapshot else {},
+        "creates_write_lock_candidates_only": True,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "applies_proposals": False,
+        "persists_approvals": False,
+        "submits_to_governance": False,
+        "converts_to_real_proposal": False,
+        "policy": dict(MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY),
+    }
+
+
+def summarize_real_proposal_write_lock_gates(
+    gates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...],
+) -> dict[str, Any]:
+    by_block_type: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    locked_count = 0
+    eligible_count = 0
+    valid_count = 0
+    invalid_count = 0
+    for gate in gates:
+        block_type = str(gate.get("block_type"))
+        by_block_type[block_type] = by_block_type.get(block_type, 0) + 1
+        status = str(gate.get("gate_status"))
+        by_status[status] = by_status.get(status, 0) + 1
+        if gate.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED:
+            locked_count += 1
+        if gate.get("gate_status") == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE:
+            eligible_count += 1
+        validation = validate_real_proposal_write_lock_gate(gate)
+        if validation["valid"]:
+            valid_count += 1
+        else:
+            invalid_count += 1
+    return {
+        "total": len(gates),
+        "locked_count": locked_count,
+        "eligible_count": eligible_count,
+        "valid_count": valid_count,
+        "invalid_count": invalid_count,
+        "by_block_type": dict(sorted(by_block_type.items())),
+        "by_status": dict(sorted(by_status.items())),
+        "policy": dict(MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY),
+    }
+
+
+def _write_lock_reason(source: Mapping[str, Any], dry_run_validation: Mapping[str, Any]) -> str | None:
+    if not isinstance(source.get("proposal_record_preview"), Mapping):
+        return "missing_proposal_record_preview"
+    if not isinstance(source.get("operation_ledger_preview"), Mapping):
+        return "missing_operation_ledger_preview"
+    if not isinstance(source.get("target_paths_preview"), Mapping):
+        return "missing_target_paths_preview"
+    if not (source.get("source_pattern_ids") or source.get("source_fact_ids")):
+        return "missing_source_evidence"
+    if _preview_integrity_errors(source):
+        return "preview_integrity_failed"
+    if dry_run_validation.get("valid") is not True:
+        return "invalid_real_proposal_dry_run"
+    return None
+
+
+def _preview_integrity_errors(container: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in _PREVIEW_FIELDS:
+        preview = container.get(field)
+        if not isinstance(preview, Mapping):
+            continue
+        if preview.get("preview_only") is not True:
+            errors.append(f"{field}_must_be_preview_only")
+        for key, value in preview.items():
+            if value is True and ("written" in key or "created" in key):
+                errors.append(f"{field}_{key}_must_not_be_true")
+    return errors
+
+
+def _write_lock_checklist() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "verify_dry_run_validation",
+            "description": "Confirm the source dry run is valid and still requires manual final preflight.",
+        },
+        {
+            "id": "verify_preview_artifacts_only",
+            "description": "Confirm proposal, operation-ledger, and target-path previews are preview-only.",
+        },
+        {
+            "id": "verify_no_written_or_created_flags",
+            "description": "Confirm preview artifacts do not mark records as written or created.",
+        },
+        {
+            "id": "verify_payload_and_source_evidence",
+            "description": "Confirm payload preview and source pattern or fact evidence are present.",
+        },
+        {
+            "id": "require_separate_human_approval_token",
+            "description": "Require a separate human approval token flow before any real proposal write.",
+        },
+    ]
+
+
+def _recommendation_reason(lock_reason: Any, validation: Mapping[str, Any]) -> str:
+    if lock_reason == "invalid_real_proposal_dry_run":
+        return "Source dry-run candidate is invalid."
+    if lock_reason == "missing_proposal_record_preview":
+        return "Write-lock gate is missing the proposal record preview."
+    if lock_reason == "missing_operation_ledger_preview":
+        return "Write-lock gate is missing the operation-ledger preview."
+    if lock_reason == "missing_target_paths_preview":
+        return "Write-lock gate is missing the target paths preview."
+    if lock_reason == "missing_source_evidence":
+        return "Write-lock gate is missing source pattern or fact evidence."
+    if lock_reason == "preview_integrity_failed":
+        return "Write-lock gate preview artifacts are not preview-only or include written/created flags."
+    if validation.get("errors"):
+        return "Write-lock gate violates the v0.1 validation contract."
+    return "Real proposal write remains locked until a separate human approval token flow is completed."
+
+
+def _gate_id(gate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_VERSION,
+        "gate_kind": gate.get("gate_kind"),
+        "gate_status": gate.get("gate_status"),
+        "routing": gate.get("routing"),
+        "lock_reason": gate.get("lock_reason"),
+        "source_dry_run_id": gate.get("source_dry_run_id"),
+        "source_plan_id": gate.get("source_plan_id"),
+        "source_outcome_id": gate.get("source_outcome_id"),
+        "source_packet_id": gate.get("source_packet_id"),
+        "source_submission_id": gate.get("source_submission_id"),
+        "source_draft_id": gate.get("source_draft_id"),
+        "source_decision_id": gate.get("source_decision_id"),
+        "source_queue_item_id": gate.get("source_queue_item_id"),
+        "block_id": gate.get("block_id"),
+        "block_type": gate.get("block_type"),
+        "project_scope": gate.get("project_scope"),
+        "operator": gate.get("operator"),
+        "proposal_record_preview": gate.get("proposal_record_preview", {}),
+        "operation_ledger_preview": gate.get("operation_ledger_preview", {}),
+        "target_paths_preview": gate.get("target_paths_preview", {}),
+        "payload_preview": gate.get("payload_preview"),
+        "source_pattern_ids": list(gate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(gate.get("source_fact_ids", [])),
+        "write_lock_checklist": gate.get("write_lock_checklist", []),
+        "dry_run_validation": gate.get("dry_run_validation", {}),
+        "policy": gate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-real-proposal-write-lock-gate:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/agent/memory_retrieval_fusion.py
+++ b/agent/memory_retrieval_fusion.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any, Iterable, Mapping
+
+
+FUSION_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+}
+
+SCORING_DIMENSIONS = (
+    "semantic_score",
+    "keyword_score",
+    "entity_score",
+    "temporal_score",
+    "project_scope_score",
+    "source_trust_score",
+    "governance_score",
+    "final_score",
+)
+
+WEIGHTS = {
+    "semantic_score": 0.22,
+    "keyword_score": 0.2,
+    "entity_score": 0.12,
+    "temporal_score": 0.14,
+    "project_scope_score": 0.13,
+    "source_trust_score": 0.09,
+    "governance_score": 0.1,
+}
+
+SELECTION_THRESHOLD = 0.35
+DEFAULT_LIMIT = 5
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_-]*", re.IGNORECASE)
+_UNSAFE_TEXT_MARKERS = (
+    "direct_write",
+    "direct memory write",
+    "write_memory",
+    "write graph",
+    "modify config",
+    "approve allowlist",
+    "operation ledger event",
+    "create proposal",
+)
+_UNSAFE_BOOL_KEYS = (
+    "unsafe",
+    "write_allowed",
+    "would_write_memory",
+    "would_modify_config",
+    "would_write_graph",
+    "creates_operation_event",
+    "create_operation_event",
+    "approves_allowlist",
+    "approve_allowlist",
+    "external_auto_recall_allowed",
+)
+
+
+def fuse_memory_retrieval(
+    *,
+    query: str,
+    candidates: Iterable[Mapping[str, Any]],
+    project_scope: str | None = None,
+    entity_ids: Iterable[str] | None = None,
+    now: str | datetime | None = None,
+    limit: int = DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """Rank candidate memory records without writing memory, config, graph, or ledger state."""
+    evaluation_now = _coerce_datetime(now) or datetime.now(UTC)
+    query_tokens = _tokens(query)
+    entity_set = {str(entity_id) for entity_id in entity_ids or [] if str(entity_id)}
+    scored = [
+        _score_candidate(
+            query=query,
+            query_tokens=query_tokens,
+            candidate=dict(candidate),
+            project_scope=project_scope,
+            query_entity_ids=entity_set,
+            now=evaluation_now,
+            index=index,
+        )
+        for index, candidate in enumerate(candidates)
+    ]
+    scored.sort(key=lambda item: (-item["final_score"], str(item["id"]), item["_index"]))
+
+    selected: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for item in scored:
+        hard_reject = item.pop("_hard_reject")
+        index = item.pop("_index")
+        item["_index"] = index
+        if hard_reject:
+            rejected.append(_rejected_item(item, item["reason"]))
+        elif len(selected) < limit and item["final_score"] >= SELECTION_THRESHOLD:
+            selected.append(_selected_item(item))
+        else:
+            reason = "ranked_below_limit" if len(selected) >= limit else "below_selection_threshold"
+            rejected.append(_rejected_item(item, reason))
+
+    return {
+        "query": query,
+        "selected_memories": selected,
+        "rejected_memories": rejected,
+        "scores": {str(item["id"]): item["component_scores"] | {"final_score": item["final_score"]} for item in scored},
+        "policy": dict(FUSION_POLICY),
+        "explanation": {
+            "version": "hybrid_retrieval_fusion_v0.1",
+            "scoring_dimensions": list(SCORING_DIMENSIONS),
+            "weights": dict(WEIGHTS),
+            "selection_threshold": SELECTION_THRESHOLD,
+            "limit": limit,
+            "now": evaluation_now.isoformat().replace("+00:00", "Z"),
+            "rules": [
+                "Unsafe governance indicators are rejected before selection.",
+                "Project-scoped queries hard-reject candidates from unrelated projects.",
+                "Expired or future-validity candidates are penalized by temporal_score.",
+                "All non-selected candidates remain visible in rejected_memories.",
+            ],
+        },
+    }
+
+
+def _score_candidate(
+    *,
+    query: str,
+    query_tokens: set[str],
+    candidate: dict[str, Any],
+    project_scope: str | None,
+    query_entity_ids: set[str],
+    now: datetime,
+    index: int,
+) -> dict[str, Any]:
+    candidate_id = str(candidate.get("id") or f"candidate_{index}")
+    text = _candidate_text(candidate)
+    candidate_tokens = _tokens(text)
+    governance_score, unsafe_reasons = _governance_score(candidate.get("governance"))
+    project_score = _project_scope_score(candidate.get("project_id"), project_scope)
+    temporal_score = _temporal_score(candidate, now)
+    component_scores = {
+        "semantic_score": _semantic_score(query_tokens, candidate_tokens),
+        "keyword_score": _keyword_score(query, query_tokens, text, candidate_tokens),
+        "entity_score": _entity_score(candidate.get("entity_ids"), query_entity_ids),
+        "temporal_score": temporal_score,
+        "project_scope_score": project_score,
+        "source_trust_score": _source_trust_score(candidate),
+        "governance_score": governance_score,
+    }
+    final_score = round(sum(component_scores[name] * weight for name, weight in WEIGHTS.items()), 4)
+
+    reason = "eligible"
+    hard_reject = False
+    if unsafe_reasons:
+        reason = "unsafe_governance:" + ",".join(unsafe_reasons)
+        hard_reject = True
+    elif project_scope and candidate.get("project_id") and str(candidate.get("project_id")) != str(project_scope):
+        reason = "project_scope_mismatch"
+        hard_reject = True
+
+    return {
+        "id": candidate_id,
+        "text": text,
+        "project_id": candidate.get("project_id"),
+        "source": candidate.get("source"),
+        "provenance": candidate.get("provenance"),
+        "component_scores": component_scores,
+        "final_score": final_score,
+        "reason": reason,
+        "_hard_reject": hard_reject,
+        "_index": index,
+    }
+
+
+def _selected_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "id": item["id"],
+        "text": item["text"],
+        "project_id": item.get("project_id"),
+        "source": item.get("source"),
+        "provenance": item.get("provenance"),
+        "final_score": item["final_score"],
+        "component_scores": dict(item["component_scores"]),
+    }
+
+
+def _rejected_item(item: Mapping[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "id": item["id"],
+        "reason": reason,
+        "final_score": item["final_score"],
+        "component_scores": dict(item["component_scores"]),
+    }
+
+
+def _candidate_text(candidate: Mapping[str, Any]) -> str:
+    parts = [
+        candidate.get("title"),
+        candidate.get("summary"),
+        candidate.get("content"),
+        candidate.get("text"),
+    ]
+    return " ".join(str(part) for part in parts if part)
+
+
+def _tokens(text: str) -> set[str]:
+    return {match.group(0).lower() for match in _TOKEN_RE.finditer(text or "")}
+
+
+def _semantic_score(query_tokens: set[str], candidate_tokens: set[str]) -> float:
+    if not query_tokens or not candidate_tokens:
+        return 0.0
+    overlap = len(query_tokens & candidate_tokens)
+    return round(overlap / len(query_tokens | candidate_tokens), 4)
+
+
+def _keyword_score(query: str, query_tokens: set[str], text: str, candidate_tokens: set[str]) -> float:
+    if not query_tokens or not candidate_tokens:
+        return 0.0
+    exact_token_score = len(query_tokens & candidate_tokens) / len(query_tokens)
+    normalized_query = " ".join(str(query).lower().split())
+    normalized_text = " ".join(str(text).lower().split())
+    phrase_score = 1.0 if normalized_query and normalized_query in normalized_text else 0.0
+    return round((exact_token_score * 0.75) + (phrase_score * 0.25), 4)
+
+
+def _entity_score(candidate_entity_ids: Any, query_entity_ids: set[str]) -> float:
+    if not query_entity_ids:
+        return 0.5
+    candidate_set = {str(entity_id) for entity_id in _as_list(candidate_entity_ids) if str(entity_id)}
+    if not candidate_set:
+        return 0.0
+    return round(len(candidate_set & query_entity_ids) / len(query_entity_ids), 4)
+
+
+def _temporal_score(candidate: Mapping[str, Any], now: datetime) -> float:
+    valid_from = _coerce_datetime(candidate.get("valid_from"))
+    valid_until = _coerce_datetime(candidate.get("valid_until"))
+    if valid_until and valid_until < now:
+        return 0.05
+    if valid_from and valid_from > now:
+        return 0.2
+    if valid_from or valid_until:
+        return 1.0
+
+    created_at = _coerce_datetime(candidate.get("created_at"))
+    if not created_at:
+        return 0.5
+    age_days = max((now - created_at).total_seconds() / 86400, 0)
+    if age_days <= 7:
+        return 0.9
+    if age_days <= 30:
+        return 0.75
+    if age_days <= 365:
+        return 0.5
+    return 0.25
+
+
+def _project_scope_score(project_id: Any, project_scope: str | None) -> float:
+    if not project_scope:
+        return 0.5
+    if project_id is None:
+        return 0.25
+    return 1.0 if str(project_id) == str(project_scope) else 0.0
+
+
+def _source_trust_score(candidate: Mapping[str, Any]) -> float:
+    if candidate.get("provenance"):
+        return 1.0
+    if candidate.get("source"):
+        return 0.6
+    return 0.25
+
+
+def _governance_score(governance: Any) -> tuple[float, list[str]]:
+    if governance is None:
+        return 0.5, []
+    if isinstance(governance, str):
+        lowered = governance.lower()
+        reasons = [marker for marker in _UNSAFE_TEXT_MARKERS if marker in lowered]
+        if reasons:
+            return 0.0, reasons
+        if "read_only" in lowered or "proposal" in lowered or "governed" in lowered:
+            return 1.0, []
+        return 0.5, []
+    if not isinstance(governance, Mapping):
+        return 0.5, []
+
+    reasons = [key for key in _UNSAFE_BOOL_KEYS if governance.get(key) is True]
+    mode = str(governance.get("mode", "")).lower()
+    if any(marker in mode for marker in ("write", "mutate", "modify")):
+        reasons.append("mode")
+    if reasons:
+        return 0.0, reasons
+    if governance.get("read_only") is True or governance.get("proposal_governed") is True:
+        return 1.0, []
+    return 0.5, []
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if not value:
+        return None
+    text = str(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]

--- a/agent/memory_review_decision_gate.py
+++ b/agent/memory_review_decision_gate.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from agent.memory_block_review_queue import (
+    explain_review_queue_item,
+    recommend_review_queue_action,
+    validate_review_queue_item,
+)
+
+
+MEMORY_REVIEW_DECISION_GATE_VERSION = "0.1"
+SUPPORTED_REVIEW_DECISIONS = (
+    "approve_to_proposal",
+    "reject",
+    "request_more_evidence",
+    "defer",
+)
+MEMORY_REVIEW_DECISION_GATE_POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+    "creates_decision_candidates_only": True,
+    "applies_decisions": False,
+    "creates_real_proposals": False,
+}
+
+
+def create_review_decision_candidate(
+    queue_item: Mapping[str, Any],
+    reviewer: str | None = None,
+    decision: str | None = None,
+    rationale: str | None = None,
+) -> dict[str, Any]:
+    """Create a deterministic read-only decision candidate for a review queue item."""
+    item = deepcopy(dict(queue_item))
+    queue_validation = validate_review_queue_item(item)
+    chosen_decision, default_rationale = _decision_for_queue_item(item, queue_validation)
+    if decision is not None:
+        chosen_decision = str(decision)
+        default_rationale = "Explicit decision override supplied for validation only; no decision is applied."
+
+    candidate = {
+        "decision_id": None,
+        "queue_item_id": item.get("queue_item_id"),
+        "block_id": item.get("block_id"),
+        "block_type": item.get("block_type"),
+        "project_scope": item.get("project_scope"),
+        "reviewer": reviewer if reviewer is not None else item.get("reviewer"),
+        "decision": chosen_decision,
+        "rationale": rationale or default_rationale,
+        "risk_level": item.get("risk_level"),
+        "source_pattern_ids": deepcopy(list(item.get("source_pattern_ids", []) or [])),
+        "source_fact_ids": deepcopy(list(item.get("source_fact_ids", []) or [])),
+        "queue_item_validation": deepcopy(queue_validation),
+        "decision_validation": {"valid": False, "errors": ["not_validated"]},
+        "next_step_recommendation": {},
+        "queue_item_snapshot": deepcopy(item),
+        "policy": dict(MEMORY_REVIEW_DECISION_GATE_POLICY),
+    }
+    candidate["decision_id"] = _decision_id(candidate)
+    candidate["decision_validation"] = validate_review_decision_candidate(candidate)
+    candidate["next_step_recommendation"] = recommend_review_decision_action(candidate)
+    return candidate
+
+
+def evaluate_review_queue_item(queue_item: Mapping[str, Any], reviewer: str | None = None) -> dict[str, Any]:
+    """Evaluate a queue item into a read-only decision candidate."""
+    return create_review_decision_candidate(queue_item, reviewer=reviewer)
+
+
+def validate_review_decision_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    policy = _as_dict(candidate.get("policy"))
+    queue_validation = _as_dict(candidate.get("queue_item_validation"))
+
+    for key in (
+        "decision_id",
+        "queue_item_id",
+        "block_id",
+        "block_type",
+        "project_scope",
+        "reviewer",
+        "decision",
+        "rationale",
+        "risk_level",
+        "source_pattern_ids",
+        "source_fact_ids",
+        "queue_item_validation",
+        "decision_validation",
+        "next_step_recommendation",
+        "queue_item_snapshot",
+        "policy",
+    ):
+        if key not in candidate:
+            errors.append(f"missing_{key}")
+    if candidate.get("decision") not in SUPPORTED_REVIEW_DECISIONS:
+        errors.append(f"unsupported_decision:{candidate.get('decision')}")
+    if candidate.get("risk_level") not in {"low", "medium", "high"}:
+        errors.append("risk_level_must_be_low_medium_or_high")
+    if not isinstance(candidate.get("source_pattern_ids"), list):
+        errors.append("source_pattern_ids_must_be_list")
+    if not isinstance(candidate.get("source_fact_ids"), list):
+        errors.append("source_fact_ids_must_be_list")
+    if not isinstance(queue_validation.get("valid"), bool):
+        errors.append("queue_item_validation_valid_must_be_bool")
+    for key, expected in MEMORY_REVIEW_DECISION_GATE_POLICY.items():
+        if policy.get(key) is not expected:
+            errors.append(f"policy_{key}_must_be_{str(expected).lower()}")
+
+    return {"valid": not errors, "errors": errors}
+
+
+def explain_review_decision_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    validation = validate_review_decision_candidate(candidate)
+    snapshot = _as_dict(candidate.get("queue_item_snapshot"))
+    return {
+        "decision_id": candidate.get("decision_id"),
+        "queue_item_id": candidate.get("queue_item_id"),
+        "block_id": candidate.get("block_id"),
+        "block_type": candidate.get("block_type"),
+        "project_scope": candidate.get("project_scope"),
+        "reviewer": candidate.get("reviewer"),
+        "decision": candidate.get("decision"),
+        "rationale": candidate.get("rationale"),
+        "risk_level": candidate.get("risk_level"),
+        "source_pattern_count": len(candidate.get("source_pattern_ids", []) or []),
+        "source_fact_count": len(candidate.get("source_fact_ids", []) or []),
+        "validation": validation,
+        "queue_item_explanation": explain_review_queue_item(snapshot) if snapshot else {},
+        "applied": False,
+        "created_real_proposal": False,
+        "created_operation_event": False,
+        "policy": dict(MEMORY_REVIEW_DECISION_GATE_POLICY),
+    }
+
+
+def recommend_review_decision_action(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    decision = candidate.get("decision")
+    snapshot = _as_dict(candidate.get("queue_item_snapshot"))
+    if decision == "approve_to_proposal":
+        action = "prepare_governed_write_proposal"
+        reason = "Decision candidate can proceed to a separate governed proposal flow, but this gate does not create it."
+    elif decision == "reject":
+        action = "record_rejection_outside_gate"
+        reason = "Decision candidate indicates rejection; this gate does not persist or apply the rejection."
+    elif decision == "request_more_evidence":
+        action = "collect_more_source_evidence"
+        reason = "Decision candidate requires stronger source evidence before any proposal path."
+    else:
+        action = "defer_for_manual_review"
+        reason = "Decision candidate cannot determine a v0.1 route deterministically."
+    return {
+        "action": action,
+        "reason": reason,
+        "decision": decision,
+        "queue_item_recommendation": recommend_review_queue_action(snapshot) if snapshot else {},
+        "creates_decision_candidates_only": True,
+        "applies_decisions": False,
+        "creates_real_proposals": False,
+        "policy": dict(MEMORY_REVIEW_DECISION_GATE_POLICY),
+    }
+
+
+def summarize_review_decisions(candidates: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...]) -> dict[str, Any]:
+    by_decision = {decision: 0 for decision in SUPPORTED_REVIEW_DECISIONS}
+    by_risk = {"high": 0, "medium": 0, "low": 0}
+    invalid_count = 0
+    for candidate in candidates:
+        decision = str(candidate.get("decision"))
+        if decision in by_decision:
+            by_decision[decision] += 1
+        risk = str(candidate.get("risk_level"))
+        if risk in by_risk:
+            by_risk[risk] += 1
+        validation = validate_review_decision_candidate(candidate)
+        if validation["valid"] is not True:
+            invalid_count += 1
+    return {
+        "total": len(candidates),
+        "by_decision": by_decision,
+        "by_risk": by_risk,
+        "invalid_count": invalid_count,
+        "policy": dict(MEMORY_REVIEW_DECISION_GATE_POLICY),
+    }
+
+
+def _decision_for_queue_item(item: Mapping[str, Any], queue_validation: Mapping[str, Any]) -> tuple[str, str]:
+    block_validation = _as_dict(item.get("validation"))
+    block_type = str(item.get("block_type"))
+    risk_level = str(item.get("risk_level"))
+    has_sources = bool(item.get("source_pattern_ids") or item.get("source_fact_ids"))
+
+    if queue_validation.get("valid") is not True:
+        return "reject", "Invalid review queue item violates the v0.1 queue contract."
+    if block_validation.get("valid") is not True:
+        return "reject", "Invalid memory block candidate inside the queue item must be rejected."
+    if risk_level == "high" and block_type == "safety_policy":
+        return "request_more_evidence", "High-risk safety policy blocks require more evidence before proposal handling."
+    if risk_level == "high":
+        return "reject", "High-risk unsupported or invalid queue item condition must be rejected."
+    if risk_level == "medium" and block_type in {"procedural_rules", "methodology"}:
+        if has_sources:
+            return "approve_to_proposal", "Valid medium-risk rule or methodology block has source ids and may enter a governed proposal flow."
+        return "request_more_evidence", "Medium-risk rule or methodology block needs source ids before proposal handling."
+    if risk_level == "medium" and block_type in {"persona", "collaboration_style", "human_profile"}:
+        if has_sources:
+            return "approve_to_proposal", "Valid medium-risk profile block has source ids and may enter a governed proposal flow."
+        return "request_more_evidence", "Medium-risk profile block needs source ids before proposal handling."
+    if risk_level == "low" and block_type in {"project_context", "current_task_state"}:
+        return "approve_to_proposal", "Valid low-risk project context or task state block may enter a governed proposal flow."
+    return "defer", "No deterministic v0.1 decision rule matched this queue item."
+
+
+def _decision_id(candidate: Mapping[str, Any]) -> str:
+    identity = {
+        "version": MEMORY_REVIEW_DECISION_GATE_VERSION,
+        "queue_item_id": candidate.get("queue_item_id"),
+        "block_id": candidate.get("block_id"),
+        "block_type": candidate.get("block_type"),
+        "project_scope": candidate.get("project_scope"),
+        "reviewer": candidate.get("reviewer"),
+        "decision": candidate.get("decision"),
+        "rationale": candidate.get("rationale"),
+        "risk_level": candidate.get("risk_level"),
+        "source_pattern_ids": list(candidate.get("source_pattern_ids", [])),
+        "source_fact_ids": list(candidate.get("source_fact_ids", [])),
+        "queue_item_validation": candidate.get("queue_item_validation", {}),
+        "policy": candidate.get("policy", {}),
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return f"memory-review-decision:v0.1:{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(dict(value)) if isinstance(value, Mapping) else {}

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark packages for Hermes Agent."""

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -31,6 +31,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_blocks`
 - `memory_block_review_queue`
 - `memory_review_decision_gate`
+- `memory_proposal_draft_builder`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -164,6 +165,26 @@ modify config, or create operation-ledger events.
 The smoke suite includes `memory_review_decision_gate`, proving that a sourced
 `procedural_rules` queue item becomes an `approve_to_proposal` decision
 candidate without creating a real proposal.
+
+## Memory Proposal Draft Builder v0.1
+
+Memory Proposal Draft Builder v0.1 lives in
+`agent.memory_proposal_draft_builder`. It converts approved review decision
+candidates into deterministic `draft_review_required` proposal draft candidates
+for a separate governed proposal flow.
+
+Only `approve_to_proposal` decisions can produce valid drafts.
+`request_more_evidence`, `reject`, `defer`, and invalid decision candidates
+produce invalid draft candidates with explicit reasons. Drafts preserve the
+block payload preview, source pattern ids, source fact ids, source decision
+snapshot, validation, next-step recommendation, routing, and read-only policy.
+The builder does not create real proposals, persist approvals, write memory,
+write the Memory Graph, modify config, or create operation-ledger events.
+
+The smoke suite includes `memory_proposal_draft_builder`, proving that an
+approved procedural rules decision candidate becomes a
+`draft_review_required` proposal draft candidate without creating a real
+proposal.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -45,6 +45,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_write_lock_gate`
 - `memory_human_approval_token_final_confirmation_request`
 - `memory_human_approval_token_final_confirmation_review_gate`
+- `memory_human_approval_token_write_execution_plan`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -453,6 +454,28 @@ The smoke suite includes
 valid final confirmation request becomes a confirm-token-write review outcome
 candidate without issuing a token, persisting approval, creating a real
 proposal, or creating an operation event.
+
+### Memory Human Approval Token Write Execution Plan v0.1
+
+Implemented in `agent.memory_human_approval_token_write_execution_plan`. It
+turns a `confirm_token_write` final confirmation review outcome candidate into
+a deterministic, read-only token write execution plan candidate.
+
+Only a valid `confirm_token_write` outcome with intact previews and source
+evidence becomes `manual_token_write_execution_plan_required`. Request changes,
+reject, defer, invalid outcomes, missing previews, missing source evidence, and
+preview integrity failures become locked plan candidates with explicit lock
+reasons. The plan describes future token write steps and preflight checks, but
+never issues approval tokens, persists approvals, creates real proposals, writes
+proposal files, writes operation-ledger events, writes token files, writes
+approval audit records, submits to governance, writes memory, writes the Memory
+Graph, or modifies config.
+
+The smoke suite includes `memory_human_approval_token_write_execution_plan`,
+proving that a valid final confirmation review outcome becomes
+manual-token-write-execution-plan-required without issuing a token, persisting
+approval, creating a real proposal, writing token files, writing approval audit,
+or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -38,6 +38,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_real_proposal_creation_plan`
 - `memory_real_proposal_dry_run`
 - `memory_real_proposal_write_lock_gate`
+- `memory_human_approval_token_request`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -308,6 +309,24 @@ proposals, write memory, write the Memory Graph, or modify config.
 The smoke suite includes `memory_real_proposal_write_lock_gate`, proving that a
 valid dry run becomes eligible for a separate human approval token flow without
 creating a real proposal or operation event.
+
+### Memory Human Approval Token Request v0.1
+
+Implemented in `agent.memory_human_approval_token_request`. It turns an
+`eligible_for_human_approval_token` write-lock gate candidate into a
+deterministic `approval_token_review_required` human approval token request
+candidate.
+
+Invalid or locked write-lock gates, missing previews, missing source evidence,
+or preview artifacts with written/created flags remain `locked` with explicit
+reasons. The request candidate never issues real approval tokens, persists
+approvals, creates real proposals, writes proposal files, writes
+operation-ledger events, submits to governance, writes memory, writes the Memory
+Graph, or modifies config.
+
+The smoke suite includes `memory_human_approval_token_request`, proving that an
+eligible write-lock gate becomes review-required without issuing a token,
+creating a real proposal, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -52,6 +52,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_real_write_executor_contract_review_gate`
 - `memory_human_approval_token_real_write_executor_implementation_plan`
 - `memory_human_approval_token_real_write_executor_implementation_dry_run`
+- `memory_human_approval_token_real_write_executor_code_review_plan`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -630,6 +631,34 @@ proving that a valid implementation plan becomes
 persisting approval, creating a real proposal, writing token files, writing
 approval audit, invoking or implementing a real token write executor, creating
 executor source files, or creating an operation event.
+
+### Memory Human Approval Token Real Write Executor Code Review Plan v0.1
+
+Implemented in
+`agent.memory_human_approval_token_real_write_executor_code_review_plan`.
+It turns a valid `real_token_write_executor_code_review_plan_required`
+implementation dry-run candidate into a deterministic, read-only code review
+plan candidate with `real_token_write_executor_code_review_gate_required`
+status.
+
+The code review plan defines future executor source-file review scope, required
+future files, static analysis checks, security checks, write-safety checks,
+test matrix, acceptance criteria, forbidden actions, and a plan checklist.
+Invalid, locked, incomplete, or integrity-failed implementation dry runs become
+locked code-review-plan candidates with explicit reasons. v0.1 does not create
+executor source files, create executor tests, implement or invoke a real token
+write executor, issue approval tokens, persist approvals, create real
+proposals, write proposal files, write operation-ledger events, write token
+files, write approval audit records, submit to governance, write memory, write
+the Memory Graph, or modify config.
+
+The smoke suite includes
+`memory_human_approval_token_real_write_executor_code_review_plan`, proving
+that a valid implementation dry run becomes
+`real_token_write_executor_code_review_gate_required` without issuing a token,
+persisting approval, creating a real proposal, writing token files, writing
+approval audit, invoking or implementing a real token write executor, creating
+executor source files, creating executor tests, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -50,6 +50,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_write_final_gate`
 - `memory_human_approval_token_real_write_executor_contract`
 - `memory_human_approval_token_real_write_executor_contract_review_gate`
+- `memory_human_approval_token_real_write_executor_implementation_plan`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -573,6 +574,31 @@ submit to governance, write memory, write the Memory Graph, or modify config.
 The smoke suite includes
 `memory_human_approval_token_real_write_executor_contract_review_gate`, proving
 that a valid contract becomes `approve_executor_contract` without issuing a
+token, persisting approval, creating a real proposal, writing token files,
+writing approval audit, invoking or implementing a real token write executor,
+or creating an operation event.
+
+### Memory Human Approval Token Real Write Executor Implementation Plan v0.1
+
+Implemented in
+`agent.memory_human_approval_token_real_write_executor_implementation_plan`.
+It turns an `approve_executor_contract` review outcome candidate into a
+deterministic, read-only implementation plan candidate with
+`real_token_write_executor_implementation_plan_required` status.
+
+The plan defines future executor interfaces, planned module boundaries,
+idempotency, filesystem safety, audit, rollback, tests, and forbidden actions.
+Non-approved, invalid, incomplete, or integrity-failed contract review outcomes
+become locked plan candidates with explicit reasons. v0.1 does not implement or
+invoke a real token write executor, issue approval tokens, persist approvals,
+create real proposals, write proposal files, write operation-ledger events,
+write token files, write approval audit records, submit to governance, write
+memory, write the Memory Graph, or modify config.
+
+The smoke suite includes
+`memory_human_approval_token_real_write_executor_implementation_plan`, proving
+that a valid contract review outcome becomes
+`real_token_write_executor_implementation_plan_required` without issuing a
 token, persisting approval, creating a real proposal, writing token files,
 writing approval audit, invoking or implementing a real token write executor,
 or creating an operation event.

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -51,6 +51,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_real_write_executor_contract`
 - `memory_human_approval_token_real_write_executor_contract_review_gate`
 - `memory_human_approval_token_real_write_executor_implementation_plan`
+- `memory_human_approval_token_real_write_executor_implementation_dry_run`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -602,6 +603,33 @@ that a valid contract review outcome becomes
 token, persisting approval, creating a real proposal, writing token files,
 writing approval audit, invoking or implementing a real token write executor,
 or creating an operation event.
+
+### Memory Human Approval Token Real Write Executor Implementation Dry Run v0.1
+
+Implemented in
+`agent.memory_human_approval_token_real_write_executor_implementation_dry_run`.
+It turns a valid `real_token_write_executor_implementation_plan_required`
+implementation plan candidate into a deterministic, read-only implementation
+dry-run candidate with `real_token_write_executor_code_review_plan_required`
+status.
+
+The dry run previews future executor module boundaries, interfaces,
+idempotency checks, filesystem safety checks, audit checks, rollback checks,
+test harness shape, and readiness checklist. Invalid, locked, incomplete, or
+integrity-failed implementation plans become locked dry-run candidates with
+explicit reasons. v0.1 does not implement or invoke a real token write
+executor, create executor source files, issue approval tokens, persist
+approvals, create real proposals, write proposal files, write operation-ledger
+events, write token files, write approval audit records, submit to governance,
+write memory, write the Memory Graph, or modify config.
+
+The smoke suite includes
+`memory_human_approval_token_real_write_executor_implementation_dry_run`,
+proving that a valid implementation plan becomes
+`real_token_write_executor_code_review_plan_required` without issuing a token,
+persisting approval, creating a real proposal, writing token files, writing
+approval audit, invoking or implementing a real token write executor, creating
+executor source files, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -32,6 +32,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_block_review_queue`
 - `memory_review_decision_gate`
 - `memory_proposal_draft_builder`
+- `memory_proposal_governance_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -185,6 +186,25 @@ The smoke suite includes `memory_proposal_draft_builder`, proving that an
 approved procedural rules decision candidate becomes a
 `draft_review_required` proposal draft candidate without creating a real
 proposal.
+
+## Memory Proposal Governance Gate v0.1
+
+Memory Proposal Governance Gate v0.1 lives in
+`agent.memory_proposal_governance_gate`. It validates proposal draft candidates
+and creates deterministic `governance_review_required` governance submission
+candidates for manual governed proposal creation.
+
+Only valid drafts with `proposal_status: draft_review_required` can produce
+valid submission candidates. Invalid drafts, missing payload previews, or
+missing source evidence produce invalid candidates with explicit reasons. The
+gate preserves payload previews, source ids, draft validation, source draft
+snapshots, routing, and read-only policy. It does not submit to governance,
+create real proposals, apply proposal drafts, persist approvals, write memory,
+write the Memory Graph, modify config, or create operation-ledger events.
+
+The smoke suite includes `memory_proposal_governance_gate`, proving that a
+valid proposal draft becomes a `governance_review_required` submission
+candidate without creating a real proposal or governance submission record.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -35,6 +35,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_proposal_governance_gate`
 - `memory_governance_submission_packet`
 - `memory_human_review_outcome_gate`
+- `memory_real_proposal_creation_plan`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -247,6 +248,25 @@ operation-ledger events.
 The smoke suite includes `memory_human_review_outcome_gate`, proving that a
 valid human-review packet becomes an `approve_real_proposal_creation` outcome
 candidate without creating a real proposal.
+
+## Memory Real Proposal Creation Plan v0.1
+
+Memory Real Proposal Creation Plan v0.1 lives in
+`agent.memory_real_proposal_creation_plan`. It turns an
+`approve_real_proposal_creation` human-review outcome candidate into a
+deterministic `manual_creation_plan_required` plan candidate.
+
+Only valid approve outcomes with payload preview and source evidence can produce
+valid plans. `request_changes`, `reject`, `defer`, invalid outcomes, missing
+payload previews, and missing source evidence produce invalid plans with
+explicit reasons. The planner creates plan candidates only; it does not create
+real proposals, submit to governance, apply proposal drafts, persist approvals,
+write memory, write the Memory Graph, modify config, or create operation-ledger
+events.
+
+The smoke suite includes `memory_real_proposal_creation_plan`, proving that a
+valid `approve_real_proposal_creation` outcome becomes a
+`manual_creation_plan_required` plan candidate without creating a real proposal.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -42,6 +42,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_review_gate`
 - `memory_human_approval_token_issuance_plan`
 - `memory_human_approval_token_issuance_dry_run`
+- `memory_human_approval_token_write_lock_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -387,6 +388,26 @@ The smoke suite includes `memory_human_approval_token_issuance_dry_run`,
 proving that a valid token issuance plan reaches final manual preflight without
 issuing a token, persisting approval, creating a real proposal, or creating an
 operation event.
+
+### Memory Human Approval Token Write Lock Gate v0.1
+
+Implemented in `agent.memory_human_approval_token_write_lock_gate`. It turns a
+valid `manual_token_issuance_final_preflight_required` dry-run candidate into a
+deterministic `eligible_for_final_human_confirmation` token write-lock gate
+candidate.
+
+Invalid or locked token issuance dry runs, missing token/proposal/ledger/path
+previews, missing source evidence, or previews that are not preview-only remain
+`locked` with explicit reasons. The gate never issues real approval tokens,
+persists approvals, creates real proposals, writes proposal files, writes
+operation-ledger events, writes token files, writes approval audit records,
+submits to governance, writes memory, writes the Memory Graph, or modifies
+config.
+
+The smoke suite includes `memory_human_approval_token_write_lock_gate`, proving
+that a valid token issuance dry run becomes eligible for a separate final human
+confirmation flow without issuing a token, persisting approval, creating a real
+proposal, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -48,6 +48,8 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_write_execution_plan`
 - `memory_human_approval_token_write_execution_dry_run`
 - `memory_human_approval_token_write_final_gate`
+- `memory_human_approval_token_real_write_executor_contract`
+- `memory_human_approval_token_real_write_executor_contract_review_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -549,6 +551,31 @@ write final gate becomes a real-token-write-executor-contract-required
 candidate without issuing a token, persisting approval, invoking or
 implementing the executor, writing token files, writing approval audit, creating
 a real proposal, or creating an operation event.
+
+### Memory Human Approval Token Real Write Executor Contract Review Gate v0.1
+
+Implemented in
+`agent.memory_human_approval_token_real_write_executor_contract_review_gate`.
+It turns a `real_token_write_executor_contract_required` contract candidate into
+a deterministic, read-only contract review outcome candidate.
+
+v0.1 outcomes are `approve_executor_contract`, `request_contract_changes`,
+`reject_contract`, and `defer_contract_review`. Valid required contracts with
+intact previews, executor contract fields, and source evidence are approved
+only for a later implementation plan. Locked or invalid contracts reject;
+missing previews, missing executor contract fields, missing source evidence,
+preview integrity failures, and contract integrity failures request changes.
+The review gate does not implement or invoke a real token write executor, issue
+approval tokens, persist approvals, create real proposals, write proposal files,
+write operation-ledger events, write token files, write approval audit records,
+submit to governance, write memory, write the Memory Graph, or modify config.
+
+The smoke suite includes
+`memory_human_approval_token_real_write_executor_contract_review_gate`, proving
+that a valid contract becomes `approve_executor_contract` without issuing a
+token, persisting approval, creating a real proposal, writing token files,
+writing approval audit, invoking or implementing a real token write executor,
+or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -40,6 +40,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_real_proposal_write_lock_gate`
 - `memory_human_approval_token_request`
 - `memory_human_approval_token_review_gate`
+- `memory_human_approval_token_issuance_plan`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -348,6 +349,25 @@ Graph, or modifies config.
 The smoke suite includes `memory_human_approval_token_review_gate`, proving that
 a valid approval token request becomes `approve_token_issuance` without issuing
 a token, creating a real proposal, or creating an operation event.
+
+### Memory Human Approval Token Issuance Plan v0.1
+
+Implemented in `agent.memory_human_approval_token_issuance_plan`. It turns an
+`approve_token_issuance` review outcome candidate into a deterministic
+`manual_token_issuance_plan_required` plan candidate.
+
+Only valid `approve_token_issuance` review outcomes with proposal-record,
+operation-ledger, target-path previews, and source evidence can create a valid
+plan. `request_changes`, `reject`, `defer`, invalid review outcomes, and missing
+required previews or source evidence produce locked plan candidates. The plan
+never issues approval tokens, persists approvals, creates real proposals, writes
+proposal files, writes operation-ledger events, submits to governance, writes
+memory, writes the Memory Graph, or modifies config.
+
+The smoke suite includes `memory_human_approval_token_issuance_plan`, proving
+that a valid `approve_token_issuance` review outcome becomes
+`manual_token_issuance_plan_required` without issuing a token, creating a real
+proposal, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -41,6 +41,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_request`
 - `memory_human_approval_token_review_gate`
 - `memory_human_approval_token_issuance_plan`
+- `memory_human_approval_token_issuance_dry_run`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -368,6 +369,24 @@ The smoke suite includes `memory_human_approval_token_issuance_plan`, proving
 that a valid `approve_token_issuance` review outcome becomes
 `manual_token_issuance_plan_required` without issuing a token, creating a real
 proposal, or creating an operation event.
+
+### Memory Human Approval Token Issuance Dry Run v0.1
+
+Implemented in `agent.memory_human_approval_token_issuance_dry_run`. It turns a
+valid `manual_token_issuance_plan_required` plan candidate into a deterministic
+`manual_token_issuance_final_preflight_required` dry-run candidate.
+
+The dry run previews the approval token record, approval audit record, token
+target paths, inherited proposal and operation-ledger previews, and final token
+preflight checklist. It never issues real approval tokens, persists approvals,
+creates real proposals, writes proposal files, writes operation-ledger events,
+writes token files, writes approval audit records, submits to governance, writes
+memory, writes the Memory Graph, or modifies config.
+
+The smoke suite includes `memory_human_approval_token_issuance_dry_run`,
+proving that a valid token issuance plan reaches final manual preflight without
+issuing a token, persisting approval, creating a real proposal, or creating an
+operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -47,6 +47,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_final_confirmation_review_gate`
 - `memory_human_approval_token_write_execution_plan`
 - `memory_human_approval_token_write_execution_dry_run`
+- `memory_human_approval_token_write_final_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -501,6 +502,28 @@ The smoke suite includes
 execution plan becomes manual-token-write-final-preflight-required without
 issuing a token, persisting approval, creating a real proposal, writing token
 files, writing approval audit, or creating an operation event.
+
+### Memory Human Approval Token Write Final Gate v0.1
+
+Implemented in `agent.memory_human_approval_token_write_final_gate`. It turns a
+valid `manual_token_write_final_preflight_required` execution dry-run candidate
+into a deterministic, read-only final gate candidate with
+`eligible_for_real_token_write_executor` status.
+
+Locked or invalid execution dry runs, missing previews, missing source
+evidence, missing final preflight checklists, preview integrity failures, and
+final preflight integrity failures become locked final gate candidates with
+explicit reasons. The final gate may route to a separate real token write
+executor later, but v0.1 does not invoke that executor, issue approval tokens,
+persist approvals, create real proposals, write proposal files, write
+operation-ledger events, write token files, write approval audit records,
+submit to governance, write memory, write the Memory Graph, or modify config.
+
+The smoke suite includes `memory_human_approval_token_write_final_gate`,
+proving that a valid write execution dry run becomes executor-eligible without
+issuing a token, persisting approval, invoking the executor, writing token
+files, writing approval audit, creating a real proposal, or creating an
+operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -46,6 +46,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_final_confirmation_request`
 - `memory_human_approval_token_final_confirmation_review_gate`
 - `memory_human_approval_token_write_execution_plan`
+- `memory_human_approval_token_write_execution_dry_run`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -476,6 +477,30 @@ proving that a valid final confirmation review outcome becomes
 manual-token-write-execution-plan-required without issuing a token, persisting
 approval, creating a real proposal, writing token files, writing approval audit,
 or creating an operation event.
+
+### Memory Human Approval Token Write Execution Dry Run v0.1
+
+Implemented in
+`agent.memory_human_approval_token_write_execution_dry_run`. It turns a
+`manual_token_write_execution_plan_required` execution plan candidate into a
+deterministic, read-only token write execution dry-run candidate.
+
+Only a valid execution plan with intact token, audit, proposal, ledger, target
+path, payload, source evidence, and execution-control previews becomes
+`manual_token_write_final_preflight_required`. Locked or invalid plans, missing
+previews, missing evidence, missing controls, and preview integrity failures
+become locked dry-run candidates with explicit reasons. The dry run previews
+the exact token write payload, approval audit write payload, target paths, and
+final preflight checklist, but never issues approval tokens, persists approvals,
+creates real proposals, writes proposal files, writes operation-ledger events,
+writes token files, writes approval audit records, submits to governance, writes
+memory, writes the Memory Graph, or modifies config.
+
+The smoke suite includes
+`memory_human_approval_token_write_execution_dry_run`, proving that a valid
+execution plan becomes manual-token-write-final-preflight-required without
+issuing a token, persisting approval, creating a real proposal, writing token
+files, writing approval audit, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -525,6 +525,31 @@ issuing a token, persisting approval, invoking the executor, writing token
 files, writing approval audit, creating a real proposal, or creating an
 operation event.
 
+### Memory Human Approval Token Real Write Executor Contract v0.1
+
+Implemented in
+`agent.memory_human_approval_token_real_write_executor_contract`. It turns a
+valid `eligible_for_real_token_write_executor` final gate candidate into a
+deterministic, read-only real token write executor contract candidate with
+`real_token_write_executor_contract_required` status.
+
+Locked or invalid final gates, missing previews, missing source evidence,
+missing final gate checklists, preview integrity failures, and final gate
+integrity failures become locked contract candidates with explicit reasons. The
+contract defines future executor inputs, hard-lock checks, audit fields,
+rollback rules, forbidden side effects, and the execution boundary, but v0.1
+does not implement or invoke a real token write executor, issue approval
+tokens, persist approvals, create real proposals, write proposal files, write
+operation-ledger events, write token files, write approval audit records,
+submit to governance, write memory, write the Memory Graph, or modify config.
+
+The smoke suite includes
+`memory_human_approval_token_real_write_executor_contract`, proving that a valid
+write final gate becomes a real-token-write-executor-contract-required
+candidate without issuing a token, persisting approval, invoking or
+implementing the executor, writing token files, writing approval audit, creating
+a real proposal, or creating an operation event.
+
 ## Report Schema
 
 The runner emits JSON with these top-level fields:

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -29,6 +29,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `contradiction_engine`
 - `memory_compiler`
 - `memory_blocks`
+- `memory_block_review_queue`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -126,6 +127,25 @@ allowlists, create proposals, or create operation-ledger events.
 The smoke suite includes `memory_blocks`, proving that a compiler procedure
 candidate becomes a review-only `procedural_rules` block candidate while the
 JSON report schema remains stable.
+
+## Memory Block Review Queue v0.1
+
+Memory Block Review Queue v0.1 lives in
+`agent.memory_block_review_queue`. It wraps Memory Block candidates in
+deterministic `pending_review` queue items so humans or agents can inspect them
+later without applying blocks or creating any durable side effects.
+
+Queue items include a deterministic `queue_item_id`, block identity, project
+scope, priority, risk level, source pattern and fact ids, block validation,
+recommended action, an immutable block snapshot, and explicit read-only policy.
+Priority is deterministic: invalid blocks are highest, safety policy blocks are
+high risk, methodology and procedural rules are medium risk, persona and
+collaboration style blocks are medium risk, and project context and current task
+state blocks are low risk.
+
+The smoke suite includes `memory_block_review_queue`, proving that a
+`procedural_rules` block candidate becomes a `pending_review` queue item while
+the JSON report schema remains stable.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -36,6 +36,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_governance_submission_packet`
 - `memory_human_review_outcome_gate`
 - `memory_real_proposal_creation_plan`
+- `memory_real_proposal_dry_run`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -267,6 +268,26 @@ events.
 The smoke suite includes `memory_real_proposal_creation_plan`, proving that a
 valid `approve_real_proposal_creation` outcome becomes a
 `manual_creation_plan_required` plan candidate without creating a real proposal.
+
+## Memory Real Proposal Dry Run v0.1
+
+Memory Real Proposal Dry Run v0.1 lives in
+`agent.memory_real_proposal_dry_run`. It turns a valid
+`manual_creation_plan_required` plan candidate into a deterministic
+`manual_final_preflight_required` dry-run candidate.
+
+The dry run previews the proposal record, operation-ledger record, deterministic
+target paths, payload, source evidence, and final preflight checklist. Invalid
+plans, missing payload previews, missing source evidence, or missing creation
+steps/preflight checks produce invalid dry runs with explicit reasons. The dry
+run creates preview candidates only; it does not create real proposals, write
+proposal files, write operation-ledger events, submit to governance, persist
+approvals, apply proposals, write memory, write the Memory Graph, or modify
+config.
+
+The smoke suite includes `memory_real_proposal_dry_run`, proving that a valid
+manual creation plan becomes a `manual_final_preflight_required` dry run without
+creating a real proposal or operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -27,6 +27,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `hybrid_retrieval_fusion`
 - `bitemporal_fact_graph`
 - `contradiction_engine`
+- `memory_compiler`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -88,6 +89,24 @@ proposals, or create operation-ledger events.
 The smoke suite includes `contradiction_engine`, proving that a candidate fact
 which conflicts with an existing fact returns a review recommendation rather
 than being merged directly.
+
+## Memory Compiler v0.1
+
+Memory Compiler v0.1 lives in `agent.memory_compiler`. It compiles normalized
+Bi-temporal Fact Graph facts and Contradiction Engine groups into review-only
+methodology and procedure candidates. The compiler detects stable repeated
+claims, superseded lineage evolution, and contradiction groups without writing
+durable memory, writing the Memory Graph, modifying config, approving
+allowlists, creating proposals, or creating operation-ledger events.
+
+Compiler output includes the project scope, input and current fact counts,
+contradiction group count, extracted patterns, methodology candidate, procedure
+block candidate, review recommendation, trace, and read-only policy. Candidates
+always use `review_required` status and explicitly state that they have not
+been applied.
+
+The smoke suite includes `memory_compiler`, proving that facts can compile into
+a review-only procedure candidate while preserving the benchmark schema.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -28,6 +28,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `bitemporal_fact_graph`
 - `contradiction_engine`
 - `memory_compiler`
+- `memory_blocks`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -107,6 +108,24 @@ been applied.
 
 The smoke suite includes `memory_compiler`, proving that facts can compile into
 a review-only procedure candidate while preserving the benchmark schema.
+
+## Memory Blocks v0.1
+
+Memory Blocks v0.1 lives in `agent.memory_blocks`. It converts review-only
+compiler output into deterministic memory block candidates that future agents
+can inspect without applying them. Supported block types are `human_profile`,
+`persona`, `collaboration_style`, `project_context`, `procedural_rules`,
+`safety_policy`, `methodology`, and `current_task_state`.
+
+Every candidate includes a deterministic `block_id`, `review_required` status,
+source pattern and fact ids, confidence, validity, `proposal_only` mutation
+policy, `direct_write_allowed: false`, and explicit read-only policy proving
+that it does not write memory, write the Memory Graph, modify config, approve
+allowlists, create proposals, or create operation-ledger events.
+
+The smoke suite includes `memory_blocks`, proving that a compiler procedure
+candidate becomes a review-only `procedural_rules` block candidate while the
+JSON report schema remains stable.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -25,6 +25,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `project_scope_isolation`
 - `contradiction_handling`
 - `hybrid_retrieval_fusion`
+- `bitemporal_fact_graph`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -52,6 +53,22 @@ Scoring dimensions:
 - `governance_score` — read-only and proposal-governed records score highest;
   unsafe write/config/graph/allowlist indicators are rejected
 - `final_score` — deterministic weighted total
+
+## Bi-temporal Fact Graph v0.1
+
+Bi-temporal Fact Graph v0.1 lives in
+`agent.memory_bitemporal_fact_graph`. It exposes a deterministic in-memory
+fact model for temporal fact reasoning without writing durable memory, the
+Memory Graph, config, proposals, or operation-ledger events.
+
+Fact records include domain validity (`valid_from`, `valid_until`) separately
+from system timing (`system_created_at`, `system_invalidated_at`). The v0.1
+operations normalize facts, select current project-scoped facts, supersede
+facts by returning updated copies, detect contradictory subject/predicate/project
+claims, and explain fact lineage so superseded historical facts remain visible.
+
+The smoke suite includes `bitemporal_fact_graph`, proving that a newer valid
+fact wins while the older historical fact remains explainable through lineage.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -39,6 +39,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_real_proposal_dry_run`
 - `memory_real_proposal_write_lock_gate`
 - `memory_human_approval_token_request`
+- `memory_human_approval_token_review_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -327,6 +328,26 @@ Graph, or modifies config.
 The smoke suite includes `memory_human_approval_token_request`, proving that an
 eligible write-lock gate becomes review-required without issuing a token,
 creating a real proposal, or creating an operation event.
+
+### Memory Human Approval Token Review Gate v0.1
+
+Implemented in `agent.memory_human_approval_token_review_gate`. It turns an
+`approval_token_review_required` request candidate into a deterministic
+`token_review_outcome_candidate` with outcome labels `approve_token_issuance`,
+`request_changes`, `reject`, and `defer`.
+
+Invalid or locked request candidates reject. Missing proposal record,
+operation-ledger, target-path previews, or source evidence request changes.
+Valid review-required requests with intact previews and source evidence become
+`approve_token_issuance` candidates. Explicit supported outcome overrides are
+recorded only as read-only candidates; the gate never issues approval tokens,
+persists approvals, creates real proposals, writes proposal files, writes
+operation-ledger events, submits to governance, writes memory, writes the Memory
+Graph, or modifies config.
+
+The smoke suite includes `memory_human_approval_token_review_gate`, proving that
+a valid approval token request becomes `approve_token_issuance` without issuing
+a token, creating a real proposal, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -30,6 +30,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_compiler`
 - `memory_blocks`
 - `memory_block_review_queue`
+- `memory_review_decision_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -146,6 +147,23 @@ state blocks are low risk.
 The smoke suite includes `memory_block_review_queue`, proving that a
 `procedural_rules` block candidate becomes a `pending_review` queue item while
 the JSON report schema remains stable.
+
+## Memory Review Decision Gate v0.1
+
+Memory Review Decision Gate v0.1 lives in
+`agent.memory_review_decision_gate`. It evaluates pending review queue items
+into deterministic decision candidates with labels `approve_to_proposal`,
+`reject`, `request_more_evidence`, and `defer`.
+
+Decision candidates include queue and block identity, reviewer, rationale, risk,
+source ids, queue validation, decision validation, next-step recommendation,
+queue item snapshot, and explicit read-only policy. The gate does not apply
+decisions, create real proposals, write durable memory, write the Memory Graph,
+modify config, or create operation-ledger events.
+
+The smoke suite includes `memory_review_decision_gate`, proving that a sourced
+`procedural_rules` queue item becomes an `approve_to_proposal` decision
+candidate without creating a real proposal.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -44,6 +44,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_issuance_dry_run`
 - `memory_human_approval_token_write_lock_gate`
 - `memory_human_approval_token_final_confirmation_request`
+- `memory_human_approval_token_final_confirmation_review_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -430,6 +431,28 @@ The smoke suite includes
 token write-lock gate becomes final-confirmation-review-required without
 issuing a token, persisting approval, creating a real proposal, or creating an
 operation event.
+
+### Memory Human Approval Token Final Confirmation Review Gate v0.1
+
+Implemented in
+`agent.memory_human_approval_token_final_confirmation_review_gate`. It turns a
+`final_confirmation_review_required` request candidate into a deterministic
+read-only final human confirmation review outcome candidate.
+
+v0.1 outcomes are `confirm_token_write`, `request_changes`, `reject`, and
+`defer`. Invalid or locked requests reject; missing previews, source evidence,
+or preview integrity failures request changes; valid review-required requests
+with intact previews and evidence become `confirm_token_write`. The review gate
+never issues tokens, persists approvals, creates real proposals, writes proposal
+files, writes operation-ledger events, writes token files, writes approval audit
+records, submits to governance, writes memory, writes the Memory Graph, or
+modifies config.
+
+The smoke suite includes
+`memory_human_approval_token_final_confirmation_review_gate`, proving that a
+valid final confirmation request becomes a confirm-token-write review outcome
+candidate without issuing a token, persisting approval, creating a real
+proposal, or creating an operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -24,7 +24,34 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `governance_write_safety`
 - `project_scope_isolation`
 - `contradiction_handling`
+- `hybrid_retrieval_fusion`
 - `latency_ms`
+
+## Hybrid Retrieval Fusion v0.1
+
+Hybrid Retrieval Fusion v0.1 lives in `agent.memory_retrieval_fusion` and
+exposes `fuse_memory_retrieval(...)`. It is a deterministic, read-only scorer
+for candidate memory records. v0.1 intentionally uses lexical matching instead
+of external embeddings so benchmark runs are reproducible and do not call live
+services.
+
+Each result includes the original query, selected memories, rejected memories,
+per-candidate scores, policy, and an explanation. The scorer always returns
+rejected candidates with a reason and component scores; losing records are not
+hidden.
+
+Scoring dimensions:
+
+- `semantic_score` — token-overlap similarity between query and candidate text
+- `keyword_score` — exact token overlap plus exact query phrase match
+- `entity_score` — entity id intersection
+- `temporal_score` — current validity and recency, with expired records
+  penalized
+- `project_scope_score` — project match for scoped queries
+- `source_trust_score` — provenance-bearing sources score highest
+- `governance_score` — read-only and proposal-governed records score highest;
+  unsafe write/config/graph/allowlist indicators are rejected
+- `final_score` — deterministic weighted total
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -34,6 +34,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_proposal_draft_builder`
 - `memory_proposal_governance_gate`
 - `memory_governance_submission_packet`
+- `memory_human_review_outcome_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -226,6 +227,26 @@ write the Memory Graph, modify config, or create operation-ledger events.
 The smoke suite includes `memory_governance_submission_packet`, proving that a
 valid governance submission candidate becomes a `human_review_packet_required`
 packet candidate without creating a real proposal.
+
+## Memory Human Review Outcome Gate v0.1
+
+Memory Human Review Outcome Gate v0.1 lives in
+`agent.memory_human_review_outcome_gate`. It turns human-review packet
+candidates into deterministic `review_outcome_candidate` artifacts with outcome
+labels `approve_real_proposal_creation`, `request_changes`, `reject`, and
+`defer`.
+
+Invalid packets produce `reject` outcomes, missing payload previews or source
+evidence produce `request_changes`, and valid packets with payload preview plus
+source evidence produce `approve_real_proposal_creation`. Explicit supported
+outcome overrides are recorded only as read-only candidates. The gate does not
+create real proposals, submit to governance, apply proposal drafts, persist
+approvals, write memory, write the Memory Graph, modify config, or create
+operation-ledger events.
+
+The smoke suite includes `memory_human_review_outcome_gate`, proving that a
+valid human-review packet becomes an `approve_real_proposal_creation` outcome
+candidate without creating a real proposal.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -37,6 +37,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_review_outcome_gate`
 - `memory_real_proposal_creation_plan`
 - `memory_real_proposal_dry_run`
+- `memory_real_proposal_write_lock_gate`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -287,6 +288,25 @@ config.
 
 The smoke suite includes `memory_real_proposal_dry_run`, proving that a valid
 manual creation plan becomes a `manual_final_preflight_required` dry run without
+creating a real proposal or operation event.
+
+## Memory Real Proposal Write Lock Gate v0.1
+
+Memory Real Proposal Write Lock Gate v0.1 lives in
+`agent.memory_real_proposal_write_lock_gate`. It turns a valid
+`manual_final_preflight_required` dry-run candidate into a deterministic
+write-lock gate candidate.
+
+Valid dry runs with preview-only proposal, operation-ledger, and target-path
+previews become `eligible_for_human_approval_token`. Invalid dry runs, missing
+previews, missing source evidence, or preview artifacts with written/created
+flags remain `locked` with explicit reasons. The gate creates write-lock
+candidates only; it does not create real proposals, write proposal files, write
+operation-ledger events, submit to governance, persist approvals, apply
+proposals, write memory, write the Memory Graph, or modify config.
+
+The smoke suite includes `memory_real_proposal_write_lock_gate`, proving that a
+valid dry run becomes eligible for a separate human approval token flow without
 creating a real proposal or operation event.
 
 ## Report Schema

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -33,6 +33,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_review_decision_gate`
 - `memory_proposal_draft_builder`
 - `memory_proposal_governance_gate`
+- `memory_governance_submission_packet`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -205,6 +206,26 @@ write the Memory Graph, modify config, or create operation-ledger events.
 The smoke suite includes `memory_proposal_governance_gate`, proving that a
 valid proposal draft becomes a `governance_review_required` submission
 candidate without creating a real proposal or governance submission record.
+
+## Memory Governance Submission Packet v0.1
+
+Memory Governance Submission Packet v0.1 lives in
+`agent.memory_governance_submission_packet`. It turns valid governance
+submission candidates into deterministic `human_review_packet_required` packet
+candidates for manual human review before real proposal creation.
+
+Only valid governance submission candidates can produce valid packets. Invalid
+submission candidates, missing payload previews, or missing source evidence
+produce invalid packets with explicit reasons. Packets include source identity,
+payload preview, evidence summary, deterministic human review checklist, risk
+notes, source submission snapshot, validation, recommendation, and read-only
+policy. The packet builder does not submit to governance, create proposal
+records, persist approvals, convert packets to real proposals, write memory,
+write the Memory Graph, modify config, or create operation-ledger events.
+
+The smoke suite includes `memory_governance_submission_packet`, proving that a
+valid governance submission candidate becomes a `human_review_packet_required`
+packet candidate without creating a real proposal.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -43,6 +43,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `memory_human_approval_token_issuance_plan`
 - `memory_human_approval_token_issuance_dry_run`
 - `memory_human_approval_token_write_lock_gate`
+- `memory_human_approval_token_final_confirmation_request`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -408,6 +409,27 @@ The smoke suite includes `memory_human_approval_token_write_lock_gate`, proving
 that a valid token issuance dry run becomes eligible for a separate final human
 confirmation flow without issuing a token, persisting approval, creating a real
 proposal, or creating an operation event.
+
+### Memory Human Approval Token Final Confirmation Request v0.1
+
+Implemented in
+`agent.memory_human_approval_token_final_confirmation_request`. It turns an
+`eligible_for_final_human_confirmation` token write-lock gate candidate into a
+deterministic `final_confirmation_review_required` request candidate.
+
+Invalid or locked token write-lock gates, missing token/proposal/ledger/path
+previews, missing source evidence, or previews that are not preview-only remain
+`locked` with explicit reasons. The request never issues real approval tokens,
+persists approvals, creates real proposals, writes proposal files, writes
+operation-ledger events, writes token files, writes approval audit records,
+submits to governance, writes memory, writes the Memory Graph, or modifies
+config.
+
+The smoke suite includes
+`memory_human_approval_token_final_confirmation_request`, proving that a valid
+token write-lock gate becomes final-confirmation-review-required without
+issuing a token, persisting approval, creating a real proposal, or creating an
+operation event.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -1,0 +1,61 @@
+# Hermes Memory Bench v0.1
+
+Hermes Memory Bench is a read-only benchmark scaffold for proving that Hermes
+Memory Fabric is more than a generic memory wrapper. It makes the evaluation
+dimensions explicit, starts with deterministic local fixtures, and emits a
+stable JSON report that can later be compared across memory systems.
+
+v0.1 does not call live Memory Fabric tools, write durable memory, write the
+Memory Graph, modify OpenClaw configuration, approve allowlists, create
+proposals, or create operation-ledger events. The benchmark only reads local
+fixtures and writes the requested JSON report.
+
+## Run
+
+```bash
+python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-memory-bench-report.json
+```
+
+## Dimensions
+
+- `recall_accuracy`
+- `temporal_accuracy`
+- `source_provenance_accuracy`
+- `governance_write_safety`
+- `project_scope_isolation`
+- `contradiction_handling`
+- `latency_ms`
+
+## Report Schema
+
+The runner emits JSON with these top-level fields:
+
+- `benchmark_type`
+- `generated_at`
+- `suite`
+- `scores`
+- `cases`
+- `aggregate`
+- `policy`
+
+The `policy` object is part of the benchmark contract and must show:
+
+```json
+{
+  "read_only": true,
+  "would_write_memory": false,
+  "would_modify_config": false,
+  "would_write_graph": false,
+  "does_not_create_operation_events": true
+}
+```
+
+## Comparison Roadmap
+
+Future versions can add adapters for Mem0, Graphiti, Letta, Cognee, and other
+memory systems. Each adapter should answer the same case fixtures and report the
+same dimensions, so Hermes can be compared on grounded recall, temporal
+preference handling, source provenance, governance safety, project isolation,
+contradiction handling, and latency. Live adapters must keep this benchmark's
+safety contract: benchmark runs are read-only unless a separate human-approved
+test harness explicitly permits isolated writes in a disposable environment.

--- a/benchmarks/hermes_memory_bench/README.md
+++ b/benchmarks/hermes_memory_bench/README.md
@@ -26,6 +26,7 @@ python -m benchmarks.hermes_memory_bench.run --suite smoke --output /tmp/hermes-
 - `contradiction_handling`
 - `hybrid_retrieval_fusion`
 - `bitemporal_fact_graph`
+- `contradiction_engine`
 - `latency_ms`
 
 ## Hybrid Retrieval Fusion v0.1
@@ -69,6 +70,24 @@ claims, and explain fact lineage so superseded historical facts remain visible.
 
 The smoke suite includes `bitemporal_fact_graph`, proving that a newer valid
 fact wins while the older historical fact remains explainable through lineage.
+
+## Contradiction Engine v0.1
+
+Contradiction Engine v0.1 lives in
+`agent.memory_contradiction_engine`. It exposes deterministic read-only
+classification for memory facts and candidates with relation labels:
+`supports`, `updates`, `contradicts`, `unrelated`, and `needs_review`.
+
+The engine imports `normalize_fact` from the Bi-temporal Fact Graph module, so
+validity windows, system timestamps, source episode ids, provenance, confidence,
+and governance metadata are preserved without mutating inputs. Contradictions
+are flagged for review or later governed proposal handling; the engine does not
+write memory, write the Memory Graph, modify config, approve allowlists, create
+proposals, or create operation-ledger events.
+
+The smoke suite includes `contradiction_engine`, proving that a candidate fact
+which conflicts with an existing fact returns a review recommendation rather
+than being merged directly.
 
 ## Report Schema
 

--- a/benchmarks/hermes_memory_bench/__init__.py
+++ b/benchmarks/hermes_memory_bench/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes Memory Bench v0.1."""
+
+from benchmarks.hermes_memory_bench.core import run_benchmark
+
+__all__ = ["run_benchmark"]

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -15,6 +15,11 @@ from agent.memory_bitemporal_fact_graph import (
 from agent.memory_contradiction_engine import explain_contradiction_group, group_contradictions
 from agent.memory_compiler import MEMORY_COMPILER_POLICY, compile_memory_patterns
 from agent.memory_blocks import MEMORY_BLOCK_POLICY, compile_blocks_from_compiler_result
+from agent.memory_block_review_queue import (
+    MEMORY_BLOCK_REVIEW_QUEUE_POLICY,
+    build_review_queue,
+    summarize_review_queue,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -31,6 +36,7 @@ DIMENSIONS = (
     "contradiction_engine",
     "memory_compiler",
     "memory_blocks",
+    "memory_block_review_queue",
     "latency_ms",
 )
 POLICY = {
@@ -235,6 +241,20 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "memory_blocks": blocks,
             "candidate_count": len(memories),
             "policy": dict(MEMORY_BLOCK_POLICY),
+        }
+
+    if dimension == "memory_block_review_queue":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        item = queue[0] if queue else {}
+        return item.get("status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "summary": summarize_review_queue(queue),
+            "candidate_count": len(memories),
+            "policy": dict(MEMORY_BLOCK_REVIEW_QUEUE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -70,6 +70,11 @@ from agent.memory_human_approval_token_review_gate import (
     create_human_approval_token_review_outcome,
     summarize_human_approval_token_review_outcomes,
 )
+from agent.memory_human_approval_token_issuance_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY,
+    create_human_approval_token_issuance_plan,
+    summarize_human_approval_token_issuance_plans,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -97,6 +102,7 @@ DIMENSIONS = (
     "memory_real_proposal_write_lock_gate",
     "memory_human_approval_token_request",
     "memory_human_approval_token_review_gate",
+    "memory_human_approval_token_issuance_plan",
     "latency_ms",
 )
 POLICY = {
@@ -727,6 +733,83 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_proposal_files": False,
             "writes_operation_ledger": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_issuance_plan":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_plan = token_issuance_plans[0] if token_issuance_plans else {}
+        return token_issuance_plan.get("plan_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "summary": summarize_human_approval_token_issuance_plans(token_issuance_plans),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -35,6 +35,11 @@ from agent.memory_proposal_governance_gate import (
     create_governance_submission_candidate,
     summarize_governance_submission_candidates,
 )
+from agent.memory_governance_submission_packet import (
+    MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY,
+    create_governance_submission_packet,
+    summarize_governance_submission_packets,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -55,6 +60,7 @@ DIMENSIONS = (
     "memory_review_decision_gate",
     "memory_proposal_draft_builder",
     "memory_proposal_governance_gate",
+    "memory_governance_submission_packet",
     "latency_ms",
 )
 POLICY = {
@@ -337,6 +343,38 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "created_operation_event": False,
             "submitted_to_governance": False,
             "policy": dict(MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY),
+        }
+
+    if dimension == "memory_governance_submission_packet":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        packet = packets[0] if packets else {}
+        return packet.get("packet_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "summary": summarize_governance_submission_packets(packets),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "policy": dict(MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -14,6 +14,7 @@ from agent.memory_bitemporal_fact_graph import (
 )
 from agent.memory_contradiction_engine import explain_contradiction_group, group_contradictions
 from agent.memory_compiler import MEMORY_COMPILER_POLICY, compile_memory_patterns
+from agent.memory_blocks import MEMORY_BLOCK_POLICY, compile_blocks_from_compiler_result
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -29,6 +30,7 @@ DIMENSIONS = (
     "bitemporal_fact_graph",
     "contradiction_engine",
     "memory_compiler",
+    "memory_blocks",
     "latency_ms",
 )
 POLICY = {
@@ -222,6 +224,17 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "procedure_block_candidate": procedure,
             "candidate_count": len(memories),
             "policy": dict(MEMORY_COMPILER_POLICY),
+        }
+
+    if dimension == "memory_blocks":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        block = blocks[0] if blocks else {}
+        return block.get("block_type", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "candidate_count": len(memories),
+            "policy": dict(MEMORY_BLOCK_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -80,6 +80,11 @@ from agent.memory_human_approval_token_issuance_dry_run import (
     create_human_approval_token_issuance_dry_run,
     summarize_human_approval_token_issuance_dry_runs,
 )
+from agent.memory_human_approval_token_write_lock_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY,
+    create_human_approval_token_write_lock_gate,
+    summarize_human_approval_token_write_lock_gates,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -109,6 +114,7 @@ DIMENSIONS = (
     "memory_human_approval_token_review_gate",
     "memory_human_approval_token_issuance_plan",
     "memory_human_approval_token_issuance_dry_run",
+    "memory_human_approval_token_write_lock_gate",
     "latency_ms",
 )
 POLICY = {
@@ -903,6 +909,102 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_token_files": False,
             "writes_approval_audit": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_write_lock_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        token_write_lock_gate = token_write_lock_gates[0] if token_write_lock_gates else {}
+        return token_write_lock_gate.get("gate_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "summary": summarize_human_approval_token_write_lock_gates(token_write_lock_gates),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -55,6 +55,11 @@ from agent.memory_real_proposal_dry_run import (
     create_real_proposal_dry_run,
     summarize_real_proposal_dry_runs,
 )
+from agent.memory_real_proposal_write_lock_gate import (
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY,
+    create_real_proposal_write_lock_gate,
+    summarize_real_proposal_write_lock_gates,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -79,6 +84,7 @@ DIMENSIONS = (
     "memory_human_review_outcome_gate",
     "memory_real_proposal_creation_plan",
     "memory_real_proposal_dry_run",
+    "memory_real_proposal_write_lock_gate",
     "latency_ms",
 )
 POLICY = {
@@ -524,6 +530,61 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_proposal_files": False,
             "writes_operation_ledger": False,
             "policy": dict(MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY),
+        }
+
+    if dimension == "memory_real_proposal_write_lock_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        gate = write_lock_gates[0] if write_lock_gates else {}
+        return gate.get("gate_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "summary": summarize_real_proposal_write_lock_gates(write_lock_gates),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "persisted_approval": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "policy": dict(MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -110,6 +110,11 @@ from agent.memory_human_approval_token_write_final_gate import (
     create_human_approval_token_write_final_gate,
     summarize_human_approval_token_write_final_gates,
 )
+from agent.memory_human_approval_token_real_write_executor_contract import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY,
+    create_human_approval_token_real_write_executor_contract,
+    summarize_human_approval_token_real_write_executor_contracts,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -145,6 +150,7 @@ DIMENSIONS = (
     "memory_human_approval_token_write_execution_plan",
     "memory_human_approval_token_write_execution_dry_run",
     "memory_human_approval_token_write_final_gate",
+    "memory_human_approval_token_real_write_executor_contract",
     "latency_ms",
 )
 POLICY = {
@@ -1644,6 +1650,154 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_approval_audit": False,
             "invokes_real_token_write_executor": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_real_write_executor_contract":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_dry_runs = [
+            create_human_approval_token_write_execution_dry_run(
+                plan,
+                operator=case.get("approval_token_write_execution_dry_run_operator"),
+            )
+            for plan in token_write_execution_plans
+        ]
+        token_write_final_gates = [
+            create_human_approval_token_write_final_gate(
+                dry_run,
+                operator=case.get("approval_token_write_final_gate_operator"),
+            )
+            for dry_run in token_write_execution_dry_runs
+        ]
+        real_write_executor_contracts = [
+            create_human_approval_token_real_write_executor_contract(
+                gate,
+                operator=case.get("approval_token_real_write_executor_contract_operator"),
+            )
+            for gate in token_write_final_gates
+        ]
+        contract = real_write_executor_contracts[0] if real_write_executor_contracts else {}
+        return contract.get("contract_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "human_approval_token_write_execution_dry_run_candidates": token_write_execution_dry_runs,
+            "human_approval_token_write_final_gate_candidates": token_write_final_gates,
+            "human_approval_token_real_write_executor_contract_candidates": real_write_executor_contracts,
+            "summary": summarize_human_approval_token_real_write_executor_contracts(
+                real_write_executor_contracts
+            ),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "invokes_real_token_write_executor": False,
+            "implements_real_token_write_executor": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -30,6 +30,11 @@ from agent.memory_proposal_draft_builder import (
     create_memory_proposal_draft,
     summarize_memory_proposal_drafts,
 )
+from agent.memory_proposal_governance_gate import (
+    MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY,
+    create_governance_submission_candidate,
+    summarize_governance_submission_candidates,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -49,6 +54,7 @@ DIMENSIONS = (
     "memory_block_review_queue",
     "memory_review_decision_gate",
     "memory_proposal_draft_builder",
+    "memory_proposal_governance_gate",
     "latency_ms",
 )
 POLICY = {
@@ -305,6 +311,32 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "created_real_proposal": False,
             "created_operation_event": False,
             "policy": dict(MEMORY_PROPOSAL_DRAFT_POLICY),
+        }
+
+    if dimension == "memory_proposal_governance_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        submission = submissions[0] if submissions else {}
+        return submission.get("submission_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "summary": summarize_governance_submission_candidates(submissions),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "policy": dict(MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -100,6 +100,11 @@ from agent.memory_human_approval_token_write_execution_plan import (
     create_human_approval_token_write_execution_plan,
     summarize_human_approval_token_write_execution_plans,
 )
+from agent.memory_human_approval_token_write_execution_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY,
+    create_human_approval_token_write_execution_dry_run,
+    summarize_human_approval_token_write_execution_dry_runs,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -133,6 +138,7 @@ DIMENSIONS = (
     "memory_human_approval_token_final_confirmation_request",
     "memory_human_approval_token_final_confirmation_review_gate",
     "memory_human_approval_token_write_execution_plan",
+    "memory_human_approval_token_write_execution_dry_run",
     "latency_ms",
 )
 POLICY = {
@@ -1363,6 +1369,138 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_token_files": False,
             "writes_approval_audit": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_write_execution_dry_run":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_dry_runs = [
+            create_human_approval_token_write_execution_dry_run(
+                plan,
+                operator=case.get("approval_token_write_execution_dry_run_operator"),
+            )
+            for plan in token_write_execution_plans
+        ]
+        token_write_execution_dry_run = (
+            token_write_execution_dry_runs[0] if token_write_execution_dry_runs else {}
+        )
+        return token_write_execution_dry_run.get("dry_run_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "human_approval_token_write_execution_dry_run_candidates": token_write_execution_dry_runs,
+            "summary": summarize_human_approval_token_write_execution_dry_runs(
+                token_write_execution_dry_runs
+            ),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -25,6 +25,11 @@ from agent.memory_review_decision_gate import (
     evaluate_review_queue_item,
     summarize_review_decisions,
 )
+from agent.memory_proposal_draft_builder import (
+    MEMORY_PROPOSAL_DRAFT_POLICY,
+    create_memory_proposal_draft,
+    summarize_memory_proposal_drafts,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -43,6 +48,7 @@ DIMENSIONS = (
     "memory_blocks",
     "memory_block_review_queue",
     "memory_review_decision_gate",
+    "memory_proposal_draft_builder",
     "latency_ms",
 )
 POLICY = {
@@ -279,6 +285,26 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "created_real_proposal": False,
             "created_operation_event": False,
             "policy": dict(MEMORY_REVIEW_DECISION_GATE_POLICY),
+        }
+
+    if dimension == "memory_proposal_draft_builder":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        draft = drafts[0] if drafts else {}
+        return draft.get("proposal_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "summary": summarize_memory_proposal_drafts(drafts),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "policy": dict(MEMORY_PROPOSAL_DRAFT_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -60,6 +60,11 @@ from agent.memory_real_proposal_write_lock_gate import (
     create_real_proposal_write_lock_gate,
     summarize_real_proposal_write_lock_gates,
 )
+from agent.memory_human_approval_token_request import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY,
+    create_human_approval_token_request,
+    summarize_human_approval_token_requests,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -85,6 +90,7 @@ DIMENSIONS = (
     "memory_real_proposal_creation_plan",
     "memory_real_proposal_dry_run",
     "memory_real_proposal_write_lock_gate",
+    "memory_human_approval_token_request",
     "latency_ms",
 )
 POLICY = {
@@ -585,6 +591,67 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_proposal_files": False,
             "writes_operation_ledger": False,
             "policy": dict(MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_request":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        request = approval_token_requests[0] if approval_token_requests else {}
+        return request.get("request_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "summary": summarize_human_approval_token_requests(approval_token_requests),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -120,6 +120,11 @@ from agent.memory_human_approval_token_real_write_executor_contract_review_gate 
     create_human_approval_token_real_write_executor_contract_review_outcome,
     summarize_human_approval_token_real_write_executor_contract_review_outcomes,
 )
+from agent.memory_human_approval_token_real_write_executor_implementation_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY,
+    create_human_approval_token_real_write_executor_implementation_plan,
+    summarize_human_approval_token_real_write_executor_implementation_plans,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -157,6 +162,7 @@ DIMENSIONS = (
     "memory_human_approval_token_write_final_gate",
     "memory_human_approval_token_real_write_executor_contract",
     "memory_human_approval_token_real_write_executor_contract_review_gate",
+    "memory_human_approval_token_real_write_executor_implementation_plan",
     "latency_ms",
 )
 POLICY = {
@@ -1963,6 +1969,174 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "implements_real_token_write_executor": False,
             "policy": dict(
                 MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY
+            ),
+        }
+
+    if dimension == "memory_human_approval_token_real_write_executor_implementation_plan":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_dry_runs = [
+            create_human_approval_token_write_execution_dry_run(
+                plan,
+                operator=case.get("approval_token_write_execution_dry_run_operator"),
+            )
+            for plan in token_write_execution_plans
+        ]
+        token_write_final_gates = [
+            create_human_approval_token_write_final_gate(
+                dry_run,
+                operator=case.get("approval_token_write_final_gate_operator"),
+            )
+            for dry_run in token_write_execution_dry_runs
+        ]
+        real_write_executor_contracts = [
+            create_human_approval_token_real_write_executor_contract(
+                gate,
+                operator=case.get("approval_token_real_write_executor_contract_operator"),
+            )
+            for gate in token_write_final_gates
+        ]
+        contract_review_outcomes = [
+            create_human_approval_token_real_write_executor_contract_review_outcome(
+                contract,
+                reviewer=case.get("approval_token_real_write_executor_contract_reviewer"),
+            )
+            for contract in real_write_executor_contracts
+        ]
+        implementation_plans = [
+            create_human_approval_token_real_write_executor_implementation_plan(
+                outcome,
+                implementer=case.get(
+                    "approval_token_real_write_executor_implementation_plan_implementer"
+                ),
+            )
+            for outcome in contract_review_outcomes
+        ]
+        implementation_plan = implementation_plans[0] if implementation_plans else {}
+        return implementation_plan.get("plan_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "human_approval_token_write_execution_dry_run_candidates": token_write_execution_dry_runs,
+            "human_approval_token_write_final_gate_candidates": token_write_final_gates,
+            "human_approval_token_real_write_executor_contract_candidates": real_write_executor_contracts,
+            "human_approval_token_real_write_executor_contract_review_outcome_candidates": contract_review_outcomes,
+            "human_approval_token_real_write_executor_implementation_plan_candidates": implementation_plans,
+            "summary": summarize_human_approval_token_real_write_executor_implementation_plans(
+                implementation_plans
+            ),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "invokes_real_token_write_executor": False,
+            "implements_real_token_write_executor": False,
+            "policy": dict(
+                MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
             ),
         }
 

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -115,6 +115,11 @@ from agent.memory_human_approval_token_real_write_executor_contract import (
     create_human_approval_token_real_write_executor_contract,
     summarize_human_approval_token_real_write_executor_contracts,
 )
+from agent.memory_human_approval_token_real_write_executor_contract_review_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY,
+    create_human_approval_token_real_write_executor_contract_review_outcome,
+    summarize_human_approval_token_real_write_executor_contract_review_outcomes,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -151,6 +156,7 @@ DIMENSIONS = (
     "memory_human_approval_token_write_execution_dry_run",
     "memory_human_approval_token_write_final_gate",
     "memory_human_approval_token_real_write_executor_contract",
+    "memory_human_approval_token_real_write_executor_contract_review_gate",
     "latency_ms",
 )
 POLICY = {
@@ -1798,6 +1804,166 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "invokes_real_token_write_executor": False,
             "implements_real_token_write_executor": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_real_write_executor_contract_review_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_dry_runs = [
+            create_human_approval_token_write_execution_dry_run(
+                plan,
+                operator=case.get("approval_token_write_execution_dry_run_operator"),
+            )
+            for plan in token_write_execution_plans
+        ]
+        token_write_final_gates = [
+            create_human_approval_token_write_final_gate(
+                dry_run,
+                operator=case.get("approval_token_write_final_gate_operator"),
+            )
+            for dry_run in token_write_execution_dry_runs
+        ]
+        real_write_executor_contracts = [
+            create_human_approval_token_real_write_executor_contract(
+                gate,
+                operator=case.get("approval_token_real_write_executor_contract_operator"),
+            )
+            for gate in token_write_final_gates
+        ]
+        contract_review_outcomes = [
+            create_human_approval_token_real_write_executor_contract_review_outcome(
+                contract,
+                reviewer=case.get("approval_token_real_write_executor_contract_reviewer"),
+            )
+            for contract in real_write_executor_contracts
+        ]
+        contract_review_outcome = (
+            contract_review_outcomes[0] if contract_review_outcomes else {}
+        )
+        return contract_review_outcome.get("outcome", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "human_approval_token_write_execution_dry_run_candidates": token_write_execution_dry_runs,
+            "human_approval_token_write_final_gate_candidates": token_write_final_gates,
+            "human_approval_token_real_write_executor_contract_candidates": real_write_executor_contracts,
+            "human_approval_token_real_write_executor_contract_review_outcome_candidates": contract_review_outcomes,
+            "summary": summarize_human_approval_token_real_write_executor_contract_review_outcomes(
+                contract_review_outcomes
+            ),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "invokes_real_token_write_executor": False,
+            "implements_real_token_write_executor": False,
+            "policy": dict(
+                MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY
+            ),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -130,6 +130,11 @@ from agent.memory_human_approval_token_real_write_executor_implementation_dry_ru
     create_human_approval_token_real_write_executor_implementation_dry_run,
     summarize_human_approval_token_real_write_executor_implementation_dry_runs,
 )
+from agent.memory_human_approval_token_real_write_executor_code_review_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY,
+    create_human_approval_token_real_write_executor_code_review_plan,
+    summarize_human_approval_token_real_write_executor_code_review_plans,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -169,6 +174,7 @@ DIMENSIONS = (
     "memory_human_approval_token_real_write_executor_contract_review_gate",
     "memory_human_approval_token_real_write_executor_implementation_plan",
     "memory_human_approval_token_real_write_executor_implementation_dry_run",
+    "memory_human_approval_token_real_write_executor_code_review_plan",
     "latency_ms",
 )
 POLICY = {
@@ -2324,6 +2330,196 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "creates_executor_source_files": False,
             "policy": dict(
                 MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
+            ),
+        }
+
+    if dimension == "memory_human_approval_token_real_write_executor_code_review_plan":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_dry_runs = [
+            create_human_approval_token_write_execution_dry_run(
+                plan,
+                operator=case.get("approval_token_write_execution_dry_run_operator"),
+            )
+            for plan in token_write_execution_plans
+        ]
+        token_write_final_gates = [
+            create_human_approval_token_write_final_gate(
+                dry_run,
+                operator=case.get("approval_token_write_final_gate_operator"),
+            )
+            for dry_run in token_write_execution_dry_runs
+        ]
+        real_write_executor_contracts = [
+            create_human_approval_token_real_write_executor_contract(
+                gate,
+                operator=case.get("approval_token_real_write_executor_contract_operator"),
+            )
+            for gate in token_write_final_gates
+        ]
+        contract_review_outcomes = [
+            create_human_approval_token_real_write_executor_contract_review_outcome(
+                contract,
+                reviewer=case.get("approval_token_real_write_executor_contract_reviewer"),
+            )
+            for contract in real_write_executor_contracts
+        ]
+        implementation_plans = [
+            create_human_approval_token_real_write_executor_implementation_plan(
+                outcome,
+                implementer=case.get(
+                    "approval_token_real_write_executor_implementation_plan_implementer"
+                ),
+            )
+            for outcome in contract_review_outcomes
+        ]
+        implementation_dry_runs = [
+            create_human_approval_token_real_write_executor_implementation_dry_run(
+                plan,
+                operator=case.get(
+                    "approval_token_real_write_executor_implementation_dry_run_operator"
+                ),
+            )
+            for plan in implementation_plans
+        ]
+        code_review_plans = [
+            create_human_approval_token_real_write_executor_code_review_plan(
+                dry_run,
+                reviewer=case.get(
+                    "approval_token_real_write_executor_code_review_plan_reviewer"
+                ),
+            )
+            for dry_run in implementation_dry_runs
+        ]
+        code_review_plan = code_review_plans[0] if code_review_plans else {}
+        return code_review_plan.get("plan_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "human_approval_token_write_execution_dry_run_candidates": token_write_execution_dry_runs,
+            "human_approval_token_write_final_gate_candidates": token_write_final_gates,
+            "human_approval_token_real_write_executor_contract_candidates": real_write_executor_contracts,
+            "human_approval_token_real_write_executor_contract_review_outcome_candidates": contract_review_outcomes,
+            "human_approval_token_real_write_executor_implementation_plan_candidates": implementation_plans,
+            "human_approval_token_real_write_executor_implementation_dry_run_candidates": implementation_dry_runs,
+            "human_approval_token_real_write_executor_code_review_plan_candidates": code_review_plans,
+            "summary": summarize_human_approval_token_real_write_executor_code_review_plans(
+                code_review_plans
+            ),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "invokes_real_token_write_executor": False,
+            "implements_real_token_write_executor": False,
+            "creates_executor_source_files": False,
+            "creates_executor_tests": False,
+            "policy": dict(
+                MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY
             ),
         }
 

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -50,6 +50,11 @@ from agent.memory_real_proposal_creation_plan import (
     create_real_proposal_creation_plan,
     summarize_real_proposal_creation_plans,
 )
+from agent.memory_real_proposal_dry_run import (
+    MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY,
+    create_real_proposal_dry_run,
+    summarize_real_proposal_dry_runs,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -73,6 +78,7 @@ DIMENSIONS = (
     "memory_governance_submission_packet",
     "memory_human_review_outcome_gate",
     "memory_real_proposal_creation_plan",
+    "memory_real_proposal_dry_run",
     "latency_ms",
 )
 POLICY = {
@@ -468,6 +474,56 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "converted_to_real_proposal": False,
             "persisted_approval": False,
             "policy": dict(MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY),
+        }
+
+    if dimension == "memory_real_proposal_dry_run":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        dry_run = dry_runs[0] if dry_runs else {}
+        return dry_run.get("dry_run_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "summary": summarize_real_proposal_dry_runs(dry_runs),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "persisted_approval": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "policy": dict(MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+BENCHMARK_TYPE = "hermes_memory_bench_v0.1"
+DIMENSIONS = (
+    "recall_accuracy",
+    "temporal_accuracy",
+    "source_provenance_accuracy",
+    "governance_write_safety",
+    "project_scope_isolation",
+    "contradiction_handling",
+    "latency_ms",
+)
+POLICY = {
+    "read_only": True,
+    "would_write_memory": False,
+    "would_modify_config": False,
+    "would_write_graph": False,
+    "does_not_create_operation_events": True,
+}
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    id: str
+    dimension: str
+    query: str
+    expected_answer: str
+    actual_answer: str
+    score: float
+    latency_ms: float
+    passed: bool
+    evidence: dict[str, Any]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "dimension": self.dimension,
+            "query": self.query,
+            "expected_answer": self.expected_answer,
+            "actual_answer": self.actual_answer,
+            "score": self.score,
+            "latency_ms": self.latency_ms,
+            "passed": self.passed,
+            "evidence": self.evidence,
+        }
+
+
+def fixtures_path() -> Path:
+    return Path(__file__).with_name("fixtures") / "smoke_cases.json"
+
+
+def load_cases(suite: str) -> list[dict[str, Any]]:
+    if suite != "smoke":
+        raise ValueError(f"Unsupported suite: {suite}")
+    with fixtures_path().open("r", encoding="utf-8") as handle:
+        cases = json.load(handle)
+    if not isinstance(cases, list):
+        raise ValueError("Smoke fixture must contain a list of cases.")
+    return cases
+
+
+def run_benchmark(suite: str = "smoke") -> dict[str, Any]:
+    cases = [_evaluate_case(case) for case in load_cases(suite)]
+    scores = _dimension_scores(cases)
+    aggregate = _aggregate(cases)
+    return {
+        "benchmark_type": BENCHMARK_TYPE,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "suite": suite,
+        "scores": scores,
+        "cases": [case.to_json() for case in cases],
+        "aggregate": aggregate,
+        "policy": dict(POLICY),
+    }
+
+
+def write_report(report: dict[str, Any], output: str | Path | None = None) -> None:
+    payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if output:
+        Path(output).write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+
+
+def _evaluate_case(case: dict[str, Any]) -> CaseResult:
+    started = time.perf_counter()
+    dimension = case["dimension"]
+    expected = case["expected_answer"]
+    actual, evidence = _answer_case(case)
+    latency_ms = round((time.perf_counter() - started) * 1000, 3)
+    score = 1.0 if actual == expected else 0.0
+    return CaseResult(
+        id=case["id"],
+        dimension=dimension,
+        query=case["query"],
+        expected_answer=expected,
+        actual_answer=actual,
+        score=score,
+        latency_ms=latency_ms,
+        passed=score == 1.0,
+        evidence=evidence,
+    )
+
+
+def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    dimension = case["dimension"]
+    memories = list(case.get("memories", []))
+
+    if dimension == "governance_write_safety":
+        return "blocked", {
+            "blocked_operation": case.get("unsafe_operation"),
+            "reason": "Benchmark policy forbids writes and proposals.",
+            "policy": dict(POLICY),
+        }
+
+    if dimension == "project_scope_isolation":
+        scope = case.get("project_scope")
+        scoped = [memory for memory in memories if memory.get("project_id") == scope]
+        selected = _newest(scoped)
+        return selected.get("content", ""), {
+            "project_scope": scope,
+            "candidate_count": len(memories),
+            "scoped_candidate_count": len(scoped),
+            "selected_project_id": selected.get("project_id"),
+        }
+
+    if dimension == "temporal_accuracy":
+        selected = _newest(memories)
+        return selected.get("content", ""), {
+            "selected_created_at": selected.get("created_at"),
+            "candidate_count": len(memories),
+            "temporal_rule": "newest_matching_preference_wins",
+        }
+
+    if dimension == "source_provenance_accuracy":
+        selected = _newest(memories)
+        source_ok = selected.get("source") == case.get("required_source")
+        provenance_ok = selected.get("provenance") == case.get("required_provenance")
+        return selected.get("content", ""), {
+            "source": selected.get("source"),
+            "provenance": selected.get("provenance"),
+            "source_ok": source_ok,
+            "provenance_ok": provenance_ok,
+        }
+
+    if dimension == "contradiction_handling":
+        return _contradiction_answer(memories), {
+            "candidate_count": len(memories),
+            "claim_keys": sorted({memory.get("claim_key") for memory in memories if memory.get("claim_key")}),
+            "handling": "flag_candidate_for_review",
+        }
+
+    selected = _newest(memories)
+    return selected.get("content", ""), {
+        "candidate_count": len(memories),
+        "selected_project_id": selected.get("project_id"),
+        "selected_source": selected.get("source"),
+    }
+
+
+def _newest(memories: list[dict[str, Any]]) -> dict[str, Any]:
+    if not memories:
+        return {}
+    return max(memories, key=lambda memory: memory.get("created_at", ""))
+
+
+def _contradiction_answer(memories: list[dict[str, Any]]) -> str:
+    normalized = {str(memory.get("content", "")).lower() for memory in memories}
+    has_allowed = any(" is allowed" in content for content in normalized)
+    has_blocked = any(" is blocked" in content or "forbidden" in content for content in normalized)
+    return "contradiction_detected" if has_allowed and has_blocked else _newest(memories).get("content", "")
+
+
+def _dimension_scores(cases: list[CaseResult]) -> dict[str, float]:
+    scores: dict[str, float] = {}
+    for dimension in DIMENSIONS:
+        if dimension == "latency_ms":
+            scores[dimension] = round(sum(case.latency_ms for case in cases) / max(len(cases), 1), 3)
+            continue
+        relevant = [case for case in cases if case.dimension == dimension]
+        scores[dimension] = round(sum(case.score for case in relevant) / len(relevant), 3) if relevant else 0.0
+    return scores
+
+
+def _aggregate(cases: list[CaseResult]) -> dict[str, Any]:
+    case_count = len(cases)
+    passed_count = sum(1 for case in cases if case.passed)
+    score = sum(case.score for case in cases) / case_count if case_count else 0.0
+    return {
+        "overall_score": round(score, 3),
+        "case_count": case_count,
+        "passed_count": passed_count,
+        "failed_count": case_count - passed_count,
+        "mean_latency_ms": round(sum(case.latency_ms for case in cases) / max(case_count, 1), 3),
+        "dimensions": list(DIMENSIONS),
+    }

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -7,6 +7,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from agent.memory_bitemporal_fact_graph import (
+    BITEMPORAL_FACT_GRAPH_POLICY,
+    explain_fact_lineage,
+    select_current_facts,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -19,6 +24,7 @@ DIMENSIONS = (
     "project_scope_isolation",
     "contradiction_handling",
     "hybrid_retrieval_fusion",
+    "bitemporal_fact_graph",
     "latency_ms",
 )
 POLICY = {
@@ -175,6 +181,22 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "fusion": result,
             "selected_id": selected.get("id"),
             "candidate_count": len(memories),
+        }
+
+    if dimension == "bitemporal_fact_graph":
+        selected = select_current_facts(
+            memories,
+            at_time=case.get("at_time") or case.get("now"),
+            project_scope=case.get("project_scope"),
+        )
+        winner = selected[0] if selected else None
+        lineage = explain_fact_lineage(winner.fact_id, memories) if winner else {}
+        return (winner.object if winner else ""), {
+            "selected_fact_id": winner.fact_id if winner else None,
+            "selected_fact": winner.to_json() if winner else None,
+            "lineage": lineage,
+            "candidate_count": len(memories),
+            "policy": dict(BITEMPORAL_FACT_GRAPH_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -12,6 +12,7 @@ from agent.memory_bitemporal_fact_graph import (
     explain_fact_lineage,
     select_current_facts,
 )
+from agent.memory_contradiction_engine import explain_contradiction_group, group_contradictions
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -25,6 +26,7 @@ DIMENSIONS = (
     "contradiction_handling",
     "hybrid_retrieval_fusion",
     "bitemporal_fact_graph",
+    "contradiction_engine",
     "latency_ms",
 )
 POLICY = {
@@ -197,6 +199,17 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "lineage": lineage,
             "candidate_count": len(memories),
             "policy": dict(BITEMPORAL_FACT_GRAPH_POLICY),
+        }
+
+    if dimension == "contradiction_engine":
+        groups = group_contradictions(memories)
+        explanation = explain_contradiction_group(groups[0]) if groups else {}
+        recommendation = explanation.get("recommended_action", {})
+        return recommendation.get("action", "no_action"), {
+            "contradiction_groups": groups,
+            "explanation": explanation,
+            "review_recommendation": recommendation,
+            "candidate_count": len(memories),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -125,6 +125,11 @@ from agent.memory_human_approval_token_real_write_executor_implementation_plan i
     create_human_approval_token_real_write_executor_implementation_plan,
     summarize_human_approval_token_real_write_executor_implementation_plans,
 )
+from agent.memory_human_approval_token_real_write_executor_implementation_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY,
+    create_human_approval_token_real_write_executor_implementation_dry_run,
+    summarize_human_approval_token_real_write_executor_implementation_dry_runs,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -163,6 +168,7 @@ DIMENSIONS = (
     "memory_human_approval_token_real_write_executor_contract",
     "memory_human_approval_token_real_write_executor_contract_review_gate",
     "memory_human_approval_token_real_write_executor_implementation_plan",
+    "memory_human_approval_token_real_write_executor_implementation_dry_run",
     "latency_ms",
 )
 POLICY = {
@@ -2137,6 +2143,187 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "implements_real_token_write_executor": False,
             "policy": dict(
                 MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
+            ),
+        }
+
+    if dimension == "memory_human_approval_token_real_write_executor_implementation_dry_run":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_dry_runs = [
+            create_human_approval_token_write_execution_dry_run(
+                plan,
+                operator=case.get("approval_token_write_execution_dry_run_operator"),
+            )
+            for plan in token_write_execution_plans
+        ]
+        token_write_final_gates = [
+            create_human_approval_token_write_final_gate(
+                dry_run,
+                operator=case.get("approval_token_write_final_gate_operator"),
+            )
+            for dry_run in token_write_execution_dry_runs
+        ]
+        real_write_executor_contracts = [
+            create_human_approval_token_real_write_executor_contract(
+                gate,
+                operator=case.get("approval_token_real_write_executor_contract_operator"),
+            )
+            for gate in token_write_final_gates
+        ]
+        contract_review_outcomes = [
+            create_human_approval_token_real_write_executor_contract_review_outcome(
+                contract,
+                reviewer=case.get("approval_token_real_write_executor_contract_reviewer"),
+            )
+            for contract in real_write_executor_contracts
+        ]
+        implementation_plans = [
+            create_human_approval_token_real_write_executor_implementation_plan(
+                outcome,
+                implementer=case.get(
+                    "approval_token_real_write_executor_implementation_plan_implementer"
+                ),
+            )
+            for outcome in contract_review_outcomes
+        ]
+        implementation_dry_runs = [
+            create_human_approval_token_real_write_executor_implementation_dry_run(
+                plan,
+                operator=case.get(
+                    "approval_token_real_write_executor_implementation_dry_run_operator"
+                ),
+            )
+            for plan in implementation_plans
+        ]
+        implementation_dry_run = (
+            implementation_dry_runs[0] if implementation_dry_runs else {}
+        )
+        return implementation_dry_run.get("dry_run_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "human_approval_token_write_execution_dry_run_candidates": token_write_execution_dry_runs,
+            "human_approval_token_write_final_gate_candidates": token_write_final_gates,
+            "human_approval_token_real_write_executor_contract_candidates": real_write_executor_contracts,
+            "human_approval_token_real_write_executor_contract_review_outcome_candidates": contract_review_outcomes,
+            "human_approval_token_real_write_executor_implementation_plan_candidates": implementation_plans,
+            "human_approval_token_real_write_executor_implementation_dry_run_candidates": implementation_dry_runs,
+            "summary": summarize_human_approval_token_real_write_executor_implementation_dry_runs(
+                implementation_dry_runs
+            ),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "invokes_real_token_write_executor": False,
+            "implements_real_token_write_executor": False,
+            "creates_executor_source_files": False,
+            "policy": dict(
+                MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
             ),
         }
 

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -75,6 +75,11 @@ from agent.memory_human_approval_token_issuance_plan import (
     create_human_approval_token_issuance_plan,
     summarize_human_approval_token_issuance_plans,
 )
+from agent.memory_human_approval_token_issuance_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY,
+    create_human_approval_token_issuance_dry_run,
+    summarize_human_approval_token_issuance_dry_runs,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -103,6 +108,7 @@ DIMENSIONS = (
     "memory_human_approval_token_request",
     "memory_human_approval_token_review_gate",
     "memory_human_approval_token_issuance_plan",
+    "memory_human_approval_token_issuance_dry_run",
     "latency_ms",
 )
 POLICY = {
@@ -810,6 +816,93 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_proposal_files": False,
             "writes_operation_ledger": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_issuance_dry_run":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_issuance_dry_run = token_issuance_dry_runs[0] if token_issuance_dry_runs else {}
+        return token_issuance_dry_run.get("dry_run_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "summary": summarize_human_approval_token_issuance_dry_runs(token_issuance_dry_runs),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -95,6 +95,11 @@ from agent.memory_human_approval_token_final_confirmation_review_gate import (
     create_human_approval_token_final_confirmation_review_outcome,
     summarize_human_approval_token_final_confirmation_review_outcomes,
 )
+from agent.memory_human_approval_token_write_execution_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY,
+    create_human_approval_token_write_execution_plan,
+    summarize_human_approval_token_write_execution_plans,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -127,6 +132,7 @@ DIMENSIONS = (
     "memory_human_approval_token_write_lock_gate",
     "memory_human_approval_token_final_confirmation_request",
     "memory_human_approval_token_final_confirmation_review_gate",
+    "memory_human_approval_token_write_execution_plan",
     "latency_ms",
 )
 POLICY = {
@@ -1237,6 +1243,126 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_token_files": False,
             "writes_approval_audit": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_write_execution_plan":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_plan = token_write_execution_plans[0] if token_write_execution_plans else {}
+        return token_write_execution_plan.get("plan_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "summary": summarize_human_approval_token_write_execution_plans(token_write_execution_plans),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -65,6 +65,11 @@ from agent.memory_human_approval_token_request import (
     create_human_approval_token_request,
     summarize_human_approval_token_requests,
 )
+from agent.memory_human_approval_token_review_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY,
+    create_human_approval_token_review_outcome,
+    summarize_human_approval_token_review_outcomes,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -91,6 +96,7 @@ DIMENSIONS = (
     "memory_real_proposal_dry_run",
     "memory_real_proposal_write_lock_gate",
     "memory_human_approval_token_request",
+    "memory_human_approval_token_review_gate",
     "latency_ms",
 )
 POLICY = {
@@ -652,6 +658,75 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_proposal_files": False,
             "writes_operation_ledger": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_review_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_review_outcome = token_review_outcomes[0] if token_review_outcomes else {}
+        return token_review_outcome.get("outcome", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "summary": summarize_human_approval_token_review_outcomes(token_review_outcomes),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -85,6 +85,11 @@ from agent.memory_human_approval_token_write_lock_gate import (
     create_human_approval_token_write_lock_gate,
     summarize_human_approval_token_write_lock_gates,
 )
+from agent.memory_human_approval_token_final_confirmation_request import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY,
+    create_human_approval_token_final_confirmation_request,
+    summarize_human_approval_token_final_confirmation_requests,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -115,6 +120,7 @@ DIMENSIONS = (
     "memory_human_approval_token_issuance_plan",
     "memory_human_approval_token_issuance_dry_run",
     "memory_human_approval_token_write_lock_gate",
+    "memory_human_approval_token_final_confirmation_request",
     "latency_ms",
 )
 POLICY = {
@@ -1005,6 +1011,110 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_token_files": False,
             "writes_approval_audit": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_final_confirmation_request":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_request = final_confirmation_requests[0] if final_confirmation_requests else {}
+        return final_confirmation_request.get("request_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "summary": summarize_human_approval_token_final_confirmation_requests(final_confirmation_requests),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -90,6 +90,11 @@ from agent.memory_human_approval_token_final_confirmation_request import (
     create_human_approval_token_final_confirmation_request,
     summarize_human_approval_token_final_confirmation_requests,
 )
+from agent.memory_human_approval_token_final_confirmation_review_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY,
+    create_human_approval_token_final_confirmation_review_outcome,
+    summarize_human_approval_token_final_confirmation_review_outcomes,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -121,6 +126,7 @@ DIMENSIONS = (
     "memory_human_approval_token_issuance_dry_run",
     "memory_human_approval_token_write_lock_gate",
     "memory_human_approval_token_final_confirmation_request",
+    "memory_human_approval_token_final_confirmation_review_gate",
     "latency_ms",
 )
 POLICY = {
@@ -1115,6 +1121,122 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_token_files": False,
             "writes_approval_audit": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_final_confirmation_review_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        final_confirmation_review_outcome = (
+            final_confirmation_review_outcomes[0] if final_confirmation_review_outcomes else {}
+        )
+        return final_confirmation_review_outcome.get("outcome", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "summary": summarize_human_approval_token_final_confirmation_review_outcomes(
+                final_confirmation_review_outcomes
+            ),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -45,6 +45,11 @@ from agent.memory_human_review_outcome_gate import (
     create_human_review_outcome_candidate,
     summarize_human_review_outcomes,
 )
+from agent.memory_real_proposal_creation_plan import (
+    MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY,
+    create_real_proposal_creation_plan,
+    summarize_real_proposal_creation_plans,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -67,6 +72,7 @@ DIMENSIONS = (
     "memory_proposal_governance_gate",
     "memory_governance_submission_packet",
     "memory_human_review_outcome_gate",
+    "memory_real_proposal_creation_plan",
     "latency_ms",
 )
 POLICY = {
@@ -419,6 +425,49 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "converted_to_real_proposal": False,
             "persisted_approval": False,
             "policy": dict(MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY),
+        }
+
+    if dimension == "memory_real_proposal_creation_plan":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        plan = plans[0] if plans else {}
+        return plan.get("plan_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "summary": summarize_real_proposal_creation_plans(plans),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "persisted_approval": False,
+            "policy": dict(MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -20,6 +20,11 @@ from agent.memory_block_review_queue import (
     build_review_queue,
     summarize_review_queue,
 )
+from agent.memory_review_decision_gate import (
+    MEMORY_REVIEW_DECISION_GATE_POLICY,
+    evaluate_review_queue_item,
+    summarize_review_decisions,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -37,6 +42,7 @@ DIMENSIONS = (
     "memory_compiler",
     "memory_blocks",
     "memory_block_review_queue",
+    "memory_review_decision_gate",
     "latency_ms",
 )
 POLICY = {
@@ -255,6 +261,24 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "summary": summarize_review_queue(queue),
             "candidate_count": len(memories),
             "policy": dict(MEMORY_BLOCK_REVIEW_QUEUE_POLICY),
+        }
+
+    if dimension == "memory_review_decision_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        candidate = decisions[0] if decisions else {}
+        return candidate.get("decision", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "summary": summarize_review_decisions(decisions),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "policy": dict(MEMORY_REVIEW_DECISION_GATE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -105,6 +105,11 @@ from agent.memory_human_approval_token_write_execution_dry_run import (
     create_human_approval_token_write_execution_dry_run,
     summarize_human_approval_token_write_execution_dry_runs,
 )
+from agent.memory_human_approval_token_write_final_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY,
+    create_human_approval_token_write_final_gate,
+    summarize_human_approval_token_write_final_gates,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -139,6 +144,7 @@ DIMENSIONS = (
     "memory_human_approval_token_final_confirmation_review_gate",
     "memory_human_approval_token_write_execution_plan",
     "memory_human_approval_token_write_execution_dry_run",
+    "memory_human_approval_token_write_final_gate",
     "latency_ms",
 )
 POLICY = {
@@ -1501,6 +1507,143 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "writes_token_files": False,
             "writes_approval_audit": False,
             "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY),
+        }
+
+    if dimension == "memory_human_approval_token_write_final_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        plans = [
+            create_real_proposal_creation_plan(outcome, planner=case.get("planner"))
+            for outcome in outcomes
+        ]
+        dry_runs = [
+            create_real_proposal_dry_run(plan, operator=case.get("operator"))
+            for plan in plans
+        ]
+        write_lock_gates = [
+            create_real_proposal_write_lock_gate(dry_run, operator=case.get("write_lock_operator"))
+            for dry_run in dry_runs
+        ]
+        approval_token_requests = [
+            create_human_approval_token_request(gate, requester=case.get("approval_token_requester"))
+            for gate in write_lock_gates
+        ]
+        token_review_outcomes = [
+            create_human_approval_token_review_outcome(
+                request,
+                reviewer=case.get("approval_token_reviewer"),
+            )
+            for request in approval_token_requests
+        ]
+        token_issuance_plans = [
+            create_human_approval_token_issuance_plan(
+                outcome,
+                planner=case.get("approval_token_issuance_planner"),
+            )
+            for outcome in token_review_outcomes
+        ]
+        token_issuance_dry_runs = [
+            create_human_approval_token_issuance_dry_run(
+                plan,
+                operator=case.get("approval_token_issuance_dry_run_operator"),
+            )
+            for plan in token_issuance_plans
+        ]
+        token_write_lock_gates = [
+            create_human_approval_token_write_lock_gate(
+                dry_run,
+                operator=case.get("approval_token_write_lock_operator"),
+            )
+            for dry_run in token_issuance_dry_runs
+        ]
+        final_confirmation_requests = [
+            create_human_approval_token_final_confirmation_request(
+                gate,
+                requester=case.get("approval_token_final_confirmation_requester"),
+            )
+            for gate in token_write_lock_gates
+        ]
+        final_confirmation_review_outcomes = [
+            create_human_approval_token_final_confirmation_review_outcome(
+                request,
+                confirmer=case.get("approval_token_final_confirmation_confirmer"),
+            )
+            for request in final_confirmation_requests
+        ]
+        token_write_execution_plans = [
+            create_human_approval_token_write_execution_plan(
+                outcome,
+                executor=case.get("approval_token_write_execution_plan_executor"),
+            )
+            for outcome in final_confirmation_review_outcomes
+        ]
+        token_write_execution_dry_runs = [
+            create_human_approval_token_write_execution_dry_run(
+                plan,
+                operator=case.get("approval_token_write_execution_dry_run_operator"),
+            )
+            for plan in token_write_execution_plans
+        ]
+        token_write_final_gates = [
+            create_human_approval_token_write_final_gate(
+                dry_run,
+                operator=case.get("approval_token_write_final_gate_operator"),
+            )
+            for dry_run in token_write_execution_dry_runs
+        ]
+        token_write_final_gate = token_write_final_gates[0] if token_write_final_gates else {}
+        return token_write_final_gate.get("gate_status", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "real_proposal_creation_plan_candidates": plans,
+            "real_proposal_dry_run_candidates": dry_runs,
+            "real_proposal_write_lock_gate_candidates": write_lock_gates,
+            "human_approval_token_request_candidates": approval_token_requests,
+            "human_approval_token_review_outcome_candidates": token_review_outcomes,
+            "human_approval_token_issuance_plan_candidates": token_issuance_plans,
+            "human_approval_token_issuance_dry_run_candidates": token_issuance_dry_runs,
+            "human_approval_token_write_lock_gate_candidates": token_write_lock_gates,
+            "human_approval_token_final_confirmation_request_candidates": final_confirmation_requests,
+            "human_approval_token_final_confirmation_review_outcome_candidates": final_confirmation_review_outcomes,
+            "human_approval_token_write_execution_plan_candidates": token_write_execution_plans,
+            "human_approval_token_write_execution_dry_run_candidates": token_write_execution_dry_runs,
+            "human_approval_token_write_final_gate_candidates": token_write_final_gates,
+            "summary": summarize_human_approval_token_write_final_gates(token_write_final_gates),
+            "candidate_count": len(memories),
+            "token_issued": False,
+            "persisted_approval": False,
+            "approved": False,
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "writes_proposal_files": False,
+            "writes_operation_ledger": False,
+            "writes_token_files": False,
+            "writes_approval_audit": False,
+            "invokes_real_token_write_executor": False,
+            "policy": dict(MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -13,6 +13,7 @@ from agent.memory_bitemporal_fact_graph import (
     select_current_facts,
 )
 from agent.memory_contradiction_engine import explain_contradiction_group, group_contradictions
+from agent.memory_compiler import MEMORY_COMPILER_POLICY, compile_memory_patterns
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -27,6 +28,7 @@ DIMENSIONS = (
     "hybrid_retrieval_fusion",
     "bitemporal_fact_graph",
     "contradiction_engine",
+    "memory_compiler",
     "latency_ms",
 )
 POLICY = {
@@ -210,6 +212,16 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "explanation": explanation,
             "review_recommendation": recommendation,
             "candidate_count": len(memories),
+        }
+
+    if dimension == "memory_compiler":
+        result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        procedure = result["procedure_block_candidate"]
+        return procedure.get("status", ""), {
+            "compiler": result,
+            "procedure_block_candidate": procedure,
+            "candidate_count": len(memories),
+            "policy": dict(MEMORY_COMPILER_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from agent.memory_retrieval_fusion import fuse_memory_retrieval
+
 
 BENCHMARK_TYPE = "hermes_memory_bench_v0.1"
 DIMENSIONS = (
@@ -16,6 +18,7 @@ DIMENSIONS = (
     "governance_write_safety",
     "project_scope_isolation",
     "contradiction_handling",
+    "hybrid_retrieval_fusion",
     "latency_ms",
 )
 POLICY = {
@@ -156,6 +159,22 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "candidate_count": len(memories),
             "claim_keys": sorted({memory.get("claim_key") for memory in memories if memory.get("claim_key")}),
             "handling": "flag_candidate_for_review",
+        }
+
+    if dimension == "hybrid_retrieval_fusion":
+        result = fuse_memory_retrieval(
+            query=case["query"],
+            candidates=memories,
+            project_scope=case.get("project_scope"),
+            entity_ids=case.get("entity_ids"),
+            now=case.get("now"),
+            limit=case.get("limit", 5),
+        )
+        selected = result["selected_memories"][0] if result["selected_memories"] else {}
+        return selected.get("text", ""), {
+            "fusion": result,
+            "selected_id": selected.get("id"),
+            "candidate_count": len(memories),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/core.py
+++ b/benchmarks/hermes_memory_bench/core.py
@@ -40,6 +40,11 @@ from agent.memory_governance_submission_packet import (
     create_governance_submission_packet,
     summarize_governance_submission_packets,
 )
+from agent.memory_human_review_outcome_gate import (
+    MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY,
+    create_human_review_outcome_candidate,
+    summarize_human_review_outcomes,
+)
 from agent.memory_retrieval_fusion import fuse_memory_retrieval
 
 
@@ -61,6 +66,7 @@ DIMENSIONS = (
     "memory_proposal_draft_builder",
     "memory_proposal_governance_gate",
     "memory_governance_submission_packet",
+    "memory_human_review_outcome_gate",
     "latency_ms",
 )
 POLICY = {
@@ -375,6 +381,44 @@ def _answer_case(case: dict[str, Any]) -> tuple[str, dict[str, Any]]:
             "submitted_to_governance": False,
             "converted_to_real_proposal": False,
             "policy": dict(MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY),
+        }
+
+    if dimension == "memory_human_review_outcome_gate":
+        compiler_result = compile_memory_patterns(memories, project_scope=case.get("project_scope"))
+        blocks = compile_blocks_from_compiler_result(compiler_result, project_scope=case.get("project_scope"))
+        queue = build_review_queue(blocks, reviewer=case.get("reviewer"))
+        decisions = [evaluate_review_queue_item(item, reviewer=case.get("reviewer")) for item in queue]
+        drafts = [create_memory_proposal_draft(decision, author=case.get("author")) for decision in decisions]
+        submissions = [
+            create_governance_submission_candidate(draft, reviewer=case.get("governance_reviewer"))
+            for draft in drafts
+        ]
+        packets = [
+            create_governance_submission_packet(submission, reviewer=case.get("packet_reviewer"))
+            for submission in submissions
+        ]
+        outcomes = [
+            create_human_review_outcome_candidate(packet, reviewer=case.get("human_reviewer"))
+            for packet in packets
+        ]
+        outcome = outcomes[0] if outcomes else {}
+        return outcome.get("outcome", ""), {
+            "compiler": compiler_result,
+            "memory_blocks": blocks,
+            "review_queue": queue,
+            "decision_candidates": decisions,
+            "proposal_draft_candidates": drafts,
+            "governance_submission_candidates": submissions,
+            "governance_submission_packet_candidates": packets,
+            "human_review_outcome_candidates": outcomes,
+            "summary": summarize_human_review_outcomes(outcomes),
+            "candidate_count": len(memories),
+            "created_real_proposal": False,
+            "created_operation_event": False,
+            "submitted_to_governance": False,
+            "converted_to_real_proposal": False,
+            "persisted_approval": False,
+            "policy": dict(MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY),
         }
 
     selected = _newest(memories)

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1183,5 +1183,68 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_final_confirmation_review_gate_confirm_token_write",
+    "dimension": "memory_human_approval_token_final_confirmation_review_gate",
+    "description": "Valid final confirmation request becomes a confirm-token-write review outcome candidate.",
+    "query": "Can Hermes Memory Fabric confirm token write readiness without issuing a token, persisting approval, creating a real proposal, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "expected_answer": "confirm_token_write",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-final-confirmation-review-gate-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only final confirmation review outcome candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-final-confirmation-review-gate-a",
+        "provenance": "bench:memory-human-approval-token-final-confirmation-review-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T11:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-final-confirmation-review-gate-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "confirm token write only as a candidate while real token issuance remains separate",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-final-confirmation-review-gate-b",
+        "provenance": "bench:memory-human-approval-token-final-confirmation-review-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T12:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1310,5 +1310,70 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_write_execution_dry_run_final_preflight_required",
+    "dimension": "memory_human_approval_token_write_execution_dry_run",
+    "description": "Valid token write execution plan becomes a read-only token write execution dry-run candidate.",
+    "query": "Can Hermes Memory Fabric create a token write execution dry-run candidate without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "approval_token_write_execution_dry_run_operator": "memory-fabric-approval-token-write-execution-dry-run-operator",
+    "expected_answer": "manual_token_write_final_preflight_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-write-execution-dry-run-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token write execution dry-run candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-execution-dry-run-a",
+        "provenance": "bench:memory-human-approval-token-write-execution-dry-run:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T15:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-write-execution-dry-run-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "require a final manual token write gate before any real token write",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-execution-dry-run-b",
+        "provenance": "bench:memory-human-approval-token-write-execution-dry-run:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T16:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -661,5 +661,59 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_real_proposal_creation_plan_manual_required",
+    "dimension": "memory_real_proposal_creation_plan",
+    "description": "Approved human review outcome becomes a manual real proposal creation plan candidate.",
+    "query": "Can Hermes Memory Fabric create a real proposal creation plan without creating a real proposal?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "expected_answer": "manual_creation_plan_required",
+    "memories": [
+      {
+        "fact_id": "real-proposal-plan-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only real proposal creation plan candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-real-proposal-creation-plan-a",
+        "provenance": "bench:memory-real-proposal-creation-plan:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "real-proposal-plan-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only real proposal creation plan candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-real-proposal-creation-plan-b",
+        "provenance": "bench:memory-real-proposal-creation-plan:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -608,5 +608,58 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_review_outcome_gate_approve_real_proposal_creation",
+    "dimension": "memory_human_review_outcome_gate",
+    "description": "Valid human review packet becomes an approve-real-proposal-creation outcome candidate.",
+    "query": "Can Hermes Memory Fabric create a human review outcome candidate without creating a real proposal?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "expected_answer": "approve_real_proposal_creation",
+    "memories": [
+      {
+        "fact_id": "human-review-outcome-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human review outcome candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-review-outcome-gate-a",
+        "provenance": "bench:memory-human-review-outcome-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-review-outcome-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human review outcome candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-review-outcome-gate-b",
+        "provenance": "bench:memory-human-review-outcome-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1060,5 +1060,66 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_write_lock_gate_final_confirmation_eligible",
+    "dimension": "memory_human_approval_token_write_lock_gate",
+    "description": "Valid token issuance dry run becomes a token write-lock gate candidate.",
+    "query": "Can Hermes Memory Fabric gate human approval token writes without issuing a token, persisting approval, creating a real proposal, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "expected_answer": "eligible_for_final_human_confirmation",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-write-lock-gate-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token write-lock gate candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-lock-gate-a",
+        "provenance": "bench:memory-human-approval-token-write-lock-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-write-lock-gate-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "require final human confirmation before any approval token write",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-lock-gate-b",
+        "provenance": "bench:memory-human-approval-token-write-lock-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1441,5 +1441,72 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_real_write_executor_contract_required",
+    "dimension": "memory_human_approval_token_real_write_executor_contract",
+    "description": "Valid write final gate becomes a read-only real write executor contract candidate.",
+    "query": "Can Hermes Memory Fabric create a real token write executor contract candidate without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, invoking or implementing a real token write executor, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "approval_token_write_execution_dry_run_operator": "memory-fabric-approval-token-write-execution-dry-run-operator",
+    "approval_token_write_final_gate_operator": "memory-fabric-approval-token-write-final-gate-operator",
+    "approval_token_real_write_executor_contract_operator": "memory-fabric-approval-token-real-write-executor-contract-operator",
+    "expected_answer": "real_token_write_executor_contract_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-real-write-executor-contract-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token real write executor contract candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-contract-a",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-contract:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T19:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-real-write-executor-contract-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "define executor inputs hard locks audit fields rollback rules and side effect boundaries without invoking or implementing the executor",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-contract-b",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-contract:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T20:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -455,5 +455,55 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_proposal_draft_builder_review_required",
+    "dimension": "memory_proposal_draft_builder",
+    "description": "Approved decision candidate becomes a review-required proposal draft candidate.",
+    "query": "Can Hermes Memory Fabric draft a proposal candidate without creating a real proposal?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "expected_answer": "draft_review_required",
+    "memories": [
+      {
+        "fact_id": "proposal-draft-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only proposal draft candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-proposal-draft-builder-a",
+        "provenance": "bench:memory-proposal-draft-builder:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "proposal-draft-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only proposal draft candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-proposal-draft-builder-b",
+        "provenance": "bench:memory-proposal-draft-builder:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1508,5 +1508,73 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_real_write_executor_contract_review_gate_approve",
+    "dimension": "memory_human_approval_token_real_write_executor_contract_review_gate",
+    "description": "Valid real write executor contract becomes a read-only contract review outcome candidate.",
+    "query": "Can Hermes Memory Fabric approve a real token write executor contract for a later implementation plan without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, invoking or implementing a real token write executor, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "approval_token_write_execution_dry_run_operator": "memory-fabric-approval-token-write-execution-dry-run-operator",
+    "approval_token_write_final_gate_operator": "memory-fabric-approval-token-write-final-gate-operator",
+    "approval_token_real_write_executor_contract_operator": "memory-fabric-approval-token-real-write-executor-contract-operator",
+    "approval_token_real_write_executor_contract_reviewer": "memory-fabric-approval-token-real-write-executor-contract-reviewer",
+    "expected_answer": "approve_executor_contract",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-real-write-executor-contract-review-gate-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token real write executor contract review outcome candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-contract-review-gate-a",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-contract-review-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T21:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-real-write-executor-contract-review-gate-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "approve executor contracts only for a later implementation plan without issuing tokens writing files or invoking executors",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-contract-review-gate-b",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-contract-review-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T22:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1246,5 +1246,69 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_write_execution_plan_manual_required",
+    "dimension": "memory_human_approval_token_write_execution_plan",
+    "description": "Valid final confirmation review outcome becomes a read-only token write execution plan candidate.",
+    "query": "Can Hermes Memory Fabric create a token write execution plan candidate without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "expected_answer": "manual_token_write_execution_plan_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-write-execution-plan-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token write execution plan candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-execution-plan-a",
+        "provenance": "bench:memory-human-approval-token-write-execution-plan:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T13:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-write-execution-plan-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "require token write dry run before any real approval token write",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-execution-plan-b",
+        "provenance": "bench:memory-human-approval-token-write-execution-plan:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T14:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1576,5 +1576,74 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_real_write_executor_implementation_plan_required",
+    "dimension": "memory_human_approval_token_real_write_executor_implementation_plan",
+    "description": "Valid contract review outcome becomes a read-only implementation plan candidate.",
+    "query": "Can Hermes Memory Fabric create a real token write executor implementation plan without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, invoking or implementing a real token write executor, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "approval_token_write_execution_dry_run_operator": "memory-fabric-approval-token-write-execution-dry-run-operator",
+    "approval_token_write_final_gate_operator": "memory-fabric-approval-token-write-final-gate-operator",
+    "approval_token_real_write_executor_contract_operator": "memory-fabric-approval-token-real-write-executor-contract-operator",
+    "approval_token_real_write_executor_contract_reviewer": "memory-fabric-approval-token-real-write-executor-contract-reviewer",
+    "approval_token_real_write_executor_implementation_plan_implementer": "memory-fabric-approval-token-real-write-executor-implementation-plan-implementer",
+    "expected_answer": "real_token_write_executor_implementation_plan_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-real-write-executor-implementation-plan-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token real write executor implementation plan candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-implementation-plan-a",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-implementation-plan:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-24T00:00:00Z",
+        "system_created_at": "2026-05-24T00:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-real-write-executor-implementation-plan-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "plan future executor interfaces idempotency filesystem safety audit rollback and tests without creating executor code",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-implementation-plan-b",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-implementation-plan:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-24T00:00:00Z",
+        "system_created_at": "2026-05-24T01:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -117,5 +117,50 @@
         "claim_key": "external_channel_exposure"
       }
     ]
+  },
+  {
+    "id": "hybrid_fusion_scoped_provenance",
+    "dimension": "hybrid_retrieval_fusion",
+    "description": "Hybrid fusion ranks scoped, current, sourced memory.",
+    "query": "Which memory retrieval method should Hermes Memory Fabric use?",
+    "project_scope": "memory-fabric",
+    "entity_ids": ["hermes-memory-fabric"],
+    "now": "2026-05-23T00:00:00Z",
+    "expected_answer": "Hermes Memory Fabric should use Hybrid Retrieval Fusion v0.1.",
+    "memories": [
+      {
+        "id": "unrelated-project",
+        "content": "OpenClaw should use a separate memory retrieval method.",
+        "project_id": "openclaw",
+        "entity_ids": ["openclaw"],
+        "created_at": "2026-05-22T09:00:00Z",
+        "source": "chat"
+      },
+      {
+        "id": "fusion-current",
+        "content": "Hermes Memory Fabric should use Hybrid Retrieval Fusion v0.1.",
+        "project_id": "memory-fabric",
+        "entity_ids": ["hermes-memory-fabric"],
+        "created_at": "2026-05-22T10:00:00Z",
+        "valid_from": "2026-05-22T00:00:00Z",
+        "source": "design_doc",
+        "provenance": "bench:hybrid-retrieval-fusion",
+        "governance": {
+          "read_only": true,
+          "proposal_governed": true
+        }
+      },
+      {
+        "id": "fusion-unsafe",
+        "content": "Hermes Memory Fabric should use Hybrid Retrieval Fusion v0.1.",
+        "project_id": "memory-fabric",
+        "entity_ids": ["hermes-memory-fabric"],
+        "created_at": "2026-05-23T10:00:00Z",
+        "source": "unreviewed",
+        "governance": {
+          "would_write_memory": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -162,5 +162,57 @@
         }
       }
     ]
+  },
+  {
+    "id": "bitemporal_newer_valid_fact_wins",
+    "dimension": "bitemporal_fact_graph",
+    "description": "Newer valid fact wins while the old historical fact remains explainable.",
+    "query": "Which fact graph foundation should Hermes Memory Fabric use?",
+    "project_scope": "memory-fabric",
+    "at_time": "2026-05-23T00:00:00Z",
+    "expected_answer": "Bi-temporal Fact Graph v0.1",
+    "memories": [
+      {
+        "fact_id": "fact-graph-old",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "foundation",
+        "object": "Hybrid Retrieval Fusion v0.1",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-hybrid-retrieval-fusion",
+        "provenance": "bench:hybrid-retrieval-fusion",
+        "confidence": 0.91,
+        "valid_from": "2026-05-20T00:00:00Z",
+        "valid_until": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-20T12:00:00Z",
+        "system_invalidated_at": "2026-05-23T00:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "fact-graph-current",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "foundation",
+        "object": "Bi-temporal Fact Graph v0.1",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-bitemporal-fact-graph",
+        "provenance": "bench:bitemporal-fact-graph",
+        "confidence": 0.95,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T08:00:00Z",
+        "supersedes": ["fact-graph-old"],
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1645,5 +1645,75 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_real_write_executor_implementation_dry_run_code_review_plan_required",
+    "dimension": "memory_human_approval_token_real_write_executor_implementation_dry_run",
+    "description": "Valid implementation plan becomes a read-only implementation dry-run candidate.",
+    "query": "Can Hermes Memory Fabric create a real token write executor implementation dry run without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, invoking or implementing a real token write executor, creating executor source files, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "approval_token_write_execution_dry_run_operator": "memory-fabric-approval-token-write-execution-dry-run-operator",
+    "approval_token_write_final_gate_operator": "memory-fabric-approval-token-write-final-gate-operator",
+    "approval_token_real_write_executor_contract_operator": "memory-fabric-approval-token-real-write-executor-contract-operator",
+    "approval_token_real_write_executor_contract_reviewer": "memory-fabric-approval-token-real-write-executor-contract-reviewer",
+    "approval_token_real_write_executor_implementation_plan_implementer": "memory-fabric-approval-token-real-write-executor-implementation-plan-implementer",
+    "approval_token_real_write_executor_implementation_dry_run_operator": "memory-fabric-approval-token-real-write-executor-implementation-dry-run-operator",
+    "expected_answer": "real_token_write_executor_code_review_plan_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-real-write-executor-implementation-dry-run-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token real write executor implementation dry-run candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-implementation-dry-run-a",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-implementation-dry-run:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-24T00:00:00Z",
+        "system_created_at": "2026-05-24T02:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-real-write-executor-implementation-dry-run-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "preview future executor module boundaries interfaces idempotency filesystem audit rollback and tests without creating executor source files",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-implementation-dry-run-b",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-implementation-dry-run:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-24T00:00:00Z",
+        "system_created_at": "2026-05-24T03:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -715,5 +715,60 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_real_proposal_dry_run_manual_final_preflight",
+    "dimension": "memory_real_proposal_dry_run",
+    "description": "Valid manual creation plan becomes a final preflight dry-run candidate.",
+    "query": "Can Hermes Memory Fabric preview a real proposal write without creating a proposal or ledger event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "expected_answer": "manual_final_preflight_required",
+    "memories": [
+      {
+        "fact_id": "real-proposal-dry-run-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only real proposal dry-run previews",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-real-proposal-dry-run-a",
+        "provenance": "bench:memory-real-proposal-dry-run:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "real-proposal-dry-run-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only real proposal dry-run previews",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-real-proposal-dry-run-b",
+        "provenance": "bench:memory-real-proposal-dry-run:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -826,5 +826,62 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_request_review_required",
+    "dimension": "memory_human_approval_token_request",
+    "description": "Eligible write-lock gate becomes a human approval token request candidate.",
+    "query": "Can Hermes Memory Fabric request human approval token review without issuing a token or writing proposal records?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "expected_answer": "approval_token_review_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-request-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token request candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-request-a",
+        "provenance": "bench:memory-human-approval-token-request:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-request-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token request candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-request-b",
+        "provenance": "bench:memory-human-approval-token-request:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -941,5 +941,64 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_issuance_plan_manual_required",
+    "dimension": "memory_human_approval_token_issuance_plan",
+    "description": "Valid approval token review outcome becomes a token issuance plan candidate.",
+    "query": "Can Hermes Memory Fabric plan human approval token issuance without issuing a token or writing proposal records?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "expected_answer": "manual_token_issuance_plan_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-issuance-plan-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token issuance plan candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-issuance-plan-a",
+        "provenance": "bench:memory-human-approval-token-issuance-plan:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-issuance-plan-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "require manual token issuance dry run before any token write",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-issuance-plan-b",
+        "provenance": "bench:memory-human-approval-token-issuance-plan:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -357,5 +357,54 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_block_review_queue_pending_procedural_rules",
+    "dimension": "memory_block_review_queue",
+    "description": "Procedural rules block candidate becomes a pending review queue item.",
+    "query": "Can Hermes Memory Fabric queue procedural rules blocks for review?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "expected_answer": "pending_review",
+    "memories": [
+      {
+        "fact_id": "review-queue-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "queue memory block candidates for read-only review",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-block-review-queue-a",
+        "provenance": "bench:memory-block-review-queue:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "review-queue-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "queue memory block candidates for read-only review",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-block-review-queue-b",
+        "provenance": "bench:memory-block-review-queue:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1121,5 +1121,67 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_final_confirmation_request_review_required",
+    "dimension": "memory_human_approval_token_final_confirmation_request",
+    "description": "Valid token write-lock gate becomes a final confirmation request candidate.",
+    "query": "Can Hermes Memory Fabric request final human confirmation without issuing a token, persisting approval, creating a real proposal, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "expected_answer": "final_confirmation_review_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-final-confirmation-request-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only final human confirmation request candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-final-confirmation-request-a",
+        "provenance": "bench:memory-human-approval-token-final-confirmation-request:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-final-confirmation-request-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "require manual final confirmation review before any approval token write",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-final-confirmation-request-b",
+        "provenance": "bench:memory-human-approval-token-final-confirmation-request:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1000,5 +1000,65 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_issuance_dry_run_final_preflight_required",
+    "dimension": "memory_human_approval_token_issuance_dry_run",
+    "description": "Valid token issuance plan becomes a token issuance dry-run candidate.",
+    "query": "Can Hermes Memory Fabric dry-run human approval token issuance without issuing a token, persisting approval, creating a real proposal, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "expected_answer": "manual_token_issuance_final_preflight_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-issuance-dry-run-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token issuance dry-run candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-issuance-dry-run-a",
+        "provenance": "bench:memory-human-approval-token-issuance-dry-run:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-issuance-dry-run-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "preview approval token record and approval audit record without persisting approval",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-issuance-dry-run-b",
+        "provenance": "bench:memory-human-approval-token-issuance-dry-run:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "exact_recall",
+    "dimension": "recall_accuracy",
+    "description": "Exact project preference recall.",
+    "query": "What editor theme does Han prefer for Hermes dashboards?",
+    "expected_answer": "Han prefers the graphite theme for Hermes dashboards.",
+    "memories": [
+      {
+        "content": "Han prefers the graphite theme for Hermes dashboards.",
+        "project_id": "hermes-dashboard",
+        "created_at": "2026-05-20T09:00:00Z",
+        "source": "chat",
+        "provenance": "conversation:dashboard-theme"
+      }
+    ]
+  },
+  {
+    "id": "temporal_old_new_preference",
+    "dimension": "temporal_accuracy",
+    "description": "Newer preference supersedes older preference.",
+    "query": "Which release note tone should Hermes use?",
+    "expected_answer": "Use terse release notes.",
+    "memories": [
+      {
+        "content": "Use expansive release notes.",
+        "project_id": "hermes-agent",
+        "created_at": "2026-05-10T12:00:00Z",
+        "source": "chat",
+        "preference_key": "release_note_tone"
+      },
+      {
+        "content": "Use terse release notes.",
+        "project_id": "hermes-agent",
+        "created_at": "2026-05-22T12:00:00Z",
+        "source": "chat",
+        "preference_key": "release_note_tone"
+      }
+    ]
+  },
+  {
+    "id": "source_provenance_present",
+    "dimension": "source_provenance_accuracy",
+    "description": "Answer includes source and provenance.",
+    "query": "Why is direct memory writing forbidden?",
+    "expected_answer": "Durable memory updates require governed proposals.",
+    "required_source": "policy_doc",
+    "required_provenance": "memory-fabric-policy:v1",
+    "memories": [
+      {
+        "content": "Durable memory updates require governed proposals.",
+        "project_id": "memory-fabric",
+        "created_at": "2026-05-18T08:30:00Z",
+        "source": "policy_doc",
+        "provenance": "memory-fabric-policy:v1"
+      }
+    ]
+  },
+  {
+    "id": "blocked_unsafe_write_check",
+    "dimension": "governance_write_safety",
+    "description": "Unsafe write request is blocked by policy.",
+    "query": "Write this preference directly to durable memory.",
+    "expected_answer": "blocked",
+    "unsafe_operation": "direct_memory_write",
+    "memories": [
+      {
+        "content": "Direct durable memory writes are blocked in this benchmark.",
+        "project_id": "memory-fabric",
+        "created_at": "2026-05-18T08:45:00Z",
+        "source": "policy_doc",
+        "provenance": "memory-fabric-policy:v1"
+      }
+    ]
+  },
+  {
+    "id": "project_scoped_query",
+    "dimension": "project_scope_isolation",
+    "description": "Scoped recall ignores another project's matching fact.",
+    "query": "What deployment target should be used?",
+    "project_scope": "openclaw",
+    "expected_answer": "Use staging for OpenClaw.",
+    "memories": [
+      {
+        "content": "Use production for Lovart.",
+        "project_id": "lovart",
+        "created_at": "2026-05-21T08:00:00Z",
+        "source": "chat"
+      },
+      {
+        "content": "Use staging for OpenClaw.",
+        "project_id": "openclaw",
+        "created_at": "2026-05-21T09:00:00Z",
+        "source": "chat"
+      }
+    ]
+  },
+  {
+    "id": "contradiction_candidate",
+    "dimension": "contradiction_handling",
+    "description": "Contradictory facts are flagged instead of merged blindly.",
+    "query": "Is external-channel memory exposure allowed?",
+    "expected_answer": "contradiction_detected",
+    "memories": [
+      {
+        "content": "External-channel memory exposure is allowed.",
+        "project_id": "memory-fabric",
+        "created_at": "2026-05-16T10:00:00Z",
+        "source": "chat",
+        "claim_key": "external_channel_exposure"
+      },
+      {
+        "content": "External-channel memory exposure is blocked until reviewed.",
+        "project_id": "memory-fabric",
+        "created_at": "2026-05-22T10:00:00Z",
+        "source": "policy_doc",
+        "claim_key": "external_channel_exposure"
+      }
+    ]
+  }
+]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -770,5 +770,61 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_real_proposal_write_lock_gate_human_token_eligible",
+    "dimension": "memory_real_proposal_write_lock_gate",
+    "description": "Valid dry run becomes eligible for a separate human approval token flow.",
+    "query": "Can Hermes Memory Fabric unlock a real proposal write without creating a proposal or ledger event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "expected_answer": "eligible_for_human_approval_token",
+    "memories": [
+      {
+        "fact_id": "real-proposal-write-lock-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only real proposal write-lock gate candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-real-proposal-write-lock-gate-a",
+        "provenance": "bench:memory-real-proposal-write-lock-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "real-proposal-write-lock-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only real proposal write-lock gate candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-real-proposal-write-lock-gate-b",
+        "provenance": "bench:memory-real-proposal-write-lock-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -214,5 +214,52 @@
         }
       }
     ]
+  },
+  {
+    "id": "contradiction_engine_review_recommendation",
+    "dimension": "contradiction_engine",
+    "description": "Contradiction engine flags conflicting facts for review.",
+    "query": "Should external-channel memory exposure be allowed?",
+    "expected_answer": "review_contradiction",
+    "memories": [
+      {
+        "fact_id": "external-exposure-allowed",
+        "subject": "external-channel memory exposure",
+        "predicate": "policy",
+        "object": "allowed",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-policy-old",
+        "provenance": "bench:contradiction-engine:old",
+        "confidence": 0.82,
+        "valid_from": "2026-05-16T00:00:00Z",
+        "system_created_at": "2026-05-16T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "external-exposure-blocked",
+        "subject": "external-channel memory exposure",
+        "predicate": "policy",
+        "object": "blocked_until_reviewed",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-policy-current",
+        "provenance": "bench:contradiction-engine:current",
+        "confidence": 0.94,
+        "valid_from": "2026-05-22T00:00:00Z",
+        "system_created_at": "2026-05-22T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -261,5 +261,53 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_compiler_review_only_procedure",
+    "dimension": "memory_compiler",
+    "description": "Stable facts compile into a review-only procedure candidate.",
+    "query": "Can Hermes Memory Fabric compile evidence into a procedure candidate?",
+    "project_scope": "memory-fabric",
+    "expected_answer": "review_required",
+    "memories": [
+      {
+        "fact_id": "compiler-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "compile review-only procedure candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-compiler-a",
+        "provenance": "bench:memory-compiler:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "compiler-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "compile review-only procedure candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-compiler-b",
+        "provenance": "bench:memory-compiler:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -309,5 +309,53 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_blocks_review_only_procedural_rules",
+    "dimension": "memory_blocks",
+    "description": "Compiler procedure candidate becomes a review-only procedural rules block.",
+    "query": "Can Hermes Memory Fabric create review-only procedural rules blocks?",
+    "project_scope": "memory-fabric",
+    "expected_answer": "procedural_rules",
+    "memories": [
+      {
+        "fact_id": "memory-blocks-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create review-only memory block candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-blocks-a",
+        "provenance": "bench:memory-blocks:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "memory-blocks-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create review-only memory block candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-blocks-b",
+        "provenance": "bench:memory-blocks:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -883,5 +883,63 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_review_gate_approve_token_issuance",
+    "dimension": "memory_human_approval_token_review_gate",
+    "description": "Valid approval token request becomes a token issuance review outcome candidate.",
+    "query": "Can Hermes Memory Fabric review human approval token issuance without issuing a token or writing proposal records?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "expected_answer": "approve_token_issuance",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-review-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token review outcome candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-review-gate-a",
+        "provenance": "bench:memory-human-approval-token-review-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-review-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token review outcome candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-review-gate-b",
+        "provenance": "bench:memory-human-approval-token-review-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -556,5 +556,57 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_governance_submission_packet_human_review_required",
+    "dimension": "memory_governance_submission_packet",
+    "description": "Valid governance submission candidate becomes a human review packet candidate.",
+    "query": "Can Hermes Memory Fabric create a human review packet without creating a real proposal?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "expected_answer": "human_review_packet_required",
+    "memories": [
+      {
+        "fact_id": "governance-packet-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only governance submission packet candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-governance-submission-packet-a",
+        "provenance": "bench:memory-governance-submission-packet:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "governance-packet-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only governance submission packet candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-governance-submission-packet-b",
+        "provenance": "bench:memory-governance-submission-packet:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -406,5 +406,54 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_review_decision_gate_approve_procedural_rules",
+    "dimension": "memory_review_decision_gate",
+    "description": "Pending procedural rules queue item becomes an approve-to-proposal decision candidate.",
+    "query": "Can Hermes Memory Fabric create a decision candidate without creating a proposal?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "expected_answer": "approve_to_proposal",
+    "memories": [
+      {
+        "fact_id": "review-decision-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "gate review queue items into decision candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-review-decision-gate-a",
+        "provenance": "bench:memory-review-decision-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "review-decision-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "gate review queue items into decision candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-review-decision-gate-b",
+        "provenance": "bench:memory-review-decision-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -505,5 +505,56 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_proposal_governance_gate_review_required",
+    "dimension": "memory_proposal_governance_gate",
+    "description": "Valid proposal draft becomes a governance review submission candidate.",
+    "query": "Can Hermes Memory Fabric create a governance submission candidate without creating a real proposal?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "expected_answer": "governance_review_required",
+    "memories": [
+      {
+        "fact_id": "proposal-governance-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only governance submission candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-proposal-governance-gate-a",
+        "provenance": "bench:memory-proposal-governance-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T09:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "proposal-governance-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only governance submission candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-proposal-governance-gate-b",
+        "provenance": "bench:memory-proposal-governance-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T10:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1715,5 +1715,76 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_real_write_executor_code_review_plan_gate_required",
+    "dimension": "memory_human_approval_token_real_write_executor_code_review_plan",
+    "description": "Valid implementation dry run becomes a read-only code review plan candidate.",
+    "query": "Can Hermes Memory Fabric create a real token write executor code review plan without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, invoking or implementing a real token write executor, creating executor source files, creating executor tests, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "approval_token_write_execution_dry_run_operator": "memory-fabric-approval-token-write-execution-dry-run-operator",
+    "approval_token_write_final_gate_operator": "memory-fabric-approval-token-write-final-gate-operator",
+    "approval_token_real_write_executor_contract_operator": "memory-fabric-approval-token-real-write-executor-contract-operator",
+    "approval_token_real_write_executor_contract_reviewer": "memory-fabric-approval-token-real-write-executor-contract-reviewer",
+    "approval_token_real_write_executor_implementation_plan_implementer": "memory-fabric-approval-token-real-write-executor-implementation-plan-implementer",
+    "approval_token_real_write_executor_implementation_dry_run_operator": "memory-fabric-approval-token-real-write-executor-implementation-dry-run-operator",
+    "approval_token_real_write_executor_code_review_plan_reviewer": "memory-fabric-approval-token-real-write-executor-code-review-plan-reviewer",
+    "expected_answer": "real_token_write_executor_code_review_gate_required",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-real-write-executor-code-review-plan-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token real write executor code review plan candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-code-review-plan-a",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-code-review-plan:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-24T00:00:00Z",
+        "system_created_at": "2026-05-24T04:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-real-write-executor-code-review-plan-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "define future executor source review scope static analysis security write safety tests and acceptance criteria without creating executor source files",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-real-write-executor-code-review-plan-b",
+        "provenance": "bench:memory-human-approval-token-real-write-executor-code-review-plan:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-24T00:00:00Z",
+        "system_created_at": "2026-05-24T05:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
+++ b/benchmarks/hermes_memory_bench/fixtures/smoke_cases.json
@@ -1375,5 +1375,71 @@
         }
       }
     ]
+  },
+  {
+    "id": "memory_human_approval_token_write_final_gate_executor_eligible",
+    "dimension": "memory_human_approval_token_write_final_gate",
+    "description": "Valid token write execution dry run becomes a read-only final gate candidate.",
+    "query": "Can Hermes Memory Fabric mark token write executor eligibility without issuing a token, persisting approval, creating a real proposal, writing token files, writing approval audit, invoking the executor, or creating an operation event?",
+    "project_scope": "memory-fabric",
+    "reviewer": "memory-fabric-reviewer",
+    "author": "memory-fabric-author",
+    "governance_reviewer": "memory-fabric-governance-reviewer",
+    "packet_reviewer": "memory-fabric-packet-reviewer",
+    "human_reviewer": "memory-fabric-human-reviewer",
+    "planner": "memory-fabric-plan-reviewer",
+    "operator": "memory-fabric-final-preflight-operator",
+    "write_lock_operator": "memory-fabric-write-lock-operator",
+    "approval_token_requester": "memory-fabric-approval-token-requester",
+    "approval_token_reviewer": "memory-fabric-approval-token-reviewer",
+    "approval_token_issuance_planner": "memory-fabric-approval-token-issuance-planner",
+    "approval_token_issuance_dry_run_operator": "memory-fabric-approval-token-issuance-dry-run-operator",
+    "approval_token_write_lock_operator": "memory-fabric-approval-token-write-lock-operator",
+    "approval_token_final_confirmation_requester": "memory-fabric-approval-token-final-confirmation-requester",
+    "approval_token_final_confirmation_confirmer": "memory-fabric-approval-token-final-confirmation-confirmer",
+    "approval_token_write_execution_plan_executor": "memory-fabric-approval-token-write-execution-plan-executor",
+    "approval_token_write_execution_dry_run_operator": "memory-fabric-approval-token-write-execution-dry-run-operator",
+    "approval_token_write_final_gate_operator": "memory-fabric-approval-token-write-final-gate-operator",
+    "expected_answer": "eligible_for_real_token_write_executor",
+    "memories": [
+      {
+        "fact_id": "human-approval-token-write-final-gate-procedure-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create read-only human approval token write final gate candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-final-gate-a",
+        "provenance": "bench:memory-human-approval-token-write-final-gate:a",
+        "confidence": 0.92,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T17:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      },
+      {
+        "fact_id": "human-approval-token-write-final-gate-procedure-2",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "determine real token write executor eligibility without invoking it",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-memory-human-approval-token-write-final-gate-b",
+        "provenance": "bench:memory-human-approval-token-write-final-gate:b",
+        "confidence": 0.91,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T18:00:00Z",
+        "governance": {
+          "read_only": true,
+          "would_write_memory": false,
+          "would_modify_config": false,
+          "would_write_graph": false,
+          "does_not_create_operation_events": true
+        }
+      }
+    ]
   }
 ]

--- a/benchmarks/hermes_memory_bench/run.py
+++ b/benchmarks/hermes_memory_bench/run.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import argparse
+
+from benchmarks.hermes_memory_bench.core import run_benchmark, write_report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Hermes Memory Bench.")
+    parser.add_argument("--suite", default="smoke", choices=("smoke",), help="Benchmark suite to run.")
+    parser.add_argument("--output", help="Optional JSON report path. Defaults to stdout.")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    report = run_benchmark(suite=args.suite)
+    write_report(report, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/memory_fabric_architecture_convergence_snapshot_v0_1.md
+++ b/docs/memory_fabric_architecture_convergence_snapshot_v0_1.md
@@ -353,3 +353,12 @@ another gate. Shared utilities should reduce duplication, a sandbox executor
 contract should define the only acceptable non-durable write experiment, and
 Subspace / Recall / Dashboard should become the first visible layer over the
 read-only Memory Fabric.
+
+## Appendix: Read-only Candidate Utilities v0.1
+
+The first utility extraction target is
+`agent/memory_read_only_candidate_utils.py`. It is a pure read-only helper module
+for shared policy assertions, preview integrity checks, source lineage copying,
+stable digests, and summary counters. It does not create a gate, executor,
+proposal, token, ledger event, graph write, benchmark dimension, or OpenClaw
+configuration change.

--- a/docs/memory_fabric_architecture_convergence_snapshot_v0_1.md
+++ b/docs/memory_fabric_architecture_convergence_snapshot_v0_1.md
@@ -1,0 +1,355 @@
+# Memory Fabric Architecture Convergence Snapshot v0.1
+
+Date: 2026-05-24
+
+This snapshot records where the Hermes Memory Fabric architecture has converged
+after the first 30 read-only foundations and the follow-on real write executor
+boundary planning modules. It is documentation and architecture analysis only.
+It does not define a new write gate, executor, token issuer, proposal path,
+operation ledger writer, Memory Graph writer, OpenClaw config mutation path, or
+governance submission path. It is also not a code review gate.
+
+## Scope
+
+In scope:
+
+- Summarize the current foundation chain from the benchmark scaffold through the
+  real write executor code review plan.
+- Identify the boundary between read-only candidates and any future real write
+  executor.
+- Prove that no real executor source file exists yet.
+- Identify repeated module patterns that should be extracted before more gates
+  are added.
+- Recommend the next architecture work.
+
+Out of scope:
+
+- Creating `agent/memory_human_approval_token_real_write_executor.py`.
+- Creating `tests/agent/test_memory_human_approval_token_real_write_executor.py`.
+- Creating executor tests, executor fixtures, approval tokens, proposal files,
+  token files, audit files, operation ledger events, or graph writes.
+- Submitting anything to governance.
+
+## Current Foundation Chain
+
+The benchmark scaffold in `benchmarks/hermes_memory_bench/core.py` now acts as a
+single read-only smoke chain. It evaluates fixture cases from
+`benchmarks/hermes_memory_bench/fixtures/smoke_cases.json`, returns a structured
+report, and carries a benchmark-level policy that explicitly keeps memory,
+configuration, graph, and operation-ledger writes disabled.
+
+The early foundations cover recall, temporal accuracy, source provenance,
+governance write safety, project scope isolation, contradiction handling, hybrid
+retrieval fusion, the bi-temporal fact graph, the contradiction engine, memory
+compilation, memory blocks, review queue construction, review decisions,
+proposal drafts, governance submission candidates, governance submission
+packets, human review outcomes, real proposal planning, real proposal dry-runs,
+and real proposal write-lock eligibility.
+
+The human approval token foundations then add a longer read-only approval chain:
+
+1. Human approval token request.
+2. Human approval token review gate.
+3. Human approval token issuance plan.
+4. Human approval token issuance dry run.
+5. Human approval token write lock gate.
+6. Final confirmation request.
+7. Final confirmation review gate.
+8. Token write execution plan.
+9. Token write execution dry run.
+10. Token write final gate.
+
+The first 30 foundations converge at
+`memory_human_approval_token_write_final_gate`, whose successful status is
+`eligible_for_real_token_write_executor`. That is the last foundation before the
+architecture-only executor boundary.
+
+Five follow-on modules then describe the future executor boundary without
+creating or invoking it:
+
+1. `agent/memory_human_approval_token_real_write_executor_contract.py` creates a
+   read-only contract candidate when the final gate is eligible.
+2. `agent/memory_human_approval_token_real_write_executor_contract_review_gate.py`
+   creates a read-only contract review outcome candidate.
+3. `agent/memory_human_approval_token_real_write_executor_implementation_plan.py`
+   creates a read-only implementation plan candidate and names future interfaces
+   and files with `create_in_v0_1: False`.
+4. `agent/memory_human_approval_token_real_write_executor_implementation_dry_run.py`
+   previews module, interface, idempotency, filesystem, audit, rollback, and test
+   boundaries while keeping source-file creation false.
+5. `agent/memory_human_approval_token_real_write_executor_code_review_plan.py`
+   creates a read-only code review plan candidate whose routing requires a later
+   code review gate before executor source creation.
+
+`tests/benchmarks/test_hermes_memory_bench.py` asserts that the smoke chain
+stays read-only, that graph and operation-ledger files are not created, and that
+the real-write-executor contract through code-review-plan dimensions do not
+invoke or implement a real executor.
+
+## Real Write Executor Boundary
+
+The current boundary is intentionally declarative. The real-write-executor
+modules define candidate records, validation, explanations, recommendations,
+summaries, future interface names, future file paths, and no-write acceptance
+criteria. They do not perform writes.
+
+Observed boundary guarantees:
+
+- Policy dictionaries set `read_only: True`.
+- Policy dictionaries set `would_write_memory`, `would_modify_config`, and
+  `would_write_graph` to false.
+- Operation ledger creation is forbidden with
+  `does_not_create_operation_events: True`.
+- Proposal, token, approval audit, and operation ledger writes remain false.
+- Executor invocation and executor implementation flags remain false.
+- Implementation plan and code review plan structures mention future executor
+  files only with `create_in_v0_1: False`, `contains_executor_code_in_v0_1:
+  False`, and `writes_files_in_v0_1: False`.
+- The code review plan requires a later
+  `real_token_write_executor_code_review_gate_required_before_executor_source_creation`
+  route before any executor source can exist.
+
+The product of this chain is therefore an architecture contract and review plan,
+not an executor.
+
+## Proof No Executor Source Exists
+
+The repository currently has the architecture and planning modules, but the
+future executor source and future executor test module are absent.
+
+Checked paths:
+
+- `agent/memory_human_approval_token_real_write_executor.py` does not exist.
+- `tests/agent/test_memory_human_approval_token_real_write_executor.py` does not
+  exist.
+
+Local checks performed during this snapshot:
+
+- `test -e agent/memory_human_approval_token_real_write_executor.py` returned
+  exit code `1`.
+- `test -e tests/agent/test_memory_human_approval_token_real_write_executor.py`
+  returned exit code `1`.
+- `rg --files agent tests/agent | rg '^agent/memory_human_approval_token_real_write_executor\.py$|^tests/agent/test_memory_human_approval_token_real_write_executor\.py$'`
+  returned no matches.
+
+This is consistent with the implementation plan and code review plan metadata:
+the future executor paths are named as required review targets, not as created
+files.
+
+## Duplication Analysis
+
+The current modules are coherent, but the chain now repeats enough structure
+that more gate modules would increase maintenance risk.
+
+Repeated create patterns:
+
+- Every candidate builder deep-copies its source input.
+- Each builder recomputes upstream validation before setting its own status.
+- Each builder forwards a long list of source IDs and preview records.
+- Each builder creates deterministic IDs using stable JSON plus SHA-256.
+- Each builder attaches a validation result, next-step recommendation, source
+  snapshot, and policy dictionary.
+
+Repeated validate patterns:
+
+- Required-key checks are locally enumerated per module.
+- Source snapshot matching is repeated by comparing copied fields back to the
+  source.
+- Preview fields are checked for `preview_only: True`.
+- Forbidden true flags are checked across the same write and executor keys.
+- Policy fields are compared against expected false values.
+- Lock reasons are recomputed and compared to stored lock reasons.
+
+Repeated explain and recommend patterns:
+
+- Explanation functions normalize validation status, routing, status, lock
+  reason, source IDs, and policy.
+- Recommendation functions map valid/locked states to the next route while
+  restating that writes, executor invocation, and executor implementation remain
+  false.
+- The same no-write flags appear in many recommendation payloads.
+
+Repeated summarize patterns:
+
+- Summaries count total, valid, invalid, locked, and by-status records.
+- Most summaries group by `block_type`, status, and lock reason.
+- Each summary returns the local policy dictionary.
+
+Repeated benchmark patterns:
+
+- `benchmarks/hermes_memory_bench/core.py` rebuilds the same long candidate
+  chain in every downstream dimension branch.
+- Evidence payload assembly repeats the same candidate arrays and no-write
+  flags.
+- The benchmark therefore scales linearly in code size with every new gate.
+
+## Shared Abstraction Candidates
+
+The next code work should extract read-only helpers before adding more gates.
+The target is not a framework rewrite; it is a small set of narrow utilities
+that remove repeated safety logic while preserving explicit module contracts.
+
+Candidate lifecycle utilities:
+
+- Deterministic ID helper for versioned candidate identity hashes.
+- Candidate envelope builder for status, routing, lock reason, validation,
+  recommendation, source snapshot, and policy.
+- Summary counter helper for total, valid, invalid, locked, by-status,
+  by-lock-reason, and by-block-type counts.
+- Source snapshot matcher that reports stable `field_must_match_source_snapshot`
+  errors.
+
+Preview integrity utilities:
+
+- Shared preview field constants for proposal, ledger, token, audit, target path,
+  and write payload previews.
+- Shared `preview_only` checker.
+- Shared forbidden true flag checker for `created`, `written`, `token_issued`,
+  `approved`, `persisted`, `writes_*`, executor invocation, executor
+  implementation, and executor source creation.
+- Shared checklist preservation checks for no-write and no-executor controls.
+
+Source lineage utilities:
+
+- Shared source key tuples for proposal, governance, approval token, final gate,
+  and executor-boundary lineages.
+- Field copier for lineage IDs and source evidence IDs.
+- Source evidence validator for `source_pattern_ids` and `source_fact_ids`.
+- Compact lineage summary for explain and benchmark evidence payloads.
+
+Policy assertion utilities:
+
+- Shared read-only policy assertion for memory, graph, config, proposal, ledger,
+  token, audit, governance, and executor flags.
+- Shared policy merge or exact-match helper for local policy dictionaries.
+- Shared error naming convention for `policy_<key>_must_be_true/false`.
+- Optional static assertion list for future tests to ensure no executor creation
+  flags drift to true.
+
+Benchmark chain builder utilities:
+
+- A read-only chain builder that can stop at a named stage and return all prior
+  candidates.
+- Evidence assembler that emits the repeated candidate arrays and no-write flags.
+- Dimension dispatch metadata mapping stages to expected answer fields and
+  summary functions.
+- Fixture-light smoke case generation or validation so new stages do not require
+  manually duplicating the full upstream chain in every branch.
+
+## Proposed Module Families
+
+These are architecture families, not required filenames:
+
+- Candidate lifecycle utilities: own deterministic candidate IDs, candidate
+  envelopes, validation-result attachment, recommendation attachment, and summary
+  counters.
+- Preview integrity utilities: own preview-only checks, forbidden true flag
+  checks, required no-write checklist preservation, and write-preview field
+  grouping.
+- Source lineage utilities: own source ID propagation, source snapshot matching,
+  source evidence validation, and compact lineage explain payloads.
+- Policy assertion utilities: own read-only/no-write/no-executor policy
+  assertions and error names.
+- Benchmark chain builder utilities: own smoke chain construction, stage stopping,
+  repeated evidence flags, and summary dispatch.
+
+## What Must Not Be Merged Yet
+
+Do not merge any of the following before the shared utilities and a separate
+sandbox executor design contract exist:
+
+- Real executor source module.
+- Real executor tests.
+- Real token write executor implementation.
+- Real token write executor invocation path.
+- Code review gate implementation that authorizes executor source creation.
+- Approval token issuance or persistence.
+- Token file writes.
+- Approval audit writes.
+- Proposal file writes.
+- Operation ledger writes or operation events.
+- Memory Graph writes.
+- OpenClaw config changes.
+- Governance submission execution.
+- Benchmark cases that expect real writes as success.
+
+## Minimum Safe Sandbox Executor Boundary
+
+A future sandbox executor can be useful, but the minimum safe boundary must be
+designed before implementation. The smallest acceptable sandbox boundary is:
+
+- It must be sandbox-only and disabled for real Hermes memory paths by default.
+- It must require an explicit caller-provided sandbox root that is not
+  `HERMES_HOME`, not the Memory Graph path, not the proposal path, and not the
+  operation ledger path.
+- It must accept only already-approved read-only candidate inputs and recompute
+  all upstream validations.
+- It must reject source candidates when any preview, policy, lineage, or
+  no-write checklist integrity check fails.
+- It must write only disposable sandbox token and sandbox approval-audit payloads
+  after resolving paths under the sandbox root.
+- It must not write proposals, operation ledger entries, graph state, OpenClaw
+  config, or durable memory.
+- It must use deterministic payload fingerprints, atomic same-directory replace,
+  and mismatch-on-existing-file lock behavior.
+- It must return a sandbox receipt, not a durable approval token.
+- It must remain separate from any future real executor.
+
+This snapshot does not implement that boundary.
+
+## Risk Table
+
+| Risk | Current signal | Impact | Recommendation |
+| --- | --- | --- | --- |
+| Gate explosion | The chain now has many read-only gate and plan modules, and the benchmark repeats the whole chain per downstream dimension. | More gates will multiply code paths without increasing user-visible capability. | Pause new gate additions and extract shared read-only utilities first. |
+| Benchmark bloat | `core.py` rebuilds the same upstream chain in many `if dimension == ...` branches. | Every new foundation adds large fixture and branch churn. | Add a benchmark chain builder before adding more dimensions. |
+| Repeated validation logic | Preview, policy, source lineage, required-key, and deterministic-ID checks are locally repeated. | A safety invariant can drift in one module while staying correct elsewhere. | Extract preview integrity, policy assertion, source lineage, and lifecycle helpers. |
+| Accidental real write | Future executor paths are named in plan metadata, and code review planning points toward source creation. | A later change could accidentally create files, issue tokens, or write audit state before the boundary is reviewed. | Keep executor source absent, require a sandbox design contract first, and assert absent real executor files in review. |
+| Unclear product entrypoint | The architecture is deep, but the user-facing Subspace / Recall / Dashboard layer is not represented in this chain. | Work may continue optimizing gates instead of making Memory Fabric usable. | Start the product layer after utility extraction and the sandbox design contract. |
+
+## Recommendations
+
+Do not continue adding gates right now. The architecture has enough read-only
+stages to describe the current governance boundary. More gates would increase
+duplication and make the product harder to understand unless they replace real
+risk, not just extend the chain.
+
+Do not implement a minimal sandbox executor now. First extract shared read-only
+candidate utilities and write a sandbox executor design contract that fixes the
+sandbox root, receipt shape, atomicity rules, idempotency behavior, and
+non-durable guarantees. A sandbox executor can follow after that contract is
+reviewed.
+
+Pivot to Subspace / Recall / Dashboard first after the utility extraction and
+sandbox design contract are underway. The product layer can expose recall,
+lineage, review status, and governance boundaries without needing real writes,
+which makes it the safer next user-visible convergence point.
+
+## Next Three Work Items
+
+1. Extract shared read-only candidate utilities.
+   Focus on lifecycle, preview integrity, source lineage, policy assertions, and
+   summary helpers. Keep behavior identical and covered by existing module tests.
+
+2. Create a sandbox executor design contract.
+   Define the allowed sandbox root, input contract, receipt shape, idempotency
+   strategy, atomic write model, rollback behavior, and explicit real-surface
+   exclusions. Do not implement executor code in this step.
+
+3. Start the Subspace / Recall / Dashboard product layer.
+   Build the first read-only entrypoint around retrieval, lineage, review state,
+   and Memory Fabric status rather than extending the write gate chain.
+
+## Convergence Conclusion
+
+Memory Fabric has reached a clear architecture boundary: the benchmark scaffold
+and first 30 foundations establish read-only recall, provenance, governance, and
+human approval token flow through the final gate; the five follow-on modules
+describe, review, plan, dry-run, and code-review-plan the future real write
+executor without creating it.
+
+The next convergence move should be consolidation and product surfacing, not
+another gate. Shared utilities should reduce duplication, a sandbox executor
+contract should define the only acceptable non-durable write experiment, and
+Subspace / Recall / Dashboard should become the first visible layer over the
+read-only Memory Fabric.

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -40,6 +40,29 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from agent.memory_fabric_bridge import (
+    create_memory_write_proposal,
+    export_memory_snapshot,
+    memory_boundary_allowlist_audit as get_memory_boundary_allowlist_audit,
+    memory_bridge_status as get_memory_bridge_status,
+    memory_evolution_status as get_memory_evolution_status,
+    memory_federation_audit as get_memory_federation_audit,
+    memory_federation_gate as get_memory_federation_gate,
+    memory_federation_status as get_memory_federation_status,
+    memory_ledger_intelligence as get_memory_ledger_intelligence,
+    memory_operation_ledger as get_memory_operation_ledger,
+    memory_policy_apply_execute as execute_memory_policy_apply_plan,
+    memory_policy_apply_plan as get_memory_policy_apply_plan,
+    memory_policy_autotune as get_memory_policy_autotune,
+    memory_policy_outcome_monitor as get_memory_policy_outcome_monitor,
+    memory_policy_proposal_create as create_memory_policy_proposal,
+    memory_policy_proposal_decision as decide_memory_policy_proposal,
+    memory_policy_proposal_ledger as get_memory_policy_proposal_ledger,
+    memory_recall_quality_evaluate as get_memory_recall_quality_evaluate,
+    read_memory_graph,
+    search_memory_fabric,
+)
+
 logger = logging.getLogger("hermes.mcp_serve")
 
 # ---------------------------------------------------------------------------
@@ -817,6 +840,376 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
                         })
 
         return json.dumps({"count": len(channels), "channels": channels}, indent=2)
+
+    # -- Memory Fabric -----------------------------------------------------
+
+    @mcp.tool()
+    def memory_bridge_status() -> str:
+        """Inspect Hermes shared Memory Fabric surfaces and write policy."""
+        return json.dumps(get_memory_bridge_status(), ensure_ascii=False, indent=2)
+
+    @mcp.tool()
+    def memory_evolution_status() -> str:
+        """Inspect the fixed Hermes memory tier taxonomy and current stage."""
+        return json.dumps(get_memory_evolution_status(), ensure_ascii=False, indent=2)
+
+    @mcp.tool()
+    def memory_recall_quality_evaluate(
+        queries: str = "",
+        scope: str = "all",
+        limit: int = 5,
+    ) -> str:
+        """Evaluate recall quality across memory surfaces without mutating memory."""
+        limit = _coerce_int(limit, default=5, minimum=1, maximum=20)
+        return json.dumps(
+            get_memory_recall_quality_evaluate(
+                queries=queries,
+                scope=scope,
+                limit=limit,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_federation_status() -> str:
+        """Inspect Hermes/OpenClaw/Codex shared memory wiring."""
+        return json.dumps(get_memory_federation_status(), ensure_ascii=False, indent=2)
+
+    @mcp.tool()
+    def memory_federation_audit(log_limit: int = 200) -> str:
+        """Audit shared memory wiring from config, logs, and ledgers."""
+        log_limit = _coerce_int(log_limit, default=200, minimum=20, maximum=2000)
+        return json.dumps(
+            get_memory_federation_audit(log_limit=log_limit),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_boundary_allowlist_audit(log_limit: int = 200) -> str:
+        """Review cross-system memory boundaries and allowlists without applying changes."""
+        log_limit = _coerce_int(log_limit, default=200, minimum=20, maximum=2000)
+        return json.dumps(
+            get_memory_boundary_allowlist_audit(log_limit=log_limit),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_federation_gate(
+        client: str = "codex",
+        operation: str = "search",
+        target_scope: str = "project",
+        channel_id: str = "",
+        log_limit: int = 200,
+    ) -> str:
+        """Evaluate a memory operation against the federation governance gate."""
+        log_limit = _coerce_int(log_limit, default=200, minimum=20, maximum=2000)
+        return json.dumps(
+            get_memory_federation_gate(
+                client=client,
+                operation=operation,
+                target_scope=target_scope,
+                channel_id=channel_id,
+                log_limit=log_limit,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_operation_ledger(
+        limit: int = 50,
+        client: str = "",
+        operation: str = "",
+        decision: str = "",
+        event_type: str = "",
+    ) -> str:
+        """Read the memory operation audit ledger."""
+        limit = _coerce_int(limit, default=50, minimum=1, maximum=500)
+        return json.dumps(
+            get_memory_operation_ledger(
+                limit=limit,
+                client=client,
+                operation=operation,
+                decision=decision,
+                event_type=event_type,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_ledger_intelligence(
+        limit: int = 500,
+        client: str = "",
+        operation: str = "",
+    ) -> str:
+        """Analyze memory operation ledger patterns and risks."""
+        limit = _coerce_int(limit, default=500, minimum=20, maximum=5000)
+        return json.dumps(
+            get_memory_ledger_intelligence(
+                limit=limit,
+                client=client,
+                operation=operation,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_policy_autotune(
+        limit: int = 500,
+        client: str = "",
+        operation: str = "",
+        mode: str = "conservative",
+    ) -> str:
+        """Generate read-only memory policy tuning suggestions."""
+        limit = _coerce_int(limit, default=500, minimum=20, maximum=5000)
+        return json.dumps(
+            get_memory_policy_autotune(
+                limit=limit,
+                client=client,
+                operation=operation,
+                mode=mode,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_policy_proposal_create(
+        source_agent: str = "codex",
+        limit: int = 500,
+        client: str = "",
+        operation: str = "",
+        mode: str = "conservative",
+        suggestion_id: str = "",
+    ) -> str:
+        """Create governed policy proposals from policy-autotune suggestions."""
+        limit = _coerce_int(limit, default=500, minimum=20, maximum=5000)
+        return json.dumps(
+            create_memory_policy_proposal(
+                source_agent=source_agent,
+                limit=limit,
+                client=client,
+                operation=operation,
+                mode=mode,
+                suggestion_id=suggestion_id,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_policy_proposal_ledger(
+        limit: int = 50,
+        status: str = "",
+        proposal_id: str = "",
+    ) -> str:
+        """Read current memory policy proposal state."""
+        limit = _coerce_int(limit, default=50, minimum=1, maximum=500)
+        return json.dumps(
+            get_memory_policy_proposal_ledger(
+                limit=limit,
+                status=status,
+                proposal_id=proposal_id,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_policy_proposal_decision(
+        proposal_id: str,
+        decision: str,
+        reviewer: str = "codex",
+        rationale: str = "",
+    ) -> str:
+        """Record approve/reject/defer for a policy proposal without applying it."""
+        return json.dumps(
+            decide_memory_policy_proposal(
+                proposal_id=proposal_id,
+                decision=decision,
+                reviewer=reviewer,
+                rationale=rationale,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_policy_apply_plan(
+        limit: int = 50,
+        status: str = "approved",
+        proposal_id: str = "",
+    ) -> str:
+        """Build a dry-run plan for applying approved memory policy proposals."""
+        limit = _coerce_int(limit, default=50, minimum=1, maximum=500)
+        return json.dumps(
+            get_memory_policy_apply_plan(
+                limit=limit,
+                status=status,
+                proposal_id=proposal_id,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_policy_apply_execute(
+        limit: int = 50,
+        proposal_id: str = "",
+        execute: bool = False,
+        confirm_token: str = "",
+        actor: str = "codex",
+    ) -> str:
+        """Guardedly execute non-mutating checks from approved policy plans."""
+        limit = _coerce_int(limit, default=50, minimum=1, maximum=500)
+        return json.dumps(
+            execute_memory_policy_apply_plan(
+                limit=limit,
+                proposal_id=proposal_id,
+                execute=execute,
+                confirm_token=confirm_token,
+                actor=actor,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_policy_outcome_monitor(
+        limit: int = 100,
+        stale_after_hours: int = 72,
+    ) -> str:
+        """Monitor policy proposal lifecycle outcomes without applying policy."""
+        limit = _coerce_int(limit, default=100, minimum=1, maximum=500)
+        stale_after_hours = _coerce_int(
+            stale_after_hours,
+            default=72,
+            minimum=1,
+            maximum=8760,
+        )
+        return json.dumps(
+            get_memory_policy_outcome_monitor(
+                limit=limit,
+                stale_after_hours=stale_after_hours,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_fabric_search(
+        query: str,
+        scope: str = "all",
+        limit: int = 8,
+    ) -> str:
+        """Search Hermes shared memory without mutating it."""
+        limit = _coerce_int(limit, default=8, minimum=1, maximum=50)
+        return json.dumps(
+            search_memory_fabric(query, scope=scope, limit=limit),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_graph_read(
+        node_id: str = "",
+        query: str = "",
+        kind: str = "",
+        limit: int = 10,
+        include_edges: bool = True,
+    ) -> str:
+        """Read Memory Graph nodes with provenance and optional edges."""
+        limit = _coerce_int(limit, default=10, minimum=1, maximum=100)
+        return json.dumps(
+            read_memory_graph(
+                node_id=node_id,
+                query=query,
+                kind=kind,
+                limit=limit,
+                include_edges=bool(include_edges),
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_write_proposal(
+        source_agent: str,
+        target_scope: str,
+        content: str,
+        rationale: str = "",
+        project: str = "",
+        tags: str = "",
+    ) -> str:
+        """Create a governed write proposal instead of mutating durable memory."""
+        gate = get_memory_federation_gate(
+            client=source_agent or "codex",
+            operation="write_proposal",
+            target_scope=target_scope,
+            log_limit=200,
+        )
+        if gate.get("decision") != "allow":
+            return json.dumps(
+                {
+                    "success": False,
+                    "action": "memory_write_proposal",
+                    "error": f"Blocked by memory_federation_gate: {gate.get('decision')}",
+                    "gate": gate,
+                    "read_only_memory": True,
+                    "would_mutate_memory": False,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        return json.dumps(
+            create_memory_write_proposal(
+                source_agent=source_agent,
+                target_scope=target_scope,
+                content=content,
+                rationale=rationale,
+                project=project,
+                tags=tags,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @mcp.tool()
+    def memory_snapshot_export(
+        scope: str = "all",
+        limit: int = 500,
+        client: str = "codex",
+    ) -> str:
+        """Export a portable memory snapshot for backup or read-only cache."""
+        limit = _coerce_int(limit, default=500, minimum=1, maximum=5000)
+        gate = get_memory_federation_gate(
+            client=client or "codex",
+            operation="snapshot_export",
+            log_limit=200,
+        )
+        if gate.get("decision") != "allow":
+            return json.dumps(
+                {
+                    "success": False,
+                    "action": "memory_snapshot_export",
+                    "error": f"Blocked by memory_federation_gate: {gate.get('decision')}",
+                    "gate": gate,
+                    "read_only_memory": True,
+                    "would_mutate_memory": False,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        return json.dumps(
+            export_memory_snapshot(scope=scope, limit=limit),
+            ensure_ascii=False,
+            indent=2,
+        )
 
     # -- permissions_list_open ---------------------------------------------
 

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -51,6 +51,7 @@ from agent.memory_fabric_bridge import (
     memory_federation_status as get_memory_federation_status,
     memory_ledger_intelligence as get_memory_ledger_intelligence,
     memory_operation_ledger as get_memory_operation_ledger,
+    memory_orchestration_routing_metrics as get_memory_orchestration_routing_metrics,
     memory_policy_apply_execute as execute_memory_policy_apply_plan,
     memory_policy_apply_plan as get_memory_policy_apply_plan,
     memory_policy_autotune as get_memory_policy_autotune,
@@ -852,6 +853,11 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
     def memory_evolution_status() -> str:
         """Inspect the fixed Hermes memory tier taxonomy and current stage."""
         return json.dumps(get_memory_evolution_status(), ensure_ascii=False, indent=2)
+
+    @mcp.tool()
+    def memory_orchestration_routing_metrics() -> str:
+        """Inspect read-only memory orchestration routing metrics."""
+        return json.dumps(get_memory_orchestration_routing_metrics(), ensure_ascii=False, indent=2)
 
     @mcp.tool()
     def memory_recall_quality_evaluate(

--- a/tests/agent/test_memory_bitemporal_fact_graph.py
+++ b/tests/agent/test_memory_bitemporal_fact_graph.py
@@ -1,0 +1,140 @@
+from agent.memory_bitemporal_fact_graph import (
+    BITEMPORAL_FACT_GRAPH_POLICY,
+    detect_fact_contradictions,
+    explain_fact_lineage,
+    fact_is_valid_at,
+    normalize_fact,
+    select_current_facts,
+    supersede_fact,
+)
+
+
+def _fact(**overrides):
+    base = {
+        "fact_id": "fact-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "retrieval_method",
+        "object": "Hybrid Retrieval Fusion v0.1",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-1",
+        "provenance": {"source": "bench"},
+        "confidence": 0.9,
+        "valid_from": "2026-05-01T00:00:00Z",
+        "system_created_at": "2026-05-20T00:00:00Z",
+        "governance": BITEMPORAL_FACT_GRAPH_POLICY,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_current_fact_selection_by_valid_from_and_valid_until():
+    current = _fact(fact_id="current", object="Bi-temporal Fact Graph v0.1", valid_from="2026-05-22T00:00:00Z")
+    expired = _fact(fact_id="expired", valid_until="2026-05-10T00:00:00Z")
+    future = _fact(fact_id="future", object="Future Graph", valid_from="2026-06-01T00:00:00Z")
+
+    selected = select_current_facts([expired, current, future], "2026-05-23T00:00:00Z")
+
+    assert [fact.fact_id for fact in selected] == ["current"]
+
+
+def test_old_fact_becomes_invalid_after_valid_until():
+    old = normalize_fact(_fact(valid_until="2026-05-10T00:00:00Z"))
+
+    assert fact_is_valid_at(old, "2026-05-09T23:59:59Z") is True
+    assert fact_is_valid_at(old, "2026-05-10T00:00:00Z") is False
+    assert fact_is_valid_at(old, "2026-05-11T00:00:00Z") is False
+
+
+def test_system_created_at_is_separate_from_valid_from():
+    fact = normalize_fact(
+        _fact(
+            fact_id="retroactive",
+            valid_from="2026-04-01T00:00:00Z",
+            system_created_at="2026-05-20T00:00:00Z",
+        )
+    )
+
+    assert fact.valid_from.isoformat() != fact.system_created_at.isoformat()
+    assert fact_is_valid_at(fact, "2026-04-15T00:00:00Z") is True
+
+
+def test_supersede_fact_returns_copies_without_mutation():
+    old = normalize_fact(_fact(fact_id="old", object="Hybrid Retrieval Fusion v0.1"))
+    new = normalize_fact(_fact(fact_id="new", object="Bi-temporal Fact Graph v0.1", valid_from=None))
+
+    updated_old, updated_new = supersede_fact(old, new, "2026-05-23T00:00:00Z")
+
+    assert old.valid_until is None
+    assert old.system_invalidated_at is None
+    assert new.supersedes == ()
+    assert updated_old.valid_until.isoformat() == "2026-05-23T00:00:00+00:00"
+    assert updated_old.system_invalidated_at.isoformat() == "2026-05-23T00:00:00+00:00"
+    assert updated_new.valid_from.isoformat() == "2026-05-23T00:00:00+00:00"
+    assert updated_new.supersedes == ("old",)
+
+
+def test_contradiction_detection_groups_conflicting_subject_predicate_project_objects():
+    facts = [
+        _fact(fact_id="allowed", object="allowed", project_id="memory-fabric"),
+        _fact(fact_id="blocked", object="blocked", project_id="memory-fabric"),
+        _fact(fact_id="other-project", object="allowed", project_id="openclaw"),
+    ]
+
+    contradictions = detect_fact_contradictions(facts)
+
+    assert len(contradictions) == 1
+    assert contradictions[0]["project_id"] == "memory-fabric"
+    assert contradictions[0]["fact_ids"] == ["allowed", "blocked"]
+    assert contradictions[0]["objects"] == ["allowed", "blocked"]
+
+
+def test_project_scope_isolation():
+    facts = [
+        _fact(fact_id="memory-fabric", object="use bitemporal graph", project_id="memory-fabric"),
+        _fact(fact_id="openclaw", object="use routing metrics", project_id="openclaw"),
+    ]
+
+    selected = select_current_facts(facts, "2026-05-23T00:00:00Z", project_scope="openclaw")
+
+    assert [fact.fact_id for fact in selected] == ["openclaw"]
+
+
+def test_provenance_and_source_episode_id_are_preserved():
+    fact = normalize_fact(
+        _fact(
+            source_episode_id="episode-memory-bench",
+            provenance={"fixture": "smoke_cases", "lineage": ["design-doc"]},
+        )
+    )
+
+    assert fact.source_episode_id == "episode-memory-bench"
+    assert fact.provenance == {"fixture": "smoke_cases", "lineage": ["design-doc"]}
+
+
+def test_lineage_keeps_historical_fact_explainable_after_new_fact_wins():
+    old = normalize_fact(_fact(fact_id="old", object="Temporal preference only"))
+    new = normalize_fact(_fact(fact_id="new", object="Bi-temporal Fact Graph v0.1", supersedes=["old"]))
+
+    explanation = explain_fact_lineage("new", [old, new])
+
+    assert explanation["found"] is True
+    assert explanation["fact"]["fact_id"] == "new"
+    assert [fact["fact_id"] for fact in explanation["lineage"]] == ["old"]
+    assert explanation["policy"] == BITEMPORAL_FACT_GRAPH_POLICY
+
+
+def test_policy_proves_no_memory_config_graph_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = explain_fact_lineage("missing", [])
+
+    assert result["policy"] == BITEMPORAL_FACT_GRAPH_POLICY
+    assert result["policy"]["read_only"] is True
+    assert result["policy"]["would_write_memory"] is False
+    assert result["policy"]["would_modify_config"] is False
+    assert result["policy"]["would_write_graph"] is False
+    assert result["policy"]["does_not_create_operation_events"] is True
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()

--- a/tests/agent/test_memory_block_review_queue.py
+++ b/tests/agent/test_memory_block_review_queue.py
@@ -1,0 +1,144 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import (
+    MEMORY_BLOCK_REVIEW_QUEUE_POLICY,
+    build_review_queue,
+    create_review_queue_item,
+    explain_review_queue_item,
+    prioritize_review_queue,
+    recommend_review_queue_action,
+    summarize_review_queue,
+    validate_review_queue_item,
+)
+from agent.memory_blocks import create_memory_block_candidate
+
+
+def test_valid_block_becomes_pending_review_queue_item():
+    block = create_memory_block_candidate("project_context", {"text": "Hermes Memory Fabric foundation."})
+
+    item = create_review_queue_item(block, reviewer="human-reviewer")
+
+    assert item["status"] == "pending_review"
+    assert item["block_id"] == block["block_id"]
+    assert item["reviewer"] == "human-reviewer"
+    assert item["validation"] == {"valid": True, "errors": []}
+    assert item["recommended_action"]["action"] == "review_candidate"
+    assert validate_review_queue_item(item) == {"valid": True, "errors": []}
+
+
+def test_invalid_block_becomes_high_priority():
+    block = create_memory_block_candidate("unsupported", {"text": "invalid"})
+
+    item = create_review_queue_item(block)
+
+    assert item["priority"] == 100
+    assert item["risk_level"] == "high"
+    assert item["validation"]["valid"] is False
+    assert recommend_review_queue_action(item)["action"] == "review_and_reject_invalid_block"
+
+
+def test_safety_policy_gets_high_risk_and_high_priority():
+    block = create_memory_block_candidate("safety_policy", "Never write memory directly.")
+
+    item = create_review_queue_item(block)
+
+    assert item["priority"] == 90
+    assert item["risk_level"] == "high"
+
+
+def test_procedural_rules_gets_medium_risk():
+    block = create_memory_block_candidate("procedural_rules", {"rules": ["Review before applying."]})
+
+    item = create_review_queue_item(block)
+
+    assert item["priority"] == 70
+    assert item["risk_level"] == "medium"
+
+
+def test_priority_sorting_is_deterministic():
+    low = create_review_queue_item(create_memory_block_candidate("project_context", "low"))
+    high = create_review_queue_item(create_memory_block_candidate("safety_policy", "high"))
+    medium_a = create_review_queue_item(create_memory_block_candidate("persona", "medium-a"))
+    medium_b = create_review_queue_item(create_memory_block_candidate("persona", "medium-b"))
+    items = [medium_b, low, high, medium_a]
+
+    first = prioritize_review_queue(items)
+    second = prioritize_review_queue(list(reversed(items)))
+
+    assert [item["priority"] for item in first] == [90, 60, 60, 40]
+    assert [item["queue_item_id"] for item in first] == [item["queue_item_id"] for item in second]
+
+
+def test_summary_counts_total_risk_block_type_and_invalid_count():
+    items = build_review_queue(
+        [
+            create_memory_block_candidate("safety_policy", "high"),
+            create_memory_block_candidate("procedural_rules", {"rules": ["medium"]}),
+            create_memory_block_candidate("project_context", "low"),
+            create_memory_block_candidate("unsupported", "invalid"),
+        ]
+    )
+
+    summary = summarize_review_queue(items)
+
+    assert summary["total"] == 4
+    assert summary["by_risk"] == {"high": 2, "medium": 1, "low": 1}
+    assert summary["by_block_type"]["safety_policy"] == 1
+    assert summary["by_block_type"]["procedural_rules"] == 1
+    assert summary["by_block_type"]["project_context"] == 1
+    assert summary["by_block_type"]["unsupported"] == 1
+    assert summary["invalid_count"] == 1
+
+
+def test_queue_item_preserves_source_pattern_ids_and_source_fact_ids():
+    block = create_memory_block_candidate(
+        "procedural_rules",
+        {"rules": ["Preserve sources."]},
+        source_pattern_ids=["pattern-b", "pattern-a"],
+        source_fact_ids=["fact-2", "fact-1"],
+    )
+
+    item = create_review_queue_item(block)
+
+    assert item["source_pattern_ids"] == ["pattern-a", "pattern-b"]
+    assert item["source_fact_ids"] == ["fact-1", "fact-2"]
+    assert item["block_snapshot"]["source_pattern_ids"] == ["pattern-a", "pattern-b"]
+    assert item["block_snapshot"]["source_fact_ids"] == ["fact-1", "fact-2"]
+
+
+def test_input_blocks_are_not_mutated():
+    block = create_memory_block_candidate(
+        "collaboration_style",
+        {"nested": ["review later"]},
+        source_pattern_ids=["pattern-1"],
+    )
+    before = deepcopy(block)
+
+    item = create_review_queue_item(block)
+    item["block_snapshot"]["content"]["nested"].append("mutated-copy")
+
+    assert block == before
+
+
+def test_policy_proves_no_memory_config_graph_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    block = create_memory_block_candidate("procedural_rules", {"rules": ["Only create review candidates."]})
+
+    item = create_review_queue_item(block)
+    explanation = explain_review_queue_item(item)
+    recommendation = recommend_review_queue_action(item)
+
+    assert item["policy"] == MEMORY_BLOCK_REVIEW_QUEUE_POLICY
+    assert item["policy"]["read_only"] is True
+    assert item["policy"]["would_write_memory"] is False
+    assert item["policy"]["would_modify_config"] is False
+    assert item["policy"]["would_write_graph"] is False
+    assert item["policy"]["does_not_create_operation_events"] is True
+    assert item["policy"]["creates_review_candidates_only"] is True
+    assert item["policy"]["applies_blocks"] is False
+    assert explanation["applied"] is False
+    assert recommendation["applies_blocks"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()

--- a/tests/agent/test_memory_blocks.py
+++ b/tests/agent/test_memory_blocks.py
@@ -1,0 +1,130 @@
+from copy import deepcopy
+
+from agent.memory_bitemporal_fact_graph import BITEMPORAL_FACT_GRAPH_POLICY
+from agent.memory_blocks import (
+    MEMORY_BLOCK_POLICY,
+    SUPPORTED_MEMORY_BLOCK_TYPES,
+    compile_blocks_from_compiler_result,
+    create_memory_block_candidate,
+    explain_memory_block_candidate,
+    normalize_memory_block,
+    recommend_memory_block_action,
+    validate_memory_block_candidate,
+)
+from agent.memory_compiler import compile_memory_patterns
+
+
+def _fact(**overrides):
+    base = {
+        "fact_id": "fact-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "create review-only memory block candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-1",
+        "provenance": {"source": "bench"},
+        "confidence": 0.9,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T08:00:00Z",
+        "governance": BITEMPORAL_FACT_GRAPH_POLICY,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_all_supported_block_types_validate():
+    for block_type in SUPPORTED_MEMORY_BLOCK_TYPES:
+        block = create_memory_block_candidate(block_type, {"text": block_type}, project_scope="memory-fabric")
+
+        assert block["validity"]["valid"] is True
+        assert validate_memory_block_candidate(block) == {"valid": True, "errors": []}
+
+
+def test_unsupported_block_type_fails_validation():
+    block = create_memory_block_candidate("unsupported", {"text": "invalid"})
+
+    assert block["validity"]["valid"] is False
+    assert "unsupported_block_type:unsupported" in block["validity"]["errors"]
+
+
+def test_block_candidate_is_review_required_and_proposal_only():
+    block = create_memory_block_candidate("persona", "Prefer terse engineering updates.")
+
+    assert block["status"] == "review_required"
+    assert block["mutation_policy"] == "proposal_only"
+    assert block["direct_write_allowed"] is False
+    assert block["last_reviewed_at"] is None
+
+
+def test_compile_blocks_from_compiler_result_creates_procedural_rules_block():
+    compiler_result = compile_memory_patterns(
+        [_fact(fact_id="stable-1"), _fact(fact_id="stable-2", source_episode_id="episode-2")],
+        project_scope="memory-fabric",
+    )
+
+    blocks = compile_blocks_from_compiler_result(compiler_result, project_scope="memory-fabric")
+
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert block["block_type"] == "procedural_rules"
+    assert block["status"] == "review_required"
+    assert block["content"]["applied"] is False
+    assert block["content"]["compiler_candidate_type"] == "procedure_candidate"
+    assert block["mutation_policy"] == "proposal_only"
+
+
+def test_source_pattern_ids_are_preserved():
+    compiler_result = compile_memory_patterns([_fact(fact_id="stable-1"), _fact(fact_id="stable-2")])
+
+    block = compile_blocks_from_compiler_result(compiler_result)[0]
+
+    assert block["source_pattern_ids"] == compiler_result["procedure_block_candidate"]["source_pattern_ids"]
+
+
+def test_source_fact_ids_are_preserved_when_provided():
+    compiler_result = compile_memory_patterns([_fact(fact_id="stable-1"), _fact(fact_id="stable-2")])
+    compiler_result["procedure_block_candidate"]["source_fact_ids"] = ["provided-2", "provided-1"]
+
+    block = compile_blocks_from_compiler_result(compiler_result)[0]
+
+    assert block["source_fact_ids"] == ["provided-1", "provided-2"]
+
+
+def test_input_data_is_not_mutated():
+    raw_block = {
+        "block_type": "project_context",
+        "content": {"nested": ["value"]},
+        "source_pattern_ids": ["pattern-b", "pattern-a"],
+        "metadata": {"source_event_id": "event-1"},
+    }
+    raw_before = deepcopy(raw_block)
+    compiler_result = compile_memory_patterns([_fact(fact_id="stable-1"), _fact(fact_id="stable-2")])
+    compiler_before = deepcopy(compiler_result)
+
+    normalize_memory_block(raw_block)
+    compile_blocks_from_compiler_result(compiler_result)
+
+    assert raw_block == raw_before
+    assert compiler_result == compiler_before
+
+
+def test_policy_proves_no_memory_config_graph_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    block = create_memory_block_candidate("safety_policy", "Never write memory directly.")
+    explanation = explain_memory_block_candidate(block)
+    recommendation = recommend_memory_block_action(block)
+
+    assert block["policy"] == MEMORY_BLOCK_POLICY
+    assert block["policy"]["read_only"] is True
+    assert block["policy"]["would_write_memory"] is False
+    assert block["policy"]["would_modify_config"] is False
+    assert block["policy"]["would_write_graph"] is False
+    assert block["policy"]["does_not_create_operation_events"] is True
+    assert block["policy"]["creates_review_candidates_only"] is True
+    assert explanation["applied"] is False
+    assert recommendation["creates_review_candidates_only"] is True
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()

--- a/tests/agent/test_memory_compiler.py
+++ b/tests/agent/test_memory_compiler.py
@@ -1,0 +1,154 @@
+from copy import deepcopy
+
+from agent.memory_bitemporal_fact_graph import BITEMPORAL_FACT_GRAPH_POLICY
+from agent.memory_compiler import (
+    MEMORY_COMPILER_POLICY,
+    compile_memory_patterns,
+    compile_methodology_candidate,
+    compile_procedure_block_candidate,
+    explain_compilation_trace,
+    recommend_compilation_action,
+)
+
+
+def _fact(**overrides):
+    base = {
+        "fact_id": "fact-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "procedure",
+        "object": "compile review-only procedure candidates",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-1",
+        "provenance": {"source": "bench"},
+        "confidence": 0.9,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T08:00:00Z",
+        "governance": BITEMPORAL_FACT_GRAPH_POLICY,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_stable_facts_compile_into_methodology_candidate():
+    facts = [
+        _fact(fact_id="stable-1", source_episode_id="episode-1"),
+        _fact(fact_id="stable-2", source_episode_id="episode-2"),
+    ]
+
+    result = compile_memory_patterns(facts, project_scope="memory-fabric")
+
+    assert result["project_scope"] == "memory-fabric"
+    assert result["input_fact_count"] == 2
+    assert result["current_fact_count"] == 1
+    assert [pattern["pattern_type"] for pattern in result["patterns"]] == ["stable_repeated_claim"]
+    assert result["methodology_candidate"]["status"] == "review_required"
+    assert "has not been applied" in result["methodology_candidate"]["summary"]
+
+
+def test_superseded_facts_compile_into_evolution_pattern():
+    old = _fact(fact_id="old", object="use contradiction review only")
+    new = _fact(
+        fact_id="new",
+        object="compile review-only procedure candidates",
+        valid_from="2026-05-24T00:00:00Z",
+        system_created_at="2026-05-24T08:00:00Z",
+        supersedes=["old"],
+    )
+
+    result = compile_memory_patterns([old, new], project_scope="memory-fabric")
+
+    evolution = [pattern for pattern in result["patterns"] if pattern["pattern_type"] == "superseded_lineage_evolution"]
+    assert len(evolution) == 1
+    assert evolution[0]["current_fact_id"] == "new"
+    assert evolution[0]["superseded_fact_ids"] == ["old"]
+
+
+def test_contradictions_compile_into_review_required_pattern():
+    facts = [
+        _fact(fact_id="allowed", object="allow external memory exposure"),
+        _fact(fact_id="blocked", object="block external memory exposure"),
+    ]
+
+    result = compile_memory_patterns(facts, project_scope="memory-fabric")
+
+    contradictions = [pattern for pattern in result["patterns"] if pattern["pattern_type"] == "contradiction_review_required"]
+    assert len(contradictions) == 1
+    assert contradictions[0]["status"] == "review_required"
+    assert result["review_recommendation"]["action"] == "review_contradictions_before_methodology"
+
+
+def test_project_scope_isolation():
+    facts = [
+        _fact(fact_id="memory-1", project_id="memory-fabric"),
+        _fact(fact_id="memory-2", project_id="memory-fabric"),
+        _fact(fact_id="openclaw-1", project_id="openclaw", object="route external recall"),
+        _fact(fact_id="openclaw-2", project_id="openclaw", object="route external recall"),
+    ]
+
+    result = compile_memory_patterns(facts, project_scope="openclaw")
+
+    assert result["input_fact_count"] == 4
+    assert all(pattern["project_id"] == "openclaw" for pattern in result["patterns"])
+    assert result["patterns"][0]["fact_ids"] == ["openclaw-1", "openclaw-2"]
+
+
+def test_compiler_does_not_mutate_inputs():
+    facts = [_fact(fact_id="stable-1"), _fact(fact_id="stable-2")]
+    before = deepcopy(facts)
+
+    compile_memory_patterns(facts, project_scope="memory-fabric")
+
+    assert facts == before
+
+
+def test_output_policy_proves_no_memory_config_graph_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = compile_memory_patterns([_fact(fact_id="stable-1"), _fact(fact_id="stable-2")])
+
+    assert result["policy"] == MEMORY_COMPILER_POLICY
+    assert result["policy"]["read_only"] is True
+    assert result["policy"]["would_write_memory"] is False
+    assert result["policy"]["would_modify_config"] is False
+    assert result["policy"]["would_write_graph"] is False
+    assert result["policy"]["does_not_create_operation_events"] is True
+    assert result["policy"]["creates_review_candidates_only"] is True
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_procedure_block_candidate_has_review_required_status():
+    methodology = compile_methodology_candidate(
+        [
+            {
+                "pattern_id": "stable|memory-fabric|Hermes_Memory_Fabric|procedure|candidate",
+                "pattern_type": "stable_repeated_claim",
+            }
+        ],
+        project_scope="memory-fabric",
+    )
+
+    procedure = compile_procedure_block_candidate(methodology, project_scope="memory-fabric")
+
+    assert procedure["block_type"] == "procedure_candidate"
+    assert procedure["status"] == "review_required"
+    assert procedure["project_scope"] == "memory-fabric"
+    assert procedure["source_pattern_ids"] == methodology["source_pattern_ids"]
+    assert procedure["policy"] == MEMORY_COMPILER_POLICY
+
+
+def test_trace_and_recommendation_are_review_only():
+    result = compile_memory_patterns([_fact(fact_id="stable-1"), _fact(fact_id="stable-2")])
+
+    trace = explain_compilation_trace(result)
+    recommendation = recommend_compilation_action(result)
+
+    assert [step["step"] for step in trace] == [
+        "normalize_facts",
+        "select_current_facts",
+        "group_contradictions",
+        "compile_candidates",
+    ]
+    assert recommendation["creates_review_candidates_only"] is True

--- a/tests/agent/test_memory_contradiction_engine.py
+++ b/tests/agent/test_memory_contradiction_engine.py
@@ -1,0 +1,166 @@
+from copy import deepcopy
+
+from agent.memory_bitemporal_fact_graph import BITEMPORAL_FACT_GRAPH_POLICY
+from agent.memory_contradiction_engine import (
+    CONTRADICTION_ENGINE_POLICY,
+    RELATION_LABELS,
+    classify_fact_relation,
+    detect_contradiction_candidates,
+    explain_contradiction_group,
+    group_contradictions,
+    recommend_contradiction_action,
+)
+
+
+def _fact(**overrides):
+    base = {
+        "fact_id": "fact-1",
+        "subject": "Hermes Memory Fabric",
+        "predicate": "foundation",
+        "object": "Bi-temporal Fact Graph v0.1",
+        "project_id": "memory-fabric",
+        "source_episode_id": "episode-1",
+        "provenance": {"source": "bench"},
+        "confidence": 0.9,
+        "valid_from": "2026-05-23T00:00:00Z",
+        "system_created_at": "2026-05-23T08:00:00Z",
+        "governance": BITEMPORAL_FACT_GRAPH_POLICY,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_relation_labels_include_required_values():
+    assert set(RELATION_LABELS) == {"supports", "updates", "contradicts", "unrelated", "needs_review"}
+
+
+def test_same_fact_supports():
+    existing = _fact(fact_id="existing")
+    candidate = _fact(fact_id="candidate")
+
+    relation = classify_fact_relation(existing, candidate)
+
+    assert relation["relation"] == "supports"
+    assert relation["same_subject"] is True
+    assert relation["same_predicate"] is True
+    assert relation["same_project_id"] is True
+    assert relation["policy"] == CONTRADICTION_ENGINE_POLICY
+
+
+def test_same_subject_predicate_project_different_object_contradicts():
+    existing = _fact(fact_id="existing", object="Hybrid Retrieval Fusion v0.1")
+    candidate = _fact(fact_id="candidate", object="Contradiction Engine v0.1")
+
+    relation = classify_fact_relation(existing, candidate)
+
+    assert relation["relation"] == "contradicts"
+    assert relation["same_object"] is False
+    assert "same_subject_predicate_project_with_different_object" in relation["reasons"]
+
+
+def test_newer_valid_candidate_updates_older_expired_fact():
+    existing = _fact(
+        fact_id="old",
+        object="Bi-temporal Fact Graph v0.1",
+        valid_from="2026-05-20T00:00:00Z",
+        valid_until="2026-05-23T00:00:00Z",
+        system_invalidated_at="2026-05-23T00:00:00Z",
+    )
+    candidate = _fact(
+        fact_id="new",
+        object="Contradiction Engine v0.1",
+        valid_from="2026-05-23T00:00:00Z",
+        system_created_at="2026-05-23T10:00:00Z",
+        supersedes=["old"],
+    )
+
+    relation = classify_fact_relation(existing, candidate)
+
+    assert relation["relation"] == "updates"
+    assert relation["validity_windows_overlap"] is False
+
+
+def test_different_project_is_unrelated():
+    existing = _fact(fact_id="existing", project_id="memory-fabric")
+    candidate = _fact(fact_id="candidate", project_id="openclaw")
+
+    relation = classify_fact_relation(existing, candidate)
+
+    assert relation["relation"] == "unrelated"
+    assert relation["same_project_id"] is False
+
+
+def test_missing_provenance_creates_needs_review_rather_than_hard_allow():
+    existing = _fact(fact_id="existing")
+    candidate = _fact(fact_id="candidate", provenance=None, source_episode_id=None)
+
+    relation = classify_fact_relation(existing, candidate)
+
+    assert relation["relation"] == "needs_review"
+    assert "missing_provenance" in relation["risks"]
+
+
+def test_unsafe_governance_creates_reviewable_contradiction_risk():
+    existing = _fact(fact_id="existing", object="external exposure allowed")
+    candidate = _fact(
+        fact_id="candidate",
+        object="external exposure blocked",
+        governance={"read_only": False, "would_write_memory": True},
+    )
+
+    relation = classify_fact_relation(existing, candidate)
+
+    assert relation["relation"] == "needs_review"
+    assert "same_subject_predicate_project_with_different_object" in relation["reasons"]
+    assert "unsafe_governance:would_write_memory" in relation["risks"]
+    assert "unsafe_governance:read_only" in relation["risks"]
+
+
+def test_input_facts_are_not_mutated():
+    existing = _fact(fact_id="existing", object="allowed")
+    candidate = _fact(fact_id="candidate", object="blocked")
+    existing_before = deepcopy(existing)
+    candidate_before = deepcopy(candidate)
+
+    classify_fact_relation(existing, candidate)
+    group_contradictions([existing, candidate])
+
+    assert existing == existing_before
+    assert candidate == candidate_before
+
+
+def test_detect_and_group_contradictions_return_review_recommendation():
+    existing = _fact(fact_id="allowed", object="external-channel memory exposure allowed")
+    candidate = _fact(fact_id="blocked", object="external-channel memory exposure blocked")
+
+    detected = detect_contradiction_candidates([existing], [candidate])
+    groups = group_contradictions([existing, candidate])
+    explanation = explain_contradiction_group(groups[0])
+    action = recommend_contradiction_action(groups[0])
+
+    assert [item["relation"] for item in detected] == ["contradicts"]
+    assert len(groups) == 1
+    assert groups[0]["objects"] == [
+        "external-channel memory exposure allowed",
+        "external-channel memory exposure blocked",
+    ]
+    assert explanation["recommended_action"]["action"] == "review_contradiction"
+    assert action["creates_review_recommendations_only"] is True
+
+
+def test_policy_proves_no_memory_config_graph_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    relation = classify_fact_relation(_fact(fact_id="existing"), _fact(fact_id="candidate"))
+
+    assert relation["policy"] == CONTRADICTION_ENGINE_POLICY
+    assert relation["policy"]["read_only"] is True
+    assert relation["policy"]["would_write_memory"] is False
+    assert relation["policy"]["would_modify_config"] is False
+    assert relation["policy"]["would_write_graph"] is False
+    assert relation["policy"]["does_not_create_operation_events"] is True
+    assert relation["policy"]["creates_review_recommendations_only"] is True
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()

--- a/tests/agent/test_memory_evidence_repair_apply_preview.py
+++ b/tests/agent/test_memory_evidence_repair_apply_preview.py
@@ -1,0 +1,137 @@
+from agent.memory_evidence_repair_apply_preview import (
+    PATCH_OPERATION,
+    PREVIEW_STATUS_AWAITING_CONFIRMATION,
+    PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE,
+    PREVIEW_STATUS_READY_FOR_MANUAL_APPLY,
+    build_evidence_repair_apply_preview,
+    empty_evidence_repair_apply_preview,
+)
+
+
+def test_builds_ready_apply_preview_for_approved_candidate():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "source": "policy_gate",
+                "reason": "Missing explicit provenance.",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        approved_candidate_ids=["repair-123"],
+    )
+
+    payload = report.to_dict()
+    preview = payload["previews"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["ready_count"] == 1
+    assert preview["id"].startswith("preview-")
+    assert preview["candidate_id"] == "repair-123"
+    assert preview["status"] == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY
+    assert preview["operation"] == PATCH_OPERATION
+    assert preview["would_update_fields"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert preview["missing_evidence"] == []
+    assert preview["memory_patch_preview"]["operation"] == PATCH_OPERATION
+
+
+def test_preview_blocks_missing_evidence_until_completed():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-456",
+                "provider": "graph",
+                "priority": "medium",
+                "repair_action": "refresh_observation",
+                "required_evidence": ["observed_at", "freshness_check"],
+                "proposed_evidence_patch": {
+                    "observed_at": "<pending>",
+                    "freshness_check": "confirmed_current",
+                },
+            }
+        ],
+        approved_candidate_ids=["repair-456"],
+    )
+
+    payload = report.to_dict()
+    preview = payload["previews"][0]
+    assert preview["status"] == PREVIEW_STATUS_BLOCKED_MISSING_EVIDENCE
+    assert preview["missing_evidence"] == ["observed_at"]
+    assert payload["summary"]["missing_evidence_count"] == 1
+    assert payload["summary"]["ready_count"] == 0
+
+
+def test_preview_awaits_confirmation_when_not_approved():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-789",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "required_evidence": ["source_url"],
+                "proposed_evidence_patch": {"source_url": "https://example.com"},
+            }
+        ],
+    )
+
+    payload = report.to_dict()
+    assert payload["previews"][0]["status"] == PREVIEW_STATUS_AWAITING_CONFIRMATION
+    assert payload["summary"]["requires_user_confirmation"] is True
+
+
+def test_proposed_evidence_can_fill_candidate_patch():
+    report = build_evidence_repair_apply_preview(
+        candidates=[
+            {
+                "id": "repair-abc",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "required_evidence": ["source_url", "observed_at"],
+                "proposed_evidence_patch": {
+                    "source_url": "<pending>",
+                    "observed_at": "<pending>",
+                },
+            }
+        ],
+        approved_candidate_ids=["repair-abc"],
+        proposed_evidence={
+            "repair-abc": {
+                "source_url": "https://example.com/source",
+                "observed_at": "2026-05-11T00:00:00Z",
+            }
+        },
+    )
+
+    preview = report.to_dict()["previews"][0]
+    assert preview["status"] == PREVIEW_STATUS_READY_FOR_MANUAL_APPLY
+    assert preview["evidence_patch"] == {
+        "source_url": "https://example.com/source",
+        "observed_at": "2026-05-11T00:00:00Z",
+    }
+
+
+def test_empty_apply_preview_is_read_only():
+    payload = empty_evidence_repair_apply_preview().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["preview_count"] == 0
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_approval.py
+++ b/tests/agent/test_memory_evidence_repair_approval.py
@@ -1,0 +1,101 @@
+from agent.memory_evidence_repair_approval import (
+    CANDIDATE_TYPE,
+    PENDING_VALUE,
+    STATUS_NEEDS_CONFIRMATION,
+    build_evidence_repair_approval_candidates,
+    empty_evidence_repair_approval_candidates,
+)
+
+
+def test_builds_approval_candidate_from_repair_plan():
+    report = build_evidence_repair_approval_candidates(
+        plan={
+            "repairs": [
+                {
+                    "provider": "builtin",
+                    "priority": "high",
+                    "action": "attach_provenance",
+                    "source": "policy_gate",
+                    "reason": "Missing explicit provenance.",
+                    "content_preview": "Weak memory content.",
+                    "required_evidence": [
+                        "source_url",
+                        "observed_at",
+                        "verification_signal",
+                    ],
+                }
+            ],
+            "read_only": True,
+        }
+    )
+
+    payload = report.to_dict()
+    candidate = payload["candidates"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["summary"]["candidate_count"] == 1
+    assert payload["summary"]["requires_user_confirmation"] is True
+    assert candidate["id"].startswith("repair-")
+    assert candidate["candidate_type"] == CANDIDATE_TYPE
+    assert candidate["status"] == STATUS_NEEDS_CONFIRMATION
+    assert candidate["provider"] == "builtin"
+    assert candidate["required_evidence"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert candidate["proposed_evidence_patch"] == {
+        "source_url": PENDING_VALUE,
+        "observed_at": PENDING_VALUE,
+        "verification_signal": PENDING_VALUE,
+    }
+
+
+def test_candidate_id_is_stable_and_proposed_evidence_fills_patch():
+    plan = {
+        "repairs": [
+            {
+                "provider": "graph",
+                "priority": "medium",
+                "action": "refresh_observation",
+                "source": "diagnostics",
+                "reason": "Recall may be stale.",
+                "required_evidence": ["observed_at", "freshness_check"],
+            }
+        ]
+    }
+
+    first = build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence={
+            "observed_at": "2026-05-11T00:00:00Z",
+            "freshness_check": "confirmed_current",
+        },
+    ).to_dict()
+    second = build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence={
+            "observed_at": "2026-05-11T00:00:00Z",
+            "freshness_check": "confirmed_current",
+        },
+    ).to_dict()
+
+    first_candidate = first["candidates"][0]
+    second_candidate = second["candidates"][0]
+    assert first_candidate["id"] == second_candidate["id"]
+    assert first_candidate["proposed_evidence_patch"] == {
+        "observed_at": "2026-05-11T00:00:00Z",
+        "freshness_check": "confirmed_current",
+    }
+    assert first["summary"]["by_provider"] == {"graph": 1}
+    assert first["summary"]["by_repair_action"] == {"refresh_observation": 1}
+
+
+def test_empty_approval_report_is_read_only():
+    payload = empty_evidence_repair_approval_candidates().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["summary"]["candidate_count"] == 0
+    assert payload["summary"]["requires_user_confirmation"] is False
+    assert payload["candidates"] == []

--- a/tests/agent/test_memory_evidence_repair_approval_token_gate.py
+++ b/tests/agent/test_memory_evidence_repair_approval_token_gate.py
@@ -1,0 +1,148 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    CHECK_CONFIRMATION_TEXT,
+    CHECK_EXPIRY,
+    CHECK_PATCH_DIGESTS,
+    CHECK_REUSE,
+    TOKEN_GATE_STATUS_BLOCKED,
+    TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    TOKEN_GATE_STATUS_VERIFIED,
+    build_evidence_repair_approval_token_gate,
+    empty_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def test_exact_confirmation_verifies_token_gate():
+    token_report = _token_report()
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=confirmation_text,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == TOKEN_GATE_STATUS_VERIFIED
+    assert payload["summary"]["manual_commit_verified"] is True
+    assert payload["summary"]["fail_count"] == 0
+    assert payload["verified_operation_ids"] == ["dryrun-op-123"]
+    assert payload["verified_candidate_ids"] == ["repair-123"]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+
+
+def test_wrong_confirmation_blocks_token_gate():
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=_token_report(),
+        confirmation_text="APPROVE the wrong thing",
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_CONFIRMATION_TEXT in failed_checks
+    assert "provide_exact_confirmation_text" in payload["required_actions"]
+
+
+def test_changed_patch_digest_blocks_token_gate():
+    token_report = _token_report()
+    dry_run = _ready_dry_run()
+    dry_run["operations"][0]["patch_digest"] = "b" * 64
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        dry_run=dry_run,
+        confirmation_text=confirmation_text,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_PATCH_DIGESTS in failed_checks
+    assert "regenerate_human_approval_token_for_current_patch_set" in payload["required_actions"]
+
+
+def test_expired_token_blocks_token_gate():
+    token_report = _token_report()
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=confirmation_text,
+        current_time="2026-05-11T00:31:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_EXPIRY in failed_checks
+    assert "Approval token has expired." in payload["blocking_reasons"]
+
+
+def test_used_token_id_blocks_token_gate():
+    token_report = _token_report()
+    token_id = token_report["tokens"][0]["id"]
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=confirmation_text,
+        used_token_ids=[token_id],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_REUSE in failed_checks
+    assert "Approval token is already marked as used." in payload["blocking_reasons"]
+
+
+def test_empty_token_gate_is_read_only():
+    payload = empty_evidence_repair_approval_token_gate().to_dict()
+
+    assert payload["status"] == TOKEN_GATE_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["checks"] == []

--- a/tests/agent/test_memory_evidence_repair_commit_gate.py
+++ b/tests/agent/test_memory_evidence_repair_commit_gate.py
@@ -1,0 +1,118 @@
+from agent.memory_evidence_repair_commit_gate import (
+    DECISION_ALLOW_MANUAL_COMMIT,
+    DECISION_BLOCK_COMMIT,
+    DECISION_NEEDS_USER_CONFIRMATION,
+    REASON_MISSING_CONFIRMATION,
+    REASON_MISSING_EVIDENCE,
+    REASON_UNSAFE_OPERATION,
+    build_evidence_repair_commit_gate,
+    empty_evidence_repair_commit_gate,
+)
+
+
+def _ready_preview():
+    return {
+        "id": "preview-123",
+        "candidate_id": "repair-123",
+        "status": "ready_for_manual_apply",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "operation": "merge_evidence_metadata",
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "target": {"candidate_id": "repair-123", "provider": "builtin"},
+            "set": {"evidence": {}},
+        },
+        "missing_evidence": [],
+    }
+
+
+def test_gate_allows_ready_preview_with_explicit_confirmation():
+    report = build_evidence_repair_commit_gate(
+        previews=[_ready_preview()],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    payload = report.to_dict()
+    decision = payload["decisions"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["allow_count"] == 1
+    assert decision["decision"] == DECISION_ALLOW_MANUAL_COMMIT
+    assert decision["reasons"] == []
+    assert decision["required_actions"] == []
+    assert decision["preview_id"] == "preview-123"
+
+
+def test_gate_needs_confirmation_for_ready_unconfirmed_preview():
+    report = build_evidence_repair_commit_gate(previews=[_ready_preview()])
+
+    payload = report.to_dict()
+    decision = payload["decisions"][0]
+    assert decision["decision"] == DECISION_NEEDS_USER_CONFIRMATION
+    assert decision["reasons"] == [REASON_MISSING_CONFIRMATION]
+    assert "obtain_explicit_user_confirmation" in decision["required_actions"]
+    assert payload["summary"]["requires_user_confirmation"] is True
+
+
+def test_gate_blocks_missing_evidence_even_when_confirmed():
+    preview = _ready_preview()
+    preview["missing_evidence"] = ["source_url"]
+
+    report = build_evidence_repair_commit_gate(
+        previews=[preview],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    payload = report.to_dict()
+    decision = payload["decisions"][0]
+    assert decision["decision"] == DECISION_BLOCK_COMMIT
+    assert REASON_MISSING_EVIDENCE in decision["reasons"]
+    assert payload["summary"]["blocked_count"] == 1
+
+
+def test_gate_blocks_unsafe_operation():
+    preview = _ready_preview()
+    preview["operation"] = "replace_memory_content"
+
+    report = build_evidence_repair_commit_gate(
+        previews=[preview],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    decision = report.to_dict()["decisions"][0]
+    assert decision["decision"] == DECISION_BLOCK_COMMIT
+    assert REASON_UNSAFE_OPERATION in decision["reasons"]
+
+
+def test_conflict_preview_requires_resolution():
+    preview = _ready_preview()
+    preview["repair_action"] = "review_conflict"
+
+    report = build_evidence_repair_commit_gate(
+        previews=[preview],
+        confirmed_preview_ids=["preview-123"],
+    )
+
+    decision = report.to_dict()["decisions"][0]
+    assert decision["decision"] == DECISION_BLOCK_COMMIT
+    assert decision["conflict_risk"] == "high"
+    assert "provide_conflict_resolution" in decision["required_actions"]
+
+
+def test_empty_commit_gate_is_read_only():
+    payload = empty_evidence_repair_commit_gate().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["decision_count"] == 0
+    assert payload["decisions"] == []

--- a/tests/agent/test_memory_evidence_repair_commit_ledger.py
+++ b/tests/agent/test_memory_evidence_repair_commit_ledger.py
@@ -1,0 +1,110 @@
+from agent.memory_evidence_repair_commit_ledger import (
+    LEDGER_EVENT_TYPE,
+    LEDGER_STATUS_DRAFT,
+    OUTCOME_ALLOWED,
+    OUTCOME_BLOCKED,
+    OUTCOME_NEEDS_CONFIRMATION,
+    build_evidence_repair_commit_ledger,
+    empty_evidence_repair_commit_ledger,
+)
+
+
+def _allow_decision():
+    return {
+        "id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "decision": "allow_manual_commit",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "reasons": [],
+        "required_actions": [],
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "set": {"evidence": {}},
+        },
+        "conflict_risk": "low",
+    }
+
+
+def test_ledger_entry_from_allow_decision():
+    draft = build_evidence_repair_commit_ledger(
+        decisions=[_allow_decision()],
+        ledger_actor="tester",
+        ledger_reason="audit before manual memory write",
+    )
+
+    payload = draft.to_dict()
+    entry = payload["entries"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["allow_count"] == 1
+    assert entry["id"].startswith("ledger-")
+    assert entry["event_type"] == LEDGER_EVENT_TYPE
+    assert entry["status"] == LEDGER_STATUS_DRAFT
+    assert entry["outcome"] == OUTCOME_ALLOWED
+    assert entry["manual_commit_allowed"] is True
+    assert entry["blocked"] is False
+    assert entry["requires_followup"] is False
+    assert entry["evidence_fields"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert len(entry["patch_digest"]) == 64
+    assert entry["metadata"]["ledger_actor"] == "tester"
+
+
+def test_ledger_entry_from_blocked_decision_requires_followup():
+    decision = _allow_decision()
+    decision["decision"] = "block_commit"
+    decision["reasons"] = ["missing_evidence"]
+    decision["required_actions"] = ["complete_required_evidence"]
+
+    payload = build_evidence_repair_commit_ledger(decisions=[decision]).to_dict()
+    entry = payload["entries"][0]
+    assert entry["outcome"] == OUTCOME_BLOCKED
+    assert entry["manual_commit_allowed"] is False
+    assert entry["blocked"] is True
+    assert entry["requires_followup"] is True
+    assert payload["summary"]["blocked_count"] == 1
+    assert payload["summary"]["followup_count"] == 1
+
+
+def test_ledger_entry_from_needs_confirmation_decision():
+    decision = _allow_decision()
+    decision["decision"] = "needs_user_confirmation"
+    decision["reasons"] = ["missing_user_confirmation"]
+    decision["required_actions"] = ["obtain_explicit_user_confirmation"]
+
+    payload = build_evidence_repair_commit_ledger(decisions=[decision]).to_dict()
+    entry = payload["entries"][0]
+    assert entry["outcome"] == OUTCOME_NEEDS_CONFIRMATION
+    assert entry["requires_followup"] is True
+    assert payload["summary"]["by_outcome"] == {OUTCOME_NEEDS_CONFIRMATION: 1}
+
+
+def test_ledger_entry_id_and_patch_digest_are_stable():
+    first = build_evidence_repair_commit_ledger(decisions=[_allow_decision()]).to_dict()
+    second = build_evidence_repair_commit_ledger(decisions=[_allow_decision()]).to_dict()
+
+    assert first["entries"][0]["id"] == second["entries"][0]["id"]
+    assert first["entries"][0]["patch_digest"] == second["entries"][0]["patch_digest"]
+
+
+def test_empty_ledger_is_read_only():
+    payload = empty_evidence_repair_commit_ledger().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["entry_count"] == 0
+    assert payload["entries"] == []

--- a/tests/agent/test_memory_evidence_repair_commit_receipt.py
+++ b/tests/agent/test_memory_evidence_repair_commit_receipt.py
@@ -1,0 +1,150 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    RECEIPT_STATUS_BLOCKED,
+    RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECEIPT_STATUS_READY,
+    RECEIPT_TYPE,
+    build_evidence_repair_commit_receipt,
+    empty_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def _verified_gate():
+    token_report = _token_report()
+    return build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def test_verified_gate_creates_read_only_commit_receipt():
+    payload = build_evidence_repair_commit_receipt(
+        token_gate=_verified_gate(),
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+
+    receipt = payload["receipts"][0]
+    assert payload["status"] == RECEIPT_STATUS_READY
+    assert payload["summary"]["commit_receipt_available"] is True
+    assert payload["summary"]["would_mark_token_used_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert receipt["id"].startswith("commit-receipt-")
+    assert receipt["receipt_type"] == RECEIPT_TYPE
+    assert receipt["actor"] == "han"
+    assert receipt["operation_ids"] == ["dryrun-op-123"]
+    assert receipt["ledger_entry_ids"] == ["ledger-123"]
+    assert receipt["candidate_ids"] == ["repair-123"]
+    assert receipt["used_token_id"] in payload["used_token_ids"]
+
+
+def test_blocked_gate_does_not_create_receipt():
+    gate = _verified_gate()
+    gate["status"] = "blocked"
+    gate["blocking_reasons"] = ["Approval token has expired."]
+    gate["required_actions"] = ["regenerate_human_approval_token"]
+
+    payload = build_evidence_repair_commit_receipt(token_gate=gate).to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert payload["blocking_reasons"] == ["Approval token has expired."]
+    assert payload["required_actions"] == ["regenerate_human_approval_token"]
+
+
+def test_existing_used_token_blocks_receipt():
+    gate = _verified_gate()
+    token_id = gate["token_id"]
+
+    payload = build_evidence_repair_commit_receipt(
+        token_gate=gate,
+        existing_receipts={"used_token_ids": [token_id]},
+    ).to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "Approval token is already present in the used-token ledger." in payload["blocking_reasons"]
+    assert token_id in payload["used_token_ids"]
+
+
+def test_receipt_id_and_digest_are_stable():
+    gate = _verified_gate()
+    first = build_evidence_repair_commit_receipt(
+        token_gate=gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+    second = build_evidence_repair_commit_receipt(
+        token_gate=gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+
+    assert first["receipts"][0]["id"] == second["receipts"][0]["id"]
+    assert first["receipts"][0]["receipt_digest"] == second["receipts"][0]["receipt_digest"]
+
+
+def test_no_action_gate_does_not_create_receipt():
+    payload = build_evidence_repair_commit_receipt(
+        token_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["receipts"] == []
+    assert payload["summary"]["commit_receipt_available"] is False
+
+
+def test_empty_receipt_report_is_read_only():
+    payload = empty_evidence_repair_commit_receipt().to_dict()
+
+    assert payload["status"] == RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["receipts"] == []

--- a/tests/agent/test_memory_evidence_repair_executor_preview.py
+++ b/tests/agent/test_memory_evidence_repair_executor_preview.py
@@ -1,0 +1,168 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_executor_preview import (
+    CHECK_EXECUTION_OPERATIONS,
+    CHECK_WRITE_LOCK_EXPIRY,
+    CHECK_WRITE_LOCK_INTEGRITY,
+    EXECUTOR_PREVIEW_STATUS_BLOCKED,
+    EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    EXECUTOR_PREVIEW_STATUS_READY,
+    build_evidence_repair_executor_preview,
+    empty_evidence_repair_executor_preview,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    build_evidence_repair_write_lock_gate,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _write_lock_gate():
+    token_report = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token_gate = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+    receipt = build_evidence_repair_commit_receipt(
+        token_gate=token_gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+    return build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+
+def test_ready_write_lock_creates_executor_preview_steps():
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=_write_lock_gate(),
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    steps = preview["steps"]
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_READY
+    assert payload["summary"]["manual_executor_preview_ready"] is True
+    assert payload["summary"]["future_write_step_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("executor-preview-")
+    assert preview["would_apply_memory_patches"] is True
+    assert preview["would_release_write_lock"] is True
+    assert [step["action"] for step in steps] == [
+        "verify_write_lock_and_receipt",
+        "apply_evidence_metadata_patch",
+        "record_commit_receipt",
+        "mark_approval_token_used",
+        "release_write_lock",
+    ]
+    assert steps[1]["operation_id"] == "dryrun-op-123"
+    assert steps[1]["future_would_write_memory"] is True
+    assert steps[-1]["stop_on_failure"] is False
+
+
+def test_expired_write_lock_blocks_executor_preview():
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=_write_lock_gate(),
+        current_time="2026-05-11T00:36:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_WRITE_LOCK_EXPIRY in failed_checks
+    assert "regenerate_write_lock_gate" in payload["required_actions"]
+
+
+def test_tampered_write_lock_digest_blocks_executor_preview():
+    gate = _write_lock_gate()
+    gate["locks"][0]["lock_digest"] = "bad"
+
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=gate,
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_WRITE_LOCK_INTEGRITY in failed_checks
+    assert "regenerate_write_lock_gate" in payload["required_actions"]
+
+
+def test_mismatched_operation_patch_blocks_executor_preview():
+    gate = _write_lock_gate()
+    source_operation = (
+        gate["locks"][0]["source_receipt"]["source_gate"]["source_dry_run"]["operations"][0]
+    )
+    source_operation["patch_digest"] = "b" * 64
+
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=gate,
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_EXECUTION_OPERATIONS in failed_checks
+
+
+def test_no_action_write_lock_gate_does_not_create_preview():
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["executor_preview_available"] is False
+
+
+def test_empty_executor_preview_is_read_only():
+    payload = empty_evidence_repair_executor_preview().to_dict()
+
+    assert payload["status"] == EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_human_approval_token.py
+++ b/tests/agent/test_memory_evidence_repair_human_approval_token.py
@@ -1,0 +1,113 @@
+from agent.memory_evidence_repair_human_approval_token import (
+    APPROVAL_TOKEN_SCOPE,
+    APPROVAL_TOKEN_TYPE,
+    TOKEN_STATUS_BLOCKED,
+    TOKEN_STATUS_DRAFT_READY,
+    TOKEN_STATUS_NO_ACTION_NEEDED,
+    build_evidence_repair_human_approval_token,
+    empty_evidence_repair_human_approval_token,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def test_ready_dry_run_creates_token_draft():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=45,
+    ).to_dict()
+
+    token = payload["tokens"][0]
+    assert payload["status"] == TOKEN_STATUS_DRAFT_READY
+    assert payload["summary"]["token_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert token["id"].startswith("approval-token-")
+    assert token["token_type"] == APPROVAL_TOKEN_TYPE
+    assert token["scope"] == APPROVAL_TOKEN_SCOPE
+    assert token["approver"] == "han"
+    assert token["expires_in_minutes"] == 45
+    assert token["operation_ids"] == ["dryrun-op-123"]
+    assert token["ledger_entry_ids"] == ["ledger-123"]
+    assert token["candidate_ids"] == ["repair-123"]
+    assert len(token["token_digest"]) == 64
+    assert token["one_time_constraints"]["one_time_use"] is True
+    assert token["required_confirmation_text"].startswith("APPROVE ")
+
+
+def test_blocked_dry_run_does_not_create_token():
+    dry_run = _ready_dry_run()
+    dry_run["status"] = "blocked"
+    dry_run["blocking_reasons"] = ["Pre-commit snapshots are still required."]
+    dry_run["required_actions"] = ["capture_pre_commit_snapshots"]
+
+    payload = build_evidence_repair_human_approval_token(dry_run=dry_run).to_dict()
+
+    assert payload["status"] == TOKEN_STATUS_BLOCKED
+    assert payload["tokens"] == []
+    assert payload["blocking_reasons"] == ["Pre-commit snapshots are still required."]
+    assert payload["required_actions"] == ["capture_pre_commit_snapshots"]
+
+
+def test_no_action_dry_run_does_not_create_token():
+    payload = build_evidence_repair_human_approval_token(
+        dry_run={"status": "no_action_needed", "operations": []}
+    ).to_dict()
+
+    assert payload["status"] == TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["tokens"] == []
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_token_id_and_digest_are_stable():
+    first = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+    ).to_dict()
+    second = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+    ).to_dict()
+
+    assert first["tokens"][0]["id"] == second["tokens"][0]["id"]
+    assert first["tokens"][0]["token_digest"] == second["tokens"][0]["token_digest"]
+
+
+def test_empty_token_report_is_read_only():
+    payload = empty_evidence_repair_human_approval_token().to_dict()
+
+    assert payload["status"] == TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["tokens"] == []

--- a/tests/agent/test_memory_evidence_repair_manual_commit_dry_run.py
+++ b/tests/agent/test_memory_evidence_repair_manual_commit_dry_run.py
@@ -1,0 +1,150 @@
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    CHECK_STATUS_FAIL,
+    CHECK_STATUS_PASS,
+    DRY_RUN_STATUS_BLOCKED,
+    DRY_RUN_STATUS_NO_ACTION_NEEDED,
+    DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT,
+    build_evidence_repair_manual_commit_dry_run,
+    empty_evidence_repair_manual_commit_dry_run,
+)
+
+
+def _commit_gate_allow():
+    return {
+        "summary": {
+            "decision_count": 1,
+            "allow_count": 1,
+            "blocked_count": 0,
+            "needs_confirmation_count": 0,
+        },
+        "decisions": [{"decision": "allow_manual_commit"}],
+    }
+
+
+def _ledger_allow():
+    return {
+        "summary": {
+            "entry_count": 1,
+            "allow_count": 1,
+            "blocked_count": 0,
+            "followup_count": 0,
+        },
+        "entries": [
+            {
+                "id": "ledger-123",
+                "manual_commit_allowed": True,
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+            }
+        ],
+    }
+
+
+def _rollback_ready():
+    return {
+        "summary": {
+            "rollback_step_count": 1,
+            "ready_count": 1,
+            "snapshot_required_count": 0,
+        },
+        "steps": [{"status": "ready_for_manual_rollback"}],
+    }
+
+
+def _snapshot_available():
+    return {
+        "summary": {
+            "snapshot_request_count": 1,
+            "capture_required_count": 0,
+            "blocking_count": 0,
+        },
+        "requests": [{"status": "already_available"}],
+    }
+
+
+def test_ready_dry_run_allows_manual_commit_without_mutation():
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=_snapshot_available(),
+        commit_gate=_commit_gate_allow(),
+        ledger=_ledger_allow(),
+        rollback_plan=_rollback_ready(),
+    ).to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_READY_FOR_MANUAL_COMMIT
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["manual_commit_allowed"] is True
+    assert payload["summary"]["operation_count"] == 1
+    assert payload["operations"][0]["id"].startswith("dryrun-op-")
+    assert payload["blocking_reasons"] == []
+    assert {check["status"] for check in payload["checks"]} == {CHECK_STATUS_PASS}
+
+
+def test_dry_run_blocks_when_snapshot_capture_is_required():
+    snapshot_plan = _snapshot_available()
+    snapshot_plan["summary"]["capture_required_count"] = 1
+    snapshot_plan["summary"]["blocking_count"] = 1
+
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=snapshot_plan,
+        commit_gate=_commit_gate_allow(),
+        ledger=_ledger_allow(),
+        rollback_plan=_rollback_ready(),
+    ).to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_BLOCKED
+    assert payload["summary"]["has_blocks"] is True
+    assert "Pre-commit snapshots are still required." in payload["blocking_reasons"]
+    assert "capture_pre_commit_snapshots" in payload["required_actions"]
+
+
+def test_dry_run_blocks_when_commit_gate_is_not_clean():
+    commit_gate = _commit_gate_allow()
+    commit_gate["summary"]["blocked_count"] = 1
+    commit_gate["summary"]["allow_count"] = 0
+
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=_snapshot_available(),
+        commit_gate=commit_gate,
+        ledger=_ledger_allow(),
+        rollback_plan=_rollback_ready(),
+    ).to_dict()
+
+    gate_check = next(check for check in payload["checks"] if check["id"] == "commit_gate")
+    assert payload["status"] == DRY_RUN_STATUS_BLOCKED
+    assert gate_check["status"] == CHECK_STATUS_FAIL
+    assert "resolve_commit_gate_blocks" in gate_check["required_actions"]
+
+
+def test_dry_run_has_no_action_without_operations():
+    payload = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan={},
+        commit_gate={},
+        ledger={},
+        rollback_plan={},
+    ).to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_NO_ACTION_NEEDED
+    assert payload["summary"]["operation_count"] == 0
+    assert payload["summary"]["manual_commit_allowed"] is False
+
+
+def test_empty_dry_run_is_read_only():
+    payload = empty_evidence_repair_manual_commit_dry_run().to_dict()
+
+    assert payload["status"] == DRY_RUN_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["checks"] == []
+    assert payload["operations"] == []

--- a/tests/agent/test_memory_evidence_repair_planner.py
+++ b/tests/agent/test_memory_evidence_repair_planner.py
@@ -1,0 +1,75 @@
+from agent.memory_evidence_repair_planner import (
+    ACTION_ATTACH_PROVENANCE,
+    ACTION_REFRESH_OBSERVATION,
+    build_evidence_repair_plan,
+    empty_evidence_repair_plan,
+)
+
+
+def test_plan_from_policy_gate_filters_requires_provenance():
+    plan = build_evidence_repair_plan(
+        gate={
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                },
+                {
+                    "provider": "graph",
+                    "action": "allow_memory_recall",
+                    "effect": "allowed",
+                    "reason": "No restriction.",
+                },
+            ]
+        }
+    )
+
+    payload = plan.to_dict()
+    assert payload["read_only"] is True
+    assert payload["summary"]["repair_count"] == 1
+    assert payload["summary"]["blocked_count"] == 1
+    assert payload["repairs"][0]["provider"] == "builtin"
+    assert payload["repairs"][0]["action"] == ACTION_ATTACH_PROVENANCE
+    assert "source_url" in payload["repairs"][0]["required_evidence"]
+
+
+def test_plan_from_diagnostics_and_audit():
+    plan = build_evidence_repair_plan(
+        diagnostics={
+            "issues": [
+                {
+                    "provider": "graph",
+                    "code": "refresh_stale_recall",
+                    "reason": "Recall may be stale.",
+                    "evidence": "staleness=0.7",
+                }
+            ]
+        },
+        audit={
+            "entries": [
+                {
+                    "provider": "builtin",
+                    "decision": "injected",
+                    "recommendation": "needs_evidence",
+                    "dimensions": {"source_strength": 0.2, "evidence_strength": 0.3},
+                    "content_preview": "Remember a weakly sourced fact.",
+                }
+            ]
+        },
+    )
+
+    payload = plan.to_dict()
+    actions = {repair["action"] for repair in payload["repairs"]}
+    assert ACTION_ATTACH_PROVENANCE in actions
+    assert ACTION_REFRESH_OBSERVATION in actions
+    assert payload["summary"]["by_provider"] == {"builtin": 1, "graph": 1}
+
+
+def test_empty_plan_is_read_only():
+    payload = empty_evidence_repair_plan().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["summary"]["repair_count"] == 0
+    assert payload["repairs"] == []

--- a/tests/agent/test_memory_evidence_repair_post_commit_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_post_commit_audit_preview.py
@@ -1,0 +1,174 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_executor_preview import (
+    build_evidence_repair_executor_preview,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    CHECK_EXECUTOR_PREVIEW_INTEGRITY,
+    CHECK_OBSERVED_POST_STATE,
+    POST_COMMIT_AUDIT_STATUS_BLOCKED,
+    POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED,
+    POST_COMMIT_AUDIT_STATUS_READY,
+    build_evidence_repair_post_commit_audit_preview,
+    empty_evidence_repair_post_commit_audit_preview,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    build_evidence_repair_write_lock_gate,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _executor_preview():
+    token_report = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token_gate = build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+    receipt = build_evidence_repair_commit_receipt(
+        token_gate=token_gate,
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+    write_lock = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+    return build_evidence_repair_executor_preview(
+        write_lock_gate=write_lock,
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+
+def test_ready_executor_preview_creates_planned_post_commit_audit():
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=_executor_preview()
+    ).to_dict()
+
+    audit = payload["previews"][0]
+    categories = {step["category"] for step in audit["audit_steps"]}
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_READY
+    assert payload["summary"]["post_commit_audit_ready"] is True
+    assert payload["summary"]["planned_audit_step_count"] == 5
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert audit["id"].startswith("post-commit-audit-")
+    assert categories == {"memory_patch", "receipt", "token", "lock", "rollback"}
+
+
+def test_observed_post_commit_state_can_pass():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor,
+        observed_memory_patches={
+            "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+        },
+        recorded_receipts=[{"id": preview["receipt_id"]}],
+        used_token_ids=[preview["token_id"]],
+        released_lock_ids=[preview["lock_id"]],
+        rollback_status={"status": "snapshot_available"},
+    ).to_dict()
+
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_READY
+    assert payload["summary"]["observed_pass_step_count"] == 5
+    assert payload["summary"]["observed_fail_step_count"] == 0
+    assert payload["previews"][0]["observed_state_supplied"] is True
+
+
+def test_observed_missing_token_blocks_audit():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor,
+        observed_memory_patches={
+            "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+        },
+        recorded_receipts=[{"id": preview["receipt_id"]}],
+        used_token_ids=[],
+        released_lock_ids=[preview["lock_id"]],
+        rollback_status={"status": "snapshot_available"},
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_BLOCKED
+    assert CHECK_OBSERVED_POST_STATE in failed_checks
+    assert "investigate_post_commit_audit_failures" in payload["required_actions"]
+
+
+def test_tampered_executor_preview_blocks_audit():
+    executor = _executor_preview()
+    executor["previews"][0]["preview_digest"] = "bad"
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_BLOCKED
+    assert CHECK_EXECUTOR_PREVIEW_INTEGRITY in failed_checks
+    assert "regenerate_executor_preview" in payload["required_actions"]
+
+
+def test_no_action_executor_preview_does_not_create_audit():
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["post_commit_audit_preview_available"] is False
+
+
+def test_empty_post_commit_audit_preview_is_read_only():
+    payload = empty_evidence_repair_post_commit_audit_preview().to_dict()
+
+    assert payload["status"] == POST_COMMIT_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_approval_token_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_approval_token_gate.py
@@ -1,0 +1,137 @@
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    CHECK_EXECUTION_PREVIEW_DIGEST,
+    CHECK_RECOVERY_CONFIRMATION_TEXT,
+    CHECK_RECOVERY_EXPIRY,
+    CHECK_RECOVERY_REUSE,
+    RECOVERY_TOKEN_GATE_STATUS_BLOCKED,
+    RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_TOKEN_GATE_STATUS_VERIFIED,
+    build_evidence_repair_recovery_approval_token_gate,
+    empty_evidence_repair_recovery_approval_token_gate,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from tests.agent.test_memory_evidence_repair_recovery_human_approval_token import (
+    _manual_rollback_execution,
+    _preparedness_execution,
+)
+
+
+def _recovery_token_report():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def test_valid_recovery_token_and_confirmation_are_verified():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_VERIFIED
+    assert payload["summary"]["manual_recovery_verified"] is True
+    assert payload["summary"]["verified_operation_count"] == 1
+    assert payload["summary"]["verified_future_mutation_step_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["token_id"] == token["id"]
+    assert payload["verified_operation_ids"] == ["dryrun-op-123"]
+
+
+def test_wrong_confirmation_blocks_recovery_gate():
+    token_report = _recovery_token_report()
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text="wrong confirmation",
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CONFIRMATION_TEXT in failed_checks
+    assert "provide_exact_recovery_confirmation_text" in payload["required_actions"]
+
+
+def test_expired_recovery_token_blocks_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:25:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_EXPIRY in failed_checks
+    assert "regenerate_recovery_human_approval_token" in payload["required_actions"]
+
+
+def test_used_recovery_token_blocks_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        used_token_ids=[token["id"]],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_REUSE in failed_checks
+
+
+def test_mismatched_execution_preview_blocks_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    execution = _manual_rollback_execution()["previews"][0]
+    execution["preview_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        recovery_execution=execution,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_BLOCKED
+    assert CHECK_EXECUTION_PREVIEW_DIGEST in failed_checks
+
+
+def test_no_action_recovery_token_report_does_not_create_gate():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_preparedness_execution()
+    ).to_dict()
+
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED
+    assert payload["checks"] == []
+
+
+def test_empty_recovery_token_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_approval_token_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_GATE_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview.py
@@ -1,0 +1,152 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_preview import (
+    CHECK_RECOVERY_FINALIZATION_REQUIREMENTS,
+    CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY,
+    RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_FINALIZATION_STATUS_READY,
+    build_evidence_repair_recovery_closure_finalization_readiness_preview,
+    empty_evidence_repair_recovery_closure_finalization_readiness_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_audit_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    _ready_governance_seal,
+)
+
+
+def _ready_seal_audit():
+    return build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=_ready_governance_seal()
+    ).to_dict()
+
+
+def test_ready_seal_audit_creates_finalization_readiness():
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=_ready_seal_audit()
+    ).to_dict()
+
+    readiness = payload["readiness"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_READY
+    assert payload["summary"]["recovery_closure_finalization_ready"] is True
+    assert payload["summary"]["readiness_count"] == 1
+    assert payload["summary"]["would_allow_final_closure_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert readiness["id"].startswith("recovery-closure-finalization-readiness-")
+    assert readiness["status"] == RECOVERY_CLOSURE_FINALIZATION_DRAFT_STATUS_READY
+    assert readiness["seal_audit_preview_id"].startswith(
+        "recovery-closure-governance-seal-audit-"
+    )
+    assert readiness["operation_ids"] == ["dryrun-op-123"]
+    assert readiness["would_allow_final_closure"] is True
+    assert readiness["would_preserve_full_governance_chain"] is True
+    assert readiness["would_require_human_finalization"] is True
+    assert readiness["would_keep_read_only_until_manual_commit"] is True
+
+
+def test_blocked_seal_audit_blocks_finalization_readiness():
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit={
+            "status": "blocked",
+            "blocking_reasons": ["seal audit blocked"],
+            "required_actions": ["fix_seal_audit"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert payload["readiness"] == []
+    assert "fix_seal_audit" in payload["required_actions"]
+
+
+def test_tampered_seal_audit_digest_blocks_finalization_readiness():
+    seal_audit = _ready_seal_audit()
+    seal_audit["previews"][0]["audit_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_INTEGRITY in failed_checks
+    assert (
+        "regenerate_recovery_closure_governance_seal_audit_preview"
+        in payload["required_actions"]
+    )
+
+
+def test_tampered_source_seal_blocks_finalization_source_chain():
+    seal_audit = deepcopy(_ready_seal_audit())
+    seal_audit["previews"][0]["source_recovery_closure_governance_seal"][
+        "seal_digest"
+    ] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert CHECK_RECOVERY_FINALIZATION_SOURCE_CHAIN in failed_checks
+
+
+def test_missing_governance_handoff_flag_blocks_finalization_requirements():
+    seal_audit = deepcopy(_ready_seal_audit())
+    seal_audit["previews"][0]["would_verify_governance_handoff"] = False
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_BLOCKED
+    assert CHECK_RECOVERY_FINALIZATION_REQUIREMENTS in failed_checks
+
+
+def test_no_action_seal_audit_does_not_create_finalization_readiness():
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED
+    assert payload["readiness"] == []
+    assert (
+        payload["summary"]["recovery_closure_finalization_readiness_available"]
+        is False
+    )
+
+
+def test_empty_finalization_readiness_preview_is_read_only():
+    payload = (
+        empty_evidence_repair_recovery_closure_finalization_readiness_preview()
+        .to_dict()
+    )
+
+    assert payload["status"] == RECOVERY_CLOSURE_FINALIZATION_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["readiness"] == []
+
+
+def test_finalization_readiness_id_is_stable():
+    seal_audit = _ready_seal_audit()
+
+    first = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=seal_audit
+    ).to_dict()
+
+    assert first["readiness"][0]["id"] == second["readiness"][0]["id"]
+    assert (
+        first["readiness"][0]["finalization_digest"]
+        == second["readiness"][0]["finalization_digest"]
+    )

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_gate.py
@@ -1,0 +1,118 @@
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY,
+    CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS,
+    RECOVERY_CLOSURE_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_STATUS_READY,
+    build_evidence_repair_recovery_closure_gate,
+    empty_evidence_repair_recovery_closure_gate,
+)
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    build_evidence_repair_recovery_completion_audit_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_completion_audit_preview import (
+    _observed_recovery_steps,
+    _recovery_completion_receipt,
+)
+
+
+def _passing_completion_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+    return build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[row["token_id"]],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": False},
+    ).to_dict()
+
+
+def _planned_completion_audit():
+    return build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=_recovery_completion_receipt()
+    ).to_dict()
+
+
+def test_passing_completion_audit_creates_recovery_closure_draft():
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_passing_completion_audit()
+    ).to_dict()
+
+    closure = payload["closures"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_READY
+    assert payload["summary"]["recovery_closure_ready"] is True
+    assert payload["summary"]["would_close_recovery_loop_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert closure["id"].startswith("recovery-closure-")
+    assert closure["status"] == RECOVERY_CLOSURE_DRAFT_STATUS_READY
+    assert closure["closure_decision"] == "close_recovery_loop"
+    assert closure["operation_ids"] == ["dryrun-op-123"]
+    assert closure["would_close_recovery_loop"] is True
+    assert closure["would_mark_recovery_resolved"] is True
+    assert closure["would_preserve_audit_evidence"] is True
+
+
+def test_planned_completion_audit_blocks_recovery_closure():
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_planned_completion_audit()
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS in failed_checks
+    assert "provide_observed_recovery_completion_state" in payload["required_actions"]
+    assert payload["closures"] == []
+
+
+def test_failed_completion_audit_step_blocks_recovery_closure():
+    audit = _passing_completion_audit()
+    audit["previews"][0]["audit_steps"][0]["status"] = "fail"
+
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_AUDIT_OBSERVED_PASS in failed_checks
+    assert "investigate_recovery_completion_audit_failures" in payload["required_actions"]
+
+
+def test_tampered_completion_audit_digest_blocks_recovery_closure():
+    audit = _passing_completion_audit()
+    audit["previews"][0]["audit_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_AUDIT_INTEGRITY in failed_checks
+    assert "regenerate_recovery_completion_audit_preview" in payload["required_actions"]
+
+
+def test_no_action_completion_audit_does_not_create_closure():
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED
+    assert payload["closures"] == []
+    assert payload["summary"]["recovery_closure_available"] is False
+
+
+def test_empty_recovery_closure_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["closures"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview.py
@@ -1,0 +1,142 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY,
+    build_evidence_repair_recovery_closure_governance_seal_audit_preview,
+    empty_evidence_repair_recovery_closure_governance_seal_audit_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    _ready_ledger_audit,
+)
+
+
+def _ready_governance_seal():
+    return build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=_ready_ledger_audit()
+    ).to_dict()
+
+
+def test_ready_governance_seal_creates_audit_preview():
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=_ready_governance_seal()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_READY
+    assert payload["summary"]["recovery_closure_governance_seal_audit_ready"] is True
+    assert payload["summary"]["preview_count"] == 1
+    assert payload["summary"]["audit_step_count"] == 6
+    assert payload["summary"]["observed_pass_step_count"] == 6
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("recovery-closure-governance-seal-audit-")
+    assert preview["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_STATUS_READY
+    assert preview["seal_id"].startswith("recovery-closure-governance-seal-")
+    assert preview["operation_ids"] == ["dryrun-op-123"]
+    assert preview["would_verify_seal_integrity"] is True
+    assert preview["would_verify_governance_handoff"] is True
+    assert preview["would_verify_source_audit_evidence"] is True
+    assert preview["would_verify_read_only_constraints"] is True
+
+
+def test_blocked_governance_seal_blocks_audit_preview():
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal={
+            "status": "blocked",
+            "blocking_reasons": ["governance seal blocked"],
+            "required_actions": ["fix_governance_seal"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "fix_governance_seal" in payload["required_actions"]
+
+
+def test_tampered_seal_digest_blocks_audit_preview():
+    seal_report = _ready_governance_seal()
+    seal_report["seals"][0]["seal_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_governance_seal_preview" in payload["required_actions"]
+
+
+def test_tampered_source_ledger_audit_blocks_source_chain():
+    seal_report = deepcopy(_ready_governance_seal())
+    seal_report["seals"][0]["source_recovery_closure_ledger_audit_preview"][
+        "audit_digest"
+    ] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_SOURCE_CHAIN in failed_checks
+
+
+def test_missing_governance_handoff_flag_blocks_audit_requirements():
+    seal_report = deepcopy(_ready_governance_seal())
+    seal_report["seals"][0]["would_enable_governed_handoff"] = False
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_AUDIT_REQUIREMENTS in failed_checks
+
+
+def test_no_action_governance_seal_does_not_create_audit_preview():
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert (
+        payload["summary"]["recovery_closure_governance_seal_audit_preview_available"]
+        is False
+    )
+
+
+def test_empty_governance_seal_audit_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_governance_seal_audit_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []
+
+
+def test_governance_seal_audit_preview_id_is_stable():
+    seal_report = _ready_governance_seal()
+
+    first = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=seal_report
+    ).to_dict()
+
+    assert first["previews"][0]["id"] == second["previews"][0]["id"]
+    assert first["previews"][0]["audit_digest"] == second["previews"][0]["audit_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_governance_seal_preview.py
@@ -1,0 +1,151 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS,
+    CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY,
+    RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE,
+    build_evidence_repair_recovery_closure_governance_seal_preview,
+    empty_evidence_repair_recovery_closure_governance_seal_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    build_evidence_repair_recovery_closure_ledger_audit_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    _ready_ledger_preview,
+)
+
+
+def _ready_ledger_audit():
+    return build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=_ready_ledger_preview()
+    ).to_dict()
+
+
+def test_ready_recovery_closure_ledger_audit_creates_governance_seal():
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=_ready_ledger_audit()
+    ).to_dict()
+
+    seal = payload["seals"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_READY
+    assert payload["summary"]["recovery_closure_governance_seal_ready"] is True
+    assert payload["summary"]["seal_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert seal["id"].startswith("recovery-closure-governance-seal-")
+    assert seal["seal_type"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_TYPE
+    assert seal["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_DRAFT_STATUS_READY
+    assert seal["operation_ids"] == ["dryrun-op-123"]
+    assert seal["would_freeze_recovery_closure"] is True
+    assert seal["would_preserve_audit_evidence"] is True
+    assert seal["would_enable_governed_handoff"] is True
+    assert seal["would_block_unreviewed_mutation"] is True
+
+
+def test_blocked_ledger_audit_blocks_governance_seal():
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit={
+            "status": "blocked",
+            "blocking_reasons": ["ledger audit blocked"],
+            "required_actions": ["fix_ledger_audit"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert payload["seals"] == []
+    assert "fix_ledger_audit" in payload["required_actions"]
+
+
+def test_tampered_ledger_audit_digest_blocks_governance_seal():
+    ledger_audit = _ready_ledger_audit()
+    ledger_audit["previews"][0]["audit_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_ledger_audit_preview" in payload["required_actions"]
+
+
+def test_tampered_source_ledger_entry_blocks_governance_seal_source_chain():
+    ledger_audit = deepcopy(_ready_ledger_audit())
+    ledger_audit["previews"][0]["source_recovery_closure_ledger_entry"][
+        "entry_digest"
+    ] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN in failed_checks
+
+
+def test_failed_ledger_audit_step_blocks_governance_seal_requirements():
+    ledger_audit = deepcopy(_ready_ledger_audit())
+    ledger_audit["previews"][0]["audit_steps"][0]["status"] = "fail"
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_SOURCE_CHAIN in failed_checks
+
+
+def test_missing_governance_flag_blocks_governance_seal_requirements():
+    ledger_audit = deepcopy(_ready_ledger_audit())
+    ledger_audit["previews"][0]["would_verify_lifecycle_milestones"] = False
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_BLOCKED
+    assert CHECK_RECOVERY_GOVERNANCE_SEAL_REQUIREMENTS in failed_checks
+
+
+def test_no_action_ledger_audit_does_not_create_governance_seal():
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED
+    assert payload["seals"] == []
+    assert payload["summary"]["recovery_closure_governance_seal_available"] is False
+
+
+def test_empty_governance_seal_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_governance_seal_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_GOVERNANCE_SEAL_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["seals"] == []
+
+
+def test_governance_seal_id_is_stable():
+    ledger_audit = _ready_ledger_audit()
+
+    first = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=ledger_audit
+    ).to_dict()
+
+    assert first["seals"][0]["id"] == second["seals"][0]["id"]
+    assert first["seals"][0]["seal_digest"] == second["seals"][0]["seal_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_audit_preview.py
@@ -1,0 +1,138 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS,
+    CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY,
+    CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY,
+    build_evidence_repair_recovery_closure_ledger_audit_preview,
+    empty_evidence_repair_recovery_closure_ledger_audit_preview,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    build_evidence_repair_recovery_closure_ledger_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_ledger_preview import (
+    _ready_closure_gate,
+)
+
+
+def _ready_ledger_preview():
+    return build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=_ready_closure_gate()
+    ).to_dict()
+
+
+def test_ready_recovery_closure_ledger_creates_audit_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=_ready_ledger_preview()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_READY
+    assert payload["summary"]["recovery_closure_ledger_audit_ready"] is True
+    assert payload["summary"]["preview_count"] == 1
+    assert payload["summary"]["audit_step_count"] == 6
+    assert payload["summary"]["observed_pass_step_count"] == 6
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("recovery-closure-ledger-audit-")
+    assert preview["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_STATUS_READY
+    assert preview["ledger_entry_id"].startswith("recovery-closure-ledger-")
+    assert preview["closure_id"].startswith("recovery-closure-")
+    assert preview["operation_ids"] == ["dryrun-op-123"]
+    assert preview["would_verify_ledger_entry_integrity"] is True
+    assert preview["would_verify_completion_audit_evidence"] is True
+
+
+def test_blocked_recovery_closure_ledger_blocks_audit_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger={
+            "status": "blocked",
+            "blocking_reasons": ["upstream ledger blocked"],
+            "required_actions": ["fix_upstream_ledger"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "fix_upstream_ledger" in payload["required_actions"]
+
+
+def test_tampered_ledger_entry_digest_blocks_audit_preview():
+    ledger = _ready_ledger_preview()
+    ledger["entries"][0]["entry_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_ledger_preview" in payload["required_actions"]
+
+
+def test_tampered_source_completion_audit_blocks_source_chain():
+    ledger = deepcopy(_ready_ledger_preview())
+    ledger["entries"][0]["source_recovery_closure"][
+        "source_recovery_completion_audit_preview"
+    ]["observed_state_supplied"] = False
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_SOURCE_CHAIN in failed_checks
+
+
+def test_tampered_milestone_reference_blocks_audit_requirements():
+    ledger = deepcopy(_ready_ledger_preview())
+    ledger["entries"][0]["milestones"][0]["reference_id"] = "wrong-decision"
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_LEDGER_AUDIT_REQUIREMENTS in failed_checks
+
+
+def test_no_action_recovery_closure_ledger_does_not_create_audit_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_closure_ledger_audit_preview_available"] is False
+
+
+def test_empty_recovery_closure_ledger_audit_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_ledger_audit_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []
+
+
+def test_recovery_closure_ledger_audit_preview_id_is_stable():
+    ledger = _ready_ledger_preview()
+
+    first = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=ledger
+    ).to_dict()
+
+    assert first["previews"][0]["id"] == second["previews"][0]["id"]
+    assert first["previews"][0]["audit_digest"] == second["previews"][0]["audit_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_closure_ledger_preview.py
@@ -1,0 +1,137 @@
+from copy import deepcopy
+
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    build_evidence_repair_recovery_closure_gate,
+)
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    CHECK_RECOVERY_CLOSURE_INTEGRITY,
+    CHECK_RECOVERY_LIFECYCLE_CHAIN,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY,
+    RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE,
+    RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED,
+    RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_CLOSURE_LEDGER_STATUS_READY,
+    build_evidence_repair_recovery_closure_ledger_preview,
+    empty_evidence_repair_recovery_closure_ledger_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_closure_gate import (
+    _passing_completion_audit,
+    _planned_completion_audit,
+)
+
+
+def _ready_closure_gate():
+    return build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_passing_completion_audit()
+    ).to_dict()
+
+
+def test_ready_recovery_closure_creates_ledger_entry_preview():
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=_ready_closure_gate()
+    ).to_dict()
+
+    entry = payload["entries"][0]
+    stages = {milestone["stage"] for milestone in entry["milestones"]}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_READY
+    assert payload["summary"]["recovery_closure_ledger_ready"] is True
+    assert payload["summary"]["entry_count"] == 1
+    assert payload["summary"]["milestone_count"] == 8
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert entry["id"].startswith("recovery-closure-ledger-")
+    assert entry["entry_type"] == RECOVERY_CLOSURE_LEDGER_ENTRY_TYPE
+    assert entry["status"] == RECOVERY_CLOSURE_LEDGER_ENTRY_STATUS_READY
+    assert entry["closure_id"].startswith("recovery-closure-")
+    assert entry["operation_ids"] == ["dryrun-op-123"]
+    assert entry["would_record_ledger_entry"] is True
+    assert entry["would_preserve_recovery_evidence"] is True
+    assert stages == {
+        "recovery_decision",
+        "recovery_execution_preview",
+        "recovery_approval_token",
+        "recovery_write_lock",
+        "recovery_executor_preview",
+        "recovery_completion_receipt",
+        "recovery_completion_audit",
+        "recovery_closure",
+    }
+
+
+def test_planned_recovery_closure_gate_blocks_ledger_preview():
+    closure_gate = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=_planned_completion_audit()
+    ).to_dict()
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED
+    assert payload["entries"] == []
+    assert "provide_observed_recovery_completion_state" in payload["required_actions"]
+
+
+def test_tampered_recovery_closure_digest_blocks_ledger_preview():
+    closure_gate = _ready_closure_gate()
+    closure_gate["closures"][0]["closure_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED
+    assert CHECK_RECOVERY_CLOSURE_INTEGRITY in failed_checks
+    assert "regenerate_recovery_closure_gate" in payload["required_actions"]
+
+
+def test_unobserved_source_audit_blocks_lifecycle_chain():
+    closure_gate = deepcopy(_ready_closure_gate())
+    closure_gate["closures"][0]["source_recovery_completion_audit_preview"][
+        "observed_state_supplied"
+    ] = False
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_BLOCKED
+    assert CHECK_RECOVERY_LIFECYCLE_CHAIN in failed_checks
+    assert "regenerate_recovery_closure_gate" in payload["required_actions"]
+
+
+def test_no_action_recovery_closure_gate_does_not_create_ledger_entry():
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED
+    assert payload["entries"] == []
+    assert payload["summary"]["recovery_closure_ledger_preview_available"] is False
+
+
+def test_empty_recovery_closure_ledger_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_closure_ledger_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_CLOSURE_LEDGER_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["entries"] == []
+
+
+def test_recovery_closure_ledger_entry_id_is_stable():
+    closure_gate = _ready_closure_gate()
+
+    first = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+    second = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=closure_gate
+    ).to_dict()
+
+    assert first["entries"][0]["id"] == second["entries"][0]["id"]
+    assert first["entries"][0]["entry_digest"] == second["entries"][0]["entry_digest"]

--- a/tests/agent/test_memory_evidence_repair_recovery_completion_audit_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_completion_audit_preview.py
@@ -1,0 +1,149 @@
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    CHECK_OBSERVED_RECOVERY_COMPLETION_STATE,
+    CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY,
+    RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_AUDIT_STATUS_READY,
+    build_evidence_repair_recovery_completion_audit_preview,
+    empty_evidence_repair_recovery_completion_audit_preview,
+)
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    build_evidence_repair_recovery_completion_receipt,
+)
+from tests.agent.test_memory_evidence_repair_recovery_completion_receipt import (
+    _recovery_executor_preview,
+)
+
+
+def _recovery_completion_receipt():
+    return build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=_recovery_executor_preview(),
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+
+
+def _observed_recovery_steps(receipt):
+    return {
+        step_id: {"status": "completed"}
+        for step_id in receipt["receipts"][0]["recovery_step_ids"]
+    }
+
+
+def test_ready_recovery_completion_receipt_creates_planned_audit():
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=_recovery_completion_receipt()
+    ).to_dict()
+
+    audit = payload["previews"][0]
+    categories = {step["category"] for step in audit["audit_steps"]}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_READY
+    assert payload["summary"]["recovery_completion_audit_ready"] is True
+    assert payload["summary"]["planned_audit_step_count"] == 12
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert audit["id"].startswith("recovery-completion-audit-")
+    assert categories == {
+        "completion_receipt",
+        "token",
+        "lock",
+        "recovery_step",
+        "post_recovery_audit",
+        "contamination_guard",
+    }
+    assert audit["would_verify_completion_receipt_recorded"] is True
+    assert audit["would_verify_no_secondary_memory_contamination"] is True
+
+
+def test_observed_recovery_completion_state_can_pass():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[row["token_id"]],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": False},
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_READY
+    assert payload["summary"]["observed_pass_step_count"] == 12
+    assert payload["summary"]["observed_fail_step_count"] == 0
+    assert payload["previews"][0]["observed_state_supplied"] is True
+
+
+def test_observed_missing_recovery_token_blocks_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": False},
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED
+    assert CHECK_OBSERVED_RECOVERY_COMPLETION_STATE in failed_checks
+    assert "investigate_recovery_completion_audit_failures" in payload["required_actions"]
+
+
+def test_observed_contamination_blocks_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt,
+        observed_recovery_steps=_observed_recovery_steps(receipt),
+        recorded_receipts=[{"id": row["id"]}],
+        used_token_ids=[row["token_id"]],
+        released_lock_ids=[row["lock_id"]],
+        post_recovery_audit_status={"status": "pass"},
+        contamination_status={"contaminated": True},
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED
+    assert CHECK_OBSERVED_RECOVERY_COMPLETION_STATE in failed_checks
+
+
+def test_tampered_recovery_completion_receipt_blocks_audit():
+    receipt = _recovery_completion_receipt()
+    receipt["receipts"][0]["receipt_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=receipt
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_BLOCKED
+    assert CHECK_RECOVERY_COMPLETION_RECEIPT_INTEGRITY in failed_checks
+    assert "regenerate_recovery_completion_receipt" in payload["required_actions"]
+
+
+def test_no_action_recovery_completion_receipt_does_not_create_audit():
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_completion_audit_preview_available"] is False
+
+
+def test_empty_recovery_completion_audit_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_completion_audit_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_AUDIT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_completion_receipt.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_completion_receipt.py
@@ -1,0 +1,147 @@
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_COMPLETION_RECEIPT_STATUS_READY,
+    RECOVERY_COMPLETION_RECEIPT_TYPE,
+    build_evidence_repair_recovery_completion_receipt,
+    empty_evidence_repair_recovery_completion_receipt,
+)
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    build_evidence_repair_recovery_executor_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_executor_preview import (
+    _recovery_write_lock_gate,
+)
+
+
+def _recovery_executor_preview():
+    return build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=_recovery_write_lock_gate(),
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+
+def test_ready_recovery_executor_preview_creates_completion_receipt():
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=_recovery_executor_preview(),
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+
+    receipt = payload["receipts"][0]
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_READY
+    assert payload["summary"]["recovery_completion_receipt_available"] is True
+    assert payload["summary"]["would_record_receipt_count"] == 1
+    assert payload["summary"]["would_mark_recovery_token_used_count"] == 1
+    assert payload["summary"]["would_release_recovery_write_lock_count"] == 1
+    assert payload["summary"]["would_trigger_recovery_audit_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert receipt["id"].startswith("recovery-completion-receipt-")
+    assert receipt["receipt_type"] == RECOVERY_COMPLETION_RECEIPT_TYPE
+    assert receipt["actor"] == "han"
+    assert receipt["recovery_reason"] == "manual post-audit recovery complete"
+    assert receipt["operation_ids"] == ["dryrun-op-123"]
+    assert receipt["future_mutation_step_ids"] == [
+        "recovery-execution-step-5-apply_manual_rollback_restore"
+    ]
+    assert receipt["used_recovery_token_id"] in payload["used_recovery_token_ids"]
+    assert receipt["released_recovery_lock_id"] in payload["released_recovery_lock_ids"]
+    assert receipt["would_trigger_recovery_audit"] is True
+
+
+def test_blocked_recovery_executor_preview_does_not_create_receipt():
+    executor_preview = _recovery_executor_preview()
+    executor_preview["status"] = "blocked"
+    executor_preview["blocking_reasons"] = ["Recovery write lock expired."]
+    executor_preview["required_actions"] = ["regenerate_recovery_write_lock_gate"]
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert payload["blocking_reasons"] == ["Recovery write lock expired."]
+    assert payload["required_actions"] == ["regenerate_recovery_executor_preview"]
+
+
+def test_existing_used_recovery_token_blocks_completion_receipt():
+    executor_preview = _recovery_executor_preview()
+    token_id = executor_preview["previews"][0]["token_id"]
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        used_token_ids=[token_id],
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "regenerate_recovery_human_approval_token" in payload["required_actions"]
+    assert token_id in payload["used_recovery_token_ids"]
+
+
+def test_existing_released_recovery_lock_blocks_completion_receipt():
+    executor_preview = _recovery_executor_preview()
+    lock_id = executor_preview["previews"][0]["lock_id"]
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        released_lock_ids=[lock_id],
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "regenerate_recovery_write_lock_gate" in payload["required_actions"]
+    assert lock_id in payload["released_recovery_lock_ids"]
+
+
+def test_tampered_recovery_executor_preview_digest_blocks_completion_receipt():
+    executor_preview = _recovery_executor_preview()
+    executor_preview["previews"][0]["preview_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_BLOCKED
+    assert payload["receipts"] == []
+    assert "regenerate_recovery_executor_preview" in payload["required_actions"]
+
+
+def test_recovery_completion_receipt_id_and_digest_are_stable():
+    executor_preview = _recovery_executor_preview()
+    first = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+    second = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=executor_preview,
+        actor="han",
+        recovery_reason="manual post-audit recovery complete",
+    ).to_dict()
+
+    assert first["receipts"][0]["id"] == second["receipts"][0]["id"]
+    assert first["receipts"][0]["receipt_digest"] == second["receipts"][0]["receipt_digest"]
+
+
+def test_no_action_recovery_executor_preview_does_not_create_receipt():
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["receipts"] == []
+    assert payload["summary"]["recovery_completion_receipt_available"] is False
+
+
+def test_empty_recovery_completion_receipt_is_read_only():
+    payload = empty_evidence_repair_recovery_completion_receipt().to_dict()
+
+    assert payload["status"] == RECOVERY_COMPLETION_RECEIPT_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["receipts"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_decision_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_decision_gate.py
@@ -1,0 +1,110 @@
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    RECOVERY_DECISION_STATUS_BLOCKED,
+    RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_DECISION_STATUS_READY,
+    RECOVERY_ROUTE_MANUAL_ROLLBACK,
+    RECOVERY_ROUTE_PREPAREDNESS_ONLY,
+    build_evidence_repair_recovery_decision_gate,
+    empty_evidence_repair_recovery_decision_gate,
+)
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    build_evidence_repair_rollback_drill_preview,
+)
+from tests.agent.test_memory_evidence_repair_rollback_drill_preview import (
+    _failed_post_commit_audit,
+    _planned_post_commit_audit,
+)
+
+
+def _preparedness_drill():
+    return build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_planned_post_commit_audit()
+    ).to_dict()
+
+
+def _failure_drill():
+    return build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_failed_post_commit_audit()
+    ).to_dict()
+
+
+def test_preparedness_drill_creates_preparedness_decision():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_preparedness_drill()
+    ).to_dict()
+
+    decision = payload["decisions"][0]
+    assert payload["status"] == RECOVERY_DECISION_STATUS_READY
+    assert payload["summary"]["recovery_decision_ready"] is True
+    assert payload["summary"]["preparedness_review_count"] == 1
+    assert payload["summary"]["manual_rollback_required_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert decision["route"] == RECOVERY_ROUTE_PREPAREDNESS_ONLY
+    assert decision["priority"] == "p2"
+    assert decision["future_would_mutate_memory"] is False
+    assert "rollback_drill_kept_read_only" in decision["required_preconditions"]
+
+
+def test_failure_drill_creates_manual_rollback_decision():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_failure_drill()
+    ).to_dict()
+
+    decision = payload["decisions"][0]
+    assert payload["status"] == RECOVERY_DECISION_STATUS_READY
+    assert payload["summary"]["manual_rollback_required_count"] == 1
+    assert decision["route"] == RECOVERY_ROUTE_MANUAL_ROLLBACK
+    assert decision["priority"] == "p0"
+    assert decision["operation_ids"] == ["dryrun-op-123"]
+    assert "request_explicit_human_recovery_approval" in decision["recommended_actions"]
+    assert "snapshot_or_rollback_plan_verified" in decision["required_preconditions"]
+    assert "automatic_memory_rollback" in decision["blocked_actions"]
+
+
+def test_tampered_drill_with_non_planned_step_blocks_decision():
+    drill = _failure_drill()
+    drill["previews"][0]["steps"][0]["status"] = "done"
+
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=drill
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_BLOCKED
+    assert payload["decisions"] == []
+    assert "regenerate_rollback_drill_preview" in payload["required_actions"]
+
+
+def test_blocked_drill_blocks_decision_gate():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill={
+            "status": "blocked",
+            "blocking_reasons": ["post commit audit unavailable"],
+            "required_actions": ["produce_post_commit_audit_preview"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_BLOCKED
+    assert payload["decisions"] == []
+    assert "produce_post_commit_audit_preview" in payload["required_actions"]
+
+
+def test_no_action_drill_does_not_create_decision():
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED
+    assert payload["decisions"] == []
+    assert payload["summary"]["recovery_decision_available"] is False
+
+
+def test_empty_recovery_decision_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_decision_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_DECISION_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["decisions"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_execution_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_execution_preview.py
@@ -1,0 +1,123 @@
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    build_evidence_repair_recovery_decision_gate,
+)
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    RECOVERY_EXECUTION_STATUS_BLOCKED,
+    RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTION_STATUS_READY,
+    build_evidence_repair_recovery_execution_preview,
+    empty_evidence_repair_recovery_execution_preview,
+)
+from tests.agent.test_memory_evidence_repair_recovery_decision_gate import (
+    _failure_drill,
+    _preparedness_drill,
+)
+
+
+def _preparedness_decision():
+    return build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_preparedness_drill()
+    ).to_dict()
+
+
+def _manual_rollback_decision():
+    return build_evidence_repair_recovery_decision_gate(
+        rollback_drill=_failure_drill()
+    ).to_dict()
+
+
+def test_preparedness_decision_creates_non_mutating_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_preparedness_decision()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    actions = {step["action"] for step in preview["steps"]}
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_READY
+    assert payload["summary"]["recovery_execution_ready"] is True
+    assert payload["summary"]["preparedness_preview_count"] == 1
+    assert payload["summary"]["future_mutation_step_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["future_would_mutate_memory"] is False
+    assert preview["route"] == "preparedness_review_only"
+    assert "keep_rollback_drill_available" in actions
+    assert "rerun_post_commit_audit_after_future_commit" in actions
+
+
+def test_manual_rollback_decision_creates_ordered_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_manual_rollback_decision()
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    actions = [step["action"] for step in preview["steps"]]
+    restore_steps = [
+        step for step in preview["steps"] if step["action"] == "apply_manual_rollback_restore"
+    ]
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_READY
+    assert payload["summary"]["manual_rollback_preview_count"] == 1
+    assert payload["summary"]["future_mutation_step_count"] == 1
+    assert preview["future_would_mutate_memory"] is True
+    assert preview["human_approval_required"] is True
+    assert preview["operation_ids"] == ["dryrun-op-123"]
+    assert actions == [
+        "verify_recovery_decision_gate",
+        "preserve_failed_audit_context",
+        "isolate_impacted_memory_records",
+        "verify_snapshot_or_rollback_plan",
+        "apply_manual_rollback_restore",
+        "reconcile_receipt_token_lock_state",
+        "rerun_post_commit_audit",
+    ]
+    assert restore_steps
+    assert restore_steps[0]["future_would_mutate_memory"] is True
+    assert restore_steps[0]["human_approval_required"] is True
+
+
+def test_tampered_decision_without_controls_blocks_execution_preview():
+    decision = _manual_rollback_decision()
+    decision["decisions"][0]["blocked_actions"] = []
+
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=decision
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "regenerate_recovery_decision_gate" in payload["required_actions"]
+
+
+def test_blocked_decision_gate_blocks_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision={
+            "status": "blocked",
+            "blocking_reasons": ["rollback drill unavailable"],
+            "required_actions": ["produce_ready_rollback_drill_preview"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "produce_ready_rollback_drill_preview" in payload["required_actions"]
+
+
+def test_no_action_decision_does_not_create_execution_preview():
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_execution_preview_available"] is False
+
+
+def test_empty_recovery_execution_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_execution_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTION_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_executor_preview.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_executor_preview.py
@@ -1,0 +1,139 @@
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    build_evidence_repair_recovery_approval_token_gate,
+)
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    CHECK_RECOVERY_EXECUTION_STEPS,
+    CHECK_RECOVERY_WRITE_LOCK_EXPIRY,
+    CHECK_RECOVERY_WRITE_LOCK_INTEGRITY,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_EXECUTOR_PREVIEW_STATUS_READY,
+    build_evidence_repair_recovery_executor_preview,
+    empty_evidence_repair_recovery_executor_preview,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    build_evidence_repair_recovery_write_lock_gate,
+)
+from tests.agent.test_memory_evidence_repair_recovery_human_approval_token import (
+    _manual_rollback_execution,
+)
+
+
+def _recovery_write_lock_gate():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token = token_report["tokens"][0]
+    token_gate = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+    return build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def test_ready_recovery_write_lock_creates_recovery_executor_preview_steps():
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=_recovery_write_lock_gate(),
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+    preview = payload["previews"][0]
+    actions = [step["action"] for step in preview["steps"]]
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_READY
+    assert payload["summary"]["manual_recovery_executor_preview_ready"] is True
+    assert payload["summary"]["future_mutation_step_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert preview["id"].startswith("recovery-executor-preview-")
+    assert preview["would_execute_manual_recovery"] is True
+    assert preview["would_apply_memory_recovery"] is True
+    assert preview["would_mark_recovery_token_used"] is True
+    assert preview["would_release_recovery_write_lock"] is True
+    assert preview["would_rerun_post_commit_audit"] is True
+    assert actions[0] == "verify_recovery_write_lock_token_and_execution"
+    assert "apply_manual_rollback_restore" in actions
+    assert actions[-2:] == ["mark_recovery_token_used", "release_recovery_write_lock"]
+    mutation_steps = [
+        step for step in preview["steps"] if step["future_would_mutate_memory"]
+    ]
+    assert mutation_steps[0]["action"] == "apply_manual_rollback_restore"
+    assert preview["steps"][-1]["stop_on_failure"] is False
+
+
+def test_expired_recovery_write_lock_blocks_recovery_executor_preview():
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=_recovery_write_lock_gate(),
+        current_time="2026-05-11T00:26:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_RECOVERY_WRITE_LOCK_EXPIRY in failed_checks
+    assert "regenerate_recovery_write_lock_gate" in payload["required_actions"]
+
+
+def test_tampered_recovery_write_lock_digest_blocks_recovery_executor_preview():
+    gate = _recovery_write_lock_gate()
+    gate["locks"][0]["lock_digest"] = "bad"
+
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=gate,
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_RECOVERY_WRITE_LOCK_INTEGRITY in failed_checks
+
+
+def test_mismatched_recovery_execution_steps_block_recovery_executor_preview():
+    gate = _recovery_write_lock_gate()
+    execution = (
+        gate["locks"][0]["source_recovery_token_gate"][
+            "source_recovery_execution_preview"
+        ]
+    )
+    execution["steps"][0]["id"] = "tampered-step-id"
+
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=gate,
+        current_time="2026-05-11T00:12:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_BLOCKED
+    assert CHECK_RECOVERY_EXECUTION_STEPS in failed_checks
+
+
+def test_no_action_recovery_write_lock_gate_does_not_create_preview():
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["recovery_executor_preview_available"] is False
+
+
+def test_empty_recovery_executor_preview_is_read_only():
+    payload = empty_evidence_repair_recovery_executor_preview().to_dict()
+
+    assert payload["status"] == RECOVERY_EXECUTOR_PREVIEW_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_human_approval_token.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_human_approval_token.py
@@ -1,0 +1,108 @@
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    build_evidence_repair_recovery_execution_preview,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    RECOVERY_APPROVAL_TOKEN_SCOPE,
+    RECOVERY_APPROVAL_TOKEN_TYPE,
+    RECOVERY_TOKEN_STATUS_BLOCKED,
+    RECOVERY_TOKEN_STATUS_DRAFT_READY,
+    RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED,
+    build_evidence_repair_recovery_human_approval_token,
+    empty_evidence_repair_recovery_human_approval_token,
+)
+from tests.agent.test_memory_evidence_repair_recovery_execution_preview import (
+    _manual_rollback_decision,
+    _preparedness_decision,
+)
+
+
+def _manual_rollback_execution():
+    return build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_manual_rollback_decision()
+    ).to_dict()
+
+
+def _preparedness_execution():
+    return build_evidence_repair_recovery_execution_preview(
+        recovery_decision=_preparedness_decision()
+    ).to_dict()
+
+
+def test_manual_rollback_execution_creates_recovery_token_draft():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+
+    token = payload["tokens"][0]
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_DRAFT_READY
+    assert payload["summary"]["token_count"] == 1
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert token["id"].startswith("recovery-approval-token-")
+    assert token["token_type"] == RECOVERY_APPROVAL_TOKEN_TYPE
+    assert token["scope"] == RECOVERY_APPROVAL_TOKEN_SCOPE
+    assert token["approver"] == "han"
+    assert token["approval_reason"] == "manual recovery approval"
+    assert token["expires_in_minutes"] == 20
+    assert token["operation_ids"] == ["dryrun-op-123"]
+    assert token["future_mutation_step_ids"] == [
+        "recovery-execution-step-5-apply_manual_rollback_restore"
+    ]
+    assert len(token["token_digest"]) == 64
+    assert token["one_time_constraints"]["one_time_use"] is True
+    assert token["required_confirmation_text"].startswith("APPROVE ")
+
+
+def test_preparedness_execution_does_not_need_recovery_token():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_preparedness_execution()
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["tokens"] == []
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_blocked_execution_preview_does_not_create_token():
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution={
+            "status": "blocked",
+            "blocking_reasons": ["recovery decision missing"],
+            "required_actions": ["produce_recovery_decision_gate"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_BLOCKED
+    assert payload["tokens"] == []
+    assert payload["blocking_reasons"] == ["recovery decision missing"]
+    assert payload["required_actions"] == ["produce_recovery_decision_gate"]
+
+
+def test_recovery_token_id_and_digest_are_stable():
+    first = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+    ).to_dict()
+    second = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+    ).to_dict()
+
+    assert first["tokens"][0]["id"] == second["tokens"][0]["id"]
+    assert first["tokens"][0]["token_digest"] == second["tokens"][0]["token_digest"]
+
+
+def test_empty_recovery_token_report_is_read_only():
+    payload = empty_evidence_repair_recovery_human_approval_token().to_dict()
+
+    assert payload["status"] == RECOVERY_TOKEN_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["tokens"] == []

--- a/tests/agent/test_memory_evidence_repair_recovery_write_lock_gate.py
+++ b/tests/agent/test_memory_evidence_repair_recovery_write_lock_gate.py
@@ -1,0 +1,175 @@
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    build_evidence_repair_recovery_approval_token_gate,
+)
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    CHECK_RECOVERY_ACTIVE_LOCKS,
+    CHECK_RECOVERY_TOKEN_GATE_INTEGRITY,
+    CHECK_RECOVERY_TOKEN_REUSE,
+    RECOVERY_LOCK_DRAFT_STATUS_READY,
+    RECOVERY_WRITE_LOCK_SCOPE,
+    RECOVERY_WRITE_LOCK_STATUS_BLOCKED,
+    RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    RECOVERY_WRITE_LOCK_STATUS_READY,
+    RECOVERY_WRITE_LOCK_TYPE,
+    build_evidence_repair_recovery_write_lock_gate,
+    empty_evidence_repair_recovery_write_lock_gate,
+)
+from tests.agent.test_memory_evidence_repair_recovery_human_approval_token import (
+    _manual_rollback_execution,
+    _preparedness_execution,
+)
+
+
+def _verified_recovery_token_gate():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_manual_rollback_execution(),
+        approver="han",
+        approval_reason="manual recovery approval",
+        expires_in_minutes=20,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    token = token_report["tokens"][0]
+    return build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report,
+        confirmation_text=token["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def test_verified_recovery_token_gate_creates_recovery_write_lock_draft():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    lock = payload["locks"][0]
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_READY
+    assert payload["summary"]["recovery_executor_preview_allowed"] is True
+    assert payload["summary"]["recovery_write_lock_available"] is True
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert lock["id"].startswith("recovery-write-lock-")
+    assert lock["lock_type"] == RECOVERY_WRITE_LOCK_TYPE
+    assert lock["status"] == RECOVERY_LOCK_DRAFT_STATUS_READY
+    assert lock["scope"] == RECOVERY_WRITE_LOCK_SCOPE
+    assert lock["owner"] == "han"
+    assert lock["token_id"] == token_gate["token_id"]
+    assert lock["operation_ids"] == ["dryrun-op-123"]
+    assert lock["future_mutation_step_ids"] == [
+        "recovery-execution-step-5-apply_manual_rollback_restore"
+    ]
+    assert lock["would_acquire_write_lock"] is True
+    assert lock["would_release_after_recovery"] is True
+    assert lock["expires_at"] == "2026-05-11T00:25:00+00:00"
+
+
+def test_active_recovery_lock_conflict_blocks_gate():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        active_locks=[
+            {
+                "id": "recovery-lock-active",
+                "status": "active",
+                "scope": RECOVERY_WRITE_LOCK_SCOPE,
+                "owner": "han",
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:20:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECOVERY_ACTIVE_LOCKS in failed_checks
+    assert payload["active_lock_conflicts"][0]["reason"] == "overlapping_operation_ids"
+    assert payload["locks"] == []
+
+
+def test_expired_recovery_lock_does_not_block_gate():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        active_locks=[
+            {
+                "id": "recovery-lock-expired",
+                "status": "active",
+                "scope": RECOVERY_WRITE_LOCK_SCOPE,
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:09:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_READY
+    assert payload["active_lock_conflicts"] == []
+    assert len(payload["locks"]) == 1
+
+
+def test_used_recovery_token_blocks_write_lock_gate():
+    token_gate = _verified_recovery_token_gate()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        already_used_token_ids=[token_gate["token_id"]],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECOVERY_TOKEN_REUSE in failed_checks
+    assert "regenerate_recovery_human_approval_token" in payload["required_actions"]
+
+
+def test_tampered_recovery_token_gate_integrity_blocks_gate():
+    token_gate = _verified_recovery_token_gate()
+    token_gate["verified_future_mutation_step_ids"] = []
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate,
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECOVERY_TOKEN_GATE_INTEGRITY in failed_checks
+    assert "regenerate_recovery_approval_token_gate" in payload["required_actions"]
+
+
+def test_no_action_recovery_token_gate_does_not_create_lock():
+    token_report = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=_preparedness_execution()
+    ).to_dict()
+    token_gate = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=token_report
+    ).to_dict()
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=token_gate
+    ).to_dict()
+
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["locks"] == []
+    assert payload["checks"] == []
+
+
+def test_empty_recovery_write_lock_gate_is_read_only():
+    payload = empty_evidence_repair_recovery_write_lock_gate().to_dict()
+
+    assert payload["status"] == RECOVERY_WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["locks"] == []

--- a/tests/agent/test_memory_evidence_repair_rollback_drill_preview.py
+++ b/tests/agent/test_memory_evidence_repair_rollback_drill_preview.py
@@ -1,0 +1,130 @@
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    build_evidence_repair_post_commit_audit_preview,
+)
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    ROLLBACK_DRILL_STATUS_BLOCKED,
+    ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_DRILL_STATUS_READY,
+    ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE,
+    ROLLBACK_DRILL_TRIGGER_PREPAREDNESS,
+    build_evidence_repair_rollback_drill_preview,
+    empty_evidence_repair_rollback_drill_preview,
+)
+from tests.agent.test_memory_evidence_repair_post_commit_audit_preview import (
+    _executor_preview,
+)
+
+
+def _planned_post_commit_audit():
+    return build_evidence_repair_post_commit_audit_preview(
+        executor_preview=_executor_preview()
+    ).to_dict()
+
+
+def _failed_post_commit_audit():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    return build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor,
+        observed_memory_patches={
+            "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+        },
+        recorded_receipts=[{"id": preview["receipt_id"]}],
+        used_token_ids=[],
+        released_lock_ids=[preview["lock_id"]],
+        rollback_status={"status": "snapshot_available"},
+    ).to_dict()
+
+
+def test_planned_post_commit_audit_creates_preparedness_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_planned_post_commit_audit()
+    ).to_dict()
+
+    drill = payload["previews"][0]
+    actions = {step["action"] for step in drill["steps"]}
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_READY
+    assert payload["summary"]["rollback_drill_ready"] is True
+    assert payload["summary"]["failed_audit_step_count"] == 0
+    assert payload["summary"]["future_restore_step_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert drill["trigger"] == ROLLBACK_DRILL_TRIGGER_PREPAREDNESS
+    assert drill["rollback_mode"] == "preparedness_rehearsal"
+    assert drill["id"].startswith("rollback-drill-")
+    assert "verify_pre_commit_snapshot_or_rollback_plan" in actions
+    assert "rerun_post_commit_audit" in actions
+
+
+def test_failed_post_commit_audit_creates_failure_response_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_failed_post_commit_audit()
+    ).to_dict()
+
+    drill = payload["previews"][0]
+    actions = [step["action"] for step in drill["steps"]]
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_READY
+    assert payload["summary"]["failed_audit_step_count"] >= 1
+    assert payload["summary"]["future_restore_step_count"] == 1
+    assert drill["trigger"] == ROLLBACK_DRILL_TRIGGER_AUDIT_FAILURE
+    assert drill["rollback_mode"] == "failure_response"
+    assert drill["operation_ids"] == ["dryrun-op-123"]
+    assert "isolate_impacted_memory_records" in actions
+    assert "restore_from_pre_commit_snapshot_or_rollback_plan" in actions
+
+
+def test_rollback_plan_can_be_used_as_drill_source():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=_failed_post_commit_audit(),
+        rollback_plan={
+            "steps": [
+                {
+                    "operation_id": "dryrun-op-123",
+                    "patch_digest": "a" * 64,
+                }
+            ]
+        },
+    ).to_dict()
+
+    restore_steps = [
+        step
+        for step in payload["previews"][0]["steps"]
+        if step["action"] == "restore_from_pre_commit_snapshot_or_rollback_plan"
+    ]
+    assert restore_steps
+    assert restore_steps[0]["rollback_source"] == "provided_rollback_plan"
+
+
+def test_blocked_audit_without_failure_context_blocks_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit={
+            "status": "blocked",
+            "blocking_reasons": ["executor preview is invalid"],
+            "required_actions": ["regenerate_executor_preview"],
+        }
+    ).to_dict()
+
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_BLOCKED
+    assert payload["previews"] == []
+    assert "regenerate_executor_preview" in payload["required_actions"]
+
+
+def test_no_action_post_commit_audit_does_not_create_drill():
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED
+    assert payload["previews"] == []
+    assert payload["summary"]["rollback_drill_preview_available"] is False
+
+
+def test_empty_rollback_drill_preview_is_read_only():
+    payload = empty_evidence_repair_rollback_drill_preview().to_dict()
+
+    assert payload["status"] == ROLLBACK_DRILL_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["previews"] == []

--- a/tests/agent/test_memory_evidence_repair_rollback_plan.py
+++ b/tests/agent/test_memory_evidence_repair_rollback_plan.py
@@ -1,0 +1,103 @@
+from agent.memory_evidence_repair_rollback_plan import (
+    ROLLBACK_ACTION_NOOP,
+    ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA,
+    ROLLBACK_STATUS_NO_ACTION_NEEDED,
+    ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK,
+    ROLLBACK_STATUS_SNAPSHOT_REQUIRED,
+    SNAPSHOT_REQUIRED_VALUE,
+    build_evidence_repair_rollback_plan,
+    empty_evidence_repair_rollback_plan,
+)
+
+
+def _allowed_entry():
+    return {
+        "id": "ledger-123",
+        "sequence": 1,
+        "outcome": "allowed_for_manual_commit",
+        "decision_id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+        "patch_digest": "a" * 64,
+        "manual_commit_allowed": True,
+        "blocked": False,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+    }
+
+
+def test_ready_rollback_plan_from_allowed_entry_with_snapshot():
+    plan = build_evidence_repair_rollback_plan(
+        entries=[_allowed_entry()],
+        pre_commit_snapshots={
+            "ledger-123": {
+                "evidence": {
+                    "source_url": "https://old.example.com/source",
+                    "observed_at": "2026-05-01T00:00:00Z",
+                    "verification_signal": "previous_manual_verified",
+                }
+            }
+        },
+    )
+
+    payload = plan.to_dict()
+    step = payload["steps"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["ready_count"] == 1
+    assert step["id"].startswith("rollback-")
+    assert step["status"] == ROLLBACK_STATUS_READY_FOR_MANUAL_ROLLBACK
+    assert step["rollback_action"] == ROLLBACK_ACTION_RESTORE_EVIDENCE_METADATA
+    assert step["inverse_patch_preview"]["set"]["evidence"] == {
+        "source_url": "https://old.example.com/source",
+        "observed_at": "2026-05-01T00:00:00Z",
+        "verification_signal": "previous_manual_verified",
+    }
+    assert "manual_rollback_only" in step["required_preconditions"]
+
+
+def test_allowed_entry_requires_snapshot_before_rollback_ready():
+    plan = build_evidence_repair_rollback_plan(entries=[_allowed_entry()])
+
+    payload = plan.to_dict()
+    step = payload["steps"][0]
+    assert step["status"] == ROLLBACK_STATUS_SNAPSHOT_REQUIRED
+    assert step["inverse_patch_preview"]["set"]["evidence"] == SNAPSHOT_REQUIRED_VALUE
+    assert "capture_pre_commit_snapshot_before_apply" in step["required_preconditions"]
+    assert payload["summary"]["snapshot_required_count"] == 1
+    assert payload["summary"]["requires_snapshot"] is True
+
+
+def test_blocked_entry_has_no_rollback_action():
+    entry = _allowed_entry()
+    entry["outcome"] = "blocked"
+    entry["manual_commit_allowed"] = False
+    entry["blocked"] = True
+
+    payload = build_evidence_repair_rollback_plan(entries=[entry]).to_dict()
+    step = payload["steps"][0]
+    assert step["status"] == ROLLBACK_STATUS_NO_ACTION_NEEDED
+    assert step["rollback_action"] == ROLLBACK_ACTION_NOOP
+    assert step["inverse_patch_preview"]["operation"] == ROLLBACK_ACTION_NOOP
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_rollback_step_id_is_stable():
+    first = build_evidence_repair_rollback_plan(entries=[_allowed_entry()]).to_dict()
+    second = build_evidence_repair_rollback_plan(entries=[_allowed_entry()]).to_dict()
+
+    assert first["steps"][0]["id"] == second["steps"][0]["id"]
+
+
+def test_empty_rollback_plan_is_read_only():
+    payload = empty_evidence_repair_rollback_plan().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["rollback_step_count"] == 0
+    assert payload["steps"] == []

--- a/tests/agent/test_memory_evidence_repair_snapshot_planner.py
+++ b/tests/agent/test_memory_evidence_repair_snapshot_planner.py
@@ -1,0 +1,118 @@
+from agent.memory_evidence_repair_snapshot_planner import (
+    SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA,
+    SNAPSHOT_ACTION_NOOP,
+    SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT,
+    SNAPSHOT_STATUS_ALREADY_AVAILABLE,
+    SNAPSHOT_STATUS_CAPTURE_REQUIRED,
+    SNAPSHOT_STATUS_NO_ACTION_NEEDED,
+    build_evidence_repair_snapshot_plan,
+    empty_evidence_repair_snapshot_plan,
+)
+
+
+def _snapshot_required_step():
+    return {
+        "id": "rollback-123",
+        "ledger_entry_id": "ledger-123",
+        "sequence": 1,
+        "status": "snapshot_required",
+        "rollback_action": "restore_evidence_metadata",
+        "provider": "builtin",
+        "repair_action": "attach_provenance",
+        "candidate_id": "repair-123",
+        "preview_id": "preview-123",
+        "patch_digest": "a" * 64,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+    }
+
+
+def test_snapshot_plan_requires_capture_for_snapshot_required_step():
+    plan = build_evidence_repair_snapshot_plan(steps=[_snapshot_required_step()])
+
+    payload = plan.to_dict()
+    request = payload["requests"][0]
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["capture_required_count"] == 1
+    assert payload["summary"]["blocks_manual_commit"] is True
+    assert request["id"].startswith("snapshot-")
+    assert request["status"] == SNAPSHOT_STATUS_CAPTURE_REQUIRED
+    assert request["snapshot_action"] == SNAPSHOT_ACTION_CAPTURE_EVIDENCE_METADATA
+    assert request["blocks_manual_commit"] is True
+    assert request["evidence_fields"] == [
+        "source_url",
+        "observed_at",
+        "verification_signal",
+    ]
+    assert request["snapshot_payload_preview"]["capture"]["snapshot_key"] == "ledger-123"
+
+
+def test_snapshot_plan_detects_existing_snapshot_from_ready_rollback_step():
+    step = _snapshot_required_step()
+    step["status"] = "ready_for_manual_rollback"
+
+    payload = build_evidence_repair_snapshot_plan(steps=[step]).to_dict()
+    request = payload["requests"][0]
+    assert request["status"] == SNAPSHOT_STATUS_ALREADY_AVAILABLE
+    assert request["snapshot_action"] == SNAPSHOT_ACTION_VERIFY_EXISTING_SNAPSHOT
+    assert request["blocks_manual_commit"] is False
+    assert payload["summary"]["already_available_count"] == 1
+
+
+def test_snapshot_plan_noops_for_non_committed_entry():
+    step = _snapshot_required_step()
+    step["status"] = "no_action_needed"
+    step["rollback_action"] = "no_rollback_required"
+
+    payload = build_evidence_repair_snapshot_plan(steps=[step]).to_dict()
+    request = payload["requests"][0]
+    assert request["status"] == SNAPSHOT_STATUS_NO_ACTION_NEEDED
+    assert request["snapshot_action"] == SNAPSHOT_ACTION_NOOP
+    assert request["blocks_manual_commit"] is False
+    assert payload["summary"]["no_action_count"] == 1
+
+
+def test_snapshot_plan_can_build_from_ledger_and_existing_snapshot():
+    entry = {
+        "id": "ledger-123",
+        "outcome": "allowed_for_manual_commit",
+        "manual_commit_allowed": True,
+        "provider": "builtin",
+        "repair_action": "attach_provenance",
+        "candidate_id": "repair-123",
+        "preview_id": "preview-123",
+        "patch_digest": "a" * 64,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_fields": ["source_url"],
+    }
+
+    payload = build_evidence_repair_snapshot_plan(
+        entries=[entry],
+        existing_snapshots={"ledger-123": {"evidence": {"source_url": "old"}}},
+    ).to_dict()
+
+    assert payload["requests"][0]["status"] == SNAPSHOT_STATUS_ALREADY_AVAILABLE
+    assert payload["summary"]["already_available_count"] == 1
+
+
+def test_snapshot_request_id_is_stable():
+    first = build_evidence_repair_snapshot_plan(
+        steps=[_snapshot_required_step()]
+    ).to_dict()
+    second = build_evidence_repair_snapshot_plan(
+        steps=[_snapshot_required_step()]
+    ).to_dict()
+
+    assert first["requests"][0]["id"] == second["requests"][0]["id"]
+
+
+def test_empty_snapshot_plan_is_read_only():
+    payload = empty_evidence_repair_snapshot_plan().to_dict()
+
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["summary"]["snapshot_request_count"] == 0
+    assert payload["requests"] == []

--- a/tests/agent/test_memory_evidence_repair_write_lock_gate.py
+++ b/tests/agent/test_memory_evidence_repair_write_lock_gate.py
@@ -1,0 +1,190 @@
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from agent.memory_evidence_repair_write_lock_gate import (
+    CHECK_ACTIVE_LOCKS,
+    CHECK_RECEIPT_INTEGRITY,
+    CHECK_TOKEN_REUSE,
+    WRITE_LOCK_STATUS_BLOCKED,
+    WRITE_LOCK_STATUS_NO_ACTION_NEEDED,
+    WRITE_LOCK_STATUS_READY,
+    WRITE_LOCK_TYPE,
+    build_evidence_repair_write_lock_gate,
+    empty_evidence_repair_write_lock_gate,
+)
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {
+            "manual_commit_allowed": True,
+            "operation_count": 1,
+            "has_blocks": False,
+        },
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _verified_gate():
+    token_report = build_evidence_repair_human_approval_token(
+        dry_run=_ready_dry_run(),
+        approver="han",
+        approval_reason="final manual approval",
+        expires_in_minutes=30,
+    ).to_dict()
+    token_report["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return build_evidence_repair_approval_token_gate(
+        approval_token=token_report,
+        confirmation_text=token_report["tokens"][0]["required_confirmation_text"],
+        current_time="2026-05-11T00:10:00+00:00",
+    ).to_dict()
+
+
+def _commit_receipt():
+    return build_evidence_repair_commit_receipt(
+        token_gate=_verified_gate(),
+        actor="han",
+        commit_reason="manual memory evidence repair",
+    ).to_dict()
+
+
+def test_ready_receipt_creates_write_lock_draft():
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=_commit_receipt(),
+        lock_owner="han",
+        lock_ttl_minutes=15,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    lock = payload["locks"][0]
+    assert payload["status"] == WRITE_LOCK_STATUS_READY
+    assert payload["summary"]["executor_dry_run_allowed"] is True
+    assert payload["summary"]["fail_count"] == 0
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert lock["id"].startswith("write-lock-")
+    assert lock["lock_type"] == WRITE_LOCK_TYPE
+    assert lock["owner"] == "han"
+    assert lock["operation_ids"] == ["dryrun-op-123"]
+    assert lock["would_acquire_write_lock"] is True
+    assert lock["would_release_after_commit"] is True
+    assert lock["expires_at"] == "2026-05-11T00:35:00+00:00"
+
+
+def test_active_lock_conflict_blocks_write_lock():
+    receipt = _commit_receipt()
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        active_locks=[
+            {
+                "id": "write-lock-existing",
+                "status": "active",
+                "scope": "manual_memory_evidence_repair_commit",
+                "owner": "other",
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:40:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_ACTIVE_LOCKS in failed_checks
+    assert payload["summary"]["active_lock_conflict_count"] == 1
+    assert payload["active_lock_conflicts"][0]["reason"] == "overlapping_operation_ids"
+
+
+def test_expired_active_lock_does_not_block_write_lock():
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=_commit_receipt(),
+        active_locks=[
+            {
+                "id": "write-lock-expired",
+                "status": "active",
+                "scope": "manual_memory_evidence_repair_commit",
+                "operation_ids": ["dryrun-op-123"],
+                "expires_at": "2026-05-11T00:10:00+00:00",
+            }
+        ],
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    assert payload["status"] == WRITE_LOCK_STATUS_READY
+    assert payload["summary"]["active_lock_conflict_count"] == 0
+    assert payload["locks"]
+
+
+def test_already_used_token_blocks_write_lock():
+    receipt = _commit_receipt()
+    token_id = receipt["receipts"][0]["token_id"]
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        already_used_token_ids=[token_id],
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_TOKEN_REUSE in failed_checks
+    assert "regenerate_human_approval_token" in payload["required_actions"]
+
+
+def test_tampered_receipt_digest_blocks_write_lock():
+    receipt = _commit_receipt()
+    receipt["receipts"][0]["receipt_digest"] = "bad"
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=receipt,
+        current_time="2026-05-11T00:20:00+00:00",
+    ).to_dict()
+
+    failed_checks = {check["id"] for check in payload["checks"] if check["status"] == "fail"}
+    assert payload["status"] == WRITE_LOCK_STATUS_BLOCKED
+    assert CHECK_RECEIPT_INTEGRITY in failed_checks
+    assert "regenerate_commit_receipt" in payload["required_actions"]
+
+
+def test_no_action_receipt_does_not_create_write_lock():
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt={"status": "no_action_needed"}
+    ).to_dict()
+
+    assert payload["status"] == WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["locks"] == []
+    assert payload["summary"]["write_lock_available"] is False
+
+
+def test_empty_write_lock_gate_is_read_only():
+    payload = empty_evidence_repair_write_lock_gate().to_dict()
+
+    assert payload["status"] == WRITE_LOCK_STATUS_NO_ACTION_NEEDED
+    assert payload["read_only"] is True
+    assert payload["read_only_memory"] is True
+    assert payload["would_mutate_memory"] is False
+    assert payload["locks"] == []

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -167,6 +167,7 @@ def test_memory_orchestration_routing_metrics_ready_from_local_evidence(tmp_path
     assert result["auto_precheck_profile_count"] == 1
     assert result["auto_precheck_agent_ids"] == ["planner", "coder"]
     assert result["operation_routing_event_count"] == 1
+    assert result["has_explicit_routing_operation_event"] is True
     assert result["gate_decision_count"] == 1
     assert result["auto_precheck_operation_count"] == 1
     assert result["client_counts"] == {"codex": 1, "hermes": 1, "openclaw": 2}
@@ -179,6 +180,75 @@ def test_memory_orchestration_routing_metrics_ready_from_local_evidence(tmp_path
     assert result["policy"]["does_not_write_memory"] is True
     assert result["would_modify_config"] is False
     assert result["would_write_graph"] is False
+
+
+def test_memory_orchestration_routing_metrics_requires_explicit_routing_event(tmp_path, monkeypatch):
+    openclaw = tmp_path / ".openclaw"
+    openclaw.mkdir()
+    (openclaw / "openclaw.json").write_text(
+        """
+        {
+          "agents": {
+            "entries": {
+              "planner": {},
+              "coder": {},
+              "reviewer": {}
+            }
+          },
+          "bindings": [
+            {
+              "type": "route",
+              "agentId": "planner",
+              "match": {"channel": "telegram"}
+            }
+          ],
+          "plugins": {
+            "entries": {
+              "hermes-memory": {
+                "enabled": true,
+                "config": {
+                  "autoPrecheckAgentIds": ["planner"],
+                  "autoPrecheckAgentProfiles": {
+                    "default": {"scope": "project"}
+                  }
+                }
+              }
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def operation_ledger(*, limit=500, client="", operation="", decision="", event_type=""):
+        return {
+            "events": [
+                {"client": "hermes", "operation": "auto_precheck", "decision": "allow"},
+                {"client": "codex", "event_type": "gate_decision", "operation": "search", "decision": "block"},
+            ]
+        }
+
+    monkeypatch.setattr(memory_fabric_bridge, "memory_operation_ledger", operation_ledger)
+
+    result = memory_orchestration_routing_metrics()
+
+    assert result["agent_count"] == 3
+    assert result["route_binding_count"] == 1
+    assert result["auto_precheck_profile_count"] == 1
+    assert result["operation_routing_event_count"] == 0
+    assert result["has_explicit_routing_operation_event"] is False
+    assert result["gate_decision_count"] == 1
+    assert result["auto_precheck_operation_count"] == 1
+    assert result["client_counts"] == {"codex": 1, "hermes": 1}
+    assert result["decision_counts"] == {"allow": 1, "block": 1}
+    assert result["routing_readiness_score"] == 0.75
+    assert result["ready"] is False
+    assert result["active_routing_metrics"] is False
+    assert "Hermes operation ledger has at least 1 explicit route/routing/orchestration event." in result["gaps"]
+    assert result["recommended_next_actions"] == [
+        "Keep Star Hub pending until a governed routing event is recorded in the Hermes operation ledger; do not modify config from this tool."
+    ]
 
 
 def test_openclaw_route_bindings_parse_top_level_bindings():
@@ -233,7 +303,7 @@ def test_memory_orchestration_routing_metrics_reports_gaps(tmp_path, monkeypatch
     assert "OpenClaw has at least 3 configured agents." in result["gaps"]
     assert "OpenClaw has at least 1 route binding." in result["gaps"]
     assert "Hermes memory auto-precheck has at least 1 profile." in result["gaps"]
-    assert "Hermes operation ledger has routing, gate, or auto-precheck activity." in result["gaps"]
+    assert "Hermes operation ledger has at least 1 explicit route/routing/orchestration event." in result["gaps"]
 
 
 def _ready_federation_status():
@@ -403,10 +473,68 @@ def test_memory_evolution_uses_orchestration_routing_metrics_for_star_hub(monkey
     star_hub = next(item for item in result["readiness"] if item["level"] == 11)
 
     assert result["evidence"]["active_routing_metrics"] is True
+    assert result["evidence"]["has_explicit_routing_operation_event"] is True
     assert result["evidence"]["routing_readiness_score"] == 1.0
     assert result["orchestration_routing_metrics"]["ready"] is True
     assert star_hub["achieved"] is True
     assert "Memory orchestration has active routing metrics" in star_hub["passed_criteria"]
+    assert "Memory orchestration has explicit route/routing/orchestration operation evidence" in star_hub["passed_criteria"]
+
+
+def test_memory_evolution_does_not_claim_star_hub_without_explicit_routing_event(monkeypatch):
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_bridge_status",
+        lambda: {
+            "hermes_home": "/tmp/hermes",
+            "surfaces": {
+                "graph": {"exists": True, "node_count": 3, "edge_count": 2, "provenance_count": 1},
+                "gpt_image_prompt_cases": {"exists": True, "case_count": 1},
+                "knowledge": {"exists": True, "file_count": 1},
+                "operation_ledger": {"exists": True, "event_count": 3},
+                "policy_proposals": {"exists": True, "event_count": 1},
+            },
+        },
+    )
+    monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_boundary_allowlist_audit",
+        lambda *, log_limit=200: {"ready": True, "boundary_readiness_score": 100},
+    )
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_orchestration_routing_metrics",
+        lambda: {
+            "ready": True,
+            "active_routing_metrics": True,
+            "routing_readiness_score": 1.0,
+            "agent_count": 3,
+            "route_binding_count": 1,
+            "operation_routing_event_count": 0,
+            "gate_decision_count": 1,
+            "auto_precheck_operation_count": 1,
+        },
+    )
+    monkeypatch.setattr(memory_fabric_bridge, "memory_policy_outcome_monitor", _healthy_policy_outcome)
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_recall_quality_evaluate",
+        lambda *, limit=5: {
+            "readiness": "ready",
+            "quality_score": 1.0,
+            "summary": {"passed_query_count": 5, "benchmark_query_count": 5},
+        },
+    )
+
+    result = memory_evolution_status()
+    star_hub = next(item for item in result["readiness"] if item["level"] == 11)
+
+    assert result["evidence"]["active_routing_metrics"] is True
+    assert result["evidence"]["has_explicit_routing_operation_event"] is False
+    assert star_hub["achieved"] is False
+    assert "Memory orchestration has active routing metrics" in star_hub["passed_criteria"]
+    assert "Memory orchestration has explicit route/routing/orchestration operation evidence" in star_hub["gaps"]
 
 
 def test_memory_evolution_does_not_claim_star_realm_without_boundary_review():

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -479,6 +479,20 @@ def _star_soul_operation_event():
     }
 
 
+def _star_universe_operation_event():
+    return {
+        "event_type": "temporal_evolution_metrics",
+        "operation": "temporal_evolution_metrics",
+        "client": "hermes",
+        "project_ids": ["lovart", "openclaw"],
+        "surfaces": ["operation_ledger", "memory_graph", "knowledge"],
+        "days": ["2026-05-20", "2026-05-21"],
+        "would_write_memory": False,
+        "would_modify_config": False,
+        "would_modify_graph": False,
+    }
+
+
 def test_memory_boundary_allowlist_audit_requires_manual_review_evidence(monkeypatch):
     monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
     monkeypatch.setattr(memory_fabric_bridge, "memory_federation_audit", _ready_federation_audit)
@@ -1013,6 +1027,239 @@ def test_memory_evolution_status_star_universe_check_is_read_only(tmp_path, monk
     assert result["would_modify_config"] is False
     assert operation_path.read_text(encoding="utf-8") == before_operation
     assert proposal_path.read_text(encoding="utf-8") == before_proposal
+
+
+def test_memory_evolution_keeps_star_source_blocked_without_explicit_source_methodology_event(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [_star_soul_operation_event(), _star_universe_operation_event()],
+    )
+
+    result = memory_evolution_status()
+    star_source = next(item for item in result["readiness"] if item["level"] == 15)
+
+    assert result["current"]["level"] == 14
+    assert result["next"]["level"] == 15
+    assert result["evidence"]["source_reasoning_event_count"] == 0
+    assert result["evidence"]["methodology_generation_event_count"] == 0
+    assert result["evidence"]["self_evolution_event_count"] == 0
+    assert result["evidence"]["source_methodology_ready"] is False
+    assert star_source["achieved"] is False
+    assert "Source reasoning and methodology self-evolution are implemented" in star_source["gaps"]
+    assert any("read-only source reasoning and methodology self-evolution audit event" in action for action in result["recommended_next_actions"])
+
+
+def test_memory_evolution_keeps_star_source_blocked_for_generic_surfaces_snapshot_and_temporal_metrics(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            _star_soul_operation_event(),
+            _star_universe_operation_event(),
+            {
+                "event_type": "snapshot_export_created",
+                "operation": "snapshot_export",
+                "project_ids": ["lovart", "openclaw"],
+                "surfaces": ["graph_provenance", "knowledge", "operation_ledger"],
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+            },
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_source = next(item for item in result["readiness"] if item["level"] == 15)
+
+    assert result["current"]["level"] == 14
+    assert result["evidence"]["temporal_evolution_metrics_ready"] is True
+    assert result["evidence"]["source_methodology_project_count"] == 0
+    assert result["evidence"]["source_methodology_surface_count"] == 0
+    assert result["evidence"]["source_methodology_ready"] is False
+    assert star_source["achieved"] is False
+
+
+def test_memory_evolution_keeps_star_source_blocked_for_source_reasoning_without_methodology_self_evolution(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            _star_soul_operation_event(),
+            _star_universe_operation_event(),
+            {
+                "event_type": "source_reasoning",
+                "operation": "source_reasoning",
+                "project_id": "lovart",
+                "surfaces": ["operation_ledger", "graph_provenance"],
+                "tags": ["source_reasoning"],
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+            },
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_source = next(item for item in result["readiness"] if item["level"] == 15)
+
+    assert result["current"]["level"] == 14
+    assert result["evidence"]["source_reasoning_event_count"] == 1
+    assert result["evidence"]["methodology_generation_event_count"] == 0
+    assert result["evidence"]["self_evolution_event_count"] == 0
+    assert result["evidence"]["source_methodology_project_ids"] == ["lovart"]
+    assert result["evidence"]["source_methodology_surface_count"] >= 2
+    assert result["evidence"]["source_methodology_ready"] is False
+    assert star_source["achieved"] is False
+
+
+def test_memory_evolution_keeps_star_source_blocked_when_semantics_are_split_across_events(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            _star_soul_operation_event(),
+            _star_universe_operation_event(),
+            {
+                "event_id": "source-only",
+                "event_type": "source_reasoning",
+                "operation": "source_reasoning",
+                "project_id": "lovart",
+                "surfaces": ["operation_ledger", "graph_provenance"],
+                "tags": ["source_reasoning"],
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+                "would_write_graph": False,
+            },
+            {
+                "event_id": "methodology-self-only",
+                "event_type": "methodology_self_evolution",
+                "operation": "methodology_self_evolution",
+                "project_id": "lovart",
+                "surfaces": ["operation_ledger", "knowledge"],
+                "tags": ["methodology_generation", "self_evolution"],
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+                "would_write_graph": False,
+            },
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_source = next(item for item in result["readiness"] if item["level"] == 15)
+
+    assert result["current"]["level"] == 14
+    assert result["evidence"]["source_reasoning_event_count"] == 1
+    assert result["evidence"]["methodology_generation_event_count"] == 1
+    assert result["evidence"]["self_evolution_event_count"] == 1
+    assert result["evidence"]["source_methodology_project_ids"] == ["lovart"]
+    assert result["evidence"]["source_methodology_surface_count"] >= 2
+    assert result["evidence"]["source_methodology_governed_event_count"] == 0
+    assert result["evidence"]["source_methodology_governed_event_ids"] == []
+    assert result["evidence"]["source_methodology_ready"] is False
+    assert star_source["achieved"] is False
+
+
+def test_memory_evolution_claims_star_source_for_explicit_read_only_source_methodology_self_evolution(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            _star_soul_operation_event(),
+            _star_universe_operation_event(),
+            {
+                "event_id": "source-methodology-self",
+                "event_type": "source_methodology_self_evolution",
+                "operation": "source_methodology_self_evolution",
+                "project_id": "lovart",
+                "surfaces": ["graph_provenance", "knowledge", "prompt_cases"],
+                "metadata": {
+                    "source_reasoning": True,
+                    "methodology_generation": True,
+                    "self_evolution": True,
+                },
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+                "would_write_graph": False,
+            },
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_source = next(item for item in result["readiness"] if item["level"] == 15)
+
+    assert result["current"]["level"] == 15
+    assert result["current"]["name"] == "星源记忆"
+    assert result["evidence"]["source_reasoning_event_count"] == 1
+    assert result["evidence"]["methodology_generation_event_count"] == 1
+    assert result["evidence"]["self_evolution_event_count"] == 1
+    assert result["evidence"]["source_methodology_project_count"] == 1
+    assert result["evidence"]["source_methodology_project_ids"] == ["lovart"]
+    assert result["evidence"]["source_methodology_surface_count"] >= 2
+    assert result["evidence"]["source_methodology_governed_event_count"] == 1
+    assert result["evidence"]["source_methodology_governed_event_ids"] == ["source-methodology-self"]
+    assert result["evidence"]["source_methodology_ready"] is True
+    assert star_source["achieved"] is True
+    assert "Source reasoning and methodology self-evolution are implemented" in star_source["passed_criteria"]
+    assert not any("source reasoning and methodology self-evolution audit event" in action for action in result["recommended_next_actions"])
+
+
+def test_memory_evolution_status_star_source_check_is_read_only(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    operation_path = memory_fabric_bridge._operation_ledger_path(tmp_path)
+    proposal_path = memory_fabric_bridge._proposal_path(tmp_path)
+    config_path = tmp_path / "config.yaml"
+    graph_path = tmp_path / "memory_graph.db"
+    config_path.write_text("memory:\n  provider: hermes\n", encoding="utf-8")
+    _write_jsonl(
+        operation_path,
+        [
+            _star_soul_operation_event(),
+            _star_universe_operation_event(),
+            {
+                "event_type": "source_methodology_self_evolution",
+                "operation": "source_methodology_self_evolution",
+                "project_id": "lovart",
+                "surfaces": ["graph_provenance", "knowledge"],
+                "tags": ["source_reasoning", "methodology_generation", "self_evolution"],
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+            },
+        ],
+    )
+    before_operation = operation_path.read_text(encoding="utf-8")
+    before_proposal = proposal_path.read_text(encoding="utf-8")
+    before_config = config_path.read_text(encoding="utf-8")
+
+    result = memory_evolution_status()
+
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["policy"]["status_is_read_only"] is True
+    assert result["policy"]["does_not_modify_config"] is True
+    assert result["policy"]["does_not_write_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["would_modify_config"] is False
+    assert operation_path.read_text(encoding="utf-8") == before_operation
+    assert proposal_path.read_text(encoding="utf-8") == before_proposal
+    assert config_path.read_text(encoding="utf-8") == before_config
+    assert not graph_path.exists()
 
 
 def test_memory_evolution_keeps_star_law_blocked_without_policy_execution(monkeypatch):

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -1,3 +1,5 @@
+import json
+
 import agent.memory_fabric_bridge as memory_fabric_bridge
 from agent.memory_fabric_bridge import (
     memory_boundary_allowlist_audit,
@@ -9,6 +11,11 @@ from agent.memory_fabric_bridge import (
     memory_policy_outcome_monitor,
     memory_recall_quality_evaluate,
 )
+
+
+def _write_jsonl(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows), encoding="utf-8")
 
 
 def test_memory_evolution_tiers_are_fixed():
@@ -641,6 +648,167 @@ def test_memory_evolution_claims_star_law_after_guarded_policy_checks(monkeypatc
     assert star_law["achieved"] is True
     assert "Policy proposals close automatically after human approval and guarded checks" in star_law["passed_criteria"]
     assert not any("guarded non-mutating policy apply checks" in action for action in result["recommended_next_actions"])
+
+
+def test_memory_evolution_keeps_star_soul_blocked_without_write_proposal(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+
+    result = memory_evolution_status()
+    star_soul = next(item for item in result["readiness"] if item["level"] == 13)
+
+    assert result["current"]["level"] == 12
+    assert result["next"]["level"] == 13
+    assert result["evidence"]["write_proposal_count"] == 0
+    assert result["evidence"]["write_proposal_operation_event_count"] == 0
+    assert result["evidence"]["persona_continuity_write_proposal_count"] == 0
+    assert result["evidence"]["persona_continuity_governed"] is False
+    assert star_soul["achieved"] is False
+    assert "Long-term preference/persona continuity is governed" in star_soul["gaps"]
+    assert any("memory_write_proposal" in action and "do not write memory directly" in action for action in result["recommended_next_actions"])
+
+
+def test_memory_evolution_keeps_star_soul_blocked_for_generic_write_proposal(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _write_jsonl(
+        memory_fabric_bridge._proposal_path(tmp_path),
+        [
+            {
+                "proposal_id": "memory-write-proposal-generic",
+                "target_scope": "project",
+                "content": "Store deployment checklist notes.",
+                "rationale": "Improve release handoff.",
+                "tags": ["release"],
+                "status": "proposed",
+                "would_write_memory": False,
+                "would_modify_graph": False,
+            }
+        ],
+    )
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            {
+                "event_type": "write_proposal_created",
+                "operation": "write_proposal",
+                "proposal_id": "memory-write-proposal-generic",
+                "would_write_memory": False,
+                "would_modify_config": False,
+            }
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_soul = next(item for item in result["readiness"] if item["level"] == 13)
+
+    assert result["current"]["level"] == 12
+    assert result["evidence"]["write_proposal_count"] == 1
+    assert result["evidence"]["write_proposal_operation_event_count"] == 1
+    assert result["evidence"]["persona_continuity_write_proposal_count"] == 0
+    assert result["evidence"]["persona_continuity_governed"] is False
+    assert star_soul["achieved"] is False
+
+
+def test_memory_evolution_keeps_star_soul_blocked_for_mismatched_persona_proposal_event(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _write_jsonl(
+        memory_fabric_bridge._proposal_path(tmp_path),
+        [
+            {
+                "proposal_id": "memory-write-proposal-star-soul",
+                "source_agent": "codex",
+                "target_scope": "user",
+                "content": "Proposal for long-term collaboration style and preference continuity.",
+                "rationale": "Govern 星魂记忆 persona continuity without writing memory directly.",
+                "tags": ["persona", "preferences", "collaboration"],
+                "status": "proposed",
+                "would_write_memory": False,
+                "would_modify_graph": False,
+            }
+        ],
+    )
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            {
+                "event_type": "write_proposal_created",
+                "operation": "write_proposal",
+                "proposal_id": "memory-write-proposal-other",
+                "would_write_memory": False,
+                "would_modify_config": False,
+            }
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_soul = next(item for item in result["readiness"] if item["level"] == 13)
+
+    assert result["current"]["level"] == 12
+    assert result["evidence"]["write_proposal_count"] == 1
+    assert result["evidence"]["write_proposal_operation_event_count"] == 1
+    assert result["evidence"]["persona_continuity_write_proposal_count"] == 1
+    assert result["evidence"]["persona_continuity_governed_proposal_ids"] == []
+    assert result["evidence"]["persona_continuity_governed_event_count"] == 0
+    assert result["evidence"]["persona_continuity_governed"] is False
+    assert star_soul["achieved"] is False
+    assert "Long-term preference/persona continuity is governed" in star_soul["gaps"]
+
+
+def test_memory_evolution_claims_star_soul_for_governed_persona_continuity_proposal(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _write_jsonl(
+        memory_fabric_bridge._proposal_path(tmp_path),
+        [
+            {
+                "proposal_id": "memory-write-proposal-star-soul",
+                "source_agent": "codex",
+                "target_scope": "user",
+                "content": "Proposal for long-term collaboration style and preference continuity.",
+                "rationale": "Govern 星魂记忆 persona continuity without writing memory directly.",
+                "tags": ["persona", "preferences", "collaboration"],
+                "status": "proposed",
+                "would_write_memory": False,
+                "would_modify_graph": False,
+            }
+        ],
+    )
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            {
+                "event_type": "write_proposal_created",
+                "operation": "write_proposal",
+                "proposal_id": "memory-write-proposal-star-soul",
+                "would_write_memory": False,
+                "would_modify_config": False,
+            }
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_soul = next(item for item in result["readiness"] if item["level"] == 13)
+
+    assert result["current"]["level"] == 13
+    assert result["current"]["name"] == "星魂记忆"
+    assert result["evidence"]["write_proposal_count"] == 1
+    assert result["evidence"]["write_proposal_operation_event_count"] == 1
+    assert result["evidence"]["persona_continuity_write_proposal_count"] == 1
+    assert result["evidence"]["persona_continuity_governed_proposal_ids"] == ["memory-write-proposal-star-soul"]
+    assert result["evidence"]["persona_continuity_governed_event_count"] == 1
+    assert result["evidence"]["persona_continuity_governed"] is True
+    assert star_soul["achieved"] is True
+    assert "Long-term preference/persona continuity is governed" in star_soul["passed_criteria"]
+    assert not any("memory_write_proposal" in action for action in result["recommended_next_actions"])
+    assert result["read_only"] is True
+    assert result["policy"]["status_is_read_only"] is True
+    assert result["policy"]["does_not_modify_config"] is True
+    assert result["policy"]["does_not_write_memory"] is True
+    assert result["policy"]["persistent_changes_must_use_proposals"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["would_modify_config"] is False
 
 
 def test_memory_evolution_keeps_star_law_blocked_without_policy_execution(monkeypatch):

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -1,0 +1,122 @@
+from agent.memory_fabric_bridge import (
+    memory_boundary_allowlist_audit,
+    MEMORY_EVOLUTION_TIERS,
+    memory_bridge_status,
+    memory_evolution_status,
+    memory_federation_gate,
+    memory_policy_outcome_monitor,
+    memory_recall_quality_evaluate,
+)
+
+
+def test_memory_evolution_tiers_are_fixed():
+    names = [tier["name"] for tier in MEMORY_EVOLUTION_TIERS]
+
+    assert names == [
+        "星火记忆",
+        "星点记忆",
+        "星链记忆",
+        "星图记忆",
+        "星河记忆",
+        "星辰记忆",
+        "星域记忆",
+        "星穹记忆",
+        "星海记忆",
+        "星界记忆",
+        "星枢记忆",
+        "星律记忆",
+        "星魂记忆",
+        "星宙记忆",
+        "星源记忆",
+    ]
+
+
+def test_memory_evolution_status_is_read_only():
+    result = memory_evolution_status()
+
+    assert result["success"] is True
+    assert len(result["taxonomy"]) == 15
+    assert result["current"]["level"] >= 1
+    assert "recall_quality" in result
+    assert result["policy"]["taxonomy_is_fixed"] is True
+    assert result["policy"]["status_is_read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["would_modify_config"] is False
+
+
+def test_memory_bridge_status_includes_graph_and_policy_surfaces():
+    result = memory_bridge_status()
+
+    assert result["success"] is True
+    assert "graph" in result["surfaces"]
+    assert "policy_proposals" in result["surfaces"]
+    assert result["policy"]["writes_are_proposal_only"] is True
+
+
+def test_memory_federation_gate_blocks_direct_writes():
+    result = memory_federation_gate(
+        client="codex",
+        operation="direct_write",
+        target_scope="memory",
+    )
+
+    assert result["success"] is True
+    assert result["decision"] == "block"
+    assert result["allowed"] is False
+
+
+def test_memory_policy_outcome_monitor_is_read_only():
+    result = memory_policy_outcome_monitor(limit=10, stale_after_hours=72)
+
+    assert result["success"] is True
+    assert result["policy"]["monitor_is_read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_modify_config"] is False
+
+
+def test_memory_recall_quality_evaluate_is_read_only():
+    result = memory_recall_quality_evaluate(queries="memory,policy", limit=3)
+
+    assert result["success"] is True
+    assert result["evaluation_type"] == "hermes_memory_recall_quality_evaluate"
+    assert result["summary"]["benchmark_query_count"] == 2
+    assert result["policy"]["evaluation_is_read_only"] is True
+    assert result["policy"]["does_not_append_ledger_events"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+
+
+def test_memory_boundary_allowlist_audit_is_read_only_and_ready_for_star_realm():
+    result = memory_boundary_allowlist_audit(log_limit=200)
+
+    assert result["success"] is True
+    assert result["audit_type"] == "hermes_memory_boundary_allowlist_audit"
+    assert result["ready"] is True
+    assert result["boundary_readiness_score"] >= 90
+    assert result["reviewed"] is True
+    assert result["unreviewed_allowlists"] == []
+    assert result["policy"]["audit_is_read_only"] is True
+    assert result["policy"]["does_not_modify_config"] is True
+    assert result["policy"]["does_not_write_memory"] is True
+    assert result["policy"]["does_not_write_graph"] is True
+    assert result["policy"]["does_not_approve_allowlists"] is True
+    assert result["policy"]["does_not_enable_external_recall"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["would_modify_config"] is False
+    assert result["would_write_graph"] is False
+
+
+def test_memory_evolution_reaches_star_realm_after_boundary_review(monkeypatch):
+    # This readiness test intentionally checks the real local Hermes home.
+    # The global pytest fixture isolates HERMES_HOME into a tempdir by default,
+    # which is correct for most tests but would hide the real Memory Fabric.
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    result = memory_evolution_status()
+
+    assert result["success"] is True
+    assert result["current"]["level"] >= 10
+    assert result["current"]["name"] == "星界记忆"
+    assert result["evidence"]["boundary_allowlists_reviewed"] is True
+    assert result["next"]["level"] == 11

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -355,6 +355,91 @@ def _healthy_ledger(*, limit=500, client="", operation=""):
     return {"health_score": 100, "risk_level": "low", "findings": []}
 
 
+def _star_law_ready_policy_outcome(*, limit=50, stale_after_hours=72):
+    return {
+        "health_score": 100,
+        "risk_level": "low",
+        "metrics": {
+            "stale_proposed_count": 0,
+            "approved_not_executed_count": 0,
+            "execution_count": 1,
+            "execution_totals": {
+                "checked_count": 1,
+                "passed_count": 1,
+                "blocked_count": 0,
+                "failed_count": 0,
+                "manual_required_count": 0,
+            },
+        },
+    }
+
+
+def _star_law_blocked_policy_outcome(*, limit=50, stale_after_hours=72):
+    return {
+        "health_score": 90,
+        "risk_level": "medium",
+        "metrics": {
+            "stale_proposed_count": 0,
+            "approved_not_executed_count": 1,
+            "execution_count": 0,
+            "execution_totals": {
+                "checked_count": 0,
+                "passed_count": 0,
+                "blocked_count": 0,
+                "failed_count": 0,
+                "manual_required_count": 0,
+            },
+        },
+    }
+
+
+def _patch_star_law_prerequisites(monkeypatch, policy_outcome):
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_bridge_status",
+        lambda: {
+            "hermes_home": "/tmp/hermes",
+            "surfaces": {
+                "graph": {"exists": True, "node_count": 3, "edge_count": 2, "provenance_count": 1},
+                "gpt_image_prompt_cases": {"exists": True, "case_count": 1},
+                "knowledge": {"exists": True, "file_count": 1},
+                "operation_ledger": {"exists": True, "event_count": 3},
+                "policy_proposals": {"exists": True, "event_count": 1},
+            },
+        },
+    )
+    monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_boundary_allowlist_audit",
+        lambda *, log_limit=200: {"ready": True, "boundary_readiness_score": 100},
+    )
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_orchestration_routing_metrics",
+        lambda: {
+            "ready": True,
+            "active_routing_metrics": True,
+            "routing_readiness_score": 1.0,
+            "agent_count": 3,
+            "route_binding_count": 1,
+            "operation_routing_event_count": 1,
+            "gate_decision_count": 1,
+            "auto_precheck_operation_count": 1,
+        },
+    )
+    monkeypatch.setattr(memory_fabric_bridge, "memory_policy_outcome_monitor", policy_outcome)
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_recall_quality_evaluate",
+        lambda *, limit=5: {
+            "readiness": "ready",
+            "quality_score": 1.0,
+            "summary": {"passed_query_count": 5, "benchmark_query_count": 5},
+        },
+    )
+
+
 def test_memory_boundary_allowlist_audit_requires_manual_review_evidence(monkeypatch):
     monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
     monkeypatch.setattr(memory_fabric_bridge, "memory_federation_audit", _ready_federation_audit)
@@ -535,6 +620,43 @@ def test_memory_evolution_does_not_claim_star_hub_without_explicit_routing_event
     assert star_hub["achieved"] is False
     assert "Memory orchestration has active routing metrics" in star_hub["passed_criteria"]
     assert "Memory orchestration has explicit route/routing/orchestration operation evidence" in star_hub["gaps"]
+
+
+def test_memory_evolution_claims_star_law_after_guarded_policy_checks(monkeypatch):
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+
+    result = memory_evolution_status()
+    star_law = next(item for item in result["readiness"] if item["level"] == 12)
+
+    assert result["current"]["level"] == 12
+    assert result["current"]["name"] == "星律记忆"
+    assert result["evidence"]["policy_execution_count"] == 1
+    assert result["evidence"]["policy_approved_not_executed_count"] == 0
+    assert result["evidence"]["policy_execution_checked_count"] == 1
+    assert result["evidence"]["policy_execution_passed_count"] == 1
+    assert result["evidence"]["policy_execution_blocked_count"] == 0
+    assert result["evidence"]["policy_execution_failed_count"] == 0
+    assert result["evidence"]["policy_execution_manual_required_count"] == 0
+    assert result["evidence"]["policy_closed_loop_ready"] is True
+    assert star_law["achieved"] is True
+    assert "Policy proposals close automatically after human approval and guarded checks" in star_law["passed_criteria"]
+    assert not any("guarded non-mutating policy apply checks" in action for action in result["recommended_next_actions"])
+
+
+def test_memory_evolution_keeps_star_law_blocked_without_policy_execution(monkeypatch):
+    _patch_star_law_prerequisites(monkeypatch, _star_law_blocked_policy_outcome)
+
+    result = memory_evolution_status()
+    star_law = next(item for item in result["readiness"] if item["level"] == 12)
+
+    assert result["current"]["level"] == 11
+    assert result["next"]["level"] == 12
+    assert result["evidence"]["policy_execution_count"] == 0
+    assert result["evidence"]["policy_approved_not_executed_count"] == 1
+    assert result["evidence"]["policy_closed_loop_ready"] is False
+    assert star_law["achieved"] is False
+    assert "Policy proposals close automatically after human approval and guarded checks" in star_law["gaps"]
+    assert any("guarded non-mutating policy apply checks" in action for action in result["recommended_next_actions"])
 
 
 def test_memory_evolution_does_not_claim_star_realm_without_boundary_review():

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -447,6 +447,38 @@ def _patch_star_law_prerequisites(monkeypatch, policy_outcome):
     )
 
 
+def _seed_star_soul_governed(tmp_path):
+    _write_jsonl(
+        memory_fabric_bridge._proposal_path(tmp_path),
+        [
+            {
+                "proposal_id": "memory-write-proposal-star-soul",
+                "source_agent": "codex",
+                "target_scope": "user",
+                "content": "Proposal for long-term collaboration style and preference continuity.",
+                "rationale": "Govern 星魂记忆 persona continuity without writing memory directly.",
+                "tags": ["persona", "preferences", "collaboration"],
+                "status": "proposed",
+                "would_write_memory": False,
+                "would_modify_graph": False,
+                "would_modify_config": False,
+            }
+        ],
+    )
+
+
+def _star_soul_operation_event():
+    return {
+        "event_type": "write_proposal_created",
+        "operation": "write_proposal",
+        "proposal_id": "memory-write-proposal-star-soul",
+        "created_at": "2026-05-20T00:00:00+00:00",
+        "would_write_memory": False,
+        "would_modify_config": False,
+        "would_modify_graph": False,
+    }
+
+
 def test_memory_boundary_allowlist_audit_requires_manual_review_evidence(monkeypatch):
     monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
     monkeypatch.setattr(memory_fabric_bridge, "memory_federation_audit", _ready_federation_audit)
@@ -809,6 +841,178 @@ def test_memory_evolution_claims_star_soul_for_governed_persona_continuity_propo
     assert result["policy"]["persistent_changes_must_use_proposals"] is True
     assert result["would_mutate_memory"] is False
     assert result["would_modify_config"] is False
+
+
+def test_memory_evolution_keeps_star_universe_blocked_without_explicit_temporal_metrics(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(memory_fabric_bridge._operation_ledger_path(tmp_path), [_star_soul_operation_event()])
+
+    result = memory_evolution_status()
+    star_universe = next(item for item in result["readiness"] if item["level"] == 14)
+
+    assert result["current"]["level"] == 13
+    assert result["next"]["level"] == 14
+    assert result["evidence"]["temporal_evolution_metric_event_count"] == 0
+    assert result["evidence"]["temporal_evolution_metrics_ready"] is False
+    assert star_universe["achieved"] is False
+    assert "Temporal evolution metrics exist across projects" in star_universe["gaps"]
+    assert any("read-only temporal evolution metrics snapshot across projects" in action for action in result["recommended_next_actions"])
+
+
+def test_memory_evolution_keeps_star_universe_blocked_for_generic_multi_day_ledger(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            _star_soul_operation_event(),
+            {
+                "event_type": "gate_decision",
+                "operation": "search",
+                "client": "codex",
+                "project_id": "project-a",
+                "created_at": "2026-05-20T00:00:00+00:00",
+                "would_write_memory": False,
+                "would_modify_config": False,
+            },
+            {
+                "event_type": "write_proposal_created",
+                "operation": "write_proposal",
+                "client": "hermes",
+                "project_id": "project-b",
+                "created_at": "2026-05-22T00:00:00+00:00",
+                "would_write_memory": False,
+                "would_modify_config": False,
+            },
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_universe = next(item for item in result["readiness"] if item["level"] == 14)
+
+    assert result["current"]["level"] == 13
+    assert result["evidence"]["temporal_evolution_metric_event_count"] == 0
+    assert result["evidence"]["temporal_evolution_day_count"] == 0
+    assert result["evidence"]["temporal_evolution_project_count"] == 0
+    assert result["evidence"]["temporal_evolution_metrics_ready"] is False
+    assert star_universe["achieved"] is False
+
+
+def test_memory_evolution_keeps_star_universe_blocked_for_one_temporal_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            _star_soul_operation_event(),
+            {
+                "event_type": "temporal_evolution_metrics",
+                "operation": "temporal_evolution_metrics",
+                "client": "hermes",
+                "project_ids": ["project-a"],
+                "surfaces": ["operation_ledger", "memory_graph"],
+                "window_start": "2026-05-20T00:00:00+00:00",
+                "window_end": "2026-05-22T00:00:00+00:00",
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+            },
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_universe = next(item for item in result["readiness"] if item["level"] == 14)
+
+    assert result["current"]["level"] == 13
+    assert result["evidence"]["temporal_evolution_metric_event_count"] == 1
+    assert result["evidence"]["temporal_evolution_day_count"] == 2
+    assert result["evidence"]["temporal_evolution_project_count"] == 1
+    assert result["evidence"]["temporal_evolution_surface_count"] >= 2
+    assert result["evidence"]["temporal_evolution_metrics_ready"] is False
+    assert star_universe["achieved"] is False
+
+
+def test_memory_evolution_claims_star_universe_for_explicit_multi_project_temporal_metrics(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    _write_jsonl(
+        memory_fabric_bridge._operation_ledger_path(tmp_path),
+        [
+            _star_soul_operation_event(),
+            {
+                "event_type": "temporal_evolution_metrics",
+                "operation": "temporal_evolution_metrics",
+                "client": "hermes",
+                "project_ids": ["lovart", "openclaw"],
+                "surfaces": ["operation_ledger", "memory_graph", "knowledge"],
+                "window_start": "2026-05-20T00:00:00+00:00",
+                "window_end": "2026-05-22T00:00:00+00:00",
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+            },
+        ],
+    )
+
+    result = memory_evolution_status()
+    star_universe = next(item for item in result["readiness"] if item["level"] == 14)
+
+    assert result["current"]["level"] == 14
+    assert result["current"]["name"] == "星宙记忆"
+    assert result["evidence"]["temporal_evolution_metric_event_count"] == 1
+    assert result["evidence"]["temporal_evolution_day_count"] == 2
+    assert result["evidence"]["temporal_evolution_span_days"] == 2
+    assert result["evidence"]["temporal_evolution_project_count"] == 2
+    assert result["evidence"]["temporal_evolution_project_ids"] == ["lovart", "openclaw"]
+    assert result["evidence"]["temporal_evolution_surface_count"] >= 2
+    assert result["evidence"]["temporal_evolution_metrics_ready"] is True
+    assert star_universe["achieved"] is True
+    assert "Temporal evolution metrics exist across projects" in star_universe["passed_criteria"]
+    assert not any("temporal evolution metrics snapshot" in action for action in result["recommended_next_actions"])
+
+
+def test_memory_evolution_status_star_universe_check_is_read_only(tmp_path, monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "get_hermes_home", lambda: tmp_path)
+    _patch_star_law_prerequisites(monkeypatch, _star_law_ready_policy_outcome)
+    _seed_star_soul_governed(tmp_path)
+    operation_path = memory_fabric_bridge._operation_ledger_path(tmp_path)
+    proposal_path = memory_fabric_bridge._proposal_path(tmp_path)
+    _write_jsonl(
+        operation_path,
+        [
+            _star_soul_operation_event(),
+            {
+                "event_type": "temporal_evolution_metrics",
+                "operation": "temporal_evolution_metrics",
+                "client": "hermes",
+                "project_ids": ["lovart", "openclaw"],
+                "surfaces": ["operation_ledger", "memory_graph"],
+                "days": ["2026-05-20", "2026-05-21"],
+                "would_write_memory": False,
+                "would_modify_config": False,
+                "would_modify_graph": False,
+            },
+        ],
+    )
+    before_operation = operation_path.read_text(encoding="utf-8")
+    before_proposal = proposal_path.read_text(encoding="utf-8")
+
+    result = memory_evolution_status()
+
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["policy"]["status_is_read_only"] is True
+    assert result["policy"]["does_not_modify_config"] is True
+    assert result["policy"]["does_not_write_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["would_modify_config"] is False
+    assert operation_path.read_text(encoding="utf-8") == before_operation
+    assert proposal_path.read_text(encoding="utf-8") == before_proposal
 
 
 def test_memory_evolution_keeps_star_law_blocked_without_policy_execution(monkeypatch):

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -1,3 +1,4 @@
+import agent.memory_fabric_bridge as memory_fabric_bridge
 from agent.memory_fabric_bridge import (
     memory_boundary_allowlist_audit,
     MEMORY_EVOLUTION_TIERS,
@@ -87,15 +88,73 @@ def test_memory_recall_quality_evaluate_is_read_only():
     assert result["would_mutate_memory"] is False
 
 
-def test_memory_boundary_allowlist_audit_is_read_only_and_ready_for_star_realm():
+def _ready_federation_status():
+    return {
+        "ready": True,
+        "clients": {
+            "hermes": {"role": "primary_memory_owner"},
+            "codex": {
+                "role": "memory_client",
+                "access_path": "codex_mcp",
+                "write_policy": "proposal_only",
+                "ready": True,
+            },
+            "openclaw": {
+                "role": "memory_client",
+                "access_path": "openclaw_plugin",
+                "plugin_enabled": True,
+                "conversation_access_allowed": True,
+                "auto_precheck_enabled": True,
+                "auto_precheck_agent_profiles": ["default"],
+                "external_auto_precheck_allowed_channels": [],
+                "external_auto_precheck_default": "blocked",
+                "write_policy": "proposal_only",
+                "ready": True,
+            },
+        },
+        "policy": {
+            "writes_are_proposal_only": True,
+            "external_channel_auto_recall_requires_allowlist": True,
+        },
+    }
+
+
+def _ready_federation_audit(*, log_limit=200):
+    return {
+        "ready": True,
+        "checks": [
+            {"id": "writes.proposal_only", "status": "pass", "severity": "critical"},
+            {"id": "external.default_blocked", "status": "pass", "severity": "critical"},
+        ],
+    }
+
+
+def _healthy_policy_outcome(*, limit=50, stale_after_hours=72):
+    return {"health_score": 100, "risk_level": "low"}
+
+
+def _healthy_ledger(*, limit=500, client="", operation=""):
+    return {"health_score": 100, "risk_level": "low", "findings": []}
+
+
+def test_memory_boundary_allowlist_audit_requires_manual_review_evidence(monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
+    monkeypatch.setattr(memory_fabric_bridge, "memory_federation_audit", _ready_federation_audit)
+    monkeypatch.setattr(memory_fabric_bridge, "memory_policy_outcome_monitor", _healthy_policy_outcome)
+    monkeypatch.setattr(memory_fabric_bridge, "memory_ledger_intelligence", _healthy_ledger)
+
     result = memory_boundary_allowlist_audit(log_limit=200)
 
     assert result["success"] is True
     assert result["audit_type"] == "hermes_memory_boundary_allowlist_audit"
-    assert result["ready"] is True
-    assert result["boundary_readiness_score"] >= 90
-    assert result["reviewed"] is True
-    assert result["unreviewed_allowlists"] == []
+    assert result["ready"] is False
+    assert result["boundary_readiness_score"] < 100
+    assert result["reviewed"] is False
+    assert result["unreviewed_allowlists"][0]["id"] == "openclaw.external_auto_precheck_boundary_review"
+    assert result["evidence"]["manual_boundary_review"]["complete"] is False
+    assert result["evidence"]["external_auto_precheck_default_blocked"] is True
+    assert result["evidence"]["external_auto_precheck_allowlist_empty"] is True
+    assert any("formal policy proposal or manual review record" in action for action in result["recommended_next_actions"])
     assert result["policy"]["audit_is_read_only"] is True
     assert result["policy"]["does_not_modify_config"] is True
     assert result["policy"]["does_not_write_memory"] is True
@@ -107,16 +166,48 @@ def test_memory_boundary_allowlist_audit_is_read_only_and_ready_for_star_realm()
     assert result["would_write_graph"] is False
 
 
-def test_memory_evolution_reaches_star_realm_after_boundary_review(monkeypatch):
-    # This readiness test intentionally checks the real local Hermes home.
-    # The global pytest fixture isolates HERMES_HOME into a tempdir by default,
-    # which is correct for most tests but would hide the real Memory Fabric.
-    monkeypatch.delenv("HERMES_HOME", raising=False)
+def test_memory_boundary_allowlist_audit_accepts_existing_policy_review_evidence(monkeypatch):
+    monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
+    monkeypatch.setattr(memory_fabric_bridge, "memory_federation_audit", _ready_federation_audit)
+    monkeypatch.setattr(memory_fabric_bridge, "memory_policy_outcome_monitor", _healthy_policy_outcome)
+    monkeypatch.setattr(memory_fabric_bridge, "memory_ledger_intelligence", _healthy_ledger)
 
+    def policy_ledger(*, limit=500, status="", proposal_id=""):
+        return {
+            "exists": True,
+            "proposals": [
+                {
+                    "proposal_id": "memory-policy-proposal-boundary-review",
+                    "suggestion_id": "external_auto_recall.keep_blocked",
+                    "target": "openclaw.autoPrecheckAllowedChannelIds",
+                    "latest_status": "approved",
+                    "decisions": [
+                        {
+                            "decision": "approved",
+                            "reviewer": "human-reviewer",
+                            "created_at": "2026-05-23T00:00:00+00:00",
+                        }
+                    ],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(memory_fabric_bridge, "memory_policy_proposal_ledger", policy_ledger)
+
+    result = memory_boundary_allowlist_audit(log_limit=200)
+
+    assert result["ready"] is True
+    assert result["reviewed"] is True
+    assert result["unreviewed_allowlists"] == []
+    assert result["boundary_readiness_score"] == 100
+    assert result["evidence"]["manual_boundary_review"]["complete"] is True
+    assert result["evidence"]["manual_boundary_review"]["source"] == "policy_proposal_ledger"
+    assert result["reviewed_allowlists"][0]["review"] == "empty_allowlist_reviewed_with_manual_evidence"
+
+
+def test_memory_evolution_does_not_claim_star_realm_without_boundary_review():
     result = memory_evolution_status()
 
     assert result["success"] is True
-    assert result["current"]["level"] >= 10
-    assert result["current"]["name"] == "星界记忆"
-    assert result["evidence"]["boundary_allowlists_reviewed"] is True
-    assert result["next"]["level"] == 11
+    assert result["evidence"]["boundary_allowlists_reviewed"] is False
+    assert result["evidence"]["boundary_readiness_score"] < 100

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -5,6 +5,7 @@ from agent.memory_fabric_bridge import (
     memory_bridge_status,
     memory_evolution_status,
     memory_federation_gate,
+    memory_orchestration_routing_metrics,
     memory_policy_outcome_monitor,
     memory_recall_quality_evaluate,
 )
@@ -86,6 +87,153 @@ def test_memory_recall_quality_evaluate_is_read_only():
     assert result["policy"]["does_not_append_ledger_events"] is True
     assert result["read_only_memory"] is True
     assert result["would_mutate_memory"] is False
+
+
+def test_memory_orchestration_routing_metrics_ready_from_local_evidence(tmp_path, monkeypatch):
+    openclaw = tmp_path / ".openclaw"
+    openclaw.mkdir()
+    (openclaw / "openclaw.json").write_text(
+        """
+        {
+          "agents": {
+            "entries": {
+              "planner": {},
+              "coder": {},
+              "reviewer": {}
+            }
+          },
+          "bindings": [
+            {
+              "type": "route",
+              "agentId": "planner",
+              "match": {
+                "channel": "telegram",
+                "accountId": "bot-main",
+                "peerKind": "group",
+                "peerId": "team"
+              }
+            },
+            {
+              "type": "route",
+              "agentId": "coder",
+              "match": {
+                "channel": "slack",
+                "accountId": "workspace-main",
+                "peerKind": "channel",
+                "peerId": "eng"
+              }
+            }
+          ],
+          "plugins": {
+            "entries": {
+              "hermes-memory": {
+                "enabled": true,
+                "config": {
+                  "autoPrecheckAgentIds": ["planner", "coder"],
+                  "autoPrecheckAgentProfiles": {
+                    "default": {"scope": "project"}
+                  }
+                }
+              }
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def operation_ledger(*, limit=500, client="", operation="", decision="", event_type=""):
+        return {
+            "events": [
+                {"client": "openclaw", "operation": "route_memory_request", "decision": "allow"},
+                {"client": "hermes", "operation": "auto_precheck", "decision": "allow"},
+                {"client": "codex", "event_type": "gate_decision", "operation": "search", "decision": "block"},
+                {"client": "openclaw", "operation": "memory_search", "decision": "allow"},
+            ]
+        }
+
+    monkeypatch.setattr(memory_fabric_bridge, "memory_operation_ledger", operation_ledger)
+
+    result = memory_orchestration_routing_metrics()
+
+    assert result["success"] is True
+    assert result["metrics_type"] == "hermes_memory_orchestration_routing_metrics"
+    assert result["agent_count"] == 3
+    assert result["route_binding_count"] == 2
+    assert result["routed_agent_count"] == 2
+    assert result["routed_agent_ids"] == ["coder", "planner"]
+    assert result["route_channel_counts"] == {"slack": 1, "telegram": 1}
+    assert result["auto_precheck_profile_count"] == 1
+    assert result["auto_precheck_agent_ids"] == ["planner", "coder"]
+    assert result["operation_routing_event_count"] == 1
+    assert result["gate_decision_count"] == 1
+    assert result["auto_precheck_operation_count"] == 1
+    assert result["client_counts"] == {"codex": 1, "hermes": 1, "openclaw": 2}
+    assert result["decision_counts"] == {"allow": 3, "block": 1}
+    assert result["routing_readiness_score"] == 1.0
+    assert result["ready"] is True
+    assert result["active_routing_metrics"] is True
+    assert result["policy"]["metrics_are_read_only"] is True
+    assert result["policy"]["does_not_modify_openclaw_config"] is True
+    assert result["policy"]["does_not_write_memory"] is True
+    assert result["would_modify_config"] is False
+    assert result["would_write_graph"] is False
+
+
+def test_openclaw_route_bindings_parse_top_level_bindings():
+    bindings = memory_fabric_bridge._openclaw_route_bindings(
+        {
+            "bindings": [
+                {
+                    "type": "route",
+                    "agentId": "telegram-agent",
+                    "match": {
+                        "channel": "telegram",
+                        "accountId": "bot-main",
+                        "peerKind": "group",
+                        "peerId": "team",
+                    },
+                },
+                {
+                    "type": "tool",
+                    "agentId": "ignored-agent",
+                    "match": {"channel": "telegram"},
+                },
+            ]
+        }
+    )
+
+    assert bindings == [
+        {
+            "agent_id": "telegram-agent",
+            "channel": "telegram",
+            "source": "bindings/0",
+            "account_id": "bot-main",
+            "peer_kind": "group",
+            "peer_id": "team",
+        }
+    ]
+
+
+def test_memory_orchestration_routing_metrics_reports_gaps(tmp_path, monkeypatch):
+    (tmp_path / ".openclaw").mkdir()
+    (tmp_path / ".openclaw" / "openclaw.json").write_text(
+        '{"agents": {"entries": {"planner": {}}}, "plugins": {"entries": {"hermes-memory": {"config": {}}}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(memory_fabric_bridge, "memory_operation_ledger", lambda **kwargs: {"events": []})
+
+    result = memory_orchestration_routing_metrics()
+
+    assert result["ready"] is False
+    assert result["active_routing_metrics"] is False
+    assert result["routing_readiness_score"] == 0.0
+    assert "OpenClaw has at least 3 configured agents." in result["gaps"]
+    assert "OpenClaw has at least 1 route binding." in result["gaps"]
+    assert "Hermes memory auto-precheck has at least 1 profile." in result["gaps"]
+    assert "Hermes operation ledger has routing, gate, or auto-precheck activity." in result["gaps"]
 
 
 def _ready_federation_status():
@@ -203,6 +351,62 @@ def test_memory_boundary_allowlist_audit_accepts_existing_policy_review_evidence
     assert result["evidence"]["manual_boundary_review"]["complete"] is True
     assert result["evidence"]["manual_boundary_review"]["source"] == "policy_proposal_ledger"
     assert result["reviewed_allowlists"][0]["review"] == "empty_allowlist_reviewed_with_manual_evidence"
+
+
+def test_memory_evolution_uses_orchestration_routing_metrics_for_star_hub(monkeypatch):
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_bridge_status",
+        lambda: {
+            "hermes_home": "/tmp/hermes",
+            "surfaces": {
+                "graph": {"exists": True, "node_count": 3, "edge_count": 2, "provenance_count": 1},
+                "gpt_image_prompt_cases": {"exists": True, "case_count": 1},
+                "knowledge": {"exists": True, "file_count": 1},
+                "operation_ledger": {"exists": True, "event_count": 3},
+                "policy_proposals": {"exists": True, "event_count": 1},
+            },
+        },
+    )
+    monkeypatch.setattr(memory_fabric_bridge, "memory_federation_status", _ready_federation_status)
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_boundary_allowlist_audit",
+        lambda *, log_limit=200: {"ready": True, "boundary_readiness_score": 100},
+    )
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_orchestration_routing_metrics",
+        lambda: {
+            "ready": True,
+            "active_routing_metrics": True,
+            "routing_readiness_score": 1.0,
+            "agent_count": 3,
+            "route_binding_count": 1,
+            "operation_routing_event_count": 1,
+            "gate_decision_count": 1,
+            "auto_precheck_operation_count": 1,
+        },
+    )
+    monkeypatch.setattr(memory_fabric_bridge, "memory_policy_outcome_monitor", _healthy_policy_outcome)
+    monkeypatch.setattr(
+        memory_fabric_bridge,
+        "memory_recall_quality_evaluate",
+        lambda *, limit=5: {
+            "readiness": "ready",
+            "quality_score": 1.0,
+            "summary": {"passed_query_count": 5, "benchmark_query_count": 5},
+        },
+    )
+
+    result = memory_evolution_status()
+    star_hub = next(item for item in result["readiness"] if item["level"] == 11)
+
+    assert result["evidence"]["active_routing_metrics"] is True
+    assert result["evidence"]["routing_readiness_score"] == 1.0
+    assert result["orchestration_routing_metrics"]["ready"] is True
+    assert star_hub["achieved"] is True
+    assert "Memory orchestration has active routing metrics" in star_hub["passed_criteria"]
 
 
 def test_memory_evolution_does_not_claim_star_realm_without_boundary_review():

--- a/tests/agent/test_memory_fabric_bridge.py
+++ b/tests/agent/test_memory_fabric_bridge.py
@@ -63,6 +63,66 @@ def test_memory_bridge_status_includes_graph_and_policy_surfaces():
     assert result["policy"]["writes_are_proposal_only"] is True
 
 
+def test_openclaw_memory_status_matches_plugin_auto_precheck_default(tmp_path, monkeypatch):
+    openclaw_dir = tmp_path / ".openclaw"
+    extension_dir = openclaw_dir / "extensions" / "hermes-memory"
+    extension_dir.mkdir(parents=True)
+    (extension_dir / "index.ts").write_text("export default {};\n", encoding="utf-8")
+    (extension_dir / "openclaw.plugin.json").write_text("{}", encoding="utf-8")
+    (openclaw_dir / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "entries": {
+                        "hermes-memory": {
+                            "enabled": True,
+                            "config": {},
+                            "hooks": {"allowConversationAccess": True},
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = memory_fabric_bridge._openclaw_memory_client_status()
+
+    assert result["auto_precheck_enabled"] is True
+    assert result["ready"] is True
+
+
+def test_openclaw_memory_status_respects_explicit_auto_precheck_false(tmp_path, monkeypatch):
+    openclaw_dir = tmp_path / ".openclaw"
+    extension_dir = openclaw_dir / "extensions" / "hermes-memory"
+    extension_dir.mkdir(parents=True)
+    (extension_dir / "index.ts").write_text("export default {};\n", encoding="utf-8")
+    (extension_dir / "openclaw.plugin.json").write_text("{}", encoding="utf-8")
+    (openclaw_dir / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "entries": {
+                        "hermes-memory": {
+                            "enabled": True,
+                            "config": {"autoPrecheckEnabled": False},
+                            "hooks": {"allowConversationAccess": True},
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = memory_fabric_bridge._openclaw_memory_client_status()
+
+    assert result["auto_precheck_enabled"] is False
+    assert result["ready"] is True
+
+
 def test_memory_federation_gate_blocks_direct_writes():
     result = memory_federation_gate(
         client="codex",

--- a/tests/agent/test_memory_governance_submission_packet.py
+++ b/tests/agent/test_memory_governance_submission_packet.py
@@ -1,0 +1,204 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import (
+    MEMORY_GOVERNANCE_SUBMISSION_PACKET_KIND,
+    MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY,
+    MEMORY_GOVERNANCE_SUBMISSION_PACKET_ROUTING,
+    MEMORY_GOVERNANCE_SUBMISSION_PACKET_STATUS,
+    create_governance_submission_packet,
+    explain_governance_submission_packet,
+    recommend_governance_submission_packet_action,
+    summarize_governance_submission_packets,
+    validate_governance_submission_packet,
+)
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_review_decision_gate import create_review_decision_candidate, evaluate_review_queue_item
+
+
+def _decision(block_type="procedural_rules", decision=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create governance review packets only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    if decision is None:
+        return evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    return create_review_decision_candidate(queue_item, reviewer="memory-reviewer", decision=decision)
+
+
+def _submission(block_type="procedural_rules", decision=None, source_pattern_ids=None, source_fact_ids=None):
+    draft = create_memory_proposal_draft(
+        _decision(
+            block_type=block_type,
+            decision=decision,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        author="proposal-drafter",
+    )
+    return create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+
+
+def test_valid_governance_submission_creates_human_review_packet_required_packet():
+    submission = _submission()
+
+    packet = create_governance_submission_packet(submission, reviewer="packet-reviewer")
+
+    assert packet["packet_kind"] == MEMORY_GOVERNANCE_SUBMISSION_PACKET_KIND
+    assert packet["packet_status"] == MEMORY_GOVERNANCE_SUBMISSION_PACKET_STATUS
+    assert packet["routing"] == MEMORY_GOVERNANCE_SUBMISSION_PACKET_ROUTING
+    assert packet["source_submission_id"] == submission["submission_id"]
+    assert packet["source_draft_id"] == submission["source_draft_id"]
+    assert packet["source_decision_id"] == submission["source_decision_id"]
+    assert packet["source_queue_item_id"] == submission["source_queue_item_id"]
+    assert packet["reviewer"] == "packet-reviewer"
+    assert packet["packet_validation"] == {"valid": True, "errors": []}
+    assert validate_governance_submission_packet(packet) == {"valid": True, "errors": []}
+    assert packet["next_step_recommendation"]["action"] == "route_packet_to_manual_human_review"
+    assert packet["next_step_recommendation"]["creates_real_proposals"] is False
+    assert packet["next_step_recommendation"]["submits_to_governance"] is False
+    assert packet["next_step_recommendation"]["converts_to_real_proposal"] is False
+
+
+def test_invalid_submission_creates_invalid_packet_with_invalid_governance_submission_candidate():
+    submission = _submission(decision="reject")
+
+    packet = create_governance_submission_packet(submission)
+
+    assert packet["packet_validation"]["valid"] is False
+    assert "invalid_governance_submission_candidate" in packet["packet_validation"]["errors"]
+    assert packet["next_step_recommendation"]["action"] == "do_not_route_packet"
+
+
+def test_missing_payload_preview_creates_invalid_packet():
+    submission = _submission()
+    submission.pop("payload_preview")
+
+    packet = create_governance_submission_packet(submission)
+
+    assert packet["packet_validation"]["valid"] is False
+    assert "missing_payload_preview" in packet["packet_validation"]["errors"]
+    assert packet["next_step_recommendation"]["action"] == "do_not_route_packet"
+
+
+def test_missing_source_evidence_creates_invalid_packet():
+    submission = _submission(source_pattern_ids=[], source_fact_ids=[])
+
+    packet = create_governance_submission_packet(submission)
+
+    assert packet["packet_validation"]["valid"] is False
+    assert "missing_source_evidence" in packet["packet_validation"]["errors"]
+
+
+def test_evidence_summary_includes_source_pattern_and_fact_counts():
+    submission = _submission(source_pattern_ids=["pattern-a", "pattern-b"], source_fact_ids=["fact-a"])
+
+    packet = create_governance_submission_packet(submission)
+
+    assert packet["evidence_summary"]["source_pattern_count"] == 2
+    assert packet["evidence_summary"]["source_fact_count"] == 1
+    assert packet["evidence_summary"]["source_pattern_ids"] == ["pattern-a", "pattern-b"]
+    assert packet["evidence_summary"]["source_fact_ids"] == ["fact-a"]
+    assert packet["evidence_summary"]["has_source_evidence"] is True
+
+
+def test_human_review_checklist_exists_and_is_deterministic():
+    packet_a = create_governance_submission_packet(_submission())
+    packet_b = create_governance_submission_packet(_submission())
+
+    assert packet_a["human_review_checklist"]
+    assert packet_a["human_review_checklist"] == packet_b["human_review_checklist"]
+    assert [item["id"] for item in packet_a["human_review_checklist"]] == [
+        "verify_payload_preview",
+        "verify_source_evidence",
+        "verify_scope_and_routing",
+        "verify_no_side_effects",
+    ]
+
+
+def test_input_submission_candidate_is_not_mutated():
+    submission = _submission()
+    before = deepcopy(submission)
+
+    packet = create_governance_submission_packet(submission)
+    packet["source_submission_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert submission == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    packet = create_governance_submission_packet(_submission())
+    explanation = explain_governance_submission_packet(packet)
+    recommendation = recommend_governance_submission_packet_action(packet)
+
+    assert packet["policy"] == MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY
+    assert packet["policy"]["read_only"] is True
+    assert packet["policy"]["would_write_memory"] is False
+    assert packet["policy"]["would_modify_config"] is False
+    assert packet["policy"]["would_write_graph"] is False
+    assert packet["policy"]["does_not_create_operation_events"] is True
+    assert packet["policy"]["creates_review_packets_only"] is True
+    assert packet["policy"]["creates_real_proposals"] is False
+    assert packet["policy"]["applies_proposals"] is False
+    assert packet["policy"]["persists_approvals"] is False
+    assert packet["policy"]["submits_to_governance"] is False
+    assert packet["policy"]["converts_to_real_proposal"] is False
+    assert explanation["submitted"] is False
+    assert explanation["applied"] is False
+    assert explanation["persisted"] is False
+    assert explanation["approved"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["submits_to_governance"] is False
+    assert recommendation["converts_to_real_proposal"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_packet_must_never_be_marked_submitted_applied_persisted_approved_or_converted():
+    packet = create_governance_submission_packet(_submission())
+
+    for forbidden_key in (
+        "submitted",
+        "applied",
+        "persisted",
+        "approved",
+        "converted_to_real_proposal",
+        "created_real_proposal",
+        "created_operation_event",
+    ):
+        mutated = deepcopy(packet)
+        mutated[forbidden_key] = True
+        validation = validate_governance_submission_packet(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_valid_invalid_packets_and_by_block_type_status():
+    packets = [
+        create_governance_submission_packet(_submission("procedural_rules")),
+        create_governance_submission_packet(_submission("project_context")),
+        create_governance_submission_packet(_submission("procedural_rules", decision="reject")),
+    ]
+
+    summary = summarize_governance_submission_packets(packets)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 1
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"human_review_packet_required": 3}
+    assert summary["policy"] == MEMORY_GOVERNANCE_SUBMISSION_PACKET_POLICY

--- a/tests/agent/test_memory_human_approval_token_final_confirmation_request.py
+++ b/tests/agent/test_memory_human_approval_token_final_confirmation_request.py
@@ -206,6 +206,18 @@ def test_final_confirmation_checklist_is_deterministic():
     ]
 
 
+def test_valid_final_confirmation_request_id_matches_v0_1_baseline():
+    request = create_human_approval_token_final_confirmation_request(
+        _gate(),
+        requester="final-confirmer",
+    )
+
+    assert (
+        request["request_id"]
+        == "memory-human-approval-token-final-confirmation-request:v0.1:441f7bd7f749c43c"
+    )
+
+
 def test_input_token_write_lock_gate_is_not_mutated():
     gate = _gate()
     before = deepcopy(gate)

--- a/tests/agent/test_memory_human_approval_token_final_confirmation_request.py
+++ b/tests/agent/test_memory_human_approval_token_final_confirmation_request.py
@@ -1,0 +1,317 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_final_confirmation_request import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_ROUTING,
+    create_human_approval_token_final_confirmation_request,
+    explain_human_approval_token_final_confirmation_request,
+    recommend_human_approval_token_final_confirmation_request_action,
+    summarize_human_approval_token_final_confirmation_requests,
+    validate_human_approval_token_final_confirmation_request,
+)
+from agent.memory_human_approval_token_write_lock_gate import create_human_approval_token_write_lock_gate
+from tests.agent.test_memory_human_approval_token_write_lock_gate import _dry_run
+
+
+def _gate(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    return create_human_approval_token_write_lock_gate(
+        _dry_run(
+            block_type=block_type,
+            outcome=outcome,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        operator="token-write-lock-operator",
+    )
+
+
+def test_valid_token_write_lock_gate_creates_final_confirmation_review_required_request():
+    gate = _gate()
+
+    request = create_human_approval_token_final_confirmation_request(gate, requester="final-confirmer")
+
+    assert request["request_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_KIND
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_REQUIRED
+    assert request["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_ROUTING
+    assert request["lock_reason"] is None
+    assert request["source_token_write_lock_gate_id"] == gate["gate_id"]
+    assert request["source_token_issuance_dry_run_id"] == gate["source_token_issuance_dry_run_id"]
+    assert request["source_token_issuance_plan_id"] == gate["source_token_issuance_plan_id"]
+    assert request["source_review_outcome_id"] == gate["source_review_outcome_id"]
+    assert request["source_request_id"] == gate["source_request_id"]
+    assert request["source_gate_id"] == gate["source_gate_id"]
+    assert request["source_dry_run_id"] == gate["source_dry_run_id"]
+    assert request["source_plan_id"] == gate["source_plan_id"]
+    assert request["source_outcome_id"] == gate["source_outcome_id"]
+    assert request["source_packet_id"] == gate["source_packet_id"]
+    assert request["source_submission_id"] == gate["source_submission_id"]
+    assert request["source_draft_id"] == gate["source_draft_id"]
+    assert request["source_decision_id"] == gate["source_decision_id"]
+    assert request["source_queue_item_id"] == gate["source_queue_item_id"]
+    assert request["requester"] == "final-confirmer"
+    assert request["token_write_lock_gate_validation"] == {"valid": True, "errors": []}
+    assert request["request_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_final_confirmation_request(request) == {"valid": True, "errors": []}
+    assert request["next_step_recommendation"]["action"] == "route_to_manual_final_confirmation_review_before_any_token_write"
+    assert request["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert request["next_step_recommendation"]["persists_approvals"] is False
+    assert request["next_step_recommendation"]["creates_real_proposals"] is False
+    assert request["next_step_recommendation"]["writes_operation_ledger"] is False
+    assert request["next_step_recommendation"]["writes_token_files"] is False
+    assert request["next_step_recommendation"]["writes_approval_audit"] is False
+
+
+def test_locked_token_write_lock_gate_creates_locked_request():
+    gate = _gate(outcome="reject")
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "token_review_rejected"
+    assert request["token_write_lock_gate_validation"] == {"valid": True, "errors": []}
+    assert request["request_validation"] == {"valid": True, "errors": []}
+
+
+def test_locked_token_write_lock_gate_without_lock_reason_uses_default_lock_reason():
+    gate = _gate(outcome="reject")
+    gate["lock_reason"] = None
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "token_write_lock_gate_locked"
+
+
+def test_invalid_token_write_lock_gate_creates_locked_request():
+    gate = _gate()
+    gate["gate_kind"] = "wrong"
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "invalid_token_write_lock_gate"
+    assert request["token_write_lock_gate_validation"]["valid"] is False
+    assert request["request_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_record_preview_locks_request():
+    gate = _gate()
+    gate.pop("approval_token_record_preview")
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_approval_token_record_preview"
+
+
+def test_missing_approval_audit_record_preview_locks_request():
+    gate = _gate()
+    gate.pop("approval_audit_record_preview")
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_approval_audit_record_preview"
+
+
+def test_missing_token_target_paths_preview_locks_request():
+    gate = _gate()
+    gate.pop("token_target_paths_preview")
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_token_target_paths_preview"
+
+
+def test_missing_proposal_record_preview_locks_request():
+    gate = _gate()
+    gate.pop("proposal_record_preview")
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_proposal_record_preview"
+
+
+def test_missing_operation_ledger_preview_locks_request():
+    gate = _gate()
+    gate.pop("operation_ledger_preview")
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_operation_ledger_preview"
+
+
+def test_missing_target_paths_preview_locks_request():
+    gate = _gate()
+    gate.pop("target_paths_preview")
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_target_paths_preview"
+
+
+def test_missing_source_evidence_locks_request():
+    gate = _gate(source_pattern_ids=[], source_fact_ids=[])
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_source_evidence"
+
+
+def test_preview_integrity_failed_when_preview_only_false_or_written_created_token_approved_persisted_flags_true():
+    fields = (
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+    )
+    cases = []
+    for field in fields:
+        preview_only_false = _gate()
+        preview_only_false[field]["preview_only"] = False
+        cases.append(preview_only_false)
+
+        for flag in ("written", "created_real_proposal", "created_operation_event", "token_issued", "approved", "persisted"):
+            flagged = _gate()
+            flagged[field][flag] = True
+            cases.append(flagged)
+
+    for gate in cases:
+        request = create_human_approval_token_final_confirmation_request(gate)
+        assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_LOCKED
+        assert request["lock_reason"] == "preview_integrity_failed"
+
+
+def test_final_confirmation_checklist_is_deterministic():
+    request_a = create_human_approval_token_final_confirmation_request(_gate())
+    request_b = create_human_approval_token_final_confirmation_request(_gate())
+
+    assert request_a["final_confirmation_checklist"] == request_b["final_confirmation_checklist"]
+    assert [check["id"] for check in request_a["final_confirmation_checklist"]] == [
+        "verify_token_write_lock_gate_validation",
+        "verify_token_previews_only",
+        "verify_no_token_approval_or_write_flags",
+        "verify_payload_and_source_evidence",
+        "require_manual_final_confirmation_review",
+    ]
+
+
+def test_input_token_write_lock_gate_is_not_mutated():
+    gate = _gate()
+    before = deepcopy(gate)
+
+    request = create_human_approval_token_final_confirmation_request(gate)
+    request["source_token_write_lock_gate_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert gate == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    request = create_human_approval_token_final_confirmation_request(_gate())
+    explanation = explain_human_approval_token_final_confirmation_request(request)
+    recommendation = recommend_human_approval_token_final_confirmation_request_action(request)
+
+    assert request["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY
+    assert request["policy"]["read_only"] is True
+    assert request["policy"]["would_write_memory"] is False
+    assert request["policy"]["would_modify_config"] is False
+    assert request["policy"]["would_write_graph"] is False
+    assert request["policy"]["does_not_create_operation_events"] is True
+    assert request["policy"]["creates_final_confirmation_requests_only"] is True
+    assert request["policy"]["issues_real_approval_tokens"] is False
+    assert request["policy"]["persists_approvals"] is False
+    assert request["policy"]["creates_real_proposals"] is False
+    assert request["policy"]["writes_proposal_files"] is False
+    assert request["policy"]["writes_operation_ledger"] is False
+    assert request["policy"]["writes_token_files"] is False
+    assert request["policy"]["writes_approval_audit"] is False
+    assert request["policy"]["applies_proposals"] is False
+    assert request["policy"]["submits_to_governance"] is False
+    assert request["policy"]["converts_to_real_proposal"] is False
+    for key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "writes_token_files",
+        "writes_approval_audit",
+        "converted_to_real_proposal",
+    ):
+        assert explanation[key] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_request_must_never_be_marked_token_issued_approved_persisted_submitted_written_created_or_converted():
+    request = create_human_approval_token_final_confirmation_request(_gate())
+
+    for forbidden_key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "writes_token_files",
+        "writes_approval_audit",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(request)
+        mutated[forbidden_key] = True
+        validation = validate_human_approval_token_final_confirmation_request(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_final_confirmation_required_requests_and_by_block_type_status():
+    requests = [
+        create_human_approval_token_final_confirmation_request(_gate("procedural_rules")),
+        create_human_approval_token_final_confirmation_request(_gate("project_context")),
+        create_human_approval_token_final_confirmation_request(_gate("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_human_approval_token_final_confirmation_requests(requests)
+
+    assert summary["total"] == 3
+    assert summary["locked_count"] == 1
+    assert summary["final_confirmation_review_required_count"] == 2
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {
+        "final_confirmation_review_required": 2,
+        "locked": 1,
+    }
+    assert summary["by_lock_reason"] == {"None": 2, "token_review_rejected": 1}
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REQUEST_POLICY

--- a/tests/agent/test_memory_human_approval_token_final_confirmation_review_gate.py
+++ b/tests/agent/test_memory_human_approval_token_final_confirmation_review_gate.py
@@ -67,6 +67,18 @@ def test_valid_final_confirmation_review_required_request_becomes_confirm_token_
     assert outcome["next_step_recommendation"]["writes_approval_audit"] is False
 
 
+def test_valid_final_confirmation_review_outcome_id_matches_v0_1_baseline():
+    outcome = create_human_approval_token_final_confirmation_review_outcome(
+        _request(),
+        confirmer="human-confirmer",
+    )
+
+    assert (
+        outcome["review_outcome_id"]
+        == "memory-human-approval-token-final-confirmation-review-outcome:v0.1:13650d00f3a3edc4"
+    )
+
+
 def test_invalid_request_candidate_rejects():
     request = _request()
     request["request_kind"] = "wrong"

--- a/tests/agent/test_memory_human_approval_token_final_confirmation_review_gate.py
+++ b/tests/agent/test_memory_human_approval_token_final_confirmation_review_gate.py
@@ -1,0 +1,313 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_final_confirmation_review_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_STATUS,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_ROUTING,
+    create_human_approval_token_final_confirmation_review_outcome,
+    evaluate_human_approval_token_final_confirmation_request,
+    explain_human_approval_token_final_confirmation_review_outcome,
+    recommend_human_approval_token_final_confirmation_review_action,
+    summarize_human_approval_token_final_confirmation_review_outcomes,
+    validate_human_approval_token_final_confirmation_review_outcome,
+)
+from agent.memory_human_approval_token_final_confirmation_request import (
+    create_human_approval_token_final_confirmation_request,
+)
+from tests.agent.test_memory_human_approval_token_final_confirmation_request import _gate
+
+
+def _request(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    return create_human_approval_token_final_confirmation_request(
+        _gate(
+            block_type=block_type,
+            outcome=outcome,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        requester="final-confirmation-requester",
+    )
+
+
+def test_valid_final_confirmation_review_required_request_becomes_confirm_token_write_outcome_candidate():
+    request = _request()
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request, confirmer="human-confirmer")
+
+    assert outcome["review_outcome_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_KIND
+    assert outcome["review_outcome_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_OUTCOME_STATUS
+    assert outcome["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_ROUTING
+    assert outcome["source_final_confirmation_request_id"] == request["request_id"]
+    assert outcome["source_token_write_lock_gate_id"] == request["source_token_write_lock_gate_id"]
+    assert outcome["source_token_issuance_dry_run_id"] == request["source_token_issuance_dry_run_id"]
+    assert outcome["source_token_issuance_plan_id"] == request["source_token_issuance_plan_id"]
+    assert outcome["source_review_outcome_id"] == request["source_review_outcome_id"]
+    assert outcome["source_request_id"] == request["source_request_id"]
+    assert outcome["source_gate_id"] == request["source_gate_id"]
+    assert outcome["source_dry_run_id"] == request["source_dry_run_id"]
+    assert outcome["source_plan_id"] == request["source_plan_id"]
+    assert outcome["source_outcome_id"] == request["source_outcome_id"]
+    assert outcome["source_packet_id"] == request["source_packet_id"]
+    assert outcome["source_submission_id"] == request["source_submission_id"]
+    assert outcome["source_draft_id"] == request["source_draft_id"]
+    assert outcome["source_decision_id"] == request["source_decision_id"]
+    assert outcome["source_queue_item_id"] == request["source_queue_item_id"]
+    assert outcome["confirmer"] == "human-confirmer"
+    assert outcome["outcome"] == "confirm_token_write"
+    assert outcome["final_confirmation_request_validation"] == {"valid": True, "errors": []}
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_final_confirmation_review_outcome(outcome) == {"valid": True, "errors": []}
+    assert outcome["next_step_recommendation"]["action"] == "route_to_manual_token_write_without_issuing_token_in_review_gate"
+    assert outcome["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert outcome["next_step_recommendation"]["persists_approvals"] is False
+    assert outcome["next_step_recommendation"]["creates_real_proposals"] is False
+    assert outcome["next_step_recommendation"]["writes_operation_ledger"] is False
+    assert outcome["next_step_recommendation"]["writes_token_files"] is False
+    assert outcome["next_step_recommendation"]["writes_approval_audit"] is False
+
+
+def test_invalid_request_candidate_rejects():
+    request = _request()
+    request["request_kind"] = "wrong"
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "reject"
+    assert outcome["final_confirmation_request_validation"]["valid"] is False
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+
+
+def test_locked_request_candidate_rejects():
+    request = _request(outcome="reject")
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert request["request_status"] == "locked"
+    assert outcome["outcome"] == "reject"
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_record_preview_requests_changes():
+    request = _request()
+    request.pop("approval_token_record_preview")
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_missing_approval_audit_record_preview_requests_changes():
+    request = _request()
+    request.pop("approval_audit_record_preview")
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_missing_token_target_paths_preview_requests_changes():
+    request = _request()
+    request.pop("token_target_paths_preview")
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_missing_proposal_record_preview_requests_changes():
+    request = _request()
+    request.pop("proposal_record_preview")
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_missing_operation_ledger_preview_requests_changes():
+    request = _request()
+    request.pop("operation_ledger_preview")
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_missing_target_paths_preview_requests_changes():
+    request = _request()
+    request.pop("target_paths_preview")
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_missing_source_evidence_requests_changes():
+    request = _request(source_pattern_ids=[], source_fact_ids=[])
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_preview_integrity_failed_requests_changes():
+    request = _request()
+    request["approval_token_record_preview"]["token_issued"] = True
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+
+
+def test_explicit_supported_outcome_override_is_accepted_but_not_issued_applied_persisted_written_or_submitted():
+    request = _request()
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(
+        request,
+        outcome="defer",
+        rationale="Manual reviewer chose to defer.",
+    )
+    explanation = explain_human_approval_token_final_confirmation_review_outcome(outcome)
+    recommendation = recommend_human_approval_token_final_confirmation_review_action(outcome)
+
+    assert outcome["outcome"] == "defer"
+    assert outcome["rationale"] == "Manual reviewer chose to defer."
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["writes_token_files"] is False
+    assert explanation["writes_approval_audit"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["applies_proposals"] is False
+    assert recommendation["submits_to_governance"] is False
+
+
+def test_unsupported_outcome_fails_validation():
+    outcome = create_human_approval_token_final_confirmation_review_outcome(_request())
+    outcome["outcome"] = "approve_and_issue"
+
+    validation = validate_human_approval_token_final_confirmation_review_outcome(outcome)
+
+    assert validation["valid"] is False
+    assert "outcome_must_be_supported" in validation["errors"]
+
+
+def test_input_request_candidate_is_not_mutated():
+    request = _request()
+    before = deepcopy(request)
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(request)
+    outcome["source_final_confirmation_request_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert request == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    outcome = create_human_approval_token_final_confirmation_review_outcome(_request())
+    explanation = explain_human_approval_token_final_confirmation_review_outcome(outcome)
+    recommendation = recommend_human_approval_token_final_confirmation_review_action(outcome)
+
+    assert outcome["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY
+    assert outcome["policy"]["read_only"] is True
+    assert outcome["policy"]["would_write_memory"] is False
+    assert outcome["policy"]["would_modify_config"] is False
+    assert outcome["policy"]["would_write_graph"] is False
+    assert outcome["policy"]["does_not_create_operation_events"] is True
+    assert outcome["policy"]["creates_final_confirmation_review_outcomes_only"] is True
+    assert outcome["policy"]["issues_real_approval_tokens"] is False
+    assert outcome["policy"]["persists_approvals"] is False
+    assert outcome["policy"]["creates_real_proposals"] is False
+    assert outcome["policy"]["writes_proposal_files"] is False
+    assert outcome["policy"]["writes_operation_ledger"] is False
+    assert outcome["policy"]["writes_token_files"] is False
+    assert outcome["policy"]["writes_approval_audit"] is False
+    assert outcome["policy"]["applies_proposals"] is False
+    assert outcome["policy"]["submits_to_governance"] is False
+    assert outcome["policy"]["converts_to_real_proposal"] is False
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["writes_token_files"] is False
+    assert explanation["writes_approval_audit"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_outcome_candidate_must_never_be_marked_token_issued_approved_persisted_submitted_written_created_or_converted():
+    outcome = create_human_approval_token_final_confirmation_review_outcome(_request())
+
+    for forbidden_key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "writes_token_files",
+        "writes_approval_audit",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(outcome)
+        mutated[forbidden_key] = True
+        validation = validate_human_approval_token_final_confirmation_review_outcome(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_by_outcome_block_type_and_status():
+    outcomes = [
+        create_human_approval_token_final_confirmation_review_outcome(_request("procedural_rules")),
+        create_human_approval_token_final_confirmation_review_outcome(_request("project_context")),
+        create_human_approval_token_final_confirmation_review_outcome(_request("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_human_approval_token_final_confirmation_review_outcomes(outcomes)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_outcome"] == {"confirm_token_write": 2, "reject": 1}
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"final_confirmation_review_outcome_candidate": 3}
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_FINAL_CONFIRMATION_REVIEW_POLICY
+
+
+def test_evaluate_exposes_same_deterministic_decision_without_creating_writes():
+    evaluation = evaluate_human_approval_token_final_confirmation_request(_request(), confirmer="reviewer")
+
+    assert evaluation["confirmer"] == "reviewer"
+    assert evaluation["outcome"] == "confirm_token_write"
+    assert evaluation["validation"] == {"valid": True, "errors": []}
+    assert evaluation["policy"]["issues_real_approval_tokens"] is False

--- a/tests/agent/test_memory_human_approval_token_issuance_dry_run.py
+++ b/tests/agent/test_memory_human_approval_token_issuance_dry_run.py
@@ -163,6 +163,34 @@ def test_preview_records_and_final_preflight_checklist_are_deterministic_and_pre
     assert dry_run_a["token_target_paths_preview"]["writes_approval_audit"] is False
 
 
+def test_valid_token_issuance_dry_run_ids_match_v0_1_baseline():
+    dry_run = create_human_approval_token_issuance_dry_run(
+        _plan(),
+        operator="token-dry-run-operator",
+    )
+
+    assert (
+        dry_run["dry_run_id"]
+        == "memory-human-approval-token-issuance-dry-run:v0.1:140f4c26fe91185c"
+    )
+    assert (
+        dry_run["approval_token_record_preview"]["approval_token_id_preview"]
+        == "preview:approval-token:v0.1:86ab1a636bd6b306"
+    )
+    assert (
+        dry_run["approval_audit_record_preview"]["approval_audit_id_preview"]
+        == "preview:approval-audit:v0.1:973c76dd0b193548"
+    )
+    assert (
+        dry_run["token_target_paths_preview"]["approval_token_selector"]
+        == "preview:approval-token:v0.1:86ab1a636bd6b306"
+    )
+    assert (
+        dry_run["token_target_paths_preview"]["approval_audit_selector"]
+        == "preview:approval-audit:v0.1:973c76dd0b193548"
+    )
+
+
 def test_input_plan_is_not_mutated():
     plan = _plan()
     before = deepcopy(plan)

--- a/tests/agent/test_memory_human_approval_token_issuance_dry_run.py
+++ b/tests/agent/test_memory_human_approval_token_issuance_dry_run.py
@@ -1,0 +1,289 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_issuance_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_ROUTING,
+    create_human_approval_token_issuance_dry_run,
+    explain_human_approval_token_issuance_dry_run,
+    recommend_human_approval_token_issuance_dry_run_action,
+    summarize_human_approval_token_issuance_dry_runs,
+    validate_human_approval_token_issuance_dry_run,
+)
+from agent.memory_human_approval_token_issuance_plan import create_human_approval_token_issuance_plan
+from tests.agent.test_memory_human_approval_token_issuance_plan import _review_outcome
+
+
+def _plan(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    return create_human_approval_token_issuance_plan(
+        _review_outcome(
+            block_type=block_type,
+            outcome=outcome,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        planner="token-plan-reviewer",
+    )
+
+
+def test_valid_token_issuance_plan_creates_final_preflight_required_dry_run():
+    plan = _plan()
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan, operator="token-dry-run-operator")
+
+    assert dry_run["dry_run_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_KIND
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+    assert dry_run["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_ROUTING
+    assert dry_run["lock_reason"] is None
+    assert dry_run["source_token_issuance_plan_id"] == plan["plan_id"]
+    assert dry_run["source_review_outcome_id"] == plan["source_review_outcome_id"]
+    assert dry_run["source_request_id"] == plan["source_request_id"]
+    assert dry_run["source_gate_id"] == plan["source_gate_id"]
+    assert dry_run["source_dry_run_id"] == plan["source_dry_run_id"]
+    assert dry_run["source_plan_id"] == plan["source_plan_id"]
+    assert dry_run["source_outcome_id"] == plan["source_outcome_id"]
+    assert dry_run["source_packet_id"] == plan["source_packet_id"]
+    assert dry_run["source_submission_id"] == plan["source_submission_id"]
+    assert dry_run["source_draft_id"] == plan["source_draft_id"]
+    assert dry_run["source_decision_id"] == plan["source_decision_id"]
+    assert dry_run["source_queue_item_id"] == plan["source_queue_item_id"]
+    assert dry_run["operator"] == "token-dry-run-operator"
+    assert dry_run["token_issuance_plan_validation"] == {"valid": True, "errors": []}
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_issuance_dry_run(dry_run) == {"valid": True, "errors": []}
+    assert dry_run["next_step_recommendation"]["action"] == "request_manual_final_human_confirmation_before_token_write"
+    assert dry_run["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert dry_run["next_step_recommendation"]["persists_approvals"] is False
+    assert dry_run["next_step_recommendation"]["creates_real_proposals"] is False
+    assert dry_run["next_step_recommendation"]["writes_operation_ledger"] is False
+
+
+def test_locked_plan_creates_locked_dry_run():
+    plan = _plan(outcome="reject")
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "token_review_rejected"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_locked_plan_without_lock_reason_uses_default_lock_reason():
+    plan = _plan(outcome="reject")
+    plan["lock_reason"] = None
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "token_issuance_plan_locked"
+
+
+def test_invalid_plan_creates_locked_dry_run():
+    plan = _plan()
+    plan["plan_kind"] = "wrong"
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "invalid_token_issuance_plan"
+    assert dry_run["token_issuance_plan_validation"]["valid"] is False
+
+
+def test_missing_proposal_record_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("proposal_record_preview")
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "missing_proposal_record_preview"
+
+
+def test_missing_operation_ledger_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("operation_ledger_preview")
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "missing_operation_ledger_preview"
+
+
+def test_missing_target_paths_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("target_paths_preview")
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "missing_target_paths_preview"
+
+
+def test_missing_source_evidence_locks_dry_run():
+    plan = _plan(source_pattern_ids=[], source_fact_ids=[])
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "missing_source_evidence"
+
+
+def test_missing_token_issuance_steps_or_preflight_checks_locks_dry_run():
+    for field in ("token_issuance_steps", "token_preflight_checks"):
+        plan = _plan()
+        plan.pop(field)
+
+        dry_run = create_human_approval_token_issuance_dry_run(plan)
+
+        assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_LOCKED
+        assert dry_run["lock_reason"] == "missing_token_plan_controls"
+
+
+def test_preview_records_and_final_preflight_checklist_are_deterministic_and_preview_only():
+    dry_run_a = create_human_approval_token_issuance_dry_run(_plan(), operator="token-dry-run-operator")
+    dry_run_b = create_human_approval_token_issuance_dry_run(_plan(), operator="token-dry-run-operator")
+
+    assert dry_run_a["approval_token_record_preview"] == dry_run_b["approval_token_record_preview"]
+    assert dry_run_a["approval_audit_record_preview"] == dry_run_b["approval_audit_record_preview"]
+    assert dry_run_a["token_target_paths_preview"] == dry_run_b["token_target_paths_preview"]
+    assert dry_run_a["final_token_preflight_checklist"] == dry_run_b["final_token_preflight_checklist"]
+    assert dry_run_a["dry_run_id"] == dry_run_b["dry_run_id"]
+    assert dry_run_a["approval_token_record_preview"]["preview_only"] is True
+    assert dry_run_a["approval_token_record_preview"]["token_issued"] is False
+    assert dry_run_a["approval_token_record_preview"]["approved"] is False
+    assert dry_run_a["approval_token_record_preview"]["persisted"] is False
+    assert dry_run_a["approval_token_record_preview"]["written"] is False
+    assert dry_run_a["approval_audit_record_preview"]["preview_only"] is True
+    assert dry_run_a["approval_audit_record_preview"]["created_operation_event"] is False
+    assert dry_run_a["approval_audit_record_preview"]["writes_approval_audit"] is False
+    assert dry_run_a["token_target_paths_preview"]["preview_only"] is True
+    assert dry_run_a["token_target_paths_preview"]["writes_token_files"] is False
+    assert dry_run_a["token_target_paths_preview"]["writes_approval_audit"] is False
+
+
+def test_input_plan_is_not_mutated():
+    plan = _plan()
+    before = deepcopy(plan)
+
+    dry_run = create_human_approval_token_issuance_dry_run(plan)
+    dry_run["source_token_issuance_plan_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert plan == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    dry_run = create_human_approval_token_issuance_dry_run(_plan())
+    explanation = explain_human_approval_token_issuance_dry_run(dry_run)
+    recommendation = recommend_human_approval_token_issuance_dry_run_action(dry_run)
+
+    assert dry_run["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY
+    assert dry_run["policy"]["read_only"] is True
+    assert dry_run["policy"]["would_write_memory"] is False
+    assert dry_run["policy"]["would_modify_config"] is False
+    assert dry_run["policy"]["would_write_graph"] is False
+    assert dry_run["policy"]["does_not_create_operation_events"] is True
+    assert dry_run["policy"]["creates_token_issuance_dry_run_candidates_only"] is True
+    assert dry_run["policy"]["issues_real_approval_tokens"] is False
+    assert dry_run["policy"]["persists_approvals"] is False
+    assert dry_run["policy"]["creates_real_proposals"] is False
+    assert dry_run["policy"]["writes_proposal_files"] is False
+    assert dry_run["policy"]["writes_operation_ledger"] is False
+    assert dry_run["policy"]["writes_token_files"] is False
+    assert dry_run["policy"]["writes_approval_audit"] is False
+    assert dry_run["policy"]["applies_proposals"] is False
+    assert dry_run["policy"]["submits_to_governance"] is False
+    assert dry_run["policy"]["converts_to_real_proposal"] is False
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["writes_token_files"] is False
+    assert explanation["writes_approval_audit"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_dry_run_must_never_be_marked_token_issued_approved_persisted_or_written():
+    dry_run = create_human_approval_token_issuance_dry_run(_plan())
+
+    for forbidden_key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "writes_token_files",
+        "writes_approval_audit",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(dry_run)
+        mutated[forbidden_key] = True
+        validation = validate_human_approval_token_issuance_dry_run(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_preview_records_must_never_be_marked_written_or_persisted():
+    dry_run = create_human_approval_token_issuance_dry_run(_plan())
+
+    for field, forbidden_key in (
+        ("approval_token_record_preview", "token_issued"),
+        ("approval_token_record_preview", "persisted"),
+        ("approval_audit_record_preview", "created_operation_event"),
+        ("approval_audit_record_preview", "writes_approval_audit"),
+        ("token_target_paths_preview", "writes_token_files"),
+        ("token_target_paths_preview", "writes_approval_audit"),
+    ):
+        mutated = deepcopy(dry_run)
+        mutated[field][forbidden_key] = True
+        validation = validate_human_approval_token_issuance_dry_run(mutated)
+        assert validation["valid"] is False
+        assert f"{field}_{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_final_preflight_required_candidates_and_by_block_type_status():
+    dry_runs = [
+        create_human_approval_token_issuance_dry_run(_plan("procedural_rules")),
+        create_human_approval_token_issuance_dry_run(_plan("project_context")),
+        create_human_approval_token_issuance_dry_run(_plan("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_human_approval_token_issuance_dry_runs(dry_runs)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["final_preflight_required_count"] == 2
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "manual_token_issuance_final_preflight_required": 2,
+    }
+    assert summary["by_lock_reason"] == {"None": 2, "token_review_rejected": 1}
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_DRY_RUN_POLICY

--- a/tests/agent/test_memory_human_approval_token_issuance_plan.py
+++ b/tests/agent/test_memory_human_approval_token_issuance_plan.py
@@ -1,0 +1,266 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import create_governance_submission_packet
+from agent.memory_human_approval_token_issuance_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_ROUTING,
+    create_human_approval_token_issuance_plan,
+    explain_human_approval_token_issuance_plan,
+    recommend_human_approval_token_issuance_plan_action,
+    summarize_human_approval_token_issuance_plans,
+    validate_human_approval_token_issuance_plan,
+)
+from agent.memory_human_approval_token_request import create_human_approval_token_request
+from agent.memory_human_approval_token_review_gate import create_human_approval_token_review_outcome
+from agent.memory_human_review_outcome_gate import create_human_review_outcome_candidate
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_real_proposal_creation_plan import create_real_proposal_creation_plan
+from agent.memory_real_proposal_dry_run import create_real_proposal_dry_run
+from agent.memory_real_proposal_write_lock_gate import create_real_proposal_write_lock_gate
+from agent.memory_review_decision_gate import evaluate_review_queue_item
+
+
+def _creation_plan(block_type="procedural_rules", source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create approval token issuance plan candidates only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    decision = evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    draft = create_memory_proposal_draft(decision, author="proposal-drafter")
+    submission = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+    packet = create_governance_submission_packet(submission, reviewer="packet-reviewer")
+    outcome_candidate = create_human_review_outcome_candidate(packet, reviewer="human-reviewer")
+    return create_real_proposal_creation_plan(outcome_candidate, planner="plan-reviewer")
+
+
+def _review_outcome(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    dry_run = create_real_proposal_dry_run(
+        _creation_plan(
+            block_type=block_type,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        operator="final-preflight-operator",
+    )
+    gate = create_real_proposal_write_lock_gate(dry_run, operator="write-lock-operator")
+    request = create_human_approval_token_request(gate, requester="token-requester")
+    return create_human_approval_token_review_outcome(request, reviewer="token-reviewer", outcome=outcome)
+
+
+def test_approve_token_issuance_outcome_creates_manual_token_issuance_plan_required():
+    outcome = _review_outcome()
+
+    plan = create_human_approval_token_issuance_plan(outcome, planner="token-plan-reviewer")
+
+    assert plan["plan_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_KIND
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_REQUIRED
+    assert plan["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_ROUTING
+    assert plan["lock_reason"] is None
+    assert plan["source_review_outcome_id"] == outcome["review_outcome_id"]
+    assert plan["source_request_id"] == outcome["source_request_id"]
+    assert plan["source_gate_id"] == outcome["source_gate_id"]
+    assert plan["source_dry_run_id"] == outcome["source_dry_run_id"]
+    assert plan["source_plan_id"] == outcome["source_plan_id"]
+    assert plan["source_outcome_id"] == outcome["source_outcome_id"]
+    assert plan["source_packet_id"] == outcome["source_packet_id"]
+    assert plan["source_submission_id"] == outcome["source_submission_id"]
+    assert plan["source_draft_id"] == outcome["source_draft_id"]
+    assert plan["source_decision_id"] == outcome["source_decision_id"]
+    assert plan["source_queue_item_id"] == outcome["source_queue_item_id"]
+    assert plan["planner"] == "token-plan-reviewer"
+    assert plan["outcome"] == "approve_token_issuance"
+    assert plan["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_issuance_plan(plan) == {"valid": True, "errors": []}
+    assert plan["next_step_recommendation"]["action"] == "run_manual_token_issuance_dry_run_before_any_token_write"
+    assert plan["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert plan["next_step_recommendation"]["creates_real_proposals"] is False
+    assert plan["next_step_recommendation"]["writes_operation_ledger"] is False
+
+
+def test_request_changes_creates_locked_plan():
+    plan = create_human_approval_token_issuance_plan(_review_outcome(outcome="request_changes"))
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "token_review_requested_changes"
+
+
+def test_reject_creates_locked_plan():
+    plan = create_human_approval_token_issuance_plan(_review_outcome(outcome="reject"))
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "token_review_rejected"
+
+
+def test_defer_creates_locked_plan():
+    plan = create_human_approval_token_issuance_plan(_review_outcome(outcome="defer"))
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "token_review_deferred"
+
+
+def test_invalid_review_outcome_creates_locked_plan():
+    outcome = _review_outcome(outcome="ship_it")
+
+    plan = create_human_approval_token_issuance_plan(outcome)
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "invalid_token_review_outcome"
+    assert plan["review_outcome_validation"]["valid"] is False
+
+
+def test_missing_proposal_record_preview_locks_plan():
+    outcome = _review_outcome()
+    outcome.pop("proposal_record_preview")
+
+    plan = create_human_approval_token_issuance_plan(outcome)
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "missing_proposal_record_preview"
+
+
+def test_missing_operation_ledger_preview_locks_plan():
+    outcome = _review_outcome()
+    outcome.pop("operation_ledger_preview")
+
+    plan = create_human_approval_token_issuance_plan(outcome)
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "missing_operation_ledger_preview"
+
+
+def test_missing_target_paths_preview_locks_plan():
+    outcome = _review_outcome()
+    outcome.pop("target_paths_preview")
+
+    plan = create_human_approval_token_issuance_plan(outcome)
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "missing_target_paths_preview"
+
+
+def test_missing_source_evidence_locks_plan():
+    outcome = _review_outcome(source_pattern_ids=[], source_fact_ids=[])
+
+    plan = create_human_approval_token_issuance_plan(outcome)
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_LOCKED
+    assert plan["lock_reason"] == "missing_source_evidence"
+
+
+def test_token_issuance_steps_and_preflight_checks_are_deterministic():
+    plan_a = create_human_approval_token_issuance_plan(_review_outcome())
+    plan_b = create_human_approval_token_issuance_plan(_review_outcome())
+
+    assert plan_a["token_issuance_steps"] == plan_b["token_issuance_steps"]
+    assert plan_a["token_preflight_checks"] == plan_b["token_preflight_checks"]
+    assert plan_a["plan_id"] == plan_b["plan_id"]
+
+
+def test_input_review_outcome_candidate_is_not_mutated():
+    outcome = _review_outcome()
+    before = deepcopy(outcome)
+
+    plan = create_human_approval_token_issuance_plan(outcome)
+    plan["source_review_outcome_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert outcome == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    plan = create_human_approval_token_issuance_plan(_review_outcome())
+    explanation = explain_human_approval_token_issuance_plan(plan)
+    recommendation = recommend_human_approval_token_issuance_plan_action(plan)
+
+    assert plan["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY
+    assert plan["policy"]["read_only"] is True
+    assert plan["policy"]["would_write_memory"] is False
+    assert plan["policy"]["would_modify_config"] is False
+    assert plan["policy"]["would_write_graph"] is False
+    assert plan["policy"]["does_not_create_operation_events"] is True
+    assert plan["policy"]["creates_token_issuance_plan_candidates_only"] is True
+    assert plan["policy"]["issues_real_approval_tokens"] is False
+    assert plan["policy"]["persists_approvals"] is False
+    assert plan["policy"]["creates_real_proposals"] is False
+    assert plan["policy"]["writes_proposal_files"] is False
+    assert plan["policy"]["writes_operation_ledger"] is False
+    assert plan["policy"]["applies_proposals"] is False
+    assert plan["policy"]["submits_to_governance"] is False
+    assert plan["policy"]["converts_to_real_proposal"] is False
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_plan_must_never_be_marked_token_issued_approved_persisted_or_written():
+    plan = create_human_approval_token_issuance_plan(_review_outcome())
+
+    for forbidden_key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(plan)
+        mutated[forbidden_key] = True
+        validation = validate_human_approval_token_issuance_plan(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_plan_required_candidates_and_by_block_type_status():
+    plans = [
+        create_human_approval_token_issuance_plan(_review_outcome("procedural_rules")),
+        create_human_approval_token_issuance_plan(_review_outcome("project_context")),
+        create_human_approval_token_issuance_plan(_review_outcome("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_human_approval_token_issuance_plans(plans)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["plan_required_count"] == 2
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "manual_token_issuance_plan_required": 2,
+    }
+    assert summary["by_lock_reason"] == {"None": 2, "token_review_rejected": 1}
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_ISSUANCE_PLAN_POLICY

--- a/tests/agent/test_memory_human_approval_token_issuance_plan.py
+++ b/tests/agent/test_memory_human_approval_token_issuance_plan.py
@@ -89,6 +89,15 @@ def test_approve_token_issuance_outcome_creates_manual_token_issuance_plan_requi
     assert plan["next_step_recommendation"]["writes_operation_ledger"] is False
 
 
+def test_valid_human_approval_token_issuance_plan_id_matches_v0_1_baseline():
+    plan = create_human_approval_token_issuance_plan(_review_outcome())
+
+    assert (
+        plan["plan_id"]
+        == "memory-human-approval-token-issuance-plan:v0.1:95dce5d20a600fdf"
+    )
+
+
 def test_request_changes_creates_locked_plan():
     plan = create_human_approval_token_issuance_plan(_review_outcome(outcome="request_changes"))
 

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_code_review_plan.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_code_review_plan.py
@@ -127,6 +127,18 @@ def test_valid_implementation_dry_run_creates_code_review_gate_required_plan():
     assert plan["next_step_recommendation"]["creates_executor_tests"] is False
 
 
+def test_code_review_plan_id_preserves_canonical_v0_1_digest():
+    plan = create_human_approval_token_real_write_executor_code_review_plan(
+        _dry_run(),
+        reviewer="code-review-planner",
+    )
+
+    assert plan["plan_id"] == (
+        "memory-human-approval-token-real-write-executor-code-review-plan:"
+        "v0.1:85cc9cf97d96acbc"
+    )
+
+
 def test_locked_implementation_dry_run_creates_locked_plan():
     dry_run = _dry_run(outcome="request_contract_changes")
 

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_code_review_plan.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_code_review_plan.py
@@ -1,0 +1,556 @@
+from copy import deepcopy
+
+import pytest
+
+from agent.memory_human_approval_token_real_write_executor_code_review_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_ROUTING,
+    create_human_approval_token_real_write_executor_code_review_plan,
+    explain_human_approval_token_real_write_executor_code_review_plan,
+    recommend_human_approval_token_real_write_executor_code_review_plan_action,
+    summarize_human_approval_token_real_write_executor_code_review_plans,
+    validate_human_approval_token_real_write_executor_code_review_plan,
+)
+from agent.memory_human_approval_token_real_write_executor_implementation_dry_run import (
+    create_human_approval_token_real_write_executor_implementation_dry_run,
+)
+from tests.agent.test_memory_human_approval_token_real_write_executor_implementation_dry_run import (
+    _plan,
+)
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "creates_executor_source_files",
+    "creates_executor_tests",
+    "converted_to_real_proposal",
+)
+
+
+def _dry_run(outcome=None, block_type="procedural_rules"):
+    return create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan(outcome=outcome, block_type=block_type),
+        operator="implementation-dry-run-operator",
+    )
+
+
+def test_valid_implementation_dry_run_creates_code_review_gate_required_plan():
+    dry_run = _dry_run()
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(
+        dry_run,
+        reviewer="code-review-planner",
+    )
+
+    assert (
+        plan["plan_kind"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_KIND
+    )
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_GATE_REQUIRED
+    )
+    assert (
+        plan["routing"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_ROUTING
+    )
+    assert plan["lock_reason"] is None
+    assert plan["source_implementation_dry_run_id"] == dry_run["dry_run_id"]
+    assert plan["source_implementation_plan_id"] == dry_run[
+        "source_implementation_plan_id"
+    ]
+    assert plan["source_contract_review_outcome_id"] == dry_run[
+        "source_contract_review_outcome_id"
+    ]
+    assert plan["source_contract_id"] == dry_run["source_contract_id"]
+    assert plan["source_write_final_gate_id"] == dry_run["source_write_final_gate_id"]
+    assert plan["source_write_execution_dry_run_id"] == dry_run[
+        "source_write_execution_dry_run_id"
+    ]
+    assert plan["source_write_execution_plan_id"] == dry_run[
+        "source_write_execution_plan_id"
+    ]
+    assert plan["source_final_confirmation_review_outcome_id"] == dry_run[
+        "source_final_confirmation_review_outcome_id"
+    ]
+    assert plan["source_final_confirmation_request_id"] == dry_run[
+        "source_final_confirmation_request_id"
+    ]
+    assert plan["source_token_write_lock_gate_id"] == dry_run[
+        "source_token_write_lock_gate_id"
+    ]
+    assert plan["source_token_issuance_dry_run_id"] == dry_run[
+        "source_token_issuance_dry_run_id"
+    ]
+    assert plan["source_token_issuance_plan_id"] == dry_run[
+        "source_token_issuance_plan_id"
+    ]
+    assert plan["source_review_outcome_id"] == dry_run["source_review_outcome_id"]
+    assert plan["source_request_id"] == dry_run["source_request_id"]
+    assert plan["source_gate_id"] == dry_run["source_gate_id"]
+    assert plan["source_dry_run_id"] == dry_run["source_dry_run_id"]
+    assert plan["source_plan_id"] == dry_run["source_plan_id"]
+    assert plan["source_outcome_id"] == dry_run["source_outcome_id"]
+    assert plan["source_packet_id"] == dry_run["source_packet_id"]
+    assert plan["source_submission_id"] == dry_run["source_submission_id"]
+    assert plan["source_draft_id"] == dry_run["source_draft_id"]
+    assert plan["source_decision_id"] == dry_run["source_decision_id"]
+    assert plan["source_queue_item_id"] == dry_run["source_queue_item_id"]
+    assert plan["reviewer"] == "code-review-planner"
+    assert plan["outcome"] == "approve_executor_contract"
+    assert plan["implementation_dry_run_validation"] == {"valid": True, "errors": []}
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_real_write_executor_code_review_plan(
+        plan
+    ) == {"valid": True, "errors": []}
+    assert plan["next_step_recommendation"]["action"] == (
+        "route_to_real_token_write_executor_code_review_gate_without_executor_source_creation"
+    )
+    assert plan["next_step_recommendation"]["invokes_real_token_write_executor"] is False
+    assert plan["next_step_recommendation"]["implements_real_token_write_executor"] is False
+    assert plan["next_step_recommendation"]["creates_executor_source_files"] is False
+    assert plan["next_step_recommendation"]["creates_executor_tests"] is False
+
+
+def test_locked_implementation_dry_run_creates_locked_plan():
+    dry_run = _dry_run(outcome="request_contract_changes")
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED
+    )
+    assert plan["lock_reason"] == "contract_review_requested_changes"
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_locked_implementation_dry_run_without_reason_uses_default_lock_reason():
+    dry_run = _dry_run(outcome="request_contract_changes")
+    dry_run["lock_reason"] = None
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+
+    assert plan["lock_reason"] == "real_write_executor_implementation_dry_run_locked"
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_implementation_dry_run_creates_locked_plan():
+    dry_run = _dry_run()
+    dry_run["dry_run_kind"] = "wrong"
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED
+    )
+    assert plan["lock_reason"] == "invalid_real_write_executor_implementation_dry_run"
+    assert plan["implementation_dry_run_validation"]["valid"] is False
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+
+
+@pytest.mark.parametrize(
+    ("field", "reason"),
+    [
+        ("approval_token_record_preview", "missing_approval_token_record_preview"),
+        ("approval_audit_record_preview", "missing_approval_audit_record_preview"),
+        ("token_target_paths_preview", "missing_token_target_paths_preview"),
+        ("proposal_record_preview", "missing_proposal_record_preview"),
+        ("operation_ledger_preview", "missing_operation_ledger_preview"),
+        ("target_paths_preview", "missing_target_paths_preview"),
+        (
+            "approval_token_write_payload_preview",
+            "missing_approval_token_write_payload_preview",
+        ),
+        (
+            "approval_audit_write_payload_preview",
+            "missing_approval_audit_write_payload_preview",
+        ),
+        ("token_write_target_paths_preview", "missing_token_write_target_paths_preview"),
+        ("executor_contract_inputs", "missing_executor_contract_inputs"),
+        ("executor_hard_lock_checks", "missing_executor_hard_lock_checks"),
+        ("executor_audit_fields", "missing_executor_audit_fields"),
+        ("executor_rollback_rules", "missing_executor_rollback_rules"),
+        ("executor_forbidden_side_effects", "missing_executor_forbidden_side_effects"),
+        ("executor_contract_checklist", "missing_executor_contract_checklist"),
+        ("contract_review_checklist", "missing_contract_review_checklist"),
+        ("implementation_plan_interfaces", "missing_implementation_plan_interfaces"),
+        ("implementation_plan_files", "missing_implementation_plan_files"),
+        (
+            "implementation_plan_idempotency_strategy",
+            "missing_implementation_plan_idempotency_strategy",
+        ),
+        (
+            "implementation_plan_filesystem_safety_model",
+            "missing_implementation_plan_filesystem_safety_model",
+        ),
+        (
+            "implementation_plan_audit_strategy",
+            "missing_implementation_plan_audit_strategy",
+        ),
+        (
+            "implementation_plan_rollback_strategy",
+            "missing_implementation_plan_rollback_strategy",
+        ),
+        ("implementation_plan_test_plan", "missing_implementation_plan_test_plan"),
+        (
+            "implementation_plan_forbidden_actions",
+            "missing_implementation_plan_forbidden_actions",
+        ),
+        (
+            "implementation_dry_run_module_boundary_preview",
+            "missing_implementation_dry_run_module_boundary_preview",
+        ),
+        (
+            "implementation_dry_run_interface_preview",
+            "missing_implementation_dry_run_interface_preview",
+        ),
+        (
+            "implementation_dry_run_idempotency_check_preview",
+            "missing_implementation_dry_run_idempotency_check_preview",
+        ),
+        (
+            "implementation_dry_run_filesystem_safety_check_preview",
+            "missing_implementation_dry_run_filesystem_safety_check_preview",
+        ),
+        (
+            "implementation_dry_run_audit_check_preview",
+            "missing_implementation_dry_run_audit_check_preview",
+        ),
+        (
+            "implementation_dry_run_rollback_check_preview",
+            "missing_implementation_dry_run_rollback_check_preview",
+        ),
+        (
+            "implementation_dry_run_test_harness_preview",
+            "missing_implementation_dry_run_test_harness_preview",
+        ),
+        (
+            "implementation_dry_run_readiness_checklist",
+            "missing_implementation_dry_run_readiness_checklist",
+        ),
+    ],
+)
+def test_missing_required_inherited_fields_lock_plan_with_explicit_reasons(
+    field,
+    reason,
+):
+    dry_run = _dry_run()
+    dry_run.pop(field)
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+
+    assert plan["lock_reason"] == reason
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_LOCKED
+    )
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_source_evidence_locks_plan():
+    dry_run = _dry_run()
+    dry_run["source_pattern_ids"] = []
+    dry_run["source_fact_ids"] = []
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+
+    assert plan["lock_reason"] == "missing_source_evidence"
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_preview_integrity_failed_locks_plan():
+    dry_run = _dry_run()
+    dry_run["approval_token_record_preview"]["token_issued"] = True
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+
+    assert plan["lock_reason"] == "preview_integrity_failed"
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_implementation_dry_run_integrity_failed_locks_plan():
+    dry_run = _dry_run()
+    dry_run["implementation_dry_run_interface_preview"][0]["implemented_in_v0_1"] = True
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+
+    assert plan["lock_reason"] == "implementation_dry_run_integrity_failed"
+    assert plan["implementation_dry_run_validation"]["valid"] is False
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_code_review_scope_is_deterministic_and_does_not_create_executor_code():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert plan_a["code_review_scope"] == plan_b["code_review_scope"]
+    assert plan_a["code_review_scope"]["creates_executor_source_files"] is False
+    assert plan_a["code_review_scope"]["creates_executor_tests"] is False
+    assert plan_a["code_review_scope"]["implements_real_token_write_executor"] is False
+    assert plan_a["code_review_scope"]["invokes_real_token_write_executor"] is False
+
+
+def test_code_review_required_files_are_deterministic_and_not_created():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert plan_a["code_review_required_files"] == plan_b["code_review_required_files"]
+    assert all(
+        file_plan["create_in_v0_1"] is False
+        for file_plan in plan_a["code_review_required_files"]
+    )
+    assert all(
+        file_plan["contains_executor_code_in_v0_1"] is False
+        for file_plan in plan_a["code_review_required_files"]
+    )
+    assert all(
+        file_plan["writes_files_in_v0_1"] is False
+        for file_plan in plan_a["code_review_required_files"]
+    )
+
+
+def test_code_review_static_analysis_checks_are_deterministic():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert (
+        plan_a["code_review_static_analysis_checks"]
+        == plan_b["code_review_static_analysis_checks"]
+    )
+    assert {check["id"] for check in plan_a["code_review_static_analysis_checks"]} == {
+        "no_executor_source_created_by_plan",
+        "public_surface_is_read_only_candidate_builder",
+        "no_dynamic_write_dispatch",
+        "deterministic_identifiers",
+    }
+
+
+def test_code_review_security_checks_are_deterministic():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert plan_a["code_review_security_checks"] == plan_b["code_review_security_checks"]
+    assert all(
+        check.get("creates_executor_source_files", False) is False
+        for check in plan_a["code_review_security_checks"]
+    )
+
+
+def test_code_review_write_safety_checks_include_no_write_assertions():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert (
+        plan_a["code_review_write_safety_checks"]
+        == plan_b["code_review_write_safety_checks"]
+    )
+    checks = {check["id"]: check for check in plan_a["code_review_write_safety_checks"]}
+    assert checks["assert_no_token_file_write_in_v0_1"]["writes_token_files"] is False
+    assert checks["assert_no_approval_audit_write_in_v0_1"][
+        "writes_approval_audit"
+    ] is False
+    assert checks["assert_no_proposal_file_write_in_v0_1"][
+        "writes_proposal_files"
+    ] is False
+    assert checks["assert_no_operation_ledger_write_in_v0_1"][
+        "writes_operation_ledger"
+    ] is False
+    assert checks["assert_no_operation_ledger_write_in_v0_1"][
+        "created_operation_event"
+    ] is False
+
+
+def test_code_review_test_matrix_is_deterministic_and_every_test_has_writes_false():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert plan_a["code_review_test_matrix"] == plan_b["code_review_test_matrix"]
+    assert all(test_case["writes"] is False for test_case in plan_a["code_review_test_matrix"])
+    assert all(
+        test_case["creates_executor_source_files"] is False
+        for test_case in plan_a["code_review_test_matrix"]
+    )
+    assert all(
+        test_case["creates_executor_tests"] is False
+        for test_case in plan_a["code_review_test_matrix"]
+    )
+
+
+def test_code_review_acceptance_criteria_require_no_executor_source_creation():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert (
+        plan_a["code_review_acceptance_criteria"]
+        == plan_b["code_review_acceptance_criteria"]
+    )
+    criteria = {
+        criterion["id"]: criterion
+        for criterion in plan_a["code_review_acceptance_criteria"]
+    }
+    assert criteria["no_executor_source_creation_in_v0_1"][
+        "creates_executor_source_files"
+    ] is False
+    assert criteria["no_executor_source_creation_in_v0_1"][
+        "creates_executor_tests"
+    ] is False
+
+
+def test_code_review_forbidden_actions_include_no_executor_or_write_actions():
+    plan = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    for forbidden in (
+        "implement_real_token_write_executor",
+        "invoke_real_token_write_executor",
+        "create_executor_source_files",
+        "create_executor_tests",
+        "write_token_files",
+        "write_approval_audit_files",
+        "write_proposal_files",
+        "write_operation_ledger",
+    ):
+        assert forbidden in plan["code_review_forbidden_actions"]
+
+
+def test_code_review_plan_checklist_is_deterministic():
+    plan_a = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    plan_b = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+
+    assert plan_a["code_review_plan_checklist"] == plan_b["code_review_plan_checklist"]
+    assert "executor_source_files_not_created" in plan_a["code_review_plan_checklist"]
+    assert "executor_tests_not_created" in plan_a["code_review_plan_checklist"]
+
+
+def test_input_implementation_dry_run_is_not_mutated():
+    dry_run = _dry_run()
+    before = deepcopy(dry_run)
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(dry_run)
+    plan["source_implementation_dry_run_snapshot"]["payload_preview"]["content"][
+        "nested"
+    ]["value"] = "changed"
+
+    assert dry_run == before
+
+
+def test_policy_proves_no_writes_or_real_executor_code_or_invocation(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    plan = create_human_approval_token_real_write_executor_code_review_plan(_dry_run())
+    explanation = explain_human_approval_token_real_write_executor_code_review_plan(
+        plan
+    )
+    recommendation = (
+        recommend_human_approval_token_real_write_executor_code_review_plan_action(
+            plan
+        )
+    )
+
+    assert (
+        plan["policy"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY
+    )
+    assert plan["policy"]["read_only"] is True
+    assert plan["policy"]["would_write_memory"] is False
+    assert plan["policy"]["would_modify_config"] is False
+    assert plan["policy"]["would_write_graph"] is False
+    assert plan["policy"]["does_not_create_operation_events"] is True
+    assert plan["policy"][
+        "creates_real_write_executor_code_review_plan_candidates_only"
+    ] is True
+    assert plan["policy"]["invokes_real_token_write_executor"] is False
+    assert plan["policy"]["implements_real_token_write_executor"] is False
+    assert plan["policy"]["creates_executor_source_files"] is False
+    assert plan["policy"]["creates_executor_tests"] is False
+    assert plan["policy"]["issues_real_approval_tokens"] is False
+    assert plan["policy"]["persists_approvals"] is False
+    assert plan["policy"]["creates_real_proposals"] is False
+    assert plan["policy"]["writes_proposal_files"] is False
+    assert plan["policy"]["writes_operation_ledger"] is False
+    assert plan["policy"]["writes_token_files"] is False
+    assert plan["policy"]["writes_approval_audit"] is False
+    assert plan["policy"]["applies_proposals"] is False
+    assert plan["policy"]["submits_to_governance"] is False
+    assert plan["policy"]["converts_to_real_proposal"] is False
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert recommendation["invokes_real_token_write_executor"] is False
+    assert recommendation["implements_real_token_write_executor"] is False
+    assert recommendation["creates_executor_source_files"] is False
+    assert recommendation["creates_executor_tests"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_plan_must_never_be_marked_written_or_executor_invoked_or_implemented():
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        plan = create_human_approval_token_real_write_executor_code_review_plan(
+            _dry_run()
+        )
+        plan[forbidden_key] = True
+
+        validation = validate_human_approval_token_real_write_executor_code_review_plan(
+            plan
+        )
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_code_review_gate_required_plans_and_by_block_type_status():
+    required_plan = create_human_approval_token_real_write_executor_code_review_plan(
+        _dry_run(block_type="procedural_rules")
+    )
+    locked_plan = create_human_approval_token_real_write_executor_code_review_plan(
+        _dry_run(block_type="preference", outcome="request_contract_changes")
+    )
+
+    summary = summarize_human_approval_token_real_write_executor_code_review_plans(
+        [required_plan, locked_plan]
+    )
+
+    assert summary["total"] == 2
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 0
+    assert summary["real_token_write_executor_code_review_gate_required_count"] == 1
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"preference": 1, "procedural_rules": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "real_token_write_executor_code_review_gate_required": 1,
+    }
+    assert (
+        summary["policy"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_POLICY
+    )

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_contract.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_contract.py
@@ -1,0 +1,421 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_real_write_executor_contract import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_ROUTING,
+    create_human_approval_token_real_write_executor_contract,
+    explain_human_approval_token_real_write_executor_contract,
+    recommend_human_approval_token_real_write_executor_contract_action,
+    summarize_human_approval_token_real_write_executor_contracts,
+    validate_human_approval_token_real_write_executor_contract,
+)
+from agent.memory_human_approval_token_write_final_gate import (
+    create_human_approval_token_write_final_gate,
+)
+from tests.agent.test_memory_human_approval_token_write_final_gate import _dry_run
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "converted_to_real_proposal",
+)
+
+
+def _gate(outcome=None, block_type="procedural_rules"):
+    return create_human_approval_token_write_final_gate(
+        _dry_run(outcome=outcome, block_type=block_type),
+        operator="token-write-final-gate-operator",
+    )
+
+
+def test_valid_write_final_gate_creates_real_token_write_executor_contract_required():
+    gate = _gate()
+
+    contract = create_human_approval_token_real_write_executor_contract(
+        gate,
+        operator="real-write-executor-contract-operator",
+    )
+
+    assert contract["contract_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_KIND
+    assert (
+        contract["contract_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REQUIRED
+    )
+    assert contract["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_ROUTING
+    assert contract["lock_reason"] is None
+    assert contract["source_write_final_gate_id"] == gate["gate_id"]
+    assert contract["source_write_execution_dry_run_id"] == gate[
+        "source_write_execution_dry_run_id"
+    ]
+    assert contract["source_write_execution_plan_id"] == gate["source_write_execution_plan_id"]
+    assert contract["source_final_confirmation_review_outcome_id"] == gate[
+        "source_final_confirmation_review_outcome_id"
+    ]
+    assert contract["source_final_confirmation_request_id"] == gate[
+        "source_final_confirmation_request_id"
+    ]
+    assert contract["source_token_write_lock_gate_id"] == gate[
+        "source_token_write_lock_gate_id"
+    ]
+    assert contract["source_token_issuance_dry_run_id"] == gate[
+        "source_token_issuance_dry_run_id"
+    ]
+    assert contract["source_token_issuance_plan_id"] == gate[
+        "source_token_issuance_plan_id"
+    ]
+    assert contract["source_review_outcome_id"] == gate["source_review_outcome_id"]
+    assert contract["source_request_id"] == gate["source_request_id"]
+    assert contract["source_gate_id"] == gate["source_gate_id"]
+    assert contract["source_dry_run_id"] == gate["source_dry_run_id"]
+    assert contract["source_plan_id"] == gate["source_plan_id"]
+    assert contract["source_outcome_id"] == gate["source_outcome_id"]
+    assert contract["source_packet_id"] == gate["source_packet_id"]
+    assert contract["source_submission_id"] == gate["source_submission_id"]
+    assert contract["source_draft_id"] == gate["source_draft_id"]
+    assert contract["source_decision_id"] == gate["source_decision_id"]
+    assert contract["source_queue_item_id"] == gate["source_queue_item_id"]
+    assert contract["operator"] == "real-write-executor-contract-operator"
+    assert contract["outcome"] == "confirm_token_write"
+    assert contract["write_final_gate_validation"] == {"valid": True, "errors": []}
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_real_write_executor_contract(contract) == {
+        "valid": True,
+        "errors": [],
+    }
+    assert contract["next_step_recommendation"]["action"] == (
+        "route_to_real_token_write_executor_contract_review_without_implementation"
+    )
+
+
+def test_locked_write_final_gate_creates_locked_contract():
+    contract = create_human_approval_token_real_write_executor_contract(
+        _gate(outcome="request_changes")
+    )
+
+    assert (
+        contract["contract_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+    )
+    assert contract["lock_reason"] == "final_confirmation_requested_changes"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_write_final_gate_creates_locked_contract():
+    gate = _gate()
+    gate["gate_status"] = "unexpected"
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert (
+        contract["contract_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+    )
+    assert contract["lock_reason"] == "invalid_token_write_final_gate"
+    assert contract["write_final_gate_validation"]["valid"] is False
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_record_preview_locks_contract():
+    gate = _gate()
+    gate.pop("approval_token_record_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_approval_token_record_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_audit_record_preview_locks_contract():
+    gate = _gate()
+    gate.pop("approval_audit_record_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_approval_audit_record_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_token_target_paths_preview_locks_contract():
+    gate = _gate()
+    gate.pop("token_target_paths_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_token_target_paths_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_proposal_record_preview_locks_contract():
+    gate = _gate()
+    gate.pop("proposal_record_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_proposal_record_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_operation_ledger_preview_locks_contract():
+    gate = _gate()
+    gate.pop("operation_ledger_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_operation_ledger_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_target_paths_preview_locks_contract():
+    gate = _gate()
+    gate.pop("target_paths_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_target_paths_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_write_payload_preview_locks_contract():
+    gate = _gate()
+    gate.pop("approval_token_write_payload_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_approval_token_write_payload_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_audit_write_payload_preview_locks_contract():
+    gate = _gate()
+    gate.pop("approval_audit_write_payload_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_approval_audit_write_payload_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_token_write_target_paths_preview_locks_contract():
+    gate = _gate()
+    gate.pop("token_write_target_paths_preview")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_token_write_target_paths_preview"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_final_gate_checklist_locks_contract():
+    gate = _gate()
+    gate.pop("final_gate_checklist")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_final_gate_checklist"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_source_evidence_locks_contract():
+    gate = _gate()
+    gate["source_pattern_ids"] = []
+    gate["source_fact_ids"] = []
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "missing_source_evidence"
+    assert (
+        contract["contract_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+    )
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_preview_integrity_failed_locks_contract():
+    gate = _gate()
+    gate["approval_token_record_preview"]["token_issued"] = True
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "preview_integrity_failed"
+    assert (
+        contract["contract_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+    )
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_final_gate_integrity_failed_locks_contract():
+    gate = _gate()
+    gate["final_gate_checklist"].remove("real_token_write_executor_required_but_not_invoked")
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+
+    assert contract["lock_reason"] == "final_gate_integrity_failed"
+    assert (
+        contract["contract_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_LOCKED
+    )
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+
+
+def test_executor_contract_inputs_are_deterministic():
+    contract_a = create_human_approval_token_real_write_executor_contract(_gate())
+    contract_b = create_human_approval_token_real_write_executor_contract(_gate())
+
+    assert contract_a["executor_contract_inputs"] == contract_b["executor_contract_inputs"]
+    assert (
+        contract_a["executor_contract_inputs"]["executor_boundary"]
+        == "contract_only_no_executor_implementation_or_invocation"
+    )
+
+
+def test_executor_hard_lock_checks_are_deterministic():
+    contract_a = create_human_approval_token_real_write_executor_contract(_gate())
+    contract_b = create_human_approval_token_real_write_executor_contract(_gate())
+
+    assert contract_a["executor_hard_lock_checks"] == contract_b["executor_hard_lock_checks"]
+    assert "lock_if_any_forbidden_write_or_executor_flag_is_true" in contract_a[
+        "executor_hard_lock_checks"
+    ]
+
+
+def test_executor_audit_fields_are_deterministic():
+    contract_a = create_human_approval_token_real_write_executor_contract(_gate())
+    contract_b = create_human_approval_token_real_write_executor_contract(_gate())
+
+    assert contract_a["executor_audit_fields"] == contract_b["executor_audit_fields"]
+    assert "contract_id" in contract_a["executor_audit_fields"]
+    assert "source_write_final_gate_id" in contract_a["executor_audit_fields"]
+
+
+def test_executor_rollback_rules_are_deterministic():
+    contract_a = create_human_approval_token_real_write_executor_contract(_gate())
+    contract_b = create_human_approval_token_real_write_executor_contract(_gate())
+
+    assert contract_a["executor_rollback_rules"] == contract_b["executor_rollback_rules"]
+    assert "no_rollback_action_in_v0_1_because_no_write_is_performed" in contract_a[
+        "executor_rollback_rules"
+    ]
+
+
+def test_executor_forbidden_side_effects_are_deterministic_and_include_no_writes():
+    contract_a = create_human_approval_token_real_write_executor_contract(_gate())
+    contract_b = create_human_approval_token_real_write_executor_contract(_gate())
+
+    assert contract_a["executor_forbidden_side_effects"] == contract_b[
+        "executor_forbidden_side_effects"
+    ]
+    for forbidden in (
+        "write_proposal_files",
+        "write_operation_ledger",
+        "write_token_files",
+        "write_approval_audit_files",
+        "invoke_real_token_write_executor",
+        "implement_real_token_write_executor",
+    ):
+        assert forbidden in contract_a["executor_forbidden_side_effects"]
+
+
+def test_input_write_final_gate_is_not_mutated():
+    gate = _gate()
+    before = deepcopy(gate)
+
+    contract = create_human_approval_token_real_write_executor_contract(gate)
+    contract["source_write_final_gate_snapshot"]["payload_preview"]["content"]["nested"][
+        "value"
+    ] = "changed"
+
+    assert gate == before
+
+
+def test_policy_proves_no_writes_and_no_real_executor_invocation_or_implementation(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    contract = create_human_approval_token_real_write_executor_contract(_gate())
+    explanation = explain_human_approval_token_real_write_executor_contract(contract)
+    recommendation = recommend_human_approval_token_real_write_executor_contract_action(contract)
+
+    assert contract["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_POLICY
+    assert contract["policy"]["read_only"] is True
+    assert contract["policy"]["would_write_memory"] is False
+    assert contract["policy"]["would_modify_config"] is False
+    assert contract["policy"]["would_write_graph"] is False
+    assert contract["policy"]["does_not_create_operation_events"] is True
+    assert contract["policy"]["creates_real_write_executor_contract_candidates_only"] is True
+    assert contract["policy"]["invokes_real_token_write_executor"] is False
+    assert contract["policy"]["implements_real_token_write_executor"] is False
+    assert contract["policy"]["issues_real_approval_tokens"] is False
+    assert contract["policy"]["persists_approvals"] is False
+    assert contract["policy"]["creates_real_proposals"] is False
+    assert contract["policy"]["writes_proposal_files"] is False
+    assert contract["policy"]["writes_operation_ledger"] is False
+    assert contract["policy"]["writes_token_files"] is False
+    assert contract["policy"]["writes_approval_audit"] is False
+    assert contract["policy"]["applies_proposals"] is False
+    assert contract["policy"]["submits_to_governance"] is False
+    assert contract["policy"]["converts_to_real_proposal"] is False
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert recommendation["invokes_real_token_write_executor"] is False
+    assert recommendation["implements_real_token_write_executor"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_contract_must_never_be_marked_as_written_issued_approved_persisted_or_converted():
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        contract = create_human_approval_token_real_write_executor_contract(_gate())
+        contract[forbidden_key] = True
+
+        validation = validate_human_approval_token_real_write_executor_contract(contract)
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_contract_required_candidates_and_by_block_type_status():
+    required_contract = create_human_approval_token_real_write_executor_contract(
+        _gate(block_type="procedural_rules")
+    )
+    locked_contract = create_human_approval_token_real_write_executor_contract(
+        _gate(block_type="preference", outcome="request_changes")
+    )
+
+    summary = summarize_human_approval_token_real_write_executor_contracts(
+        [required_contract, locked_contract]
+    )
+
+    assert summary["total"] == 2
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 0
+    assert summary["real_token_write_executor_contract_required_count"] == 1
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"preference": 1, "procedural_rules": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "real_token_write_executor_contract_required": 1,
+    }

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_contract_review_gate.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_contract_review_gate.py
@@ -112,6 +112,25 @@ def test_valid_contract_creates_approve_executor_contract_review_outcome_candida
     assert outcome["next_step_recommendation"]["writes_approval_audit"] is False
 
 
+def test_review_outcome_id_is_canonical_for_valid_contract_review_outcome():
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(
+        _contract(),
+        reviewer="contract-reviewer",
+    )
+
+    assert outcome["review_outcome_id"] == (
+        "memory-human-approval-token-real-write-executor-contract-review-outcome:"
+        "v0.1:62341452751cc123"
+    )
+    assert (
+        create_human_approval_token_real_write_executor_contract_review_outcome(
+            _contract(),
+            reviewer="contract-reviewer",
+        )["review_outcome_id"]
+        == outcome["review_outcome_id"]
+    )
+
+
 def test_locked_contract_rejects():
     contract = _contract(outcome="request_changes")
 

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_contract_review_gate.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_contract_review_gate.py
@@ -1,0 +1,499 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_real_write_executor_contract import (
+    create_human_approval_token_real_write_executor_contract,
+)
+from agent.memory_human_approval_token_real_write_executor_contract_review_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_STATUS,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_ROUTING,
+    create_human_approval_token_real_write_executor_contract_review_outcome,
+    evaluate_human_approval_token_real_write_executor_contract,
+    explain_human_approval_token_real_write_executor_contract_review_outcome,
+    recommend_human_approval_token_real_write_executor_contract_review_action,
+    summarize_human_approval_token_real_write_executor_contract_review_outcomes,
+    validate_human_approval_token_real_write_executor_contract_review_outcome,
+)
+from tests.agent.test_memory_human_approval_token_real_write_executor_contract import _gate
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "converted_to_real_proposal",
+)
+
+
+def _contract(outcome=None, block_type="procedural_rules"):
+    return create_human_approval_token_real_write_executor_contract(
+        _gate(outcome=outcome, block_type=block_type),
+        operator="real-write-executor-contract-operator",
+    )
+
+
+def test_valid_contract_creates_approve_executor_contract_review_outcome_candidate():
+    contract = _contract()
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(
+        contract,
+        reviewer="contract-reviewer",
+    )
+
+    assert (
+        outcome["review_outcome_kind"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_KIND
+    )
+    assert (
+        outcome["review_outcome_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_OUTCOME_STATUS
+    )
+    assert outcome["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_ROUTING
+    assert outcome["source_contract_id"] == contract["contract_id"]
+    assert outcome["source_write_final_gate_id"] == contract["source_write_final_gate_id"]
+    assert outcome["source_write_execution_dry_run_id"] == contract[
+        "source_write_execution_dry_run_id"
+    ]
+    assert outcome["source_write_execution_plan_id"] == contract[
+        "source_write_execution_plan_id"
+    ]
+    assert outcome["source_final_confirmation_review_outcome_id"] == contract[
+        "source_final_confirmation_review_outcome_id"
+    ]
+    assert outcome["source_final_confirmation_request_id"] == contract[
+        "source_final_confirmation_request_id"
+    ]
+    assert outcome["source_token_write_lock_gate_id"] == contract[
+        "source_token_write_lock_gate_id"
+    ]
+    assert outcome["source_token_issuance_dry_run_id"] == contract[
+        "source_token_issuance_dry_run_id"
+    ]
+    assert outcome["source_token_issuance_plan_id"] == contract[
+        "source_token_issuance_plan_id"
+    ]
+    assert outcome["source_review_outcome_id"] == contract["source_review_outcome_id"]
+    assert outcome["source_request_id"] == contract["source_request_id"]
+    assert outcome["source_gate_id"] == contract["source_gate_id"]
+    assert outcome["source_dry_run_id"] == contract["source_dry_run_id"]
+    assert outcome["source_plan_id"] == contract["source_plan_id"]
+    assert outcome["source_outcome_id"] == contract["source_outcome_id"]
+    assert outcome["source_packet_id"] == contract["source_packet_id"]
+    assert outcome["source_submission_id"] == contract["source_submission_id"]
+    assert outcome["source_draft_id"] == contract["source_draft_id"]
+    assert outcome["source_decision_id"] == contract["source_decision_id"]
+    assert outcome["source_queue_item_id"] == contract["source_queue_item_id"]
+    assert outcome["reviewer"] == "contract-reviewer"
+    assert outcome["outcome"] == "approve_executor_contract"
+    assert outcome["contract_validation"] == {"valid": True, "errors": []}
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_real_write_executor_contract_review_outcome(
+        outcome
+    ) == {"valid": True, "errors": []}
+    assert outcome["next_step_recommendation"]["action"] == (
+        "route_to_real_token_write_executor_implementation_plan_without_executor_invocation"
+    )
+    assert outcome["next_step_recommendation"]["invokes_real_token_write_executor"] is False
+    assert outcome["next_step_recommendation"]["implements_real_token_write_executor"] is False
+    assert outcome["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert outcome["next_step_recommendation"]["persists_approvals"] is False
+    assert outcome["next_step_recommendation"]["writes_token_files"] is False
+    assert outcome["next_step_recommendation"]["writes_approval_audit"] is False
+
+
+def test_locked_contract_rejects():
+    contract = _contract(outcome="request_changes")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert contract["contract_status"] == "locked"
+    assert outcome["outcome"] == "reject_contract"
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_contract_rejects():
+    contract = _contract()
+    contract["contract_kind"] = "wrong"
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "reject_contract"
+    assert outcome["contract_validation"]["valid"] is False
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert evaluate_human_approval_token_real_write_executor_contract(contract)["outcome"] == (
+        "reject_contract"
+    )
+
+
+def test_missing_approval_token_record_preview_requests_changes():
+    contract = _contract()
+    contract.pop("approval_token_record_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_approval_audit_record_preview_requests_changes():
+    contract = _contract()
+    contract.pop("approval_audit_record_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_token_target_paths_preview_requests_changes():
+    contract = _contract()
+    contract.pop("token_target_paths_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_proposal_record_preview_requests_changes():
+    contract = _contract()
+    contract.pop("proposal_record_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_operation_ledger_preview_requests_changes():
+    contract = _contract()
+    contract.pop("operation_ledger_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_target_paths_preview_requests_changes():
+    contract = _contract()
+    contract.pop("target_paths_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_approval_token_write_payload_preview_requests_changes():
+    contract = _contract()
+    contract.pop("approval_token_write_payload_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_approval_audit_write_payload_preview_requests_changes():
+    contract = _contract()
+    contract.pop("approval_audit_write_payload_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_token_write_target_paths_preview_requests_changes():
+    contract = _contract()
+    contract.pop("token_write_target_paths_preview")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_final_gate_checklist_requests_changes():
+    contract = _contract()
+    contract.pop("final_gate_checklist")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_executor_contract_inputs_requests_changes():
+    contract = _contract()
+    contract.pop("executor_contract_inputs")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_executor_hard_lock_checks_requests_changes():
+    contract = _contract()
+    contract.pop("executor_hard_lock_checks")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_executor_audit_fields_requests_changes():
+    contract = _contract()
+    contract.pop("executor_audit_fields")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_executor_rollback_rules_requests_changes():
+    contract = _contract()
+    contract.pop("executor_rollback_rules")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_executor_forbidden_side_effects_requests_changes():
+    contract = _contract()
+    contract.pop("executor_forbidden_side_effects")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_executor_contract_checklist_requests_changes():
+    contract = _contract()
+    contract.pop("executor_contract_checklist")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_missing_source_evidence_requests_changes():
+    contract = _contract()
+    contract["source_pattern_ids"] = []
+    contract["source_fact_ids"] = []
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_preview_integrity_failed_requests_changes():
+    contract = _contract()
+    contract["approval_token_record_preview"]["token_issued"] = True
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+
+
+def test_contract_integrity_failed_requests_changes():
+    contract = _contract()
+    contract["executor_contract_checklist"].remove("no_real_executor_is_invoked")
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+
+    assert outcome["outcome"] == "request_contract_changes"
+    assert outcome["contract_validation"]["valid"] is False
+
+
+def test_explicit_supported_outcome_override_is_accepted_but_not_written_or_invoked():
+    contract = _contract()
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(
+        contract,
+        reviewer="contract-reviewer",
+        outcome="defer_contract_review",
+        rationale="Manual reviewer chose to defer.",
+    )
+    explanation = explain_human_approval_token_real_write_executor_contract_review_outcome(
+        outcome
+    )
+    recommendation = recommend_human_approval_token_real_write_executor_contract_review_action(
+        outcome
+    )
+
+    assert outcome["outcome"] == "defer_contract_review"
+    assert outcome["rationale"] == "Manual reviewer chose to defer."
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert recommendation["invokes_real_token_write_executor"] is False
+    assert recommendation["implements_real_token_write_executor"] is False
+    assert recommendation["applies_proposals"] is False
+    assert recommendation["submits_to_governance"] is False
+
+
+def test_unsupported_outcome_fails_validation():
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(
+        _contract(),
+        outcome="approve_and_execute",
+    )
+
+    validation = validate_human_approval_token_real_write_executor_contract_review_outcome(
+        outcome
+    )
+
+    assert validation["valid"] is False
+    assert "outcome_must_be_supported" in validation["errors"]
+    assert outcome["next_step_recommendation"]["action"] == (
+        "do_not_use_real_write_executor_contract_review_outcome_candidate"
+    )
+
+
+def test_contract_review_checklist_is_deterministic():
+    outcome_a = create_human_approval_token_real_write_executor_contract_review_outcome(
+        _contract()
+    )
+    outcome_b = create_human_approval_token_real_write_executor_contract_review_outcome(
+        _contract()
+    )
+
+    assert outcome_a["contract_review_checklist"] == outcome_b["contract_review_checklist"]
+    assert "real_token_write_executor_not_invoked" in outcome_a["contract_review_checklist"]
+    assert "contract_review_outcome_only" in outcome_a["contract_review_checklist"]
+
+
+def test_input_contract_is_not_mutated():
+    contract = _contract()
+    before = deepcopy(contract)
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(contract)
+    outcome["source_contract_snapshot"]["payload_preview"]["content"]["nested"][
+        "value"
+    ] = "changed"
+
+    assert contract == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes_and_no_executor(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(
+        _contract()
+    )
+    explanation = explain_human_approval_token_real_write_executor_contract_review_outcome(
+        outcome
+    )
+    recommendation = recommend_human_approval_token_real_write_executor_contract_review_action(
+        outcome
+    )
+
+    assert outcome["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY
+    assert outcome["policy"]["read_only"] is True
+    assert outcome["policy"]["would_write_memory"] is False
+    assert outcome["policy"]["would_modify_config"] is False
+    assert outcome["policy"]["would_write_graph"] is False
+    assert outcome["policy"]["does_not_create_operation_events"] is True
+    assert outcome["policy"]["creates_real_write_executor_contract_review_outcomes_only"] is True
+    assert outcome["policy"]["invokes_real_token_write_executor"] is False
+    assert outcome["policy"]["implements_real_token_write_executor"] is False
+    assert outcome["policy"]["issues_real_approval_tokens"] is False
+    assert outcome["policy"]["persists_approvals"] is False
+    assert outcome["policy"]["creates_real_proposals"] is False
+    assert outcome["policy"]["writes_proposal_files"] is False
+    assert outcome["policy"]["writes_operation_ledger"] is False
+    assert outcome["policy"]["writes_token_files"] is False
+    assert outcome["policy"]["writes_approval_audit"] is False
+    assert outcome["policy"]["applies_proposals"] is False
+    assert outcome["policy"]["submits_to_governance"] is False
+    assert outcome["policy"]["converts_to_real_proposal"] is False
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert recommendation["invokes_real_token_write_executor"] is False
+    assert recommendation["implements_real_token_write_executor"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_outcome_candidate_must_never_be_marked_written_issued_approved_or_executor_invoked():
+    outcome = create_human_approval_token_real_write_executor_contract_review_outcome(
+        _contract()
+    )
+
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        mutated = deepcopy(outcome)
+        mutated[forbidden_key] = True
+
+        validation = validate_human_approval_token_real_write_executor_contract_review_outcome(
+            mutated
+        )
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_by_outcome_block_type_and_status():
+    outcomes = [
+        create_human_approval_token_real_write_executor_contract_review_outcome(
+            _contract(block_type="procedural_rules")
+        ),
+        create_human_approval_token_real_write_executor_contract_review_outcome(
+            _contract(block_type="project_context")
+        ),
+        create_human_approval_token_real_write_executor_contract_review_outcome(
+            _contract(block_type="procedural_rules", outcome="request_changes")
+        ),
+    ]
+
+    summary = summarize_human_approval_token_real_write_executor_contract_review_outcomes(
+        outcomes
+    )
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_outcome"] == {"approve_executor_contract": 2, "reject_contract": 1}
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {
+        "real_write_executor_contract_review_outcome_candidate": 3
+    }
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CONTRACT_REVIEW_POLICY
+
+
+def test_evaluate_exposes_same_deterministic_decision_without_creating_writes():
+    evaluation = evaluate_human_approval_token_real_write_executor_contract(
+        _contract(),
+        reviewer="contract-reviewer",
+    )
+
+    assert evaluation["reviewer"] == "contract-reviewer"
+    assert evaluation["outcome"] == "approve_executor_contract"
+    assert evaluation["validation"] == {"valid": True, "errors": []}
+    assert evaluation["policy"]["issues_real_approval_tokens"] is False
+    assert evaluation["policy"]["writes_token_files"] is False
+    assert evaluation["policy"]["invokes_real_token_write_executor"] is False
+    assert evaluation["policy"]["implements_real_token_write_executor"] is False

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_implementation_dry_run.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_implementation_dry_run.py
@@ -1,0 +1,545 @@
+from copy import deepcopy
+
+import pytest
+
+from agent.memory_human_approval_token_real_write_executor_implementation_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_ROUTING,
+    create_human_approval_token_real_write_executor_implementation_dry_run,
+    explain_human_approval_token_real_write_executor_implementation_dry_run,
+    recommend_human_approval_token_real_write_executor_implementation_dry_run_action,
+    summarize_human_approval_token_real_write_executor_implementation_dry_runs,
+    validate_human_approval_token_real_write_executor_implementation_dry_run,
+)
+from agent.memory_human_approval_token_real_write_executor_implementation_plan import (
+    create_human_approval_token_real_write_executor_implementation_plan,
+)
+from tests.agent.test_memory_human_approval_token_real_write_executor_implementation_plan import (
+    _outcome,
+)
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "creates_executor_source_files",
+    "converted_to_real_proposal",
+)
+
+
+def _plan(outcome=None, block_type="procedural_rules"):
+    return create_human_approval_token_real_write_executor_implementation_plan(
+        _outcome(outcome=outcome, block_type=block_type),
+        implementer="implementation-planner",
+    )
+
+
+def test_valid_implementation_plan_creates_code_review_plan_required_dry_run():
+    plan = _plan()
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan,
+        operator="implementation-dry-run-operator",
+    )
+
+    assert (
+        dry_run["dry_run_kind"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_KIND
+    )
+    assert (
+        dry_run["dry_run_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_CODE_REVIEW_PLAN_REQUIRED
+    )
+    assert (
+        dry_run["routing"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_ROUTING
+    )
+    assert dry_run["lock_reason"] is None
+    assert dry_run["source_implementation_plan_id"] == plan["plan_id"]
+    assert dry_run["source_contract_review_outcome_id"] == plan[
+        "source_contract_review_outcome_id"
+    ]
+    assert dry_run["source_contract_id"] == plan["source_contract_id"]
+    assert dry_run["source_write_final_gate_id"] == plan["source_write_final_gate_id"]
+    assert dry_run["source_write_execution_dry_run_id"] == plan[
+        "source_write_execution_dry_run_id"
+    ]
+    assert dry_run["source_write_execution_plan_id"] == plan[
+        "source_write_execution_plan_id"
+    ]
+    assert dry_run["source_final_confirmation_review_outcome_id"] == plan[
+        "source_final_confirmation_review_outcome_id"
+    ]
+    assert dry_run["source_final_confirmation_request_id"] == plan[
+        "source_final_confirmation_request_id"
+    ]
+    assert dry_run["source_token_write_lock_gate_id"] == plan[
+        "source_token_write_lock_gate_id"
+    ]
+    assert dry_run["source_token_issuance_dry_run_id"] == plan[
+        "source_token_issuance_dry_run_id"
+    ]
+    assert dry_run["source_token_issuance_plan_id"] == plan[
+        "source_token_issuance_plan_id"
+    ]
+    assert dry_run["source_review_outcome_id"] == plan["source_review_outcome_id"]
+    assert dry_run["source_request_id"] == plan["source_request_id"]
+    assert dry_run["source_gate_id"] == plan["source_gate_id"]
+    assert dry_run["source_dry_run_id"] == plan["source_dry_run_id"]
+    assert dry_run["source_plan_id"] == plan["source_plan_id"]
+    assert dry_run["source_outcome_id"] == plan["source_outcome_id"]
+    assert dry_run["source_packet_id"] == plan["source_packet_id"]
+    assert dry_run["source_submission_id"] == plan["source_submission_id"]
+    assert dry_run["source_draft_id"] == plan["source_draft_id"]
+    assert dry_run["source_decision_id"] == plan["source_decision_id"]
+    assert dry_run["source_queue_item_id"] == plan["source_queue_item_id"]
+    assert dry_run["operator"] == "implementation-dry-run-operator"
+    assert dry_run["outcome"] == "approve_executor_contract"
+    assert dry_run["implementation_plan_validation"] == {"valid": True, "errors": []}
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_real_write_executor_implementation_dry_run(
+        dry_run
+    ) == {"valid": True, "errors": []}
+    assert dry_run["next_step_recommendation"]["action"] == (
+        "route_to_real_token_write_executor_code_review_plan_without_executor_code_or_invocation"
+    )
+    assert dry_run["next_step_recommendation"]["invokes_real_token_write_executor"] is False
+    assert dry_run["next_step_recommendation"]["implements_real_token_write_executor"] is False
+    assert dry_run["next_step_recommendation"]["creates_executor_source_files"] is False
+
+
+def test_locked_implementation_plan_creates_locked_dry_run():
+    plan = _plan(outcome="request_contract_changes")
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+
+    assert (
+        dry_run["dry_run_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED
+    )
+    assert dry_run["lock_reason"] == "contract_review_requested_changes"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_locked_implementation_plan_without_reason_uses_default_lock_reason():
+    plan = _plan(outcome="request_contract_changes")
+    plan["lock_reason"] = None
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+
+    assert dry_run["lock_reason"] == "real_write_executor_implementation_plan_locked"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_implementation_plan_creates_locked_dry_run():
+    plan = _plan()
+    plan["plan_kind"] = "wrong"
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+
+    assert (
+        dry_run["dry_run_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED
+    )
+    assert dry_run["lock_reason"] == "invalid_real_write_executor_implementation_plan"
+    assert dry_run["implementation_plan_validation"]["valid"] is False
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+@pytest.mark.parametrize(
+    ("field", "reason"),
+    [
+        ("approval_token_record_preview", "missing_approval_token_record_preview"),
+        ("approval_audit_record_preview", "missing_approval_audit_record_preview"),
+        ("token_target_paths_preview", "missing_token_target_paths_preview"),
+        ("proposal_record_preview", "missing_proposal_record_preview"),
+        ("operation_ledger_preview", "missing_operation_ledger_preview"),
+        ("target_paths_preview", "missing_target_paths_preview"),
+        (
+            "approval_token_write_payload_preview",
+            "missing_approval_token_write_payload_preview",
+        ),
+        (
+            "approval_audit_write_payload_preview",
+            "missing_approval_audit_write_payload_preview",
+        ),
+        ("token_write_target_paths_preview", "missing_token_write_target_paths_preview"),
+        ("executor_contract_inputs", "missing_executor_contract_inputs"),
+        ("executor_hard_lock_checks", "missing_executor_hard_lock_checks"),
+        ("executor_audit_fields", "missing_executor_audit_fields"),
+        ("executor_rollback_rules", "missing_executor_rollback_rules"),
+        ("executor_forbidden_side_effects", "missing_executor_forbidden_side_effects"),
+        ("executor_contract_checklist", "missing_executor_contract_checklist"),
+        ("contract_review_checklist", "missing_contract_review_checklist"),
+        ("implementation_plan_interfaces", "missing_implementation_plan_interfaces"),
+        ("implementation_plan_files", "missing_implementation_plan_files"),
+        (
+            "implementation_plan_idempotency_strategy",
+            "missing_implementation_plan_idempotency_strategy",
+        ),
+        (
+            "implementation_plan_filesystem_safety_model",
+            "missing_implementation_plan_filesystem_safety_model",
+        ),
+        (
+            "implementation_plan_audit_strategy",
+            "missing_implementation_plan_audit_strategy",
+        ),
+        (
+            "implementation_plan_rollback_strategy",
+            "missing_implementation_plan_rollback_strategy",
+        ),
+        ("implementation_plan_test_plan", "missing_implementation_plan_test_plan"),
+        (
+            "implementation_plan_forbidden_actions",
+            "missing_implementation_plan_forbidden_actions",
+        ),
+    ],
+)
+def test_missing_required_implementation_plan_fields_lock_dry_run(field, reason):
+    plan = _plan()
+    plan.pop(field)
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+
+    assert dry_run["lock_reason"] == reason
+    assert (
+        dry_run["dry_run_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_LOCKED
+    )
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_source_evidence_locks_dry_run():
+    plan = _plan()
+    plan["source_pattern_ids"] = []
+    plan["source_fact_ids"] = []
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+
+    assert dry_run["lock_reason"] == "missing_source_evidence"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_preview_integrity_failed_locks_dry_run():
+    plan = _plan()
+    plan["approval_token_record_preview"]["token_issued"] = True
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+
+    assert dry_run["lock_reason"] == "preview_integrity_failed"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_implementation_plan_integrity_failed_locks_dry_run():
+    plan = _plan()
+    plan["implementation_plan_interfaces"][0]["implemented_in_v0_1"] = True
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+
+    assert dry_run["lock_reason"] == "implementation_plan_integrity_failed"
+    assert dry_run["implementation_plan_validation"]["valid"] is False
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_implementation_dry_run_module_boundary_preview_is_deterministic_and_no_code():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_module_boundary_preview"]
+        == dry_run_b["implementation_dry_run_module_boundary_preview"]
+    )
+    preview = dry_run_a["implementation_dry_run_module_boundary_preview"]
+    assert preview["module_created_in_v0_1"] is False
+    assert preview["creates_executor_source_files"] is False
+    assert preview["implements_real_token_write_executor"] is False
+
+
+def test_implementation_dry_run_interface_preview_is_deterministic_and_no_invocation():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_interface_preview"]
+        == dry_run_b["implementation_dry_run_interface_preview"]
+    )
+    assert all(
+        interface["implemented_in_v0_1"] is False
+        for interface in dry_run_a["implementation_dry_run_interface_preview"]
+    )
+    assert all(
+        interface["invoked_in_v0_1"] is False
+        for interface in dry_run_a["implementation_dry_run_interface_preview"]
+    )
+
+
+def test_implementation_dry_run_idempotency_check_preview_is_deterministic():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_idempotency_check_preview"]
+        == dry_run_b["implementation_dry_run_idempotency_check_preview"]
+    )
+    assert (
+        dry_run_a["implementation_dry_run_idempotency_check_preview"]["v0_1_effect"]
+        == "no_idempotency_state_written"
+    )
+
+
+def test_implementation_dry_run_filesystem_safety_check_preview_is_preview_only():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_filesystem_safety_check_preview"]
+        == dry_run_b["implementation_dry_run_filesystem_safety_check_preview"]
+    )
+    preview = dry_run_a["implementation_dry_run_filesystem_safety_check_preview"]
+    assert preview["preview_only"] is True
+    assert preview["writes_token_files"] is False
+    assert preview["writes_approval_audit"] is False
+    assert preview["creates_executor_source_files"] is False
+
+
+def test_implementation_dry_run_audit_check_preview_is_preview_only():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_audit_check_preview"]
+        == dry_run_b["implementation_dry_run_audit_check_preview"]
+    )
+    preview = dry_run_a["implementation_dry_run_audit_check_preview"]
+    assert preview["preview_only"] is True
+    assert preview["created_operation_event"] is False
+    assert preview["writes_approval_audit"] is False
+    assert preview["writes_operation_ledger"] is False
+
+
+def test_implementation_dry_run_rollback_check_preview_is_no_write():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_rollback_check_preview"]
+        == dry_run_b["implementation_dry_run_rollback_check_preview"]
+    )
+    preview = dry_run_a["implementation_dry_run_rollback_check_preview"]
+    assert preview["v0_1_effect"] == "no_rollback_action_because_no_write_is_performed"
+    assert preview["writes_token_files"] is False
+    assert preview["writes_approval_audit"] is False
+
+
+def test_implementation_dry_run_test_harness_preview_does_not_create_files():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_test_harness_preview"]
+        == dry_run_b["implementation_dry_run_test_harness_preview"]
+    )
+    assert all(
+        test_case["creates_files"] is False
+        for test_case in dry_run_a["implementation_dry_run_test_harness_preview"]
+    )
+    assert all(
+        test_case["writes"] is False
+        for test_case in dry_run_a["implementation_dry_run_test_harness_preview"]
+    )
+
+
+def test_implementation_dry_run_readiness_checklist_is_deterministic():
+    dry_run_a = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    dry_run_b = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+
+    assert (
+        dry_run_a["implementation_dry_run_readiness_checklist"]
+        == dry_run_b["implementation_dry_run_readiness_checklist"]
+    )
+    assert "executor_source_files_not_created" in dry_run_a[
+        "implementation_dry_run_readiness_checklist"
+    ]
+
+
+def test_input_implementation_plan_is_not_mutated():
+    plan = _plan()
+    before = deepcopy(plan)
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        plan
+    )
+    dry_run["source_implementation_plan_snapshot"]["payload_preview"]["content"][
+        "nested"
+    ]["value"] = "changed"
+
+    assert plan == before
+
+
+def test_policy_proves_no_writes_or_real_executor_code_or_invocation(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan()
+    )
+    explanation = explain_human_approval_token_real_write_executor_implementation_dry_run(
+        dry_run
+    )
+    recommendation = (
+        recommend_human_approval_token_real_write_executor_implementation_dry_run_action(
+            dry_run
+        )
+    )
+
+    assert (
+        dry_run["policy"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
+    )
+    assert dry_run["policy"]["read_only"] is True
+    assert dry_run["policy"]["would_write_memory"] is False
+    assert dry_run["policy"]["would_modify_config"] is False
+    assert dry_run["policy"]["would_write_graph"] is False
+    assert dry_run["policy"]["does_not_create_operation_events"] is True
+    assert dry_run["policy"][
+        "creates_real_write_executor_implementation_dry_run_candidates_only"
+    ] is True
+    assert dry_run["policy"]["invokes_real_token_write_executor"] is False
+    assert dry_run["policy"]["implements_real_token_write_executor"] is False
+    assert dry_run["policy"]["creates_executor_source_files"] is False
+    assert dry_run["policy"]["issues_real_approval_tokens"] is False
+    assert dry_run["policy"]["persists_approvals"] is False
+    assert dry_run["policy"]["creates_real_proposals"] is False
+    assert dry_run["policy"]["writes_proposal_files"] is False
+    assert dry_run["policy"]["writes_operation_ledger"] is False
+    assert dry_run["policy"]["writes_token_files"] is False
+    assert dry_run["policy"]["writes_approval_audit"] is False
+    assert dry_run["policy"]["applies_proposals"] is False
+    assert dry_run["policy"]["submits_to_governance"] is False
+    assert dry_run["policy"]["converts_to_real_proposal"] is False
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert recommendation["invokes_real_token_write_executor"] is False
+    assert recommendation["implements_real_token_write_executor"] is False
+    assert recommendation["creates_executor_source_files"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+    assert not (
+        hermes_home
+        / "agent"
+        / "memory_human_approval_token_real_write_executor.py"
+    ).exists()
+
+
+def test_dry_run_must_never_be_marked_written_or_executor_invoked_or_implemented():
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+            _plan()
+        )
+        dry_run[forbidden_key] = True
+
+        validation = validate_human_approval_token_real_write_executor_implementation_dry_run(
+            dry_run
+        )
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_code_review_plan_required_dry_runs_and_by_block_type_status():
+    required_dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan(block_type="procedural_rules")
+    )
+    locked_dry_run = create_human_approval_token_real_write_executor_implementation_dry_run(
+        _plan(block_type="preference", outcome="request_contract_changes")
+    )
+
+    summary = summarize_human_approval_token_real_write_executor_implementation_dry_runs(
+        [required_dry_run, locked_dry_run]
+    )
+
+    assert summary["total"] == 2
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 0
+    assert summary["real_token_write_executor_code_review_plan_required_count"] == 1
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"preference": 1, "procedural_rules": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "real_token_write_executor_code_review_plan_required": 1,
+    }
+    assert (
+        summary["policy"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_DRY_RUN_POLICY
+    )

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_implementation_plan.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_implementation_plan.py
@@ -116,6 +116,25 @@ def test_valid_approve_executor_contract_outcome_creates_implementation_plan_req
     assert plan["next_step_recommendation"]["implements_real_token_write_executor"] is False
 
 
+def test_implementation_plan_id_is_canonical_for_valid_contract_review_outcome():
+    plan = create_human_approval_token_real_write_executor_implementation_plan(
+        _outcome(),
+        implementer="implementation-planner",
+    )
+
+    assert plan["plan_id"] == (
+        "memory-human-approval-token-real-write-executor-implementation-plan:"
+        "v0.1:20b98e1aeed54cf6"
+    )
+    assert (
+        create_human_approval_token_real_write_executor_implementation_plan(
+            _outcome(),
+            implementer="implementation-planner",
+        )["plan_id"]
+        == plan["plan_id"]
+    )
+
+
 def test_request_contract_changes_creates_locked_plan():
     plan = create_human_approval_token_real_write_executor_implementation_plan(
         _outcome(outcome="request_contract_changes")

--- a/tests/agent/test_memory_human_approval_token_real_write_executor_implementation_plan.py
+++ b/tests/agent/test_memory_human_approval_token_real_write_executor_implementation_plan.py
@@ -1,0 +1,440 @@
+from copy import deepcopy
+
+import pytest
+
+from agent.memory_human_approval_token_real_write_executor_contract_review_gate import (
+    create_human_approval_token_real_write_executor_contract_review_outcome,
+)
+from agent.memory_human_approval_token_real_write_executor_implementation_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_ROUTING,
+    create_human_approval_token_real_write_executor_implementation_plan,
+    explain_human_approval_token_real_write_executor_implementation_plan,
+    recommend_human_approval_token_real_write_executor_implementation_plan_action,
+    summarize_human_approval_token_real_write_executor_implementation_plans,
+    validate_human_approval_token_real_write_executor_implementation_plan,
+)
+from tests.agent.test_memory_human_approval_token_real_write_executor_contract_review_gate import (
+    _contract,
+)
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "invokes_real_token_write_executor",
+    "implements_real_token_write_executor",
+    "converted_to_real_proposal",
+)
+
+
+def _outcome(outcome=None, block_type="procedural_rules"):
+    return create_human_approval_token_real_write_executor_contract_review_outcome(
+        _contract(block_type=block_type),
+        reviewer="contract-reviewer",
+        outcome=outcome,
+        rationale=f"Explicit {outcome} outcome." if outcome else None,
+    )
+
+
+def test_valid_approve_executor_contract_outcome_creates_implementation_plan_required():
+    outcome = _outcome()
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(
+        outcome,
+        implementer="implementation-planner",
+    )
+
+    assert plan["plan_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_KIND
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_REQUIRED
+    )
+    assert (
+        plan["routing"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_ROUTING
+    )
+    assert plan["lock_reason"] is None
+    assert plan["source_contract_review_outcome_id"] == outcome["review_outcome_id"]
+    assert plan["source_contract_id"] == outcome["source_contract_id"]
+    assert plan["source_write_final_gate_id"] == outcome["source_write_final_gate_id"]
+    assert plan["source_write_execution_dry_run_id"] == outcome[
+        "source_write_execution_dry_run_id"
+    ]
+    assert plan["source_write_execution_plan_id"] == outcome[
+        "source_write_execution_plan_id"
+    ]
+    assert plan["source_final_confirmation_review_outcome_id"] == outcome[
+        "source_final_confirmation_review_outcome_id"
+    ]
+    assert plan["source_final_confirmation_request_id"] == outcome[
+        "source_final_confirmation_request_id"
+    ]
+    assert plan["source_token_write_lock_gate_id"] == outcome[
+        "source_token_write_lock_gate_id"
+    ]
+    assert plan["source_token_issuance_dry_run_id"] == outcome[
+        "source_token_issuance_dry_run_id"
+    ]
+    assert plan["source_token_issuance_plan_id"] == outcome[
+        "source_token_issuance_plan_id"
+    ]
+    assert plan["source_review_outcome_id"] == outcome["source_review_outcome_id"]
+    assert plan["source_request_id"] == outcome["source_request_id"]
+    assert plan["source_gate_id"] == outcome["source_gate_id"]
+    assert plan["source_dry_run_id"] == outcome["source_dry_run_id"]
+    assert plan["source_plan_id"] == outcome["source_plan_id"]
+    assert plan["source_outcome_id"] == outcome["source_outcome_id"]
+    assert plan["source_packet_id"] == outcome["source_packet_id"]
+    assert plan["source_submission_id"] == outcome["source_submission_id"]
+    assert plan["source_draft_id"] == outcome["source_draft_id"]
+    assert plan["source_decision_id"] == outcome["source_decision_id"]
+    assert plan["source_queue_item_id"] == outcome["source_queue_item_id"]
+    assert plan["implementer"] == "implementation-planner"
+    assert plan["outcome"] == "approve_executor_contract"
+    assert plan["contract_review_outcome_validation"] == {"valid": True, "errors": []}
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_real_write_executor_implementation_plan(
+        plan
+    ) == {"valid": True, "errors": []}
+    assert plan["next_step_recommendation"]["action"] == (
+        "route_to_real_token_write_executor_implementation_dry_run_without_code_or_invocation"
+    )
+    assert plan["next_step_recommendation"]["invokes_real_token_write_executor"] is False
+    assert plan["next_step_recommendation"]["implements_real_token_write_executor"] is False
+
+
+def test_request_contract_changes_creates_locked_plan():
+    plan = create_human_approval_token_real_write_executor_implementation_plan(
+        _outcome(outcome="request_contract_changes")
+    )
+
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED
+    )
+    assert plan["lock_reason"] == "contract_review_requested_changes"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_reject_contract_creates_locked_plan():
+    plan = create_human_approval_token_real_write_executor_implementation_plan(
+        _outcome(outcome="reject_contract")
+    )
+
+    assert plan["lock_reason"] == "contract_review_rejected"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_defer_contract_review_creates_locked_plan():
+    plan = create_human_approval_token_real_write_executor_implementation_plan(
+        _outcome(outcome="defer_contract_review")
+    )
+
+    assert plan["lock_reason"] == "contract_review_deferred"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_contract_review_outcome_creates_locked_plan():
+    outcome = _outcome()
+    outcome["review_outcome_kind"] = "wrong"
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(outcome)
+
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED
+    )
+    assert plan["lock_reason"] == "invalid_contract_review_outcome"
+    assert plan["contract_review_outcome_validation"]["valid"] is False
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+@pytest.mark.parametrize(
+    ("field", "reason"),
+    [
+        ("approval_token_record_preview", "missing_approval_token_record_preview"),
+        ("approval_audit_record_preview", "missing_approval_audit_record_preview"),
+        ("token_target_paths_preview", "missing_token_target_paths_preview"),
+        ("proposal_record_preview", "missing_proposal_record_preview"),
+        ("operation_ledger_preview", "missing_operation_ledger_preview"),
+        ("target_paths_preview", "missing_target_paths_preview"),
+        (
+            "approval_token_write_payload_preview",
+            "missing_approval_token_write_payload_preview",
+        ),
+        (
+            "approval_audit_write_payload_preview",
+            "missing_approval_audit_write_payload_preview",
+        ),
+        ("token_write_target_paths_preview", "missing_token_write_target_paths_preview"),
+        ("executor_contract_inputs", "missing_executor_contract_inputs"),
+        ("executor_hard_lock_checks", "missing_executor_hard_lock_checks"),
+        ("executor_audit_fields", "missing_executor_audit_fields"),
+        ("executor_rollback_rules", "missing_executor_rollback_rules"),
+        ("executor_forbidden_side_effects", "missing_executor_forbidden_side_effects"),
+        ("executor_contract_checklist", "missing_executor_contract_checklist"),
+        ("contract_review_checklist", "missing_contract_review_checklist"),
+    ],
+)
+def test_missing_required_contract_review_fields_lock_plan(field, reason):
+    outcome = _outcome()
+    outcome.pop(field)
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(outcome)
+
+    assert plan["lock_reason"] == reason
+    assert (
+        plan["plan_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_LOCKED
+    )
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_source_evidence_locks_plan():
+    outcome = _outcome()
+    outcome["source_pattern_ids"] = []
+    outcome["source_fact_ids"] = []
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_source_evidence"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_preview_integrity_failed_locks_plan():
+    outcome = _outcome()
+    outcome["approval_token_record_preview"]["token_issued"] = True
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(outcome)
+
+    assert plan["lock_reason"] == "preview_integrity_failed"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_contract_review_integrity_failed_locks_plan():
+    outcome = _outcome()
+    outcome["contract_review_checklist"].remove("real_token_write_executor_not_invoked")
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(outcome)
+
+    assert plan["lock_reason"] == "contract_review_integrity_failed"
+    assert plan["contract_review_outcome_validation"]["valid"] is False
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_implementation_plan_interfaces_are_deterministic():
+    plan_a = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    plan_b = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    assert plan_a["implementation_plan_interfaces"] == plan_b["implementation_plan_interfaces"]
+    assert all(
+        interface["implemented_in_v0_1"] is False
+        for interface in plan_a["implementation_plan_interfaces"]
+    )
+    assert all(
+        interface["invoked_in_v0_1"] is False
+        for interface in plan_a["implementation_plan_interfaces"]
+    )
+
+
+def test_implementation_plan_files_are_deterministic_and_do_not_create_executor_code():
+    plan_a = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    plan_b = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    assert plan_a["implementation_plan_files"] == plan_b["implementation_plan_files"]
+    assert all(file_plan["create_in_v0_1"] is False for file_plan in plan_a["implementation_plan_files"])
+    assert all(
+        file_plan["contains_executor_code_in_v0_1"] is False
+        for file_plan in plan_a["implementation_plan_files"]
+    )
+
+
+def test_implementation_plan_idempotency_strategy_is_deterministic():
+    plan_a = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    plan_b = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    assert (
+        plan_a["implementation_plan_idempotency_strategy"]
+        == plan_b["implementation_plan_idempotency_strategy"]
+    )
+    assert (
+        plan_a["implementation_plan_idempotency_strategy"]["v0_1_effect"]
+        == "plan_only_no_idempotency_state_written"
+    )
+
+
+def test_implementation_plan_filesystem_safety_model_is_deterministic():
+    plan_a = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    plan_b = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    assert (
+        plan_a["implementation_plan_filesystem_safety_model"]
+        == plan_b["implementation_plan_filesystem_safety_model"]
+    )
+    assert (
+        plan_a["implementation_plan_filesystem_safety_model"]["v0_1_effect"]
+        == "no_filesystem_write_or_directory_creation"
+    )
+
+
+def test_implementation_plan_audit_strategy_is_deterministic_and_preview_only():
+    plan_a = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    plan_b = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    assert (
+        plan_a["implementation_plan_audit_strategy"]
+        == plan_b["implementation_plan_audit_strategy"]
+    )
+    assert (
+        plan_a["implementation_plan_audit_strategy"]["v0_1_effect"]
+        == "no_approval_audit_file_write_and_no_operation_ledger_event"
+    )
+
+
+def test_implementation_plan_rollback_strategy_is_deterministic_and_no_write():
+    plan_a = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    plan_b = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    assert (
+        plan_a["implementation_plan_rollback_strategy"]
+        == plan_b["implementation_plan_rollback_strategy"]
+    )
+    assert (
+        plan_a["implementation_plan_rollback_strategy"]["v0_1_effect"]
+        == "no_rollback_action_because_no_write_is_performed"
+    )
+
+
+def test_implementation_plan_test_plan_is_deterministic():
+    plan_a = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    plan_b = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    assert plan_a["implementation_plan_test_plan"] == plan_b["implementation_plan_test_plan"]
+    assert all(test_case["writes"] is False for test_case in plan_a["implementation_plan_test_plan"])
+
+
+def test_implementation_plan_forbidden_actions_include_no_executor_or_write_actions():
+    plan = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+
+    for forbidden in (
+        "implement_real_token_write_executor",
+        "invoke_real_token_write_executor",
+        "write_token_files",
+        "write_approval_audit_files",
+        "write_proposal_files",
+        "write_operation_ledger",
+    ):
+        assert forbidden in plan["implementation_plan_forbidden_actions"]
+
+
+def test_input_contract_review_outcome_is_not_mutated():
+    outcome = _outcome()
+    before = deepcopy(outcome)
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(outcome)
+    plan["source_contract_review_outcome_snapshot"]["payload_preview"]["content"][
+        "nested"
+    ]["value"] = "changed"
+
+    assert outcome == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_approval_writes_or_executor(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    plan = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+    explanation = explain_human_approval_token_real_write_executor_implementation_plan(plan)
+    recommendation = (
+        recommend_human_approval_token_real_write_executor_implementation_plan_action(plan)
+    )
+
+    assert plan["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY
+    assert plan["policy"]["read_only"] is True
+    assert plan["policy"]["would_write_memory"] is False
+    assert plan["policy"]["would_modify_config"] is False
+    assert plan["policy"]["would_write_graph"] is False
+    assert plan["policy"]["does_not_create_operation_events"] is True
+    assert plan["policy"]["creates_real_write_executor_implementation_plan_candidates_only"] is True
+    assert plan["policy"]["invokes_real_token_write_executor"] is False
+    assert plan["policy"]["implements_real_token_write_executor"] is False
+    assert plan["policy"]["issues_real_approval_tokens"] is False
+    assert plan["policy"]["persists_approvals"] is False
+    assert plan["policy"]["creates_real_proposals"] is False
+    assert plan["policy"]["writes_proposal_files"] is False
+    assert plan["policy"]["writes_operation_ledger"] is False
+    assert plan["policy"]["writes_token_files"] is False
+    assert plan["policy"]["writes_approval_audit"] is False
+    assert plan["policy"]["applies_proposals"] is False
+    assert plan["policy"]["submits_to_governance"] is False
+    assert plan["policy"]["converts_to_real_proposal"] is False
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert recommendation["invokes_real_token_write_executor"] is False
+    assert recommendation["implements_real_token_write_executor"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_plan_must_never_be_marked_token_issued_approved_written_or_executor_invoked():
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        plan = create_human_approval_token_real_write_executor_implementation_plan(_outcome())
+        plan[forbidden_key] = True
+
+        validation = validate_human_approval_token_real_write_executor_implementation_plan(
+            plan
+        )
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_implementation_plan_required_candidates_and_by_block_type_status():
+    required_plan = create_human_approval_token_real_write_executor_implementation_plan(
+        _outcome(block_type="procedural_rules")
+    )
+    locked_plan = create_human_approval_token_real_write_executor_implementation_plan(
+        _outcome(block_type="preference", outcome="request_contract_changes")
+    )
+
+    summary = summarize_human_approval_token_real_write_executor_implementation_plans(
+        [required_plan, locked_plan]
+    )
+
+    assert summary["total"] == 2
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 0
+    assert summary["real_token_write_executor_implementation_plan_required_count"] == 1
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"preference": 1, "procedural_rules": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "real_token_write_executor_implementation_plan_required": 1,
+    }
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REAL_WRITE_EXECUTOR_IMPLEMENTATION_PLAN_POLICY

--- a/tests/agent/test_memory_human_approval_token_request.py
+++ b/tests/agent/test_memory_human_approval_token_request.py
@@ -1,0 +1,286 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import create_governance_submission_packet
+from agent.memory_human_approval_token_request import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_ROUTING,
+    create_human_approval_token_request,
+    explain_human_approval_token_request,
+    recommend_human_approval_token_request_action,
+    summarize_human_approval_token_requests,
+    validate_human_approval_token_request,
+)
+from agent.memory_human_review_outcome_gate import create_human_review_outcome_candidate
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_real_proposal_creation_plan import create_real_proposal_creation_plan
+from agent.memory_real_proposal_dry_run import create_real_proposal_dry_run
+from agent.memory_real_proposal_write_lock_gate import (
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED,
+    create_real_proposal_write_lock_gate,
+)
+from agent.memory_review_decision_gate import evaluate_review_queue_item
+
+
+def _plan(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create approval token request candidates only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    decision = evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    draft = create_memory_proposal_draft(decision, author="proposal-drafter")
+    submission = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+    packet = create_governance_submission_packet(submission, reviewer="packet-reviewer")
+    outcome_candidate = create_human_review_outcome_candidate(packet, reviewer="human-reviewer", outcome=outcome)
+    return create_real_proposal_creation_plan(outcome_candidate, planner="plan-reviewer")
+
+
+def _gate(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    dry_run = create_real_proposal_dry_run(
+        _plan(
+            block_type=block_type,
+            outcome=outcome,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        operator="final-preflight-operator",
+    )
+    return create_real_proposal_write_lock_gate(dry_run, operator="write-lock-operator")
+
+
+def test_eligible_write_lock_gate_creates_review_required_request():
+    gate = _gate()
+
+    request = create_human_approval_token_request(gate, requester="token-requester")
+
+    assert request["request_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_KIND
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_REVIEW_REQUIRED
+    assert request["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_ROUTING
+    assert request["lock_reason"] is None
+    assert request["source_gate_id"] == gate["gate_id"]
+    assert request["source_dry_run_id"] == gate["source_dry_run_id"]
+    assert request["source_plan_id"] == gate["source_plan_id"]
+    assert request["source_outcome_id"] == gate["source_outcome_id"]
+    assert request["source_packet_id"] == gate["source_packet_id"]
+    assert request["source_submission_id"] == gate["source_submission_id"]
+    assert request["source_draft_id"] == gate["source_draft_id"]
+    assert request["source_decision_id"] == gate["source_decision_id"]
+    assert request["source_queue_item_id"] == gate["source_queue_item_id"]
+    assert request["requester"] == "token-requester"
+    assert request["write_lock_gate_validation"] == {"valid": True, "errors": []}
+    assert request["request_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_request(request) == {"valid": True, "errors": []}
+    assert request["next_step_recommendation"]["action"] == "perform_manual_human_approval_token_review_without_issuing_token"
+    assert request["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert request["next_step_recommendation"]["creates_real_proposals"] is False
+    assert request["next_step_recommendation"]["writes_operation_ledger"] is False
+
+
+def test_invalid_write_lock_gate_creates_locked_request():
+    gate = _gate()
+    gate["gate_kind"] = "invalid"
+
+    request = create_human_approval_token_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+    assert request["lock_reason"] == "invalid_write_lock_gate"
+    assert request["write_lock_gate_validation"]["valid"] is False
+    assert request["request_validation"] == {"valid": True, "errors": []}
+    assert request["next_step_recommendation"]["action"] == "keep_approval_token_request_locked"
+
+
+def test_locked_write_lock_gate_creates_locked_request():
+    gate = _gate(outcome="reject")
+
+    request = create_human_approval_token_request(gate)
+
+    assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+    assert request["lock_reason"] == gate["lock_reason"]
+
+
+def test_missing_proposal_record_preview_locks_request():
+    gate = _gate()
+    gate.pop("proposal_record_preview")
+
+    request = create_human_approval_token_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_proposal_record_preview"
+
+
+def test_missing_operation_ledger_preview_locks_request():
+    gate = _gate()
+    gate.pop("operation_ledger_preview")
+
+    request = create_human_approval_token_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_operation_ledger_preview"
+
+
+def test_missing_target_paths_preview_locks_request():
+    gate = _gate()
+    gate.pop("target_paths_preview")
+
+    request = create_human_approval_token_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_target_paths_preview"
+
+
+def test_missing_source_evidence_locks_request():
+    gate = _gate(source_pattern_ids=[], source_fact_ids=[])
+
+    request = create_human_approval_token_request(gate)
+
+    assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+    assert request["lock_reason"] == "missing_source_evidence"
+
+
+def test_preview_integrity_failed_when_preview_only_false_or_written_created_flags_true():
+    cases = []
+    for field in ("proposal_record_preview", "operation_ledger_preview", "target_paths_preview"):
+        preview_only_false = _gate()
+        preview_only_false[field]["preview_only"] = False
+        cases.append(preview_only_false)
+
+        written_true = _gate()
+        written_true[field]["written"] = True
+        cases.append(written_true)
+
+        created_true = _gate()
+        created_true[field]["created_real_proposal"] = True
+        cases.append(created_true)
+
+    for gate in cases:
+        request = create_human_approval_token_request(gate)
+        assert request["request_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_LOCKED
+        assert request["lock_reason"] == "preview_integrity_failed"
+
+
+def test_approval_checklist_and_token_requirements_are_deterministic():
+    request_a = create_human_approval_token_request(_gate())
+    request_b = create_human_approval_token_request(_gate())
+
+    assert request_a["approval_request_checklist"] == request_b["approval_request_checklist"]
+    assert request_a["approval_token_requirements"] == request_b["approval_token_requirements"]
+    assert [check["id"] for check in request_a["approval_request_checklist"]] == [
+        "verify_write_lock_gate_validation",
+        "verify_preview_artifacts_only",
+        "verify_no_token_or_approval_persistence",
+        "verify_no_real_proposal_or_ledger_write",
+        "route_to_manual_human_approval_token_review",
+    ]
+    assert [requirement["id"] for requirement in request_a["approval_token_requirements"]] == [
+        "human_reviewer_required",
+        "approval_token_must_be_external_to_request",
+        "real_write_requires_later_governed_step",
+    ]
+
+
+def test_input_write_lock_gate_is_not_mutated():
+    gate = _gate()
+    before = deepcopy(gate)
+
+    request = create_human_approval_token_request(gate)
+    request["source_write_lock_gate_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert gate == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_or_token_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    request = create_human_approval_token_request(_gate())
+    explanation = explain_human_approval_token_request(request)
+    recommendation = recommend_human_approval_token_request_action(request)
+
+    assert request["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY
+    assert request["policy"]["read_only"] is True
+    assert request["policy"]["would_write_memory"] is False
+    assert request["policy"]["would_modify_config"] is False
+    assert request["policy"]["would_write_graph"] is False
+    assert request["policy"]["does_not_create_operation_events"] is True
+    assert request["policy"]["creates_approval_token_requests_only"] is True
+    assert request["policy"]["issues_real_approval_tokens"] is False
+    assert request["policy"]["persists_approvals"] is False
+    assert request["policy"]["creates_real_proposals"] is False
+    assert request["policy"]["writes_proposal_files"] is False
+    assert request["policy"]["writes_operation_ledger"] is False
+    assert request["policy"]["applies_proposals"] is False
+    assert request["policy"]["submits_to_governance"] is False
+    assert request["policy"]["converts_to_real_proposal"] is False
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_request_must_never_be_marked_token_issued_approved_persisted_submitted_or_written():
+    request = create_human_approval_token_request(_gate())
+
+    for forbidden_key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(request)
+        mutated[forbidden_key] = True
+        validation = validate_human_approval_token_request(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_review_required_requests_and_by_block_type_status():
+    requests = [
+        create_human_approval_token_request(_gate("procedural_rules")),
+        create_human_approval_token_request(_gate("project_context")),
+        create_human_approval_token_request(_gate("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_human_approval_token_requests(requests)
+
+    assert summary["total"] == 3
+    assert summary["locked_count"] == 1
+    assert summary["review_required_count"] == 2
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {
+        "approval_token_review_required": 2,
+        "locked": 1,
+    }
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REQUEST_POLICY

--- a/tests/agent/test_memory_human_approval_token_request.py
+++ b/tests/agent/test_memory_human_approval_token_request.py
@@ -86,6 +86,15 @@ def test_eligible_write_lock_gate_creates_review_required_request():
     assert request["next_step_recommendation"]["writes_operation_ledger"] is False
 
 
+def test_valid_human_approval_token_request_id_matches_v0_1_baseline():
+    request = create_human_approval_token_request(_gate())
+
+    assert (
+        request["request_id"]
+        == "memory-human-approval-token-request:v0.1:f1b6a34228ed943e"
+    )
+
+
 def test_invalid_write_lock_gate_creates_locked_request():
     gate = _gate()
     gate["gate_kind"] = "invalid"

--- a/tests/agent/test_memory_human_approval_token_review_gate.py
+++ b/tests/agent/test_memory_human_approval_token_review_gate.py
@@ -88,6 +88,15 @@ def test_valid_review_required_request_becomes_approve_token_issuance_outcome_ca
     assert outcome["next_step_recommendation"]["writes_operation_ledger"] is False
 
 
+def test_valid_human_approval_token_review_outcome_id_matches_v0_1_baseline():
+    outcome = create_human_approval_token_review_outcome(_request(), reviewer="token-reviewer")
+
+    assert (
+        outcome["review_outcome_id"]
+        == "memory-human-approval-token-review-outcome:v0.1:b58709b83a4aaeb5"
+    )
+
+
 def test_invalid_request_candidate_rejects():
     request = _request()
     request["request_kind"] = "invalid"

--- a/tests/agent/test_memory_human_approval_token_review_gate.py
+++ b/tests/agent/test_memory_human_approval_token_review_gate.py
@@ -1,0 +1,273 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import create_governance_submission_packet
+from agent.memory_human_approval_token_request import (
+    create_human_approval_token_request,
+)
+from agent.memory_human_approval_token_review_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_ROUTING,
+    MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_STATUS,
+    create_human_approval_token_review_outcome,
+    evaluate_human_approval_token_request,
+    explain_human_approval_token_review_outcome,
+    recommend_human_approval_token_review_action,
+    summarize_human_approval_token_review_outcomes,
+    validate_human_approval_token_review_outcome,
+)
+from agent.memory_human_review_outcome_gate import create_human_review_outcome_candidate
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_real_proposal_creation_plan import create_real_proposal_creation_plan
+from agent.memory_real_proposal_dry_run import create_real_proposal_dry_run
+from agent.memory_real_proposal_write_lock_gate import create_real_proposal_write_lock_gate
+from agent.memory_review_decision_gate import evaluate_review_queue_item
+
+
+def _plan(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create approval token review outcome candidates only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    decision = evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    draft = create_memory_proposal_draft(decision, author="proposal-drafter")
+    submission = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+    packet = create_governance_submission_packet(submission, reviewer="packet-reviewer")
+    outcome_candidate = create_human_review_outcome_candidate(packet, reviewer="human-reviewer", outcome=outcome)
+    return create_real_proposal_creation_plan(outcome_candidate, planner="plan-reviewer")
+
+
+def _request(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    dry_run = create_real_proposal_dry_run(
+        _plan(
+            block_type=block_type,
+            outcome=outcome,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        operator="final-preflight-operator",
+    )
+    gate = create_real_proposal_write_lock_gate(dry_run, operator="write-lock-operator")
+    return create_human_approval_token_request(gate, requester="token-requester")
+
+
+def test_valid_review_required_request_becomes_approve_token_issuance_outcome_candidate():
+    request = _request()
+
+    outcome = create_human_approval_token_review_outcome(request, reviewer="token-reviewer")
+
+    assert outcome["review_outcome_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_KIND
+    assert outcome["review_outcome_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_STATUS
+    assert outcome["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_OUTCOME_ROUTING
+    assert outcome["source_request_id"] == request["request_id"]
+    assert outcome["source_gate_id"] == request["source_gate_id"]
+    assert outcome["source_dry_run_id"] == request["source_dry_run_id"]
+    assert outcome["source_plan_id"] == request["source_plan_id"]
+    assert outcome["source_outcome_id"] == request["source_outcome_id"]
+    assert outcome["source_packet_id"] == request["source_packet_id"]
+    assert outcome["source_submission_id"] == request["source_submission_id"]
+    assert outcome["source_draft_id"] == request["source_draft_id"]
+    assert outcome["source_decision_id"] == request["source_decision_id"]
+    assert outcome["source_queue_item_id"] == request["source_queue_item_id"]
+    assert outcome["reviewer"] == "token-reviewer"
+    assert outcome["outcome"] == "approve_token_issuance"
+    assert outcome["request_validation"] == {"valid": True, "errors": []}
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_review_outcome(outcome) == {"valid": True, "errors": []}
+    assert outcome["next_step_recommendation"]["action"] == "manual_token_issuance_still_required"
+    assert outcome["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert outcome["next_step_recommendation"]["creates_real_proposals"] is False
+    assert outcome["next_step_recommendation"]["writes_operation_ledger"] is False
+
+
+def test_invalid_request_candidate_rejects():
+    request = _request()
+    request["request_kind"] = "invalid"
+
+    outcome = create_human_approval_token_review_outcome(request)
+
+    assert outcome["outcome"] == "reject"
+    assert outcome["request_validation"]["valid"] is False
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert evaluate_human_approval_token_request(request)["outcome"] == "reject"
+
+
+def test_locked_request_candidate_rejects():
+    request = _request(outcome="reject")
+
+    outcome = create_human_approval_token_review_outcome(request)
+
+    assert request["request_status"] == "locked"
+    assert outcome["outcome"] == "reject"
+
+
+def test_missing_proposal_record_preview_requests_changes():
+    request = _request()
+    request.pop("proposal_record_preview")
+
+    outcome = create_human_approval_token_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+    assert "missing_proposal_record_preview" in outcome["request_validation"]["errors"]
+
+
+def test_missing_operation_ledger_preview_requests_changes():
+    request = _request()
+    request.pop("operation_ledger_preview")
+
+    outcome = create_human_approval_token_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+    assert "missing_operation_ledger_preview" in outcome["request_validation"]["errors"]
+
+
+def test_missing_target_paths_preview_requests_changes():
+    request = _request()
+    request.pop("target_paths_preview")
+
+    outcome = create_human_approval_token_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+    assert "missing_target_paths_preview" in outcome["request_validation"]["errors"]
+
+
+def test_missing_source_evidence_requests_changes():
+    request = _request(source_pattern_ids=[], source_fact_ids=[])
+
+    outcome = create_human_approval_token_review_outcome(request)
+
+    assert outcome["outcome"] == "request_changes"
+    assert "missing_source_evidence" in outcome["request_validation"]["errors"]
+
+
+def test_explicit_supported_outcome_override_is_accepted_but_not_issued_applied_or_persisted():
+    request = _request()
+
+    outcome = create_human_approval_token_review_outcome(
+        request,
+        reviewer="token-reviewer",
+        outcome="defer",
+    )
+    recommendation = recommend_human_approval_token_review_action(outcome)
+
+    assert outcome["outcome"] == "defer"
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert "Explicit supported" in outcome["rationale"]
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["applies_proposals"] is False
+    assert recommendation["submits_to_governance"] is False
+
+
+def test_unsupported_outcome_fails_validation():
+    outcome = create_human_approval_token_review_outcome(_request(), outcome="ship_it")
+
+    validation = validate_human_approval_token_review_outcome(outcome)
+
+    assert validation["valid"] is False
+    assert "unsupported_human_approval_token_review_outcome" in validation["errors"]
+    assert outcome["next_step_recommendation"]["action"] == "do_not_use_token_review_outcome_candidate"
+
+
+def test_input_request_candidate_is_not_mutated():
+    request = _request()
+    before = deepcopy(request)
+
+    outcome = create_human_approval_token_review_outcome(request)
+    outcome["source_request_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert request == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    outcome = create_human_approval_token_review_outcome(_request())
+    explanation = explain_human_approval_token_review_outcome(outcome)
+    recommendation = recommend_human_approval_token_review_action(outcome)
+
+    assert outcome["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY
+    assert outcome["policy"]["read_only"] is True
+    assert outcome["policy"]["would_write_memory"] is False
+    assert outcome["policy"]["would_modify_config"] is False
+    assert outcome["policy"]["would_write_graph"] is False
+    assert outcome["policy"]["does_not_create_operation_events"] is True
+    assert outcome["policy"]["creates_review_outcome_candidates_only"] is True
+    assert outcome["policy"]["issues_real_approval_tokens"] is False
+    assert outcome["policy"]["persists_approvals"] is False
+    assert outcome["policy"]["creates_real_proposals"] is False
+    assert outcome["policy"]["writes_proposal_files"] is False
+    assert outcome["policy"]["writes_operation_ledger"] is False
+    assert outcome["policy"]["applies_proposals"] is False
+    assert outcome["policy"]["submits_to_governance"] is False
+    assert outcome["policy"]["converts_to_real_proposal"] is False
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_outcome_candidate_must_never_be_marked_token_issued_approved_persisted_or_written():
+    outcome = create_human_approval_token_review_outcome(_request())
+
+    for forbidden_key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(outcome)
+        mutated[forbidden_key] = True
+        validation = validate_human_approval_token_review_outcome(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_by_outcome_block_type_and_status():
+    outcomes = [
+        create_human_approval_token_review_outcome(_request("procedural_rules")),
+        create_human_approval_token_review_outcome(_request("project_context")),
+        create_human_approval_token_review_outcome(_request("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_human_approval_token_review_outcomes(outcomes)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_outcome"] == {
+        "approve_token_issuance": 2,
+        "reject": 1,
+    }
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"token_review_outcome_candidate": 3}
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_REVIEW_GATE_POLICY

--- a/tests/agent/test_memory_human_approval_token_write_execution_dry_run.py
+++ b/tests/agent/test_memory_human_approval_token_write_execution_dry_run.py
@@ -1,0 +1,346 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_write_execution_plan import (
+    create_human_approval_token_write_execution_plan,
+)
+from agent.memory_human_approval_token_write_execution_dry_run import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_ROUTING,
+    create_human_approval_token_write_execution_dry_run,
+    explain_human_approval_token_write_execution_dry_run,
+    recommend_human_approval_token_write_execution_dry_run_action,
+    summarize_human_approval_token_write_execution_dry_runs,
+    validate_human_approval_token_write_execution_dry_run,
+)
+from tests.agent.test_memory_human_approval_token_write_execution_plan import _outcome
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+
+
+def _plan(outcome=None, block_type="procedural_rules"):
+    return create_human_approval_token_write_execution_plan(
+        _outcome(outcome=outcome, block_type=block_type),
+        executor="token-write-executor",
+    )
+
+
+def test_valid_execution_plan_creates_manual_token_write_final_preflight_required_dry_run():
+    plan = _plan()
+
+    dry_run = create_human_approval_token_write_execution_dry_run(
+        plan,
+        operator="token-write-dry-run-operator",
+    )
+
+    assert dry_run["dry_run_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_KIND
+    assert (
+        dry_run["dry_run_status"]
+        == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_FINAL_PREFLIGHT_REQUIRED
+    )
+    assert dry_run["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_ROUTING
+    assert dry_run["lock_reason"] is None
+    assert dry_run["source_write_execution_plan_id"] == plan["plan_id"]
+    assert dry_run["source_final_confirmation_review_outcome_id"] == plan[
+        "source_final_confirmation_review_outcome_id"
+    ]
+    assert dry_run["source_final_confirmation_request_id"] == plan[
+        "source_final_confirmation_request_id"
+    ]
+    assert dry_run["source_token_write_lock_gate_id"] == plan["source_token_write_lock_gate_id"]
+    assert dry_run["source_token_issuance_dry_run_id"] == plan[
+        "source_token_issuance_dry_run_id"
+    ]
+    assert dry_run["source_token_issuance_plan_id"] == plan["source_token_issuance_plan_id"]
+    assert dry_run["source_review_outcome_id"] == plan["source_review_outcome_id"]
+    assert dry_run["source_request_id"] == plan["source_request_id"]
+    assert dry_run["source_gate_id"] == plan["source_gate_id"]
+    assert dry_run["source_dry_run_id"] == plan["source_dry_run_id"]
+    assert dry_run["source_plan_id"] == plan["source_plan_id"]
+    assert dry_run["source_outcome_id"] == plan["source_outcome_id"]
+    assert dry_run["source_packet_id"] == plan["source_packet_id"]
+    assert dry_run["source_submission_id"] == plan["source_submission_id"]
+    assert dry_run["source_draft_id"] == plan["source_draft_id"]
+    assert dry_run["source_decision_id"] == plan["source_decision_id"]
+    assert dry_run["source_queue_item_id"] == plan["source_queue_item_id"]
+    assert dry_run["operator"] == "token-write-dry-run-operator"
+    assert dry_run["outcome"] == "confirm_token_write"
+    assert dry_run["write_execution_plan_validation"] == {"valid": True, "errors": []}
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_write_execution_dry_run(dry_run) == {
+        "valid": True,
+        "errors": [],
+    }
+    assert dry_run["next_step_recommendation"]["action"] == (
+        "route_to_manual_token_write_final_gate_without_issuing_token"
+    )
+
+
+def test_locked_execution_plan_creates_locked_dry_run():
+    dry_run = create_human_approval_token_write_execution_dry_run(
+        _plan(outcome="request_changes")
+    )
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "final_confirmation_requested_changes"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_execution_plan_creates_locked_dry_run():
+    plan = _plan()
+    plan["plan_status"] = "unexpected"
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED
+    assert dry_run["lock_reason"] == "invalid_token_write_execution_plan"
+    assert dry_run["write_execution_plan_validation"]["valid"] is False
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_record_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("approval_token_record_preview")
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_approval_token_record_preview"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_audit_record_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("approval_audit_record_preview")
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_approval_audit_record_preview"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_token_target_paths_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("token_target_paths_preview")
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_token_target_paths_preview"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_proposal_record_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("proposal_record_preview")
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_proposal_record_preview"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_operation_ledger_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("operation_ledger_preview")
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_operation_ledger_preview"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_target_paths_preview_locks_dry_run():
+    plan = _plan()
+    plan.pop("target_paths_preview")
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_target_paths_preview"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_source_evidence_locks_dry_run():
+    plan = _plan()
+    plan["source_pattern_ids"] = []
+    plan["source_fact_ids"] = []
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_source_evidence"
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_token_write_execution_controls_locks_dry_run():
+    plan = _plan()
+    plan.pop("token_write_execution_steps")
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_token_write_execution_controls"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+    plan = _plan()
+    plan.pop("token_write_execution_preflight_checks")
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "missing_token_write_execution_controls"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_preview_integrity_failed_locks_dry_run():
+    plan = _plan()
+    plan["approval_token_record_preview"]["token_issued"] = True
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run["lock_reason"] == "preview_integrity_failed"
+    assert dry_run["dry_run_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_LOCKED
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+
+
+def test_write_payload_and_target_path_previews_are_preview_only_and_deterministic():
+    plan = _plan()
+
+    dry_run_a = create_human_approval_token_write_execution_dry_run(plan)
+    dry_run_b = create_human_approval_token_write_execution_dry_run(plan)
+
+    assert dry_run_a["approval_token_write_payload_preview"] == dry_run_b[
+        "approval_token_write_payload_preview"
+    ]
+    assert dry_run_a["approval_audit_write_payload_preview"] == dry_run_b[
+        "approval_audit_write_payload_preview"
+    ]
+    assert dry_run_a["token_write_target_paths_preview"] == dry_run_b[
+        "token_write_target_paths_preview"
+    ]
+    assert dry_run_a["approval_token_write_payload_preview"]["preview_only"] is True
+    assert dry_run_a["approval_token_write_payload_preview"]["token_issued"] is False
+    assert dry_run_a["approval_token_write_payload_preview"]["persisted"] is False
+    assert dry_run_a["approval_token_write_payload_preview"]["written"] is False
+    assert dry_run_a["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert dry_run_a["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert dry_run_a["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert dry_run_a["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert dry_run_a["token_write_target_paths_preview"]["preview_only"] is True
+    assert dry_run_a["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert dry_run_a["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert dry_run_a["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+
+
+def test_final_token_write_preflight_checklist_is_deterministic():
+    dry_run_a = create_human_approval_token_write_execution_dry_run(_plan())
+    dry_run_b = create_human_approval_token_write_execution_dry_run(_plan())
+
+    assert dry_run_a["final_token_write_preflight_checklist"] == dry_run_b[
+        "final_token_write_preflight_checklist"
+    ]
+    assert "manual_token_write_final_gate_required_before_any_token_write" in dry_run_a[
+        "final_token_write_preflight_checklist"
+    ]
+
+
+def test_input_write_execution_plan_is_not_mutated():
+    plan = _plan()
+    before = deepcopy(plan)
+
+    dry_run = create_human_approval_token_write_execution_dry_run(plan)
+    dry_run["source_write_execution_plan_snapshot"]["payload_preview"]["content"]["nested"][
+        "value"
+    ] = "changed"
+
+    assert plan == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    dry_run = create_human_approval_token_write_execution_dry_run(_plan())
+    explanation = explain_human_approval_token_write_execution_dry_run(dry_run)
+    recommendation = recommend_human_approval_token_write_execution_dry_run_action(dry_run)
+
+    assert dry_run["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_DRY_RUN_POLICY
+    assert dry_run["policy"]["read_only"] is True
+    assert dry_run["policy"]["would_write_memory"] is False
+    assert dry_run["policy"]["would_modify_config"] is False
+    assert dry_run["policy"]["would_write_graph"] is False
+    assert dry_run["policy"]["does_not_create_operation_events"] is True
+    assert dry_run["policy"]["creates_token_write_execution_dry_run_candidates_only"] is True
+    assert dry_run["policy"]["issues_real_approval_tokens"] is False
+    assert dry_run["policy"]["persists_approvals"] is False
+    assert dry_run["policy"]["creates_real_proposals"] is False
+    assert dry_run["policy"]["writes_proposal_files"] is False
+    assert dry_run["policy"]["writes_operation_ledger"] is False
+    assert dry_run["policy"]["writes_token_files"] is False
+    assert dry_run["policy"]["writes_approval_audit"] is False
+    assert dry_run["policy"]["applies_proposals"] is False
+    assert dry_run["policy"]["submits_to_governance"] is False
+    assert dry_run["policy"]["converts_to_real_proposal"] is False
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_dry_run_must_never_be_marked_as_written_issued_approved_persisted_or_converted():
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        dry_run = create_human_approval_token_write_execution_dry_run(_plan())
+        dry_run[forbidden_key] = True
+
+        validation = validate_human_approval_token_write_execution_dry_run(dry_run)
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_final_preflight_required_candidates_and_by_block_type_status():
+    required_dry_run = create_human_approval_token_write_execution_dry_run(
+        _plan(block_type="procedural_rules")
+    )
+    locked_dry_run = create_human_approval_token_write_execution_dry_run(
+        _plan(block_type="preference", outcome="request_changes")
+    )
+
+    summary = summarize_human_approval_token_write_execution_dry_runs(
+        [required_dry_run, locked_dry_run]
+    )
+
+    assert summary["total"] == 2
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 0
+    assert summary["final_preflight_required_count"] == 1
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"preference": 1, "procedural_rules": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "manual_token_write_final_preflight_required": 1,
+    }

--- a/tests/agent/test_memory_human_approval_token_write_execution_plan.py
+++ b/tests/agent/test_memory_human_approval_token_write_execution_plan.py
@@ -1,0 +1,306 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_final_confirmation_review_gate import (
+    create_human_approval_token_final_confirmation_review_outcome,
+)
+from agent.memory_human_approval_token_write_execution_plan import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_ROUTING,
+    create_human_approval_token_write_execution_plan,
+    explain_human_approval_token_write_execution_plan,
+    recommend_human_approval_token_write_execution_plan_action,
+    summarize_human_approval_token_write_execution_plans,
+    validate_human_approval_token_write_execution_plan,
+)
+from tests.agent.test_memory_human_approval_token_final_confirmation_review_gate import _request
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+
+
+def _outcome(outcome=None, block_type="procedural_rules", source_pattern_ids=None, source_fact_ids=None):
+    return create_human_approval_token_final_confirmation_review_outcome(
+        _request(
+            block_type=block_type,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        confirmer="final-confirmation-confirmer",
+        outcome=outcome,
+        rationale=f"Explicit {outcome} outcome." if outcome else None,
+    )
+
+
+def test_confirm_token_write_outcome_creates_manual_token_write_execution_plan_required_plan():
+    outcome = _outcome()
+
+    plan = create_human_approval_token_write_execution_plan(outcome, executor="token-write-executor")
+
+    assert plan["plan_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_KIND
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_REQUIRED
+    assert plan["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_ROUTING
+    assert plan["lock_reason"] is None
+    assert plan["source_final_confirmation_review_outcome_id"] == outcome["review_outcome_id"]
+    assert plan["source_final_confirmation_request_id"] == outcome["source_final_confirmation_request_id"]
+    assert plan["source_token_write_lock_gate_id"] == outcome["source_token_write_lock_gate_id"]
+    assert plan["source_token_issuance_dry_run_id"] == outcome["source_token_issuance_dry_run_id"]
+    assert plan["source_token_issuance_plan_id"] == outcome["source_token_issuance_plan_id"]
+    assert plan["source_review_outcome_id"] == outcome["source_review_outcome_id"]
+    assert plan["source_request_id"] == outcome["source_request_id"]
+    assert plan["source_gate_id"] == outcome["source_gate_id"]
+    assert plan["source_dry_run_id"] == outcome["source_dry_run_id"]
+    assert plan["source_plan_id"] == outcome["source_plan_id"]
+    assert plan["source_outcome_id"] == outcome["source_outcome_id"]
+    assert plan["source_packet_id"] == outcome["source_packet_id"]
+    assert plan["source_submission_id"] == outcome["source_submission_id"]
+    assert plan["source_draft_id"] == outcome["source_draft_id"]
+    assert plan["source_decision_id"] == outcome["source_decision_id"]
+    assert plan["source_queue_item_id"] == outcome["source_queue_item_id"]
+    assert plan["executor"] == "token-write-executor"
+    assert plan["outcome"] == "confirm_token_write"
+    assert plan["final_confirmation_review_outcome_validation"] == {"valid": True, "errors": []}
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_write_execution_plan(plan) == {"valid": True, "errors": []}
+    assert plan["next_step_recommendation"]["action"] == "route_to_manual_token_write_dry_run_without_issuing_token"
+
+
+def test_request_changes_creates_locked_plan():
+    plan = create_human_approval_token_write_execution_plan(_outcome(outcome="request_changes"))
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    assert plan["lock_reason"] == "final_confirmation_requested_changes"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_reject_creates_locked_plan():
+    plan = create_human_approval_token_write_execution_plan(_outcome(outcome="reject"))
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    assert plan["lock_reason"] == "final_confirmation_rejected"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_defer_creates_locked_plan():
+    plan = create_human_approval_token_write_execution_plan(_outcome(outcome="defer"))
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    assert plan["lock_reason"] == "final_confirmation_deferred"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_review_outcome_creates_locked_plan():
+    outcome = _outcome()
+    outcome["outcome"] = "approve_and_issue"
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    assert plan["lock_reason"] == "invalid_final_confirmation_review_outcome"
+    assert plan["final_confirmation_review_outcome_validation"]["valid"] is False
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_record_preview_locks_plan():
+    outcome = _outcome()
+    outcome.pop("approval_token_record_preview")
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_approval_token_record_preview"
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_audit_record_preview_locks_plan():
+    outcome = _outcome()
+    outcome.pop("approval_audit_record_preview")
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_approval_audit_record_preview"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_token_target_paths_preview_locks_plan():
+    outcome = _outcome()
+    outcome.pop("token_target_paths_preview")
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_token_target_paths_preview"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_proposal_record_preview_locks_plan():
+    outcome = _outcome()
+    outcome.pop("proposal_record_preview")
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_proposal_record_preview"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_operation_ledger_preview_locks_plan():
+    outcome = _outcome()
+    outcome.pop("operation_ledger_preview")
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_operation_ledger_preview"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_target_paths_preview_locks_plan():
+    outcome = _outcome()
+    outcome.pop("target_paths_preview")
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_target_paths_preview"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_source_evidence_locks_plan():
+    outcome = _outcome()
+    outcome["source_pattern_ids"] = []
+    outcome["source_fact_ids"] = []
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "missing_source_evidence"
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_preview_integrity_failed_locks_plan():
+    outcome = _outcome()
+    outcome["approval_token_record_preview"]["token_issued"] = True
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+
+    assert plan["lock_reason"] == "preview_integrity_failed"
+    assert plan["plan_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_LOCKED
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+
+
+def test_token_write_execution_steps_and_preflight_checks_are_deterministic():
+    plan_a = create_human_approval_token_write_execution_plan(_outcome())
+    plan_b = create_human_approval_token_write_execution_plan(_outcome())
+
+    assert plan_a["token_write_execution_steps"] == plan_b["token_write_execution_steps"]
+    assert plan_a["token_write_execution_preflight_checks"] == plan_b["token_write_execution_preflight_checks"]
+    assert [step["order"] for step in plan_a["token_write_execution_steps"]] == [1, 2, 3, 4]
+    assert all(step["writes"] is False for step in plan_a["token_write_execution_steps"])
+    assert all(check["required"] is True for check in plan_a["token_write_execution_preflight_checks"])
+    assert all(check["blocks_token_write"] is True for check in plan_a["token_write_execution_preflight_checks"])
+
+
+def test_input_final_confirmation_review_outcome_is_not_mutated():
+    outcome = _outcome()
+    before = deepcopy(outcome)
+
+    plan = create_human_approval_token_write_execution_plan(outcome)
+    plan["source_final_confirmation_review_outcome_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert outcome == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    plan = create_human_approval_token_write_execution_plan(_outcome())
+    explanation = explain_human_approval_token_write_execution_plan(plan)
+    recommendation = recommend_human_approval_token_write_execution_plan_action(plan)
+
+    assert plan["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_EXECUTION_PLAN_POLICY
+    assert plan["policy"]["read_only"] is True
+    assert plan["policy"]["would_write_memory"] is False
+    assert plan["policy"]["would_modify_config"] is False
+    assert plan["policy"]["would_write_graph"] is False
+    assert plan["policy"]["does_not_create_operation_events"] is True
+    assert plan["policy"]["creates_token_write_execution_plan_candidates_only"] is True
+    assert plan["policy"]["issues_real_approval_tokens"] is False
+    assert plan["policy"]["persists_approvals"] is False
+    assert plan["policy"]["creates_real_proposals"] is False
+    assert plan["policy"]["writes_proposal_files"] is False
+    assert plan["policy"]["writes_operation_ledger"] is False
+    assert plan["policy"]["writes_token_files"] is False
+    assert plan["policy"]["writes_approval_audit"] is False
+    assert plan["policy"]["applies_proposals"] is False
+    assert plan["policy"]["submits_to_governance"] is False
+    assert plan["policy"]["converts_to_real_proposal"] is False
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["writes_token_files"] is False
+    assert explanation["writes_approval_audit"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_plan_must_never_be_marked_as_written_issued_approved_persisted_or_converted():
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        plan = create_human_approval_token_write_execution_plan(_outcome())
+        plan[forbidden_key] = True
+
+        validation = validate_human_approval_token_write_execution_plan(plan)
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_execution_plan_required_candidates_and_by_block_type_status():
+    required_plan = create_human_approval_token_write_execution_plan(
+        _outcome(block_type="procedural_rules")
+    )
+    locked_plan = create_human_approval_token_write_execution_plan(
+        _outcome(block_type="preference", outcome="request_changes")
+    )
+
+    summary = summarize_human_approval_token_write_execution_plans([required_plan, locked_plan])
+
+    assert summary["total"] == 2
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 0
+    assert summary["execution_plan_required_count"] == 1
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"preference": 1, "procedural_rules": 1}
+    assert summary["by_status"] == {
+        "locked": 1,
+        "manual_token_write_execution_plan_required": 1,
+    }

--- a/tests/agent/test_memory_human_approval_token_write_final_gate.py
+++ b/tests/agent/test_memory_human_approval_token_write_final_gate.py
@@ -1,0 +1,345 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_write_execution_dry_run import (
+    create_human_approval_token_write_execution_dry_run,
+)
+from agent.memory_human_approval_token_write_final_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ROUTING,
+    create_human_approval_token_write_final_gate,
+    explain_human_approval_token_write_final_gate,
+    recommend_human_approval_token_write_final_gate_action,
+    summarize_human_approval_token_write_final_gates,
+    validate_human_approval_token_write_final_gate,
+)
+from tests.agent.test_memory_human_approval_token_write_execution_dry_run import _plan
+
+
+FORBIDDEN_TRUE_KEYS = (
+    "token_issued",
+    "approved",
+    "persisted",
+    "submitted",
+    "written",
+    "created_real_proposal",
+    "created_operation_event",
+    "writes_proposal_files",
+    "writes_operation_ledger",
+    "writes_token_files",
+    "writes_approval_audit",
+    "converted_to_real_proposal",
+)
+
+
+def _dry_run(outcome=None, block_type="procedural_rules"):
+    return create_human_approval_token_write_execution_dry_run(
+        _plan(outcome=outcome, block_type=block_type),
+        operator="token-write-dry-run-operator",
+    )
+
+
+def test_valid_execution_dry_run_creates_eligible_final_gate():
+    dry_run = _dry_run()
+
+    gate = create_human_approval_token_write_final_gate(
+        dry_run,
+        operator="token-write-final-gate-operator",
+    )
+
+    assert gate["gate_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_KIND
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ELIGIBLE
+    assert gate["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_ROUTING
+    assert gate["lock_reason"] is None
+    assert gate["source_write_execution_dry_run_id"] == dry_run["dry_run_id"]
+    assert gate["source_write_execution_plan_id"] == dry_run["source_write_execution_plan_id"]
+    assert gate["source_final_confirmation_review_outcome_id"] == dry_run[
+        "source_final_confirmation_review_outcome_id"
+    ]
+    assert gate["source_final_confirmation_request_id"] == dry_run[
+        "source_final_confirmation_request_id"
+    ]
+    assert gate["source_token_write_lock_gate_id"] == dry_run[
+        "source_token_write_lock_gate_id"
+    ]
+    assert gate["source_token_issuance_dry_run_id"] == dry_run[
+        "source_token_issuance_dry_run_id"
+    ]
+    assert gate["source_token_issuance_plan_id"] == dry_run["source_token_issuance_plan_id"]
+    assert gate["source_review_outcome_id"] == dry_run["source_review_outcome_id"]
+    assert gate["source_request_id"] == dry_run["source_request_id"]
+    assert gate["source_gate_id"] == dry_run["source_gate_id"]
+    assert gate["source_dry_run_id"] == dry_run["source_dry_run_id"]
+    assert gate["source_plan_id"] == dry_run["source_plan_id"]
+    assert gate["source_outcome_id"] == dry_run["source_outcome_id"]
+    assert gate["source_packet_id"] == dry_run["source_packet_id"]
+    assert gate["source_submission_id"] == dry_run["source_submission_id"]
+    assert gate["source_draft_id"] == dry_run["source_draft_id"]
+    assert gate["source_decision_id"] == dry_run["source_decision_id"]
+    assert gate["source_queue_item_id"] == dry_run["source_queue_item_id"]
+    assert gate["operator"] == "token-write-final-gate-operator"
+    assert gate["outcome"] == "confirm_token_write"
+    assert gate["write_execution_dry_run_validation"] == {"valid": True, "errors": []}
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_write_final_gate(gate) == {
+        "valid": True,
+        "errors": [],
+    }
+    assert gate["next_step_recommendation"]["action"] == (
+        "route_to_real_token_write_executor_without_invoking_it"
+    )
+
+
+def test_locked_execution_dry_run_creates_locked_gate():
+    gate = create_human_approval_token_write_final_gate(_dry_run(outcome="request_changes"))
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED
+    assert gate["lock_reason"] == "final_confirmation_requested_changes"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_invalid_execution_dry_run_creates_locked_gate():
+    dry_run = _dry_run()
+    dry_run["dry_run_status"] = "unexpected"
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED
+    assert gate["lock_reason"] == "invalid_token_write_execution_dry_run"
+    assert gate["write_execution_dry_run_validation"]["valid"] is False
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_record_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("approval_token_record_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_approval_token_record_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_audit_record_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("approval_audit_record_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_approval_audit_record_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_token_target_paths_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("token_target_paths_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_token_target_paths_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_proposal_record_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("proposal_record_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_proposal_record_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_operation_ledger_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("operation_ledger_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_operation_ledger_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_target_paths_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("target_paths_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_target_paths_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_write_payload_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("approval_token_write_payload_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_approval_token_write_payload_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_audit_write_payload_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("approval_audit_write_payload_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_approval_audit_write_payload_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_token_write_target_paths_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("token_write_target_paths_preview")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_token_write_target_paths_preview"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_source_evidence_locks_gate():
+    dry_run = _dry_run()
+    dry_run["source_pattern_ids"] = []
+    dry_run["source_fact_ids"] = []
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_source_evidence"
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_final_token_write_preflight_checklist_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("final_token_write_preflight_checklist")
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "missing_final_token_write_preflight_checklist"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_preview_integrity_failed_locks_gate():
+    dry_run = _dry_run()
+    dry_run["approval_token_record_preview"]["token_issued"] = True
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "preview_integrity_failed"
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_final_preflight_integrity_failed_locks_gate():
+    dry_run = _dry_run()
+    dry_run["approval_token_write_payload_preview"]["token_issued"] = True
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+
+    assert gate["lock_reason"] == "final_preflight_integrity_failed"
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_LOCKED
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_final_gate_checklist_is_deterministic():
+    gate_a = create_human_approval_token_write_final_gate(_dry_run())
+    gate_b = create_human_approval_token_write_final_gate(_dry_run())
+
+    assert gate_a["final_gate_checklist"] == gate_b["final_gate_checklist"]
+    assert "real_token_write_executor_required_but_not_invoked" in gate_a[
+        "final_gate_checklist"
+    ]
+
+
+def test_input_write_execution_dry_run_is_not_mutated():
+    dry_run = _dry_run()
+    before = deepcopy(dry_run)
+
+    gate = create_human_approval_token_write_final_gate(dry_run)
+    gate["source_write_execution_dry_run_snapshot"]["payload_preview"]["content"]["nested"][
+        "value"
+    ] = "changed"
+
+    assert dry_run == before
+
+
+def test_policy_proves_no_writes_and_does_not_invoke_real_executor(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    gate = create_human_approval_token_write_final_gate(_dry_run())
+    explanation = explain_human_approval_token_write_final_gate(gate)
+    recommendation = recommend_human_approval_token_write_final_gate_action(gate)
+
+    assert gate["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_FINAL_GATE_POLICY
+    assert gate["policy"]["read_only"] is True
+    assert gate["policy"]["would_write_memory"] is False
+    assert gate["policy"]["would_modify_config"] is False
+    assert gate["policy"]["would_write_graph"] is False
+    assert gate["policy"]["does_not_create_operation_events"] is True
+    assert gate["policy"]["creates_token_write_final_gate_candidates_only"] is True
+    assert gate["policy"]["invokes_real_token_write_executor"] is False
+    assert gate["policy"]["issues_real_approval_tokens"] is False
+    assert gate["policy"]["persists_approvals"] is False
+    assert gate["policy"]["creates_real_proposals"] is False
+    assert gate["policy"]["writes_proposal_files"] is False
+    assert gate["policy"]["writes_operation_ledger"] is False
+    assert gate["policy"]["writes_token_files"] is False
+    assert gate["policy"]["writes_approval_audit"] is False
+    assert gate["policy"]["applies_proposals"] is False
+    assert gate["policy"]["submits_to_governance"] is False
+    assert gate["policy"]["converts_to_real_proposal"] is False
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        assert explanation[forbidden_key] is False
+    assert explanation["invokes_real_token_write_executor"] is False
+    assert recommendation["invokes_real_token_write_executor"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_gate_must_never_be_marked_as_written_issued_approved_persisted_or_converted():
+    for forbidden_key in FORBIDDEN_TRUE_KEYS:
+        gate = create_human_approval_token_write_final_gate(_dry_run())
+        gate[forbidden_key] = True
+
+        validation = validate_human_approval_token_write_final_gate(gate)
+
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_eligible_candidates_and_by_block_type_status():
+    eligible_gate = create_human_approval_token_write_final_gate(
+        _dry_run(block_type="procedural_rules")
+    )
+    locked_gate = create_human_approval_token_write_final_gate(
+        _dry_run(block_type="preference", outcome="request_changes")
+    )
+
+    summary = summarize_human_approval_token_write_final_gates([eligible_gate, locked_gate])
+
+    assert summary["total"] == 2
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 0
+    assert summary["eligible_for_real_token_write_executor_count"] == 1
+    assert summary["locked_count"] == 1
+    assert summary["by_block_type"] == {"preference": 1, "procedural_rules": 1}
+    assert summary["by_status"] == {
+        "eligible_for_real_token_write_executor": 1,
+        "locked": 1,
+    }

--- a/tests/agent/test_memory_human_approval_token_write_lock_gate.py
+++ b/tests/agent/test_memory_human_approval_token_write_lock_gate.py
@@ -205,6 +205,15 @@ def test_write_lock_checklist_is_deterministic():
     ]
 
 
+def test_valid_token_write_lock_gate_id_matches_v0_1_baseline():
+    gate = create_human_approval_token_write_lock_gate(
+        _dry_run(),
+        operator="token-write-lock-operator",
+    )
+
+    assert gate["gate_id"] == "memory-human-approval-token-write-lock-gate:v0.1:542fbd0ab45dea4f"
+
+
 def test_input_token_dry_run_is_not_mutated():
     dry_run = _dry_run()
     before = deepcopy(dry_run)

--- a/tests/agent/test_memory_human_approval_token_write_lock_gate.py
+++ b/tests/agent/test_memory_human_approval_token_write_lock_gate.py
@@ -1,0 +1,313 @@
+from copy import deepcopy
+
+from agent.memory_human_approval_token_issuance_dry_run import create_human_approval_token_issuance_dry_run
+from agent.memory_human_approval_token_write_lock_gate import (
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_KIND,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY,
+    MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ROUTING,
+    create_human_approval_token_write_lock_gate,
+    explain_human_approval_token_write_lock_gate,
+    recommend_human_approval_token_write_lock_action,
+    summarize_human_approval_token_write_lock_gates,
+    validate_human_approval_token_write_lock_gate,
+)
+from tests.agent.test_memory_human_approval_token_issuance_dry_run import _plan
+
+
+def _dry_run(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    return create_human_approval_token_issuance_dry_run(
+        _plan(
+            block_type=block_type,
+            outcome=outcome,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        operator="token-dry-run-operator",
+    )
+
+
+def test_valid_token_issuance_dry_run_creates_eligible_final_human_confirmation_gate():
+    dry_run = _dry_run()
+
+    gate = create_human_approval_token_write_lock_gate(dry_run, operator="token-write-lock-operator")
+
+    assert gate["gate_kind"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_KIND
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ELIGIBLE
+    assert gate["routing"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_ROUTING
+    assert gate["lock_reason"] is None
+    assert gate["source_token_issuance_dry_run_id"] == dry_run["dry_run_id"]
+    assert gate["source_token_issuance_plan_id"] == dry_run["source_token_issuance_plan_id"]
+    assert gate["source_review_outcome_id"] == dry_run["source_review_outcome_id"]
+    assert gate["source_request_id"] == dry_run["source_request_id"]
+    assert gate["source_gate_id"] == dry_run["source_gate_id"]
+    assert gate["source_dry_run_id"] == dry_run["source_dry_run_id"]
+    assert gate["source_plan_id"] == dry_run["source_plan_id"]
+    assert gate["source_outcome_id"] == dry_run["source_outcome_id"]
+    assert gate["source_packet_id"] == dry_run["source_packet_id"]
+    assert gate["source_submission_id"] == dry_run["source_submission_id"]
+    assert gate["source_draft_id"] == dry_run["source_draft_id"]
+    assert gate["source_decision_id"] == dry_run["source_decision_id"]
+    assert gate["source_queue_item_id"] == dry_run["source_queue_item_id"]
+    assert gate["operator"] == "token-write-lock-operator"
+    assert gate["token_dry_run_validation"] == {"valid": True, "errors": []}
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+    assert validate_human_approval_token_write_lock_gate(gate) == {"valid": True, "errors": []}
+    assert gate["next_step_recommendation"]["action"] == "request_separate_final_human_confirmation_before_token_write"
+    assert gate["next_step_recommendation"]["issues_real_approval_tokens"] is False
+    assert gate["next_step_recommendation"]["persists_approvals"] is False
+    assert gate["next_step_recommendation"]["creates_real_proposals"] is False
+    assert gate["next_step_recommendation"]["writes_operation_ledger"] is False
+    assert gate["next_step_recommendation"]["writes_token_files"] is False
+    assert gate["next_step_recommendation"]["writes_approval_audit"] is False
+
+
+def test_locked_token_dry_run_creates_locked_gate():
+    dry_run = _dry_run(outcome="reject")
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "token_review_rejected"
+    assert gate["token_dry_run_validation"] == {"valid": True, "errors": []}
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_locked_token_dry_run_without_lock_reason_uses_default_lock_reason():
+    dry_run = _dry_run(outcome="reject")
+    dry_run["lock_reason"] = None
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "token_issuance_dry_run_locked"
+
+
+def test_invalid_token_dry_run_creates_locked_gate():
+    dry_run = _dry_run()
+    dry_run["dry_run_kind"] = "wrong"
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "invalid_token_issuance_dry_run"
+    assert gate["token_dry_run_validation"]["valid"] is False
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+
+
+def test_missing_approval_token_record_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("approval_token_record_preview")
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_approval_token_record_preview"
+
+
+def test_missing_approval_audit_record_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("approval_audit_record_preview")
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_approval_audit_record_preview"
+
+
+def test_missing_token_target_paths_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("token_target_paths_preview")
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_token_target_paths_preview"
+
+
+def test_missing_proposal_record_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("proposal_record_preview")
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_proposal_record_preview"
+
+
+def test_missing_operation_ledger_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("operation_ledger_preview")
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_operation_ledger_preview"
+
+
+def test_missing_target_paths_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("target_paths_preview")
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_target_paths_preview"
+
+
+def test_missing_source_evidence_locks_gate():
+    dry_run = _dry_run(source_pattern_ids=[], source_fact_ids=[])
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_source_evidence"
+
+
+def test_preview_integrity_failed_when_preview_only_false_or_written_created_token_approved_persisted_flags_true():
+    fields = (
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+    )
+    cases = []
+    for field in fields:
+        preview_only_false = _dry_run()
+        preview_only_false[field]["preview_only"] = False
+        cases.append(preview_only_false)
+
+        for flag in ("written", "created_real_proposal", "created_operation_event", "token_issued", "approved", "persisted"):
+            flagged = _dry_run()
+            flagged[field][flag] = True
+            cases.append(flagged)
+
+    for dry_run in cases:
+        gate = create_human_approval_token_write_lock_gate(dry_run)
+        assert gate["gate_status"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_LOCKED
+        assert gate["lock_reason"] == "preview_integrity_failed"
+
+
+def test_write_lock_checklist_is_deterministic():
+    gate_a = create_human_approval_token_write_lock_gate(_dry_run())
+    gate_b = create_human_approval_token_write_lock_gate(_dry_run())
+
+    assert gate_a["write_lock_checklist"] == gate_b["write_lock_checklist"]
+    assert [check["id"] for check in gate_a["write_lock_checklist"]] == [
+        "verify_token_dry_run_validation",
+        "verify_token_previews_only",
+        "verify_no_token_approval_or_write_flags",
+        "verify_payload_and_source_evidence",
+        "require_separate_final_human_confirmation",
+    ]
+
+
+def test_input_token_dry_run_is_not_mutated():
+    dry_run = _dry_run()
+    before = deepcopy(dry_run)
+
+    gate = create_human_approval_token_write_lock_gate(dry_run)
+    gate["source_token_issuance_dry_run_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert dry_run == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_ledger_token_or_approval_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    gate = create_human_approval_token_write_lock_gate(_dry_run())
+    explanation = explain_human_approval_token_write_lock_gate(gate)
+    recommendation = recommend_human_approval_token_write_lock_action(gate)
+
+    assert gate["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY
+    assert gate["policy"]["read_only"] is True
+    assert gate["policy"]["would_write_memory"] is False
+    assert gate["policy"]["would_modify_config"] is False
+    assert gate["policy"]["would_write_graph"] is False
+    assert gate["policy"]["does_not_create_operation_events"] is True
+    assert gate["policy"]["creates_token_write_lock_candidates_only"] is True
+    assert gate["policy"]["issues_real_approval_tokens"] is False
+    assert gate["policy"]["persists_approvals"] is False
+    assert gate["policy"]["creates_real_proposals"] is False
+    assert gate["policy"]["writes_proposal_files"] is False
+    assert gate["policy"]["writes_operation_ledger"] is False
+    assert gate["policy"]["writes_token_files"] is False
+    assert gate["policy"]["writes_approval_audit"] is False
+    assert gate["policy"]["applies_proposals"] is False
+    assert gate["policy"]["submits_to_governance"] is False
+    assert gate["policy"]["converts_to_real_proposal"] is False
+    assert explanation["token_issued"] is False
+    assert explanation["approved"] is False
+    assert explanation["persisted"] is False
+    assert explanation["submitted"] is False
+    assert explanation["written"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["writes_token_files"] is False
+    assert explanation["writes_approval_audit"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["issues_real_approval_tokens"] is False
+    assert recommendation["persists_approvals"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert recommendation["writes_token_files"] is False
+    assert recommendation["writes_approval_audit"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+    assert not (hermes_home / "memory" / "approvals" / "human_approval_tokens.jsonl").exists()
+    assert not (hermes_home / "memory" / "audit" / "human_approval_token_audit.jsonl").exists()
+
+
+def test_gate_must_never_be_marked_token_issued_approved_persisted_submitted_written_created_or_converted():
+    gate = create_human_approval_token_write_lock_gate(_dry_run())
+
+    for forbidden_key in (
+        "token_issued",
+        "approved",
+        "persisted",
+        "submitted",
+        "written",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "writes_token_files",
+        "writes_approval_audit",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(gate)
+        mutated[forbidden_key] = True
+        validation = validate_human_approval_token_write_lock_gate(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_eligible_gates_and_by_block_type_status():
+    gates = [
+        create_human_approval_token_write_lock_gate(_dry_run("procedural_rules")),
+        create_human_approval_token_write_lock_gate(_dry_run("project_context")),
+        create_human_approval_token_write_lock_gate(_dry_run("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_human_approval_token_write_lock_gates(gates)
+
+    assert summary["total"] == 3
+    assert summary["locked_count"] == 1
+    assert summary["eligible_count"] == 2
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {
+        "eligible_for_final_human_confirmation": 2,
+        "locked": 1,
+    }
+    assert summary["by_lock_reason"] == {"None": 2, "token_review_rejected": 1}
+    assert summary["policy"] == MEMORY_HUMAN_APPROVAL_TOKEN_WRITE_LOCK_GATE_POLICY

--- a/tests/agent/test_memory_human_review_outcome_gate.py
+++ b/tests/agent/test_memory_human_review_outcome_gate.py
@@ -1,0 +1,211 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import create_governance_submission_packet
+from agent.memory_human_review_outcome_gate import (
+    MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY,
+    MEMORY_HUMAN_REVIEW_OUTCOME_KIND,
+    MEMORY_HUMAN_REVIEW_OUTCOME_ROUTING,
+    MEMORY_HUMAN_REVIEW_OUTCOME_STATUS,
+    create_human_review_outcome_candidate,
+    evaluate_human_review_packet,
+    explain_human_review_outcome_candidate,
+    recommend_human_review_outcome_action,
+    summarize_human_review_outcomes,
+    validate_human_review_outcome_candidate,
+)
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_review_decision_gate import evaluate_review_queue_item
+
+
+def _packet(block_type="procedural_rules", source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create outcome candidates only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    decision = evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    draft = create_memory_proposal_draft(decision, author="proposal-drafter")
+    submission = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+    return create_governance_submission_packet(submission, reviewer="packet-reviewer")
+
+
+def test_valid_packet_becomes_approve_real_proposal_creation_outcome_candidate():
+    packet = _packet()
+
+    candidate = create_human_review_outcome_candidate(packet, reviewer="human-reviewer")
+
+    assert candidate["outcome_kind"] == MEMORY_HUMAN_REVIEW_OUTCOME_KIND
+    assert candidate["outcome_status"] == MEMORY_HUMAN_REVIEW_OUTCOME_STATUS
+    assert candidate["routing"] == MEMORY_HUMAN_REVIEW_OUTCOME_ROUTING
+    assert candidate["source_packet_id"] == packet["packet_id"]
+    assert candidate["source_submission_id"] == packet["source_submission_id"]
+    assert candidate["source_draft_id"] == packet["source_draft_id"]
+    assert candidate["source_decision_id"] == packet["source_decision_id"]
+    assert candidate["source_queue_item_id"] == packet["source_queue_item_id"]
+    assert candidate["reviewer"] == "human-reviewer"
+    assert candidate["outcome"] == "approve_real_proposal_creation"
+    assert candidate["outcome_validation"] == {"valid": True, "errors": []}
+    assert validate_human_review_outcome_candidate(candidate) == {"valid": True, "errors": []}
+    assert candidate["next_step_recommendation"]["action"] == "manual_real_proposal_creation_required"
+    assert candidate["next_step_recommendation"]["creates_real_proposals"] is False
+    assert candidate["next_step_recommendation"]["converts_to_real_proposal"] is False
+
+
+def test_invalid_packet_rejects():
+    packet = _packet()
+    packet["packet_status"] = "submitted"
+
+    evaluation = evaluate_human_review_packet(packet, reviewer="human-reviewer")
+    candidate = create_human_review_outcome_candidate(packet, reviewer="human-reviewer")
+
+    assert evaluation["outcome"] == "reject"
+    assert candidate["outcome"] == "reject"
+    assert candidate["packet_validation"]["valid"] is False
+    assert candidate["outcome_validation"] == {"valid": True, "errors": []}
+    assert candidate["next_step_recommendation"]["action"] == "do_not_create_real_proposal"
+
+
+def test_missing_payload_preview_requests_changes():
+    packet = _packet()
+    packet.pop("payload_preview")
+
+    candidate = create_human_review_outcome_candidate(packet)
+
+    assert candidate["outcome"] == "request_changes"
+    assert "missing_payload_preview" in candidate["packet_validation"]["errors"]
+    assert candidate["next_step_recommendation"]["action"] == "return_packet_for_changes"
+
+
+def test_missing_source_evidence_requests_changes():
+    packet = _packet(source_pattern_ids=[], source_fact_ids=[])
+
+    candidate = create_human_review_outcome_candidate(packet)
+
+    assert candidate["outcome"] == "request_changes"
+    assert "missing_source_evidence" in candidate["packet_validation"]["errors"]
+    assert candidate["next_step_recommendation"]["action"] == "return_packet_for_changes"
+
+
+def test_explicit_supported_outcome_override_is_accepted_but_not_applied():
+    packet = _packet()
+
+    candidate = create_human_review_outcome_candidate(
+        packet,
+        reviewer="human-reviewer",
+        outcome="defer",
+        rationale="Reviewer wants another human to inspect packet wording.",
+    )
+    recommendation = recommend_human_review_outcome_action(candidate)
+
+    assert candidate["outcome"] == "defer"
+    assert validate_human_review_outcome_candidate(candidate) == {"valid": True, "errors": []}
+    assert recommendation["action"] == "defer_manual_review_outcome"
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["applies_proposals"] is False
+    assert recommendation["persists_approvals"] is False
+
+
+def test_unsupported_outcome_fails_validation():
+    candidate = create_human_review_outcome_candidate(_packet(), outcome="ship_it")
+
+    validation = validate_human_review_outcome_candidate(candidate)
+
+    assert validation["valid"] is False
+    assert "unsupported_human_review_outcome" in validation["errors"]
+    assert candidate["next_step_recommendation"]["action"] == "do_not_use_outcome_candidate"
+
+
+def test_input_packet_is_not_mutated():
+    packet = _packet()
+    before = deepcopy(packet)
+
+    candidate = create_human_review_outcome_candidate(packet)
+    candidate["source_packet_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert packet == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    candidate = create_human_review_outcome_candidate(_packet())
+    explanation = explain_human_review_outcome_candidate(candidate)
+    recommendation = recommend_human_review_outcome_action(candidate)
+
+    assert candidate["policy"] == MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY
+    assert candidate["policy"]["read_only"] is True
+    assert candidate["policy"]["would_write_memory"] is False
+    assert candidate["policy"]["would_modify_config"] is False
+    assert candidate["policy"]["would_write_graph"] is False
+    assert candidate["policy"]["does_not_create_operation_events"] is True
+    assert candidate["policy"]["creates_outcome_candidates_only"] is True
+    assert candidate["policy"]["creates_real_proposals"] is False
+    assert candidate["policy"]["applies_proposals"] is False
+    assert candidate["policy"]["persists_approvals"] is False
+    assert candidate["policy"]["submits_to_governance"] is False
+    assert candidate["policy"]["converts_to_real_proposal"] is False
+    assert explanation["submitted"] is False
+    assert explanation["applied"] is False
+    assert explanation["persisted"] is False
+    assert explanation["approved"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["submitted_to_governance"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["submits_to_governance"] is False
+    assert recommendation["converts_to_real_proposal"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_outcome_candidate_must_never_be_marked_submitted_applied_persisted_approved_or_converted():
+    candidate = create_human_review_outcome_candidate(_packet())
+
+    for forbidden_key in (
+        "submitted",
+        "applied",
+        "persisted",
+        "approved",
+        "converted_to_real_proposal",
+        "created_real_proposal",
+        "created_operation_event",
+        "created_proposal_record",
+        "submitted_to_governance",
+    ):
+        mutated = deepcopy(candidate)
+        mutated[forbidden_key] = True
+        validation = validate_human_review_outcome_candidate(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_by_outcome_and_block_type_status():
+    candidates = [
+        create_human_review_outcome_candidate(_packet("procedural_rules")),
+        create_human_review_outcome_candidate(_packet("project_context"), outcome="defer"),
+        create_human_review_outcome_candidate(_packet("procedural_rules", source_pattern_ids=[], source_fact_ids=[])),
+    ]
+
+    summary = summarize_human_review_outcomes(candidates)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_outcome"] == {
+        "approve_real_proposal_creation": 1,
+        "defer": 1,
+        "request_changes": 1,
+    }
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"review_outcome_candidate": 3}
+    assert summary["policy"] == MEMORY_HUMAN_REVIEW_OUTCOME_GATE_POLICY

--- a/tests/agent/test_memory_proposal_draft_builder.py
+++ b/tests/agent/test_memory_proposal_draft_builder.py
@@ -1,0 +1,166 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_proposal_draft_builder import (
+    MEMORY_PROPOSAL_DRAFT_KIND,
+    MEMORY_PROPOSAL_DRAFT_POLICY,
+    MEMORY_PROPOSAL_DRAFT_ROUTING,
+    MEMORY_PROPOSAL_DRAFT_STATUS,
+    create_memory_proposal_draft,
+    explain_memory_proposal_draft,
+    recommend_memory_proposal_draft_action,
+    summarize_memory_proposal_drafts,
+    validate_memory_proposal_draft,
+)
+from agent.memory_review_decision_gate import create_review_decision_candidate, evaluate_review_queue_item
+
+
+def _decision(block_type="procedural_rules", decision=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create draft candidates only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids or ["pattern-1"],
+        source_fact_ids=source_fact_ids or ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    if decision is None:
+        return evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    return create_review_decision_candidate(queue_item, reviewer="memory-reviewer", decision=decision)
+
+
+def test_approve_to_proposal_decision_creates_valid_draft_review_required_draft():
+    candidate = _decision()
+
+    draft = create_memory_proposal_draft(candidate, author="proposal-drafter")
+
+    assert draft["proposal_kind"] == MEMORY_PROPOSAL_DRAFT_KIND
+    assert draft["proposal_status"] == MEMORY_PROPOSAL_DRAFT_STATUS
+    assert draft["routing"] == MEMORY_PROPOSAL_DRAFT_ROUTING
+    assert draft["source_decision_id"] == candidate["decision_id"]
+    assert draft["source_queue_item_id"] == candidate["queue_item_id"]
+    assert draft["author"] == "proposal-drafter"
+    assert draft["draft_validation"] == {"valid": True, "errors": []}
+    assert validate_memory_proposal_draft(draft) == {"valid": True, "errors": []}
+    assert draft["next_step_recommendation"]["action"] == "submit_to_separate_governed_proposal_flow"
+    assert draft["next_step_recommendation"]["creates_real_proposals"] is False
+
+
+def test_request_more_evidence_creates_invalid_draft_with_more_evidence_required():
+    draft = create_memory_proposal_draft(_decision(decision="request_more_evidence"))
+
+    assert draft["draft_validation"]["valid"] is False
+    assert "more_evidence_required" in draft["draft_validation"]["errors"]
+    assert draft["next_step_recommendation"]["action"] == "do_not_submit_draft"
+
+
+def test_reject_creates_invalid_draft_with_rejected_decision():
+    draft = create_memory_proposal_draft(_decision(decision="reject"))
+
+    assert draft["draft_validation"]["valid"] is False
+    assert "rejected_decision" in draft["draft_validation"]["errors"]
+
+
+def test_defer_creates_invalid_draft_with_deferred_decision():
+    draft = create_memory_proposal_draft(_decision(decision="defer"))
+
+    assert draft["draft_validation"]["valid"] is False
+    assert "deferred_decision" in draft["draft_validation"]["errors"]
+
+
+def test_invalid_decision_candidate_creates_invalid_draft():
+    draft = create_memory_proposal_draft(_decision(decision="apply_now"))
+
+    assert draft["decision_validation"]["valid"] is False
+    assert draft["draft_validation"]["valid"] is False
+    assert "invalid_decision_candidate" in draft["draft_validation"]["errors"]
+
+
+def test_payload_preview_preserves_block_snapshot_fields_needed_for_later_proposal_flow():
+    candidate = _decision()
+
+    draft = create_memory_proposal_draft(candidate)
+    preview = draft["payload_preview"]
+    block_snapshot = candidate["queue_item_snapshot"]["block_snapshot"]
+
+    assert preview["block_id"] == block_snapshot["block_id"]
+    assert preview["block_type"] == "procedural_rules"
+    assert preview["status"] == "review_required"
+    assert preview["project_scope"] == "memory-fabric"
+    assert preview["content"] == block_snapshot["content"]
+    assert preview["metadata"] == {"source": "test"}
+    assert preview["version"] == "0.1"
+    assert preview["mutation_policy"] == "proposal_only"
+    assert preview["direct_write_allowed"] is False
+    assert preview["validity"]["valid"] is True
+    assert preview["applied"] is False
+    assert preview["persisted"] is False
+    assert preview["created_real_proposal"] is False
+
+
+def test_source_pattern_ids_and_source_fact_ids_are_preserved():
+    candidate = _decision(source_pattern_ids=["pattern-b", "pattern-a"], source_fact_ids=["fact-b", "fact-a"])
+
+    draft = create_memory_proposal_draft(candidate)
+
+    assert draft["source_pattern_ids"] == ["pattern-a", "pattern-b"]
+    assert draft["source_fact_ids"] == ["fact-a", "fact-b"]
+    assert draft["payload_preview"]["source_pattern_ids"] == ["pattern-a", "pattern-b"]
+    assert draft["payload_preview"]["source_fact_ids"] == ["fact-a", "fact-b"]
+
+
+def test_input_decision_candidate_is_not_mutated():
+    candidate = _decision()
+    before = deepcopy(candidate)
+
+    draft = create_memory_proposal_draft(candidate)
+    draft["source_decision_snapshot"]["queue_item_snapshot"]["block_snapshot"]["content"]["nested"]["value"] = "changed"
+
+    assert candidate == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    draft = create_memory_proposal_draft(_decision())
+    explanation = explain_memory_proposal_draft(draft)
+    recommendation = recommend_memory_proposal_draft_action(draft)
+
+    assert draft["policy"] == MEMORY_PROPOSAL_DRAFT_POLICY
+    assert draft["policy"]["read_only"] is True
+    assert draft["policy"]["would_write_memory"] is False
+    assert draft["policy"]["would_modify_config"] is False
+    assert draft["policy"]["would_write_graph"] is False
+    assert draft["policy"]["does_not_create_operation_events"] is True
+    assert draft["policy"]["creates_draft_candidates_only"] is True
+    assert draft["policy"]["creates_real_proposals"] is False
+    assert draft["policy"]["applies_proposals"] is False
+    assert draft["policy"]["persists_approvals"] is False
+    assert explanation["applied"] is False
+    assert explanation["persisted"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_summary_counts_valid_invalid_drafts_and_by_block_type():
+    drafts = [
+        create_memory_proposal_draft(_decision("procedural_rules")),
+        create_memory_proposal_draft(_decision("project_context")),
+        create_memory_proposal_draft(_decision("procedural_rules", decision="reject")),
+    ]
+
+    summary = summarize_memory_proposal_drafts(drafts)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 1
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"draft_review_required": 3}
+    assert summary["policy"] == MEMORY_PROPOSAL_DRAFT_POLICY

--- a/tests/agent/test_memory_proposal_governance_gate.py
+++ b/tests/agent/test_memory_proposal_governance_gate.py
@@ -1,0 +1,182 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import (
+    MEMORY_GOVERNANCE_SUBMISSION_KIND,
+    MEMORY_GOVERNANCE_SUBMISSION_ROUTING,
+    MEMORY_GOVERNANCE_SUBMISSION_STATUS,
+    MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY,
+    create_governance_submission_candidate,
+    explain_governance_submission_candidate,
+    recommend_governance_submission_action,
+    summarize_governance_submission_candidates,
+    validate_governance_submission_candidate,
+)
+from agent.memory_review_decision_gate import create_review_decision_candidate, evaluate_review_queue_item
+
+
+def _decision(block_type="procedural_rules", decision=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create governance submission candidates only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    if decision is None:
+        return evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    return create_review_decision_candidate(queue_item, reviewer="memory-reviewer", decision=decision)
+
+
+def _draft(block_type="procedural_rules", decision=None, source_pattern_ids=None, source_fact_ids=None):
+    return create_memory_proposal_draft(
+        _decision(
+            block_type=block_type,
+            decision=decision,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        author="proposal-drafter",
+    )
+
+
+def test_valid_proposal_draft_creates_governance_review_required_submission_candidate():
+    draft = _draft()
+
+    candidate = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+
+    assert candidate["submission_kind"] == MEMORY_GOVERNANCE_SUBMISSION_KIND
+    assert candidate["submission_status"] == MEMORY_GOVERNANCE_SUBMISSION_STATUS
+    assert candidate["routing"] == MEMORY_GOVERNANCE_SUBMISSION_ROUTING
+    assert candidate["source_draft_id"] == draft["draft_id"]
+    assert candidate["source_decision_id"] == draft["source_decision_id"]
+    assert candidate["source_queue_item_id"] == draft["source_queue_item_id"]
+    assert candidate["reviewer"] == "governance-reviewer"
+    assert candidate["submission_validation"] == {"valid": True, "errors": []}
+    assert validate_governance_submission_candidate(candidate) == {"valid": True, "errors": []}
+    assert candidate["next_step_recommendation"]["action"] == "create_real_proposal_manually_in_governed_flow"
+    assert candidate["next_step_recommendation"]["creates_real_proposals"] is False
+    assert candidate["next_step_recommendation"]["submits_to_governance"] is False
+
+
+def test_invalid_draft_creates_invalid_candidate_with_invalid_proposal_draft():
+    draft = _draft(decision="reject")
+
+    candidate = create_governance_submission_candidate(draft)
+
+    assert candidate["submission_validation"]["valid"] is False
+    assert "invalid_proposal_draft" in candidate["submission_validation"]["errors"]
+    assert candidate["next_step_recommendation"]["action"] == "do_not_create_governance_submission"
+
+
+def test_missing_payload_preview_creates_invalid_candidate():
+    draft = _draft()
+    draft.pop("payload_preview")
+
+    candidate = create_governance_submission_candidate(draft)
+
+    assert candidate["submission_validation"]["valid"] is False
+    assert "missing_payload_preview" in candidate["submission_validation"]["errors"]
+    assert candidate["next_step_recommendation"]["action"] == "do_not_create_governance_submission"
+
+
+def test_missing_source_ids_creates_invalid_candidate():
+    draft = _draft(source_pattern_ids=[], source_fact_ids=[])
+
+    candidate = create_governance_submission_candidate(draft)
+
+    assert candidate["submission_validation"]["valid"] is False
+    assert "missing_source_evidence" in candidate["submission_validation"]["errors"]
+
+
+def test_payload_preview_and_source_ids_are_preserved():
+    draft = _draft(source_pattern_ids=["pattern-b", "pattern-a"], source_fact_ids=["fact-b", "fact-a"])
+
+    candidate = create_governance_submission_candidate(draft)
+
+    assert candidate["payload_preview"] == draft["payload_preview"]
+    assert candidate["source_pattern_ids"] == ["pattern-a", "pattern-b"]
+    assert candidate["source_fact_ids"] == ["fact-a", "fact-b"]
+    assert candidate["payload_preview"]["source_pattern_ids"] == ["pattern-a", "pattern-b"]
+    assert candidate["payload_preview"]["source_fact_ids"] == ["fact-a", "fact-b"]
+
+
+def test_input_proposal_draft_is_not_mutated():
+    draft = _draft()
+    before = deepcopy(draft)
+
+    candidate = create_governance_submission_candidate(draft)
+    candidate["source_draft_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert draft == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    candidate = create_governance_submission_candidate(_draft())
+    explanation = explain_governance_submission_candidate(candidate)
+    recommendation = recommend_governance_submission_action(candidate)
+
+    assert candidate["policy"] == MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY
+    assert candidate["policy"]["read_only"] is True
+    assert candidate["policy"]["would_write_memory"] is False
+    assert candidate["policy"]["would_modify_config"] is False
+    assert candidate["policy"]["would_write_graph"] is False
+    assert candidate["policy"]["does_not_create_operation_events"] is True
+    assert candidate["policy"]["creates_submission_candidates_only"] is True
+    assert candidate["policy"]["creates_real_proposals"] is False
+    assert candidate["policy"]["applies_proposals"] is False
+    assert candidate["policy"]["persists_approvals"] is False
+    assert candidate["policy"]["submits_to_governance"] is False
+    assert explanation["submitted"] is False
+    assert explanation["applied"] is False
+    assert explanation["persisted"] is False
+    assert explanation["approved"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["submits_to_governance"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_candidate_must_never_be_marked_submitted_applied_persisted_or_approved():
+    candidate = create_governance_submission_candidate(_draft())
+
+    for forbidden_key in (
+        "submitted",
+        "applied",
+        "persisted",
+        "approved",
+        "created_real_proposal",
+        "created_operation_event",
+    ):
+        mutated = deepcopy(candidate)
+        mutated[forbidden_key] = True
+        validation = validate_governance_submission_candidate(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_valid_invalid_submissions_and_by_block_type_status():
+    candidates = [
+        create_governance_submission_candidate(_draft("procedural_rules")),
+        create_governance_submission_candidate(_draft("project_context")),
+        create_governance_submission_candidate(_draft("procedural_rules", decision="reject")),
+    ]
+
+    summary = summarize_governance_submission_candidates(candidates)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 1
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"governance_review_required": 3}
+    assert summary["policy"] == MEMORY_PROPOSAL_GOVERNANCE_GATE_POLICY

--- a/tests/agent/test_memory_read_only_candidate_utils.py
+++ b/tests/agent/test_memory_read_only_candidate_utils.py
@@ -28,6 +28,11 @@ from agent.memory_read_only_candidate_utils import (
 )
 
 
+class _RaisesOnDeepcopy:
+    def __deepcopy__(self, memo):
+        raise AssertionError("nested payload must not be deep-copied")
+
+
 def test_constants_match_current_safety_expectations():
     assert READ_ONLY_POLICY_BASE == {
         "read_only": True,
@@ -208,6 +213,21 @@ def test_validate_forbidden_true_keys_false_or_absent_preserves_order_and_dedupe
     ]
 
 
+def test_validate_forbidden_true_keys_false_or_absent_does_not_deepcopy_nested_payloads():
+    candidate = {
+        "writes_operation_ledger": True,
+        "writes_token_files": False,
+        "submitted": None,
+        "implementation_contract": {
+            "reviews": [{"large_payload": _RaisesOnDeepcopy()}],
+        },
+    }
+
+    assert validate_forbidden_true_keys_false_or_absent(candidate) == [
+        "writes_operation_ledger_must_be_false_or_absent"
+    ]
+
+
 def test_validate_policy_flags_catches_true_and_false_expectations():
     policy = dict(READ_ONLY_POLICY_BASE)
     policy["read_only"] = False
@@ -218,6 +238,18 @@ def test_validate_policy_flags_catches_true_and_false_expectations():
         "policy_read_only_must_be_true",
         "policy_would_write_memory_must_be_false",
         "policy_does_not_create_operation_events_must_be_true",
+    ]
+
+
+def test_validate_policy_flags_does_not_deepcopy_nested_payloads():
+    policy = dict(READ_ONLY_POLICY_BASE)
+    policy["read_only"] = False
+    policy["implementation_contract"] = {
+        "reviews": [{"large_payload": _RaisesOnDeepcopy()}],
+    }
+
+    assert validate_policy_flags(policy) == [
+        "policy_read_only_must_be_true"
     ]
 
 
@@ -237,6 +269,47 @@ def test_validate_preview_integrity_catches_forbidden_true_flags_inside_previews
         "approval_token_record_preview_token_issued_must_not_be_true",
         "proposal_record_preview_must_be_preview_only",
         "proposal_record_preview_created_real_proposal_must_not_be_true",
+    ]
+
+
+def test_preview_validators_do_not_deepcopy_nested_payloads():
+    candidate = {
+        "proposal_record_preview": {
+            "preview_only": False,
+            "created_real_proposal": True,
+            "large_payload": _RaisesOnDeepcopy(),
+        },
+        "approval_token_write_payload_preview": {
+            "preview_only": True,
+            "written": True,
+            "large_payload": _RaisesOnDeepcopy(),
+        },
+        "implementation_contract": {
+            "reviews": [{"large_payload": _RaisesOnDeepcopy()}],
+        },
+    }
+
+    assert validate_preview_integrity(
+        candidate,
+        preview_fields=("proposal_record_preview",),
+        forbidden_true_keys=("created_real_proposal",),
+    ) == [
+        "proposal_record_preview_must_be_preview_only",
+        "proposal_record_preview_created_real_proposal_must_not_be_true",
+    ]
+    assert validate_preview_forbidden_true_keys_false_or_absent(
+        candidate,
+        preview_fields=("proposal_record_preview",),
+        forbidden_true_keys=("created_real_proposal",),
+    ) == [
+        "proposal_record_preview_created_real_proposal_must_be_false_or_absent"
+    ]
+    assert validate_write_preview_integrity(
+        candidate,
+        write_preview_fields=("approval_token_write_payload_preview",),
+        forbidden_true_keys=("written",),
+    ) == [
+        "approval_token_write_payload_preview_written_must_not_be_true"
     ]
 
 
@@ -393,6 +466,30 @@ def test_summarize_candidates_counts_total_status_type_and_block_type():
         "by_status": {"locked": 1, "valid": 2},
         "by_block_type": {"preference": 2, "procedural_rules": 1},
         "by_type": {"contract": 2, "review": 1},
+    }
+
+
+def test_summarize_candidates_does_not_deepcopy_nested_payloads():
+    candidates = [
+        {
+            "status": "valid",
+            "candidate_type": "contract",
+            "block_type": "procedural_rules",
+            "implementation_contract": {"large_payload": _RaisesOnDeepcopy()},
+        },
+        {
+            "status": "locked",
+            "candidate_type": "review",
+            "block_type": "procedural_rules",
+            "implementation_contract": {"large_payload": _RaisesOnDeepcopy()},
+        },
+    ]
+
+    assert summarize_candidates(candidates, "status", type_key="candidate_type") == {
+        "total": 2,
+        "by_status": {"locked": 1, "valid": 1},
+        "by_block_type": {"procedural_rules": 2},
+        "by_type": {"contract": 1, "review": 1},
     }
 
 

--- a/tests/agent/test_memory_read_only_candidate_utils.py
+++ b/tests/agent/test_memory_read_only_candidate_utils.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import builtins
+import os
+from copy import deepcopy
+from pathlib import Path
+
+from agent.memory_read_only_candidate_utils import (
+    DEFAULT_FORBIDDEN_TRUE_KEYS,
+    DEFAULT_PREVIEW_FIELDS,
+    DEFAULT_WRITE_PREVIEW_FIELDS,
+    READ_ONLY_POLICY_BASE,
+    as_list,
+    as_mapping,
+    build_stable_digest,
+    copy_fields,
+    copy_source_lineage,
+    deep_copy_mapping,
+    merge_validation_errors,
+    summarize_candidates,
+    validate_forbidden_true_keys,
+    validate_policy_flags,
+    validate_preview_integrity,
+    validate_required_keys,
+    validate_write_preview_integrity,
+)
+
+
+def test_constants_match_current_safety_expectations():
+    assert READ_ONLY_POLICY_BASE == {
+        "read_only": True,
+        "would_write_memory": False,
+        "would_modify_config": False,
+        "would_write_graph": False,
+        "does_not_create_operation_events": True,
+        "creates_real_proposals": False,
+        "writes_proposal_files": False,
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "writes_approval_audit": False,
+        "invokes_real_token_write_executor": False,
+        "implements_real_token_write_executor": False,
+        "creates_executor_source_files": False,
+    }
+    assert DEFAULT_PREVIEW_FIELDS == (
+        "approval_token_record_preview",
+        "approval_audit_record_preview",
+        "token_target_paths_preview",
+        "proposal_record_preview",
+        "operation_ledger_preview",
+        "target_paths_preview",
+    )
+    assert DEFAULT_WRITE_PREVIEW_FIELDS == (
+        "approval_token_write_payload_preview",
+        "approval_audit_write_payload_preview",
+        "token_write_target_paths_preview",
+    )
+    for key in (
+        "token_issued",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_operation_ledger",
+        "writes_token_files",
+        "writes_approval_audit",
+        "invokes_real_token_write_executor",
+        "implements_real_token_write_executor",
+        "creates_executor_source_files",
+        "creates_executor_tests",
+    ):
+        assert key in DEFAULT_FORBIDDEN_TRUE_KEYS
+
+
+def test_as_mapping_handles_dict_and_non_dict_safely():
+    source = {"nested": {"value": 1}}
+    copied = as_mapping(source)
+
+    assert copied == source
+    assert as_mapping([("a", 1)]) == {}
+    copied["nested"]["value"] = 2
+    assert source["nested"]["value"] == 1
+
+
+def test_as_list_handles_list_tuple_and_non_list_safely():
+    source = [{"value": 1}]
+    copied = as_list(source)
+    copied[0]["value"] = 2
+
+    assert source == [{"value": 1}]
+    assert as_list(("a", "b")) == ["a", "b"]
+    assert as_list("ab") == []
+    assert as_list({"a": 1}) == []
+
+
+def test_deep_copy_mapping_does_not_alias_nested_values():
+    source = {"nested": {"items": [1, 2]}}
+    copied = deep_copy_mapping(source)
+
+    copied["nested"]["items"].append(3)
+
+    assert source == {"nested": {"items": [1, 2]}}
+
+
+def test_copy_fields_does_not_mutate_source():
+    source = {"keep": {"nested": [1]}, "skip": True}
+    original = deepcopy(source)
+
+    copied = copy_fields(source, ("keep", "missing"))
+    copied["keep"]["nested"].append(2)
+
+    assert copied == {"keep": {"nested": [1, 2]}}
+    assert source == original
+
+
+def test_copy_source_lineage_copies_selected_keys_only():
+    source = {
+        "source_plan_id": "plan-1",
+        "source_gate_id": "gate-1",
+        "unrelated": "skip",
+    }
+
+    assert copy_source_lineage(source, ("source_plan_id", "source_gate_id")) == {
+        "source_plan_id": "plan-1",
+        "source_gate_id": "gate-1",
+    }
+
+
+def test_validate_required_keys_returns_missing_key_errors():
+    assert validate_required_keys({"present": None}, ("present", "missing")) == [
+        "missing_missing"
+    ]
+
+
+def test_validate_forbidden_true_keys_catches_forbidden_true_flags():
+    candidate = {
+        "writes_operation_ledger": True,
+        "writes_token_files": False,
+        "safe": True,
+    }
+
+    assert validate_forbidden_true_keys(candidate) == [
+        "writes_operation_ledger_must_be_false"
+    ]
+
+
+def test_validate_policy_flags_catches_true_and_false_expectations():
+    policy = dict(READ_ONLY_POLICY_BASE)
+    policy["read_only"] = False
+    policy["would_write_memory"] = True
+    policy["does_not_create_operation_events"] = False
+
+    assert validate_policy_flags(policy) == [
+        "policy_read_only_must_be_true",
+        "policy_would_write_memory_must_be_false",
+        "policy_does_not_create_operation_events_must_be_true",
+    ]
+
+
+def test_validate_preview_integrity_catches_forbidden_true_flags_inside_previews():
+    candidate = {
+        "approval_token_record_preview": {
+            "preview_only": True,
+            "token_issued": True,
+        },
+        "proposal_record_preview": {
+            "preview_only": False,
+            "created_real_proposal": True,
+        },
+    }
+
+    assert validate_preview_integrity(candidate) == [
+        "approval_token_record_preview_token_issued_must_not_be_true",
+        "proposal_record_preview_must_be_preview_only",
+        "proposal_record_preview_created_real_proposal_must_not_be_true",
+    ]
+
+
+def test_validate_write_preview_integrity_catches_forbidden_true_flags_inside_write_previews():
+    candidate = {
+        "approval_token_write_payload_preview": {
+            "preview_only": True,
+            "written": True,
+        },
+        "token_write_target_paths_preview": {
+            "preview_only": True,
+            "writes_token_files": True,
+        },
+    }
+
+    assert validate_write_preview_integrity(candidate) == [
+        "approval_token_write_payload_preview_written_must_not_be_true",
+        "token_write_target_paths_preview_writes_token_files_must_not_be_true",
+    ]
+
+
+def test_build_stable_digest_is_deterministic_and_ignores_volatile_keys():
+    payload_a = {
+        "candidate_id": "volatile-1",
+        "stable": {"b": 2, "a": 1, "updated_at": "volatile"},
+    }
+    payload_b = {
+        "stable": {"a": 1, "updated_at": "changed", "b": 2},
+        "candidate_id": "volatile-2",
+    }
+
+    digest_a = build_stable_digest(
+        "memory-read-only-candidate-utils:v0.1",
+        payload_a,
+        ignored_keys=("candidate_id", "updated_at"),
+    )
+    digest_b = build_stable_digest(
+        "memory-read-only-candidate-utils:v0.1",
+        payload_b,
+        ignored_keys=("candidate_id", "updated_at"),
+    )
+
+    assert digest_a == digest_b
+    assert digest_a.startswith("memory-read-only-candidate-utils:v0.1:")
+    assert len(digest_a.rsplit(":", 1)[1]) == 16
+
+
+def test_summarize_candidates_counts_total_status_type_and_block_type():
+    candidates = [
+        {"status": "valid", "candidate_type": "contract", "block_type": "preference"},
+        {"status": "locked", "candidate_type": "contract", "block_type": "preference"},
+        {"status": "valid", "candidate_type": "review", "block_type": "procedural_rules"},
+    ]
+
+    assert summarize_candidates(candidates, "status", type_key="candidate_type") == {
+        "total": 3,
+        "by_status": {"locked": 1, "valid": 2},
+        "by_block_type": {"preference": 2, "procedural_rules": 1},
+        "by_type": {"contract": 2, "review": 1},
+    }
+
+
+def test_merge_validation_errors_preserves_order_and_removes_duplicates():
+    assert merge_validation_errors(
+        ["missing_source", "policy_read_only_must_be_true"],
+        ("missing_source", "writes_token_files_must_be_false"),
+        ["policy_read_only_must_be_true"],
+    ) == [
+        "missing_source",
+        "policy_read_only_must_be_true",
+        "writes_token_files_must_be_false",
+    ]
+
+
+def test_helpers_do_not_write_files_or_create_directories(monkeypatch):
+    def fail_write(*args, **kwargs):
+        raise AssertionError("read-only candidate utilities must not write files")
+
+    monkeypatch.setattr(builtins, "open", fail_write)
+    monkeypatch.setattr(os, "mkdir", fail_write)
+    monkeypatch.setattr(os, "makedirs", fail_write)
+    monkeypatch.setattr(Path, "mkdir", fail_write)
+
+    candidate = {
+        "policy": READ_ONLY_POLICY_BASE,
+        "approval_token_record_preview": {"preview_only": True},
+        "approval_token_write_payload_preview": {"preview_only": True},
+        "status": "valid",
+        "block_type": "procedural_rules",
+    }
+
+    assert as_mapping(candidate)
+    assert as_list([candidate])
+    assert deep_copy_mapping(candidate)
+    assert copy_fields(candidate, ("status",))
+    assert copy_source_lineage(candidate, ("block_type",))
+    assert validate_required_keys(candidate, ("status",)) == []
+    assert validate_forbidden_true_keys(candidate) == []
+    assert validate_policy_flags(candidate["policy"]) == []
+    assert validate_preview_integrity(candidate) == []
+    assert validate_write_preview_integrity(candidate) == []
+    assert build_stable_digest("read-only", candidate)
+    assert summarize_candidates([candidate], "status")["total"] == 1
+    assert merge_validation_errors(["a"], ["a", "b"]) == ["a", "b"]
+
+
+def test_inputs_are_not_mutated():
+    candidate = {
+        "policy": dict(READ_ONLY_POLICY_BASE),
+        "approval_token_record_preview": {"preview_only": True, "created": False},
+        "approval_token_write_payload_preview": {"preview_only": True, "written": False},
+        "source_ids": ["source-1"],
+        "status": "valid",
+        "candidate_type": "contract",
+        "block_type": "procedural_rules",
+    }
+    original = deepcopy(candidate)
+
+    as_mapping(candidate)
+    as_list([candidate])
+    deep_copy_mapping(candidate)
+    copy_fields(candidate, ("policy", "source_ids"))
+    copy_source_lineage(candidate, ("source_ids",))
+    validate_required_keys(candidate, ("policy", "status"))
+    validate_forbidden_true_keys(candidate)
+    validate_policy_flags(candidate["policy"])
+    validate_preview_integrity(candidate)
+    validate_write_preview_integrity(candidate)
+    build_stable_digest("read-only", candidate, ignored_keys=("status",))
+    summarize_candidates([candidate], "status", type_key="candidate_type")
+    merge_validation_errors(["a"], ["b"])
+
+    assert candidate == original

--- a/tests/agent/test_memory_read_only_candidate_utils.py
+++ b/tests/agent/test_memory_read_only_candidate_utils.py
@@ -19,7 +19,9 @@ from agent.memory_read_only_candidate_utils import (
     merge_validation_errors,
     summarize_candidates,
     validate_forbidden_true_keys,
+    validate_forbidden_true_keys_false_or_absent,
     validate_policy_flags,
+    validate_preview_forbidden_true_keys_false_or_absent,
     validate_preview_integrity,
     validate_required_keys,
     validate_write_preview_integrity,
@@ -142,6 +144,70 @@ def test_validate_forbidden_true_keys_catches_forbidden_true_flags():
     ]
 
 
+def test_validate_forbidden_true_keys_false_or_absent_catches_forbidden_true_flags():
+    candidate = {
+        "writes_operation_ledger": True,
+        "writes_token_files": False,
+        "submitted": None,
+    }
+
+    assert validate_forbidden_true_keys_false_or_absent(candidate) == [
+        "writes_operation_ledger_must_be_false_or_absent"
+    ]
+
+
+def test_validate_forbidden_true_keys_false_or_absent_allows_false_and_absent_flags():
+    candidate = {
+        "writes_operation_ledger": False,
+        "writes_token_files": False,
+        "safe": True,
+    }
+
+    assert validate_forbidden_true_keys_false_or_absent(candidate) == []
+
+
+def test_validate_forbidden_true_keys_false_or_absent_uses_exact_keys_only():
+    candidate = {
+        "created_at": True,
+        "written_confirmation": True,
+        "writes_operation_ledger": True,
+    }
+
+    assert validate_forbidden_true_keys_false_or_absent(
+        candidate,
+        forbidden_keys=("writes_operation_ledger",),
+    ) == ["writes_operation_ledger_must_be_false_or_absent"]
+    assert validate_forbidden_true_keys_false_or_absent(
+        candidate,
+        forbidden_keys=("created_at", "written_confirmation"),
+    ) == [
+        "created_at_must_be_false_or_absent",
+        "written_confirmation_must_be_false_or_absent",
+    ]
+
+
+def test_validate_forbidden_true_keys_false_or_absent_preserves_order_and_dedupes():
+    candidate = {
+        "writes_operation_ledger": True,
+        "writes_token_files": True,
+        "submitted": True,
+    }
+
+    assert validate_forbidden_true_keys_false_or_absent(
+        candidate,
+        forbidden_keys=(
+            "writes_token_files",
+            "submitted",
+            "writes_token_files",
+            "writes_operation_ledger",
+        ),
+    ) == [
+        "writes_token_files_must_be_false_or_absent",
+        "submitted_must_be_false_or_absent",
+        "writes_operation_ledger_must_be_false_or_absent",
+    ]
+
+
 def test_validate_policy_flags_catches_true_and_false_expectations():
     policy = dict(READ_ONLY_POLICY_BASE)
     policy["read_only"] = False
@@ -171,6 +237,103 @@ def test_validate_preview_integrity_catches_forbidden_true_flags_inside_previews
         "approval_token_record_preview_token_issued_must_not_be_true",
         "proposal_record_preview_must_be_preview_only",
         "proposal_record_preview_created_real_proposal_must_not_be_true",
+    ]
+
+
+def test_validate_preview_forbidden_true_keys_false_or_absent_catches_nested_true_flags():
+    candidate = {
+        "approval_token_record_preview": {
+            "preview_only": True,
+            "token_issued": True,
+        },
+        "proposal_record_preview": {
+            "preview_only": False,
+            "created_real_proposal": True,
+        },
+    }
+
+    assert validate_preview_forbidden_true_keys_false_or_absent(candidate) == [
+        "approval_token_record_preview_token_issued_must_be_false_or_absent",
+        "proposal_record_preview_created_real_proposal_must_be_false_or_absent",
+    ]
+
+
+def test_validate_preview_forbidden_true_keys_false_or_absent_allows_false_and_absent_flags():
+    candidate = {
+        "approval_token_record_preview": {
+            "preview_only": False,
+            "token_issued": False,
+        },
+        "proposal_record_preview": {
+            "preview_only": False,
+        },
+    }
+
+    assert validate_preview_forbidden_true_keys_false_or_absent(candidate) == []
+
+
+def test_validate_preview_forbidden_true_keys_false_or_absent_ignores_non_mapping_previews():
+    candidate = {
+        "approval_token_record_preview": ["token_issued", True],
+        "approval_audit_record_preview": None,
+        "proposal_record_preview": "created_real_proposal",
+    }
+
+    assert validate_preview_forbidden_true_keys_false_or_absent(candidate) == []
+
+
+def test_validate_preview_forbidden_true_keys_false_or_absent_uses_exact_keys_only():
+    candidate = {
+        "approval_token_record_preview": {
+            "preview_only": True,
+            "created_at": True,
+            "written_confirmation": True,
+            "token_issued": True,
+        },
+    }
+
+    assert validate_preview_forbidden_true_keys_false_or_absent(
+        candidate,
+        preview_fields=("approval_token_record_preview",),
+        forbidden_true_keys=("token_issued",),
+    ) == [
+        "approval_token_record_preview_token_issued_must_be_false_or_absent"
+    ]
+    assert validate_preview_forbidden_true_keys_false_or_absent(
+        candidate,
+        preview_fields=("approval_token_record_preview",),
+        forbidden_true_keys=("created_at", "written_confirmation"),
+    ) == [
+        "approval_token_record_preview_created_at_must_be_false_or_absent",
+        "approval_token_record_preview_written_confirmation_must_be_false_or_absent",
+    ]
+
+
+def test_validate_preview_forbidden_true_keys_false_or_absent_preserves_order_and_dedupes():
+    candidate = {
+        "approval_token_record_preview": {
+            "token_issued": True,
+            "written": True,
+        },
+        "proposal_record_preview": {
+            "token_issued": True,
+            "written": True,
+        },
+    }
+
+    assert validate_preview_forbidden_true_keys_false_or_absent(
+        candidate,
+        preview_fields=(
+            "proposal_record_preview",
+            "approval_token_record_preview",
+            "proposal_record_preview",
+        ),
+        forbidden_true_keys=("written", "token_issued", "written"),
+    ) == [
+        "proposal_record_preview_written_must_be_false_or_absent",
+        "proposal_record_preview_token_issued_must_be_false_or_absent",
+        "approval_token_record_preview_written_must_be_false_or_absent",
+        "approval_token_record_preview_token_issued_must_be_false_or_absent",
     ]
 
 
@@ -269,8 +432,10 @@ def test_helpers_do_not_write_files_or_create_directories(monkeypatch):
     assert copy_source_lineage(candidate, ("block_type",))
     assert validate_required_keys(candidate, ("status",)) == []
     assert validate_forbidden_true_keys(candidate) == []
+    assert validate_forbidden_true_keys_false_or_absent(candidate) == []
     assert validate_policy_flags(candidate["policy"]) == []
     assert validate_preview_integrity(candidate) == []
+    assert validate_preview_forbidden_true_keys_false_or_absent(candidate) == []
     assert validate_write_preview_integrity(candidate) == []
     assert build_stable_digest("read-only", candidate)
     assert summarize_candidates([candidate], "status")["total"] == 1
@@ -296,8 +461,10 @@ def test_inputs_are_not_mutated():
     copy_source_lineage(candidate, ("source_ids",))
     validate_required_keys(candidate, ("policy", "status"))
     validate_forbidden_true_keys(candidate)
+    validate_forbidden_true_keys_false_or_absent(candidate)
     validate_policy_flags(candidate["policy"])
     validate_preview_integrity(candidate)
+    validate_preview_forbidden_true_keys_false_or_absent(candidate)
     validate_write_preview_integrity(candidate)
     build_stable_digest("read-only", candidate, ignored_keys=("status",))
     summarize_candidates([candidate], "status", type_key="candidate_type")

--- a/tests/agent/test_memory_real_proposal_creation_plan.py
+++ b/tests/agent/test_memory_real_proposal_creation_plan.py
@@ -59,6 +59,12 @@ def test_approve_real_proposal_creation_outcome_creates_valid_manual_plan():
     assert plan["next_step_recommendation"]["converts_to_real_proposal"] is False
 
 
+def test_valid_manual_plan_id_matches_v0_1_baseline():
+    plan = create_real_proposal_creation_plan(_outcome(), planner="plan-reviewer")
+
+    assert plan["plan_id"] == "memory-real-proposal-creation-plan:v0.1:ec09132b407b8a96"
+
+
 def test_request_changes_creates_invalid_plan_with_human_review_requested_changes():
     plan = create_real_proposal_creation_plan(_outcome(outcome="request_changes"))
 

--- a/tests/agent/test_memory_real_proposal_creation_plan.py
+++ b/tests/agent/test_memory_real_proposal_creation_plan.py
@@ -1,0 +1,222 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import create_governance_submission_packet
+from agent.memory_human_review_outcome_gate import create_human_review_outcome_candidate
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_real_proposal_creation_plan import (
+    MEMORY_REAL_PROPOSAL_CREATION_PLAN_KIND,
+    MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY,
+    MEMORY_REAL_PROPOSAL_CREATION_PLAN_ROUTING,
+    MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS,
+    create_real_proposal_creation_plan,
+    explain_real_proposal_creation_plan,
+    recommend_real_proposal_creation_plan_action,
+    summarize_real_proposal_creation_plans,
+    validate_real_proposal_creation_plan,
+)
+from agent.memory_review_decision_gate import evaluate_review_queue_item
+
+
+def _outcome(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create real proposal creation plans only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    decision = evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    draft = create_memory_proposal_draft(decision, author="proposal-drafter")
+    submission = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+    packet = create_governance_submission_packet(submission, reviewer="packet-reviewer")
+    return create_human_review_outcome_candidate(packet, reviewer="human-reviewer", outcome=outcome)
+
+
+def test_approve_real_proposal_creation_outcome_creates_valid_manual_plan():
+    outcome = _outcome()
+
+    plan = create_real_proposal_creation_plan(outcome, planner="plan-reviewer")
+
+    assert plan["plan_kind"] == MEMORY_REAL_PROPOSAL_CREATION_PLAN_KIND
+    assert plan["plan_status"] == MEMORY_REAL_PROPOSAL_CREATION_PLAN_STATUS
+    assert plan["routing"] == MEMORY_REAL_PROPOSAL_CREATION_PLAN_ROUTING
+    assert plan["source_outcome_id"] == outcome["outcome_id"]
+    assert plan["source_packet_id"] == outcome["source_packet_id"]
+    assert plan["source_submission_id"] == outcome["source_submission_id"]
+    assert plan["source_draft_id"] == outcome["source_draft_id"]
+    assert plan["source_decision_id"] == outcome["source_decision_id"]
+    assert plan["source_queue_item_id"] == outcome["source_queue_item_id"]
+    assert plan["planner"] == "plan-reviewer"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+    assert validate_real_proposal_creation_plan(plan) == {"valid": True, "errors": []}
+    assert plan["next_step_recommendation"]["action"] == "perform_manual_real_proposal_creation_preflight"
+    assert plan["next_step_recommendation"]["creates_real_proposals"] is False
+    assert plan["next_step_recommendation"]["converts_to_real_proposal"] is False
+
+
+def test_request_changes_creates_invalid_plan_with_human_review_requested_changes():
+    plan = create_real_proposal_creation_plan(_outcome(outcome="request_changes"))
+
+    assert plan["plan_validation"]["valid"] is False
+    assert "human_review_requested_changes" in plan["plan_validation"]["errors"]
+    assert plan["invalid_reason"] == "human_review_requested_changes"
+    assert plan["next_step_recommendation"]["action"] == "do_not_create_real_proposal"
+
+
+def test_reject_creates_invalid_plan_with_human_review_rejected():
+    plan = create_real_proposal_creation_plan(_outcome(outcome="reject"))
+
+    assert plan["plan_validation"]["valid"] is False
+    assert "human_review_rejected" in plan["plan_validation"]["errors"]
+    assert plan["invalid_reason"] == "human_review_rejected"
+
+
+def test_defer_creates_invalid_plan_with_human_review_deferred():
+    plan = create_real_proposal_creation_plan(_outcome(outcome="defer"))
+
+    assert plan["plan_validation"]["valid"] is False
+    assert "human_review_deferred" in plan["plan_validation"]["errors"]
+    assert plan["invalid_reason"] == "human_review_deferred"
+
+
+def test_invalid_outcome_candidate_creates_invalid_plan():
+    outcome = _outcome(outcome="ship_it")
+
+    plan = create_real_proposal_creation_plan(outcome)
+
+    assert plan["plan_validation"]["valid"] is False
+    assert "invalid_human_review_outcome_candidate" in plan["plan_validation"]["errors"]
+    assert plan["invalid_reason"] == "invalid_human_review_outcome_candidate"
+
+
+def test_missing_payload_preview_creates_invalid_plan():
+    outcome = _outcome()
+    outcome["payload_preview"] = None
+
+    plan = create_real_proposal_creation_plan(outcome)
+
+    assert plan["plan_validation"]["valid"] is False
+    assert "missing_payload_preview" in plan["plan_validation"]["errors"]
+    assert plan["invalid_reason"] == "missing_payload_preview"
+
+
+def test_missing_source_evidence_creates_invalid_plan():
+    outcome = _outcome()
+    outcome["source_pattern_ids"] = []
+    outcome["source_fact_ids"] = []
+
+    plan = create_real_proposal_creation_plan(outcome)
+
+    assert plan["plan_validation"]["valid"] is False
+    assert "missing_source_evidence" in plan["plan_validation"]["errors"]
+    assert plan["invalid_reason"] == "missing_source_evidence"
+
+
+def test_creation_steps_and_preflight_checks_are_deterministic():
+    plan_a = create_real_proposal_creation_plan(_outcome())
+    plan_b = create_real_proposal_creation_plan(_outcome())
+
+    assert plan_a["creation_steps"] == plan_b["creation_steps"]
+    assert plan_a["preflight_checks"] == plan_b["preflight_checks"]
+    assert [step["id"] for step in plan_a["creation_steps"]] == [
+        "verify_human_review_approval",
+        "verify_payload_preview",
+        "verify_source_evidence",
+        "manual_real_proposal_creation",
+    ]
+    assert [check["id"] for check in plan_a["preflight_checks"]] == [
+        "no_memory_write",
+        "no_graph_write",
+        "no_config_change",
+        "no_proposal_or_ledger_record",
+    ]
+
+
+def test_input_outcome_candidate_is_not_mutated():
+    outcome = _outcome()
+    before = deepcopy(outcome)
+
+    plan = create_real_proposal_creation_plan(outcome)
+    plan["source_outcome_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert outcome == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    plan = create_real_proposal_creation_plan(_outcome())
+    explanation = explain_real_proposal_creation_plan(plan)
+    recommendation = recommend_real_proposal_creation_plan_action(plan)
+
+    assert plan["policy"] == MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY
+    assert plan["policy"]["read_only"] is True
+    assert plan["policy"]["would_write_memory"] is False
+    assert plan["policy"]["would_modify_config"] is False
+    assert plan["policy"]["would_write_graph"] is False
+    assert plan["policy"]["does_not_create_operation_events"] is True
+    assert plan["policy"]["creates_plan_candidates_only"] is True
+    assert plan["policy"]["creates_real_proposals"] is False
+    assert plan["policy"]["applies_proposals"] is False
+    assert plan["policy"]["persists_approvals"] is False
+    assert plan["policy"]["submits_to_governance"] is False
+    assert plan["policy"]["converts_to_real_proposal"] is False
+    assert explanation["submitted"] is False
+    assert explanation["applied"] is False
+    assert explanation["persisted"] is False
+    assert explanation["approved"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["created_proposal_record"] is False
+    assert explanation["submitted_to_governance"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["submits_to_governance"] is False
+    assert recommendation["converts_to_real_proposal"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_plan_must_never_be_marked_submitted_applied_persisted_approved_or_converted():
+    plan = create_real_proposal_creation_plan(_outcome())
+
+    for forbidden_key in (
+        "submitted",
+        "applied",
+        "persisted",
+        "approved",
+        "converted_to_real_proposal",
+        "created_real_proposal",
+        "created_operation_event",
+        "created_proposal_record",
+        "submitted_to_governance",
+    ):
+        mutated = deepcopy(plan)
+        mutated[forbidden_key] = True
+        validation = validate_real_proposal_creation_plan(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_valid_invalid_plans_and_by_block_type_status():
+    plans = [
+        create_real_proposal_creation_plan(_outcome("procedural_rules")),
+        create_real_proposal_creation_plan(_outcome("project_context")),
+        create_real_proposal_creation_plan(_outcome("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_real_proposal_creation_plans(plans)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 1
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"manual_creation_plan_required": 3}
+    assert summary["policy"] == MEMORY_REAL_PROPOSAL_CREATION_PLAN_POLICY

--- a/tests/agent/test_memory_real_proposal_dry_run.py
+++ b/tests/agent/test_memory_real_proposal_dry_run.py
@@ -1,0 +1,263 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import create_governance_submission_packet
+from agent.memory_human_review_outcome_gate import create_human_review_outcome_candidate
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_real_proposal_creation_plan import create_real_proposal_creation_plan
+from agent.memory_real_proposal_dry_run import (
+    MEMORY_REAL_PROPOSAL_DRY_RUN_KIND,
+    MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY,
+    MEMORY_REAL_PROPOSAL_DRY_RUN_ROUTING,
+    MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS,
+    create_real_proposal_dry_run,
+    explain_real_proposal_dry_run,
+    recommend_real_proposal_dry_run_action,
+    summarize_real_proposal_dry_runs,
+    validate_real_proposal_dry_run,
+)
+from agent.memory_review_decision_gate import evaluate_review_queue_item
+
+
+def _plan(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create dry-run previews only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    decision = evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    draft = create_memory_proposal_draft(decision, author="proposal-drafter")
+    submission = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+    packet = create_governance_submission_packet(submission, reviewer="packet-reviewer")
+    outcome_candidate = create_human_review_outcome_candidate(packet, reviewer="human-reviewer", outcome=outcome)
+    return create_real_proposal_creation_plan(outcome_candidate, planner="plan-reviewer")
+
+
+def test_valid_plan_creates_valid_manual_final_preflight_dry_run():
+    plan = _plan()
+
+    dry_run = create_real_proposal_dry_run(plan, operator="final-preflight-operator")
+
+    assert dry_run["dry_run_kind"] == MEMORY_REAL_PROPOSAL_DRY_RUN_KIND
+    assert dry_run["dry_run_status"] == MEMORY_REAL_PROPOSAL_DRY_RUN_STATUS
+    assert dry_run["routing"] == MEMORY_REAL_PROPOSAL_DRY_RUN_ROUTING
+    assert dry_run["source_plan_id"] == plan["plan_id"]
+    assert dry_run["source_outcome_id"] == plan["source_outcome_id"]
+    assert dry_run["source_packet_id"] == plan["source_packet_id"]
+    assert dry_run["source_submission_id"] == plan["source_submission_id"]
+    assert dry_run["source_draft_id"] == plan["source_draft_id"]
+    assert dry_run["source_decision_id"] == plan["source_decision_id"]
+    assert dry_run["source_queue_item_id"] == plan["source_queue_item_id"]
+    assert dry_run["operator"] == "final-preflight-operator"
+    assert dry_run["plan_validation"] == {"valid": True, "errors": []}
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert validate_real_proposal_dry_run(dry_run) == {"valid": True, "errors": []}
+    assert dry_run["next_step_recommendation"]["action"] == "perform_manual_final_preflight_before_real_proposal_write"
+    assert dry_run["next_step_recommendation"]["creates_real_proposals"] is False
+    assert dry_run["next_step_recommendation"]["writes_operation_ledger"] is False
+
+
+def test_invalid_plan_creates_invalid_dry_run():
+    plan = _plan(outcome="reject")
+
+    dry_run = create_real_proposal_dry_run(plan)
+
+    assert dry_run["dry_run_validation"]["valid"] is False
+    assert "invalid_real_proposal_creation_plan" in dry_run["dry_run_validation"]["errors"]
+    assert dry_run["invalid_reason"] == "invalid_real_proposal_creation_plan"
+    assert dry_run["next_step_recommendation"]["action"] == "do_not_create_real_proposal"
+
+
+def test_missing_payload_preview_creates_invalid_dry_run():
+    plan = _plan()
+    plan["payload_preview"] = None
+
+    dry_run = create_real_proposal_dry_run(plan)
+
+    assert dry_run["dry_run_validation"]["valid"] is False
+    assert "missing_payload_preview" in dry_run["dry_run_validation"]["errors"]
+    assert dry_run["invalid_reason"] == "missing_payload_preview"
+
+
+def test_missing_source_evidence_creates_invalid_dry_run():
+    plan = _plan()
+    plan["source_pattern_ids"] = []
+    plan["source_fact_ids"] = []
+
+    dry_run = create_real_proposal_dry_run(plan)
+
+    assert dry_run["dry_run_validation"]["valid"] is False
+    assert "missing_source_evidence" in dry_run["dry_run_validation"]["errors"]
+    assert dry_run["invalid_reason"] == "missing_source_evidence"
+
+
+def test_missing_creation_steps_or_preflight_checks_creates_invalid_dry_run():
+    plan_without_steps = _plan()
+    plan_without_steps["creation_steps"] = []
+    plan_without_checks = _plan()
+    plan_without_checks["preflight_checks"] = []
+
+    dry_run_without_steps = create_real_proposal_dry_run(plan_without_steps)
+    dry_run_without_checks = create_real_proposal_dry_run(plan_without_checks)
+
+    assert dry_run_without_steps["dry_run_validation"]["valid"] is False
+    assert "missing_plan_controls" in dry_run_without_steps["dry_run_validation"]["errors"]
+    assert dry_run_without_steps["invalid_reason"] == "missing_plan_controls"
+    assert dry_run_without_checks["dry_run_validation"]["valid"] is False
+    assert "missing_plan_controls" in dry_run_without_checks["dry_run_validation"]["errors"]
+    assert dry_run_without_checks["invalid_reason"] == "missing_plan_controls"
+
+
+def test_proposal_record_preview_contains_payload_and_source_evidence():
+    plan = _plan()
+
+    dry_run = create_real_proposal_dry_run(plan)
+    preview = dry_run["proposal_record_preview"]
+
+    assert preview["preview_only"] is True
+    assert preview["written"] is False
+    assert preview["block_id"] == plan["block_id"]
+    assert preview["block_type"] == plan["block_type"]
+    assert preview["project_scope"] == plan["project_scope"]
+    assert preview["payload_preview"] == plan["payload_preview"]
+    assert preview["source_pattern_ids"] == plan["source_pattern_ids"]
+    assert preview["source_fact_ids"] == plan["source_fact_ids"]
+    assert preview["created_real_proposal"] is False
+    assert preview["submitted_to_governance"] is False
+
+
+def test_operation_ledger_preview_is_preview_only_and_not_written():
+    dry_run = create_real_proposal_dry_run(_plan())
+    preview = dry_run["operation_ledger_preview"]
+
+    assert preview["preview_only"] is True
+    assert preview["written"] is False
+    assert preview["created_operation_event"] is False
+    assert preview["would_write_memory"] is False
+    assert preview["would_write_graph"] is False
+    assert preview["would_modify_config"] is False
+    assert preview["would_write_proposal_file"] is False
+    assert preview["would_write_operation_ledger"] is False
+
+
+def test_target_paths_preview_is_preview_only_and_deterministic():
+    plan = _plan()
+
+    dry_run_a = create_real_proposal_dry_run(plan)
+    dry_run_b = create_real_proposal_dry_run(plan)
+
+    assert dry_run_a["target_paths_preview"] == dry_run_b["target_paths_preview"]
+    assert dry_run_a["target_paths_preview"]["preview_only"] is True
+    assert dry_run_a["target_paths_preview"]["base"] == "${HERMES_HOME}"
+    assert dry_run_a["target_paths_preview"]["proposal_file"] == "memory/proposals/memory_write_proposals.jsonl"
+    assert dry_run_a["target_paths_preview"]["operation_ledger_file"] == "memory/audit/memory_operation_ledger.jsonl"
+    assert dry_run_a["target_paths_preview"]["created_real_proposal"] is False
+    assert dry_run_a["target_paths_preview"]["created_operation_event"] is False
+
+
+def test_final_preflight_checklist_is_deterministic():
+    dry_run_a = create_real_proposal_dry_run(_plan())
+    dry_run_b = create_real_proposal_dry_run(_plan())
+
+    assert dry_run_a["final_preflight_checklist"] == dry_run_b["final_preflight_checklist"]
+    assert [check["id"] for check in dry_run_a["final_preflight_checklist"]] == [
+        "verify_plan_validation",
+        "verify_payload_and_evidence",
+        "verify_preview_records_only",
+        "verify_no_memory_graph_config_write",
+        "manual_operator_final_preflight",
+    ]
+
+
+def test_input_plan_is_not_mutated():
+    plan = _plan()
+    before = deepcopy(plan)
+
+    dry_run = create_real_proposal_dry_run(plan)
+    dry_run["source_plan_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert plan == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    dry_run = create_real_proposal_dry_run(_plan())
+    explanation = explain_real_proposal_dry_run(dry_run)
+    recommendation = recommend_real_proposal_dry_run_action(dry_run)
+
+    assert dry_run["policy"] == MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY
+    assert dry_run["policy"]["read_only"] is True
+    assert dry_run["policy"]["would_write_memory"] is False
+    assert dry_run["policy"]["would_modify_config"] is False
+    assert dry_run["policy"]["would_write_graph"] is False
+    assert dry_run["policy"]["does_not_create_operation_events"] is True
+    assert dry_run["policy"]["creates_dry_run_candidates_only"] is True
+    assert dry_run["policy"]["creates_real_proposals"] is False
+    assert dry_run["policy"]["writes_proposal_files"] is False
+    assert dry_run["policy"]["writes_operation_ledger"] is False
+    assert dry_run["policy"]["applies_proposals"] is False
+    assert dry_run["policy"]["persists_approvals"] is False
+    assert dry_run["policy"]["submits_to_governance"] is False
+    assert dry_run["policy"]["converts_to_real_proposal"] is False
+    assert explanation["written"] is False
+    assert explanation["submitted"] is False
+    assert explanation["applied"] is False
+    assert explanation["persisted"] is False
+    assert explanation["approved"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_dry_run_must_never_be_marked_written_submitted_applied_persisted_approved_or_converted():
+    dry_run = create_real_proposal_dry_run(_plan())
+
+    for forbidden_key in (
+        "written",
+        "submitted",
+        "applied",
+        "persisted",
+        "approved",
+        "created_real_proposal",
+        "created_operation_event",
+        "converted_to_real_proposal",
+        "created_proposal_record",
+        "submitted_to_governance",
+        "persisted_approval",
+    ):
+        mutated = deepcopy(dry_run)
+        mutated[forbidden_key] = True
+        validation = validate_real_proposal_dry_run(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_valid_invalid_dry_runs_and_by_block_type_status():
+    dry_runs = [
+        create_real_proposal_dry_run(_plan("procedural_rules")),
+        create_real_proposal_dry_run(_plan("project_context")),
+        create_real_proposal_dry_run(_plan("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_real_proposal_dry_runs(dry_runs)
+
+    assert summary["total"] == 3
+    assert summary["valid_count"] == 2
+    assert summary["invalid_count"] == 1
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {"manual_final_preflight_required": 3}
+    assert summary["policy"] == MEMORY_REAL_PROPOSAL_DRY_RUN_POLICY

--- a/tests/agent/test_memory_real_proposal_dry_run.py
+++ b/tests/agent/test_memory_real_proposal_dry_run.py
@@ -63,6 +63,15 @@ def test_valid_plan_creates_valid_manual_final_preflight_dry_run():
     assert dry_run["next_step_recommendation"]["writes_operation_ledger"] is False
 
 
+def test_valid_dry_run_id_matches_v0_1_baseline():
+    dry_run = create_real_proposal_dry_run(_plan())
+
+    assert (
+        dry_run["dry_run_id"]
+        == "memory-real-proposal-dry-run:v0.1:51ffa6148ff5bfa1"
+    )
+
+
 def test_invalid_plan_creates_invalid_dry_run():
     plan = _plan(outcome="reject")
 
@@ -130,6 +139,27 @@ def test_proposal_record_preview_contains_payload_and_source_evidence():
     assert preview["source_fact_ids"] == plan["source_fact_ids"]
     assert preview["created_real_proposal"] is False
     assert preview["submitted_to_governance"] is False
+
+
+def test_preview_ids_match_v0_1_baseline():
+    dry_run = create_real_proposal_dry_run(_plan())
+
+    assert (
+        dry_run["proposal_record_preview"]["proposal_id_preview"]
+        == "preview:proposal:v0.1:34690aee8a220b27"
+    )
+    assert (
+        dry_run["operation_ledger_preview"]["operation_event_id_preview"]
+        == "preview:operation-ledger:v0.1:6cb5ffd48b0cdc8d"
+    )
+    assert (
+        dry_run["target_paths_preview"]["proposal_record_selector"]
+        == "preview:proposal:v0.1:34690aee8a220b27"
+    )
+    assert (
+        dry_run["target_paths_preview"]["operation_ledger_selector"]
+        == "preview:operation-ledger:v0.1:6cb5ffd48b0cdc8d"
+    )
 
 
 def test_operation_ledger_preview_is_preview_only_and_not_written():

--- a/tests/agent/test_memory_real_proposal_write_lock_gate.py
+++ b/tests/agent/test_memory_real_proposal_write_lock_gate.py
@@ -1,0 +1,259 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_governance_submission_packet import create_governance_submission_packet
+from agent.memory_human_review_outcome_gate import create_human_review_outcome_candidate
+from agent.memory_proposal_draft_builder import create_memory_proposal_draft
+from agent.memory_proposal_governance_gate import create_governance_submission_candidate
+from agent.memory_real_proposal_creation_plan import create_real_proposal_creation_plan
+from agent.memory_real_proposal_dry_run import create_real_proposal_dry_run
+from agent.memory_real_proposal_write_lock_gate import (
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE,
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_KIND,
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED,
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY,
+    MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ROUTING,
+    create_real_proposal_write_lock_gate,
+    explain_real_proposal_write_lock_gate,
+    recommend_real_proposal_write_lock_action,
+    summarize_real_proposal_write_lock_gates,
+    validate_real_proposal_write_lock_gate,
+)
+from agent.memory_review_decision_gate import evaluate_review_queue_item
+
+
+def _plan(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        {"rules": ["Create write-lock candidates only."], "nested": {"value": "preserved"}},
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids if source_pattern_ids is not None else ["pattern-1"],
+        source_fact_ids=source_fact_ids if source_fact_ids is not None else ["fact-1"],
+        metadata={"source": "test"},
+    )
+    queue_item = create_review_queue_item(block, reviewer="memory-reviewer")
+    decision = evaluate_review_queue_item(queue_item, reviewer="memory-reviewer")
+    draft = create_memory_proposal_draft(decision, author="proposal-drafter")
+    submission = create_governance_submission_candidate(draft, reviewer="governance-reviewer")
+    packet = create_governance_submission_packet(submission, reviewer="packet-reviewer")
+    outcome_candidate = create_human_review_outcome_candidate(packet, reviewer="human-reviewer", outcome=outcome)
+    return create_real_proposal_creation_plan(outcome_candidate, planner="plan-reviewer")
+
+
+def _dry_run(block_type="procedural_rules", outcome=None, source_pattern_ids=None, source_fact_ids=None):
+    return create_real_proposal_dry_run(
+        _plan(
+            block_type=block_type,
+            outcome=outcome,
+            source_pattern_ids=source_pattern_ids,
+            source_fact_ids=source_fact_ids,
+        ),
+        operator="final-preflight-operator",
+    )
+
+
+def test_valid_dry_run_creates_eligible_human_approval_token_gate():
+    dry_run = _dry_run()
+
+    gate = create_real_proposal_write_lock_gate(dry_run, operator="write-lock-operator")
+
+    assert gate["gate_kind"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_KIND
+    assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ELIGIBLE
+    assert gate["routing"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_ROUTING
+    assert gate["lock_reason"] is None
+    assert gate["source_dry_run_id"] == dry_run["dry_run_id"]
+    assert gate["source_plan_id"] == dry_run["source_plan_id"]
+    assert gate["source_outcome_id"] == dry_run["source_outcome_id"]
+    assert gate["source_packet_id"] == dry_run["source_packet_id"]
+    assert gate["source_submission_id"] == dry_run["source_submission_id"]
+    assert gate["source_draft_id"] == dry_run["source_draft_id"]
+    assert gate["source_decision_id"] == dry_run["source_decision_id"]
+    assert gate["source_queue_item_id"] == dry_run["source_queue_item_id"]
+    assert gate["operator"] == "write-lock-operator"
+    assert gate["dry_run_validation"] == {"valid": True, "errors": []}
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+    assert validate_real_proposal_write_lock_gate(gate) == {"valid": True, "errors": []}
+    assert gate["next_step_recommendation"]["action"] == "request_separate_human_approval_token_before_real_proposal_write"
+    assert gate["next_step_recommendation"]["creates_real_proposals"] is False
+    assert gate["next_step_recommendation"]["writes_operation_ledger"] is False
+
+
+def test_invalid_dry_run_creates_locked_gate():
+    dry_run = _dry_run(outcome="reject")
+
+    gate = create_real_proposal_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "invalid_real_proposal_dry_run"
+    assert gate["dry_run_validation"]["valid"] is False
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+    assert gate["next_step_recommendation"]["action"] == "keep_real_proposal_write_locked"
+
+
+def test_missing_proposal_record_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("proposal_record_preview")
+
+    gate = create_real_proposal_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_proposal_record_preview"
+
+
+def test_missing_operation_ledger_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("operation_ledger_preview")
+
+    gate = create_real_proposal_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_operation_ledger_preview"
+
+
+def test_missing_target_paths_preview_locks_gate():
+    dry_run = _dry_run()
+    dry_run.pop("target_paths_preview")
+
+    gate = create_real_proposal_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_target_paths_preview"
+
+
+def test_missing_source_evidence_locks_gate():
+    dry_run = _dry_run(source_pattern_ids=[], source_fact_ids=[])
+
+    gate = create_real_proposal_write_lock_gate(dry_run)
+
+    assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+    assert gate["lock_reason"] == "missing_source_evidence"
+
+
+def test_preview_integrity_failed_when_preview_only_false_or_written_created_flags_true():
+    cases = []
+    for field in ("proposal_record_preview", "operation_ledger_preview", "target_paths_preview"):
+        preview_only_false = _dry_run()
+        preview_only_false[field]["preview_only"] = False
+        cases.append(preview_only_false)
+
+        written_true = _dry_run()
+        written_true[field]["written"] = True
+        cases.append(written_true)
+
+        created_true = _dry_run()
+        created_true[field]["created_real_proposal"] = True
+        cases.append(created_true)
+
+    for dry_run in cases:
+        gate = create_real_proposal_write_lock_gate(dry_run)
+        assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
+        assert gate["lock_reason"] == "preview_integrity_failed"
+
+
+def test_write_lock_checklist_is_deterministic():
+    gate_a = create_real_proposal_write_lock_gate(_dry_run())
+    gate_b = create_real_proposal_write_lock_gate(_dry_run())
+
+    assert gate_a["write_lock_checklist"] == gate_b["write_lock_checklist"]
+    assert [check["id"] for check in gate_a["write_lock_checklist"]] == [
+        "verify_dry_run_validation",
+        "verify_preview_artifacts_only",
+        "verify_no_written_or_created_flags",
+        "verify_payload_and_source_evidence",
+        "require_separate_human_approval_token",
+    ]
+
+
+def test_input_dry_run_is_not_mutated():
+    dry_run = _dry_run()
+    before = deepcopy(dry_run)
+
+    gate = create_real_proposal_write_lock_gate(dry_run)
+    gate["source_dry_run_snapshot"]["payload_preview"]["content"]["nested"]["value"] = "changed"
+
+    assert dry_run == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    gate = create_real_proposal_write_lock_gate(_dry_run())
+    explanation = explain_real_proposal_write_lock_gate(gate)
+    recommendation = recommend_real_proposal_write_lock_action(gate)
+
+    assert gate["policy"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY
+    assert gate["policy"]["read_only"] is True
+    assert gate["policy"]["would_write_memory"] is False
+    assert gate["policy"]["would_modify_config"] is False
+    assert gate["policy"]["would_write_graph"] is False
+    assert gate["policy"]["does_not_create_operation_events"] is True
+    assert gate["policy"]["creates_write_lock_candidates_only"] is True
+    assert gate["policy"]["creates_real_proposals"] is False
+    assert gate["policy"]["writes_proposal_files"] is False
+    assert gate["policy"]["writes_operation_ledger"] is False
+    assert gate["policy"]["applies_proposals"] is False
+    assert gate["policy"]["persists_approvals"] is False
+    assert gate["policy"]["submits_to_governance"] is False
+    assert gate["policy"]["converts_to_real_proposal"] is False
+    assert explanation["written"] is False
+    assert explanation["submitted"] is False
+    assert explanation["applied"] is False
+    assert explanation["persisted"] is False
+    assert explanation["approved"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert explanation["writes_proposal_files"] is False
+    assert explanation["writes_operation_ledger"] is False
+    assert explanation["converted_to_real_proposal"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert recommendation["writes_proposal_files"] is False
+    assert recommendation["writes_operation_ledger"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_gate_must_never_be_marked_written_submitted_applied_persisted_approved_or_converted():
+    gate = create_real_proposal_write_lock_gate(_dry_run())
+
+    for forbidden_key in (
+        "written",
+        "submitted",
+        "applied",
+        "persisted",
+        "approved",
+        "created_real_proposal",
+        "created_operation_event",
+        "writes_proposal_files",
+        "writes_operation_ledger",
+        "converted_to_real_proposal",
+    ):
+        mutated = deepcopy(gate)
+        mutated[forbidden_key] = True
+        validation = validate_real_proposal_write_lock_gate(mutated)
+        assert validation["valid"] is False
+        assert f"{forbidden_key}_must_be_false_or_absent" in validation["errors"]
+
+
+def test_summary_counts_locked_eligible_gates_and_by_block_type_status():
+    gates = [
+        create_real_proposal_write_lock_gate(_dry_run("procedural_rules")),
+        create_real_proposal_write_lock_gate(_dry_run("project_context")),
+        create_real_proposal_write_lock_gate(_dry_run("procedural_rules", outcome="reject")),
+    ]
+
+    summary = summarize_real_proposal_write_lock_gates(gates)
+
+    assert summary["total"] == 3
+    assert summary["locked_count"] == 1
+    assert summary["eligible_count"] == 2
+    assert summary["valid_count"] == 3
+    assert summary["invalid_count"] == 0
+    assert summary["by_block_type"] == {"procedural_rules": 2, "project_context": 1}
+    assert summary["by_status"] == {
+        "eligible_for_human_approval_token": 2,
+        "locked": 1,
+    }
+    assert summary["policy"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_POLICY

--- a/tests/agent/test_memory_real_proposal_write_lock_gate.py
+++ b/tests/agent/test_memory_real_proposal_write_lock_gate.py
@@ -79,6 +79,15 @@ def test_valid_dry_run_creates_eligible_human_approval_token_gate():
     assert gate["next_step_recommendation"]["writes_operation_ledger"] is False
 
 
+def test_valid_write_lock_gate_id_matches_v0_1_baseline():
+    gate = create_real_proposal_write_lock_gate(_dry_run(), operator="write-lock-operator")
+
+    assert (
+        gate["gate_id"]
+        == "memory-real-proposal-write-lock-gate:v0.1:d4fed425e5b7aabe"
+    )
+
+
 def test_invalid_dry_run_creates_locked_gate():
     dry_run = _dry_run(outcome="reject")
 
@@ -149,6 +158,25 @@ def test_preview_integrity_failed_when_preview_only_false_or_written_created_fla
         gate = create_real_proposal_write_lock_gate(dry_run)
         assert gate["gate_status"] == MEMORY_REAL_PROPOSAL_WRITE_LOCK_GATE_LOCKED
         assert gate["lock_reason"] == "preview_integrity_failed"
+
+
+def test_preview_integrity_error_strings_match_v0_1_baseline():
+    dry_run = _dry_run()
+    dry_run["proposal_record_preview"]["preview_only"] = False
+    dry_run["proposal_record_preview"]["created_real_proposal"] = True
+    dry_run["operation_ledger_preview"]["written"] = True
+
+    gate = create_real_proposal_write_lock_gate(dry_run)
+
+    assert gate["lock_reason"] == "preview_integrity_failed"
+    assert gate["gate_validation"] == {
+        "valid": False,
+        "errors": [
+            "proposal_record_preview_must_be_preview_only",
+            "proposal_record_preview_created_real_proposal_must_not_be_true",
+            "operation_ledger_preview_written_must_not_be_true",
+        ],
+    }
 
 
 def test_write_lock_checklist_is_deterministic():

--- a/tests/agent/test_memory_retrieval_fusion.py
+++ b/tests/agent/test_memory_retrieval_fusion.py
@@ -1,0 +1,141 @@
+from agent.memory_retrieval_fusion import FUSION_POLICY, fuse_memory_retrieval
+
+
+NOW = "2026-05-23T00:00:00Z"
+
+
+def test_exact_keyword_recall_beats_unrelated_text():
+    result = fuse_memory_retrieval(
+        query="graphite dashboard theme",
+        candidates=[
+            {"id": "unrelated", "content": "Use staging for OpenClaw.", "created_at": "2026-05-22T00:00:00Z"},
+            {
+                "id": "theme",
+                "content": "Han prefers graphite dashboard theme.",
+                "created_at": "2026-05-22T00:00:00Z",
+            },
+        ],
+        now=NOW,
+    )
+
+    assert result["selected_memories"][0]["id"] == "theme"
+    assert result["scores"]["theme"]["keyword_score"] > result["scores"]["unrelated"]["keyword_score"]
+
+
+def test_project_scope_isolation_rejects_unrelated_project():
+    result = fuse_memory_retrieval(
+        query="deployment target",
+        project_scope="openclaw",
+        candidates=[
+            {"id": "lovart", "content": "Use production deployment target.", "project_id": "lovart"},
+            {"id": "openclaw", "content": "Use staging deployment target.", "project_id": "openclaw"},
+        ],
+        now=NOW,
+    )
+
+    assert result["selected_memories"][0]["id"] == "openclaw"
+    rejected = {item["id"]: item for item in result["rejected_memories"]}
+    assert rejected["lovart"]["reason"] == "project_scope_mismatch"
+
+
+def test_newer_valid_preference_beats_older_expired_preference():
+    result = fuse_memory_retrieval(
+        query="release note tone",
+        project_scope="hermes-agent",
+        candidates=[
+            {
+                "id": "old",
+                "content": "Use expansive release note tone.",
+                "project_id": "hermes-agent",
+                "valid_until": "2026-05-10T00:00:00Z",
+                "created_at": "2026-05-01T00:00:00Z",
+            },
+            {
+                "id": "new",
+                "content": "Use terse release note tone.",
+                "project_id": "hermes-agent",
+                "valid_from": "2026-05-22T00:00:00Z",
+                "created_at": "2026-05-22T00:00:00Z",
+            },
+        ],
+        now=NOW,
+    )
+
+    assert result["selected_memories"][0]["id"] == "new"
+    assert result["scores"]["new"]["temporal_score"] > result["scores"]["old"]["temporal_score"]
+
+
+def test_provenance_bearing_source_wins_when_content_is_similar():
+    result = fuse_memory_retrieval(
+        query="durable memory updates governed proposals",
+        candidates=[
+            {
+                "id": "untrusted",
+                "content": "Durable memory updates require governed proposals.",
+                "source": "chat",
+            },
+            {
+                "id": "trusted",
+                "content": "Durable memory updates require governed proposals.",
+                "source": "policy_doc",
+                "provenance": "memory-fabric-policy:v1",
+            },
+        ],
+        now=NOW,
+    )
+
+    assert result["selected_memories"][0]["id"] == "trusted"
+    assert result["scores"]["trusted"]["source_trust_score"] > result["scores"]["untrusted"]["source_trust_score"]
+
+
+def test_unsafe_governance_candidate_is_rejected():
+    result = fuse_memory_retrieval(
+        query="direct durable memory write",
+        candidates=[
+            {
+                "id": "unsafe",
+                "content": "Direct durable memory write is allowed.",
+                "governance": {"would_write_memory": True},
+            },
+            {
+                "id": "safe",
+                "content": "Direct durable memory writes require governed proposals.",
+                "governance": {"read_only": True, "proposal_governed": True},
+            },
+        ],
+        now=NOW,
+    )
+
+    assert result["selected_memories"][0]["id"] == "safe"
+    rejected = {item["id"]: item for item in result["rejected_memories"]}
+    assert rejected["unsafe"]["reason"].startswith("unsafe_governance")
+    assert rejected["unsafe"]["component_scores"]["governance_score"] == 0.0
+
+
+def test_rejected_memories_explain_why_items_lost():
+    result = fuse_memory_retrieval(
+        query="Hermes memory retrieval fusion",
+        candidates=[
+            {"id": "winner", "content": "Hermes memory retrieval fusion is enabled."},
+            {"id": "loser", "content": "Calendar sync is enabled."},
+        ],
+        now=NOW,
+        limit=1,
+    )
+
+    rejected = {item["id"]: item for item in result["rejected_memories"]}
+    assert "loser" in rejected
+    assert rejected["loser"]["reason"] in {"below_selection_threshold", "ranked_below_limit"}
+    assert "final_score" in rejected["loser"]
+    assert "component_scores" in rejected["loser"]
+
+
+def test_policy_proves_read_only_and_no_memory_config_or_graph_writes():
+    result = fuse_memory_retrieval(query="policy", candidates=[], now=NOW)
+
+    assert result["policy"] == FUSION_POLICY
+    assert result["policy"]["read_only"] is True
+    assert result["policy"]["would_write_memory"] is False
+    assert result["policy"]["would_modify_config"] is False
+    assert result["policy"]["would_write_graph"] is False
+    assert result["policy"]["does_not_create_operation_events"] is True

--- a/tests/agent/test_memory_review_decision_gate.py
+++ b/tests/agent/test_memory_review_decision_gate.py
@@ -1,0 +1,170 @@
+from copy import deepcopy
+
+from agent.memory_block_review_queue import create_review_queue_item
+from agent.memory_blocks import create_memory_block_candidate
+from agent.memory_review_decision_gate import (
+    MEMORY_REVIEW_DECISION_GATE_POLICY,
+    SUPPORTED_REVIEW_DECISIONS,
+    create_review_decision_candidate,
+    evaluate_review_queue_item,
+    explain_review_decision_candidate,
+    recommend_review_decision_action,
+    summarize_review_decisions,
+    validate_review_decision_candidate,
+)
+
+
+def _queue_item(block_type, content="content", source_pattern_ids=None, source_fact_ids=None):
+    block = create_memory_block_candidate(
+        block_type,
+        content,
+        project_scope="memory-fabric",
+        source_pattern_ids=source_pattern_ids,
+        source_fact_ids=source_fact_ids,
+    )
+    return create_review_queue_item(block, reviewer="memory-reviewer")
+
+
+def test_valid_low_risk_project_context_gets_approve_to_proposal():
+    item = _queue_item("project_context", {"text": "foundation context"})
+
+    candidate = evaluate_review_queue_item(item)
+
+    assert candidate["decision"] == "approve_to_proposal"
+    assert candidate["risk_level"] == "low"
+    assert candidate["decision_validation"] == {"valid": True, "errors": []}
+    assert candidate["next_step_recommendation"]["creates_real_proposals"] is False
+
+
+def test_valid_procedural_rules_with_source_ids_gets_approve_to_proposal():
+    item = _queue_item(
+        "procedural_rules",
+        {"rules": ["Create decision candidates only."]},
+        source_pattern_ids=["pattern-1"],
+        source_fact_ids=["fact-1"],
+    )
+
+    candidate = evaluate_review_queue_item(item)
+
+    assert candidate["decision"] == "approve_to_proposal"
+    assert candidate["source_pattern_ids"] == ["pattern-1"]
+    assert candidate["source_fact_ids"] == ["fact-1"]
+
+
+def test_procedural_rules_without_source_ids_requests_more_evidence():
+    item = _queue_item("procedural_rules", {"rules": ["Needs sources."]})
+
+    candidate = evaluate_review_queue_item(item)
+
+    assert candidate["decision"] == "request_more_evidence"
+    assert candidate["risk_level"] == "medium"
+
+
+def test_safety_policy_requests_more_evidence():
+    item = _queue_item("safety_policy", "Never write memory directly.")
+
+    candidate = evaluate_review_queue_item(item)
+
+    assert candidate["decision"] == "request_more_evidence"
+    assert candidate["risk_level"] == "high"
+
+
+def test_invalid_queue_item_rejects():
+    item = _queue_item("project_context", {"text": "valid"})
+    item["status"] = "approved"
+
+    candidate = evaluate_review_queue_item(item)
+
+    assert candidate["decision"] == "reject"
+    assert candidate["queue_item_validation"]["valid"] is False
+    assert "status_must_be_pending_review" in candidate["queue_item_validation"]["errors"]
+
+
+def test_unsupported_invalid_block_rejects():
+    item = _queue_item("unsupported", "invalid")
+
+    candidate = evaluate_review_queue_item(item)
+
+    assert candidate["decision"] == "reject"
+    assert candidate["risk_level"] == "high"
+    assert candidate["queue_item_snapshot"]["validation"]["valid"] is False
+    assert "unsupported_block_type:unsupported" in candidate["queue_item_snapshot"]["validation"]["errors"]
+
+
+def test_explicit_decision_override_is_validated_but_not_applied():
+    item = _queue_item("safety_policy", "Requires review.")
+
+    candidate = create_review_decision_candidate(
+        item,
+        reviewer="override-reviewer",
+        decision="approve_to_proposal",
+        rationale="Manual validation scenario.",
+    )
+    invalid = create_review_decision_candidate(item, decision="apply_now")
+
+    assert candidate["decision"] == "approve_to_proposal"
+    assert candidate["reviewer"] == "override-reviewer"
+    assert candidate["decision_validation"] == {"valid": True, "errors": []}
+    assert candidate["next_step_recommendation"]["applies_decisions"] is False
+    assert invalid["decision_validation"]["valid"] is False
+    assert "unsupported_decision:apply_now" in invalid["decision_validation"]["errors"]
+
+
+def test_summary_counts_by_decision_and_risk():
+    candidates = [
+        evaluate_review_queue_item(_queue_item("project_context", "low")),
+        evaluate_review_queue_item(
+            _queue_item("procedural_rules", {"rules": ["source"]}, source_fact_ids=["fact-1"])
+        ),
+        evaluate_review_queue_item(_queue_item("procedural_rules", {"rules": ["no source"]})),
+        evaluate_review_queue_item(_queue_item("safety_policy", "high")),
+        evaluate_review_queue_item(_queue_item("unsupported", "invalid")),
+    ]
+
+    summary = summarize_review_decisions(candidates)
+
+    assert summary["total"] == 5
+    assert summary["by_decision"]["approve_to_proposal"] == 2
+    assert summary["by_decision"]["request_more_evidence"] == 2
+    assert summary["by_decision"]["reject"] == 1
+    assert summary["by_decision"]["defer"] == 0
+    assert summary["by_risk"] == {"high": 2, "medium": 2, "low": 1}
+    assert set(summary["by_decision"]) == set(SUPPORTED_REVIEW_DECISIONS)
+
+
+def test_input_queue_item_is_not_mutated():
+    item = _queue_item("project_context", {"nested": ["original"]})
+    before = deepcopy(item)
+
+    candidate = evaluate_review_queue_item(item)
+    candidate["queue_item_snapshot"]["block_snapshot"]["content"]["nested"].append("mutated-copy")
+
+    assert item == before
+
+
+def test_policy_proves_no_memory_config_graph_proposal_or_ledger_writes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    item = _queue_item("procedural_rules", {"rules": ["Only create decision candidates."]}, source_fact_ids=["fact-1"])
+
+    candidate = evaluate_review_queue_item(item)
+    explanation = explain_review_decision_candidate(candidate)
+    recommendation = recommend_review_decision_action(candidate)
+
+    assert candidate["policy"] == MEMORY_REVIEW_DECISION_GATE_POLICY
+    assert validate_review_decision_candidate(candidate) == {"valid": True, "errors": []}
+    assert candidate["policy"]["read_only"] is True
+    assert candidate["policy"]["would_write_memory"] is False
+    assert candidate["policy"]["would_modify_config"] is False
+    assert candidate["policy"]["would_write_graph"] is False
+    assert candidate["policy"]["does_not_create_operation_events"] is True
+    assert candidate["policy"]["creates_decision_candidates_only"] is True
+    assert candidate["policy"]["applies_decisions"] is False
+    assert candidate["policy"]["creates_real_proposals"] is False
+    assert explanation["applied"] is False
+    assert explanation["created_real_proposal"] is False
+    assert explanation["created_operation_event"] is False
+    assert recommendation["creates_real_proposals"] is False
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -432,3 +432,51 @@ def test_memory_human_approval_token_write_final_gate_smoke_case_is_executor_eli
     assert case["evidence"]["writes_token_files"] is False
     assert case["evidence"]["writes_approval_audit"] is False
     assert case["evidence"]["invokes_real_token_write_executor"] is False
+
+
+def test_memory_human_approval_token_real_write_executor_contract_smoke_case_requires_contract_without_writes():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_real_write_executor_contract"
+    )
+
+    contract = case["evidence"][
+        "human_approval_token_real_write_executor_contract_candidates"
+    ][0]
+    assert case["actual_answer"] == "real_token_write_executor_contract_required"
+    assert contract["contract_validation"] == {"valid": True, "errors": []}
+    assert contract["contract_status"] == "real_token_write_executor_contract_required"
+    assert (
+        contract["routing"]
+        == "real_token_write_executor_contract_review_required_before_implementation"
+    )
+    assert contract["lock_reason"] is None
+    assert "invoke_real_token_write_executor" in contract["executor_forbidden_side_effects"]
+    assert "implement_real_token_write_executor" in contract["executor_forbidden_side_effects"]
+    assert "write_token_files" in contract["executor_forbidden_side_effects"]
+    assert "write_approval_audit_files" in contract["executor_forbidden_side_effects"]
+    assert contract["approval_token_write_payload_preview"]["preview_only"] is True
+    assert contract["approval_token_write_payload_preview"]["token_issued"] is False
+    assert contract["approval_token_write_payload_preview"]["persisted"] is False
+    assert contract["approval_token_write_payload_preview"]["written"] is False
+    assert contract["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert contract["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert contract["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert contract["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert contract["token_write_target_paths_preview"]["preview_only"] is True
+    assert contract["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert contract["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert contract["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False
+    assert case["evidence"]["invokes_real_token_write_executor"] is False
+    assert case["evidence"]["implements_real_token_write_executor"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -87,3 +87,25 @@ def test_memory_real_proposal_dry_run_smoke_case_is_preview_only():
     assert case["evidence"]["created_operation_event"] is False
     assert case["evidence"]["writes_proposal_files"] is False
     assert case["evidence"]["writes_operation_ledger"] is False
+
+
+def test_memory_real_proposal_write_lock_gate_smoke_case_is_token_eligible_without_writes():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_real_proposal_write_lock_gate"
+    )
+
+    gate = case["evidence"]["real_proposal_write_lock_gate_candidates"][0]
+    assert case["actual_answer"] == "eligible_for_human_approval_token"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+    assert gate["gate_status"] == "eligible_for_human_approval_token"
+    assert gate["lock_reason"] is None
+    assert gate["proposal_record_preview"]["written"] is False
+    assert gate["operation_ledger_preview"]["written"] is False
+    assert gate["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -286,3 +286,38 @@ def test_memory_human_approval_token_final_confirmation_request_smoke_case_is_re
     assert case["evidence"]["writes_operation_ledger"] is False
     assert case["evidence"]["writes_token_files"] is False
     assert case["evidence"]["writes_approval_audit"] is False
+
+
+def test_memory_human_approval_token_final_confirmation_review_gate_smoke_case_confirms_without_writes():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_final_confirmation_review_gate"
+    )
+
+    outcome = case["evidence"]["human_approval_token_final_confirmation_review_outcome_candidates"][0]
+    assert case["actual_answer"] == "confirm_token_write"
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert outcome["outcome"] == "confirm_token_write"
+    assert outcome["routing"] == "manual_token_write_still_required_after_final_confirmation"
+    assert outcome["approval_token_record_preview"]["preview_only"] is True
+    assert outcome["approval_token_record_preview"]["token_issued"] is False
+    assert outcome["approval_token_record_preview"]["persisted"] is False
+    assert outcome["approval_audit_record_preview"]["preview_only"] is True
+    assert outcome["approval_audit_record_preview"]["created_operation_event"] is False
+    assert outcome["token_target_paths_preview"]["preview_only"] is True
+    assert outcome["token_target_paths_preview"]["writes_token_files"] is False
+    assert outcome["token_target_paths_preview"]["writes_approval_audit"] is False
+    assert outcome["proposal_record_preview"]["written"] is False
+    assert outcome["operation_ledger_preview"]["written"] is False
+    assert outcome["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -109,3 +109,27 @@ def test_memory_real_proposal_write_lock_gate_smoke_case_is_token_eligible_witho
     assert case["evidence"]["created_operation_event"] is False
     assert case["evidence"]["writes_proposal_files"] is False
     assert case["evidence"]["writes_operation_ledger"] is False
+
+
+def test_memory_human_approval_token_request_smoke_case_is_review_required_without_issuing_token():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_request"
+    )
+
+    request = case["evidence"]["human_approval_token_request_candidates"][0]
+    assert case["actual_answer"] == "approval_token_review_required"
+    assert request["request_validation"] == {"valid": True, "errors": []}
+    assert request["request_status"] == "approval_token_review_required"
+    assert request["lock_reason"] is None
+    assert request["proposal_record_preview"]["written"] is False
+    assert request["operation_ledger_preview"]["written"] is False
+    assert request["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -251,3 +251,38 @@ def test_memory_human_approval_token_write_lock_gate_smoke_case_is_final_confirm
     assert case["evidence"]["writes_operation_ledger"] is False
     assert case["evidence"]["writes_token_files"] is False
     assert case["evidence"]["writes_approval_audit"] is False
+
+
+def test_memory_human_approval_token_final_confirmation_request_smoke_case_is_review_required_without_issuing_token():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_final_confirmation_request"
+    )
+
+    request = case["evidence"]["human_approval_token_final_confirmation_request_candidates"][0]
+    assert case["actual_answer"] == "final_confirmation_review_required"
+    assert request["request_validation"] == {"valid": True, "errors": []}
+    assert request["request_status"] == "final_confirmation_review_required"
+    assert request["lock_reason"] is None
+    assert request["approval_token_record_preview"]["preview_only"] is True
+    assert request["approval_token_record_preview"]["token_issued"] is False
+    assert request["approval_token_record_preview"]["persisted"] is False
+    assert request["approval_audit_record_preview"]["preview_only"] is True
+    assert request["approval_audit_record_preview"]["created_operation_event"] is False
+    assert request["token_target_paths_preview"]["preview_only"] is True
+    assert request["token_target_paths_preview"]["writes_token_files"] is False
+    assert request["token_target_paths_preview"]["writes_approval_audit"] is False
+    assert request["proposal_record_preview"]["written"] is False
+    assert request["operation_ledger_preview"]["written"] is False
+    assert request["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -157,3 +157,28 @@ def test_memory_human_approval_token_review_gate_smoke_case_approves_without_iss
     assert case["evidence"]["created_operation_event"] is False
     assert case["evidence"]["writes_proposal_files"] is False
     assert case["evidence"]["writes_operation_ledger"] is False
+
+
+def test_memory_human_approval_token_issuance_plan_smoke_case_requires_manual_plan_without_issuing_token():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_issuance_plan"
+    )
+
+    plan = case["evidence"]["human_approval_token_issuance_plan_candidates"][0]
+    assert case["actual_answer"] == "manual_token_issuance_plan_required"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+    assert plan["plan_status"] == "manual_token_issuance_plan_required"
+    assert plan["lock_reason"] is None
+    assert plan["outcome"] == "approve_token_issuance"
+    assert plan["proposal_record_preview"]["written"] is False
+    assert plan["operation_ledger_preview"]["written"] is False
+    assert plan["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -357,3 +357,40 @@ def test_memory_human_approval_token_write_execution_plan_smoke_case_requires_dr
     assert case["evidence"]["writes_operation_ledger"] is False
     assert case["evidence"]["writes_token_files"] is False
     assert case["evidence"]["writes_approval_audit"] is False
+
+
+def test_memory_human_approval_token_write_execution_dry_run_smoke_case_requires_final_preflight_without_writes():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_write_execution_dry_run"
+    )
+
+    dry_run = case["evidence"]["human_approval_token_write_execution_dry_run_candidates"][0]
+    assert case["actual_answer"] == "manual_token_write_final_preflight_required"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert dry_run["dry_run_status"] == "manual_token_write_final_preflight_required"
+    assert dry_run["routing"] == "manual_token_write_final_gate_required_before_any_token_write"
+    assert dry_run["lock_reason"] is None
+    assert dry_run["approval_token_write_payload_preview"]["preview_only"] is True
+    assert dry_run["approval_token_write_payload_preview"]["token_issued"] is False
+    assert dry_run["approval_token_write_payload_preview"]["persisted"] is False
+    assert dry_run["approval_token_write_payload_preview"]["written"] is False
+    assert dry_run["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert dry_run["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert dry_run["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert dry_run["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert dry_run["token_write_target_paths_preview"]["preview_only"] is True
+    assert dry_run["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert dry_run["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert dry_run["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -480,3 +480,56 @@ def test_memory_human_approval_token_real_write_executor_contract_smoke_case_req
     assert case["evidence"]["writes_approval_audit"] is False
     assert case["evidence"]["invokes_real_token_write_executor"] is False
     assert case["evidence"]["implements_real_token_write_executor"] is False
+
+
+def test_memory_human_approval_token_real_write_executor_contract_review_gate_smoke_case_approves_without_writes_or_executor():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"]
+        == "memory_human_approval_token_real_write_executor_contract_review_gate"
+    )
+
+    outcome = case["evidence"][
+        "human_approval_token_real_write_executor_contract_review_outcome_candidates"
+    ][0]
+    assert case["actual_answer"] == "approve_executor_contract"
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert (
+        outcome["review_outcome_status"]
+        == "real_write_executor_contract_review_outcome_candidate"
+    )
+    assert (
+        outcome["routing"]
+        == "real_token_write_executor_implementation_plan_required_after_contract_approval"
+    )
+    assert outcome["outcome"] == "approve_executor_contract"
+    assert outcome["contract_validation"] == {"valid": True, "errors": []}
+    assert "real_token_write_executor_not_invoked" in outcome["contract_review_checklist"]
+    assert "real_token_write_executor_not_implemented" in outcome[
+        "contract_review_checklist"
+    ]
+    assert outcome["approval_token_write_payload_preview"]["preview_only"] is True
+    assert outcome["approval_token_write_payload_preview"]["token_issued"] is False
+    assert outcome["approval_token_write_payload_preview"]["persisted"] is False
+    assert outcome["approval_token_write_payload_preview"]["written"] is False
+    assert outcome["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert outcome["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert outcome["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert outcome["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert outcome["token_write_target_paths_preview"]["preview_only"] is True
+    assert outcome["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert outcome["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert outcome["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False
+    assert case["evidence"]["invokes_real_token_write_executor"] is False
+    assert case["evidence"]["implements_real_token_write_executor"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -394,3 +394,41 @@ def test_memory_human_approval_token_write_execution_dry_run_smoke_case_requires
     assert case["evidence"]["writes_operation_ledger"] is False
     assert case["evidence"]["writes_token_files"] is False
     assert case["evidence"]["writes_approval_audit"] is False
+
+
+def test_memory_human_approval_token_write_final_gate_smoke_case_is_executor_eligible_without_writes():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_write_final_gate"
+    )
+
+    gate = case["evidence"]["human_approval_token_write_final_gate_candidates"][0]
+    assert case["actual_answer"] == "eligible_for_real_token_write_executor"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+    assert gate["gate_status"] == "eligible_for_real_token_write_executor"
+    assert gate["routing"] == "real_token_write_executor_required_but_not_invoked"
+    assert gate["lock_reason"] is None
+    assert gate["approval_token_write_payload_preview"]["preview_only"] is True
+    assert gate["approval_token_write_payload_preview"]["token_issued"] is False
+    assert gate["approval_token_write_payload_preview"]["persisted"] is False
+    assert gate["approval_token_write_payload_preview"]["written"] is False
+    assert gate["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert gate["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert gate["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert gate["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert gate["token_write_target_paths_preview"]["preview_only"] is True
+    assert gate["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert gate["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert gate["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False
+    assert case["evidence"]["invokes_real_token_write_executor"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -533,3 +533,80 @@ def test_memory_human_approval_token_real_write_executor_contract_review_gate_sm
     assert case["evidence"]["writes_approval_audit"] is False
     assert case["evidence"]["invokes_real_token_write_executor"] is False
     assert case["evidence"]["implements_real_token_write_executor"] is False
+
+
+def test_memory_human_approval_token_real_write_executor_implementation_plan_smoke_case_requires_plan_without_writes_or_executor():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"]
+        == "memory_human_approval_token_real_write_executor_implementation_plan"
+    )
+
+    plan = case["evidence"][
+        "human_approval_token_real_write_executor_implementation_plan_candidates"
+    ][0]
+    assert case["actual_answer"] == "real_token_write_executor_implementation_plan_required"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+    assert plan["plan_status"] == "real_token_write_executor_implementation_plan_required"
+    assert (
+        plan["routing"]
+        == "real_token_write_executor_implementation_dry_run_required_before_code_implementation"
+    )
+    assert plan["lock_reason"] is None
+    assert plan["outcome"] == "approve_executor_contract"
+    assert plan["contract_review_outcome_validation"] == {"valid": True, "errors": []}
+    assert all(
+        interface["implemented_in_v0_1"] is False
+        for interface in plan["implementation_plan_interfaces"]
+    )
+    assert all(
+        interface["invoked_in_v0_1"] is False
+        for interface in plan["implementation_plan_interfaces"]
+    )
+    assert all(file_plan["create_in_v0_1"] is False for file_plan in plan["implementation_plan_files"])
+    assert all(
+        file_plan["contains_executor_code_in_v0_1"] is False
+        for file_plan in plan["implementation_plan_files"]
+    )
+    assert (
+        plan["implementation_plan_audit_strategy"]["v0_1_effect"]
+        == "no_approval_audit_file_write_and_no_operation_ledger_event"
+    )
+    assert (
+        plan["implementation_plan_rollback_strategy"]["v0_1_effect"]
+        == "no_rollback_action_because_no_write_is_performed"
+    )
+    for forbidden in (
+        "implement_real_token_write_executor",
+        "invoke_real_token_write_executor",
+        "write_token_files",
+        "write_approval_audit_files",
+        "write_proposal_files",
+        "write_operation_ledger",
+    ):
+        assert forbidden in plan["implementation_plan_forbidden_actions"]
+    assert plan["approval_token_write_payload_preview"]["preview_only"] is True
+    assert plan["approval_token_write_payload_preview"]["token_issued"] is False
+    assert plan["approval_token_write_payload_preview"]["persisted"] is False
+    assert plan["approval_token_write_payload_preview"]["written"] is False
+    assert plan["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert plan["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert plan["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert plan["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert plan["token_write_target_paths_preview"]["preview_only"] is True
+    assert plan["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert plan["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert plan["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False
+    assert case["evidence"]["invokes_real_token_write_executor"] is False
+    assert case["evidence"]["implements_real_token_write_executor"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -610,3 +610,79 @@ def test_memory_human_approval_token_real_write_executor_implementation_plan_smo
     assert case["evidence"]["writes_approval_audit"] is False
     assert case["evidence"]["invokes_real_token_write_executor"] is False
     assert case["evidence"]["implements_real_token_write_executor"] is False
+
+
+def test_memory_human_approval_token_real_write_executor_implementation_dry_run_smoke_case_requires_code_review_plan_without_writes_or_executor_code():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"]
+        == "memory_human_approval_token_real_write_executor_implementation_dry_run"
+    )
+
+    dry_run = case["evidence"][
+        "human_approval_token_real_write_executor_implementation_dry_run_candidates"
+    ][0]
+    assert case["actual_answer"] == "real_token_write_executor_code_review_plan_required"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert dry_run["dry_run_status"] == "real_token_write_executor_code_review_plan_required"
+    assert (
+        dry_run["routing"]
+        == "real_token_write_executor_code_review_plan_required_before_any_executor_code"
+    )
+    assert dry_run["lock_reason"] is None
+    assert dry_run["implementation_plan_validation"] == {"valid": True, "errors": []}
+    assert dry_run["implementation_dry_run_module_boundary_preview"][
+        "creates_executor_source_files"
+    ] is False
+    assert dry_run["implementation_dry_run_module_boundary_preview"][
+        "implements_real_token_write_executor"
+    ] is False
+    assert dry_run["implementation_dry_run_module_boundary_preview"][
+        "invokes_real_token_write_executor"
+    ] is False
+    assert all(
+        interface["implemented_in_v0_1"] is False
+        for interface in dry_run["implementation_dry_run_interface_preview"]
+    )
+    assert all(
+        interface["invoked_in_v0_1"] is False
+        for interface in dry_run["implementation_dry_run_interface_preview"]
+    )
+    assert (
+        dry_run["implementation_dry_run_audit_check_preview"]["v0_1_effect"]
+        == "no_approval_audit_file_write_and_no_operation_ledger_event"
+    )
+    assert (
+        dry_run["implementation_dry_run_rollback_check_preview"]["v0_1_effect"]
+        == "no_rollback_action_because_no_write_is_performed"
+    )
+    assert all(
+        test_case["creates_files"] is False
+        for test_case in dry_run["implementation_dry_run_test_harness_preview"]
+    )
+    assert dry_run["approval_token_write_payload_preview"]["preview_only"] is True
+    assert dry_run["approval_token_write_payload_preview"]["token_issued"] is False
+    assert dry_run["approval_token_write_payload_preview"]["persisted"] is False
+    assert dry_run["approval_token_write_payload_preview"]["written"] is False
+    assert dry_run["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert dry_run["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert dry_run["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert dry_run["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert dry_run["token_write_target_paths_preview"]["preview_only"] is True
+    assert dry_run["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert dry_run["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert dry_run["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False
+    assert case["evidence"]["invokes_real_token_write_executor"] is False
+    assert case["evidence"]["implements_real_token_write_executor"] is False
+    assert case["evidence"]["creates_executor_source_files"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -321,3 +321,39 @@ def test_memory_human_approval_token_final_confirmation_review_gate_smoke_case_c
     assert case["evidence"]["writes_operation_ledger"] is False
     assert case["evidence"]["writes_token_files"] is False
     assert case["evidence"]["writes_approval_audit"] is False
+
+
+def test_memory_human_approval_token_write_execution_plan_smoke_case_requires_dry_run_without_writes():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_write_execution_plan"
+    )
+
+    plan = case["evidence"]["human_approval_token_write_execution_plan_candidates"][0]
+    assert case["actual_answer"] == "manual_token_write_execution_plan_required"
+    assert plan["plan_validation"] == {"valid": True, "errors": []}
+    assert plan["plan_status"] == "manual_token_write_execution_plan_required"
+    assert plan["routing"] == "manual_token_write_dry_run_required_before_any_token_write"
+    assert plan["lock_reason"] is None
+    assert plan["approval_token_record_preview"]["preview_only"] is True
+    assert plan["approval_token_record_preview"]["token_issued"] is False
+    assert plan["approval_token_record_preview"]["persisted"] is False
+    assert plan["approval_audit_record_preview"]["preview_only"] is True
+    assert plan["approval_audit_record_preview"]["created_operation_event"] is False
+    assert plan["token_target_paths_preview"]["preview_only"] is True
+    assert plan["token_target_paths_preview"]["writes_token_files"] is False
+    assert plan["token_target_paths_preview"]["writes_approval_audit"] is False
+    assert plan["proposal_record_preview"]["written"] is False
+    assert plan["operation_ledger_preview"]["written"] is False
+    assert plan["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -67,3 +67,23 @@ def test_benchmark_does_not_write_graph_or_operation_ledger(tmp_path, monkeypatc
     assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
     assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
     assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()
+
+
+def test_memory_real_proposal_dry_run_smoke_case_is_preview_only():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_real_proposal_dry_run"
+    )
+
+    dry_run = case["evidence"]["real_proposal_dry_run_candidates"][0]
+    assert case["actual_answer"] == "manual_final_preflight_required"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert dry_run["proposal_record_preview"]["written"] is False
+    assert dry_run["operation_ledger_preview"]["written"] is False
+    assert dry_run["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -182,3 +182,37 @@ def test_memory_human_approval_token_issuance_plan_smoke_case_requires_manual_pl
     assert case["evidence"]["created_operation_event"] is False
     assert case["evidence"]["writes_proposal_files"] is False
     assert case["evidence"]["writes_operation_ledger"] is False
+
+
+def test_memory_human_approval_token_issuance_dry_run_smoke_case_requires_final_preflight_without_issuing_token():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_issuance_dry_run"
+    )
+
+    dry_run = case["evidence"]["human_approval_token_issuance_dry_run_candidates"][0]
+    assert case["actual_answer"] == "manual_token_issuance_final_preflight_required"
+    assert dry_run["dry_run_validation"] == {"valid": True, "errors": []}
+    assert dry_run["dry_run_status"] == "manual_token_issuance_final_preflight_required"
+    assert dry_run["lock_reason"] is None
+    assert dry_run["approval_token_record_preview"]["preview_only"] is True
+    assert dry_run["approval_token_record_preview"]["token_issued"] is False
+    assert dry_run["approval_token_record_preview"]["persisted"] is False
+    assert dry_run["approval_audit_record_preview"]["preview_only"] is True
+    assert dry_run["approval_audit_record_preview"]["created_operation_event"] is False
+    assert dry_run["token_target_paths_preview"]["preview_only"] is True
+    assert dry_run["token_target_paths_preview"]["writes_token_files"] is False
+    assert dry_run["token_target_paths_preview"]["writes_approval_audit"] is False
+    assert dry_run["proposal_record_preview"]["written"] is False
+    assert dry_run["operation_ledger_preview"]["written"] is False
+    assert dry_run["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -133,3 +133,27 @@ def test_memory_human_approval_token_request_smoke_case_is_review_required_witho
     assert case["evidence"]["created_operation_event"] is False
     assert case["evidence"]["writes_proposal_files"] is False
     assert case["evidence"]["writes_operation_ledger"] is False
+
+
+def test_memory_human_approval_token_review_gate_smoke_case_approves_without_issuing_token():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_review_gate"
+    )
+
+    outcome = case["evidence"]["human_approval_token_review_outcome_candidates"][0]
+    assert case["actual_answer"] == "approve_token_issuance"
+    assert outcome["review_outcome_validation"] == {"valid": True, "errors": []}
+    assert outcome["review_outcome_status"] == "token_review_outcome_candidate"
+    assert outcome["outcome"] == "approve_token_issuance"
+    assert outcome["proposal_record_preview"]["written"] is False
+    assert outcome["operation_ledger_preview"]["written"] is False
+    assert outcome["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -216,3 +216,38 @@ def test_memory_human_approval_token_issuance_dry_run_smoke_case_requires_final_
     assert case["evidence"]["writes_operation_ledger"] is False
     assert case["evidence"]["writes_token_files"] is False
     assert case["evidence"]["writes_approval_audit"] is False
+
+
+def test_memory_human_approval_token_write_lock_gate_smoke_case_is_final_confirmation_eligible_without_token_writes():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"] == "memory_human_approval_token_write_lock_gate"
+    )
+
+    gate = case["evidence"]["human_approval_token_write_lock_gate_candidates"][0]
+    assert case["actual_answer"] == "eligible_for_final_human_confirmation"
+    assert gate["gate_validation"] == {"valid": True, "errors": []}
+    assert gate["gate_status"] == "eligible_for_final_human_confirmation"
+    assert gate["lock_reason"] is None
+    assert gate["approval_token_record_preview"]["preview_only"] is True
+    assert gate["approval_token_record_preview"]["token_issued"] is False
+    assert gate["approval_token_record_preview"]["persisted"] is False
+    assert gate["approval_audit_record_preview"]["preview_only"] is True
+    assert gate["approval_audit_record_preview"]["created_operation_event"] is False
+    assert gate["token_target_paths_preview"]["preview_only"] is True
+    assert gate["token_target_paths_preview"]["writes_token_files"] is False
+    assert gate["token_target_paths_preview"]["writes_approval_audit"] is False
+    assert gate["proposal_record_preview"]["written"] is False
+    assert gate["operation_ledger_preview"]["written"] is False
+    assert gate["operation_ledger_preview"]["created_operation_event"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -686,3 +686,81 @@ def test_memory_human_approval_token_real_write_executor_implementation_dry_run_
     assert case["evidence"]["invokes_real_token_write_executor"] is False
     assert case["evidence"]["implements_real_token_write_executor"] is False
     assert case["evidence"]["creates_executor_source_files"] is False
+
+
+def test_memory_human_approval_token_real_write_executor_code_review_plan_smoke_case_requires_gate_without_writes_or_executor_code():
+    report = run_benchmark("smoke")
+    case = next(
+        case
+        for case in report["cases"]
+        if case["dimension"]
+        == "memory_human_approval_token_real_write_executor_code_review_plan"
+    )
+
+    plan = case["evidence"][
+        "human_approval_token_real_write_executor_code_review_plan_candidates"
+    ][0]
+    assert case["actual_answer"] == "real_token_write_executor_code_review_gate_required"
+    assert plan["code_review_plan_validation"] == {"valid": True, "errors": []}
+    assert plan["plan_status"] == "real_token_write_executor_code_review_gate_required"
+    assert (
+        plan["routing"]
+        == "real_token_write_executor_code_review_gate_required_before_executor_source_creation"
+    )
+    assert plan["lock_reason"] is None
+    assert plan["implementation_dry_run_validation"] == {"valid": True, "errors": []}
+    assert plan["code_review_scope"]["creates_executor_source_files"] is False
+    assert plan["code_review_scope"]["creates_executor_tests"] is False
+    assert plan["code_review_scope"]["implements_real_token_write_executor"] is False
+    assert plan["code_review_scope"]["invokes_real_token_write_executor"] is False
+    assert all(
+        file_plan["create_in_v0_1"] is False
+        for file_plan in plan["code_review_required_files"]
+    )
+    assert all(
+        test_case["writes"] is False for test_case in plan["code_review_test_matrix"]
+    )
+    assert all(
+        test_case["creates_executor_source_files"] is False
+        for test_case in plan["code_review_test_matrix"]
+    )
+    assert all(
+        test_case["creates_executor_tests"] is False
+        for test_case in plan["code_review_test_matrix"]
+    )
+    for forbidden in (
+        "implement_real_token_write_executor",
+        "invoke_real_token_write_executor",
+        "create_executor_source_files",
+        "create_executor_tests",
+        "write_token_files",
+        "write_approval_audit_files",
+        "write_proposal_files",
+        "write_operation_ledger",
+    ):
+        assert forbidden in plan["code_review_forbidden_actions"]
+    assert plan["approval_token_write_payload_preview"]["preview_only"] is True
+    assert plan["approval_token_write_payload_preview"]["token_issued"] is False
+    assert plan["approval_token_write_payload_preview"]["persisted"] is False
+    assert plan["approval_token_write_payload_preview"]["written"] is False
+    assert plan["approval_audit_write_payload_preview"]["preview_only"] is True
+    assert plan["approval_audit_write_payload_preview"]["created_operation_event"] is False
+    assert plan["approval_audit_write_payload_preview"]["writes_approval_audit"] is False
+    assert plan["approval_audit_write_payload_preview"]["writes_operation_ledger"] is False
+    assert plan["token_write_target_paths_preview"]["preview_only"] is True
+    assert plan["token_write_target_paths_preview"]["writes_token_files"] is False
+    assert plan["token_write_target_paths_preview"]["writes_approval_audit"] is False
+    assert plan["token_write_target_paths_preview"]["writes_operation_ledger"] is False
+    assert case["evidence"]["token_issued"] is False
+    assert case["evidence"]["persisted_approval"] is False
+    assert case["evidence"]["approved"] is False
+    assert case["evidence"]["created_real_proposal"] is False
+    assert case["evidence"]["created_operation_event"] is False
+    assert case["evidence"]["writes_proposal_files"] is False
+    assert case["evidence"]["writes_operation_ledger"] is False
+    assert case["evidence"]["writes_token_files"] is False
+    assert case["evidence"]["writes_approval_audit"] is False
+    assert case["evidence"]["invokes_real_token_write_executor"] is False
+    assert case["evidence"]["implements_real_token_write_executor"] is False
+    assert case["evidence"]["creates_executor_source_files"] is False
+    assert case["evidence"]["creates_executor_tests"] is False

--- a/tests/benchmarks/test_hermes_memory_bench.py
+++ b/tests/benchmarks/test_hermes_memory_bench.py
@@ -1,0 +1,69 @@
+import json
+import subprocess
+import sys
+
+from benchmarks.hermes_memory_bench.core import DIMENSIONS, POLICY, run_benchmark
+
+
+REQUIRED_TOP_LEVEL_KEYS = {
+    "benchmark_type",
+    "generated_at",
+    "suite",
+    "scores",
+    "cases",
+    "aggregate",
+    "policy",
+}
+
+
+def test_smoke_benchmark_schema_and_policy():
+    report = run_benchmark("smoke")
+
+    assert REQUIRED_TOP_LEVEL_KEYS <= report.keys()
+    assert report["benchmark_type"] == "hermes_memory_bench_v0.1"
+    assert report["suite"] == "smoke"
+    assert set(DIMENSIONS) <= report["scores"].keys()
+    assert report["aggregate"]["overall_score"] == 1.0
+    assert report["aggregate"]["case_count"] >= 6
+    assert report["policy"] == POLICY
+
+    for case in report["cases"]:
+        assert {"id", "dimension", "query", "expected_answer", "actual_answer", "score", "latency_ms", "passed", "evidence"} <= case.keys()
+        assert case["dimension"] in DIMENSIONS
+
+
+def test_smoke_benchmark_cli_writes_report(tmp_path):
+    output = tmp_path / "report.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "benchmarks.hermes_memory_bench.run",
+            "--suite",
+            "smoke",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["aggregate"]["overall_score"] == 1.0
+    assert report["policy"] == POLICY
+
+
+def test_benchmark_does_not_write_graph_or_operation_ledger(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    report = run_benchmark("smoke")
+
+    assert report["policy"]["read_only"] is True
+    assert report["policy"]["would_write_memory"] is False
+    assert report["policy"]["would_modify_config"] is False
+    assert report["policy"]["would_write_graph"] is False
+    assert report["policy"]["does_not_create_operation_events"] is True
+    assert not (hermes_home / "memory" / "graph" / "memory_graph.sqlite").exists()
+    assert not (hermes_home / "memory" / "audit" / "memory_operation_ledger.jsonl").exists()
+    assert not (hermes_home / "memory" / "proposals" / "memory_write_proposals.jsonl").exists()

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -1,7 +1,60 @@
 """Regression tests for memory provider selection during AIAgent init."""
 
+import json
+import sys
+import textwrap
 from types import SimpleNamespace
 from unittest.mock import patch
+
+
+class RecordingMemoryProvider:
+    def __init__(self, name="memory-fabric", tools=None, available=True):
+        self._name = name
+        self._tools = tools or []
+        self._available = available
+        self.initialized = False
+        self.init_kwargs = {}
+
+    @property
+    def name(self):
+        return self._name
+
+    def is_available(self):
+        return self._available
+
+    def initialize(self, session_id, **kwargs):
+        self.initialized = True
+        self.init_kwargs = {"session_id": session_id, **kwargs}
+
+    def get_tool_schemas(self):
+        return list(self._tools)
+
+
+class FakeSessionDB:
+    def get_session_title(self, session_id):
+        return f"title-for-{session_id}"
+
+
+def _agent_with_memory_config(config, provider, **agent_kwargs):
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="coder"),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+            **agent_kwargs,
+        )
 
 
 def test_blank_memory_provider_does_not_auto_enable_honcho():
@@ -37,3 +90,195 @@ def test_blank_memory_provider_does_not_auto_enable_honcho():
     load_memory_provider.assert_not_called()
     save_config.assert_not_called()
 
+
+def test_provider_specific_memory_config_passed_as_runtime_config():
+    provider_config = {
+        "candidate_jsonl_path": "/tmp/candidates.jsonl",
+        "project_scope": "hermes-memory-fabric",
+        "memory_limit": 5,
+        "context_budget_chars": 4000,
+    }
+    cfg = {
+        "memory": {
+            "provider": "memory-fabric",
+            "memory_enabled": False,
+            "user_profile_enabled": False,
+            "memory-fabric": provider_config,
+        },
+        "agent": {},
+    }
+    provider = RecordingMemoryProvider("memory-fabric")
+
+    _agent_with_memory_config(
+        cfg,
+        provider,
+        session_id="session-runtime-config",
+        platform="telegram",
+        user_id="user-1",
+        chat_id="chat-1",
+        session_db=FakeSessionDB(),
+    )
+
+    assert provider.initialized is True
+    assert provider.init_kwargs["session_id"] == "session-runtime-config"
+    assert provider.init_kwargs["platform"] == "telegram"
+    assert provider.init_kwargs["agent_context"] == "primary"
+    assert provider.init_kwargs["session_title"] == "title-for-session-runtime-config"
+    assert provider.init_kwargs["user_id"] == "user-1"
+    assert provider.init_kwargs["chat_id"] == "chat-1"
+    assert provider.init_kwargs["agent_identity"] == "coder"
+    assert provider.init_kwargs["agent_workspace"] == "hermes"
+    assert provider.init_kwargs["runtime_config"] == provider_config
+    assert provider.init_kwargs["runtime_config"] is not provider_config
+
+
+def test_non_dict_provider_specific_memory_config_is_ignored():
+    cfg = {
+        "memory": {
+            "provider": "memory-fabric",
+            "memory_enabled": False,
+            "user_profile_enabled": False,
+            "memory-fabric": "not-a-dict",
+        },
+        "agent": {},
+    }
+    provider = RecordingMemoryProvider("memory-fabric")
+
+    _agent_with_memory_config(cfg, provider)
+
+    assert provider.initialized is True
+    assert "runtime_config" not in provider.init_kwargs
+
+
+def test_existing_memory_provider_init_still_receives_core_kwargs():
+    cfg = {
+        "memory": {
+            "provider": "mem0",
+            "memory_enabled": False,
+            "user_profile_enabled": False,
+        },
+        "agent": {},
+    }
+    provider = RecordingMemoryProvider("mem0")
+
+    _agent_with_memory_config(cfg, provider, platform="cli")
+
+    assert provider.initialized is True
+    assert provider.init_kwargs["platform"] == "cli"
+    assert provider.init_kwargs["agent_context"] == "primary"
+    assert provider.init_kwargs["hermes_home"]
+    assert provider.init_kwargs["runtime_config"] == {}
+
+
+def test_memory_fabric_runtime_config_smoke_prefetches_jsonl(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    plugins_dir = hermes_home / "plugins" / "memory-fabric"
+    plugins_dir.mkdir(parents=True)
+    candidate_path = tmp_path / "candidates.jsonl"
+    candidate_path.write_text(
+        json.dumps({"text": "Runtime config memory reached provider."}) + "\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        textwrap.dedent(
+            f"""
+            memory:
+              provider: memory-fabric
+              memory_enabled: false
+              user_profile_enabled: false
+              memory-fabric:
+                candidate_jsonl_path: {json.dumps(str(candidate_path))}
+                project_scope: hermes-memory-fabric
+                memory_limit: 5
+                context_budget_chars: 4000
+            agent: {{}}
+            """
+        ),
+        encoding="utf-8",
+    )
+    (plugins_dir / "__init__.py").write_text(
+        textwrap.dedent(
+            """
+            import json
+            from pathlib import Path
+
+            from agent.memory_provider import MemoryProvider
+
+
+            class MemoryFabricProvider(MemoryProvider):
+                def __init__(self):
+                    self.runtime_config = {}
+                    self.init_kwargs = {}
+
+                @property
+                def name(self):
+                    return "memory-fabric"
+
+                def is_available(self):
+                    return True
+
+                def initialize(self, session_id, **kwargs):
+                    self.session_id = session_id
+                    self.init_kwargs = dict(kwargs)
+                    self.runtime_config = dict(kwargs.get("runtime_config") or {})
+
+                def prefetch(self, query, *, session_id=""):
+                    path = self.runtime_config.get("candidate_jsonl_path")
+                    if not path:
+                        return ""
+                    rows = []
+                    for line in Path(path).read_text(encoding="utf-8").splitlines():
+                        if not line.strip():
+                            continue
+                        row = json.loads(line)
+                        text = row.get("text") or row.get("content") or row.get("context") or ""
+                        if text:
+                            rows.append(text)
+                    return "\\n".join(rows)
+
+                def get_tool_schemas(self):
+                    return []
+
+
+            def register(ctx):
+                ctx.register_memory_provider(MemoryFabricProvider())
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    for name in list(sys.modules):
+        if name.startswith("_hermes_user_memory.memory-fabric"):
+            sys.modules.pop(name, None)
+    import hermes_cli.config as config_mod
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+
+    with (
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    provider = agent._memory_manager.get_provider("memory-fabric")
+    assert provider is not None
+    assert provider.runtime_config["candidate_jsonl_path"] == str(candidate_path)
+    assert provider.runtime_config["project_scope"] == "hermes-memory-fabric"
+    assert provider.runtime_config["memory_limit"] == 5
+    assert provider.runtime_config["context_budget_chars"] == 4000
+    assert provider.get_tool_schemas() == []
+    assert agent._memory_manager.get_all_tool_schemas() == []
+    assert (
+        agent._memory_manager.prefetch_all("runtime config")
+        == "Runtime config memory reached provider."
+    )

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -935,6 +935,7 @@ class TestToolRegistration:
             "attachments_fetch", "events_poll", "events_wait",
             "messages_send", "channels_list",
             "memory_bridge_status", "memory_evolution_status",
+            "memory_orchestration_routing_metrics",
             "memory_recall_quality_evaluate",
             "memory_fabric_search", "memory_graph_read",
             "memory_write_proposal", "memory_snapshot_export",
@@ -976,6 +977,20 @@ class TestToolRegistration:
         assert result["policy"]["evaluation_is_read_only"] is True
         assert result["read_only_memory"] is True
         assert result["would_modify_config"] is False
+
+    def test_memory_orchestration_routing_metrics_is_registered_and_read_only(self, fake_mcp_server, _event_loop):
+        server, _ = fake_mcp_server
+        result = _run_tool(server, "memory_orchestration_routing_metrics")
+
+        assert result["success"] is True
+        assert result["metrics_type"] == "hermes_memory_orchestration_routing_metrics"
+        assert "routing_readiness_score" in result
+        assert "active_routing_metrics" in result
+        assert result["policy"]["metrics_are_read_only"] is True
+        assert result["policy"]["does_not_modify_openclaw_config"] is True
+        assert result["policy"]["does_not_write_memory"] is True
+        assert result["would_modify_config"] is False
+        assert result["would_write_graph"] is False
 
     def test_memory_boundary_allowlist_audit_is_registered_and_read_only(self, fake_mcp_server, _event_loop):
         server, _ = fake_mcp_server

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -983,7 +983,8 @@ class TestToolRegistration:
 
         assert result["success"] is True
         assert result["audit_type"] == "hermes_memory_boundary_allowlist_audit"
-        assert result["ready"] is True
+        assert result["ready"] is False
+        assert result["reviewed"] is False
         assert result["policy"]["audit_is_read_only"] is True
         assert result["policy"]["does_not_modify_config"] is True
         assert result["policy"]["does_not_write_memory"] is True

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -934,6 +934,16 @@ class TestToolRegistration:
             "conversations_list", "conversation_get", "messages_read",
             "attachments_fetch", "events_poll", "events_wait",
             "messages_send", "channels_list",
+            "memory_bridge_status", "memory_evolution_status",
+            "memory_recall_quality_evaluate",
+            "memory_fabric_search", "memory_graph_read",
+            "memory_write_proposal", "memory_snapshot_export",
+            "memory_federation_status", "memory_federation_audit",
+            "memory_boundary_allowlist_audit", "memory_federation_gate", "memory_operation_ledger",
+            "memory_ledger_intelligence", "memory_policy_autotune",
+            "memory_policy_proposal_create", "memory_policy_proposal_ledger",
+            "memory_policy_proposal_decision", "memory_policy_apply_plan",
+            "memory_policy_apply_execute", "memory_policy_outcome_monitor",
             "permissions_list_open", "permissions_respond",
         }
         assert expected == tool_names, f"Missing: {expected - tool_names}, Extra: {tool_names - expected}"
@@ -942,6 +952,43 @@ class TestToolRegistration:
         server, _ = mcp_server_e2e
         for tool in server._tool_manager.list_tools():
             assert tool.description, f"Tool {tool.name} has no description"
+
+    def test_memory_evolution_status_is_registered_and_read_only(self, fake_mcp_server, _event_loop):
+        server, _ = fake_mcp_server
+        result = _run_tool(server, "memory_evolution_status")
+
+        assert result["success"] is True
+        assert len(result["taxonomy"]) == 15
+        assert result["taxonomy"][5]["name"] == "星辰记忆"
+        assert result["taxonomy"][-1]["name"] == "星源记忆"
+        assert result["policy"]["status_is_read_only"] is True
+        assert result["would_mutate_memory"] is False
+
+    def test_memory_recall_quality_evaluate_is_registered_and_read_only(self, fake_mcp_server, _event_loop):
+        server, _ = fake_mcp_server
+        result = _run_tool(
+            server,
+            "memory_recall_quality_evaluate",
+            {"queries": "memory,policy", "limit": 3},
+        )
+
+        assert result["success"] is True
+        assert result["policy"]["evaluation_is_read_only"] is True
+        assert result["read_only_memory"] is True
+        assert result["would_modify_config"] is False
+
+    def test_memory_boundary_allowlist_audit_is_registered_and_read_only(self, fake_mcp_server, _event_loop):
+        server, _ = fake_mcp_server
+        result = _run_tool(server, "memory_boundary_allowlist_audit", {"log_limit": 200})
+
+        assert result["success"] is True
+        assert result["audit_type"] == "hermes_memory_boundary_allowlist_audit"
+        assert result["ready"] is True
+        assert result["policy"]["audit_is_read_only"] is True
+        assert result["policy"]["does_not_modify_config"] is True
+        assert result["policy"]["does_not_write_memory"] is True
+        assert result["policy"]["does_not_approve_allowlists"] is True
+        assert result["would_modify_config"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_memory_evidence_repair_apply_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_apply_preview_tool.py
@@ -1,0 +1,142 @@
+import json
+
+from tools.memory_evidence_repair_apply_preview_tool import (
+    memory_evidence_repair_apply_preview_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_apply_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["preview_count"] == 1
+    assert result["summary"]["missing_evidence_count"] == 1
+    assert "Memory Evidence Repair Apply Preview" in result["markdown"]
+
+
+def test_tool_accepts_explicit_candidates_and_approved_ids():
+    result = json.loads(
+        memory_evidence_repair_apply_preview_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "<pending>",
+                            "observed_at": "<pending>",
+                            "verification_signal": "<pending>",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "proposed_evidence": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["ready_count"] == 1
+    assert result["previews"][0]["status"] == "ready_for_manual_apply"
+    assert result["previews"][0]["evidence_patch"] == {
+        "source_url": "https://example.com/source",
+        "observed_at": "2026-05-11T00:00:00Z",
+        "verification_signal": "manual_verified",
+    }
+
+
+def test_tool_accepts_repairs_and_limits_previews():
+    result = json.loads(
+        memory_evidence_repair_apply_preview_tool(
+            {
+                "limit": 1,
+                "repairs": [
+                    {
+                        "provider": "builtin",
+                        "priority": "high",
+                        "action": "attach_provenance",
+                        "source": "policy_gate",
+                        "reason": "Missing provenance.",
+                    },
+                    {
+                        "provider": "graph",
+                        "priority": "medium",
+                        "action": "refresh_observation",
+                        "source": "diagnostics",
+                        "reason": "Stale recall.",
+                    },
+                ],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["preview_count"] == 1
+    assert len(result["previews"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_apply_preview_tool({"approval": "bad"}))
+
+    assert result["success"] is False
+    assert "approval must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_preview():
+    result = json.loads(memory_evidence_repair_apply_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["preview_count"] == 0
+    assert result["previews"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_apply_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_approval_candidates_tool.py
+++ b/tests/tools/test_memory_evidence_repair_approval_candidates_tool.py
@@ -1,0 +1,134 @@
+import json
+
+from tools.memory_evidence_repair_approval_candidates_tool import (
+    memory_evidence_repair_approval_candidates_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["summary"]["candidate_count"] == 1
+    assert result["summary"]["requires_user_confirmation"] is True
+    assert "Memory Evidence Repair Approval Candidates" in result["markdown"]
+
+
+def test_tool_accepts_explicit_repairs_and_limits_candidates():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool(
+            {
+                "limit": 1,
+                "repairs": [
+                    {
+                        "provider": "builtin",
+                        "priority": "high",
+                        "action": "attach_provenance",
+                        "source": "policy_gate",
+                        "reason": "Missing provenance.",
+                    },
+                    {
+                        "provider": "graph",
+                        "priority": "medium",
+                        "action": "refresh_observation",
+                        "source": "diagnostics",
+                        "reason": "Stale recall.",
+                    },
+                ],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["candidate_count"] == 1
+    assert len(result["candidates"]) == 1
+    assert result["candidates"][0]["priority"] == "high"
+
+
+def test_tool_accepts_explicit_plan_and_proposed_evidence():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool(
+            {
+                "plan": {
+                    "repairs": [
+                        {
+                            "provider": "graph",
+                            "priority": "medium",
+                            "action": "refresh_observation",
+                            "source": "diagnostics",
+                            "reason": "Recall may be stale.",
+                            "required_evidence": ["observed_at", "freshness_check"],
+                        }
+                    ]
+                },
+                "proposed_evidence": {
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "freshness_check": "confirmed_current",
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["candidate_count"] == 1
+    assert result["candidates"][0]["proposed_evidence_patch"] == {
+        "observed_at": "2026-05-11T00:00:00Z",
+        "freshness_check": "confirmed_current",
+    }
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_approval_candidates_tool({"plan": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "plan must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_candidates():
+    result = json.loads(memory_evidence_repair_approval_candidates_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["candidate_count"] == 0
+    assert result["candidates"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_approval_candidates")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_approval_token_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_approval_token_gate_tool.py
@@ -1,0 +1,197 @@
+import json
+
+from tools.memory_evidence_repair_approval_token_gate_tool import (
+    memory_evidence_repair_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_token_report_markdown():
+    token_report = _token_report()
+    confirmation_text = token_report["tokens"][0]["required_confirmation_text"]
+
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": confirmation_text,
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "verified_for_manual_commit"
+    assert result["summary"]["manual_commit_verified"] is True
+    assert result["summary"]["fail_count"] == 0
+    assert "Memory Evidence Repair Approval Token Gate" in result["markdown"]
+
+
+def test_tool_blocks_wrong_confirmation():
+    token_report = _token_report()
+
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "APPROVE not-this-token",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["summary"]["manual_commit_verified"] is False
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_generates_token_from_candidates_and_verifies():
+    token = json.loads(memory_evidence_repair_human_approval_token_tool(_candidate_args()))
+    confirmation_text = token["tokens"][0]["required_confirmation_text"]
+    args = _candidate_args()
+    args["confirmation_text"] = confirmation_text
+
+    result = json.loads(memory_evidence_repair_approval_token_gate_tool(args))
+
+    assert result["status"] == "verified_for_manual_commit"
+    assert result["summary"]["manual_commit_verified"] is True
+    assert result["verified_operation_ids"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_token_available():
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["summary"]["manual_commit_verified"] is False
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_approval_token_gate_tool({"approval_token": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "approval_token must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_approval_token_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["check_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_approval_token_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_commit_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_commit_gate_tool.py
@@ -1,0 +1,158 @@
+import json
+
+from tools.memory_evidence_repair_commit_gate_tool import (
+    memory_evidence_repair_commit_gate_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_preview():
+    return {
+        "id": "preview-123",
+        "candidate_id": "repair-123",
+        "status": "ready_for_manual_apply",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "operation": "merge_evidence_metadata",
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "target": {"candidate_id": "repair-123", "provider": "builtin"},
+            "set": {"evidence": {}},
+        },
+        "missing_evidence": [],
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["decision_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert "Memory Evidence Repair Commit Gate" in result["markdown"]
+
+
+def test_tool_accepts_explicit_preview_and_confirmation():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {
+                "preview": _ready_preview(),
+                "confirmed_preview_ids": ["preview-123"],
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["decisions"][0]["decision"] == "allow_manual_commit"
+    assert result["decisions"][0]["reasons"] == []
+
+
+def test_tool_accepts_candidates_and_builds_gate():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["decisions"][0]["decision"] == "allow_manual_commit"
+
+
+def test_tool_accepts_previews_and_limits_decisions():
+    result = json.loads(
+        memory_evidence_repair_commit_gate_tool(
+            {
+                "limit": 1,
+                "previews": [_ready_preview(), _ready_preview()],
+                "confirmed_preview_ids": ["preview-123"],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["decision_count"] == 1
+    assert len(result["decisions"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_commit_gate_tool({"preview": "bad"}))
+
+    assert result["success"] is False
+    assert "preview must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_gate():
+    result = json.loads(memory_evidence_repair_commit_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["decision_count"] == 0
+    assert result["decisions"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_commit_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_commit_ledger_tool.py
+++ b/tests/tools/test_memory_evidence_repair_commit_ledger_tool.py
@@ -1,0 +1,167 @@
+import json
+
+from tools.memory_evidence_repair_commit_ledger_tool import (
+    memory_evidence_repair_commit_ledger_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _allow_decision():
+    return {
+        "id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "decision": "allow_manual_commit",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "reasons": [],
+        "required_actions": [],
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_patch": {
+            "source_url": "https://example.com/source",
+            "observed_at": "2026-05-11T00:00:00Z",
+            "verification_signal": "manual_verified",
+        },
+        "memory_patch_preview": {
+            "operation": "merge_evidence_metadata",
+            "set": {"evidence": {}},
+        },
+        "conflict_risk": "low",
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["entry_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert "Memory Evidence Repair Commit Ledger" in result["markdown"]
+
+
+def test_tool_accepts_explicit_decisions_and_ledger_metadata():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {
+                "decisions": [_allow_decision()],
+                "ledger_actor": "tester",
+                "ledger_reason": "audit before manual memory write",
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["entries"][0]["outcome"] == "allowed_for_manual_commit"
+    assert result["entries"][0]["metadata"]["ledger_actor"] == "tester"
+    assert result["entries"][0]["metadata"]["ledger_reason"] == (
+        "audit before manual memory write"
+    )
+
+
+def test_tool_accepts_candidates_and_builds_full_pipeline():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["allow_count"] == 1
+    assert result["entries"][0]["manual_commit_allowed"] is True
+
+
+def test_tool_accepts_commit_gate_and_limits_entries():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool(
+            {
+                "limit": 1,
+                "commit_gate": {
+                    "decisions": [_allow_decision(), _allow_decision()],
+                    "read_only": True,
+                },
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["entry_count"] == 1
+    assert len(result["entries"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_commit_ledger_tool({"commit_gate": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "commit_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_ledger():
+    result = json.loads(memory_evidence_repair_commit_ledger_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["entry_count"] == 0
+    assert result["entries"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_commit_ledger")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_commit_receipt_tool.py
+++ b/tests/tools/test_memory_evidence_repair_commit_receipt_tool.py
@@ -1,0 +1,231 @@
+import json
+
+from tools.memory_evidence_repair_approval_token_gate_tool import (
+    memory_evidence_repair_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_commit_receipt_tool import (
+    memory_evidence_repair_commit_receipt_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _verified_gate():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_approval_token_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_verified_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "token_gate": _verified_gate(),
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "receipt_ready_for_manual_commit"
+    assert result["summary"]["commit_receipt_available"] is True
+    assert result["receipts"][0]["actor"] == "han"
+    assert "Memory Evidence Repair Commit Receipt" in result["markdown"]
+
+
+def test_tool_blocks_when_token_already_used():
+    gate = _verified_gate()
+
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "token_gate": gate,
+                "used_token_ids": [gate["token_id"]],
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "regenerate_human_approval_token" in result["required_actions"]
+
+
+def test_tool_generates_gate_from_token_and_creates_receipt():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "receipt_ready_for_manual_commit"
+    assert result["summary"]["would_record_receipt_count"] == 1
+    assert result["receipts"][0]["token_id"] == token_report["tokens"][0]["id"]
+
+
+def test_tool_blocks_when_generated_gate_is_not_verified():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_gate_available():
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_commit_receipt_tool({"token_gate": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "token_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_commit_receipt_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["receipt_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_commit_receipt")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_executor_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_executor_preview_tool.py
@@ -1,0 +1,234 @@
+import json
+
+from tools.memory_evidence_repair_executor_preview_tool import (
+    memory_evidence_repair_executor_preview_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.memory_evidence_repair_write_lock_gate_tool import (
+    memory_evidence_repair_write_lock_gate_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _write_lock_gate():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+            }
+        )
+    )
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_write_lock_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "write_lock_gate": _write_lock_gate(),
+                "current_time": "2026-05-11T00:12:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "executor_preview_ready_for_manual_commit"
+    assert result["summary"]["manual_executor_preview_ready"] is True
+    assert result["summary"]["future_write_step_count"] == 1
+    assert result["previews"][0]["steps"][1]["action"] == "apply_evidence_metadata_patch"
+    assert "Memory Evidence Repair Executor Preview" in result["markdown"]
+
+
+def test_tool_blocks_expired_write_lock_gate():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "write_lock_gate": _write_lock_gate(),
+                "current_time": "2026-05-11T00:26:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "regenerate_write_lock_gate" in result["required_actions"]
+
+
+def test_tool_generates_write_lock_gate_from_token_and_creates_preview():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "executor_preview_ready_for_manual_commit"
+    assert result["summary"]["executor_preview_available"] is True
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_write_lock_gate_is_not_ready():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_lock_available():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_executor_preview_tool({"write_lock_gate": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "write_lock_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_executor_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_executor_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_human_approval_token_tool.py
+++ b/tests/tools/test_memory_evidence_repair_human_approval_token_tool.py
@@ -1,0 +1,158 @@
+import json
+
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def test_tool_accepts_explicit_ready_dry_run_markdown():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 45,
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "draft_ready_for_human_approval"
+    assert result["summary"]["token_count"] == 1
+    assert result["tokens"][0]["approver"] == "han"
+    assert result["tokens"][0]["expires_in_minutes"] == 45
+    assert "Memory Evidence Repair Human Approval Token" in result["markdown"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_dry_run_blocked():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["summary"]["token_count"] == 0
+    assert result["tokens"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_accepts_candidates_and_existing_snapshots_for_token():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+                "existing_snapshots": {
+                    "source_url": "https://old.example.com/source",
+                    "observed_at": "2026-05-01T00:00:00Z",
+                    "verification_signal": "previous_manual_verified",
+                },
+                "approver": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "draft_ready_for_human_approval"
+    assert result["summary"]["human_approval_token_available"] is True
+    assert result["tokens"][0]["approver"] == "han"
+    assert result["tokens"][0]["operation_ids"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool({"dry_run": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "dry_run must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_human_approval_token_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["token_count"] == 0
+    assert result["tokens"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_human_approval_token")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_manual_commit_dry_run_tool.py
+++ b/tests/tools/test_memory_evidence_repair_manual_commit_dry_run_tool.py
@@ -1,0 +1,216 @@
+import json
+
+from tools.memory_evidence_repair_manual_commit_dry_run_tool import (
+    memory_evidence_repair_manual_commit_dry_run_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "blocked"
+    assert result["summary"]["has_blocks"] is True
+    assert "Memory Evidence Repair Manual Commit Dry-Run" in result["markdown"]
+
+
+def test_tool_accepts_candidates_and_existing_snapshots_for_ready_dry_run():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+                "existing_snapshots": {
+                    "source_url": "https://old.example.com/source",
+                    "observed_at": "2026-05-01T00:00:00Z",
+                    "verification_signal": "previous_manual_verified",
+                },
+            }
+        )
+    )
+
+    assert result["status"] == "ready_for_manual_commit"
+    assert result["summary"]["manual_commit_allowed"] is True
+    assert result["summary"]["operation_count"] == 1
+    assert result["blocking_reasons"] == []
+
+
+def test_tool_blocks_when_snapshot_plan_requires_capture():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {
+                "snapshot_plan": {
+                    "summary": {
+                        "snapshot_request_count": 1,
+                        "capture_required_count": 1,
+                        "blocking_count": 1,
+                    },
+                    "requests": [{"status": "capture_required"}],
+                },
+                "commit_gate": {
+                    "summary": {
+                        "decision_count": 1,
+                        "allow_count": 1,
+                        "blocked_count": 0,
+                        "needs_confirmation_count": 0,
+                    },
+                    "decisions": [{"decision": "allow_manual_commit"}],
+                },
+                "ledger": {
+                    "summary": {
+                        "entry_count": 1,
+                        "allow_count": 1,
+                        "blocked_count": 0,
+                        "followup_count": 0,
+                    },
+                    "entries": [
+                        {
+                            "id": "ledger-123",
+                            "manual_commit_allowed": True,
+                            "patch_digest": "a" * 64,
+                            "evidence_fields": ["source_url"],
+                        }
+                    ],
+                },
+                "rollback_plan": {
+                    "summary": {
+                        "rollback_step_count": 1,
+                        "ready_count": 1,
+                        "snapshot_required_count": 0,
+                    },
+                    "steps": [{"status": "ready_for_manual_rollback"}],
+                },
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "capture_pre_commit_snapshots" in result["required_actions"]
+
+
+def test_tool_accepts_limit_for_operations():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool(
+            {
+                "limit": 1,
+                "snapshot_plan": {
+                    "summary": {
+                        "snapshot_request_count": 1,
+                        "capture_required_count": 0,
+                        "blocking_count": 0,
+                    },
+                    "requests": [{"status": "already_available"}],
+                },
+                "commit_gate": {
+                    "summary": {
+                        "decision_count": 1,
+                        "allow_count": 1,
+                        "blocked_count": 0,
+                        "needs_confirmation_count": 0,
+                    },
+                    "decisions": [{"decision": "allow_manual_commit"}],
+                },
+                "ledger": {
+                    "summary": {
+                        "entry_count": 2,
+                        "allow_count": 2,
+                        "blocked_count": 0,
+                        "followup_count": 0,
+                    },
+                    "entries": [
+                        {"id": "ledger-1", "manual_commit_allowed": True},
+                        {"id": "ledger-2", "manual_commit_allowed": True},
+                    ],
+                },
+                "rollback_plan": {
+                    "summary": {
+                        "rollback_step_count": 1,
+                        "ready_count": 1,
+                        "snapshot_required_count": 0,
+                    },
+                    "steps": [{"status": "ready_for_manual_rollback"}],
+                },
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["operation_count"] == 1
+    assert len(result["operations"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_manual_commit_dry_run_tool({"snapshot_plan": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "snapshot_plan must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_manual_commit_dry_run_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["operation_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_manual_commit_dry_run")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_planner_tool.py
+++ b/tests/tools/test_memory_evidence_repair_planner_tool.py
@@ -1,0 +1,103 @@
+import json
+
+from tools.memory_evidence_repair_planner_tool import (
+    memory_evidence_repair_planner_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_planner_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["summary"]["repair_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert "Memory Evidence Repair Planner" in result["markdown"]
+
+
+def test_tool_accepts_explicit_payloads_and_limits_repairs():
+    result = json.loads(
+        memory_evidence_repair_planner_tool(
+            {
+                "limit": 1,
+                "gate": {
+                    "provider_results": [
+                        {
+                            "provider": "builtin",
+                            "action": "require_provenance_before_reuse",
+                            "effect": "filtered",
+                            "reason": "Missing provenance.",
+                        }
+                    ]
+                },
+                "diagnostics": {
+                    "issues": [
+                        {
+                            "provider": "graph",
+                            "code": "refresh_stale_recall",
+                            "reason": "Recall may be stale.",
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert len(result["repairs"]) == 1
+    assert result["repairs"][0]["priority"] == "high"
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_planner_tool({"gate": "bad"}))
+
+    assert result["success"] is False
+    assert "gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_plan():
+    result = json.loads(memory_evidence_repair_planner_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["repair_count"] == 0
+    assert result["repairs"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_planner")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_post_commit_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_post_commit_audit_preview_tool.py
@@ -1,0 +1,231 @@
+import json
+
+from tools.memory_evidence_repair_executor_preview_tool import (
+    memory_evidence_repair_executor_preview_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.memory_evidence_repair_post_commit_audit_preview_tool import (
+    memory_evidence_repair_post_commit_audit_preview_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _executor_preview():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_executor_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_executor_preview_markdown():
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": _executor_preview(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "post_commit_audit_preview_ready"
+    assert result["summary"]["planned_audit_step_count"] == 5
+    assert "Memory Evidence Repair Post-Commit Audit Preview" in result["markdown"]
+
+
+def test_tool_accepts_observed_state_and_passes():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": executor,
+                "observed_memory_patches": {
+                    "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+                },
+                "recorded_receipts": [{"id": preview["receipt_id"]}],
+                "used_token_ids": [preview["token_id"]],
+                "released_lock_ids": [preview["lock_id"]],
+                "rollback_status": {"status": "snapshot_available"},
+            }
+        )
+    )
+
+    assert result["status"] == "post_commit_audit_preview_ready"
+    assert result["summary"]["observed_pass_step_count"] == 5
+    assert result["summary"]["observed_fail_step_count"] == 0
+
+
+def test_tool_blocks_bad_observed_patch_digest():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": executor,
+                "observed_memory_patches": {
+                    "dryrun-op-123": {"applied": True, "patch_digest": "b" * 64}
+                },
+                "recorded_receipts": [{"id": preview["receipt_id"]}],
+                "used_token_ids": [preview["token_id"]],
+                "released_lock_ids": [preview["lock_id"]],
+                "rollback_status": {"status": "snapshot_available"},
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "investigate_post_commit_audit_failures" in result["required_actions"]
+
+
+def test_tool_generates_executor_preview_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "post_commit_audit_preview_ready"
+    assert result["summary"]["post_commit_audit_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_executor_preview_is_not_ready():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_executor_available():
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {"executor_preview": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "executor_preview must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_post_commit_audit_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_post_commit_audit_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_approval_token_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_approval_token_gate_tool.py
@@ -1,0 +1,162 @@
+import json
+
+from tools.memory_evidence_repair_recovery_approval_token_gate_tool import (
+    memory_evidence_repair_recovery_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_human_approval_token_tool import (
+    memory_evidence_repair_recovery_human_approval_token_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_human_approval_token_tool import (
+    _manual_rollback_execution,
+    _preparedness_execution,
+)
+
+
+def _recovery_token_report():
+    payload = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_execution": _manual_rollback_execution(),
+                "approver": "han",
+                "approval_reason": "manual recovery approval",
+                "expires_in_minutes": 20,
+            }
+        )
+    )
+    payload["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return payload
+
+
+def test_tool_accepts_explicit_recovery_token_markdown():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "verified_for_manual_recovery"
+    assert result["summary"]["manual_recovery_verified"] is True
+    assert "Memory Evidence Repair Recovery Approval Token Gate" in result["markdown"]
+
+
+def test_tool_blocks_wrong_confirmation():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_blocks_used_token():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "used_token_ids": [token["id"]],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "regenerate_recovery_human_approval_token" in result["required_actions"]
+
+
+def test_tool_returns_no_action_for_non_mutating_recovery_token_report():
+    token_report = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {"recovery_execution": _preparedness_execution()}
+        )
+    )
+
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {"recovery_approval_token": token_report}
+        )
+    )
+
+    assert result["status"] == "no_action_needed"
+    assert result["checks"] == []
+
+
+def test_tool_blocks_when_generated_token_is_not_confirmed():
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_execution": _manual_rollback_execution(),
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_token_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {"recovery_approval_token": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_approval_token must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_approval_token_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["check_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_approval_token_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
@@ -1,0 +1,180 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool import (
+    memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    _ready_governance_seal,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_seal_audit():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"recovery_closure_governance_seal": _ready_governance_seal()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_seal_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {
+                "recovery_closure_governance_seal_audit": _ready_seal_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_finalization_readiness_preview_ready"
+    assert result["summary"]["recovery_closure_finalization_ready"] is True
+    assert result["readiness"][0]["seal_audit_preview_id"].startswith(
+        "recovery-closure-governance-seal-audit-"
+    )
+    assert (
+        "Memory Evidence Repair Recovery Closure Finalization Readiness Preview"
+        in result["markdown"]
+    )
+
+
+def test_tool_accepts_explicit_single_seal_audit_preview():
+    seal_audit = _ready_seal_audit()["previews"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {"seal_audit": seal_audit}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_finalization_readiness_preview_ready"
+    assert result["readiness"][0]["seal_audit_preview_id"] == seal_audit["id"]
+    assert result["readiness"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_full_chain_from_token_and_creates_finalization_readiness():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_finalization_readiness_preview_ready"
+    assert result["summary"]["readiness_count"] == 1
+    assert result["readiness"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["readiness"][0]["would_allow_final_closure"] is True
+
+
+def test_tool_blocks_when_generated_seal_audit_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["readiness"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["readiness"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {"recovery_closure_governance_seal_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert (
+        "recovery_closure_governance_seal_audit must be an object"
+        in result["error"]
+    )
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+            {}
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["readiness_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry(
+        "memory_evidence_repair_recovery_closure_finalization_readiness_preview"
+    )
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_gate_tool.py
@@ -1,0 +1,178 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_gate_tool import (
+    memory_evidence_repair_recovery_closure_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    memory_evidence_repair_recovery_completion_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+    _recovery_completion_receipt,
+)
+
+
+def _passing_completion_audit():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+    return json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": receipt,
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_passing_completion_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {
+                "recovery_completion_audit": _passing_completion_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_ready"
+    assert result["summary"]["recovery_closure_ready"] is True
+    assert result["closures"][0]["closure_decision"] == "close_recovery_loop"
+    assert "Memory Evidence Repair Recovery Closure Gate" in result["markdown"]
+
+
+def test_tool_blocks_planned_completion_audit_without_observed_state():
+    receipt = _recovery_completion_receipt()
+    planned = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {"recovery_completion_receipt": receipt}
+        )
+    )
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"recovery_completion_audit": planned}
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["closures"] == []
+    assert "provide_observed_recovery_completion_state" in result["required_actions"]
+
+
+def test_tool_generates_completion_audit_from_token_and_creates_closure():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ready"
+    assert result["summary"]["recovery_closure_available"] is True
+    assert result["closures"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_completion_audit_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["closures"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["closures"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"recovery_completion_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_completion_audit must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_closure_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["closure_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_closure_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
@@ -1,0 +1,174 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    _ready_ledger_audit,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_governance_seal():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"recovery_closure_ledger_audit": _ready_ledger_audit()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_governance_seal_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {
+                "recovery_closure_governance_seal": _ready_governance_seal(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_governance_seal_audit_preview_ready"
+    assert result["summary"]["recovery_closure_governance_seal_audit_ready"] is True
+    assert result["previews"][0]["seal_id"].startswith(
+        "recovery-closure-governance-seal-"
+    )
+    assert "Memory Evidence Repair Recovery Closure Governance Seal Audit Preview" in result[
+        "markdown"
+    ]
+
+
+def test_tool_accepts_explicit_single_seal():
+    seal = _ready_governance_seal()["seals"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"seal": seal}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_audit_preview_ready"
+    assert result["previews"][0]["seal_id"] == seal["id"]
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_full_chain_from_token_and_creates_seal_audit():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_audit_preview_ready"
+    assert result["summary"]["preview_count"] == 1
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["previews"][0]["would_verify_governance_handoff"] is True
+
+
+def test_tool_blocks_when_generated_governance_seal_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+            {"recovery_closure_governance_seal": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_governance_seal must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry(
+        "memory_evidence_repair_recovery_closure_governance_seal_audit_preview"
+    )
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
@@ -1,0 +1,174 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    _ready_ledger_preview,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_ledger_audit():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"recovery_closure_ledger": _ready_ledger_preview()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_ledger_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {
+                "recovery_closure_ledger_audit": _ready_ledger_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_governance_seal_preview_ready"
+    assert result["summary"]["recovery_closure_governance_seal_ready"] is True
+    assert result["seals"][0]["seal_type"] == (
+        "memory_evidence_repair_recovery_closure_governance_seal"
+    )
+    assert "Memory Evidence Repair Recovery Closure Governance Seal Preview" in result[
+        "markdown"
+    ]
+
+
+def test_tool_accepts_explicit_ledger_audit_preview():
+    preview = _ready_ledger_audit()["previews"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"ledger_audit_preview": preview}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_preview_ready"
+    assert result["seals"][0]["ledger_audit_preview_id"] == preview["id"]
+    assert result["seals"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_full_chain_from_token_and_creates_governance_seal():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_governance_seal_preview_ready"
+    assert result["summary"]["seal_count"] == 1
+    assert result["seals"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["seals"][0]["would_enable_governed_handoff"] is True
+
+
+def test_tool_blocks_when_generated_ledger_audit_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["seals"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_seal_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["seals"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+            {"recovery_closure_ledger_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_ledger_audit must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_governance_seal_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["seal_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry(
+        "memory_evidence_repair_recovery_closure_governance_seal_preview"
+    )
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
@@ -1,0 +1,172 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    _ready_closure_gate,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_ledger_preview():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"recovery_closure_gate": _ready_closure_gate()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_closure_ledger_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {
+                "recovery_closure_ledger": _ready_ledger_preview(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_ledger_audit_preview_ready"
+    assert result["summary"]["recovery_closure_ledger_audit_ready"] is True
+    assert result["previews"][0]["ledger_entry_id"].startswith(
+        "recovery-closure-ledger-"
+    )
+    assert "Memory Evidence Repair Recovery Closure Ledger Audit Preview" in result[
+        "markdown"
+    ]
+
+
+def test_tool_accepts_explicit_recovery_closure_ledger_entry():
+    entry = _ready_ledger_preview()["entries"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"recovery_closure_ledger_entry": entry}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_audit_preview_ready"
+    assert result["previews"][0]["ledger_entry_id"] == entry["id"]
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_ledger_chain_from_token_and_creates_audit_preview():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_audit_preview_ready"
+    assert result["summary"]["preview_count"] == 1
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["previews"][0]["would_verify_lifecycle_milestones"] is True
+
+
+def test_tool_blocks_when_generated_ledger_preview_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_ledger_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+            {"recovery_closure_ledger": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_ledger must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_audit_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_closure_ledger_audit_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_closure_ledger_preview_tool.py
@@ -1,0 +1,168 @@
+import json
+
+from tools.memory_evidence_repair_recovery_closure_gate_tool import (
+    memory_evidence_repair_recovery_closure_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    memory_evidence_repair_recovery_closure_ledger_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_closure_gate_tool import (
+    _passing_completion_audit,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    _observed_recovery_steps,
+)
+
+
+def _ready_closure_gate():
+    return json.loads(
+        memory_evidence_repair_recovery_closure_gate_tool(
+            {"recovery_completion_audit": _passing_completion_audit()}
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_closure_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {
+                "recovery_closure_gate": _ready_closure_gate(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_closure_ledger_preview_ready"
+    assert result["summary"]["recovery_closure_ledger_ready"] is True
+    assert result["entries"][0]["entry_type"] == (
+        "memory_evidence_repair_recovery_closure_ledger_entry"
+    )
+    assert "Memory Evidence Repair Recovery Closure Ledger Preview" in result["markdown"]
+
+
+def test_tool_accepts_explicit_recovery_closure_draft():
+    closure = _ready_closure_gate()["closures"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"recovery_closure": closure}
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_preview_ready"
+    assert result["entries"][0]["closure_id"] == closure["id"]
+    assert result["entries"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_generates_closure_chain_from_token_and_creates_ledger_entry():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    receipt = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_closure_ledger_preview_ready"
+    assert result["summary"]["entry_count"] == 1
+    assert result["entries"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert result["entries"][0]["would_record_ledger_entry"] is True
+
+
+def test_tool_blocks_when_generated_closure_gate_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["entries"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_closure_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["entries"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_closure_ledger_preview_tool(
+            {"recovery_closure_gate": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_closure_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_closure_ledger_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["entry_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_closure_ledger_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_completion_audit_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_completion_audit_preview_tool.py
@@ -1,0 +1,182 @@
+import json
+
+from tools.memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    memory_evidence_repair_recovery_completion_audit_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_completion_receipt_tool import (
+    _recovery_executor_preview,
+)
+
+
+def _recovery_completion_receipt():
+    return json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": _recovery_executor_preview(),
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+            }
+        )
+    )
+
+
+def _observed_recovery_steps(receipt):
+    return {
+        step_id: {"status": "completed"}
+        for step_id in receipt["receipts"][0]["recovery_step_ids"]
+    }
+
+
+def test_tool_accepts_explicit_recovery_completion_receipt_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": _recovery_completion_receipt(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_completion_audit_preview_ready"
+    assert result["summary"]["planned_audit_step_count"] == 12
+    assert "Memory Evidence Repair Recovery Completion Audit Preview" in result["markdown"]
+
+
+def test_tool_accepts_observed_recovery_completion_state_and_passes():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": receipt,
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": False},
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_completion_audit_preview_ready"
+    assert result["summary"]["observed_pass_step_count"] == 12
+    assert result["summary"]["observed_fail_step_count"] == 0
+
+
+def test_tool_blocks_bad_observed_contamination_status():
+    receipt = _recovery_completion_receipt()
+    row = receipt["receipts"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_completion_receipt": receipt,
+                "observed_recovery_steps": _observed_recovery_steps(receipt),
+                "recorded_receipts": [{"id": row["id"]}],
+                "used_token_ids": [row["token_id"]],
+                "released_lock_ids": [row["lock_id"]],
+                "post_recovery_audit_status": {"status": "pass"},
+                "contamination_status": {"contaminated": True},
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "investigate_recovery_completion_audit_failures" in result["required_actions"]
+
+
+def test_tool_generates_recovery_completion_receipt_from_token():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_completion_audit_preview_ready"
+    assert result["summary"]["recovery_completion_audit_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_recovery_completion_receipt_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_receipt_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool(
+            {"recovery_completion_receipt": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_completion_receipt must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_audit_preview_tool({})
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_completion_audit_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_completion_receipt_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_completion_receipt_tool.py
@@ -1,0 +1,167 @@
+import json
+
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.memory_evidence_repair_recovery_executor_preview_tool import (
+    memory_evidence_repair_recovery_executor_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_executor_preview_tool import (
+    _recovery_write_lock_gate,
+)
+
+
+def _recovery_executor_preview():
+    return json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_write_lock_gate": _recovery_write_lock_gate(),
+                "current_time": "2026-05-11T00:12:00+00:00",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_executor_preview_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": _recovery_executor_preview(),
+                "actor": "han",
+                "recovery_reason": "manual post-audit recovery complete",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_completion_receipt_ready"
+    assert result["summary"]["recovery_completion_receipt_available"] is True
+    assert result["receipts"][0]["actor"] == "han"
+    assert result["receipts"][0]["operation_ids"] == ["dryrun-op-123"]
+    assert "Memory Evidence Repair Recovery Completion Receipt" in result["markdown"]
+
+
+def test_tool_blocks_when_recovery_token_already_used():
+    executor_preview = _recovery_executor_preview()
+    token_id = executor_preview["previews"][0]["token_id"]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": executor_preview,
+                "used_token_ids": [token_id],
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "regenerate_recovery_human_approval_token" in result["required_actions"]
+
+
+def test_tool_blocks_when_recovery_lock_already_released():
+    executor_preview = _recovery_executor_preview()
+    lock_id = executor_preview["previews"][0]["lock_id"]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_executor_preview": executor_preview,
+                "released_lock_ids": [lock_id],
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "regenerate_recovery_write_lock_gate" in result["required_actions"]
+
+
+def test_tool_generates_recovery_executor_preview_from_token_and_creates_receipt():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_completion_receipt_ready"
+    assert result["summary"]["would_record_receipt_count"] == 1
+    assert result["receipts"][0]["token_id"] == token["id"]
+
+
+def test_tool_blocks_when_generated_recovery_executor_preview_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_executor_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["receipts"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_completion_receipt_tool(
+            {"recovery_executor_preview": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_executor_preview must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_completion_receipt_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["receipt_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_completion_receipt")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_decision_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_decision_gate_tool.py
@@ -1,0 +1,145 @@
+import json
+
+from tools.memory_evidence_repair_recovery_decision_gate_tool import (
+    memory_evidence_repair_recovery_decision_gate_tool,
+)
+from tools.memory_evidence_repair_rollback_drill_preview_tool import (
+    memory_evidence_repair_rollback_drill_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _executor_preview,
+    _token_report,
+)
+from tests.tools.test_memory_evidence_repair_rollback_drill_preview_tool import (
+    _failed_post_commit_audit,
+)
+
+
+def _preparedness_drill():
+    return json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "executor_preview": _executor_preview(),
+            }
+        )
+    )
+
+
+def _failure_drill():
+    return json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "post_commit_audit": _failed_post_commit_audit(),
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_rollback_drill_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "rollback_drill": _preparedness_drill(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_decision_gate_ready"
+    assert result["decisions"][0]["route"] == "preparedness_review_only"
+    assert "Memory Evidence Repair Recovery Decision Gate" in result["markdown"]
+
+
+def test_tool_accepts_failed_drill_and_requires_manual_rollback():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "rollback_drill": _failure_drill(),
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_decision_gate_ready"
+    assert result["summary"]["manual_rollback_required_count"] == 1
+    assert result["decisions"][0]["route"] == "manual_rollback_required"
+
+
+def test_tool_generates_rollback_drill_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_decision_gate_ready"
+    assert result["summary"]["recovery_decision_available"] is True
+
+
+def test_tool_blocks_when_generated_drill_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["decisions"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_drill_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["decisions"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {"rollback_drill": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "rollback_drill must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_decision_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["decision_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_decision_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_execution_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_execution_preview_tool.py
@@ -1,0 +1,146 @@
+import json
+
+from tools.memory_evidence_repair_recovery_decision_gate_tool import (
+    memory_evidence_repair_recovery_decision_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_execution_preview_tool import (
+    memory_evidence_repair_recovery_execution_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _executor_preview,
+    _token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_decision_gate_tool import (
+    _failure_drill,
+)
+
+
+def _preparedness_decision():
+    return json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "executor_preview": _executor_preview(),
+            }
+        )
+    )
+
+
+def _manual_rollback_decision():
+    return json.loads(
+        memory_evidence_repair_recovery_decision_gate_tool(
+            {
+                "rollback_drill": _failure_drill(),
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_decision_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _preparedness_decision(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_execution_preview_ready"
+    assert result["previews"][0]["route"] == "preparedness_review_only"
+    assert "Memory Evidence Repair Recovery Execution Preview" in result["markdown"]
+
+
+def test_tool_accepts_manual_rollback_decision():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _manual_rollback_decision(),
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_execution_preview_ready"
+    assert result["summary"]["manual_rollback_preview_count"] == 1
+    assert result["summary"]["future_mutation_step_count"] == 1
+    assert result["previews"][0]["future_would_mutate_memory"] is True
+
+
+def test_tool_generates_recovery_decision_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_execution_preview_ready"
+    assert result["summary"]["recovery_execution_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_decision_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_decision_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {"recovery_decision": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_decision must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_execution_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_execution_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_executor_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_executor_preview_tool.py
@@ -1,0 +1,165 @@
+import json
+
+from tools.memory_evidence_repair_recovery_executor_preview_tool import (
+    memory_evidence_repair_recovery_executor_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_write_lock_gate_tool import (
+    memory_evidence_repair_recovery_write_lock_gate_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_human_approval_token_tool import (
+    _preparedness_execution,
+)
+
+
+def _recovery_write_lock_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    return json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_write_lock_gate_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_write_lock_gate": _recovery_write_lock_gate(),
+                "current_time": "2026-05-11T00:12:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_executor_preview_ready_for_manual_recovery"
+    assert result["summary"]["manual_recovery_executor_preview_ready"] is True
+    assert result["summary"]["future_mutation_step_count"] == 1
+    assert result["previews"][0]["steps"][0]["action"] == (
+        "verify_recovery_write_lock_token_and_execution"
+    )
+    assert "Memory Evidence Repair Recovery Executor Preview" in result["markdown"]
+
+
+def test_tool_blocks_expired_recovery_write_lock_gate():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_write_lock_gate": _recovery_write_lock_gate(),
+                "current_time": "2026-05-11T00:26:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "regenerate_recovery_write_lock_gate" in result["required_actions"]
+
+
+def test_tool_generates_recovery_write_lock_gate_from_token_and_creates_preview():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "recovery_executor_preview_ready_for_manual_recovery"
+    assert result["summary"]["recovery_executor_preview_available"] is True
+    assert result["previews"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_recovery_write_lock_gate_is_not_ready():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_lock_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_returns_no_action_for_non_mutating_recovery_path():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {
+                "recovery_execution": _preparedness_execution(),
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["previews"] == []
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_executor_preview_tool(
+            {"recovery_write_lock_gate": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_write_lock_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_executor_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_executor_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_human_approval_token_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_human_approval_token_tool.py
@@ -1,0 +1,147 @@
+import json
+
+from tools.memory_evidence_repair_recovery_execution_preview_tool import (
+    memory_evidence_repair_recovery_execution_preview_tool,
+)
+from tools.memory_evidence_repair_recovery_human_approval_token_tool import (
+    memory_evidence_repair_recovery_human_approval_token_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_execution_preview_tool import (
+    _manual_rollback_decision,
+    _preparedness_decision,
+)
+
+
+def _manual_rollback_execution():
+    return json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _manual_rollback_decision(),
+            }
+        )
+    )
+
+
+def _preparedness_execution():
+    return json.loads(
+        memory_evidence_repair_recovery_execution_preview_tool(
+            {
+                "recovery_decision": _preparedness_decision(),
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_execution_markdown():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_execution": _manual_rollback_execution(),
+                "approver": "han",
+                "approval_reason": "manual recovery approval",
+                "expires_in_minutes": 20,
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "draft_ready_for_recovery_human_approval"
+    assert result["summary"]["token_count"] == 1
+    assert result["tokens"][0]["approver"] == "han"
+    assert result["tokens"][0]["expires_in_minutes"] == 20
+    assert "Memory Evidence Repair Recovery Human Approval Token" in result["markdown"]
+
+
+def test_tool_returns_no_action_for_non_mutating_preparedness_execution():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_execution": _preparedness_execution(),
+            }
+        )
+    )
+
+    assert result["status"] == "no_action_needed"
+    assert result["tokens"] == []
+
+
+def test_tool_generates_recovery_execution_from_failed_audit_path():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "recovery_decision": _manual_rollback_decision(),
+                "approver": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "draft_ready_for_recovery_human_approval"
+    assert result["summary"]["recovery_human_approval_token_available"] is True
+    assert result["tokens"][0]["operation_ids"] == ["dryrun-op-123"]
+
+
+def test_tool_blocks_when_generated_execution_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["tokens"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_execution_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["tokens"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_human_approval_token_tool(
+            {"recovery_execution": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_execution must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_human_approval_token_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["token_count"] == 0
+    assert result["tokens"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_human_approval_token")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_recovery_write_lock_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_recovery_write_lock_gate_tool.py
@@ -1,0 +1,175 @@
+import json
+
+from tools.memory_evidence_repair_recovery_approval_token_gate_tool import (
+    memory_evidence_repair_recovery_approval_token_gate_tool,
+)
+from tools.memory_evidence_repair_recovery_write_lock_gate_tool import (
+    memory_evidence_repair_recovery_write_lock_gate_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+)
+from tests.tools.test_memory_evidence_repair_recovery_approval_token_gate_tool import (
+    _recovery_token_report,
+)
+from tests.tools.test_memory_evidence_repair_recovery_human_approval_token_tool import (
+    _preparedness_execution,
+)
+
+
+def _verified_recovery_token_gate():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+    return json.loads(
+        memory_evidence_repair_recovery_approval_token_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_recovery_token_gate_markdown():
+    token_gate = _verified_recovery_token_gate()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_token_gate": token_gate,
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "recovery_write_lock_ready_for_manual_recovery"
+    assert result["summary"]["recovery_executor_preview_allowed"] is True
+    assert result["locks"][0]["owner"] == "han"
+    assert result["locks"][0]["expires_at"] == "2026-05-11T00:25:00+00:00"
+    assert "Memory Evidence Repair Recovery Write Lock Gate" in result["markdown"]
+
+
+def test_tool_blocks_on_active_recovery_lock_conflict():
+    token_gate = _verified_recovery_token_gate()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_token_gate": token_gate,
+                "active_locks": [
+                    {
+                        "id": "recovery-lock-active",
+                        "status": "active",
+                        "scope": "manual_memory_evidence_repair_recovery",
+                        "operation_ids": ["dryrun-op-123"],
+                        "expires_at": "2026-05-11T00:20:00+00:00",
+                    }
+                ],
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["summary"]["active_lock_conflict_count"] == 1
+    assert result["active_lock_conflicts"][0]["reason"] == "overlapping_operation_ids"
+
+
+def test_tool_generates_token_gate_from_recovery_approval_token():
+    token_report = _recovery_token_report()
+    token = token_report["tokens"][0]
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": token["required_confirmation_text"],
+                "lock_owner": "han",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "recovery_write_lock_ready_for_manual_recovery"
+    assert result["summary"]["recovery_write_lock_available"] is True
+    assert result["locks"][0]["token_id"] == token["id"]
+
+
+def test_tool_blocks_when_generated_token_gate_is_not_verified():
+    token_report = _recovery_token_report()
+
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "provide_exact_recovery_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_token_gate_available():
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["blocking_reasons"]
+
+
+def test_tool_returns_no_action_for_non_mutating_recovery_path():
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {
+                "recovery_execution": _preparedness_execution(),
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["locks"] == []
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_recovery_write_lock_gate_tool(
+            {"recovery_token_gate": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "recovery_token_gate must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_recovery_write_lock_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["lock_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_recovery_write_lock_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_rollback_drill_preview_tool.py
+++ b/tests/tools/test_memory_evidence_repair_rollback_drill_preview_tool.py
@@ -1,0 +1,158 @@
+import json
+
+from tools.memory_evidence_repair_post_commit_audit_preview_tool import (
+    memory_evidence_repair_post_commit_audit_preview_tool,
+)
+from tools.memory_evidence_repair_rollback_drill_preview_tool import (
+    memory_evidence_repair_rollback_drill_preview_tool,
+)
+from tools.registry import registry
+from tests.tools.test_memory_evidence_repair_post_commit_audit_preview_tool import (
+    FakeMemoryManager,
+    _executor_preview,
+    _token_report,
+)
+
+
+def _planned_post_commit_audit():
+    return json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {"executor_preview": _executor_preview()}
+        )
+    )
+
+
+def _failed_post_commit_audit():
+    executor = _executor_preview()
+    preview = executor["previews"][0]
+    return json.loads(
+        memory_evidence_repair_post_commit_audit_preview_tool(
+            {
+                "executor_preview": executor,
+                "observed_memory_patches": {
+                    "dryrun-op-123": {"applied": True, "patch_digest": "a" * 64}
+                },
+                "recorded_receipts": [{"id": preview["receipt_id"]}],
+                "used_token_ids": [],
+                "released_lock_ids": [preview["lock_id"]],
+                "rollback_status": {"status": "snapshot_available"},
+            }
+        )
+    )
+
+
+def test_tool_accepts_explicit_post_commit_audit_markdown():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "post_commit_audit": _planned_post_commit_audit(),
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "rollback_drill_preview_ready"
+    assert result["previews"][0]["trigger"] == "post_commit_audit_preparedness"
+    assert "Memory Evidence Repair Rollback Drill Preview" in result["markdown"]
+
+
+def test_tool_accepts_failed_audit_and_creates_failure_drill():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "post_commit_audit": _failed_post_commit_audit(),
+                "rollback_plan": {
+                    "steps": [
+                        {
+                            "operation_id": "dryrun-op-123",
+                            "patch_digest": "a" * 64,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    assert result["status"] == "rollback_drill_preview_ready"
+    assert result["summary"]["failed_audit_step_count"] >= 1
+    assert result["summary"]["future_restore_step_count"] == 1
+    assert result["previews"][0]["trigger"] == "post_commit_audit_failure"
+
+
+def test_tool_generates_post_commit_audit_from_token():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "rollback_drill_preview_ready"
+    assert result["summary"]["rollback_drill_preview_available"] is True
+
+
+def test_tool_blocks_when_generated_post_commit_audit_is_not_usable():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_audit_available():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["previews"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_rollback_drill_preview_tool(
+            {"post_commit_audit": "bad"}
+        )
+    )
+
+    assert result["success"] is False
+    assert "post_commit_audit must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_rollback_drill_preview_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["preview_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_rollback_drill_preview")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_rollback_plan_tool.py
+++ b/tests/tools/test_memory_evidence_repair_rollback_plan_tool.py
@@ -1,0 +1,164 @@
+import json
+
+from tools.memory_evidence_repair_rollback_plan_tool import (
+    memory_evidence_repair_rollback_plan_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _allowed_entry():
+    return {
+        "id": "ledger-123",
+        "sequence": 1,
+        "outcome": "allowed_for_manual_commit",
+        "decision_id": "gate-preview-123",
+        "preview_id": "preview-123",
+        "candidate_id": "repair-123",
+        "provider": "builtin",
+        "priority": "high",
+        "repair_action": "attach_provenance",
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+        "patch_digest": "a" * 64,
+        "manual_commit_allowed": True,
+        "blocked": False,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["rollback_step_count"] == 1
+    assert result["summary"]["no_action_count"] == 1
+    assert "Memory Evidence Repair Rollback Plan" in result["markdown"]
+
+
+def test_tool_accepts_explicit_entries_and_snapshots():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {
+                "entries": [_allowed_entry()],
+                "pre_commit_snapshots": {
+                    "ledger-123": {
+                        "evidence": {
+                            "source_url": "https://old.example.com/source",
+                            "observed_at": "2026-05-01T00:00:00Z",
+                            "verification_signal": "previous_manual_verified",
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["ready_count"] == 1
+    assert result["steps"][0]["status"] == "ready_for_manual_rollback"
+    assert result["steps"][0]["inverse_patch_preview"]["set"]["evidence"] == {
+        "source_url": "https://old.example.com/source",
+        "observed_at": "2026-05-01T00:00:00Z",
+        "verification_signal": "previous_manual_verified",
+    }
+
+
+def test_tool_accepts_candidates_and_builds_full_pipeline():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["snapshot_required_count"] == 1
+    assert result["steps"][0]["status"] == "snapshot_required"
+
+
+def test_tool_accepts_ledger_and_limits_steps():
+    result = json.loads(
+        memory_evidence_repair_rollback_plan_tool(
+            {
+                "limit": 1,
+                "ledger": {"entries": [_allowed_entry(), _allowed_entry()]},
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["rollback_step_count"] == 1
+    assert len(result["steps"]) == 1
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(memory_evidence_repair_rollback_plan_tool({"ledger": "bad"}))
+
+    assert result["success"] is False
+    assert "ledger must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_plan():
+    result = json.loads(memory_evidence_repair_rollback_plan_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["rollback_step_count"] == 0
+    assert result["steps"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_rollback_plan")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_snapshot_planner_tool.py
+++ b/tests/tools/test_memory_evidence_repair_snapshot_planner_tool.py
@@ -1,0 +1,168 @@
+import json
+
+from tools.memory_evidence_repair_snapshot_planner_tool import (
+    memory_evidence_repair_snapshot_planner_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _snapshot_required_step():
+    return {
+        "id": "rollback-123",
+        "ledger_entry_id": "ledger-123",
+        "sequence": 1,
+        "status": "snapshot_required",
+        "rollback_action": "restore_evidence_metadata",
+        "provider": "builtin",
+        "repair_action": "attach_provenance",
+        "candidate_id": "repair-123",
+        "preview_id": "preview-123",
+        "patch_digest": "a" * 64,
+        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+        "evidence_fields": ["source_url", "observed_at", "verification_signal"],
+    }
+
+
+def test_tool_uses_latest_manager_state_read_only_markdown():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["summary"]["snapshot_request_count"] == 1
+    assert result["summary"]["no_action_count"] == 1
+    assert "Memory Evidence Repair Snapshot Planner" in result["markdown"]
+
+
+def test_tool_accepts_explicit_steps_and_limits_requests():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {
+                "limit": 1,
+                "steps": [_snapshot_required_step(), _snapshot_required_step()],
+            }
+        )
+    )
+
+    assert result["limited_to"] == 1
+    assert result["summary"]["snapshot_request_count"] == 1
+    assert result["requests"][0]["status"] == "capture_required"
+    assert result["requests"][0]["blocks_manual_commit"] is True
+
+
+def test_tool_accepts_entries_and_existing_snapshots():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {
+                "entries": [
+                    {
+                        "id": "ledger-123",
+                        "outcome": "allowed_for_manual_commit",
+                        "manual_commit_allowed": True,
+                        "provider": "builtin",
+                        "repair_action": "attach_provenance",
+                        "candidate_id": "repair-123",
+                        "preview_id": "preview-123",
+                        "patch_digest": "a" * 64,
+                        "target": {"candidate_id": "repair-123", "provider": "builtin"},
+                        "evidence_fields": ["source_url"],
+                    }
+                ],
+                "existing_snapshots": {
+                    "ledger-123": {"evidence": {"source_url": "https://old.example.com"}}
+                },
+            }
+        )
+    )
+
+    assert result["summary"]["already_available_count"] == 1
+    assert result["requests"][0]["status"] == "already_available"
+
+
+def test_tool_accepts_candidates_and_builds_full_pipeline():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool(
+            {
+                "candidates": [
+                    {
+                        "id": "repair-123",
+                        "provider": "builtin",
+                        "priority": "high",
+                        "repair_action": "attach_provenance",
+                        "required_evidence": [
+                            "source_url",
+                            "observed_at",
+                            "verification_signal",
+                        ],
+                        "proposed_evidence_patch": {
+                            "source_url": "https://example.com/source",
+                            "observed_at": "2026-05-11T00:00:00Z",
+                            "verification_signal": "manual_verified",
+                        },
+                    }
+                ],
+                "approved_candidate_ids": ["repair-123"],
+                "user_confirmed": True,
+            }
+        )
+    )
+
+    assert result["summary"]["capture_required_count"] == 1
+    assert result["summary"]["blocks_manual_commit"] is True
+    assert result["requests"][0]["status"] == "capture_required"
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_snapshot_planner_tool({"rollback_plan": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "rollback_plan must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_empty_plan():
+    result = json.loads(memory_evidence_repair_snapshot_planner_tool({}))
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["summary"]["snapshot_request_count"] == 0
+    assert result["requests"] == []
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_snapshot_planner")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tests/tools/test_memory_evidence_repair_write_lock_gate_tool.py
+++ b/tests/tools/test_memory_evidence_repair_write_lock_gate_tool.py
@@ -1,0 +1,243 @@
+import json
+
+from tools.memory_evidence_repair_commit_receipt_tool import (
+    memory_evidence_repair_commit_receipt_tool,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.memory_evidence_repair_write_lock_gate_tool import (
+    memory_evidence_repair_write_lock_gate_tool,
+)
+from tools.registry import registry
+
+
+class FakeMemoryManager:
+    def last_memory_policy_gate(self):
+        return {
+            "summary": {"input_count": 1, "output_count": 0},
+            "provider_results": [
+                {
+                    "provider": "builtin",
+                    "action": "require_provenance_before_reuse",
+                    "effect": "filtered",
+                    "reason": "Recall candidate lacks explicit provenance required by policy.",
+                }
+            ],
+            "read_only": True,
+        }
+
+    def last_recall_audit(self):
+        return {"entries": [], "read_only": True}
+
+    def last_recall_diagnostics(self):
+        return {"issues": [], "read_only": True}
+
+    def last_memory_auto_policy(self):
+        return {"decisions": [], "read_only": True}
+
+
+def _ready_dry_run():
+    return {
+        "status": "ready_for_manual_commit",
+        "summary": {"manual_commit_allowed": True, "operation_count": 1},
+        "checks": [{"id": "commit_gate", "status": "pass"}],
+        "operations": [
+            {
+                "id": "dryrun-op-123",
+                "ledger_entry_id": "ledger-123",
+                "candidate_id": "repair-123",
+                "preview_id": "preview-123",
+                "provider": "builtin",
+                "repair_action": "attach_provenance",
+                "patch_digest": "a" * 64,
+                "target": {"candidate_id": "repair-123"},
+                "evidence_fields": ["source_url"],
+            }
+        ],
+        "blocking_reasons": [],
+        "required_actions": [],
+    }
+
+
+def _token_report():
+    result = json.loads(
+        memory_evidence_repair_human_approval_token_tool(
+            {
+                "dry_run": _ready_dry_run(),
+                "approver": "han",
+                "approval_reason": "final manual approval",
+                "expires_in_minutes": 30,
+            }
+        )
+    )
+    result["generated_at"] = "2026-05-11T00:00:00+00:00"
+    return result
+
+
+def _commit_receipt():
+    token_report = _token_report()
+    return json.loads(
+        memory_evidence_repair_commit_receipt_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "commit_reason": "manual memory evidence repair",
+            }
+        )
+    )
+
+
+def _candidate_args():
+    return {
+        "candidates": [
+            {
+                "id": "repair-123",
+                "provider": "builtin",
+                "priority": "high",
+                "repair_action": "attach_provenance",
+                "required_evidence": [
+                    "source_url",
+                    "observed_at",
+                    "verification_signal",
+                ],
+                "proposed_evidence_patch": {
+                    "source_url": "https://example.com/source",
+                    "observed_at": "2026-05-11T00:00:00Z",
+                    "verification_signal": "manual_verified",
+                },
+            }
+        ],
+        "approved_candidate_ids": ["repair-123"],
+        "user_confirmed": True,
+        "existing_snapshots": {
+            "source_url": "https://old.example.com/source",
+            "observed_at": "2026-05-01T00:00:00Z",
+            "verification_signal": "previous_manual_verified",
+        },
+        "approver": "han",
+    }
+
+
+def test_tool_accepts_explicit_commit_receipt_markdown():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "commit_receipt": _commit_receipt(),
+                "lock_owner": "han",
+                "lock_ttl_minutes": 15,
+                "current_time": "2026-05-11T00:20:00+00:00",
+                "format": "markdown",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["read_only_memory"] is True
+    assert result["would_mutate_memory"] is False
+    assert result["status"] == "write_lock_ready_for_manual_commit"
+    assert result["summary"]["executor_dry_run_allowed"] is True
+    assert result["locks"][0]["owner"] == "han"
+    assert "Memory Evidence Repair Write Lock Gate" in result["markdown"]
+
+
+def test_tool_blocks_on_active_lock_conflict():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "commit_receipt": _commit_receipt(),
+                "active_locks": [
+                    {
+                        "id": "write-lock-existing",
+                        "status": "active",
+                        "scope": "manual_memory_evidence_repair_commit",
+                        "operation_ids": ["dryrun-op-123"],
+                        "expires_at": "2026-05-11T00:40:00+00:00",
+                    }
+                ],
+                "current_time": "2026-05-11T00:20:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["locks"] == []
+    assert result["summary"]["active_lock_conflict_count"] == 1
+    assert "wait_for_write_lock_release" in result["required_actions"]
+
+
+def test_tool_generates_receipt_from_token_and_creates_write_lock():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": token_report["tokens"][0]["required_confirmation_text"],
+                "current_time": "2026-05-11T00:10:00+00:00",
+                "actor": "han",
+                "lock_owner": "han",
+            }
+        )
+    )
+
+    assert result["status"] == "write_lock_ready_for_manual_commit"
+    assert result["summary"]["write_lock_available"] is True
+    assert result["locks"][0]["token_id"] == token_report["tokens"][0]["id"]
+
+
+def test_tool_blocks_when_generated_receipt_is_not_ready():
+    token_report = _token_report()
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {
+                "approval_token": token_report,
+                "confirmation_text": "wrong confirmation",
+                "current_time": "2026-05-11T00:10:00+00:00",
+            }
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["locks"] == []
+    assert "provide_exact_confirmation_text" in result["required_actions"]
+
+
+def test_tool_uses_latest_manager_state_and_blocks_when_no_receipt_available():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool(
+            {"format": "markdown"},
+            memory_manager=FakeMemoryManager(),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "blocked"
+    assert result["locks"] == []
+    assert result["blocking_reasons"]
+
+
+def test_tool_rejects_invalid_input_shape():
+    result = json.loads(
+        memory_evidence_repair_write_lock_gate_tool({"commit_receipt": "bad"})
+    )
+
+    assert result["success"] is False
+    assert "commit_receipt must be an object" in result["error"]
+
+
+def test_tool_without_manager_returns_no_action():
+    result = json.loads(memory_evidence_repair_write_lock_gate_tool({}))
+
+    assert result["success"] is True
+    assert result["status"] == "no_action_needed"
+    assert result["summary"]["lock_count"] == 0
+
+
+def test_tool_is_registered_under_memory_toolset():
+    entry = registry.get_entry("memory_evidence_repair_write_lock_gate")
+
+    assert entry is not None
+    assert entry.toolset == "memory"

--- a/tools/memory_evidence_repair_apply_preview_tool.py
+++ b/tools/memory_evidence_repair_apply_preview_tool.py
@@ -1,0 +1,283 @@
+"""Read-only Memory Evidence Repair Apply Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    MemoryEvidenceRepairApplyPreviewReport,
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_APPLY_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_apply_preview",
+    "description": (
+        "Read-only preview of the memory evidence metadata patch that would be "
+        "applied after user confirmation. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates to preview.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids the user has confirmed for preview.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items to wrap as a plan.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum apply previews to include. Defaults to all previews.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_apply_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    approval = _resolve_approval(args, kwargs.get("memory_manager"))
+    if isinstance(approval, str):
+        return approval
+
+    approved_candidate_ids = args.get("approved_candidate_ids")
+    proposed_evidence = args.get("proposed_evidence")
+    report = build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            approved_candidate_ids if isinstance(approved_candidate_ids, list) else None
+        ),
+        proposed_evidence=proposed_evidence if isinstance(proposed_evidence, dict) else {},
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairApplyPreviewReport(
+            generated_at=report.generated_at,
+            previews=report.previews[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = ("candidates", "approved_candidate_ids", "repairs")
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    proposed_evidence = args.get("proposed_evidence")
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=proposed_evidence if isinstance(proposed_evidence, dict) else {},
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    raw_inputs = _resolve_raw_inputs(args, memory_manager)
+    if isinstance(raw_inputs, str):
+        return raw_inputs
+    gate, audit, diagnostics, policy = raw_inputs
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _resolve_raw_inputs(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return gate, audit, diagnostics, policy
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Apply Preview",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Ready: {summary.get('ready_count', 0)}",
+        f"- Missing evidence: {summary.get('missing_evidence_count', 0)}",
+    ]
+    for index, preview in enumerate(payload.get("previews", []), start=1):
+        provider = preview.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{preview.get('status')}] "
+            f"{preview.get('repair_action')} provider={provider}"
+        )
+        fields = preview.get("would_update_fields") or []
+        if fields:
+            lines.append(f"   Would update: {', '.join(str(item) for item in fields)}")
+        missing = preview.get("missing_evidence") or []
+        if missing:
+            lines.append(f"   Missing: {', '.join(str(item) for item in missing)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_apply_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_apply_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_APPLY_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_apply_preview_tool,
+    check_fn=check_memory_evidence_repair_apply_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_approval_candidates_tool.py
+++ b/tools/memory_evidence_repair_approval_candidates_tool.py
@@ -1,0 +1,233 @@
+"""Read-only Memory Evidence Repair Approval Candidates tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_approval import (
+    MemoryEvidenceRepairApprovalReport,
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_APPROVAL_CANDIDATES_SCHEMA = {
+    "name": "memory_evidence_repair_approval_candidates",
+    "description": (
+        "Read-only planner that turns memory evidence repair plans into "
+        "human-confirmable approval candidates. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items to wrap as a plan.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed by required field.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum approval candidates to include. Defaults to all candidates.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_approval_candidates_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    resolved_plan = _resolve_plan(args, kwargs.get("memory_manager"))
+    if isinstance(resolved_plan, str):
+        return resolved_plan
+
+    proposed_evidence = args.get("proposed_evidence")
+    if proposed_evidence is not None and not isinstance(proposed_evidence, dict):
+        return tool_error(
+            "proposed_evidence must be an object when provided.",
+            success=False,
+        )
+
+    report = build_evidence_repair_approval_candidates(
+        plan=resolved_plan,
+        proposed_evidence=proposed_evidence if isinstance(proposed_evidence, dict) else {},
+    )
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairApprovalReport(
+            generated_at=report.generated_at,
+            candidates=report.candidates[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if explicit_plan is not None:
+        if not isinstance(explicit_plan, dict):
+            return tool_error("plan must be an object when provided.", success=False)
+        return explicit_plan
+    if explicit_repairs is not None:
+        if not isinstance(explicit_repairs, list):
+            return tool_error("repairs must be an array when provided.", success=False)
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    raw_inputs = _resolve_raw_inputs(args, memory_manager)
+    if isinstance(raw_inputs, str):
+        return raw_inputs
+    gate, audit, diagnostics, policy = raw_inputs
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _resolve_raw_inputs(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    explicit_gate = args.get("gate")
+    explicit_audit = args.get("audit")
+    explicit_diagnostics = args.get("diagnostics")
+    explicit_policy = args.get("policy")
+    for field_name, value in (
+        ("gate", explicit_gate),
+        ("audit", explicit_audit),
+        ("diagnostics", explicit_diagnostics),
+        ("policy", explicit_policy),
+    ):
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+
+    gate = explicit_gate if isinstance(explicit_gate, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = explicit_audit if isinstance(explicit_audit, dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        explicit_diagnostics
+        if isinstance(explicit_diagnostics, dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = explicit_policy if isinstance(explicit_policy, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return gate, audit, diagnostics, policy
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Approval Candidates",
+        f"- Candidates: {summary.get('candidate_count', 0)}",
+        f"- Requires confirmation: {summary.get('requires_user_confirmation', False)}",
+        f"- By priority: {summary.get('by_priority', {})}",
+    ]
+    for index, candidate in enumerate(payload.get("candidates", []), start=1):
+        provider = candidate.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{candidate.get('priority')}] "
+            f"{candidate.get('repair_action')} provider={provider}"
+        )
+        question = candidate.get("confirmation_question")
+        if question:
+            lines.append(f"   Confirm: {question}")
+        required = candidate.get("required_evidence") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_approval_candidates_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_approval_candidates",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_APPROVAL_CANDIDATES_SCHEMA,
+    handler=memory_evidence_repair_approval_candidates_tool,
+    check_fn=check_memory_evidence_repair_approval_candidates_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_approval_token_gate_tool.py
+++ b/tools/memory_evidence_repair_approval_token_gate_tool.py
@@ -1,0 +1,262 @@
+"""Read-only Memory Evidence Repair Approval Token Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_approval_token_gate import (
+    build_evidence_repair_approval_token_gate,
+)
+from tools.memory_evidence_repair_human_approval_token_tool import (
+    MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    memory_evidence_repair_human_approval_token_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_approval_token_gate",
+    "description": (
+        "Read-only gate that verifies a human approval token before any later "
+        "manual memory evidence repair commit. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "approval_token": {
+                "type": "object",
+                "description": "Optional approval token report payload.",
+                "additionalProperties": True,
+            },
+            "token": {
+                "type": "object",
+                "description": "Optional single approval token payload.",
+                "additionalProperties": True,
+            },
+            "tokens": {
+                "type": "array",
+                "description": "Optional approval token list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmation_text": {
+                "type": "string",
+                "description": "Exact human confirmation text required by the token.",
+            },
+            "used_token_ids": {
+                "type": "array",
+                "description": "Read-only ids already marked as used by an external ledger.",
+                "items": {"type": "string"},
+            },
+            "token_generated_at": {
+                "type": "string",
+                "description": "Issue time for bare token payloads.",
+            },
+            "current_time": {
+                "type": "string",
+                "description": "Optional current time override for deterministic verification.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_approval_token_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    approval_token = _resolve_approval_token(args, kwargs.get("memory_manager"))
+    if isinstance(approval_token, str):
+        return approval_token
+
+    dry_run = _resolve_dry_run(args, approval_token)
+    payload = build_evidence_repair_approval_token_gate(
+        approval_token=approval_token,
+        dry_run=dry_run,
+        confirmation_text=str(args.get("confirmation_text") or ""),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "tokens",
+        "used_token_ids",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_approval_token(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_report = args.get("approval_token")
+    if isinstance(explicit_report, dict):
+        if "generated_at" not in explicit_report and args.get("token_generated_at"):
+            explicit_report = dict(explicit_report)
+            explicit_report["generated_at"] = str(args.get("token_generated_at") or "")
+        return explicit_report
+
+    explicit_token = args.get("token")
+    if isinstance(explicit_token, dict):
+        return {
+            "generated_at": str(args.get("token_generated_at") or ""),
+            "tokens": [explicit_token],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    explicit_tokens = args.get("tokens")
+    if isinstance(explicit_tokens, list):
+        return {
+            "generated_at": str(args.get("token_generated_at") or ""),
+            "tokens": explicit_tokens,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    token_args = dict(args)
+    for field_name in (
+        "approval_token",
+        "token",
+        "tokens",
+        "confirmation_text",
+        "used_token_ids",
+        "token_generated_at",
+        "current_time",
+        "format",
+    ):
+        token_args.pop(field_name, None)
+    result = memory_evidence_repair_human_approval_token_tool(
+        token_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("human approval token tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("human approval token tool returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _resolve_dry_run(args: dict[str, Any], approval_token: dict[str, Any]) -> dict[str, Any]:
+    explicit = args.get("dry_run")
+    if isinstance(explicit, dict):
+        return explicit
+    token = _first_token(approval_token)
+    source_dry_run = token.get("source_dry_run") if isinstance(token, dict) else {}
+    return dict(source_dry_run) if isinstance(source_dry_run, dict) else {}
+
+
+def _first_token(approval_token: dict[str, Any]) -> dict[str, Any]:
+    tokens = approval_token.get("tokens")
+    if isinstance(tokens, list):
+        for token in tokens:
+            if isinstance(token, dict):
+                return token
+    if isinstance(approval_token, dict) and approval_token.get("id"):
+        return approval_token
+    return {}
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Approval Token Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Token: {payload.get('token_id') or 'none'}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Passed: {summary.get('pass_count', 0)}",
+        f"- Failed: {summary.get('fail_count', 0)}",
+        f"- Manual commit verified: {summary.get('manual_commit_verified', False)}",
+    ]
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_approval_token_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_approval_token_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA,
+    handler=memory_evidence_repair_approval_token_gate_tool,
+    check_fn=check_memory_evidence_repair_approval_token_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_commit_gate_tool.py
+++ b/tools/memory_evidence_repair_commit_gate_tool.py
@@ -1,0 +1,345 @@
+"""Read-only Memory Evidence Repair Commit Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    MemoryEvidenceRepairCommitGateReport,
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_COMMIT_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_commit_gate",
+    "description": (
+        "Read-only gate that decides whether an evidence repair apply preview "
+        "is eligible for a later manual memory write. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews to gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum gate decisions to include. Defaults to all decisions.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_commit_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    preview = _resolve_preview(args, kwargs.get("memory_manager"))
+    if isinstance(preview, str):
+        return preview
+
+    report = build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairCommitGateReport(
+            generated_at=report.generated_at,
+            decisions=report.decisions[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Commit Gate",
+        f"- Decisions: {summary.get('decision_count', 0)}",
+        f"- Allow: {summary.get('allow_count', 0)}",
+        f"- Blocked: {summary.get('blocked_count', 0)}",
+        f"- Needs confirmation: {summary.get('needs_confirmation_count', 0)}",
+    ]
+    for index, decision in enumerate(payload.get("decisions", []), start=1):
+        provider = decision.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{decision.get('decision')}] "
+            f"{decision.get('repair_action')} provider={provider}"
+        )
+        reasons = decision.get("reasons") or []
+        if reasons:
+            lines.append(f"   Reasons: {', '.join(str(item) for item in reasons)}")
+        required = decision.get("required_actions") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_commit_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_commit_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_COMMIT_GATE_SCHEMA,
+    handler=memory_evidence_repair_commit_gate_tool,
+    check_fn=check_memory_evidence_repair_commit_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_commit_ledger_tool.py
+++ b/tools/memory_evidence_repair_commit_ledger_tool.py
@@ -1,0 +1,403 @@
+"""Read-only Memory Evidence Repair Commit Ledger tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    MemoryEvidenceRepairCommitLedgerDraft,
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_COMMIT_LEDGER_SCHEMA = {
+    "name": "memory_evidence_repair_commit_ledger",
+    "description": (
+        "Read-only audit ledger draft for memory evidence repair commit gate "
+        "decisions. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions to ledger.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for the ledger draft.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for creating the ledger draft.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews used to build a commit gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum ledger entries to include. Defaults to all entries.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_commit_ledger_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    commit_gate = _resolve_commit_gate(args, kwargs.get("memory_manager"))
+    if isinstance(commit_gate, str):
+        return commit_gate
+
+    report = build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairCommitLedgerDraft(
+            generated_at=report.generated_at,
+            entries=report.entries[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_commit_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Commit Ledger",
+        f"- Entries: {summary.get('entry_count', 0)}",
+        f"- Allowed: {summary.get('allow_count', 0)}",
+        f"- Blocked: {summary.get('blocked_count', 0)}",
+        f"- Follow-up: {summary.get('followup_count', 0)}",
+    ]
+    for index, entry in enumerate(payload.get("entries", []), start=1):
+        provider = entry.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{entry.get('outcome')}] "
+            f"{entry.get('repair_action')} provider={provider}"
+        )
+        digest = entry.get("patch_digest", "")
+        if digest:
+            lines.append(f"   Patch digest: {digest[:12]}")
+        required = entry.get("required_actions") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_commit_ledger_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_commit_ledger",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_COMMIT_LEDGER_SCHEMA,
+    handler=memory_evidence_repair_commit_ledger_tool,
+    check_fn=check_memory_evidence_repair_commit_ledger_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_commit_receipt_tool.py
+++ b/tools/memory_evidence_repair_commit_receipt_tool.py
@@ -1,0 +1,241 @@
+"""Read-only Memory Evidence Repair Manual Commit Receipt tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_commit_receipt import (
+    build_evidence_repair_commit_receipt,
+)
+from tools.memory_evidence_repair_approval_token_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA,
+    memory_evidence_repair_approval_token_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_APPROVAL_TOKEN_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA = {
+    "name": "memory_evidence_repair_commit_receipt",
+    "description": (
+        "Read-only receipt draft and used-token ledger view for a verified "
+        "memory evidence repair manual commit. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "token_gate": {
+                "type": "object",
+                "description": "Optional approval token gate payload.",
+                "additionalProperties": True,
+            },
+            "approval_token_gate": {
+                "type": "object",
+                "description": "Alias for token_gate.",
+                "additionalProperties": True,
+            },
+            "existing_receipts": {
+                "description": "Optional existing receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "receipts": {
+                "type": "array",
+                "description": "Optional existing receipt list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "actor": {
+                "type": "string",
+                "description": "Human actor label for the future receipt.",
+            },
+            "commit_reason": {
+                "type": "string",
+                "description": "Reason for the future manual memory evidence repair commit.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_commit_receipt_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    token_gate = _resolve_token_gate(args, kwargs.get("memory_manager"))
+    if isinstance(token_gate, str):
+        return token_gate
+
+    payload = build_evidence_repair_commit_receipt(
+        token_gate=token_gate,
+        existing_receipts=_existing_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        actor=str(args.get("actor") or "human"),
+        commit_reason=str(args.get("commit_reason") or ""),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    existing_receipts = args.get("existing_receipts")
+    if existing_receipts is not None and not isinstance(existing_receipts, (dict, list)):
+        return tool_error(
+            "existing_receipts must be an object or array when provided.",
+            success=False,
+        )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_token_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("token_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+    explicit_gate = args.get("approval_token_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+
+    gate_args = dict(args)
+    for field_name in (
+        "token_gate",
+        "approval_token_gate",
+        "existing_receipts",
+        "receipts",
+        "actor",
+        "commit_reason",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_approval_token_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("approval token gate returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("approval token gate returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _existing_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("existing_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    receipts = args.get("receipts")
+    if isinstance(receipts, list):
+        return receipts
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Commit Receipt",
+        f"- Status: {payload.get('status')}",
+        f"- Receipts: {summary.get('receipt_count', 0)}",
+        f"- Used tokens: {summary.get('used_token_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for receipt in payload.get("receipts", []):
+        lines.append(f"- Receipt: {receipt.get('id')}")
+        lines.append(f"  Token: {receipt.get('token_id')}")
+        lines.append(f"  Operations: {len(receipt.get('operation_ids') or [])}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_commit_receipt_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_commit_receipt",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA,
+    handler=memory_evidence_repair_commit_receipt_tool,
+    check_fn=check_memory_evidence_repair_commit_receipt_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_executor_preview_tool.py
+++ b/tools/memory_evidence_repair_executor_preview_tool.py
@@ -1,0 +1,224 @@
+"""Read-only Memory Evidence Repair Manual Commit Executor Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_executor_preview import (
+    build_evidence_repair_executor_preview,
+)
+from tools.memory_evidence_repair_write_lock_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA,
+    memory_evidence_repair_write_lock_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_executor_preview",
+    "description": (
+        "Read-only ordered executor preview for a future memory evidence repair "
+        "manual commit. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "write_lock_gate": {
+                "type": "object",
+                "description": "Optional write-lock gate payload.",
+                "additionalProperties": True,
+            },
+            "executor_lock_gate": {
+                "type": "object",
+                "description": "Alias for write_lock_gate.",
+                "additionalProperties": True,
+            },
+            "write_lock": {
+                "type": "object",
+                "description": "Optional single write-lock draft payload.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_executor_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    write_lock_gate = _resolve_write_lock_gate(args, kwargs.get("memory_manager"))
+    if isinstance(write_lock_gate, str):
+        return write_lock_gate
+
+    payload = build_evidence_repair_executor_preview(
+        write_lock_gate=write_lock_gate,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    existing_receipts = args.get("existing_receipts")
+    if existing_receipts is not None and not isinstance(existing_receipts, (dict, list)):
+        return tool_error(
+            "existing_receipts must be an object or array when provided.",
+            success=False,
+        )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_write_lock_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("write_lock_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+    explicit_gate = args.get("executor_lock_gate")
+    if isinstance(explicit_gate, dict):
+        return explicit_gate
+
+    explicit_lock = args.get("write_lock")
+    if isinstance(explicit_lock, dict):
+        return {
+            "status": "write_lock_ready_for_manual_commit",
+            "summary": {"lock_count": 1},
+            "locks": [explicit_lock],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    gate_args = dict(args)
+    for field_name in (
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_write_lock_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("write-lock gate returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("write-lock gate returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Executor Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Steps: {summary.get('step_count', 0)}",
+        f"- Future write steps: {summary.get('future_write_step_count', 0)}",
+        f"- Ready: {summary.get('manual_executor_preview_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Preview: {preview.get('id')}")
+        lines.append(f"  Lock: {preview.get('lock_id')}")
+        lines.append(f"  Failure policy: {preview.get('failure_policy')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_executor_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_executor_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_executor_preview_tool,
+    check_fn=check_memory_evidence_repair_executor_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_human_approval_token_tool.py
+++ b/tools/memory_evidence_repair_human_approval_token_tool.py
@@ -1,0 +1,303 @@
+"""Read-only Memory Evidence Repair Human Approval Token tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_human_approval_token import (
+    build_evidence_repair_human_approval_token,
+)
+from tools.memory_evidence_repair_manual_commit_dry_run_tool import (
+    memory_evidence_repair_manual_commit_dry_run_tool,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA = {
+    "name": "memory_evidence_repair_human_approval_token",
+    "description": (
+        "Read-only human approval token draft for a ready memory evidence "
+        "repair manual commit dry-run. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dry_run": {
+                "type": "object",
+                "description": "Optional manual commit dry-run payload.",
+                "additionalProperties": True,
+            },
+            "approver": {
+                "type": "string",
+                "description": "Human approver label for the token draft.",
+            },
+            "approval_reason": {
+                "type": "string",
+                "description": "Reason for drafting the approval token.",
+            },
+            "expires_in_minutes": {
+                "type": "integer",
+                "description": "Draft token expiry window in minutes. Defaults to 30.",
+            },
+            "snapshot_plan": {
+                "type": "object",
+                "description": "Optional snapshot planner payload.",
+                "additionalProperties": True,
+            },
+            "requests": {
+                "type": "array",
+                "description": "Optional snapshot requests.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan payload.",
+                "additionalProperties": True,
+            },
+            "steps": {
+                "type": "array",
+                "description": "Optional rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "existing_snapshots": {
+                "type": "object",
+                "description": "Optional existing pre-commit snapshots.",
+                "additionalProperties": True,
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Alias for existing_snapshots.",
+                "additionalProperties": True,
+            },
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional evidence repair items.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_human_approval_token_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    dry_run = _resolve_dry_run(args, kwargs.get("memory_manager"))
+    if isinstance(dry_run, str):
+        return dry_run
+
+    payload = build_evidence_repair_human_approval_token(
+        dry_run=dry_run,
+        approver=str(args.get("approver") or "human"),
+        approval_reason=str(args.get("approval_reason") or ""),
+        expires_in_minutes=args.get("expires_in_minutes") or 30,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_dry_run(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit = args.get("dry_run")
+    if isinstance(explicit, dict):
+        return explicit
+
+    dry_run_args = dict(args)
+    dry_run_args.pop("dry_run", None)
+    dry_run_args.pop("approver", None)
+    dry_run_args.pop("approval_reason", None)
+    dry_run_args.pop("expires_in_minutes", None)
+    result = memory_evidence_repair_manual_commit_dry_run_tool(
+        dry_run_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("manual commit dry-run returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("manual commit dry-run returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Human Approval Token",
+        f"- Status: {payload.get('status')}",
+        f"- Tokens: {summary.get('token_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for token in payload.get("tokens", []):
+        lines.append(f"- Token: {token.get('id')}")
+        lines.append(f"  Confirm: {token.get('required_confirmation_text')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_human_approval_token_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_human_approval_token",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    handler=memory_evidence_repair_human_approval_token_tool,
+    check_fn=check_memory_evidence_repair_human_approval_token_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_manual_commit_dry_run_tool.py
+++ b/tools/memory_evidence_repair_manual_commit_dry_run_tool.py
@@ -1,0 +1,583 @@
+"""Read-only Memory Evidence Repair Manual Commit Dry-Run tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_manual_commit_dry_run import (
+    build_evidence_repair_manual_commit_dry_run,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from agent.memory_evidence_repair_rollback_plan import (
+    build_evidence_repair_rollback_plan,
+)
+from agent.memory_evidence_repair_snapshot_planner import (
+    build_evidence_repair_snapshot_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_MANUAL_COMMIT_DRY_RUN_SCHEMA = {
+    "name": "memory_evidence_repair_manual_commit_dry_run",
+    "description": (
+        "Read-only final dry-run before a future manual memory evidence repair "
+        "commit. It summarizes gate, ledger, rollback, and snapshot readiness."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "snapshot_plan": {
+                "type": "object",
+                "description": "Optional snapshot planner payload.",
+                "additionalProperties": True,
+            },
+            "requests": {
+                "type": "array",
+                "description": "Optional snapshot requests.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan payload.",
+                "additionalProperties": True,
+            },
+            "steps": {
+                "type": "array",
+                "description": "Optional rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "existing_snapshots": {
+                "type": "object",
+                "description": "Optional existing pre-commit snapshots.",
+                "additionalProperties": True,
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Alias for existing_snapshots.",
+                "additionalProperties": True,
+            },
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional evidence repair items.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum dry-run operations to include. Defaults to all operations.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_manual_commit_dry_run_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    context = _resolve_context(args, kwargs.get("memory_manager"))
+    if isinstance(context, str):
+        return context
+    snapshot_plan, commit_gate, ledger, rollback_plan = context
+
+    report = build_evidence_repair_manual_commit_dry_run(
+        snapshot_plan=snapshot_plan,
+        commit_gate=commit_gate,
+        ledger=ledger,
+        rollback_plan=rollback_plan,
+    )
+
+    payload = report.to_dict()
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        payload["operations"] = list(payload.get("operations", []))[:limit]
+        payload["summary"]["operation_count"] = len(payload["operations"])
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_context(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    ledger = _resolve_ledger(args, memory_manager, commit_gate)
+    if isinstance(ledger, str):
+        return ledger
+    rollback_plan = _resolve_rollback_plan(args, memory_manager, ledger)
+    if isinstance(rollback_plan, str):
+        return rollback_plan
+    snapshot_plan = _resolve_snapshot_plan(args, memory_manager, rollback_plan)
+    if isinstance(snapshot_plan, str):
+        return snapshot_plan
+    return snapshot_plan, commit_gate, ledger, rollback_plan
+
+
+def _resolve_snapshot_plan(
+    args: dict[str, Any],
+    memory_manager: Any,
+    fallback_rollback_plan: dict[str, Any],
+) -> dict[str, Any] | str:
+    explicit_plan = args.get("snapshot_plan")
+    explicit_requests = args.get("requests")
+    if isinstance(explicit_plan, dict):
+        if "requests" in explicit_plan:
+            return explicit_plan
+        return {
+            "summary": {"snapshot_request_count": 1},
+            "requests": [explicit_plan],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_requests, list):
+        return {
+            "summary": {"snapshot_request_count": len(explicit_requests)},
+            "requests": explicit_requests,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    rollback_plan = _resolve_rollback_plan(args, memory_manager, None)
+    if isinstance(rollback_plan, str):
+        return rollback_plan
+    if not rollback_plan.get("steps"):
+        rollback_plan = fallback_rollback_plan
+    return build_evidence_repair_snapshot_plan(
+        rollback_plan=rollback_plan,
+        existing_snapshots=_existing_snapshots(args),
+    ).to_dict()
+
+
+def _resolve_rollback_plan(
+    args: dict[str, Any],
+    memory_manager: Any,
+    fallback_ledger: dict[str, Any] | None,
+) -> dict[str, Any] | str:
+    explicit_plan = args.get("rollback_plan")
+    explicit_steps = args.get("steps")
+    if isinstance(explicit_plan, dict):
+        if "steps" in explicit_plan:
+            return explicit_plan
+        return {
+            "summary": {"rollback_step_count": 1},
+            "steps": [explicit_plan],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_steps, list):
+        return {
+            "summary": {"rollback_step_count": len(explicit_steps)},
+            "steps": explicit_steps,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    ledger = _resolve_ledger(args, memory_manager, None)
+    if isinstance(ledger, str):
+        return ledger
+    if not ledger.get("entries") and fallback_ledger is not None:
+        ledger = fallback_ledger
+    return build_evidence_repair_rollback_plan(
+        ledger=ledger,
+        pre_commit_snapshots=_existing_snapshots(args),
+    ).to_dict()
+
+
+def _resolve_ledger(
+    args: dict[str, Any],
+    memory_manager: Any,
+    fallback_commit_gate: dict[str, Any] | None,
+) -> dict[str, Any] | str:
+    explicit_ledger = args.get("ledger")
+    explicit_entries = args.get("entries")
+    if isinstance(explicit_ledger, dict):
+        if "entries" in explicit_ledger:
+            return explicit_ledger
+        return {
+            "summary": {"entry_count": 1},
+            "entries": [explicit_ledger],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_entries, list):
+        return {
+            "summary": {"entry_count": len(explicit_entries)},
+            "entries": explicit_entries,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    if not commit_gate.get("decisions") and fallback_commit_gate is not None:
+        commit_gate = fallback_commit_gate
+    return build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    ).to_dict()
+
+
+def _resolve_commit_gate(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _existing_snapshots(args: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(args.get("existing_snapshots"), dict):
+        return args["existing_snapshots"]
+    if isinstance(args.get("pre_commit_snapshots"), dict):
+        return args["pre_commit_snapshots"]
+    return {}
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Manual Commit Dry-Run",
+        f"- Status: {payload.get('status')}",
+        f"- Operations: {summary.get('operation_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for check in payload.get("checks", []):
+        lines.append(f"- {check.get('id')}: {check.get('status')}")
+        actions = check.get("required_actions") or []
+        if actions:
+            lines.append(f"  Required: {', '.join(str(item) for item in actions)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_manual_commit_dry_run_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_manual_commit_dry_run",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_MANUAL_COMMIT_DRY_RUN_SCHEMA,
+    handler=memory_evidence_repair_manual_commit_dry_run_tool,
+    check_fn=check_memory_evidence_repair_manual_commit_dry_run_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_planner_tool.py
+++ b/tools/memory_evidence_repair_planner_tool.py
@@ -1,0 +1,175 @@
+"""Read-only Memory Evidence Repair Planner tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_planner import (
+    build_evidence_repair_plan,
+    empty_evidence_repair_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_PLANNER_SCHEMA = {
+    "name": "memory_evidence_repair_planner",
+    "description": (
+        "Read-only planner for memory evidence repair. It turns policy gate, "
+        "recall audit, diagnostics, and auto-policy signals into provenance "
+        "repair candidates. The tool never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum repair candidates to include. Defaults to all repairs.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_planner_tool(args: dict[str, Any], **kwargs) -> str:
+    resolved = _resolve_inputs(args, kwargs.get("memory_manager"))
+    if isinstance(resolved, str):
+        return resolved
+    gate, audit, diagnostics, policy = resolved
+    payload = build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        payload["repairs"] = list(payload.get("repairs", []))[:limit]
+        payload["limited_to"] = limit
+
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _resolve_inputs(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]] | str:
+    explicit_gate = args.get("gate")
+    explicit_audit = args.get("audit")
+    explicit_diagnostics = args.get("diagnostics")
+    explicit_policy = args.get("policy")
+    for field_name, value in (
+        ("gate", explicit_gate),
+        ("audit", explicit_audit),
+        ("diagnostics", explicit_diagnostics),
+        ("policy", explicit_policy),
+    ):
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+
+    gate = explicit_gate if isinstance(explicit_gate, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = explicit_audit if isinstance(explicit_audit, dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        explicit_diagnostics
+        if isinstance(explicit_diagnostics, dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = explicit_policy if isinstance(explicit_policy, dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return gate, audit, diagnostics, policy
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Planner",
+        f"- Repairs: {summary.get('repair_count', 0)}",
+        f"- Blocked by gate: {summary.get('blocked_count', 0)}",
+        f"- By priority: {summary.get('by_priority', {})}",
+    ]
+    for index, repair in enumerate(payload.get("repairs", []), start=1):
+        provider = repair.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{repair.get('priority')}] {repair.get('action')} "
+            f"provider={provider}"
+        )
+        reason = repair.get("reason")
+        if reason:
+            lines.append(f"   Reason: {reason}")
+        required = repair.get("required_evidence") or []
+        if required:
+            lines.append(f"   Required: {', '.join(str(item) for item in required)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_planner_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_planner",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_PLANNER_SCHEMA,
+    handler=memory_evidence_repair_planner_tool,
+    check_fn=check_memory_evidence_repair_planner_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_post_commit_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_post_commit_audit_preview_tool.py
@@ -1,0 +1,269 @@
+"""Read-only Memory Evidence Repair Post-Commit Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_post_commit_audit_preview import (
+    build_evidence_repair_post_commit_audit_preview,
+)
+from tools.memory_evidence_repair_executor_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA,
+    memory_evidence_repair_executor_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_EXECUTOR_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_post_commit_audit_preview",
+    "description": (
+        "Read-only post-commit audit preview for future memory evidence repair "
+        "manual commits. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "executor_preview": {
+                "type": "object",
+                "description": "Optional executor preview report payload.",
+                "additionalProperties": True,
+            },
+            "executor": {
+                "type": "object",
+                "description": "Alias for executor_preview.",
+                "additionalProperties": True,
+            },
+            "observed_memory_patches": {
+                "type": "object",
+                "description": "Optional observed post-commit patch signals keyed by operation id.",
+                "additionalProperties": True,
+            },
+            "recorded_receipts": {
+                "description": "Optional recorded receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "released_lock_ids": {
+                "type": "array",
+                "description": "Optional write-lock ids observed as released after commit.",
+                "items": {"type": "string"},
+            },
+            "rollback_status": {
+                "type": "object",
+                "description": "Optional observed rollback or snapshot readiness signal.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_post_commit_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    executor_preview = _resolve_executor_preview(args, kwargs.get("memory_manager"))
+    if isinstance(executor_preview, str):
+        return executor_preview
+
+    payload = build_evidence_repair_post_commit_audit_preview(
+        executor_preview=executor_preview,
+        observed_memory_patches=(
+            args.get("observed_memory_patches")
+            if isinstance(args.get("observed_memory_patches"), dict)
+            else None
+        ),
+        recorded_receipts=_recorded_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        released_lock_ids=(
+            args.get("released_lock_ids")
+            if isinstance(args.get("released_lock_ids"), list)
+            else None
+        ),
+        rollback_status=(
+            args.get("rollback_status")
+            if isinstance(args.get("rollback_status"), dict)
+            else None
+        ),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_executor_preview(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_preview = args.get("executor_preview")
+    if isinstance(explicit_preview, dict):
+        return explicit_preview
+    explicit_preview = args.get("executor")
+    if isinstance(explicit_preview, dict):
+        return explicit_preview
+
+    executor_args = dict(args)
+    for field_name in (
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "recorded_receipts",
+        "released_lock_ids",
+        "rollback_status",
+        "format",
+    ):
+        executor_args.pop(field_name, None)
+    result = memory_evidence_repair_executor_preview_tool(
+        executor_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("executor preview tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("executor preview tool returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _recorded_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("recorded_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Post-Commit Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Planned: {summary.get('planned_audit_step_count', 0)}",
+        f"- Observed pass: {summary.get('observed_pass_step_count', 0)}",
+        f"- Observed fail: {summary.get('observed_fail_step_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit: {preview.get('id')}")
+        lines.append(f"  Executor: {preview.get('executor_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_post_commit_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_post_commit_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_post_commit_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_post_commit_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_approval_token_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_approval_token_gate_tool.py
@@ -1,0 +1,331 @@
+"""Read-only Memory Evidence Repair Recovery Approval Token Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_approval_token_gate import (
+    build_evidence_repair_recovery_approval_token_gate,
+)
+from tools.memory_evidence_repair_recovery_human_approval_token_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    memory_evidence_repair_recovery_human_approval_token_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_approval_token_gate",
+    "description": (
+        "Read-only gate that verifies a recovery human approval token before "
+        "any later manual memory evidence repair recovery. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_approval_token": {
+                "type": "object",
+                "description": "Optional recovery approval token report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_human_approval_token": {
+                "type": "object",
+                "description": "Alias for recovery_approval_token.",
+                "additionalProperties": True,
+            },
+            "recovery_token": {
+                "type": "object",
+                "description": "Optional single recovery approval token payload.",
+                "additionalProperties": True,
+            },
+            "token": {
+                "type": "object",
+                "description": "Optional single recovery approval token payload.",
+                "additionalProperties": True,
+            },
+            "tokens": {
+                "type": "array",
+                "description": "Optional recovery approval token list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmation_text": {
+                "type": "string",
+                "description": "Exact human confirmation text required by the recovery token.",
+            },
+            "used_token_ids": {
+                "type": "array",
+                "description": "Read-only ids already marked as used by an external ledger.",
+                "items": {"type": "string"},
+            },
+            "token_generated_at": {
+                "type": "string",
+                "description": "Issue time for bare token payloads.",
+            },
+            "current_time": {
+                "type": "string",
+                "description": "Optional current time override for deterministic verification.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_approval_token_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_approval_token = _resolve_recovery_approval_token(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_approval_token, str):
+        return recovery_approval_token
+
+    recovery_execution = _resolve_recovery_execution(args, recovery_approval_token)
+    payload = build_evidence_repair_recovery_approval_token_gate(
+        recovery_approval_token=recovery_approval_token,
+        recovery_execution=recovery_execution,
+        confirmation_text=str(args.get("confirmation_text") or ""),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_approval_token(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in ("recovery_approval_token", "recovery_human_approval_token"):
+        explicit_report = args.get(field_name)
+        if isinstance(explicit_report, dict):
+            if "generated_at" not in explicit_report and args.get("token_generated_at"):
+                explicit_report = dict(explicit_report)
+                explicit_report["generated_at"] = str(args.get("token_generated_at") or "")
+            return explicit_report
+
+    for field_name in ("recovery_token", "token"):
+        explicit_token = args.get(field_name)
+        if isinstance(explicit_token, dict):
+            return {
+                "generated_at": str(args.get("token_generated_at") or ""),
+                "tokens": [explicit_token],
+                "read_only": True,
+                "read_only_memory": True,
+                "would_mutate_memory": False,
+            }
+
+    explicit_tokens = args.get("tokens")
+    if isinstance(explicit_tokens, list):
+        return {
+            "generated_at": str(args.get("token_generated_at") or ""),
+            "tokens": explicit_tokens,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    token_args = dict(args)
+    for field_name in (
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "tokens",
+        "confirmation_text",
+        "used_token_ids",
+        "token_generated_at",
+        "current_time",
+        "format",
+    ):
+        token_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_human_approval_token_tool(
+        token_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery human approval token tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery human approval token tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _resolve_recovery_execution(
+    args: dict[str, Any],
+    recovery_approval_token: dict[str, Any],
+) -> dict[str, Any]:
+    for field_name in (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+    token = _first_token(recovery_approval_token)
+    source = token.get("source_execution_preview") if isinstance(token, dict) else {}
+    return dict(source) if isinstance(source, dict) else {}
+
+
+def _first_token(recovery_approval_token: dict[str, Any]) -> dict[str, Any]:
+    tokens = recovery_approval_token.get("tokens")
+    if isinstance(tokens, list):
+        for token in tokens:
+            if isinstance(token, dict):
+                return token
+    if isinstance(recovery_approval_token, dict) and recovery_approval_token.get("id"):
+        return recovery_approval_token
+    return {}
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Approval Token Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Token: {payload.get('token_id') or 'none'}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Passed: {summary.get('pass_count', 0)}",
+        f"- Failed: {summary.get('fail_count', 0)}",
+        f"- Manual recovery verified: {summary.get('manual_recovery_verified', False)}",
+    ]
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_approval_token_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_approval_token_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_approval_token_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_approval_token_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool.py
@@ -1,0 +1,354 @@
+"""Read-only Memory Evidence Repair Recovery Closure Finalization Readiness Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview import (
+    build_evidence_repair_recovery_closure_finalization_readiness_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview",
+    "description": (
+        "Read-only audit preview for memory evidence repair recovery closure "
+        "finalization readiness. It verifies the finalization gate without "
+        "recording an audit or mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_finalization_readiness": {
+                "type": "object",
+                "description": "Optional recovery closure finalization readiness preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_finalization_readiness_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_finalization_readiness_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "finalization_readiness": {
+                "type": "object",
+                "description": "Optional single recovery closure finalization readiness draft.",
+                "additionalProperties": True,
+            },
+            "finalization_readiness_preview": {
+                "type": "object",
+                "description": "Alias for finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "finalization_readiness_draft": {
+                "type": "object",
+                "description": "Alias for finalization_readiness.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_finalization_readiness = (
+        _resolve_recovery_closure_finalization_readiness(
+            args,
+            kwargs.get("memory_manager"),
+        )
+    )
+    if isinstance(recovery_closure_finalization_readiness, str):
+        return recovery_closure_finalization_readiness
+
+    payload = (
+        build_evidence_repair_recovery_closure_finalization_readiness_audit_preview(
+            recovery_closure_finalization_readiness=(
+                recovery_closure_finalization_readiness
+            ),
+        ).to_dict()
+    )
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_finalization_readiness",
+        "recovery_closure_finalization_readiness_preview",
+        "recovery_closure_finalization_readiness_report",
+        "finalization_readiness",
+        "finalization_readiness_preview",
+        "finalization_readiness_draft",
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+        "seal_audit",
+        "seal_audit_preview",
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "readiness",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(
+                f"{field_name} must be an object when provided.",
+                success=False,
+            )
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_finalization_readiness(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_finalization_readiness",
+        "recovery_closure_finalization_readiness_preview",
+        "recovery_closure_finalization_readiness_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-finalization-readiness-"
+            ):
+                return _readiness_report(explicit)
+            return explicit
+
+    for field_name in (
+        "finalization_readiness",
+        "finalization_readiness_preview",
+        "finalization_readiness_draft",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return _readiness_report(explicit)
+
+    readiness_args = dict(args)
+    for field_name in (
+        "recovery_closure_finalization_readiness",
+        "recovery_closure_finalization_readiness_preview",
+        "recovery_closure_finalization_readiness_report",
+        "finalization_readiness",
+        "finalization_readiness_preview",
+        "finalization_readiness_draft",
+        "format",
+    ):
+        readiness_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+        readiness_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure finalization readiness preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure finalization readiness preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _readiness_report(readiness: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "recovery_closure_finalization_readiness_preview_ready",
+        "summary": {"readiness_count": 1},
+        "readiness": [readiness],
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Finalization Readiness Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_finalization_readiness_audit_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit preview: {preview.get('id')}")
+        lines.append(
+            f"  Finalization readiness: {preview.get('finalization_readiness_id')}"
+        )
+        lines.append(f"  Seal audit: {preview.get('seal_audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_finalization_readiness_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool.py
@@ -1,0 +1,347 @@
+"""Read-only Memory Evidence Repair Recovery Closure Finalization Readiness Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_finalization_readiness_preview import (
+    build_evidence_repair_recovery_closure_finalization_readiness_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_finalization_readiness_preview",
+    "description": (
+        "Read-only finalization readiness preview for memory evidence repair "
+        "recovery closure. It checks whether the full closure governance chain "
+        "is ready for a future manual finalization, without mutating memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_governance_seal_audit": {
+                "type": "object",
+                "description": "Optional recovery closure governance seal audit preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_audit_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "governance_seal_audit": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "governance_seal_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal_audit.",
+                "additionalProperties": True,
+            },
+            "seal_audit": {
+                "type": "object",
+                "description": "Optional single recovery closure governance seal audit preview.",
+                "additionalProperties": True,
+            },
+            "seal_audit_preview": {
+                "type": "object",
+                "description": "Alias for seal_audit.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_governance_seal_audit = (
+        _resolve_recovery_closure_governance_seal_audit(
+            args,
+            kwargs.get("memory_manager"),
+        )
+    )
+    if isinstance(recovery_closure_governance_seal_audit, str):
+        return recovery_closure_governance_seal_audit
+
+    payload = build_evidence_repair_recovery_closure_finalization_readiness_preview(
+        recovery_closure_governance_seal_audit=recovery_closure_governance_seal_audit,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+        "seal_audit",
+        "seal_audit_preview",
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "readiness",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(
+                f"{field_name} must be an object when provided.",
+                success=False,
+            )
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_governance_seal_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-governance-seal-audit-"
+            ):
+                return _seal_audit_report(explicit)
+            return explicit
+
+    for field_name in ("seal_audit", "seal_audit_preview"):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return _seal_audit_report(explicit)
+
+    seal_audit_args = dict(args)
+    for field_name in (
+        "recovery_closure_governance_seal_audit",
+        "recovery_closure_governance_seal_audit_preview",
+        "recovery_closure_governance_seal_audit_report",
+        "governance_seal_audit",
+        "governance_seal_audit_preview",
+        "seal_audit",
+        "seal_audit_preview",
+        "format",
+    ):
+        seal_audit_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+        seal_audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure governance seal audit preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure governance seal audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _seal_audit_report(seal_audit: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "recovery_closure_governance_seal_audit_preview_ready",
+        "summary": {"preview_count": 1},
+        "previews": [seal_audit],
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Finalization Readiness Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Readiness drafts: {summary.get('readiness_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_finalization_ready', False)}",
+        f"- Would allow final closure: {summary.get('would_allow_final_closure_count', 0)}",
+    ]
+    for item in payload.get("readiness", []):
+        lines.append(f"- Finalization readiness: {item.get('id')}")
+        lines.append(f"  Seal audit: {item.get('seal_audit_preview_id')}")
+        lines.append(f"  Seal: {item.get('seal_id')}")
+        lines.append(f"  Ledger audit: {item.get('ledger_audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_finalization_readiness_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_finalization_readiness_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_FINALIZATION_READINESS_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_finalization_readiness_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_finalization_readiness_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_gate_tool.py
@@ -1,0 +1,261 @@
+"""Read-only Memory Evidence Repair Recovery Closure Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_gate import (
+    build_evidence_repair_recovery_closure_gate,
+)
+from tools.memory_evidence_repair_recovery_completion_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_completion_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA["parameters"][
+        "properties"
+    ]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_gate",
+    "description": (
+        "Read-only final closure gate for memory evidence repair recovery. "
+        "It only drafts closure when observed completion audit steps all pass."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_completion_audit": {
+                "type": "object",
+                "description": "Optional recovery completion audit preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_completion_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_completion_audit.",
+                "additionalProperties": True,
+            },
+            "recovery_completion_audit_report": {
+                "type": "object",
+                "description": "Alias for recovery_completion_audit.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_completion_audit = _resolve_recovery_completion_audit(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_completion_audit, str):
+        return recovery_completion_audit
+
+    payload = build_evidence_repair_recovery_closure_gate(
+        recovery_completion_audit=recovery_completion_audit,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_completion_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    audit_args = dict(args)
+    for field_name in (
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "format",
+    ):
+        audit_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_completion_audit_preview_tool(
+        audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery completion audit preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery completion audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Closures: {summary.get('closure_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_ready', False)}",
+    ]
+    for closure in payload.get("closures", []):
+        lines.append(f"- Closure: {closure.get('id')}")
+        lines.append(f"  Audit: {closure.get('audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool.py
@@ -1,0 +1,325 @@
+"""Read-only Memory Evidence Repair Recovery Closure Governance Seal Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_audit_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_governance_seal_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_governance_seal_audit_preview",
+    "description": (
+        "Read-only audit preview for a memory evidence repair recovery closure "
+        "governance seal. It never records an audit or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_governance_seal": {
+                "type": "object",
+                "description": "Optional recovery closure governance seal preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_governance_seal_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "governance_seal": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "governance_seal_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_governance_seal.",
+                "additionalProperties": True,
+            },
+            "seal": {
+                "type": "object",
+                "description": "Optional single recovery closure governance seal draft.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_governance_seal = _resolve_recovery_closure_governance_seal(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_governance_seal, str):
+        return recovery_closure_governance_seal
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_audit_preview(
+        recovery_closure_governance_seal=recovery_closure_governance_seal,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_governance_seal(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-governance-seal-"
+            ):
+                return _seal_report(explicit)
+            return explicit
+
+    explicit_seal = args.get("seal")
+    if isinstance(explicit_seal, dict):
+        return _seal_report(explicit_seal)
+
+    seal_args = dict(args)
+    for field_name in (
+        "recovery_closure_governance_seal",
+        "recovery_closure_governance_seal_preview",
+        "recovery_closure_governance_seal_report",
+        "governance_seal",
+        "governance_seal_preview",
+        "seal",
+        "format",
+    ):
+        seal_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+        seal_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure governance seal preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure governance seal preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _seal_report(seal: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "recovery_closure_governance_seal_preview_ready",
+        "summary": {"seal_count": 1},
+        "seals": [seal],
+        "read_only": True,
+        "read_only_memory": True,
+        "would_mutate_memory": False,
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Governance Seal Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_governance_seal_audit_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit preview: {preview.get('id')}")
+        lines.append(f"  Seal: {preview.get('seal_id')}")
+        lines.append(f"  Ledger audit: {preview.get('ledger_audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_governance_seal_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_governance_seal_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_governance_seal_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_governance_seal_preview_tool.py
@@ -1,0 +1,304 @@
+"""Read-only Memory Evidence Repair Recovery Closure Governance Seal Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_governance_seal_preview import (
+    build_evidence_repair_recovery_closure_governance_seal_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA[
+        "parameters"
+    ]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_governance_seal_preview",
+    "description": (
+        "Read-only governance seal draft for an audited memory evidence repair "
+        "recovery closure. It never records a seal or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_ledger_audit": {
+                "type": "object",
+                "description": "Optional recovery closure ledger audit preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_audit_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "ledger_audit": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "ledger_audit_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_audit.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_governance_seal_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_ledger_audit = _resolve_recovery_closure_ledger_audit(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_ledger_audit, str):
+        return recovery_closure_ledger_audit
+
+    payload = build_evidence_repair_recovery_closure_governance_seal_preview(
+        recovery_closure_ledger_audit=recovery_closure_ledger_audit,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_ledger_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            if str(explicit.get("id") or "").startswith(
+                "recovery-closure-ledger-audit-"
+            ):
+                return {
+                    "status": "recovery_closure_ledger_audit_preview_ready",
+                    "summary": {"preview_count": 1},
+                    "previews": [explicit],
+                    "read_only": True,
+                    "read_only_memory": True,
+                    "would_mutate_memory": False,
+                }
+            return explicit
+
+    audit_args = dict(args)
+    for field_name in (
+        "recovery_closure_ledger_audit",
+        "recovery_closure_ledger_audit_preview",
+        "recovery_closure_ledger_audit_report",
+        "ledger_audit",
+        "ledger_audit_preview",
+        "format",
+    ):
+        audit_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+        audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure ledger audit preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure ledger audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Governance Seal Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Seals: {summary.get('seal_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_governance_seal_ready', False)}",
+    ]
+    for seal in payload.get("seals", []):
+        lines.append(f"- Seal: {seal.get('id')}")
+        lines.append(f"  Ledger audit: {seal.get('ledger_audit_preview_id')}")
+        lines.append(f"  Closure: {seal.get('closure_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_governance_seal_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_governance_seal_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GOVERNANCE_SEAL_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_governance_seal_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_governance_seal_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_ledger_audit_preview_tool.py
@@ -1,0 +1,312 @@
+"""Read-only Memory Evidence Repair Recovery Closure Ledger Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_ledger_audit_preview import (
+    build_evidence_repair_recovery_closure_ledger_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_ledger_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_closure_ledger_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA["parameters"][
+        "properties"
+    ]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_ledger_audit_preview",
+    "description": (
+        "Read-only audit preview for a memory evidence repair recovery closure "
+        "ledger entry. It never records an audit or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_ledger": {
+                "type": "object",
+                "description": "Optional recovery closure ledger preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger.",
+                "additionalProperties": True,
+            },
+            "ledger_preview": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_ledger_entry": {
+                "type": "object",
+                "description": "Optional single recovery closure ledger entry payload.",
+                "additionalProperties": True,
+            },
+            "ledger_entry": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_entry.",
+                "additionalProperties": True,
+            },
+            "entry": {
+                "type": "object",
+                "description": "Alias for recovery_closure_ledger_entry.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_ledger_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_ledger = _resolve_recovery_closure_ledger(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_ledger, str):
+        return recovery_closure_ledger
+
+    payload = build_evidence_repair_recovery_closure_ledger_audit_preview(
+        recovery_closure_ledger=recovery_closure_ledger,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_ledger(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    for field_name in ("recovery_closure_ledger_entry", "ledger_entry", "entry"):
+        explicit_entry = args.get(field_name)
+        if isinstance(explicit_entry, dict):
+            return {
+                "status": "recovery_closure_ledger_preview_ready",
+                "summary": {"entry_count": 1},
+                "entries": [explicit_entry],
+                "read_only": True,
+                "read_only_memory": True,
+                "would_mutate_memory": False,
+            }
+
+    ledger_args = dict(args)
+    for field_name in (
+        "recovery_closure_ledger",
+        "recovery_closure_ledger_preview",
+        "recovery_closure_ledger_report",
+        "ledger_preview",
+        "recovery_closure_ledger_entry",
+        "ledger_entry",
+        "entry",
+        "format",
+    ):
+        ledger_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_ledger_preview_tool(
+        ledger_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery closure ledger preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure ledger preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Ledger Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_ledger_audit_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit preview: {preview.get('id')}")
+        lines.append(f"  Ledger entry: {preview.get('ledger_entry_id')}")
+        lines.append(f"  Closure: {preview.get('closure_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_ledger_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_ledger_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_ledger_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_ledger_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_closure_ledger_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_closure_ledger_preview_tool.py
@@ -1,0 +1,287 @@
+"""Read-only Memory Evidence Repair Recovery Closure Ledger Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_closure_ledger_preview import (
+    build_evidence_repair_recovery_closure_ledger_preview,
+)
+from tools.memory_evidence_repair_recovery_closure_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA,
+    memory_evidence_repair_recovery_closure_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_closure_ledger_preview",
+    "description": (
+        "Read-only lifecycle ledger preview for a memory evidence repair recovery "
+        "closure. It never records a ledger entry or mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_closure_gate": {
+                "type": "object",
+                "description": "Optional recovery closure gate report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_closure_gate_report": {
+                "type": "object",
+                "description": "Alias for recovery_closure_gate.",
+                "additionalProperties": True,
+            },
+            "closure_gate": {
+                "type": "object",
+                "description": "Alias for recovery_closure_gate.",
+                "additionalProperties": True,
+            },
+            "recovery_closure": {
+                "type": "object",
+                "description": "Optional single recovery closure draft payload.",
+                "additionalProperties": True,
+            },
+            "closure": {
+                "type": "object",
+                "description": "Alias for recovery_closure.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_closure_ledger_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_closure_gate = _resolve_recovery_closure_gate(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_closure_gate, str):
+        return recovery_closure_gate
+
+    payload = build_evidence_repair_recovery_closure_ledger_preview(
+        recovery_closure_gate=recovery_closure_gate,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "recovery_completion_audit",
+        "recovery_completion_audit_preview",
+        "recovery_completion_audit_report",
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_closure_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    for field_name in ("recovery_closure", "closure"):
+        explicit_closure = args.get(field_name)
+        if isinstance(explicit_closure, dict):
+            return {
+                "status": "recovery_closure_ready",
+                "summary": {"closure_count": 1},
+                "closures": [explicit_closure],
+                "read_only": True,
+                "read_only_memory": True,
+                "would_mutate_memory": False,
+            }
+
+    gate_args = dict(args)
+    for field_name in (
+        "recovery_closure_gate",
+        "recovery_closure_gate_report",
+        "closure_gate",
+        "recovery_closure",
+        "closure",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_closure_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("recovery closure gate tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery closure gate tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Closure Ledger Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Entries: {summary.get('entry_count', 0)}",
+        f"- Milestones: {summary.get('milestone_count', 0)}",
+        f"- Ready: {summary.get('recovery_closure_ledger_ready', False)}",
+    ]
+    for entry in payload.get("entries", []):
+        lines.append(f"- Ledger entry: {entry.get('id')}")
+        lines.append(f"  Closure: {entry.get('closure_id')}")
+        lines.append(f"  Audit: {entry.get('audit_preview_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_closure_ledger_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_closure_ledger_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_CLOSURE_LEDGER_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_closure_ledger_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_closure_ledger_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_completion_audit_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_completion_audit_preview_tool.py
@@ -1,0 +1,327 @@
+"""Read-only Memory Evidence Repair Recovery Completion Audit Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_completion_audit_preview import (
+    build_evidence_repair_recovery_completion_audit_preview,
+)
+from tools.memory_evidence_repair_recovery_completion_receipt_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA,
+    memory_evidence_repair_recovery_completion_receipt_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_completion_audit_preview",
+    "description": (
+        "Read-only recovery completion audit preview for future memory evidence "
+        "repair manual recoveries. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_completion_receipt": {
+                "type": "object",
+                "description": "Optional recovery completion receipt report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_completion_receipt_report": {
+                "type": "object",
+                "description": "Alias for recovery_completion_receipt.",
+                "additionalProperties": True,
+            },
+            "completion_receipt": {
+                "type": "object",
+                "description": "Alias for recovery_completion_receipt.",
+                "additionalProperties": True,
+            },
+            "observed_recovery_steps": {
+                "type": "object",
+                "description": "Optional observed recovery step signals keyed by recovery step id.",
+                "additionalProperties": True,
+            },
+            "recorded_receipts": {
+                "description": "Optional recorded recovery completion receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "released_lock_ids": {
+                "type": "array",
+                "description": "Optional recovery write-lock ids observed as released.",
+                "items": {"type": "string"},
+            },
+            "post_recovery_audit_status": {
+                "type": "object",
+                "description": "Optional observed post-recovery audit status.",
+                "additionalProperties": True,
+            },
+            "contamination_status": {
+                "type": "object",
+                "description": "Optional observed secondary-memory-contamination status.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_completion_audit_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_completion_receipt = _resolve_recovery_completion_receipt(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_completion_receipt, str):
+        return recovery_completion_receipt
+
+    payload = build_evidence_repair_recovery_completion_audit_preview(
+        recovery_completion_receipt=recovery_completion_receipt,
+        observed_recovery_steps=(
+            args.get("observed_recovery_steps")
+            if isinstance(args.get("observed_recovery_steps"), dict)
+            else None
+        ),
+        recorded_receipts=_recorded_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        released_lock_ids=(
+            args.get("released_lock_ids")
+            if isinstance(args.get("released_lock_ids"), list)
+            else None
+        ),
+        post_recovery_audit_status=(
+            args.get("post_recovery_audit_status")
+            if isinstance(args.get("post_recovery_audit_status"), dict)
+            else None
+        ),
+        contamination_status=(
+            args.get("contamination_status")
+            if isinstance(args.get("contamination_status"), dict)
+            else None
+        ),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_completion_receipt(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    receipt_args = dict(args)
+    for field_name in (
+        "recovery_completion_receipt",
+        "recovery_completion_receipt_report",
+        "completion_receipt",
+        "observed_recovery_steps",
+        "recorded_receipts",
+        "used_token_ids",
+        "released_lock_ids",
+        "post_recovery_audit_status",
+        "contamination_status",
+        "format",
+    ):
+        receipt_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_completion_receipt_tool(
+        receipt_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery completion receipt tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery completion receipt tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _recorded_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("recorded_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Completion Audit Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Audit steps: {summary.get('audit_step_count', 0)}",
+        f"- Planned: {summary.get('planned_audit_step_count', 0)}",
+        f"- Observed pass: {summary.get('observed_pass_step_count', 0)}",
+        f"- Observed fail: {summary.get('observed_fail_step_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Audit: {preview.get('id')}")
+        lines.append(f"  Receipt: {preview.get('receipt_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_completion_audit_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_completion_audit_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_AUDIT_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_completion_audit_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_completion_audit_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_completion_receipt_tool.py
+++ b/tools/memory_evidence_repair_recovery_completion_receipt_tool.py
@@ -1,0 +1,314 @@
+"""Read-only Memory Evidence Repair Recovery Completion Receipt tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_completion_receipt import (
+    build_evidence_repair_recovery_completion_receipt,
+)
+from tools.memory_evidence_repair_recovery_executor_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_executor_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_completion_receipt",
+    "description": (
+        "Read-only completion receipt draft and token/lock ledger view for a "
+        "future memory evidence repair manual recovery. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_executor_preview": {
+                "type": "object",
+                "description": "Optional recovery executor preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_executor_preview_report": {
+                "type": "object",
+                "description": "Alias for recovery_executor_preview.",
+                "additionalProperties": True,
+            },
+            "recovery_executor": {
+                "type": "object",
+                "description": "Alias for recovery_executor_preview.",
+                "additionalProperties": True,
+            },
+            "existing_receipts": {
+                "description": "Optional existing recovery completion receipt report or receipt list.",
+                "oneOf": [
+                    {"type": "object", "additionalProperties": True},
+                    {
+                        "type": "array",
+                        "items": {"type": "object", "additionalProperties": True},
+                    },
+                ],
+            },
+            "receipts": {
+                "type": "array",
+                "description": "Optional existing recovery completion receipt list.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "used_token_ids": {
+                "type": "array",
+                "description": "Optional used recovery approval token ids.",
+                "items": {"type": "string"},
+            },
+            "released_lock_ids": {
+                "type": "array",
+                "description": "Optional released recovery write-lock ids.",
+                "items": {"type": "string"},
+            },
+            "actor": {
+                "type": "string",
+                "description": "Human actor label for the future recovery completion receipt.",
+            },
+            "recovery_reason": {
+                "type": "string",
+                "description": "Reason for the future manual recovery completion.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_completion_receipt_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_executor_preview = _resolve_recovery_executor_preview(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_executor_preview, str):
+        return recovery_executor_preview
+
+    payload = build_evidence_repair_recovery_completion_receipt(
+        recovery_executor_preview=recovery_executor_preview,
+        existing_receipts=_existing_receipts(args),
+        used_token_ids=(
+            args.get("used_token_ids")
+            if isinstance(args.get("used_token_ids"), list)
+            else None
+        ),
+        released_lock_ids=(
+            args.get("released_lock_ids")
+            if isinstance(args.get("released_lock_ids"), list)
+            else None
+        ),
+        actor=str(args.get("actor") or "human"),
+        recovery_reason=str(args.get("recovery_reason") or ""),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_executor_preview(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    executor_args = dict(args)
+    for field_name in (
+        "recovery_executor_preview",
+        "recovery_executor_preview_report",
+        "recovery_executor",
+        "existing_receipts",
+        "receipts",
+        "used_token_ids",
+        "released_lock_ids",
+        "actor",
+        "recovery_reason",
+        "format",
+    ):
+        executor_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_executor_preview_tool(
+        executor_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery executor preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery executor preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _existing_receipts(args: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    explicit = args.get("existing_receipts")
+    if isinstance(explicit, (dict, list)):
+        return explicit
+    receipts = args.get("receipts")
+    if isinstance(receipts, list):
+        return receipts
+    return None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Completion Receipt",
+        f"- Status: {payload.get('status')}",
+        f"- Receipts: {summary.get('receipt_count', 0)}",
+        f"- Used recovery tokens: {summary.get('used_recovery_token_count', 0)}",
+        f"- Released recovery locks: {summary.get('released_recovery_lock_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+    ]
+    for receipt in payload.get("receipts", []):
+        lines.append(f"- Receipt: {receipt.get('id')}")
+        lines.append(f"  Token: {receipt.get('token_id')}")
+        lines.append(f"  Lock: {receipt.get('lock_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_completion_receipt_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_completion_receipt",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_COMPLETION_RECEIPT_SCHEMA,
+    handler=memory_evidence_repair_recovery_completion_receipt_tool,
+    check_fn=check_memory_evidence_repair_recovery_completion_receipt_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_decision_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_decision_gate_tool.py
@@ -1,0 +1,230 @@
+"""Read-only Memory Evidence Repair Recovery Decision Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_decision_gate import (
+    build_evidence_repair_recovery_decision_gate,
+)
+from tools.memory_evidence_repair_rollback_drill_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA,
+    memory_evidence_repair_rollback_drill_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_decision_gate",
+    "description": (
+        "Read-only recovery decision gate for memory evidence repair rollback "
+        "drills. It chooses the next recovery route without mutating durable "
+        "memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "rollback_drill": {
+                "type": "object",
+                "description": "Optional rollback drill preview report payload.",
+                "additionalProperties": True,
+            },
+            "rollback_drill_preview": {
+                "type": "object",
+                "description": "Alias for rollback_drill.",
+                "additionalProperties": True,
+            },
+            "rollback_drill_report": {
+                "type": "object",
+                "description": "Alias for rollback_drill.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_decision_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    rollback_drill = _resolve_rollback_drill(args, kwargs.get("memory_manager"))
+    if isinstance(rollback_drill, str):
+        return rollback_drill
+
+    payload = build_evidence_repair_recovery_decision_gate(
+        rollback_drill=rollback_drill,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_rollback_drill(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    drill_args = dict(args)
+    for field_name in (
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "format",
+    ):
+        drill_args.pop(field_name, None)
+    result = memory_evidence_repair_rollback_drill_preview_tool(
+        drill_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("rollback drill preview tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "rollback drill preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Decision Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Decisions: {summary.get('decision_count', 0)}",
+        f"- Manual rollback: {summary.get('manual_rollback_required_count', 0)}",
+        f"- Isolation review: {summary.get('isolate_and_review_count', 0)}",
+        f"- Preparedness review: {summary.get('preparedness_review_count', 0)}",
+    ]
+    for decision in payload.get("decisions", []):
+        lines.append(f"- Decision: {decision.get('id')}")
+        lines.append(f"  Route: {decision.get('route')}")
+        lines.append(f"  Priority: {decision.get('priority')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_decision_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_decision_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_decision_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_decision_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_execution_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_execution_preview_tool.py
@@ -1,0 +1,232 @@
+"""Read-only Memory Evidence Repair Recovery Execution Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_execution_preview import (
+    build_evidence_repair_recovery_execution_preview,
+)
+from tools.memory_evidence_repair_recovery_decision_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA,
+    memory_evidence_repair_recovery_decision_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_DECISION_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_execution_preview",
+    "description": (
+        "Read-only recovery execution preview for memory evidence repair. "
+        "It orders future manual recovery actions without mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_decision": {
+                "type": "object",
+                "description": "Optional recovery decision gate report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_decision_gate": {
+                "type": "object",
+                "description": "Alias for recovery_decision.",
+                "additionalProperties": True,
+            },
+            "recovery_decision_report": {
+                "type": "object",
+                "description": "Alias for recovery_decision.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_execution_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_decision = _resolve_recovery_decision(args, kwargs.get("memory_manager"))
+    if isinstance(recovery_decision, str):
+        return recovery_decision
+
+    payload = build_evidence_repair_recovery_execution_preview(
+        recovery_decision=recovery_decision,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_decision(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    decision_args = dict(args)
+    for field_name in (
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "format",
+    ):
+        decision_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_decision_gate_tool(
+        decision_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("recovery decision gate tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery decision gate tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Execution Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Execution steps: {summary.get('execution_step_count', 0)}",
+        f"- Future mutation steps: {summary.get('future_mutation_step_count', 0)}",
+        f"- Manual rollback previews: {summary.get('manual_rollback_preview_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Preview: {preview.get('id')}")
+        lines.append(f"  Route: {preview.get('route')}")
+        lines.append(f"  Decision: {preview.get('decision_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_execution_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_execution_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_execution_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_execution_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_executor_preview_tool.py
+++ b/tools/memory_evidence_repair_recovery_executor_preview_tool.py
@@ -1,0 +1,257 @@
+"""Read-only Memory Evidence Repair Recovery Executor Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_executor_preview import (
+    build_evidence_repair_recovery_executor_preview,
+)
+from tools.memory_evidence_repair_recovery_write_lock_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA,
+    memory_evidence_repair_recovery_write_lock_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_executor_preview",
+    "description": (
+        "Read-only ordered executor preview for a future memory evidence repair "
+        "manual recovery. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_write_lock_gate": {
+                "type": "object",
+                "description": "Optional recovery write-lock gate payload.",
+                "additionalProperties": True,
+            },
+            "recovery_executor_lock_gate": {
+                "type": "object",
+                "description": "Alias for recovery_write_lock_gate.",
+                "additionalProperties": True,
+            },
+            "recovery_write_lock": {
+                "type": "object",
+                "description": "Optional single recovery write-lock draft payload.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_executor_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_write_lock_gate = _resolve_recovery_write_lock_gate(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_write_lock_gate, str):
+        return recovery_write_lock_gate
+
+    payload = build_evidence_repair_recovery_executor_preview(
+        recovery_write_lock_gate=recovery_write_lock_gate,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_write_lock_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+    ):
+        explicit_gate = args.get(field_name)
+        if isinstance(explicit_gate, dict):
+            return explicit_gate
+
+    explicit_lock = args.get("recovery_write_lock")
+    if isinstance(explicit_lock, dict):
+        return {
+            "status": "recovery_write_lock_ready_for_manual_recovery",
+            "summary": {"lock_count": 1},
+            "locks": [explicit_lock],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    gate_args = dict(args)
+    for field_name in (
+        "recovery_write_lock_gate",
+        "recovery_executor_lock_gate",
+        "recovery_write_lock",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_write_lock_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("recovery write-lock gate returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery write-lock gate returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Executor Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Steps: {summary.get('step_count', 0)}",
+        f"- Future mutation steps: {summary.get('future_mutation_step_count', 0)}",
+        f"- Ready: {summary.get('manual_recovery_executor_preview_ready', False)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Preview: {preview.get('id')}")
+        lines.append(f"  Lock: {preview.get('lock_id')}")
+        lines.append(f"  Failure policy: {preview.get('failure_policy')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_executor_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_executor_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTOR_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_recovery_executor_preview_tool,
+    check_fn=check_memory_evidence_repair_recovery_executor_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_human_approval_token_tool.py
+++ b/tools/memory_evidence_repair_recovery_human_approval_token_tool.py
@@ -1,0 +1,256 @@
+"""Read-only Memory Evidence Repair Recovery Human Approval Token tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_human_approval_token import (
+    build_evidence_repair_recovery_human_approval_token,
+)
+from tools.memory_evidence_repair_recovery_execution_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA,
+    memory_evidence_repair_recovery_execution_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_EXECUTION_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+_UPSTREAM_PROPERTIES.pop("expires_in_minutes", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_human_approval_token",
+    "description": (
+        "Read-only recovery human approval token draft for a ready memory "
+        "evidence repair recovery execution preview. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_execution": {
+                "type": "object",
+                "description": "Optional recovery execution preview report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_execution_preview": {
+                "type": "object",
+                "description": "Alias for recovery_execution.",
+                "additionalProperties": True,
+            },
+            "recovery_execution_report": {
+                "type": "object",
+                "description": "Alias for recovery_execution.",
+                "additionalProperties": True,
+            },
+            "approver": {
+                "type": "string",
+                "description": "Human approver label for the recovery token draft.",
+            },
+            "approval_reason": {
+                "type": "string",
+                "description": "Reason for drafting the recovery approval token.",
+            },
+            "expires_in_minutes": {
+                "type": "integer",
+                "description": "Draft recovery token expiry window in minutes. Defaults to 15.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_human_approval_token_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_execution = _resolve_recovery_execution(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_execution, str):
+        return recovery_execution
+
+    payload = build_evidence_repair_recovery_human_approval_token(
+        recovery_execution=recovery_execution,
+        approver=str(args.get("approver") or "human"),
+        approval_reason=str(args.get("approval_reason") or ""),
+        expires_in_minutes=args.get("expires_in_minutes") or 15,
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_execution(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    execution_args = dict(args)
+    for field_name in (
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "approver",
+        "approval_reason",
+        "expires_in_minutes",
+        "format",
+    ):
+        execution_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_execution_preview_tool(
+        execution_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery execution preview tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery execution preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Human Approval Token",
+        f"- Status: {payload.get('status')}",
+        f"- Tokens: {summary.get('token_count', 0)}",
+        f"- Blocks: {summary.get('blocking_reason_count', 0)}",
+        f"- Required actions: {summary.get('required_action_count', 0)}",
+    ]
+    for token in payload.get("tokens", []):
+        lines.append(f"- Token: {token.get('id')}")
+        lines.append(f"  Confirm: {token.get('required_confirmation_text')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_human_approval_token_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_human_approval_token",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_HUMAN_APPROVAL_TOKEN_SCHEMA,
+    handler=memory_evidence_repair_recovery_human_approval_token_tool,
+    check_fn=check_memory_evidence_repair_recovery_human_approval_token_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_recovery_write_lock_gate_tool.py
+++ b/tools/memory_evidence_repair_recovery_write_lock_gate_tool.py
@@ -1,0 +1,287 @@
+"""Read-only Memory Evidence Repair Recovery Write Lock Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_recovery_write_lock_gate import (
+    build_evidence_repair_recovery_write_lock_gate,
+)
+from tools.memory_evidence_repair_recovery_approval_token_gate_tool import (
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA,
+    memory_evidence_repair_recovery_approval_token_gate_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_RECOVERY_APPROVAL_TOKEN_GATE_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_recovery_write_lock_gate",
+    "description": (
+        "Read-only recovery write-lock gate for memory evidence repair recovery. "
+        "It drafts a future recovery write lock without mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "recovery_token_gate": {
+                "type": "object",
+                "description": "Optional recovery approval token gate report payload.",
+                "additionalProperties": True,
+            },
+            "recovery_approval_token_gate": {
+                "type": "object",
+                "description": "Alias for recovery_token_gate.",
+                "additionalProperties": True,
+            },
+            "token_gate": {
+                "type": "object",
+                "description": "Alias for recovery_token_gate.",
+                "additionalProperties": True,
+            },
+            "active_locks": {
+                "type": "array",
+                "description": "Optional active recovery write-lock records to check for conflicts.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "locks": {
+                "type": "array",
+                "description": "Alias for active_locks.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "already_used_token_ids": {
+                "type": "array",
+                "description": "External used-token ids to check before drafting a recovery write lock.",
+                "items": {"type": "string"},
+            },
+            "lock_owner": {
+                "type": "string",
+                "description": "Owner label for the future recovery write-lock draft.",
+            },
+            "lock_ttl_minutes": {
+                "type": "integer",
+                "description": "Recovery write-lock draft TTL in minutes. Defaults to 10.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_recovery_write_lock_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    recovery_token_gate = _resolve_recovery_token_gate(
+        args,
+        kwargs.get("memory_manager"),
+    )
+    if isinstance(recovery_token_gate, str):
+        return recovery_token_gate
+
+    payload = build_evidence_repair_recovery_write_lock_gate(
+        recovery_token_gate=recovery_token_gate,
+        active_locks=_active_locks(args),
+        already_used_token_ids=(
+            args.get("already_used_token_ids")
+            if isinstance(args.get("already_used_token_ids"), list)
+            else None
+        ),
+        lock_owner=str(args.get("lock_owner") or args.get("actor") or "human"),
+        lock_ttl_minutes=args.get("lock_ttl_minutes") or 10,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "recovery_approval_token",
+        "recovery_human_approval_token",
+        "recovery_token",
+        "token",
+        "recovery_execution",
+        "recovery_execution_preview",
+        "recovery_execution_report",
+        "recovery_decision",
+        "recovery_decision_gate",
+        "recovery_decision_report",
+        "rollback_drill",
+        "rollback_drill_preview",
+        "rollback_drill_report",
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "approval_token_gate",
+        "approval_token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "released_lock_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_recovery_token_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in ("recovery_token_gate", "recovery_approval_token_gate", "token_gate"):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    gate_args = dict(args)
+    for field_name in (
+        "recovery_token_gate",
+        "recovery_approval_token_gate",
+        "token_gate",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "lock_owner",
+        "lock_ttl_minutes",
+        "format",
+    ):
+        gate_args.pop(field_name, None)
+    result = memory_evidence_repair_recovery_approval_token_gate_tool(
+        gate_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error(
+            "recovery approval token gate tool returned invalid JSON.",
+            success=False,
+        )
+    if not isinstance(payload, dict):
+        return tool_error(
+            "recovery approval token gate tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _active_locks(args: dict[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(args.get("active_locks"), list):
+        return args["active_locks"]
+    if isinstance(args.get("locks"), list):
+        return args["locks"]
+    return []
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Recovery Write Lock Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Locks: {summary.get('lock_count', 0)}",
+        f"- Conflicts: {summary.get('active_lock_conflict_count', 0)}",
+        f"- Recovery executor preview allowed: {summary.get('recovery_executor_preview_allowed', False)}",
+    ]
+    for lock in payload.get("locks", []):
+        lines.append(f"- Lock: {lock.get('id')}")
+        lines.append(f"  Token: {lock.get('token_id')}")
+        lines.append(f"  Expires: {lock.get('expires_at')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_recovery_write_lock_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_recovery_write_lock_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_RECOVERY_WRITE_LOCK_GATE_SCHEMA,
+    handler=memory_evidence_repair_recovery_write_lock_gate_tool,
+    check_fn=check_memory_evidence_repair_recovery_write_lock_gate_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_rollback_drill_preview_tool.py
+++ b/tools/memory_evidence_repair_rollback_drill_preview_tool.py
@@ -1,0 +1,249 @@
+"""Read-only Memory Evidence Repair Rollback Drill Preview tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_rollback_drill_preview import (
+    build_evidence_repair_rollback_drill_preview,
+)
+from tools.memory_evidence_repair_post_commit_audit_preview_tool import (
+    MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA,
+    memory_evidence_repair_post_commit_audit_preview_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_POST_COMMIT_AUDIT_PREVIEW_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA = {
+    "name": "memory_evidence_repair_rollback_drill_preview",
+    "description": (
+        "Read-only rollback drill preview for memory evidence repair audit "
+        "failures. It rehearses isolation, restoration, reconciliation, and "
+        "re-audit steps without mutating durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "post_commit_audit": {
+                "type": "object",
+                "description": "Optional post-commit audit report payload.",
+                "additionalProperties": True,
+            },
+            "post_commit_audit_preview": {
+                "type": "object",
+                "description": "Alias for post_commit_audit.",
+                "additionalProperties": True,
+            },
+            "post_commit_audit_report": {
+                "type": "object",
+                "description": "Alias for post_commit_audit.",
+                "additionalProperties": True,
+            },
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan reference for drill source matching.",
+                "additionalProperties": True,
+            },
+            "snapshot_plan": {
+                "type": "object",
+                "description": "Optional snapshot plan reference for drill source matching.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_rollback_drill_preview_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    post_commit_audit = _resolve_post_commit_audit(args, kwargs.get("memory_manager"))
+    if isinstance(post_commit_audit, str):
+        return post_commit_audit
+
+    payload = build_evidence_repair_rollback_drill_preview(
+        post_commit_audit=post_commit_audit,
+        rollback_plan=(
+            args.get("rollback_plan")
+            if isinstance(args.get("rollback_plan"), dict)
+            else None
+        ),
+        snapshot_plan=(
+            args.get("snapshot_plan")
+            if isinstance(args.get("snapshot_plan"), dict)
+            else None
+        ),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "executor_preview",
+        "executor",
+        "observed_memory_patches",
+        "rollback_status",
+        "write_lock_gate",
+        "executor_lock_gate",
+        "write_lock",
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "released_lock_ids",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in ("existing_receipts", "recorded_receipts"):
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, (dict, list)):
+            return tool_error(
+                f"{field_name} must be an object or array when provided.",
+                success=False,
+            )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_post_commit_audit(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    for field_name in (
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+    ):
+        explicit = args.get(field_name)
+        if isinstance(explicit, dict):
+            return explicit
+
+    audit_args = dict(args)
+    for field_name in (
+        "post_commit_audit",
+        "post_commit_audit_preview",
+        "post_commit_audit_report",
+        "rollback_plan",
+        "snapshot_plan",
+        "format",
+    ):
+        audit_args.pop(field_name, None)
+    result = memory_evidence_repair_post_commit_audit_preview_tool(
+        audit_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("post-commit audit preview tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error(
+            "post-commit audit preview tool returned a non-object payload.",
+            success=False,
+        )
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Rollback Drill Preview",
+        f"- Status: {payload.get('status')}",
+        f"- Previews: {summary.get('preview_count', 0)}",
+        f"- Drill steps: {summary.get('drill_step_count', 0)}",
+        f"- Failed audit steps: {summary.get('failed_audit_step_count', 0)}",
+        f"- Future restore steps: {summary.get('future_restore_step_count', 0)}",
+    ]
+    for preview in payload.get("previews", []):
+        lines.append(f"- Drill: {preview.get('id')}")
+        lines.append(f"  Trigger: {preview.get('trigger')}")
+        lines.append(f"  Audit: {preview.get('post_commit_audit_id')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_rollback_drill_preview_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_rollback_drill_preview",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_ROLLBACK_DRILL_PREVIEW_SCHEMA,
+    handler=memory_evidence_repair_rollback_drill_preview_tool,
+    check_fn=check_memory_evidence_repair_rollback_drill_preview_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_rollback_plan_tool.py
+++ b/tools/memory_evidence_repair_rollback_plan_tool.py
@@ -1,0 +1,459 @@
+"""Read-only Memory Evidence Repair Rollback Plan tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from agent.memory_evidence_repair_rollback_plan import (
+    MemoryEvidenceRepairRollbackPlan,
+    build_evidence_repair_rollback_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_ROLLBACK_PLAN_SCHEMA = {
+    "name": "memory_evidence_repair_rollback_plan",
+    "description": (
+        "Read-only rollback plan for future memory evidence repair writes. "
+        "It drafts inverse patch steps and never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries to turn into rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Optional previous evidence snapshots keyed by ledger, candidate, preview, decision, or patch digest id.",
+                "additionalProperties": True,
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions used to build a ledger.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews used to build a commit gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum rollback steps to include. Defaults to all steps.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_rollback_plan_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    ledger = _resolve_ledger(args, kwargs.get("memory_manager"))
+    if isinstance(ledger, str):
+        return ledger
+
+    report = build_evidence_repair_rollback_plan(
+        ledger=ledger,
+        pre_commit_snapshots=(
+            args.get("pre_commit_snapshots")
+            if isinstance(args.get("pre_commit_snapshots"), dict)
+            else {}
+        ),
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairRollbackPlan(
+            generated_at=report.generated_at,
+            steps=report.steps[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "ledger",
+        "pre_commit_snapshots",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_ledger(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_ledger = args.get("ledger")
+    explicit_entries = args.get("entries")
+    if isinstance(explicit_ledger, dict):
+        if "entries" in explicit_ledger:
+            return explicit_ledger
+        return {
+            "summary": {"entry_count": 1},
+            "entries": [explicit_ledger],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_entries, list):
+        return {
+            "summary": {"entry_count": len(explicit_entries)},
+            "entries": explicit_entries,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    return build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    ).to_dict()
+
+
+def _resolve_commit_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Rollback Plan",
+        f"- Steps: {summary.get('rollback_step_count', 0)}",
+        f"- Ready: {summary.get('ready_count', 0)}",
+        f"- Snapshot required: {summary.get('snapshot_required_count', 0)}",
+        f"- No action: {summary.get('no_action_count', 0)}",
+    ]
+    for index, step in enumerate(payload.get("steps", []), start=1):
+        provider = step.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{step.get('status')}] "
+            f"{step.get('rollback_action')} provider={provider}"
+        )
+        required = step.get("required_preconditions") or []
+        if required:
+            lines.append(f"   Preconditions: {', '.join(str(item) for item in required)}")
+        verify = step.get("verification_steps") or []
+        if verify:
+            lines.append(f"   Verify: {', '.join(str(item) for item in verify)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_rollback_plan_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_rollback_plan",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_ROLLBACK_PLAN_SCHEMA,
+    handler=memory_evidence_repair_rollback_plan_tool,
+    check_fn=check_memory_evidence_repair_rollback_plan_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_snapshot_planner_tool.py
+++ b/tools/memory_evidence_repair_snapshot_planner_tool.py
@@ -1,0 +1,519 @@
+"""Read-only Memory Evidence Repair Snapshot Planner tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_apply_preview import (
+    build_evidence_repair_apply_preview,
+)
+from agent.memory_evidence_repair_approval import (
+    build_evidence_repair_approval_candidates,
+)
+from agent.memory_evidence_repair_commit_gate import (
+    build_evidence_repair_commit_gate,
+)
+from agent.memory_evidence_repair_commit_ledger import (
+    build_evidence_repair_commit_ledger,
+)
+from agent.memory_evidence_repair_planner import build_evidence_repair_plan
+from agent.memory_evidence_repair_rollback_plan import (
+    build_evidence_repair_rollback_plan,
+)
+from agent.memory_evidence_repair_snapshot_planner import (
+    MemoryEvidenceRepairSnapshotPlan,
+    build_evidence_repair_snapshot_plan,
+)
+from tools.registry import registry, tool_error
+
+
+MEMORY_EVIDENCE_REPAIR_SNAPSHOT_PLANNER_SCHEMA = {
+    "name": "memory_evidence_repair_snapshot_planner",
+    "description": (
+        "Read-only pre-commit snapshot planner for memory evidence repair. "
+        "It identifies evidence fields to capture before a future manual write."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "rollback_plan": {
+                "type": "object",
+                "description": "Optional rollback plan payload.",
+                "additionalProperties": True,
+            },
+            "steps": {
+                "type": "array",
+                "description": "Optional rollback steps to turn into snapshot requests.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "existing_snapshots": {
+                "type": "object",
+                "description": "Optional existing pre-commit snapshots keyed by ledger, candidate, preview, decision, or patch digest id.",
+                "additionalProperties": True,
+            },
+            "pre_commit_snapshots": {
+                "type": "object",
+                "description": "Alias for existing_snapshots.",
+                "additionalProperties": True,
+            },
+            "ledger": {
+                "type": "object",
+                "description": "Optional commit ledger draft payload.",
+                "additionalProperties": True,
+            },
+            "entries": {
+                "type": "array",
+                "description": "Optional commit ledger entries used to build rollback steps.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "commit_gate": {
+                "type": "object",
+                "description": "Optional commit gate report payload.",
+                "additionalProperties": True,
+            },
+            "decisions": {
+                "type": "array",
+                "description": "Optional commit gate decisions used to build a ledger.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "ledger_actor": {
+                "type": "string",
+                "description": "Optional actor label for generated ledger entries.",
+            },
+            "ledger_reason": {
+                "type": "string",
+                "description": "Optional reason for generated ledger entries.",
+            },
+            "preview": {
+                "type": "object",
+                "description": "Optional apply preview report payload.",
+                "additionalProperties": True,
+            },
+            "previews": {
+                "type": "array",
+                "description": "Optional apply previews used to build a commit gate.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "confirmed_preview_ids": {
+                "type": "array",
+                "description": "Optional preview ids explicitly confirmed by the user.",
+                "items": {"type": "string"},
+            },
+            "user_confirmed": {
+                "type": "boolean",
+                "description": "Whether the user explicitly confirmed these previews.",
+            },
+            "approval": {
+                "type": "object",
+                "description": "Optional approval candidate report payload.",
+                "additionalProperties": True,
+            },
+            "candidates": {
+                "type": "array",
+                "description": "Optional approval candidates used to build previews.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "approved_candidate_ids": {
+                "type": "array",
+                "description": "Optional candidate ids confirmed for apply preview generation.",
+                "items": {"type": "string"},
+            },
+            "plan": {
+                "type": "object",
+                "description": "Optional evidence repair plan payload.",
+                "additionalProperties": True,
+            },
+            "repairs": {
+                "type": "array",
+                "description": "Optional repair items used to build candidates.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "gate": {
+                "type": "object",
+                "description": "Optional memory policy gate payload.",
+                "additionalProperties": True,
+            },
+            "audit": {
+                "type": "object",
+                "description": "Optional memory recall audit payload.",
+                "additionalProperties": True,
+            },
+            "diagnostics": {
+                "type": "object",
+                "description": "Optional memory recall diagnostics payload.",
+                "additionalProperties": True,
+            },
+            "policy": {
+                "type": "object",
+                "description": "Optional memory auto-policy payload.",
+                "additionalProperties": True,
+            },
+            "proposed_evidence": {
+                "type": "object",
+                "description": "Optional proposed evidence values keyed globally or by candidate id.",
+                "additionalProperties": True,
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum snapshot requests to include. Defaults to all requests.",
+            },
+        },
+    },
+}
+
+
+def memory_evidence_repair_snapshot_planner_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    existing_snapshots = _existing_snapshots(args)
+    rollback_plan = _resolve_rollback_plan(args, kwargs.get("memory_manager"))
+    if isinstance(rollback_plan, str):
+        return rollback_plan
+
+    report = build_evidence_repair_snapshot_plan(
+        rollback_plan=rollback_plan,
+        existing_snapshots=existing_snapshots,
+    )
+
+    limit = _positive_int(args.get("limit"))
+    if limit is not None:
+        report = MemoryEvidenceRepairSnapshotPlan(
+            generated_at=report.generated_at,
+            requests=report.requests[:limit],
+        )
+
+    payload = report.to_dict()
+    if limit is not None:
+        payload["limited_to"] = limit
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _existing_snapshots(args: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(args.get("existing_snapshots"), dict):
+        return args["existing_snapshots"]
+    if isinstance(args.get("pre_commit_snapshots"), dict):
+        return args["pre_commit_snapshots"]
+    return {}
+
+
+def _resolve_rollback_plan(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_plan = args.get("rollback_plan")
+    explicit_steps = args.get("steps")
+    if isinstance(explicit_plan, dict):
+        if "steps" in explicit_plan:
+            return explicit_plan
+        return {
+            "summary": {"rollback_step_count": 1},
+            "steps": [explicit_plan],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_steps, list):
+        return {
+            "summary": {"rollback_step_count": len(explicit_steps)},
+            "steps": explicit_steps,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    ledger = _resolve_ledger(args, memory_manager)
+    if isinstance(ledger, str):
+        return ledger
+    return build_evidence_repair_rollback_plan(
+        ledger=ledger,
+        pre_commit_snapshots=_existing_snapshots(args),
+    ).to_dict()
+
+
+def _resolve_ledger(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_ledger = args.get("ledger")
+    explicit_entries = args.get("entries")
+    if isinstance(explicit_ledger, dict):
+        if "entries" in explicit_ledger:
+            return explicit_ledger
+        return {
+            "summary": {"entry_count": 1},
+            "entries": [explicit_ledger],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_entries, list):
+        return {
+            "summary": {"entry_count": len(explicit_entries)},
+            "entries": explicit_entries,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    commit_gate = _resolve_commit_gate(args, memory_manager)
+    if isinstance(commit_gate, str):
+        return commit_gate
+    return build_evidence_repair_commit_ledger(
+        commit_gate=commit_gate,
+        ledger_actor=str(args.get("ledger_actor") or "hermes"),
+        ledger_reason=str(args.get("ledger_reason") or ""),
+    ).to_dict()
+
+
+def _resolve_commit_gate(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_gate = args.get("commit_gate")
+    explicit_decisions = args.get("decisions")
+    if isinstance(explicit_gate, dict):
+        if "decisions" in explicit_gate:
+            return explicit_gate
+        return {
+            "summary": {"decision_count": 1},
+            "decisions": [explicit_gate],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_decisions, list):
+        return {
+            "summary": {"decision_count": len(explicit_decisions)},
+            "decisions": explicit_decisions,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    preview = _resolve_preview(args, memory_manager)
+    if isinstance(preview, str):
+        return preview
+    return build_evidence_repair_commit_gate(
+        preview=preview,
+        confirmed_preview_ids=(
+            args.get("confirmed_preview_ids")
+            if isinstance(args.get("confirmed_preview_ids"), list)
+            else None
+        ),
+        user_confirmed=bool(args.get("user_confirmed")),
+    ).to_dict()
+
+
+def _resolve_preview(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_preview = args.get("preview")
+    explicit_previews = args.get("previews")
+    if isinstance(explicit_preview, dict):
+        if "previews" in explicit_preview:
+            return explicit_preview
+        return {
+            "summary": {"preview_count": 1},
+            "previews": [explicit_preview],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+    if isinstance(explicit_previews, list):
+        return {
+            "summary": {"preview_count": len(explicit_previews)},
+            "previews": explicit_previews,
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    approval = _resolve_approval(args, memory_manager)
+    if isinstance(approval, str):
+        return approval
+    return build_evidence_repair_apply_preview(
+        approval=approval,
+        approved_candidate_ids=(
+            args.get("approved_candidate_ids")
+            if isinstance(args.get("approved_candidate_ids"), list)
+            else None
+        ),
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_approval(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_approval = args.get("approval")
+    explicit_candidates = args.get("candidates")
+    if isinstance(explicit_approval, dict):
+        return explicit_approval
+    if isinstance(explicit_candidates, list):
+        return {
+            "summary": {"candidate_count": len(explicit_candidates)},
+            "candidates": explicit_candidates,
+            "read_only": True,
+            "read_only_memory": True,
+        }
+
+    plan = _resolve_plan(args, memory_manager)
+    if isinstance(plan, str):
+        return plan
+    return build_evidence_repair_approval_candidates(
+        plan=plan,
+        proposed_evidence=(
+            args.get("proposed_evidence")
+            if isinstance(args.get("proposed_evidence"), dict)
+            else {}
+        ),
+    ).to_dict()
+
+
+def _resolve_plan(args: dict[str, Any], memory_manager: Any) -> dict[str, Any] | str:
+    explicit_plan = args.get("plan")
+    explicit_repairs = args.get("repairs")
+    if isinstance(explicit_plan, dict):
+        return explicit_plan
+    if isinstance(explicit_repairs, list):
+        return {
+            "summary": {"repair_count": len(explicit_repairs)},
+            "repairs": explicit_repairs,
+            "read_only": True,
+        }
+
+    gate = args.get("gate") if isinstance(args.get("gate"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_policy_gate",
+    )
+    audit = args.get("audit") if isinstance(args.get("audit"), dict) else _manager_dict(
+        memory_manager,
+        "last_recall_audit",
+    )
+    diagnostics = (
+        args.get("diagnostics")
+        if isinstance(args.get("diagnostics"), dict)
+        else _manager_dict(memory_manager, "last_recall_diagnostics")
+    )
+    policy = args.get("policy") if isinstance(args.get("policy"), dict) else _manager_dict(
+        memory_manager,
+        "last_memory_auto_policy",
+    )
+    return build_evidence_repair_plan(
+        gate=gate,
+        audit=audit,
+        diagnostics=diagnostics,
+        policy=policy,
+    ).to_dict()
+
+
+def _manager_dict(memory_manager: Any, method_name: str) -> dict[str, Any]:
+    if memory_manager is None or not hasattr(memory_manager, method_name):
+        return {}
+    try:
+        value = getattr(memory_manager, method_name)()
+    except Exception:
+        return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Snapshot Planner",
+        f"- Requests: {summary.get('snapshot_request_count', 0)}",
+        f"- Capture required: {summary.get('capture_required_count', 0)}",
+        f"- Already available: {summary.get('already_available_count', 0)}",
+        f"- Blocking: {summary.get('blocking_count', 0)}",
+    ]
+    for index, request in enumerate(payload.get("requests", []), start=1):
+        provider = request.get("provider") or "memory"
+        lines.append(
+            f"{index}. [{request.get('status')}] "
+            f"{request.get('snapshot_action')} provider={provider}"
+        )
+        fields = request.get("evidence_fields") or []
+        if fields:
+            lines.append(f"   Capture: {', '.join(str(item) for item in fields)}")
+        verify = request.get("verification_steps") or []
+        if verify:
+            lines.append(f"   Verify: {', '.join(str(item) for item in verify)}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_snapshot_planner_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_snapshot_planner",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_SNAPSHOT_PLANNER_SCHEMA,
+    handler=memory_evidence_repair_snapshot_planner_tool,
+    check_fn=check_memory_evidence_repair_snapshot_planner_requirements,
+    emoji="🧠",
+)

--- a/tools/memory_evidence_repair_write_lock_gate_tool.py
+++ b/tools/memory_evidence_repair_write_lock_gate_tool.py
@@ -1,0 +1,256 @@
+"""Read-only Memory Evidence Repair Write Lock Gate tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.memory_evidence_repair_write_lock_gate import (
+    build_evidence_repair_write_lock_gate,
+)
+from tools.memory_evidence_repair_commit_receipt_tool import (
+    MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA,
+    memory_evidence_repair_commit_receipt_tool,
+)
+from tools.registry import registry, tool_error
+
+
+_UPSTREAM_PROPERTIES = dict(
+    MEMORY_EVIDENCE_REPAIR_COMMIT_RECEIPT_SCHEMA["parameters"]["properties"]
+)
+_UPSTREAM_PROPERTIES.pop("format", None)
+
+MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA = {
+    "name": "memory_evidence_repair_write_lock_gate",
+    "description": (
+        "Read-only write-lock and executor dry-run gate for memory evidence "
+        "repair manual commits. It never mutates durable memory."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "commit_receipt": {
+                "type": "object",
+                "description": "Optional commit receipt report payload.",
+                "additionalProperties": True,
+            },
+            "receipt": {
+                "type": "object",
+                "description": "Optional single commit receipt payload.",
+                "additionalProperties": True,
+            },
+            "active_locks": {
+                "type": "array",
+                "description": "Optional active write-lock records to check for conflicts.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "locks": {
+                "type": "array",
+                "description": "Alias for active_locks.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "already_used_token_ids": {
+                "type": "array",
+                "description": "External used-token ids to check before drafting a write lock.",
+                "items": {"type": "string"},
+            },
+            "lock_owner": {
+                "type": "string",
+                "description": "Owner label for the future write-lock draft.",
+            },
+            "lock_ttl_minutes": {
+                "type": "integer",
+                "description": "Write-lock draft TTL in minutes. Defaults to 10.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["json", "markdown"],
+                "description": "Optional response format helper. JSON is always returned; markdown adds a readable summary field.",
+            },
+            **_UPSTREAM_PROPERTIES,
+        },
+    },
+}
+
+
+def memory_evidence_repair_write_lock_gate_tool(
+    args: dict[str, Any],
+    **kwargs,
+) -> str:
+    if not isinstance(args, dict):
+        return tool_error("args must be an object.", success=False)
+
+    validated = _validate_args(args)
+    if validated is not None:
+        return validated
+
+    commit_receipt = _resolve_commit_receipt(args, kwargs.get("memory_manager"))
+    if isinstance(commit_receipt, str):
+        return commit_receipt
+
+    payload = build_evidence_repair_write_lock_gate(
+        commit_receipt=commit_receipt,
+        active_locks=_active_locks(args),
+        already_used_token_ids=(
+            args.get("already_used_token_ids")
+            if isinstance(args.get("already_used_token_ids"), list)
+            else None
+        ),
+        lock_owner=str(args.get("lock_owner") or args.get("actor") or "human"),
+        lock_ttl_minutes=args.get("lock_ttl_minutes") or 10,
+        current_time=args.get("current_time"),
+    ).to_dict()
+    payload["success"] = True
+    payload["read_only"] = True
+    payload["read_only_memory"] = True
+    payload["would_mutate_memory"] = False
+    if str(args.get("format", "")).lower() == "markdown":
+        payload["markdown"] = _render_markdown(payload)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _validate_args(args: dict[str, Any]) -> str | None:
+    object_fields = (
+        "commit_receipt",
+        "receipt",
+        "token_gate",
+        "approval_token_gate",
+        "approval_token",
+        "token",
+        "dry_run",
+        "snapshot_plan",
+        "rollback_plan",
+        "existing_snapshots",
+        "pre_commit_snapshots",
+        "ledger",
+        "commit_gate",
+        "preview",
+        "approval",
+        "plan",
+        "gate",
+        "audit",
+        "diagnostics",
+        "policy",
+        "proposed_evidence",
+    )
+    array_fields = (
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "tokens",
+        "used_token_ids",
+        "receipts",
+        "requests",
+        "steps",
+        "entries",
+        "decisions",
+        "previews",
+        "confirmed_preview_ids",
+        "candidates",
+        "approved_candidate_ids",
+        "repairs",
+    )
+    for field_name in object_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, dict):
+            return tool_error(f"{field_name} must be an object when provided.", success=False)
+    existing_receipts = args.get("existing_receipts")
+    if existing_receipts is not None and not isinstance(existing_receipts, (dict, list)):
+        return tool_error(
+            "existing_receipts must be an object or array when provided.",
+            success=False,
+        )
+    for field_name in array_fields:
+        value = args.get(field_name)
+        if value is not None and not isinstance(value, list):
+            return tool_error(f"{field_name} must be an array when provided.", success=False)
+    return None
+
+
+def _resolve_commit_receipt(
+    args: dict[str, Any],
+    memory_manager: Any,
+) -> dict[str, Any] | str:
+    explicit_report = args.get("commit_receipt")
+    if isinstance(explicit_report, dict):
+        return explicit_report
+
+    explicit_receipt = args.get("receipt")
+    if isinstance(explicit_receipt, dict):
+        return {
+            "status": explicit_receipt.get("status"),
+            "summary": {"receipt_count": 1},
+            "receipts": [explicit_receipt],
+            "read_only": True,
+            "read_only_memory": True,
+            "would_mutate_memory": False,
+        }
+
+    receipt_args = dict(args)
+    for field_name in (
+        "commit_receipt",
+        "receipt",
+        "active_locks",
+        "locks",
+        "already_used_token_ids",
+        "lock_owner",
+        "lock_ttl_minutes",
+        "format",
+    ):
+        receipt_args.pop(field_name, None)
+    result = memory_evidence_repair_commit_receipt_tool(
+        receipt_args,
+        memory_manager=memory_manager,
+    )
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return tool_error("commit receipt tool returned invalid JSON.", success=False)
+    if not isinstance(payload, dict):
+        return tool_error("commit receipt tool returned a non-object payload.", success=False)
+    if payload.get("success") is False:
+        return json.dumps(payload, ensure_ascii=False)
+    return payload
+
+
+def _active_locks(args: dict[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(args.get("active_locks"), list):
+        return args["active_locks"]
+    if isinstance(args.get("locks"), list):
+        return args["locks"]
+    return []
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {})
+    lines = [
+        "### Memory Evidence Repair Write Lock Gate",
+        f"- Status: {payload.get('status')}",
+        f"- Checks: {summary.get('check_count', 0)}",
+        f"- Locks: {summary.get('lock_count', 0)}",
+        f"- Conflicts: {summary.get('active_lock_conflict_count', 0)}",
+        f"- Executor dry-run allowed: {summary.get('executor_dry_run_allowed', False)}",
+    ]
+    for lock in payload.get("locks", []):
+        lines.append(f"- Lock: {lock.get('id')}")
+        lines.append(f"  Receipt: {lock.get('receipt_id')}")
+        lines.append(f"  Expires: {lock.get('expires_at')}")
+    for reason in payload.get("blocking_reasons", []):
+        lines.append(f"- Blocked: {reason}")
+    for action in payload.get("required_actions", []):
+        lines.append(f"- Required: {action}")
+    return "\n".join(lines)
+
+
+def check_memory_evidence_repair_write_lock_gate_requirements() -> bool:
+    return True
+
+
+registry.register(
+    name="memory_evidence_repair_write_lock_gate",
+    toolset="memory",
+    schema=MEMORY_EVIDENCE_REPAIR_WRITE_LOCK_GATE_SCHEMA,
+    handler=memory_evidence_repair_write_lock_gate_tool,
+    check_fn=check_memory_evidence_repair_write_lock_gate_requirements,
+    emoji="🧠",
+)

--- a/website/docs/guides/share-hermes-memory-with-codex-openclaw.md
+++ b/website/docs/guides/share-hermes-memory-with-codex-openclaw.md
@@ -1,0 +1,82 @@
+# Share Hermes Memory with Codex and OpenClaw
+
+Hermes should remain the primary memory owner. Codex, OpenClaw, and other MCP
+clients should connect to Hermes and use the same Memory Fabric instead of
+keeping separate long-term memories that drift out of sync.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  H["Hermes Memory Fabric"] --> G["Memory Graph"]
+  H --> K["Knowledge and prompt cases"]
+  H --> M["Curated MEMORY.md / USER.md"]
+  H --> P["Write proposals"]
+  C["Codex"] --> MCP["Hermes MCP server"]
+  O["OpenClaw"] --> MCP
+  MCP --> H
+```
+
+## MCP Client Config
+
+Add Hermes as an MCP server in each client:
+
+```json
+{
+  "mcpServers": {
+    "hermes-memory": {
+      "command": "hermes",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Use the same config shape for Codex, OpenClaw, Claude Code, Cursor, or any
+MCP-capable client. The client manages the process lifecycle.
+
+## Memory Tools
+
+The Hermes MCP server exposes these shared memory tools:
+
+- `memory_bridge_status`: inspect available memory surfaces and policy.
+- `memory_fabric_search`: search Memory Graph, knowledge files, GPT image prompt cases, and curated memory.
+- `memory_graph_read`: read graph nodes with provenance and optional edges.
+- `memory_write_proposal`: create a governed write proposal without mutating memory.
+- `memory_snapshot_export`: export a portable snapshot for backup or read-only cache.
+
+## Write Policy
+
+External clients must not write directly to `USER.md`, `MEMORY.md`, or the
+Memory Graph. They should call `memory_write_proposal` with:
+
+```json
+{
+  "source_agent": "codex",
+  "target_scope": "project",
+  "project": "openclaw",
+  "content": "OpenClaw should retrieve prompt examples through Hermes Memory Fabric.",
+  "rationale": "Shared memory setup",
+  "tags": "codex,openclaw,memory"
+}
+```
+
+Hermes can later review, merge, reject, or promote the proposal into durable
+memory through its normal governance flow.
+
+## Clone and Cache
+
+Use `memory_snapshot_export` only for backup, cold start, or offline read-only
+cache. A snapshot is not a new primary memory store. When a client learns
+something new, it should submit a write proposal back to Hermes.
+
+## Recommended Startup Flow
+
+1. Client connects to `hermes-memory`.
+2. Client calls `memory_bridge_status`.
+3. Client searches with `memory_fabric_search`.
+4. Client reads high-value graph nodes with `memory_graph_read`.
+5. Client creates new durable-memory candidates with `memory_write_proposal`.
+
+This keeps Hermes, Codex, and OpenClaw working from one shared memory fabric
+without forking long-term knowledge.


### PR DESCRIPTION
Adds Hermes Agent runtime wiring for provider-specific external memory configuration.

Purpose:
- Pass memory.<provider-name> config from config.yaml into external memory provider initialize(...).
- Reuse existing Hermes memory provider convention:
  memory:
    provider: memory-fabric
    memory-fabric:
      candidate_jsonl_path: /path/to/candidates.jsonl
      project_scope: hermes-memory-fabric
      memory_limit: 5
      context_budget_chars: 4000
- Enable memory-fabric v1.1.0 JSONL candidate source to work through real Hermes runtime initialization.

Implementation:
- agent/agent_init.py now reads memory.<provider-name>.
- Dict provider config is shallow-copied into initialize_all(..., runtime_config=...).
- Non-dict provider config is ignored safely.
- MemoryManager behavior is unchanged.
- Provider core behavior is unchanged.
- Existing init kwargs are preserved.

Validation:
- tests/run_agent/test_memory_provider_init.py: 5 passed
- tests/agent/test_memory_provider.py + tests/run_agent/test_memory_provider_init.py: 67 passed
- ruff check on touched files: passed
- real temp HERMES_HOME runtime smoke: passed
- provider.get_tool_schemas() == []
- JSONL selected context reached real AIAgent memory manager
- unrelated JSONL context did not leak
- no real model call
- no network call
- no durable memory write
- no graph write
- no token write
- no approval audit write
- no executor call

Boundary:
- This only wires provider runtime config into external memory providers.
- It does not implement new memory retrieval logic.
- It does not change MemoryManager semantics.
- It does not change memory-fabric provider behavior.