### PR TITLE
Use launchctl print for launchd status

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -110,23 +110,11 @@ def _get_service_pids() -> set:
     # --- launchd (macOS) ---
     if is_macos():
         try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+            service_status = _read_launchd_service_status()
+            pid = service_status.get("pid")
+            if isinstance(pid, int) and pid > 0:
+                pids.add(pid)
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             pass
 
     return pids
@@ -958,15 +946,9 @@ def _probe_launchd_service_running() -> bool:
     if not get_launchd_plist_path().exists():
         return False
     try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
+        return bool(_read_launchd_service_status().get("loaded"))
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return False
-    return result.returncode == 0
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -2802,6 +2784,64 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _read_launchd_service_status() -> dict[str, object]:
+    """Return launchd service status for the current Hermes label.
+
+    ``launchctl list <label>`` is unreliable on modern macOS for agents loaded
+    in a GUI bootstrap namespace: the job can be running while ``list`` still
+    returns "Could not find service". Use ``launchctl print gui/<uid>/<label>``
+    instead, which queries the correct domain explicitly and matches what
+    operators use when debugging live launchd state.
+    """
+    label = get_launchd_label()
+    target = f"{_launchd_domain()}/{label}"
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", target],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return {
+            "loaded": False,
+            "state": None,
+            "pid": None,
+            "raw": "",
+            "reason": "launchctl unavailable or timed out",
+        }
+
+    raw = (result.stdout or "").strip()
+    combined = "\n".join(part for part in ((result.stdout or "").strip(), (result.stderr or "").strip()) if part)
+    if result.returncode != 0:
+        reason = (combined or f"launchctl exited {result.returncode}").strip()
+        return {
+            "loaded": False,
+            "state": None,
+            "pid": None,
+            "raw": raw,
+            "reason": reason,
+            "returncode": result.returncode,
+        }
+
+    state = None
+    pid = None
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("state ="):
+            state = stripped.split("=", 1)[1].strip()
+        elif stripped.startswith("pid ="):
+            value = stripped.split("=", 1)[1].strip()
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                parsed = None
+            if parsed and parsed > 0:
+                pid = parsed
+
+    return {"loaded": True, "state": state, "pid": pid, "raw": raw, "reason": ""}
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -3082,19 +3122,8 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
-        loaded = False
-        loaded_output = ""
+    service_status = _read_launchd_service_status()
+    loaded = bool(service_status.get("loaded"))
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -3105,13 +3134,26 @@ def launchd_status(deep: bool = False):
 
     if loaded:
         print("✓ Gateway service is loaded")
-        print(loaded_output)
+        state = service_status.get("state")
+        pid = service_status.get("pid")
+        if state:
+            print(f"  State: {state}")
+        if pid:
+            print(f"  PID: {pid}")
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
         print("  Run: hermes gateway start")
+        reason = str(service_status.get("reason") or "").strip()
+        if reason:
+            print(f"  launchctl: {reason}")
     
     if deep:
+        raw = str(service_status.get("raw") or "").strip()
+        if raw:
+            print()
+            print("launchctl details:")
+            print(raw)
         log_file = get_hermes_home() / "logs" / "gateway.log"
         if log_file.exists():
             print()
@@ -4193,12 +4235,8 @@ def _is_service_running() -> bool:
         return False
     elif is_macos() and get_launchd_plist_path().exists():
         try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
+            return bool(_read_launchd_service_status().get("loaded"))
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             return False
     elif is_windows():
         from hermes_cli import gateway_windows

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -677,6 +677,50 @@ class TestLaunchdServiceRecovery:
         assert str(plist_path) in output
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
+        assert "could not find service" in output.lower()
+
+    def test_launchd_status_reports_loaded_service_via_launchctl_print(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "gui/501/ai.hermes.gateway = {\n"
+                    "\tstate = running\n"
+                    "\tpid = 36480\n"
+                    "}\n"
+                ),
+                stderr="",
+            ),
+        )
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert str(plist_path) in output
+        assert "loaded" in output.lower()
+        assert "state: running" in output.lower()
+        assert "pid: 36480" in output.lower()
+
+    def test_probe_launchd_service_running_uses_launchctl_print_status(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("plist\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_read_launchd_service_status",
+            lambda: {"loaded": True, "state": "running", "pid": 36480, "raw": "", "reason": ""},
+        )
+
+        assert gateway_cli._probe_launchd_service_running() is True
 
 
 class TestGatewayServiceDetection:
@@ -735,6 +779,34 @@ class TestGatewayServiceDetection:
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         assert gateway_cli._is_service_running() is False
+
+    def test_is_service_running_uses_launchctl_print_status_on_macos(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("plist\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_read_launchd_service_status",
+            lambda: {"loaded": True, "state": "running", "pid": 36480, "raw": "", "reason": ""},
+        )
+
+        assert gateway_cli._is_service_running() is True
+
+    def test_find_gateway_pids_includes_launchd_pid_from_service_status(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_scan_gateway_pids", lambda exclude_pids, all_profiles=False: [])
+        monkeypatch.setattr(
+            gateway_cli,
+            "_read_launchd_service_status",
+            lambda: {"loaded": True, "state": "running", "pid": 36480, "raw": "", "reason": ""},
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+
+        assert gateway_cli.find_gateway_pids() == [36480]
 
 class TestGatewaySystemServiceRouting:
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Fix macOS launchd status detection by switching Hermes from `launchctl list <label>` to `launchctl print gui/<uid>/<label>` and reusing that parsed service status across the CLI.

## Problem

On modern macOS, a user LaunchAgent can be loaded and running in the GUI bootstrap namespace while `launchctl list <label>` still returns `Could not find service`.

That caused `hermes gateway status` and related probes to falsely report that the gateway service was not loaded even when launchd was actually running it.

## Changes

- add `_read_launchd_service_status()` to parse `launchctl print gui/<uid>/<label>`
- make `launchd_status()` report parsed `State` and `PID`
- make `_probe_launchd_service_running()` use the same launchd status reader
- make `_get_service_pids()` read the launchd-managed PID from the same source
- make `_is_service_running()` use the same launchd status reader
- add regression tests covering loaded launchd state, PID detection, and service-running checks

## Scope

This is a macOS-specific service-management fix. It does not change Linux/systemd or Windows behavior.

## Verification

- `pytest -o addopts='' -q tests/hermes_cli/test_gateway_service.py -k 'launchd or is_service_running or find_gateway_pids'`
- local launchd status now reports the running service correctly instead of a false negative
