### PR TITLE
fix(telegram): quiet operational chatter — cluster 1 (noise/UX) salvage

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -916,6 +916,11 @@ display:
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 
+  # Per-platform defaults can be quieter than the global setting. Telegram
+  # defaults to final-answer-first on mobile: tool progress, interim assistant
+  # updates, long-running "Still working..." heartbeats, and detailed busy acks
+  # are off unless re-enabled under display.platforms.telegram.
+
   # Auto-cleanup of temporary progress bubbles after the final response lands.
   # On platforms that support message deletion (currently Telegram), this
   # removes the tool-progress bubble, "⏳ Still working..." notices, and
@@ -938,6 +943,16 @@ display:
   #   true:  Send mid-turn assistant updates as separate messages (default)
   #   false: Only send the final response
   interim_assistant_messages: true
+
+  # Gateway-only long-running status heartbeats.
+  # When false, the platform does not receive periodic "Still working..."
+  # notifications even if agent.gateway_notify_interval is non-zero.
+  # Telegram default: false. Other high-capability chat platforms default true.
+  long_running_notifications: true
+
+  # Include detailed iteration/tool/status context in busy acknowledgments when
+  # a new user message arrives while a run is active. Telegram default: false.
+  busy_ack_detail: true
 
   # What Enter does when Hermes is already busy (CLI and gateway platforms).
   #   interrupt: Interrupt the current run and redirect Hermes (default)

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -35,6 +35,11 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
+    # Gateway-only assistant/status chatter controls. These default on for
+    # back-compat, but mobile platforms can opt down to final-answer-first.
+    "interim_assistant_messages": True,
+    "long_running_notifications": True,
+    "busy_ack_detail": True,
     # When true, delete tool-progress / "Still working..." / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
@@ -56,6 +61,9 @@ _TIER_HIGH = {
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,  # follow global
+    "interim_assistant_messages": True,
+    "long_running_notifications": True,
+    "busy_ack_detail": True,
 }
 
 _TIER_MEDIUM = {
@@ -63,6 +71,9 @@ _TIER_MEDIUM = {
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,
+    "interim_assistant_messages": True,
+    "long_running_notifications": True,
+    "busy_ack_detail": True,
 }
 
 _TIER_LOW = {
@@ -70,6 +81,9 @@ _TIER_LOW = {
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": False,
+    "interim_assistant_messages": False,
+    "long_running_notifications": False,
+    "busy_ack_detail": False,
 }
 
 _TIER_MINIMAL = {
@@ -77,11 +91,23 @@ _TIER_MINIMAL = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": False,
+    "interim_assistant_messages": False,
+    "long_running_notifications": False,
+    "busy_ack_detail": False,
 }
 
 _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # Tier 1 — full edit support, personal/team use
-    "telegram":    {**_TIER_HIGH, "tool_progress": "new"},
+    # Telegram is usually a mobile inbox: default to final-answer-first and
+    # avoid permanent operational breadcrumbs unless users opt back in with
+    # display.platforms.telegram.tool_progress / long_running_notifications.
+    "telegram":    {
+        **_TIER_HIGH,
+        "tool_progress": "off",
+        "interim_assistant_messages": False,
+        "long_running_notifications": False,
+        "busy_ack_detail": False,
+    },
     "discord":     _TIER_HIGH,
 
     # Tier 2 — edit support, often customer/workspace channels
@@ -190,7 +216,13 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in {"show_reasoning", "streaming"}:
+    if setting in {
+        "show_reasoning",
+        "streaming",
+        "interim_assistant_messages",
+        "long_running_notifications",
+        "busy_ack_detail",
+    }:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3226,17 +3226,16 @@ class GatewayRunner:
         # Build a status-rich acknowledgment. Mobile chat defaults keep this
         # terse; detailed iteration/tool state is still available in logs and
         # can be opted in per platform via display.platforms.<platform>.busy_ack_detail.
+        from gateway.display_config import resolve_display_setting
         status_parts = []
-        busy_ack_detail_enabled = True
-        try:
-            from gateway.display_config import resolve_display_setting as _resolve_display_setting
-            _user_cfg = _load_gateway_config()
-            _platform_key = _platform_config_key(event.source.platform)
-            busy_ack_detail_enabled = bool(
-                _resolve_display_setting(_user_cfg, _platform_key, "busy_ack_detail", True)
+        busy_ack_detail_enabled = bool(
+            resolve_display_setting(
+                _load_gateway_config(),
+                _platform_config_key(event.source.platform),
+                "busy_ack_detail",
+                True,
             )
-        except Exception:
-            busy_ack_detail_enabled = True
+        )
 
         if busy_ack_detail_enabled and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
@@ -17430,18 +17429,14 @@ class GatewayRunner:
         # 0 = disable notifications.
         _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
-        try:
-            _notify_enabled = bool(
-                resolve_display_setting(
-                    user_config,
-                    platform_key,
-                    "long_running_notifications",
-                    True,
-                )
+        if not bool(
+            resolve_display_setting(
+                user_config,
+                platform_key,
+                "long_running_notifications",
+                True,
             )
-        except Exception:
-            _notify_enabled = True
-        if not _notify_enabled:
+        ):
             _NOTIFY_INTERVAL = None
         _notify_start = time.time()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3223,9 +3223,22 @@ class GatewayRunner:
 
         self._busy_ack_ts[session_key] = now
 
-        # Build a status-rich acknowledgment
+        # Build a status-rich acknowledgment. Mobile chat defaults keep this
+        # terse; detailed iteration/tool state is still available in logs and
+        # can be opted in per platform via display.platforms.<platform>.busy_ack_detail.
         status_parts = []
-        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+        busy_ack_detail_enabled = True
+        try:
+            from gateway.display_config import resolve_display_setting as _resolve_display_setting
+            _user_cfg = _load_gateway_config()
+            _platform_key = _platform_config_key(event.source.platform)
+            busy_ack_detail_enabled = bool(
+                _resolve_display_setting(_user_cfg, _platform_key, "busy_ack_detail", True)
+            )
+        except Exception:
+            busy_ack_detail_enabled = True
+
+        if busy_ack_detail_enabled and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 summary = running_agent.get_activity_summary()
                 iteration = summary.get("api_call_count", 0)
@@ -15874,9 +15887,13 @@ class GatewayRunner:
         # in chat platforms while opting into concise mid-turn updates.
         interim_assistant_messages_enabled = (
             source.platform != Platform.WEBHOOK
-            and is_truthy_value(
-                display_config.get("interim_assistant_messages"),
-                default=True,
+            and bool(
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "interim_assistant_messages",
+                    True,
+                )
             )
         )
         
@@ -17413,6 +17430,19 @@ class GatewayRunner:
         # 0 = disable notifications.
         _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
+        try:
+            _notify_enabled = bool(
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "long_running_notifications",
+                    True,
+                )
+            )
+        except Exception:
+            _notify_enabled = True
+        if not _notify_enabled:
+            _NOTIFY_INTERVAL = None
         _notify_start = time.time()
 
         async def _notify_long_running():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -75,6 +75,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
+    r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7025,6 +7025,13 @@ class GatewayRunner:
                 if _denied is not None:
                     return _denied
 
+            # Telegram sends /start for bot launches/deep-links. Treat it as a
+            # platform ping, not a user command: no help dump, no agent
+            # interrupt, no queued text.
+            if _cmd_def_inner and _cmd_def_inner.name == "start":
+                logger.info("Ignoring /start platform ping for active session %s", _quick_key)
+                return ""
+
             if _cmd_def_inner and _cmd_def_inner.name == "restart":
                 return await self._handle_restart_command(event)
 
@@ -7457,6 +7464,10 @@ class GatewayRunner:
         
         if canonical == "help":
             return await self._handle_help_command(event)
+
+        if canonical == "start":
+            logger.info("Ignoring /start platform ping for session %s", _quick_key)
+            return ""
 
         if canonical == "commands":
             return await self._handle_commands_command(event)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -63,6 +63,8 @@ class CommandDef:
 
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
+    CommandDef("start", "Acknowledge platform start pings without a reply", "Session",
+               gateway_only=True),
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1285,6 +1285,10 @@ AUTHOR_MAP = {
     "172729123+felix-windsor@users.noreply.github.com": "felix-windsor",  # PR #28019 salvage (cron asterisks)
     "felixwindsor3344@gmail.com": "felix-windsor",
     "259054917+houenyang-momo@users.noreply.github.com": "houenyang-momo",  # PR #28205 salvage (charizard contrast)
+    "33547839+sir-ad@users.noreply.github.com": "sir-ad",  # PR #31941 salvage (compaction noise)
+    "adarsh.agrahari26@gmail.com": "sir-ad",
+    "269599864+rdasilva1016-ui@users.noreply.github.com": "rdasilva1016-ui",  # PR #31098 salvage (Telegram /start ping)
+    "rdasilva1016-ui@users.noreply.github.com": "rdasilva1016-ui",
     "35931201+iqdoctor@users.noreply.github.com": "iqdoctor",  # PR #28095 salvage (windows installer docs)
     "29513231+joe102084@users.noreply.github.com": "joe102084",  # PR #28151 salvage (whitespace cron responses)
     "joe102084@gmail.com": "joe102084",

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -378,8 +378,15 @@ class TestBusySessionAck:
         assert adapter._send_with_retry.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_includes_status_detail(self):
+    async def test_includes_status_detail_when_opted_in(self, monkeypatch):
         """Ack message should include iteration and tool info when available."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"platforms": {"telegram": {"busy_ack_detail": True}}}},
+        )
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()
@@ -407,6 +414,37 @@ class TestBusySessionAck:
         assert "21/60" in content  # iteration
         assert "terminal" in content  # current tool
         assert "10 min" in content  # elapsed
+
+    @pytest.mark.asyncio
+    async def test_telegram_omits_status_detail_by_default(self):
+        """Telegram busy acks stay concise unless busy_ack_detail is enabled."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="yo")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 21,
+            "max_iterations": 60,
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "terminal",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 600
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Interrupting current task" in content
+        assert "21/60" not in content
+        assert "terminal" not in content
+        assert "10 min" not in content
 
     @pytest.mark.asyncio
     async def test_draining_still_works(self):

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -41,9 +41,9 @@ class TestResolveDisplaySetting:
 
         # Empty config — should get built-in defaults
         config = {}
-        # Telegram tier_high override: "new" (not "all") to reduce edit
-        # pressure during streaming on Telegram's ~1 edit/s flood envelope.
-        assert resolve_display_setting(config, "telegram", "tool_progress") == "new"
+        # Telegram is a mobile inbox by default — final-answer-first unless
+        # explicitly configured otherwise.
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "off"
         # Email defaults to tier_minimal → "off"
         assert resolve_display_setting(config, "email", "tool_progress") == "off"
 
@@ -180,12 +180,11 @@ class TestPlatformDefaults:
     """Built-in defaults reflect platform capability tiers."""
 
     def test_high_tier_platforms(self):
-        """Discord defaults to 'all' tool progress; Telegram is in tier_high
-        but overrides tool_progress to 'new' (less edit pressure)."""
+        """Discord defaults to 'all'; Telegram defaults quiet for mobile."""
         from gateway.display_config import resolve_display_setting
 
-        # Telegram: tier_high member with tool_progress="new" override.
-        assert resolve_display_setting({}, "telegram", "tool_progress") == "new"
+        # Telegram: tier_high transport, but quiet mobile default.
+        assert resolve_display_setting({}, "telegram", "tool_progress") == "off"
         # Discord: pure tier_high.
         assert resolve_display_setting({}, "discord", "tool_progress") == "all"
 
@@ -228,6 +227,36 @@ class TestPlatformDefaults:
         from gateway.display_config import resolve_display_setting
 
         assert resolve_display_setting({}, "telegram", "streaming") is None
+
+    def test_telegram_mobile_chatter_defaults_off(self):
+        """Telegram suppresses operational chat noise unless opted in."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "telegram", "long_running_notifications") is False
+        assert resolve_display_setting({}, "telegram", "busy_ack_detail") is False
+        assert resolve_display_setting({}, "discord", "interim_assistant_messages") is True
+        assert resolve_display_setting({}, "discord", "long_running_notifications") is True
+        assert resolve_display_setting({}, "discord", "busy_ack_detail") is True
+
+    def test_telegram_mobile_chatter_can_opt_in(self):
+        """Per-platform config can re-enable Telegram status chatter."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "interim_assistant_messages": True,
+                        "long_running_notifications": "yes",
+                        "busy_ack_detail": "on",
+                    }
+                }
+            }
+        }
+        assert resolve_display_setting(config, "telegram", "interim_assistant_messages") is True
+        assert resolve_display_setting(config, "telegram", "long_running_notifications") is True
+        assert resolve_display_setting(config, "telegram", "busy_ack_detail") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_gateway_command_help.py
+++ b/tests/gateway/test_gateway_command_help.py
@@ -26,6 +26,16 @@ def _make_runner():
     return object.__new__(GatewayRunner)
 
 
+def test_start_is_known_gateway_command():
+    """Telegram sends /start automatically; gateway should intercept it as a no-op."""
+    from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+
+    cmd = resolve_command("start")
+    assert "start" in GATEWAY_KNOWN_COMMANDS
+    assert cmd is not None
+    assert cmd.name == "start"
+
+
 @pytest.mark.asyncio
 async def test_help_sanitizes_slash_command_mentions_for_telegram(monkeypatch):
     """Telegram help output must not expose invalid uppercase/hyphenated slashes."""

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -784,12 +784,13 @@ async def test_run_agent_surfaces_real_interim_commentary(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_run_agent_surfaces_interim_commentary_by_default(monkeypatch, tmp_path):
+async def test_run_agent_surfaces_interim_commentary_when_globally_enabled(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,
         tmp_path,
         CommentaryAgent,
-        session_id="sess-commentary-default-on",
+        session_id="sess-commentary-global-on",
+        config_data={"display": {"interim_assistant_messages": True}},
     )
 
     assert any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -331,6 +331,42 @@ async def test_command_messages_do_not_leave_sentinel():
 
 
 @pytest.mark.asyncio
+async def test_start_command_is_noop_and_does_not_show_help():
+    """Telegram /start is a platform ping; it must not dump /help output."""
+    runner = _make_runner()
+    event = _make_event(text="/start")
+    session_key = build_session_key(event.source)
+
+    runner._handle_help_command = AsyncMock(return_value="Help text")
+
+    result = await runner._handle_message(event)
+
+    assert result == ""
+    runner._handle_help_command.assert_not_awaited()
+    assert session_key not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_start_command_is_noop_during_active_session():
+    """A mid-run /start must not interrupt the active agent or show commands."""
+    runner = _make_runner()
+    event = _make_event(text="/start")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    runner._running_agents[session_key] = fake_agent
+    runner._handle_help_command = AsyncMock(return_value="Help text")
+
+    result = await runner._handle_message(event)
+
+    assert result == ""
+    runner._handle_help_command.assert_not_awaited()
+    fake_agent.interrupt.assert_not_called()
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("command_text", "handler_attr", "handler_result"),
     [

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -12,6 +12,7 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
     noisy_messages = [
         "⚠ Auxiliary title generation failed: HTTP 400: Operation contains cybersecurity risk",
         "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+        "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
         "ℹ Configured compression model 'small-model' failed (timeout). Recovered using main model — check auxiliary.compression.model in config.yaml.",
         "⏳ Retrying in 4.2s (attempt 1/3)...",
         "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -507,9 +507,23 @@ Scheduled auto-resume for N restart-interrupted session(s)
 
 No configuration is required. If you don't want the heads-up, set `gateway_restart_notification: false` on the platform.
 
+### Mobile-friendly progress defaults
+
+Telegram defaults to final-answer-first output: no tool-progress stream, no periodic "still working…" heartbeat, no interim assistant status messages, and concise busy acknowledgments. Opt back into any of those per platform:
+
+```yaml
+display:
+  platforms:
+    telegram:
+      tool_progress: new
+      interim_assistant_messages: true
+      long_running_notifications: true
+      busy_ack_detail: true
+```
+
 ### Progress bubble cleanup (opt-in)
 
-Tool-progress messages, the "still working…" heartbeat, and status-callback bubbles can be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
+Tool-progress messages, the "still working…" heartbeat, and status-callback bubbles can also be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
 
 ```yaml
 display:


### PR DESCRIPTION
Quiet down three sources of Telegram chat noise so the gateway stops bleeding operational chatter into user-facing chats.

Salvage of three external Telegram UX PRs (cluster 1: noise/chatter) on current `main` with original authorship preserved.

## Changes

- **`fix(gateway): hide telegram compaction status noise`** @sir-ad (#31941)
  Suppresses the "🗜️ Compacting context — summarizing earlier conversation…" status from being delivered to Telegram by adding it to `_TELEGRAM_NOISY_STATUS_RE`. Em-dash + ASCII-hyphen collapsed into one `[—-]` alternative (1 regex line instead of 2).

- **`fix: ignore Telegram start pings`** @rdasilva1016-ui (#31098)
  Telegram auto-sends `/start` when a user opens the bot / follows a deep link. Hermes was treating it as an unknown command and dumping `/help` (or worse, interrupting an active agent). Registers `start` as a `gateway_only` CommandDef and intercepts on both the running-agent fast-path and the cold-path. Silent no-op.

- **`gateway: quiet Telegram operational chatter`** @houenyang-momo (#31034)
  Reframes Telegram defaults as final-answer-first for mobile chat:
  - `tool_progress`: `new` → `off`
  - `interim_assistant_messages`: `True` → `False` (new platform key)
  - `long_running_notifications`: `True` → `False` (new global+platform key)
  - `busy_ack_detail`: `True` → `False` (new platform key)
  All opt-back-in via `display.platforms.telegram.<key>: true`. Other tier-high platforms (Discord, etc.) keep their current chatty defaults.

- **`refactor(gateway): drop try/except wrappers around resolve_display_setting`** — follow-up on top of #31034.
  Both new display-resolution sites it added (busy_ack_detail + long_running_notifications) wrapped `resolve_display_setting()` in `try/except Exception`. The existing 4 call sites in this file don't — the function is safe by contract. Match the established pattern. -16 LOC, no behaviour change.

## Validation

```
tests/gateway/test_display_config.py            ✓
tests/gateway/test_busy_session_ack.py          ✓
tests/gateway/test_run_progress_topics.py       ✓
tests/gateway/test_run_cleanup_progress.py      ✓
tests/gateway/test_telegram_noise_filter.py     ✓
tests/gateway/test_gateway_command_help.py      ✓
tests/gateway/test_session_race_guard.py        ✓
                                              113/113 passing
```

## Closes

- closes #31098 (own PR — salvaged)
- closes #31034 (own PR — salvaged)
- closes #31941 (own PR — salvaged)
- closes #31943 (byte-identical duplicate of #31941 from same author)


## Infographic

![cluster-1-quiet-telegram](https://v3b.fal.media/files/b/0a9bdfa8/ZdQbaoG6B38i7I4mkttIK_I6He92TU.png)
