### PR TITLE
feat: add deepseek/deepseek-v4-flash to OpenRouter model catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -58,6 +58,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("x-ai/grok-4.3",                          ""),
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     ("deepseek/deepseek-v4-pro",               ""),
+    ("deepseek/deepseek-v4-flash",             ""),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
     ("openrouter/owl-alpha",                   "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -117,6 +117,10 @@
           "description": ""
         },
         {
+          "id": "deepseek/deepseek-v4-flash",
+          "description": ""
+        },
+        {
           "id": "openrouter/elephant-alpha",
           "description": "free"
         },


### PR DESCRIPTION
`deepseek/deepseek-v4-flash` is live on OpenRouter and supports tool calling, but it was missing from both the curated catalog manifest (`website/static/api/model-catalog.json`) and the hardcoded fallback (`hermes_cli/models.py` `OPENROUTER_MODELS`).

This means the `/model` picker never shows it as an option — users who want to set it as their default model have to manually `hermes config set model.default`.

## Changes

- Added `deepseek/deepseek-v4-flash` to `website/static/api/model-catalog.json` (OpenRouter provider block)
- Added `deepseek/deepseek-v4-flash` to `hermes_cli/models.py` `OPENROUTER_MODELS` fallback list (right after `deepseek-v4-pro`)

## Verification

```bash
# Flash is on OpenRouter live API with tool support
curl https://openrouter.ai/api/v1/models | jq '.data[] | select(.id | startswith("deepseek/deepseek-v4")) | {id, tools: (.supported_parameters | contains(["tools"]))}'
# deepseek-v4-flash: tools=true
# deepseek-v4-flash:free: tools=true
# deepseek-v4-pro: tools=true
```