### PR TITLE
fix(codex): correct stale-timeout hint — gpt-5.4-codex doesn't exist

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1002,13 +1002,14 @@ class AIAgent:
         if not re.search(r"(?:^|[/\-_])gpt-5\.5(?:$|[\-_])", model_lower):
             return None
         return (
-            f"Codex backend appears to be silently rejecting {eff_model!r} "
-            "on chatgpt.com/backend-api/codex (no stream events, no error). "
-            "This is a known backend-side pattern that has affected ChatGPT "
-            "Plus accounts intermittently. "
-            "Workaround: try `gpt-5.4-codex` on the same OAuth profile, "
-            "or switch to a different model/provider in your fallback chain. "
-            "See hermes-agent#21444 for symptom history."
+            f"Codex backend did not return any stream events for {eff_model!r} "
+            "on chatgpt.com/backend-api/codex within the stale-call timeout. "
+            "This pattern has been observed intermittently with `gpt-5.5` on "
+            "ChatGPT Plus accounts (see hermes-agent#21444) but may also "
+            "indicate transient backend latency. "
+            "Workaround: retry, or switch to a different model via `/model` "
+            "(e.g. `gpt-5.4` on the same OAuth profile, or any model in "
+            "your fallback chain)."
         )
 
     def _is_openrouter_url(self) -> bool:

--- a/tests/run_agent/test_codex_silent_hang_hint.py
+++ b/tests/run_agent/test_codex_silent_hang_hint.py
@@ -43,7 +43,7 @@ def test_hint_fires_for_bare_gpt_5_5_on_codex(tmp_path):
     agent.api_mode = "codex_responses"
     hint = agent._codex_silent_hang_hint(model="gpt-5.5")
     assert hint is not None
-    assert "gpt-5.4-codex" in hint
+    assert "gpt-5.4" in hint
     assert "fallback chain" in hint
 
 
@@ -72,11 +72,11 @@ def test_hint_fires_when_model_arg_omitted(tmp_path):
 # ── negative cases: hint stays None ────────────────────────────────────────
 
 
-def test_hint_skipped_for_gpt_5_4_codex(tmp_path):
-    """gpt-5.4-codex is the recommended workaround — must not trigger."""
-    agent = _make_agent(tmp_path, model="gpt-5.4-codex")
+def test_hint_skipped_for_gpt_5_4(tmp_path):
+    """gpt-5.4 is the recommended workaround — must not trigger the gpt-5.5 hint."""
+    agent = _make_agent(tmp_path, model="gpt-5.4")
     agent.api_mode = "codex_responses"
-    assert agent._codex_silent_hang_hint(model="gpt-5.4-codex") is None
+    assert agent._codex_silent_hang_hint(model="gpt-5.4") is None
 
 
 def test_hint_skipped_for_gpt_5_50_false_positive(tmp_path):
@@ -107,11 +107,11 @@ def test_hint_skipped_for_non_codex_provider(tmp_path):
 
 def test_hint_skipped_for_empty_model(tmp_path):
     """Explicit empty string ``model`` short-circuits the regex."""
-    agent = _make_agent(tmp_path, model="gpt-5.4-codex")  # self.model non-matching
+    agent = _make_agent(tmp_path, model="gpt-5.4")  # self.model non-matching
     agent.api_mode = "codex_responses"
     # Explicit empty string: regex won't match
     assert agent._codex_silent_hang_hint(model="") is None
-    # model=None falls back to self.model which is gpt-5.4-codex, also no match
+    # model=None falls back to self.model which is gpt-5.4, also no match
     assert agent._codex_silent_hang_hint(model=None) is None
 
 


### PR DESCRIPTION
## Summary
The Codex silent-hang hint suggested `gpt-5.4-codex` as the workaround when `gpt-5.5` stalls on the chatgpt.com backend, but **that model name doesn't exist in the OpenAI Codex catalog**. The Codex-tagged SKUs are `gpt-5.3-codex` / `gpt-5.2-codex`; the plain sibling that works is `gpt-5.4`. Users following the hint hit a second error trying to switch to a phantom model.

Also softens the framing: the previous text asserted "appears to be silently rejecting" as fact, but the detector only knows the stale-timeout fired — it can't actually distinguish backend rejection from network drop or latency spike. The original phrasing led users to believe `gpt-5.5` was broken when it's often transient.

## Changes
- `run_agent.py`: rewrite the user-facing message — drop the false "silently rejecting" claim, point to `gpt-5.4` (which exists), suggest retry first.
- `tests/run_agent/test_codex_silent_hang_hint.py`: update assertions; rename negative-case test from `gpt-5.4-codex` (phantom) to `gpt-5.4` (real).

## Validation
| | Before | After |
|---|---|---|
| Workaround model | `gpt-5.4-codex` (doesn't exist) | `gpt-5.4` (real) |
| Framing | "silently rejecting" (asserted fact) | "did not return any stream events within timeout" (observed) |
| Test suite | — | 10/10 passing |

User report that surfaced this: ChatGPT Plus account getting the stale-timeout hint, following the suggestion, hitting another error because `gpt-5.4-codex` is not a known model.