### PR TITLE
test(codex): cover null output stream terminal events

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,7 @@ AUTHOR_MAP = {
     "45688690+fujinice@users.noreply.github.com": "fujinice",
     "276689385+carltonawong@users.noreply.github.com": "carltonawong",
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",
+    "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "wangpuv@hotmail.com": "wangpuv",
     "202622897+ticketclosed-wontfix@users.noreply.github.com": "ticketclosed-wontfix",
     "wuxuebin1993@gmail.com": "victorGPT",

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -483,6 +483,54 @@ def test_run_codex_stream_parses_create_stream_events(monkeypatch):
     assert response.status == "completed"
 
 
+def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatch):
+    """Regression: Codex may send response.completed.response.output=null.
+
+    The SDK's high-level ``responses.stream(...)`` helper used to reconstruct
+    the final Response from that terminal field and raised ``TypeError:
+    'NoneType' object is not iterable``. The Hermes runtime consumes raw
+    ``response.output_item.done`` events instead, so a null terminal ``output``
+    must not affect the returned assistant/function-call items.
+    """
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="terminal output was null")],
+    )
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=output_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    id="resp_null_output",
+                    status="completed",
+                    output=None,
+                    usage=SimpleNamespace(input_tokens=7, output_tokens=4, total_tokens=11),
+                ),
+            ),
+        ]
+    )
+
+    def _fake_create(**kwargs):
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response is not None
+    assert create_stream.closed is True
+    assert response.id == "resp_null_output"
+    assert response.status == "completed"
+    assert response.output == [output_item]
+    assert response.usage.total_tokens == 11
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
Salvage of #33122 (@superearn-fisher) onto current main — defense-in-depth regression test.

## Summary
Adds one targeted assertion the #33042 refactor didn't have: when `response.completed.response.output` is `null` AND the terminal event carries a populated `usage` field, the event-driven consumer must preserve BOTH the items assembled from `response.output_item.done` AND the usage tokens. Catches any future regression where someone might accidentally re-route content reconstruction through the terminal `output` field.

## Changes
- `tests/run_agent/test_run_agent_codex_responses.py`: +48 / -0, one new test `test_run_codex_stream_ignores_completed_response_with_null_output`

## Validation
- 68/68 passing in `tests/run_agent/test_run_agent_codex_responses.py`

## Attribution
Cherry-picked from @superearn-fisher's #33122. AUTHOR_MAP updated in follow-up commit. Complements the structural fix in #33042 — that PR removed the SDK helper so the bug class can't fire; this PR locks the assertion in.

## Infographic

![codex-regression-lock](https://v3b.fal.media/files/b/0a9bdef8/JcdhiT_qNVFgjgP7pTLjV_JR2LYaF2.png)
