### PR TITLE
feat(web): add live cron resource polling

### DIFF
--- a/web/src/hooks/useLiveResource.ts
+++ b/web/src/hooks/useLiveResource.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+export interface UseLiveResourceOptions<T> {
+  load: (signal?: AbortSignal) => Promise<T>;
+  intervalMs?: number;
+  enabled?: boolean;
+  initialData?: T;
+  refreshOnWindowFocus?: boolean;
+  refreshWhenVisible?: boolean;
+}
+
+export interface UseLiveResourceResult<T> {
+  data: T | undefined;
+  setData: Dispatch<SetStateAction<T | undefined>>;
+  loading: boolean;
+  isRefreshing: boolean;
+  error: Error | null;
+  lastUpdated: Date | null;
+  refresh: () => Promise<void>;
+}
+
+function isDocumentHidden(): boolean {
+  return typeof document !== "undefined" && document.hidden;
+}
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+/**
+ * Poll a dashboard resource without wiping the last good state on transient
+ * errors. The hook pauses interval refreshes while the tab is hidden and
+ * refreshes immediately when the tab becomes visible again.
+ */
+export function useLiveResource<T>({
+  load,
+  intervalMs = 0,
+  enabled = true,
+  initialData,
+  refreshOnWindowFocus = true,
+  refreshWhenVisible = true,
+}: UseLiveResourceOptions<T>): UseLiveResourceResult<T> {
+  const [data, setData] = useState<T | undefined>(initialData);
+  const [loading, setLoading] = useState(enabled && initialData === undefined);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const requestSeq = useRef(0);
+  const mounted = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+
+    const seq = requestSeq.current + 1;
+    requestSeq.current = seq;
+    const controller = new AbortController();
+
+    setIsRefreshing(true);
+
+    try {
+      const next = await load(controller.signal);
+      if (requestSeq.current !== seq) return;
+      setData(next);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (requestSeq.current !== seq) return;
+      if (!controller.signal.aborted) {
+        setError(toError(err));
+      }
+    } finally {
+      if (requestSeq.current === seq) {
+        setLoading(false);
+        setIsRefreshing(false);
+      }
+    }
+  }, [enabled, load]);
+
+  useEffect(() => {
+    mounted.current = true;
+    const id = window.setTimeout(() => {
+      if (mounted.current) {
+        void refresh();
+      }
+    }, 0);
+    return () => {
+      window.clearTimeout(id);
+      mounted.current = false;
+      requestSeq.current += 1;
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!enabled || !intervalMs) return;
+    const id = window.setInterval(() => {
+      if (refreshWhenVisible && isDocumentHidden()) return;
+      void refresh();
+    }, intervalMs);
+    return () => window.clearInterval(id);
+  }, [enabled, intervalMs, refresh, refreshWhenVisible]);
+
+  useEffect(() => {
+    if (!enabled || !refreshWhenVisible || typeof document === "undefined") return;
+    const onVisibilityChange = () => {
+      if (!document.hidden && mounted.current) {
+        void refresh();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [enabled, refresh, refreshWhenVisible]);
+
+  useEffect(() => {
+    if (!enabled || !refreshOnWindowFocus || typeof window === "undefined") return;
+    const onFocus = () => {
+      if (!isDocumentHidden() && mounted.current) {
+        void refresh();
+      }
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [enabled, refresh, refreshOnWindowFocus]);
+
+  return { data, setData, loading, isRefreshing, error, lastUpdated, refresh };
+}

--- a/web/src/hooks/useSidebarStatus.ts
+++ b/web/src/hooks/useSidebarStatus.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
+import { useLiveResource } from "@/hooks/useLiveResource";
 
 const POLL_MS = 10_000;
 
@@ -8,20 +8,13 @@ const POLL_MS = 10_000;
  * Light-weight status poll for the app shell (sidebar). The Status page uses
  * its own faster interval; we keep this slower to avoid duplicate load.
  */
-export function useSidebarStatus() {
-  const [status, setStatus] = useState<StatusResponse | null>(null);
+export function useSidebarStatus(): StatusResponse | null {
+  const { data } = useLiveResource<StatusResponse>({
+    load: () => api.getStatus(),
+    intervalMs: POLL_MS,
+    refreshOnWindowFocus: true,
+    refreshWhenVisible: true,
+  });
 
-  useEffect(() => {
-    const load = () => {
-      api
-        .getStatus()
-        .then(setStatus)
-        .catch(() => {});
-    };
-    load();
-    const id = setInterval(load, POLL_MS);
-    return () => clearInterval(id);
-  }, []);
-
-  return status;
+  return data ?? null;
 }

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
-import { Clock, Pause, Play, Trash2, X, Zap } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { Clock, Pause, Play, RefreshCw, Trash2, X, Zap } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
@@ -7,6 +7,7 @@ import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { H2 } from "@/components/NouiTypography";
 import { api } from "@/lib/api";
 import type { CronJob, ProfileInfo } from "@/lib/api";
+import { useLiveResource } from "@/hooks/useLiveResource";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@/hooks/useToast";
 import { useConfirmDelete } from "@/hooks/useConfirmDelete";
@@ -96,11 +97,19 @@ const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
   completed: "destructive",
 };
 
+function formatLastUpdated(value: Date | null): string {
+  if (!value) return "not refreshed yet";
+  const seconds = Math.max(0, Math.floor((Date.now() - value.getTime()) / 1000));
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return value.toLocaleTimeString();
+}
+
 export default function CronPage() {
-  const [jobs, setJobs] = useState<CronJob[]>([]);
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [selectedProfile, setSelectedProfile] = useState("all");
-  const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { t } = useI18n();
   const { setEnd } = usePageHeader();
@@ -119,13 +128,21 @@ export default function CronPage() {
   const [creating, setCreating] = useState(false);
   const createProfile = selectedProfile === "all" ? "default" : selectedProfile;
 
-  const loadJobs = useCallback(() => {
-    api
-      .getCronJobs(selectedProfile)
-      .then(setJobs)
-      .catch(() => showToast(t.common.loading, "error"))
-      .finally(() => setLoading(false));
-  }, [selectedProfile, showToast, t.common.loading]);
+  const loadJobs = useCallback(() => api.getCronJobs(selectedProfile), [selectedProfile]);
+  const {
+    data: liveJobs,
+    loading,
+    isRefreshing,
+    error: jobsError,
+    lastUpdated,
+    refresh: refreshJobs,
+  } = useLiveResource<CronJob[]>({
+    load: loadJobs,
+    intervalMs: 5_000,
+    refreshOnWindowFocus: true,
+    refreshWhenVisible: true,
+  });
+  const jobs = useMemo(() => liveJobs ?? [], [liveJobs]);
 
   useEffect(() => {
     api
@@ -133,10 +150,6 @@ export default function CronPage() {
       .then((res) => setProfiles(res.profiles))
       .catch(() => setProfiles([]));
   }, []);
-
-  useEffect(() => {
-    loadJobs();
-  }, [loadJobs]);
 
   const handleCreate = async () => {
     if (!prompt.trim() || !schedule.trim()) {
@@ -160,7 +173,7 @@ export default function CronPage() {
       setName("");
       setDeliver("local");
       setCreateModalOpen(false);
-      loadJobs();
+      void refreshJobs();
     } catch (e) {
       showToast(`${t.config.failedToSave}: ${e}`, "error");
     } finally {
@@ -185,7 +198,7 @@ export default function CronPage() {
           "success",
         );
       }
-      loadJobs();
+      void refreshJobs();
     } catch (e) {
       showToast(`${t.status.error}: ${e}`, "error");
     }
@@ -198,7 +211,7 @@ export default function CronPage() {
         `${t.cron.triggerNow}: "${truncateText(getJobTitle(job), 30)}"`,
         "success",
       );
-      loadJobs();
+      void refreshJobs();
     } catch (e) {
       showToast(`${t.status.error}: ${e}`, "error");
     }
@@ -215,13 +228,13 @@ export default function CronPage() {
             `${t.common.delete}: "${job ? truncateText(getJobTitle(job), 30) : id}"`,
             "success",
           );
-          loadJobs();
+          void refreshJobs();
         } catch (e) {
           showToast(`${t.status.error}: ${e}`, "error");
           throw e;
         }
       },
-      [jobs, loadJobs, showToast, t.common.delete, t.status.error],
+      [jobs, refreshJobs, showToast, t.common.delete, t.status.error],
     ),
   });
 
@@ -418,6 +431,26 @@ export default function CronPage() {
                 </SelectOption>
               ))}
             </Select>
+            <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+              <span>
+                Auto-refresh · updated {formatLastUpdated(lastUpdated)}
+              </span>
+              <Button
+                ghost
+                size="icon"
+                title="Refresh cron jobs"
+                aria-label="Refresh cron jobs"
+                onClick={() => void refreshJobs()}
+                className="h-6 w-6"
+              >
+                <RefreshCw className={cn("h-3 w-3", isRefreshing && "animate-spin")} />
+              </Button>
+            </div>
+            {jobsError && (
+              <p className="text-[11px] text-destructive">
+                Last refresh failed; showing last known state.
+              </p>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Adds a reusable useLiveResource hook for dashboard resources that need periodic refresh
- Updates the Cron page to poll jobs every 5 seconds while visible and refresh on focus/visibility changes
- Shows last-refresh/error state without wiping the last good cron job list
- Reuses the live-resource hook for sidebar status polling

## Test Plan
- npm run build
- npm exec -- eslint src/hooks/useLiveResource.ts src/hooks/useSidebarStatus.ts src/pages/CronPage.tsx

## Notes
- Full npm run lint still fails on pre-existing repo-wide React compiler / refresh lint debt outside this change.