### PR TITLE
fix(docker): set S6_KEEP_ENV=1 to preserve container environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,12 @@ COPY --chmod=0755 docker/cont-init.d/02-reconcile-profiles /etc/cont-init.d/02-r
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
+# s6-overlay v3 strips the container environment by default before
+# execing the main program. The main-wrapper.sh CMD needs all K8s env
+# vars (MATTERMOST_TOKEN, API keys, etc.) to survive into the hermes
+# process. S6_KEEP_ENV=1 preserves them. See:
+# https://github.com/just-containers/s6-overlay#customizing-s6-overlay-behaviour
+ENV S6_KEEP_ENV=1
 # Pre-s6 entrypoint.sh did `source .venv/bin/activate` which exported
 # the venv bin onto PATH; Architecture B's main-wrapper.sh does the
 # same for the container's main process, but `docker exec` and our


### PR DESCRIPTION
## Summary

s6-overlay v3 strips the container's environment by default before exec'ing the main program (CMD). This causes **all** Kubernetes-injected env vars (`MATTERMOST_TOKEN`, `MATTERMOST_URL`, `HERMES_HOME`, `HOME`, provider API keys) to vanish by the time the hermes gateway process starts.

The gateway then fails to detect any messaging platforms because `os.getenv()` returns empty for every credential, producing:
```
WARNING gateway.run: No messaging platforms enabled.
```

## Root Cause

The migration from tini (v2026.5.16) to s6-overlay on main changed the PID 1 from tini (which preserves env) to s6's `/init` (which strips env by default per the [s6-overlay docs](https://github.com/just-containers/s6-overlay#customizing-s6-overlay-behaviour)).

The `#!/command/with-contenv` shebang in s6 service scripts restores the env from `/run/s6/container_environment/`, but `main-wrapper.sh` (the CMD) uses plain `#!/bin/sh` and does NOT use `with-contenv`.

## Fix

One line: `ENV S6_KEEP_ENV=1` in the Dockerfile. This preserves the full container environment for the main program and all cont-init.d scripts.

## Verification

Tested on a two-tenant Hermes deployment on Talos Kubernetes:
- Without fix: `HERMES_HOME=<UNSET>`, `MATTERMOST_TOKEN` len=0, gateway reports "No messaging platforms enabled"
- With fix: `HERMES_HOME=/opt/data`, `MATTERMOST_TOKEN` len=26, gateway detects and connects to Mattermost

## Impact

This affects **every** Docker/Kubernetes deployment running from `main` since the s6-overlay migration. The v2026.5.16 release (tini-based) is not affected.