### PR TITLE
fix(codex): drop transient rs_tmp reasoning replay state

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -932,6 +932,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
     saw_commentary_phase = False
     saw_final_answer_phase = False
+    saw_reasoning_item = False
 
     for item in output:
         item_type = getattr(item, "type", None)
@@ -969,6 +970,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                     raw_message_item["phase"] = normalized_phase
                 message_items_raw.append(raw_message_item)
         elif item_type == "reasoning":
+            saw_reasoning_item = True
             reasoning_text = _extract_responses_reasoning_text(item)
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
@@ -979,6 +981,12 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             if isinstance(encrypted, str) and encrypted:
                 raw_item = {"type": "reasoning", "encrypted_content": encrypted}
                 item_id = getattr(item, "id", None)
+                if isinstance(item_id, str) and item_id.startswith("rs_tmp_"):
+                    logger.debug(
+                        "Skipping transient Codex reasoning item during normalization: %s",
+                        item_id,
+                    )
+                    continue
                 if isinstance(item_id, str) and item_id:
                     raw_item["id"] = item_id
                 # Capture summary — required by the API when replaying reasoning items
@@ -1089,13 +1097,13 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         finish_reason = "incomplete"
     elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase):
         finish_reason = "incomplete"
-    elif reasoning_items_raw and not final_text:
-        # Response contains only reasoning (encrypted thinking state) with
-        # no visible content or tool calls.  The model is still thinking and
-        # needs another turn to produce the actual answer.  Marking this as
-        # "stop" would send it into the empty-content retry loop which burns
-        # 3 retries then fails — treat it as incomplete instead so the Codex
-        # continuation path handles it correctly.
+    elif (reasoning_items_raw or reasoning_parts or saw_reasoning_item) and not final_text:
+        # Response contains only reasoning (encrypted thinking state and/or
+        # human-readable summary) with no visible content or tool calls. The
+        # model is still thinking and needs another turn to produce the actual
+        # answer. Marking this as "stop" would send it into the empty-content
+        # retry loop which burns retries then fails — treat it as incomplete so
+        # the Codex continuation path handles it correctly.
         finish_reason = "incomplete"
     else:
         finish_reason = "stop"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -50,6 +50,7 @@ AUTHOR_MAP = {
     "276689385+carltonawong@users.noreply.github.com": "carltonawong",
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
+    "3540493+kpadilha@users.noreply.github.com": "kpadilha",
     "wangpuv@hotmail.com": "wangpuv",
     "202622897+ticketclosed-wontfix@users.noreply.github.com": "ticketclosed-wontfix",
     "wuxuebin1993@gmail.com": "victorGPT",

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from agent.codex_responses_adapter import _normalize_codex_response
+
+
+def test_normalize_codex_response_drops_transient_rs_tmp_reasoning_items():
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_tmp_123",
+                encrypted_content="opaque-transient",
+                summary=[],
+            ),
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_456",
+                encrypted_content="opaque-stable",
+                summary=[SimpleNamespace(text="stable summary")],
+            ),
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="done")],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == "done"
+    assert assistant_message.codex_reasoning_items == [
+        {
+            "type": "reasoning",
+            "encrypted_content": "opaque-stable",
+            "id": "rs_456",
+            "summary": [{"type": "summary_text", "text": "stable summary"}],
+        }
+    ]
+
+
+def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_tmp_789",
+                encrypted_content="opaque-transient",
+                summary=[SimpleNamespace(text="still thinking")],
+            )
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.content == ""
+    assert assistant_message.reasoning == "still thinking"
+    assert assistant_message.codex_reasoning_items is None


### PR DESCRIPTION
Salvage of #11038 (@kpadilha) onto current main — prevention layer for encrypted-content corruption.

## Summary
Stops Hermes from persisting transient Codex reasoning replay items whose ids use the `rs_tmp_*` prefix. These temporary blobs were getting written into conversation history and replayed on subsequent turns, where they surface as HTTP 400 `invalid_encrypted_content` failures.

This is a **prevention** fix — complements the existing **recovery** path in PR #33035 (`_disable_codex_reasoning_replay` + retry). With both in place: prevent at write time (this PR), recover at read time (#33035).

## Changes
- `agent/codex_responses_adapter.py`: `_normalize_codex_response` skips reasoning items whose id starts with `rs_tmp_` before they get persisted. Adds `saw_reasoning_item` tracking so the finish_reason heuristic still treats reasoning-only turns as "incomplete" even when the only reasoning item was a transient one that got dropped.
- `tests/agent/test_codex_responses_adapter.py`: new test file with two assertions — drops `rs_tmp_*` items, keeps stable `rs_*` items.

## Validation
- `tests/agent/test_codex_responses_adapter.py` + `tests/run_agent/test_run_agent_codex_responses.py` → 70/70 passing

## Attribution
Cherry-picked from @kpadilha's #11038. AUTHOR_MAP updated in follow-up commit. Original PR was opened May 13; cherry-pick onto current main was clean (no conflicts).

## Infographic

![codex-rs-tmp-prevention](https://v3b.fal.media/files/b/0a9bdf49/lshpTP2_L8nB10zqwGlrH_iwSUihRf.png)
