### PR TITLE
[codex] guard null output_text validation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1224,8 +1224,14 @@ def run_conversation(
                                 error_details.append(f"response.status={_codex_resp_status}: {_codex_error_msg}")
                             else:
                                 # output_text fallback: stream backfill may have failed
-                                # but normalize can still recover from output_text
-                                _out_text = getattr(response, "output_text", None)
+                                # but normalize can still recover from output_text.
+                                # The OpenAI SDK property iterates response.output;
+                                # if the backend returns output=None, reading it raises
+                                # TypeError ("NoneType object is not iterable").
+                                _response_output = getattr(response, "output", None)
+                                _out_text = None
+                                if isinstance(_response_output, list):
+                                    _out_text = getattr(response, "output_text", None)
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:
                                     logger.debug(
@@ -1244,7 +1250,12 @@ def run_conversation(
                                         f"api_mode={agent.api_mode} provider={agent.provider}",
                                     )
                                     response_invalid = True
-                                    error_details.append("response.output is empty")
+                                    if _response_output is None:
+                                        error_details.append("response.output is None")
+                                    elif not isinstance(_response_output, list):
+                                        error_details.append("response.output is not a list")
+                                    else:
+                                        error_details.append("response.output is empty")
                 elif agent.api_mode == "anthropic_messages":
                     _tv = agent._get_transport()
                     if not _tv.validate_response(response):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -545,6 +545,41 @@ def test_run_conversation_codex_empty_output_no_output_text_retries(monkeypatch)
     assert result["final_response"] == "Recovered"
 
 
+def test_run_conversation_codex_none_output_does_not_read_output_text(monkeypatch):
+    """The OpenAI SDK output_text property iterates response.output.
+    If a malformed backend response has output=None, validation must retry
+    instead of raising TypeError while reading output_text."""
+    agent = _build_agent(monkeypatch)
+    calls = {"api": 0}
+
+    class _SdkLikeMalformedResponse:
+        output = None
+        usage = SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8)
+        status = "completed"
+        model = "gpt-5-codex"
+
+        @property
+        def output_text(self):
+            for output in self.output:
+                if output.type == "message":
+                    return "unreachable"
+            return ""
+
+    def _fake_api_call(api_kwargs):
+        calls["api"] += 1
+        if calls["api"] == 1:
+            return _SdkLikeMalformedResponse()
+        return _codex_message_response("Recovered")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("Say hello")
+
+    assert calls["api"] >= 2
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered"
+
+
 def test_run_conversation_codex_refreshes_after_401_and_retries(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"api": 0, "refresh": 0}


### PR DESCRIPTION
## Summary

- Avoid reading the Responses `output_text` convenience property unless `response.output` is a list.
- Treat `response.output is None` and other non-list shapes as invalid Codex responses so the existing retry/fallback path can handle them.
- Add a regression with an SDK-like `output_text` property that would otherwise raise `TypeError: NoneType object is not iterable`.

## Why

The main Codex stream path now avoids the known null-output terminal event by consuming SSE events directly. This keeps the later validation fallback defensive if a malformed Response-like object still reaches it, including third-party Responses-compatible providers or future SDK shape drift.

No issue was opened because the broader null-output problem already has existing reports and fixes. This PR is intentionally narrow hardening.

## Validation

```bash
pytest tests/run_agent/test_run_agent_codex_responses.py -k "empty_output or none_output"
```

Result: 3 passed, 65 deselected.
