### PR TITLE
fix(gateway): accept bare-string home_channel from `hermes config set`

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -239,10 +239,21 @@ class HomeChannel:
         if isinstance(data, str):
             if platform_default is None:
                 raise TypeError(
-                    "HomeChannel.from_dict received a bare string but no "
-                    "platform_default was provided to associate it with"
+                    "HomeChannel.from_dict received a bare string chat_id but "
+                    "no platform_default was provided to associate it with. "
+                    "Accepted shapes: a string chat_id (when called with "
+                    "platform_default=<Platform>), or a dict "
+                    "{'platform': ..., 'chat_id': ..., 'name': ..., 'thread_id': ...}."
                 )
             return cls(platform=platform_default, chat_id=data, name="Home")
+        if not isinstance(data, dict):
+            raise TypeError(
+                f"HomeChannel.from_dict expects a str chat_id or a dict, "
+                f"got {type(data).__name__}: {data!r}. "
+                f"Accepted shapes: a string chat_id (when called with "
+                f"platform_default=<Platform>), or a dict "
+                f"{{'platform': ..., 'chat_id': ..., 'name': ..., 'thread_id': ...}}."
+            )
         return cls(
             platform=Platform(data["platform"]),
             chat_id=str(data["chat_id"]),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -225,7 +225,24 @@ class HomeChannel:
         return result
     
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
+    def from_dict(
+        cls,
+        data: Any,
+        *,
+        platform_default: Optional[Platform] = None,
+    ) -> "HomeChannel":
+        # `hermes config set platforms.<name>.home_channel <chat_id>` writes a
+        # bare string, since the CLI has no schema awareness of the structured
+        # HomeChannel shape.  Accept that shape here too — the parent platform
+        # is known from the surrounding `platforms.<name>:` key, threaded in
+        # via platform_default.
+        if isinstance(data, str):
+            if platform_default is None:
+                raise TypeError(
+                    "HomeChannel.from_dict received a bare string but no "
+                    "platform_default was provided to associate it with"
+                )
+            return cls(platform=platform_default, chat_id=data, name="Home")
         return cls(
             platform=Platform(data["platform"]),
             chat_id=str(data["chat_id"]),
@@ -317,10 +334,17 @@ class PlatformConfig:
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        *,
+        platform: Optional[Platform] = None,
+    ) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
-            home_channel = HomeChannel.from_dict(data["home_channel"])
+            home_channel = HomeChannel.from_dict(
+                data["home_channel"], platform_default=platform,
+            )
 
         # gateway_restart_notification may be bridged into extra via the
         # shared-key loop in load_gateway_config(); check both top-level
@@ -604,7 +628,9 @@ class GatewayConfig:
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
+                platforms[platform] = PlatformConfig.from_dict(
+                    platform_data, platform=platform,
+                )
             except ValueError:
                 pass  # Skip unknown platforms
         

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -48,6 +48,14 @@ class TestHomeChannelFromString:
         with pytest.raises(TypeError, match="platform_default"):
             HomeChannel.from_dict("oc_123")
 
+    def test_non_str_non_dict_raises_clear_type_error(self):
+        with pytest.raises(TypeError, match="expects a str chat_id or a dict"):
+            HomeChannel.from_dict(123, platform_default=Platform.FEISHU)
+        with pytest.raises(TypeError, match="expects a str chat_id or a dict"):
+            HomeChannel.from_dict([1, 2, 3], platform_default=Platform.FEISHU)
+        with pytest.raises(TypeError, match="expects a str chat_id or a dict"):
+            HomeChannel.from_dict(None, platform_default=Platform.FEISHU)
+
     def test_platform_config_threads_platform_through(self):
         """End-to-end: a config dict produced by `hermes config set
         platforms.feishu.home_channel <chat_id>` round-trips through

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from gateway.config import (
     GatewayConfig,
     HomeChannel,
@@ -24,6 +26,56 @@ class TestHomeChannelRoundtrip:
         assert restored.platform == Platform.DISCORD
         assert restored.chat_id == "999"
         assert restored.name == "general"
+
+
+class TestHomeChannelFromString:
+    """`hermes config set platforms.<name>.home_channel <chat_id>` writes a bare
+    string; the loader must accept that shape and wrap it under the surrounding
+    platform.  Without this, the gateway crashes with ``TypeError: string
+    indices must be integers, not 'str'`` (issue #33141)."""
+
+    def test_string_is_wrapped_under_platform_default(self):
+        restored = HomeChannel.from_dict(
+            "oc_b0b897cce6e70190959898f94fe8f9a8",
+            platform_default=Platform.FEISHU,
+        )
+        assert restored.platform == Platform.FEISHU
+        assert restored.chat_id == "oc_b0b897cce6e70190959898f94fe8f9a8"
+        assert restored.name == "Home"
+        assert restored.thread_id is None
+
+    def test_string_without_platform_default_raises(self):
+        with pytest.raises(TypeError, match="platform_default"):
+            HomeChannel.from_dict("oc_123")
+
+    def test_platform_config_threads_platform_through(self):
+        """End-to-end: a config dict produced by `hermes config set
+        platforms.feishu.home_channel <chat_id>` round-trips through
+        ``GatewayConfig.from_dict`` instead of raising."""
+        config = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "feishu": {
+                        "home_channel": "oc_b0b897cce6e70190959898f94fe8f9a8",
+                    },
+                },
+            }
+        )
+        pc = config.platforms[Platform.FEISHU]
+        assert pc.home_channel is not None
+        assert pc.home_channel.platform == Platform.FEISHU
+        assert pc.home_channel.chat_id == "oc_b0b897cce6e70190959898f94fe8f9a8"
+        assert pc.home_channel.name == "Home"
+
+    def test_dict_shape_still_wins_over_platform_default(self):
+        """If the user wrote the structured dict form by hand, the platform key
+        in the dict (not the surrounding platforms.<name>: key) is the source
+        of truth — preserves the prior round-trip behavior."""
+        restored = HomeChannel.from_dict(
+            {"platform": "discord", "chat_id": "555", "name": "general"},
+            platform_default=Platform.TELEGRAM,
+        )
+        assert restored.platform == Platform.DISCORD
 
 
 class TestPlatformConfigRoundtrip:


### PR DESCRIPTION
## What does this PR do?

`hermes config set platforms.<name>.home_channel <chat_id>` writes the value as a plain string because the CLI has no schema awareness of the structured `HomeChannel` shape.  On the next gateway load the call chain becomes `PlatformConfig.from_dict` → `HomeChannel.from_dict("oc_xxx")` → `Platform("oc_xxx"["platform"])`, which raises `TypeError: string indices must be integers, not 'str'` and `load_gateway_config()` aborts.  The same crash hits any manual `config.yaml` edit that put just the chat id under `home_channel:`.

Fix at the loader, not at `hermes config set`, because (a) the CLI write path has no general schema and a per-key special case is the wrong abstraction, and (b) any user who already has the string form in `config.yaml` would still be stuck without the loader-side fix.  The surrounding `platforms.<name>:` key is the source of truth for the platform, so `GatewayConfig.from_dict` threads the resolved `Platform` enum down to `PlatformConfig.from_dict` and then to `HomeChannel.from_dict` via a new keyword-only `platform_default` parameter.  When the data is a string, wrap it as `HomeChannel(platform=<default>, chat_id=<string>, name="Home")`.  Dict shape and field semantics are unchanged — the dict's own `platform` key still wins over `platform_default`, so the roundtrip path is untouched.

Mirrors the `hermes config set` write shape: bare string under `platforms.<name>.home_channel` → wrap to `HomeChannel(platform=<name>, chat_id=<string>, name="Home")`.

## Related Issue

Fixes #33141

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/config.py` — `HomeChannel.from_dict` accepts `data: Any`; if it's a string, wrap under `platform_default`.  `PlatformConfig.from_dict` takes a new keyword-only `platform=` and forwards it.  `GatewayConfig.from_dict` passes the loop's `platform` enum into `PlatformConfig.from_dict`.  Both new params are keyword-only with defaults, so existing call sites (`tests/gateway/test_telegram_reply_mode.py`, `test_discord_reply_mode.py`, etc.) keep working without changes.
- `tests/gateway/test_config.py` — new `TestHomeChannelFromString` class covering: (1) bare-string wrapped under `platform_default`, (2) bare string without `platform_default` raises (negative case), (3) end-to-end `GatewayConfig.from_dict({"platforms": {"feishu": {"home_channel": "oc_xxx"}}})` succeeds, (4) dict shape with its own `platform` key wins over `platform_default` (roundtrip preserved).

## How to Test

1. Reproduce on `origin/main`:
   ```bash
   hermes config set platforms.feishu.home_channel oc_b0b897cce6e70190959898f94fe8f9a8
   python3 -c "from gateway.config import load_gateway_config; load_gateway_config()"
   # TypeError: string indices must be integers, not 'str'
   ```
2. With this PR applied, the `load_gateway_config()` call succeeds and `config.platforms[Platform.FEISHU].home_channel.chat_id == "oc_b0b897cce6e70190959898f94fe8f9a8"`.
3. Focused tests:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_config.py -v
   ```
   52 pass (4 new in `TestHomeChannelFromString`, 48 pre-existing).
4. Broader regression sweep on every caller of `PlatformConfig.from_dict` / `HomeChannel.from_dict`:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_config.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_discord_reply_mode.py tests/gateway/test_teams.py tests/gateway/test_pii_redaction.py tests/gateway/test_weixin.py tests/gateway/test_webhook_integration.py
   ```
   245 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (loader-side bug fix, no docs surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python config parsing, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

There are two adjacent open PRs in this code path that address different facets of `home_channel`:

- #13791 (ms-alan) — accepts explicit `home_channel: null` and treats it as absent.  Different shape (`null`, not bare string).  Both fixes can land independently; this PR keeps the `null` path falling into the existing `HomeChannel.from_dict({...})` failure mode so it doesn't pre-empt #13791's review surface.  The defensive guard against `data["home_channel"] is None` deliberately stays out of this PR.
- #19445 (liuhao1024) — wires `HOME_CHANNEL` env var injection for plugin platforms.  Different code path; no overlap.

> Audited siblings: confirmed every other `from_dict` classmethod in `gateway/config.py` (SessionResetPolicy, StreamingConfig, GatewayConfig itself) already handles its own user-typed shapes defensively — only HomeChannel had the bare-string crash.  No widening needed.