### PR TITLE
fix: accept on/off booleans in kanban tools

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -872,6 +872,24 @@ def test_create_parses_triage_string_false(worker_env):
         conn.close()
 
 
+def test_create_parses_triage_string_off(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    out = kt._handle_create({
+        "title": "not triage",
+        "assignee": "peer",
+        "triage": "off",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, d["task_id"])
+        assert task.status == "ready"
+    finally:
+        conn.close()
+
+
 def test_create_parses_triage_string_true(worker_env):
     from tools import kanban_tools as kt
     from hermes_cli import kanban_db as kb

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -197,11 +197,11 @@ def _parse_bool_arg(args: dict, name: str, *, default: bool = False):
     if isinstance(value, bool):
         return value, None
     text = str(value).strip().lower()
-    if text in {"true", "1", "yes"}:
+    if text in {"true", "1", "yes", "on"}:
         return True, None
-    if text in {"false", "0", "no"}:
+    if text in {"false", "0", "no", "off"}:
         return False, None
-    return default, f"{name} must be a boolean or 'true'/'false'"
+    return default, f"{name} must be a boolean or one of: true/false, yes/no, on/off, 1/0"
 
 
 def _require_orchestrator_tool(tool_name: str) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Accept `on`/`off` string values in Kanban tool boolean parsing alongside existing true/false, yes/no, and 1/0 forms
- Update the invalid-boolean error to list accepted forms
- Add regression coverage for `triage: "off"` creating a ready task

## Test Plan
- RED before fix: `python -m pytest tests/tools/test_kanban_tools.py::test_create_parses_triage_string_off -q -o 'addopts='` failed with `KeyError: 'ok'`
- GREEN focused: `python -m pytest tests/tools/test_kanban_tools.py::test_create_parses_triage_string_off tests/tools/test_kanban_tools.py::test_create_rejects_bad_triage -q -o 'addopts='` → 2 passed
- Full focused file: `python -m pytest tests/tools/test_kanban_tools.py -q -o 'addopts='` → 82 passed, 1 warning (discord/audioop deprecation)
