### PR TITLE
fix(computer_use): route screenshots through auxiliary vision for non-vision main models

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1633,6 +1633,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             session_id=agent.session_id or "",
             enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
             skip_pre_tool_call_hook=True,
+            provider=agent.provider,
+            model=agent.model,
         )
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -747,6 +747,8 @@ def handle_function_call(
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     skip_pre_tool_call_hook: bool = False,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -837,12 +839,16 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 enabled_tools=sandbox_enabled,
+                provider=provider,
+                model=model,
             )
         else:
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                provider=provider,
+                model=model,
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2256,6 +2256,8 @@ class TestConcurrentToolExecution:
                 session_id=agent.session_id,
                 enabled_tools=list(agent.valid_tool_names),
                 skip_pre_tool_call_hook=True,
+                provider=agent.provider,
+                model=agent.model,
             )
             assert result == "result"
 

--- a/tests/tools/test_computer_use_capture_routing.py
+++ b/tests/tools/test_computer_use_capture_routing.py
@@ -267,10 +267,14 @@ class TestCaptureResponseRoutedToAuxVision:
                    new_callable=lambda: fake_vat):
             resp = cu_tool._capture_response(cap)
 
-        # Aux failure → fall back to multimodal envelope (so the user still
-        # gets *something* useful even if vision is broken).
-        assert isinstance(resp, dict)
-        assert resp.get("_multimodal") is True
+        # Aux failure → fall back to text-only summary (so the user still
+        # gets *something* useful even if vision is broken, without tripping
+        # a hard tool-result error on a non-vision main model).
+        assert isinstance(resp, str)
+        body = json.loads(resp)
+        assert body["mode"] == "som"
+        assert "summary" in body
+        assert body.get("note", "").startswith("auxiliary vision unavailable")
         # Temp file must still be cleaned up.
         assert observed_path["path"]
         assert not os.path.exists(observed_path["path"])
@@ -292,10 +296,13 @@ class TestCaptureResponseRoutedToAuxVision:
                    new_callable=lambda: fake_vat):
             resp = cu_tool._capture_response(cap)
 
-        # Empty analysis is treated as failure — we'd rather show pixels
-        # than embed an empty 'vision_analysis' string into the result.
-        assert isinstance(resp, dict)
-        assert resp.get("_multimodal") is True
+        # Empty analysis is treated as failure — text-only summary so the
+        # agent still gets context without an image_url envelope.
+        assert isinstance(resp, str)
+        body = json.loads(resp)
+        assert body["mode"] == "som"
+        assert "summary" in body
+        assert body.get("note", "").startswith("auxiliary vision unavailable")
 
     def test_invalid_aux_response_falls_back_to_multimodal(self, tmp_cache_dir):
         from tools.computer_use import tool as cu_tool
@@ -314,8 +321,12 @@ class TestCaptureResponseRoutedToAuxVision:
                    new_callable=lambda: fake_vat):
             resp = cu_tool._capture_response(cap)
 
-        assert isinstance(resp, dict)
-        assert resp.get("_multimodal") is True
+        # Invalid aux response → text-only summary fallback.
+        assert isinstance(resp, str)
+        body = json.loads(resp)
+        assert body["mode"] == "som"
+        assert "summary" in body
+        assert body.get("note", "").startswith("auxiliary vision unavailable")
 
 
 # ---------------------------------------------------------------------------
@@ -337,12 +348,10 @@ class TestRoutingDecisionWiring:
                 }
             },
         }
-        with patch("agent.auxiliary_client._read_main_provider",
-                   return_value="openrouter"), \
-             patch("agent.auxiliary_client._read_main_model",
-                   return_value="tencent/hy3-preview"), \
-             patch("hermes_cli.config.load_config", return_value=cfg):
-            assert cu_tool._should_route_through_aux_vision() is True
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert cu_tool._should_route_through_aux_vision(
+                provider="openrouter", model="tencent/hy3-preview"
+            ) is True
 
     def test_no_explicit_aux_and_vision_capable_main_keeps_multimodal(self):
         from tools.computer_use import tool as cu_tool
@@ -350,39 +359,35 @@ class TestRoutingDecisionWiring:
         cfg = {
             "model": {"default": "claude-opus-4-5", "provider": "anthropic"},
         }
-        with patch("agent.auxiliary_client._read_main_provider",
-                   return_value="anthropic"), \
-             patch("agent.auxiliary_client._read_main_model",
-                   return_value="claude-opus-4-5"), \
-             patch("hermes_cli.config.load_config", return_value=cfg), \
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
              patch("tools.computer_use.vision_routing._lookup_supports_vision",
                    return_value=True), \
              patch("tools.computer_use.vision_routing."
                    "_provider_accepts_multimodal_tool_result",
                    return_value=True):
-            assert cu_tool._should_route_through_aux_vision() is False
+            assert cu_tool._should_route_through_aux_vision(
+                provider="anthropic", model="claude-opus-4-5"
+            ) is False
 
-    def test_config_load_failure_disables_routing_safely(self):
+    def test_config_load_failure_defaults_to_safe_routing(self):
         from tools.computer_use import tool as cu_tool
 
         with patch("hermes_cli.config.load_config",
                    side_effect=RuntimeError("config.yaml unreadable")):
-            # No exception should bubble up — fail open by returning False
-            # so the legacy multimodal envelope continues to work.
-            assert cu_tool._should_route_through_aux_vision() is False
+            # No exception should bubble up — fail safe by returning True
+            # so we avoid sending image_url envelopes to unknown models.
+            assert cu_tool._should_route_through_aux_vision() is True
 
     def test_helper_decision_exception_is_swallowed(self):
         from tools.computer_use import tool as cu_tool
         from tools.computer_use import vision_routing as vr_mod
 
-        with patch("agent.auxiliary_client._read_main_provider",
-                   return_value="openrouter"), \
-             patch("agent.auxiliary_client._read_main_model",
-                   return_value="x"), \
-             patch("hermes_cli.config.load_config", return_value={}), \
+        with patch("hermes_cli.config.load_config", return_value={}), \
              patch.object(vr_mod, "should_route_capture_to_aux_vision",
                           side_effect=ValueError("policy bug")):
-            assert cu_tool._should_route_through_aux_vision() is False
+            assert cu_tool._should_route_through_aux_vision(
+                provider="openrouter", model="x"
+            ) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -255,7 +255,7 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         })
 
     try:
-        return _dispatch(backend, action, args)
+        return _dispatch(backend, action, args, **kwargs)
     except Exception as e:
         logger.exception("computer_use %s failed", action)
         return json.dumps({"error": f"{action} failed: {e}"})
@@ -313,7 +313,7 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
     return action
 
 
-def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
+def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any], **kwargs) -> Any:
     capture_after = bool(args.get("capture_after"))
 
     if action == "capture":
@@ -321,7 +321,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
         cap = backend.capture(mode=mode, app=args.get("app"))
-        return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
+        return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")), **kwargs)
 
     if action == "wait":
         seconds = float(args.get("seconds", 1.0))
@@ -337,7 +337,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, **kwargs)
 
     if action in {"click", "double_click", "right_click", "middle_click"}:
         button = args.get("button")
@@ -358,7 +358,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, **kwargs)
 
     if action == "drag":
         has_elements = args.get("from_element") is not None and args.get("to_element") is not None
@@ -375,7 +375,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, **kwargs)
 
     if action == "scroll":
         coord = args.get("coordinate") or (None, None)
@@ -387,22 +387,22 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, **kwargs)
 
     if action == "type":
         res = backend.type_text(args.get("text", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, **kwargs)
 
     if action == "key":
         res = backend.key(args.get("keys", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, **kwargs)
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, **kwargs)
 
     return json.dumps({"error": f"unknown action {action!r}"})
 
@@ -453,7 +453,7 @@ def _coerce_max_elements(value: Any) -> int:
     return n
 
 
-def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS) -> Any:
+def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS, **kwargs) -> Any:
     total_elements = len(cap.elements)
     visible_elements = cap.elements[:max_elements]
     truncated_elements = max(0, total_elements - len(visible_elements))
@@ -485,14 +485,24 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
         # multimodal envelope was returned unconditionally, so non-vision
         # main models tripped HTTP 404 / 400 at the provider boundary even
         # when auxiliary.vision was explicitly configured to handle this.
-        if _should_route_through_aux_vision():
+        if _should_route_through_aux_vision(**kwargs):
             routed = _route_capture_through_aux_vision(cap, summary)
             if routed is not None:
                 return routed
-            # Aux routing was requested but failed (no vision client, aux
-            # call raised, etc.). Fall through to the multimodal envelope —
-            # better to surface a tool-result error from the main model
-            # than to silently drop the screenshot entirely.
+            # Aux routing was required but failed (no vision client, aux call
+            # raised, etc.). Don't fall through to the multimodal envelope —
+            # that would trip a hard tool-result error on a non-vision main
+            # model. Return a text-only summary instead.
+            return json.dumps({
+                "mode": cap.mode,
+                "width": cap.width,
+                "height": cap.height,
+                "app": cap.app,
+                "window_title": cap.window_title,
+                "elements": [_element_to_dict(e) for e in cap.elements],
+                "summary": summary,
+                "note": "auxiliary vision unavailable — text summary only",
+            })
 
         # Detect actual image format from base64 magic bytes so the MIME type
         # matches what the data contains (cua-driver may return JPEG or PNG).
@@ -540,36 +550,46 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
 # auxiliary.vision routing for captured screenshots (#24015)
 # ---------------------------------------------------------------------------
 
-def _should_route_through_aux_vision() -> bool:
+def _should_route_through_aux_vision(**kwargs) -> bool:
     """Return True when ``_capture_response`` should hand the PNG to aux vision.
 
-    Reads the active main provider/model and the loaded config and asks the
-    routing helper. Any failure (config import, runtime override missing,
-    etc.) returns False so the existing multimodal envelope continues to be
-    returned — fail open on the routing decision so a broken config can
-    never silently drop the screenshot for vision-capable main models.
+    Reads the active main provider/model (from kwargs, then config) and asks
+    the routing helper. Any failure defaults to ``True`` — routing through
+    auxiliary vision costs one extra LLM call but always yields a usable
+    text description. Returning a raw screenshot to a non-vision main model
+    produces a hard tool-result error, so ``True`` is the safer default.
     """
+    provider = (kwargs.get("provider") or "").strip().lower()
+    model = (kwargs.get("model") or "").strip()
+
+    cfg: Optional[Dict[str, Any]] = None
     try:
-        from agent.auxiliary_client import _read_main_model, _read_main_provider
         from hermes_cli.config import load_config
-        from tools.computer_use.vision_routing import (
-            should_route_capture_to_aux_vision,
-        )
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("computer_use: aux-vision routing import failed: %s", exc)
-        return False
-    try:
-        provider = _read_main_provider()
-        model = _read_main_model()
         cfg = load_config()
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("computer_use: aux-vision routing config read failed: %s", exc)
-        return False
+
+    if (not provider or not model) and isinstance(cfg, dict):
+        model_cfg = cfg.get("model", {}) or {}
+        if not provider:
+            provider = str(model_cfg.get("provider") or "").strip().lower()
+        if not model:
+            model = str(model_cfg.get("model") or model_cfg.get("default") or "").strip()
+
+    if not provider or not model:
+        # Can't determine model capabilities — fail safe (route through aux)
+        # so we never send a multimodal envelope to an unknown / non-vision
+        # main model.
+        return True
+
     try:
+        from tools.computer_use.vision_routing import (
+            should_route_capture_to_aux_vision,
+        )
         return bool(should_route_capture_to_aux_vision(provider, model, cfg))
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("computer_use: aux-vision routing decision failed: %s", exc)
-        return False
+        return True
 
 
 def _route_capture_through_aux_vision(
@@ -672,6 +692,7 @@ def _route_capture_through_aux_vision(
 
 def _maybe_follow_capture(
     backend: ComputerUseBackend, res: ActionResult, do_capture: bool,
+    **kwargs,
 ) -> Any:
     if not do_capture:
         return _text_response(res)
@@ -690,7 +711,7 @@ def _maybe_follow_capture(
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)
     # Combine action summary with the capture.
-    resp = _capture_response(cap)
+    resp = _capture_response(cap, **kwargs)
     if isinstance(resp, dict) and resp.get("_multimodal"):
         prefix = f"[{res.action}] ok={res.ok}" + (f" — {res.message}" if res.message else "")
         resp["content"][0]["text"] = prefix + "\n\n" + resp["content"][0]["text"]


### PR DESCRIPTION
## Summary

When a main model lacks vision capability but `auxiliary.vision` is configured, `computer_use` captures should be routed through the auxiliary vision client and returned as a text description — rather than emitting a multimodal `image_url` envelope that the provider rejects with HTTP 400 / 404 at the tool-result boundary.

The previous routing helper read provider/model via private `agent.auxiliary_client._read_main_provider` / `_read_main_model` indirection that wasn't reliable from the tool dispatch path, and failed open to `False`, which silently sent multimodal envelopes to non-vision main models.

This PR threads `provider` and `model` from the live `AIAgent` instance down into the tool dispatch chain so `computer_use` can make a correct routing decision, and flips the failure mode to fail-**safe** (route through aux when in doubt) since the multimodal envelope is the unrecoverable path.

## Changes

* **`agent/agent_runtime_helpers.py`** — `invoke_tool` now forwards `provider=agent.provider` and `model=agent.model` into `handle_function_call`.
* **`model_tools.py`** — `handle_function_call` accepts new `provider` / `model` kwargs and forwards them into `registry.dispatch(...)`.
* **`tools/computer_use/tool.py`**
  * Threads `provider` / `model` kwargs through `_dispatch`, `_maybe_follow_capture`, and `_capture_response`.
  * Rewrites `_should_route_through_aux_vision` to read provider/model from kwargs first, then fall back to `hermes_cli.config.load_config()`. Loads config once at the top of the function — the previous draft loaded it twice and the second load was dead code.
  * Fail-safe default returns `True` when provider/model can't be determined, so unknown / non-vision main models never receive a raw screenshot envelope.
  * When aux vision routing is required but unavailable (no PNG, no client, exception, empty/invalid response), returns a text-only JSON summary with `note: "auxiliary vision unavailable — text summary only"` instead of the legacy multimodal envelope. Temp-file cleanup preserved on every path.
* **Tests**
  * `tests/tools/test_computer_use_capture_routing.py` — drops mocks of the removed `_read_main_provider` / `_read_main_model` helpers, exercises provider/model via kwargs, asserts the new text-only fallback shape, renames `test_config_load_failure_disables_routing_safely` → `test_config_load_failure_defaults_to_safe_routing` and flips the expected return from `False` to `True`.
  * `tests/run_agent/test_run_agent.py` — expected `handle_function_call` kwargs in `test_invoke_tool_dispatches_to_handle_function_call` now include `provider` and `model`.

## Test status

* 35/35 pass in the touched test files (`test_computer_use_capture_routing.py` + the relevant block of `test_run_agent.py`).
* Targeted runs of `test_model_tools.py`, `test_sanitize_tool_error.py`, `test_code_execution_modes.py` all green locally.
* Full suite was not run end-to-end (timed out at 60s on macOS without GNU `timeout`). CI is the source of truth here.

## Disclosure

This patch was **AI-generated** (Hermes Agent), reviewed and shipped by me. Happy to revise per maintainer feedback.
