### PR TITLE
Respect explicit api_mode on fallback providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -980,11 +980,28 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # Determine api_mode from provider / base URL / model.  If the
+        # fallback entry declares api_mode explicitly, respect it the same way
+        # primary model initialization respects an explicit api_mode.  Model
+        # name heuristics are only defaults.
+        valid_api_modes = {
+            "chat_completions",
+            "codex_responses",
+            "anthropic_messages",
+            "bedrock_converse",
+            "codex_app_server",
+        }
+        explicit_fb_api_mode = str(fb.get("api_mode") or "").strip()
+        fb_api_mode = (
+            explicit_fb_api_mode
+            if explicit_fb_api_mode in valid_api_modes
+            else "chat_completions"
+        )
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        if explicit_fb_api_mode in valid_api_modes:
+            pass
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
             fb_api_mode = "anthropic_messages"

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -182,6 +182,33 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
+    def test_custom_gpt5_fallback_respects_explicit_chat_completions(self):
+        """Explicit fallback api_mode must override GPT-5 name heuristics."""
+        fbs = [
+            {
+                "provider": "custom",
+                "model": "gpt-5.4",
+                "base_url": "https://custom.example/v1",
+                "api_mode": "chat_completions",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url="https://custom.example/v1"),
+                    "gpt-5.4",
+                ),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.provider == "custom"
+        assert agent.model == "gpt-5.4"
+        assert agent.api_mode == "chat_completions"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
  ## Summary

  Preserve explicit `api_mode` on fallback provider entries.

  A fallback entry like:

  ```yaml
  fallback_providers:
  - provider: custom
    model: gpt-5.4
    api_mode: chat_completions

  should continue using chat_completions after fallback activation. It should not be auto-upgraded to codex_responses based only on the GPT-5-style model name.

  ## Motivation

  Current main respects explicit api_mode for the primary model, but fallback activation can still recompute the transport from provider/model heuristics and ignore the fallback entry-level override.

  This is related to #29749 and the custom GPT-5 api_mode issues discussed around #10473 / #10548.

  ## Changes

  - Respect explicit fallback entry api_mode before applying provider/model heuristics.
  - Add a regression test for a custom GPT-5-style fallback with explicit api_mode: chat_completions.

  ## Test plan

  scripts/run_tests.sh tests/run_agent/test_provider_fallback.py

  Result:

  23 passed