### PR TITLE
Fix timeouts for named custom providers

### DIFF
--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -24,10 +24,7 @@ def get_provider_request_timeout(
     except Exception:
         return None
 
-    providers = config.get("providers", {}) if isinstance(config, dict) else {}
-    provider_config = (
-        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
-    )
+    provider_config = _get_provider_config(config, provider_id)
     if not isinstance(provider_config, dict):
         return None
 
@@ -53,10 +50,7 @@ def get_provider_stale_timeout(
     except Exception:
         return None
 
-    providers = config.get("providers", {}) if isinstance(config, dict) else {}
-    provider_config = (
-        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
-    )
+    provider_config = _get_provider_config(config, provider_id)
     if not isinstance(provider_config, dict):
         return None
 
@@ -80,3 +74,34 @@ def _get_model_config(
     if isinstance(model_config, dict):
         return model_config
     return None
+
+
+def _get_provider_config(config: object, provider_id: str) -> dict[str, object] | None:
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    if not isinstance(providers, dict):
+        return None
+
+    direct_config = providers.get(provider_id)
+    if isinstance(direct_config, dict):
+        return direct_config
+
+    if provider_id != "custom" or not isinstance(config, dict):
+        return None
+
+    model_cfg = config.get("model", {})
+    configured_provider = (
+        model_cfg.get("provider") if isinstance(model_cfg, dict) else None
+    )
+    if not isinstance(configured_provider, str):
+        return None
+
+    configured_provider = configured_provider.strip()
+    if not configured_provider.startswith("custom:"):
+        return None
+
+    named_provider = configured_provider.split(":", 1)[1].strip()
+    if not named_provider:
+        return None
+
+    named_config = providers.get(named_provider)
+    return named_config if isinstance(named_config, dict) else None

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -43,6 +43,26 @@ def test_provider_timeout_used_when_no_model_override(monkeypatch, tmp_path):
     assert get_provider_request_timeout("ollama-local", "qwen3:32b") == 300.0
 
 
+def test_named_custom_provider_timeout_used_for_custom_runtime(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        model:
+          provider: custom:nb
+        providers:
+          nb:
+            request_timeout_seconds: 180
+            models:
+              gpt-5.5:
+                timeout_seconds: 240
+        """,
+    )
+
+    assert get_provider_request_timeout("custom", "gpt-5.5") == 240.0
+    assert get_provider_request_timeout("custom", "gpt-5.4") == 180.0
+
+
 def test_model_stale_timeout_override_wins(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _write_config(
@@ -72,6 +92,28 @@ def test_provider_stale_timeout_used_when_no_model_override(monkeypatch, tmp_pat
     )
 
     assert get_provider_stale_timeout("openai-codex", "gpt-5.4") == 900.0
+
+
+def test_named_custom_provider_stale_timeout_used_for_custom_runtime(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(
+        tmp_path,
+        """\
+        model:
+          provider: custom:nb
+        providers:
+          nb:
+            stale_timeout_seconds: 600
+            models:
+              gpt-5.5:
+                stale_timeout_seconds: 1200
+        """,
+    )
+
+    assert get_provider_stale_timeout("custom", "gpt-5.5") == 1200.0
+    assert get_provider_stale_timeout("custom", "gpt-5.4") == 600.0
 
 
 def test_missing_timeout_returns_none(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- resolve timeout config for named custom providers when runtime provider is `custom`
- keep per-model timeout and stale-timeout overrides working for `model.provider: custom:<name>`
- add regression coverage for named custom provider request and stale timeouts

## Test
- `uv run --extra dev pytest tests/hermes_cli/test_timeouts.py`