### PR TITLE
fix(codex): guard None response.output in Responses-API stream and tool-call path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4899,6 +4899,21 @@ class AIAgent:
         prefix = f"HTTP {status_code}: " if status_code else ""
         return f"{prefix}{raw[:500]}"
 
+    @staticmethod
+    def _nonretryable_error_kind(status_code, api_error) -> str:
+        """Short label for a non-retryable failure.
+
+        Returns ``"HTTP <code>"`` when the provider returned a status code,
+        otherwise the exception class name. Transport- and parse-level failures
+        (e.g. a ``TypeError`` raised while decoding a streamed response) carry
+        no status code; labelling them ``"HTTP None"`` hid their true nature and
+        led to them being mistaken for transport errors. Surfacing the exception
+        class keeps the non-retryable warning honest.
+        """
+        if status_code:
+            return f"HTTP {status_code}"
+        return type(api_error).__name__
+
     def _mask_api_key_for_logs(self, key: Optional[str]) -> Optional[str]:
         if not key:
             return None
@@ -14195,7 +14210,14 @@ class AIAgent:
                     if is_client_error:
                         # Try fallback before aborting — a different provider
                         # may not have the same issue (rate limit, auth, etc.)
-                        self._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                        # Label with the exception class (not "HTTP None") when
+                        # there is no HTTP status, and include the error message,
+                        # so transport/parse failures aren't masked as transport.
+                        _err_kind = self._nonretryable_error_kind(status_code, api_error)
+                        self._emit_status(
+                            f"⚠️ Non-retryable error ({_err_kind}): "
+                            f"{self._summarize_api_error(api_error)} — trying fallback..."
+                        )
                         if self._try_activate_fallback():
                             retry_count = 0
                             compression_attempts = 0
@@ -14206,10 +14228,10 @@ class AIAgent:
                                 api_kwargs, reason="non_retryable_client_error", error=api_error,
                             )
                         self._emit_status(
-                            f"❌ Non-retryable error (HTTP {status_code}): "
+                            f"❌ Non-retryable error ({_err_kind}): "
                             f"{self._summarize_api_error(api_error)}"
                         )
-                        self._vprint(f"{self.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
+                        self._vprint(f"{self.log_prefix}❌ Non-retryable client error ({_err_kind}). Aborting.", force=True)
                         self._vprint(f"{self.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                         self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)
                         # Actionable guidance for common auth errors

--- a/run_agent.py
+++ b/run_agent.py
@@ -6963,6 +6963,49 @@ class AIAgent:
                     )
                     return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
                 raise
+            except TypeError as exc:
+                # The OpenAI SDK streaming Responses accumulator
+                # (openai/lib/streaming/responses/_responses.py accumulate_event
+                # -> openai/lib/_parsing/_responses.py parse_response) runs
+                # ``for output in response.output`` with no None-guard, as does
+                # the SDK ``Response.output_text`` property. The ChatGPT Codex
+                # backend (chatgpt.com/backend-api/codex) can emit a streamed
+                # snapshot whose ``response.output`` is null, so the SDK raises
+                # ``TypeError: 'NoneType' object is not iterable`` from inside
+                # ``for event in stream`` here. Narrow to that signature so
+                # genuine TypeErrors in our own event handling still surface.
+                if "not iterable" not in str(exc):
+                    raise
+                # The assistant text already arrived via output_text.delta
+                # events (collected in self._codex_streamed_text_parts), so
+                # synthesize the response from it — same shape as the empty-output
+                # backfill above. Re-driving via create(stream=True) returns the
+                # same null output, so prefer the text we already streamed.
+                if self._codex_streamed_text_parts and not has_tool_calls:
+                    assembled = "".join(self._codex_streamed_text_parts)
+                    logger.debug(
+                        "Codex stream accumulator hit SDK None-output TypeError; "
+                        "recovered %d chars from streamed deltas. %s",
+                        len(assembled), self._client_log_context(),
+                    )
+                    return SimpleNamespace(
+                        output=[SimpleNamespace(
+                            type="message", role="assistant", status="completed",
+                            content=[SimpleNamespace(type="output_text", text=assembled)],
+                        )],
+                        output_text=assembled,
+                        usage=None,
+                        status="completed",
+                        model=api_kwargs.get("model"),
+                    )
+                # Nothing recoverable from the stream (e.g. a tool-call turn) —
+                # re-drive via create(stream=True), which parses events manually.
+                logger.debug(
+                    "Codex stream accumulator hit SDK None-output TypeError with no "
+                    "recoverable streamed text; falling back to create(stream=True). %s",
+                    self._client_log_context(),
+                )
+                return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
 
     def _run_codex_create_stream_fallback(self, api_kwargs: dict, client: Any = None):
         """Fallback path for stream completion edge cases on Codex-style Responses backends."""
@@ -6974,6 +7017,12 @@ class AIAgent:
 
         # Compatibility shim for mocks or providers that still return a concrete response.
         if hasattr(stream_or_response, "output"):
+            # The Codex backend can return a completed response with output=None
+            # (not merely an empty list). The SDK Response.output_text property
+            # and the codex normalizer both iterate .output, so coerce the null
+            # to an empty list here to avoid 'NoneType' object is not iterable.
+            if getattr(stream_or_response, "output", None) is None:
+                stream_or_response.output = []
             return stream_or_response
         if not hasattr(stream_or_response, "__iter__"):
             return stream_or_response

--- a/run_agent.py
+++ b/run_agent.py
@@ -7013,11 +7013,31 @@ class AIAgent:
                         status="completed",
                         model=api_kwargs.get("model"),
                     )
-                # Nothing recoverable from the stream (e.g. a tool-call turn) —
-                # re-drive via create(stream=True), which parses events manually.
+                # A tool-call turn hits the same null-output crash. The
+                # function_call item(s) already arrived via
+                # response.output_item.done events (collected above) before the
+                # accumulator choked, so synthesize the response from them —
+                # re-driving via create(stream=True) returns the same null
+                # output and would silently drop the tool call.
+                if collected_output_items:
+                    logger.debug(
+                        "Codex stream accumulator hit SDK None-output TypeError; "
+                        "recovered %d output item(s) from stream events. %s",
+                        len(collected_output_items), self._client_log_context(),
+                    )
+                    return SimpleNamespace(
+                        output=list(collected_output_items),
+                        output_text="",
+                        usage=None,
+                        status="completed",
+                        model=api_kwargs.get("model"),
+                    )
+                # Nothing recoverable from the stream — re-drive via
+                # create(stream=True), which parses events manually and guards
+                # a null output.
                 logger.debug(
                     "Codex stream accumulator hit SDK None-output TypeError with no "
-                    "recoverable streamed text; falling back to create(stream=True). %s",
+                    "recoverable streamed output; falling back to create(stream=True). %s",
                     self._client_log_context(),
                 )
                 return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
@@ -7075,7 +7095,7 @@ class AIAgent:
                 if terminal_response is not None:
                     # Backfill empty output from collected stream events
                     _out = getattr(terminal_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    if _out is None or (isinstance(_out, list) and not _out):
                         if collected_output_items:
                             terminal_response.output = list(collected_output_items)
                             logger.debug(
@@ -7093,6 +7113,10 @@ class AIAgent:
                                 "Codex fallback stream: synthesized from %d deltas (%d chars)",
                                 len(collected_text_deltas), len(assembled),
                             )
+                        elif _out is None:
+                            # Null output with nothing to backfill — coerce to
+                            # [] so downstream never iterates None.
+                            terminal_response.output = []
                     return terminal_response
         finally:
             close_fn = getattr(stream_or_response, "close", None)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5305,3 +5305,20 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+def test_nonretryable_error_kind_surfaces_exception_type_without_status():
+    """Non-retryable failures with no HTTP status (transport- or parse-level
+    errors such as a TypeError raised while decoding a streamed response) must
+    be labelled with the exception class, not the misleading "HTTP None" that
+    previously masked them as transport failures and derailed diagnosis.
+    """
+    # No status code -> surface the exception class name.
+    assert (
+        AIAgent._nonretryable_error_kind(None, TypeError("'NoneType' object is not iterable"))
+        == "TypeError"
+    )
+    # A falsy status (0) is treated as "no status" too.
+    assert AIAgent._nonretryable_error_kind(0, ValueError("bad")) == "ValueError"
+    # A real HTTP status is preserved unchanged.
+    assert AIAgent._nonretryable_error_kind(404, RuntimeError("nope")) == "HTTP 404"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -157,9 +157,11 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, iter_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._iter_error = iter_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -168,7 +170,12 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        # Yield any streamed events first (so callers can observe text deltas),
+        # then raise iter_error to simulate a mid-stream accumulator failure.
+        for ev in self._events:
+            yield ev
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -483,6 +490,90 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_from_sdk_none_output_typeerror(monkeypatch):
+    """ChatGPT Codex backend can stream a response whose ``response.output`` is
+    null. The OpenAI SDK's streaming accumulator (lib/_parsing/_responses.py
+    ``parse_response``) then runs ``for output in response.output`` with no
+    None-guard and raises ``TypeError: 'NoneType' object is not iterable`` from
+    inside ``for event in stream``. _run_codex_stream only caught transport
+    errors and RuntimeError, so the TypeError bubbled up and was misclassified
+    as a non-retryable client error ("HTTP None"), forcing a provider fallback
+    on every codex turn. It must instead fall back to create(stream=True),
+    which parses events manually and guards ``output``.
+    """
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            iter_error=TypeError("'NoneType' object is not iterable")
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("create fallback ok")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    # No recoverable streamed text -> re-drive via the create(stream=True)
+    # fallback rather than retrying the same (deterministically failing) stream.
+    assert calls["stream"] == 1
+    assert calls["create"] == 1
+    assert response.output[0].content[0].text == "create fallback ok"
+
+
+def test_run_codex_stream_recovers_streamed_text_on_sdk_none_output_typeerror(monkeypatch):
+    """When the SDK accumulator chokes on a null response.output mid-stream, the
+    assistant text has already arrived via output_text.delta events. Recover it
+    and synthesize the response rather than re-driving the request — create
+    (stream=True) returns the same null output, so re-driving would just fail
+    again downstream.
+    """
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            events=[SimpleNamespace(type="response.output_text.delta", delta="ok")],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("should not be reached")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    # Recovered from the streamed deltas — no re-drive of the request.
+    assert calls["create"] == 0
+    assert response.output[0].content[0].text == "ok"
+
+
+def test_run_codex_create_stream_fallback_coerces_none_output(monkeypatch):
+    """The ChatGPT Codex backend can return a completed response whose .output
+    is None (not merely an empty list). The create(stream=True) fallback must
+    not hand a None-output response downstream — the SDK Response.output_text
+    property and the codex normalizer both iterate .output and would raise
+    TypeError: 'NoneType' object is not iterable.
+    """
+    agent = _build_agent(monkeypatch)
+    none_output_response = SimpleNamespace(output=None, status="completed", model="gpt-5-codex")
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: none_output_response)
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert response.output == []
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -576,6 +576,82 @@ def test_run_codex_create_stream_fallback_coerces_none_output(monkeypatch):
     assert response.output == []
 
 
+def test_run_codex_stream_recovers_streamed_tool_call_on_sdk_none_output_typeerror(monkeypatch):
+    """Same SDK null-output crash, but on a tool-call turn. The function_call
+    item already arrived via a response.output_item.done event before the
+    accumulator choked on the null response.output, so recover it and
+    synthesize the response. Re-driving via create(stream=True) returns the
+    same null output (coerced to an empty list), which would silently drop the
+    tool call so it never executes.
+    """
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    fc_item = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments='{"command": "echo ok"}',
+        status="completed",
+    )
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(
+                    type="response.function_call_arguments.delta",
+                    delta='{"command": "echo ok"}',
+                ),
+                SimpleNamespace(type="response.output_item.done", item=fc_item),
+            ],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    def _fake_create(**kwargs):
+        # Re-drive returns the same null output the SDK chokes on — proves we
+        # must recover from the stream, not by re-driving.
+        calls["create"] += 1
+        return SimpleNamespace(output=None, status="completed", model="gpt-5-codex")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    # Recovered from the streamed function_call item — request not re-driven.
+    assert calls["stream"] == 1
+    assert calls["create"] == 0
+    fc = next(item for item in response.output if getattr(item, "type", None) == "function_call")
+    assert fc.call_id == "call_1"
+    assert fc.name == "terminal"
+
+
+def test_run_codex_create_stream_fallback_coerces_none_terminal_output(monkeypatch):
+    """The create(stream=True) fallback can emit a terminal response.completed
+    event whose .output is null (not merely []). With nothing collected to
+    backfill from, coerce the null to [] so the SDK Response.output_text
+    property and the codex normalizer never iterate None.
+    """
+    agent = _build_agent(monkeypatch)
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(output=None, status="completed", model="gpt-5-codex"),
+            ),
+        ]
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: create_stream)
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert response.output == []
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## What

Guard against a null `response.output` from the ChatGPT Codex backend
(`chatgpt.com/backend-api/codex`, provider `openai-codex`, e.g. `gpt-5.5`)
that crashes the Responses-API streaming path and forces a provider fallback
on **every** codex turn.

## Symptom

Every gpt-5.5 codex turn fails with `TypeError: 'NoneType' object is not
iterable` and falls back to the secondary provider; users see
`⚠️ Non-retryable error (HTTP None) — trying fallback...`. The HTTP request
completes cleanly (`request_complete, tcp_force_closed=0`) — it's a
post-response parse crash, not a transport error.

## Root cause (OpenAI SDK)

The backend streams a terminal snapshot whose `response.output` is `null`.
The OpenAI SDK (v2.24.0) iterates `response.output` with **no None-guard** in
two places:
- `openai/lib/_parsing/_responses.py:61` — `parse_response` does
  `for output in response.output` (invoked by the streaming accumulator
  `accumulate_event`), and
- the `Response.output_text` property (`openai/types/responses/response.py:315`).

`_run_codex_stream` only caught transport errors and `RuntimeError`, so the
`TypeError` bubbled to the retry loop, was classified non-retryable, and was
mislabeled "HTTP None". **You may want to file this upstream with
`openai/openai-python` as well** (the unguarded `for output in
response.output`) — but this patch shields the agent regardless of SDK version.

## Repro

`hermes -z "Reply with exactly: ok" -m gpt-5.5 --provider openai-codex`
→ empty output; `agent.log` shows
`error_type=TypeError ... 'NoneType' object is not iterable`.

## Fix (3 commits)

- **`27c27ea76`** — on the not-iterable `TypeError`, synthesize the response
  from the already-streamed `output_text.delta` text (answer preserved, no
  fallback). When nothing is recoverable, fall back to `create(stream=True)`
  and coerce a null `output` → `[]`. Narrowed to the not-iterable signature so
  genuine `TypeError`s still surface.
- **`3ffd7fde8`** — same guard for the **tool-call path**: the `function_call`
  item arrives via `response.output_item.done` before the crash, so synthesize
  from the collected output items rather than re-driving (the re-drive returns
  the same null output and would drop the tool call). Also coerces a null
  terminal `output` → `[]` in the create-stream fallback's streaming branch.
- **`151fd55bf`** — surfaces the exception class in the non-retryable warning
  instead of "HTTP None". **Bundled deliberately:** it's a separate concern,
  but the "HTTP None" label is exactly what mis-pointed the diagnosis at the
  transport layer, it's tiny, and it's worth shipping alongside. Happy to split
  it into its own PR if you'd prefer.

All three include targeted unit tests under `tests/run_agent/`.
