### PR TITLE
feat(mattermost): add 'auto' reply mode — flat DMs, threaded channels

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -46,6 +46,16 @@ _CHANNEL_TYPE_MAP = {
 
 _MATTERMOST_DISABLE_MENTIONS_PROPS = {"disable_mentions": True}
 
+# Raw Mattermost channel-type codes that behave like channels for "auto" reply
+# mode. O (public) and P (private) are channels, where threading keeps a busy
+# channel legible; D (direct) and G (group DM) read as conversations, where a
+# nested thread is just noise. Anything else -- an unrecognised code, a missing
+# type, or a failed lookup -- counts as unknown and falls back to flat.
+#
+# Deliberately keyed on the RAW code rather than _CHANNEL_TYPE_MAP, which folds
+# P into "group" alongside real group DMs; a private channel should thread.
+_AUTO_THREAD_CHANNEL_TYPES = frozenset({"O", "P"})
+
 # Reconnect parameters (exponential backoff).
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
@@ -110,11 +120,17 @@ class MattermostAdapter(BasePlatformAdapter):
         self._reconnect_task: Optional[asyncio.Task] = None
         self._closing = False
 
-        # Reply mode: "thread" to nest replies, "off" for flat messages.
+        # Reply mode: "thread" to nest replies, "off" for flat messages, "auto"
+        # to thread in channels but stay flat in DMs and group DMs.
         self._reply_mode: str = (
             config.extra.get("reply_mode", "")
             or os.getenv("MATTERMOST_REPLY_MODE", "off")
         ).lower()
+
+        # chat_id -> raw Mattermost channel-type code, for "auto" reply mode.
+        # A channel's type does not change, so this is cached for the process
+        # lifetime; only successful lookups are recorded.
+        self._channel_type_cache: Dict[str, str] = {}
 
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
@@ -178,13 +194,61 @@ class MattermostAdapter(BasePlatformAdapter):
             logger.error("MM API POST %s network error: %s", path, exc)
             return {}
 
+    async def _auto_mode_should_thread(self, chat_id: str) -> bool:
+        """Whether "auto" reply mode should thread in this conversation.
+
+        Resolves the channel type from the API directly rather than via
+        ``get_chat_info()``. That helper reports ``"channel"`` when its lookup
+        fails, and ``"channel"`` is the threadable answer -- so a transient DM
+        lookup failure would silently start threading inside a DM. Here an
+        indeterminate answer means flat.
+        """
+        if not chat_id:
+            return False
+
+        cached = self._channel_type_cache.get(chat_id)
+        if cached is None:
+            data = await self._api_get(f"channels/{chat_id}")
+            raw = (data or {}).get("type")
+            if not raw:
+                # Lookup failed or carried no type. Stay flat, and do not cache,
+                # so a later send can still learn the real type once the API
+                # recovers. Threading a DM is the worse failure: it is visible
+                # to the user and cannot be undone by a retry.
+                logger.debug(
+                    "MM auto reply mode: channel type unknown for %s; sending flat",
+                    chat_id,
+                )
+                return False
+            cached = str(raw)
+            self._channel_type_cache[chat_id] = cached
+
+        return cached in _AUTO_THREAD_CHANNEL_TYPES
+
+    def _mode_threads_raw_type(self, channel_type_raw: str) -> bool:
+        """Whether the active reply mode threads in a channel of this raw type.
+
+        Used on the inbound path, where the websocket event already carries the
+        channel type, so no lookup is needed. "thread" mode threads everywhere
+        except DMs (unchanged); "auto" threads only in real channels.
+        """
+        if self._reply_mode == "thread":
+            return channel_type_raw != "D"
+        if self._reply_mode == "auto":
+            return channel_type_raw in _AUTO_THREAD_CHANNEL_TYPES
+        return False
+
     async def _thread_root_for_send(
         self,
+        chat_id: str,
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[str]:
         """Resolve the Mattermost root_id from reply_to or metadata."""
-        if self._reply_mode != "thread":
+        if self._reply_mode == "auto":
+            if not await self._auto_mode_should_thread(chat_id):
+                return None
+        elif self._reply_mode != "thread":
             return None
         candidate = reply_to
         if not candidate and isinstance(metadata, dict):
@@ -378,7 +442,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 "message": chunk,
             })
             # Thread support: reply_to or metadata["thread_id"] is the root post ID.
-            resolved_root = await self._thread_root_for_send(reply_to, metadata)
+            resolved_root = await self._thread_root_for_send(chat_id, reply_to, metadata)
             if resolved_root:
                 payload["root_id"] = resolved_root
 
@@ -560,7 +624,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         })
-        resolved_root = await self._thread_root_for_send(reply_to, metadata)
+        resolved_root = await self._thread_root_for_send(chat_id, reply_to, metadata)
         if resolved_root:
             payload["root_id"] = resolved_root
 
@@ -601,7 +665,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         })
-        resolved_root = await self._thread_root_for_send(reply_to, metadata)
+        resolved_root = await self._thread_root_for_send(chat_id, reply_to, metadata)
         if resolved_root:
             payload["root_id"] = resolved_root
 
@@ -689,7 +753,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 })
-                resolved_root = await self._thread_root_for_send(None, metadata)
+                resolved_root = await self._thread_root_for_send(chat_id, None, metadata)
                 if resolved_root:
                     payload["root_id"] = resolved_root
                 logger.info(
@@ -887,8 +951,7 @@ class MattermostAdapter(BasePlatformAdapter):
         thread_id = post.get("root_id") or None
         if (
             not thread_id
-            and self._reply_mode == "thread"
-            and channel_type_raw != "D"
+            and self._mode_threads_raw_type(channel_type_raw)
             and post_id
         ):
             thread_id = post_id

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -32,8 +32,8 @@ optional_env:
     prompt: "Home channel ID"
     password: false
   - name: MATTERMOST_REPLY_MODE
-    description: "How replies are sent: 'thread' (nested) or 'off' (flat). Default: off."
-    prompt: "Reply mode (thread|off)"
+    description: "How replies are sent: 'thread' (nested), 'off' (flat), or 'auto' (nested in channels, flat in DMs). Default: off."
+    prompt: "Reply mode (thread|off|auto)"
     password: false
   - name: MATTERMOST_REQUIRE_MENTION
     description: "Require @bot mention in channels (default true). Set false for free-response everywhere."

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -1122,3 +1122,153 @@ async def test_mattermost_dm_post_does_not_seed_thread_root():
     msg_event = adapter.handle_message.call_args[0][0]
     assert msg_event.source.thread_id is None
     assert msg_event.source.message_id == "dm_post_123"
+
+
+# ----------------------------------------------------------------------
+# "auto" reply mode: thread in channels, stay flat in DMs / group DMs.
+# ----------------------------------------------------------------------
+
+
+def _auto_adapter(channel_type):
+    """Adapter in auto mode whose channel lookup returns ``channel_type``.
+
+    ``channel_type`` of None simulates a failed lookup (``_api_get`` returning
+    an empty dict), which is the case that must NOT thread.
+    """
+    adapter = _make_adapter()
+    adapter._reply_mode = "auto"
+    body = {} if channel_type is None else {"id": "chan", "type": channel_type}
+
+    async def fake_get(path, *args, **kwargs):
+        if path.startswith("channels/"):
+            return body
+        # _resolve_root_id: report the post as its own root.
+        return {"id": "root_post", "root_id": ""}
+
+    adapter._api_get = AsyncMock(side_effect=fake_get)
+    return adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_type", ["O", "P"])
+async def test_auto_mode_threads_in_channels(raw_type):
+    """Public and private channels both thread: both are channels."""
+    adapter = _auto_adapter(raw_type)
+
+    root = await adapter._thread_root_for_send("chan", "root_post", None)
+
+    assert root == "root_post"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_type", ["D", "G"])
+async def test_auto_mode_stays_flat_in_dms_and_group_dms(raw_type):
+    """A one-on-one or group conversation should not nest a thread."""
+    adapter = _auto_adapter(raw_type)
+
+    root = await adapter._thread_root_for_send("chan", "root_post", None)
+
+    assert root is None
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_stays_flat_when_channel_lookup_fails():
+    """A failed lookup must not thread.
+
+    get_chat_info() reports "channel" when its lookup fails, and "channel" is
+    the threadable answer -- so routing auto mode through it would start
+    threading inside a DM on any transient API failure. Regression for that.
+    """
+    adapter = _auto_adapter(None)
+
+    root = await adapter._thread_root_for_send("chan", "root_post", None)
+
+    assert root is None
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_stays_flat_for_unrecognised_channel_type():
+    """An unknown type code is indeterminate, so it must fall back to flat."""
+    adapter = _auto_adapter("Z")
+
+    root = await adapter._thread_root_for_send("chan", "root_post", None)
+
+    assert root is None
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_failed_lookup_is_not_cached():
+    """A failure must not poison the cache; a later send can still learn."""
+    adapter = _auto_adapter(None)
+
+    assert await adapter._thread_root_for_send("chan", "root_post", None) is None
+    assert "chan" not in adapter._channel_type_cache
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_caches_channel_type_across_sends():
+    """The type of a channel does not change; look it up once."""
+    adapter = _auto_adapter("O")
+
+    await adapter._thread_root_for_send("chan", "root_post", None)
+    await adapter._thread_root_for_send("chan", "root_post", None)
+
+    channel_lookups = [
+        call for call in adapter._api_get.call_args_list
+        if str(call.args[0]).startswith("channels/")
+    ]
+    assert len(channel_lookups) == 1
+    assert adapter._channel_type_cache["chan"] == "O"
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_honours_metadata_thread_root():
+    """Auto mode must keep the metadata-root handling thread mode has."""
+    adapter = _auto_adapter("O")
+
+    root = await adapter._thread_root_for_send(
+        "chan", None, {"thread_id": "root_post"}
+    )
+
+    assert root == "root_post"
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_ignores_metadata_root_in_a_dm():
+    """A metadata root does not override the DM decision."""
+    adapter = _auto_adapter("D")
+
+    root = await adapter._thread_root_for_send(
+        "chan", None, {"thread_id": "root_post"}
+    )
+
+    assert root is None
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_does_not_look_up_channel_without_a_root():
+    """No reply_to and no metadata root means nothing to thread under."""
+    adapter = _auto_adapter("O")
+
+    assert await adapter._thread_root_for_send("chan", None, None) is None
+
+
+def test_mode_threads_raw_type_matrix():
+    """Inbound path: thread mode excludes only DMs, auto only real channels."""
+    adapter = _make_adapter()
+
+    adapter._reply_mode = "thread"
+    assert adapter._mode_threads_raw_type("O") is True
+    assert adapter._mode_threads_raw_type("P") is True
+    assert adapter._mode_threads_raw_type("G") is True
+    assert adapter._mode_threads_raw_type("D") is False
+
+    adapter._reply_mode = "auto"
+    assert adapter._mode_threads_raw_type("O") is True
+    assert adapter._mode_threads_raw_type("P") is True
+    assert adapter._mode_threads_raw_type("G") is False
+    assert adapter._mode_threads_raw_type("D") is False
+
+    adapter._reply_mode = "off"
+    assert adapter._mode_threads_raw_type("O") is False
+    assert adapter._mode_threads_raw_type("D") is False

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -205,6 +205,11 @@ The `MATTERMOST_REPLY_MODE` setting controls how Hermes posts responses:
 |------|----------|
 | `off` (default) | Hermes posts flat messages in the channel, like a normal user. |
 | `thread` | Hermes replies in a thread under your original message. Keeps channels clean when there's lots of back-and-forth. |
+| `auto` | Threads in channels, stays flat in DMs and group DMs. Gives you the channel tidiness of `thread` without the awkwardness of a one-on-one conversation nested inside itself. |
+
+`auto` decides per conversation by looking up the channel type, and caches the
+answer. If that lookup fails it posts flat, on the principle that a stray flat
+message is easier to live with than an unwanted thread in a DM.
 
 Set it in your `~/.hermes/.env`:
 


### PR DESCRIPTION
## Summary

`MATTERMOST_REPLY_MODE` supports only `thread` (always nest) and `off` (always flat). `thread` keeps a busy channel legible but looks wrong in a DM, where a one-on-one conversation ends up nested inside itself; `off` gives up thread tidiness everywhere. `auto` decides per conversation: thread in channels, stay flat in DMs and group DMs.

Reimplemented against current `main` per review — the previous revision patched inline call sites that no longer exist, since thread-root selection is now centralised in `_thread_root_for_send()`.

Root cause of the trap this had to avoid: `get_chat_info()` returns `{"type": "channel"}` when its API lookup **fails**, and `"channel"` is the threadable answer. Routing an `auto` decision through it means a transient DM lookup failure silently starts threading inside a DM.

## Changes

- `plugins/platforms/mattermost/adapter.py`:
  - `_auto_mode_should_thread()` (new) resolves the channel type from `channels/<id>` directly, **not** via `get_chat_info()`, and treats a failed lookup, a missing type, or an unrecognised code as unknown → flat. Successful lookups are cached (a channel's type doesn't change); failures are deliberately **not** cached, so a later send can still learn the real type.
  - `_thread_root_for_send()` takes `chat_id` (already in scope at all four call sites) and consults the new resolver in `auto`; metadata roots (`metadata["thread_id"]` / `["root_id"]`) keep working for `auto` exactly as for `thread`.
  - `_mode_threads_raw_type()` (new) shares the same decision on the inbound path, where the websocket event already carries the channel type so no lookup is needed. `thread` behaviour there is unchanged (it already excluded DMs).
  - `_AUTO_THREAD_CHANNEL_TYPES = {"O","P"}` keys on the **raw** Mattermost code rather than `_CHANNEL_TYPE_MAP`, which folds `P` (private channel) into `"group"` alongside real group DMs — a private channel is a channel and should thread.
- `plugins/platforms/mattermost/plugin.yaml`: description and prompt now list `thread|off|auto`.
- `website/docs/user-guide/messaging/mattermost.md`: reply-mode table documents `auto`, including the flat-on-unknown behaviour.
- `tests/gateway/test_mattermost.py`: 12 new tests.

## Validation

| Conversation | raw type | `thread` | `off` | `auto` |
|---|---|---|---|---|
| public channel | `O` | thread | flat | **thread** |
| private channel | `P` | thread | flat | **thread** |
| group DM | `G` | thread | flat | **flat** |
| DM | `D` | flat | flat | **flat** |
| lookup failed / unknown code | — | thread | flat | **flat** |

| Check | Result |
|---|---|
| `pytest tests/gateway/test_mattermost.py -q` | 75/75 pass (12 new) |
| `pytest tests/gateway/test_send_multiple_images.py -q` | 24/24 pass (covers the multi-image call site) |

New cases: channels vs DMs vs group DMs; failed lookup stays flat; unrecognised code stays flat; failed lookup is not cached; successful type cached and looked up once across sends; metadata roots honoured in a channel and ignored in a DM; no-root short circuit skips the lookup; inbound matrix for all three modes across all four codes.

## Overlap with #47079 — flagging rather than competing

#47079 by @sidorovanthon also adds `reply_mode "auto"`, opened after this one. Two open PRs for one feature is the worst outcome, so rather than leave that implicit — the two differ in coverage and a maintainer may well prefer parts of each:

| | this PR | #47079 |
|---|---|---|
| decision point | centralised `_thread_root_for_send()` + inbound resolver | adapter call sites |
| failed / unknown channel type | explicitly flat, and not cached | worth confirming |
| private channel (`P`) vs group DM (`G`) | distinguished via raw code | folded by `_CHANNEL_TYPE_MAP` |
| gateway session keying | untouched | also updates `hermes_cli/gateway.py` |
| docs | `mattermost.md` | `mattermost.md` + `environment-variables.md` |

Happy to close this in favour of #47079, or to fold the unknown-type handling and the `P`/`G` distinction into it — whichever the platforms maintainer prefers. Flagging @sidorovanthon.

## Notes

- **Dependency worth knowing**: #67810 reports that `mattermost.reply_mode` from `config.yaml` is dropped by the plugin's YAML→env bridge. Until that lands, `reply_mode: auto` set in `config.yaml` won't reach this code — only `MATTERMOST_REPLY_MODE` will.
- **Duplicate check**: searched open and merged PRs for mattermost reply-mode work — #47079 (above), #67810 (bridge), #20874 / #56936 (thread continuity, separate concerns).
