### PR TITLE
feat(catalog): add qwen3.7-max to alibaba + alibaba-coding-plan model lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -393,6 +393,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        "qwen3.7-max",
         "qwen3.6-plus",
         "kimi-k2.5",
         "qwen3.5-plus",
@@ -406,6 +407,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),
     # separate provider ID with its own base_url_env_var.
     "alibaba-coding-plan": [
+        "qwen3.7-max",
         "qwen3.6-plus",
         "qwen3.5-plus",
         "qwen3-coder-plus",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -260,6 +260,7 @@ AUTHOR_MAP = {
     "asslaenn5@gmail.com": "Aslaaen",
     "trae.anderson17@icloud.com": "Tkander1715",
     "beardthelion@users.noreply.github.com": "beardthelion",
+    "orkunozturk@gmail.com": "orcool",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",
     "santoshhumagain1887@gmail.com": "npmisantosh",


### PR DESCRIPTION
## Summary

Salvages the alibaba / alibaba-coding-plan catalog additions from @orcool's PR #32806 onto current main.

## What landed elsewhere first

- **#32780** (merged) — opencode-go routing fix + opencode-go setup wizard entry
- **#32809** (merged) — qwen3.7-max in openrouter + nous catalogs

## What's left from #32806

Just the alibaba and alibaba-coding-plan catalog entries. The Vercel AI Gateway entry from the original PR was dropped because Vercel AI Gateway was removed in #33067.

## Changes

| File | Change |
|---|---|
| `hermes_cli/models.py` | +`qwen3.7-max` to `_PROVIDER_MODELS["alibaba"]` and `_PROVIDER_MODELS["alibaba-coding-plan"]` |
| `scripts/release.py` | AUTHOR_MAP entry for @orcool |

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_model_validation.py` → 81/81
- `scripts/run_tests.sh tests/hermes_cli/test_models.py` → 73/73

Credit to @orcool — original PR #32806.