### PR TITLE
fix(gateway): add .md to MEDIA attachment extension whitelist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|md|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16852,7 +16852,7 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|csv|md|apk|ipa))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -17158,7 +17158,7 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'txt|csv|md|apk|ipa))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):


### PR DESCRIPTION
## Problem

The `MEDIA:<path>` tag extraction regex silently drops `.md` files. When an agent (or skill) emits `MEDIA:/path/to/file.md`, the gateway never routes it to `send_document()` — the path is stripped from the response and the file is never delivered to the user.

This affects all platform adapters (Telegram, Discord, Slack, etc.) since the filtering happens in the shared gateway layer.

## Root Cause

Three locations define the allowed file-extension regex:

| File | Lines |
|------|-------|
| `gateway/run.py` | ~16855 |
| `gateway/run.py` | ~17161 |
| `gateway/platforms/base.py` | ~2416 |

All three include `txt` and `csv` as plain-text formats but omit `md`. This appears to be an oversight from commit `ea49b38` which tightened the regex — the existing extension list was copied without adding Markdown.

## Fix

Add `md` alongside `txt` and `csv` in all three regex patterns.

### Diff
```diff
- r'txt|csv|apk|ipa))',
+ r'txt|csv|md|apk|ipa))',
```

3 insertions, 3 deletions — no behavioral change for any other format.

## Testing

- Manual: `MEDIA:/tmp/test.md` now triggers `send_document()` on Telegram
- Existing test suite: `./scripts/run_tests.sh` passes (no tests depend on the extension list being exclusive)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have added documentation where necessary