### PR TITLE
fix(kanban): keep gave_up tasks blocked

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2196,10 +2196,9 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
+    """Return True when ``task_id`` is blocked until explicit unblocking.
 
-    A ``blocked`` status can come from two very different sources:
+    A ``blocked`` status can come from three different sources:
 
     * **Worker- or operator-initiated** — a worker called
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
@@ -2209,28 +2208,28 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits
-      ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
-      automatically once the underlying conditions change (e.g. parents
-      finish, transient infra error clears).
+      ``"gave_up"``, *not* ``"blocked"``.  Once the breaker trips, the
+      task must stay blocked until an operator explicitly intervenes;
+      otherwise ``recompute_ready`` can promote parentless tasks back to
+      ``ready`` immediately because ``all([])`` is true.
 
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    * **Legacy dependency auto-block** — older/manual rows may have
+      ``status='blocked'`` without a sticky event.  Those preserve the
+      historical auto-recovery semantics and may be promoted when parent
+      dependencies are satisfied.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    The cheapest signal that distinguishes these cases is the most recent
+    sticky-state event for the task.  ``blocked`` and ``gave_up`` are
+    sticky; ``unblocked`` clears stickiness so an explicit human action can
+    release the task back into normal dependency recomputation.
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "WHERE task_id = ? AND kind IN ('blocked', 'gave_up', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    return bool(row) and row["kind"] in {"blocked", "gave_up"}
 
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
@@ -2241,12 +2240,12 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
 
     ``blocked`` tasks are also considered for promotion (so a task
     blocked purely by a parent dependency unblocks itself when the
-    parent completes), *except* when the most recent block event was a
-    worker-initiated ``kanban_block`` — those stay blocked until an
-    explicit ``kanban_unblock`` (#28712).  Without that guard, a
-    ``review-required`` handoff would auto-respawn, the fresh worker
-    would find nothing to do, exit cleanly, get recorded as a protocol
-    violation, and the cycle would repeat indefinitely.
+    parent completes), *except* when the most recent sticky event was a
+    worker/operator ``blocked`` event or dispatcher ``gave_up`` event —
+    those stay blocked until an explicit ``kanban_unblock``.  Without
+    that guard, ``review-required`` handoffs and circuit-breaker blocks
+    could auto-respawn, the fresh worker would hit the same condition,
+    and the cycle would repeat indefinitely.
     """
     promoted = 0
     with write_txn(conn):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -320,6 +320,101 @@ def test_max_retries_none_falls_through_to_dispatcher_limit(kanban_home, all_ass
         conn.close()
 
 
+def test_gave_up_auto_block_is_not_repromoted_by_recompute_ready_parentless(
+    kanban_home, all_assignees_spawnable
+):
+    """A protocol/crash circuit-breaker block must survive recompute_ready.
+
+    Parentless tasks are the sharp edge: ``all([])`` is true, so a blocked
+    task with no sticky signal used to be immediately promoted back to ready.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="auth-loop", assignee="oracle")
+        tripped = kb._record_task_failure(
+            conn, tid,
+            error="Primary auth failed; OpenRouter HTTP 402",
+            outcome="crashed",
+            failure_limit=1,
+            release_claim=False,
+            end_run=False,
+        )
+        assert tripped is True
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert [e.kind for e in kb.list_events(conn, tid)].count("gave_up") == 1
+
+        promoted = kb.recompute_ready(conn)
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert promoted == 0
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+        assert "promoted" not in [e.kind for e in kb.list_events(conn, tid)]
+    finally:
+        conn.close()
+
+
+def test_gave_up_auto_block_repromotes_only_after_explicit_unblock(
+    kanban_home, all_assignees_spawnable
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs-human", assignee="worker")
+        assert kb._record_task_failure(
+            conn, tid,
+            error="clean exit without kanban transition",
+            outcome="crashed",
+            failure_limit=1,
+            release_claim=False,
+            end_run=False,
+        ) is True
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        assert kb.unblock_task(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
+    finally:
+        conn.close()
+
+
+def test_blocked_dependency_recovery_without_sticky_event_still_promotes(
+    kanban_home, all_assignees_spawnable
+):
+    """Preserve legacy auto-recovery for non-sticky dependency blocks."""
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = kb.create_task(conn, title="child", assignee="worker", parents=[parent])
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked', consecutive_failures = 2, "
+                "last_failure_error = 'waiting for parent' WHERE id = ?",
+                (child,),
+            )
+
+        kb.complete_task(conn, parent, result="ok")
+        promoted = kb.recompute_ready(conn)
+
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert promoted in (0, 1)  # complete_task may already recompute.
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+    finally:
+        conn.close()
+
+
 def test_workspace_resolution_failure_also_counts(kanban_home, all_assignees_spawnable):
     """`dir:` workspace with no path should fail workspace resolution AND
     count against the failure budget — not just crash the tick."""


### PR DESCRIPTION
## Summary
- Treat dispatcher `gave_up` circuit-breaker events as sticky blocks in `recompute_ready`.
- Preserve explicit `unblocked` as the release path back to normal ready recomputation.
- Add regressions for parentless `gave_up` tasks, explicit unblock recovery, and legacy dependency auto-recovery without sticky events.

## Spec / Source
Kanban task `t_11004d21` / Pulse P0: dispatcher loop `gave_up → promoted → respawn` observed on Oracle workers after protocol/auth failure.

## Verification
- RED observed before fix: `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_gave_up_auto_block_is_not_repromoted_by_recompute_ready_parentless -q -o 'addopts='` failed with `assert 1 == 0` (recompute promoted parentless `gave_up`).
- PASS: `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_gave_up_auto_block_is_not_repromoted_by_recompute_ready_parentless tests/hermes_cli/test_kanban_core_functionality.py::test_gave_up_auto_block_repromotes_only_after_explicit_unblock tests/hermes_cli/test_kanban_core_functionality.py::test_blocked_dependency_recovery_without_sticky_event_still_promotes tests/hermes_cli/test_kanban_core_functionality.py::test_recompute_ready_emits_promoted_not_ready tests/hermes_cli/test_kanban_core_functionality.py::test_spawn_failure_circuit_breaker_emits_gave_up -q -o 'addopts='` → 5 passed.
- PASS: `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -q -o 'addopts='` → 168 passed.

## Risk
- No auth/secrets/config changes.
- No Supabase/migration impact.
- Behavior change is scoped to blocked tasks whose latest sticky-state event is `gave_up`; legacy blocked rows without a sticky event still auto-promote when dependencies are satisfied.

Reviewer expected: Pulse.