### PR TITLE
feat: add OnchainDivers/W3E research skill

### DIFF
--- a/skills/research/onchaindivers-w3e/SKILL.md
+++ b/skills/research/onchaindivers-w3e/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: onchaindivers-w3e
+description: "Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hyperliquid, or Solana research without exposing credentials."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [research, clickhouse, onchaindivers, w3e, polymarket, hyperliquid, solana]
+    related_skills: [polymarket, arxiv]
+---
+
+# OnchainDivers / W3E Research Access
+
+## Overview
+
+Use this skill when the user wants practical research on **Polymarket**, **Hyperliquid**, or **Solana** using the hosted OnchainDivers / W3E data warehouse instead of only public REST endpoints.
+
+This workflow is optimized for:
+- quick access validation,
+- safe handling of bearer keys and readonly ClickHouse credentials,
+- schema discovery,
+- writing real SQL against the warehouse,
+- and staying honest when docs/examples diverge from the actual tables.
+
+The main lesson: **treat the docs as a map, not as ground truth**. Verify real table names and row availability with live queries before building analysis on top.
+
+## When to Use
+
+- User already has OnchainDivers / W3E access and wants live data checks
+- User wants research on Polymarket fills, market metadata, or event metadata
+- User wants Hyperliquid fills / funding / wallet state from a warehouse
+- User wants Solana research from curated tables instead of raw RPC scraping
+- You need repeatable SQL-backed evidence, not hand-wavy market commentary
+
+Do **not** use this skill when:
+- public Polymarket REST data is enough,
+- the user wants trading execution,
+- or credentials are unavailable and no public fallback exists.
+
+## Safe Credential Handling
+
+Never commit or print real secrets into repo files, chat summaries, skills, or Git history.
+
+Preferred pattern:
+
+```bash
+export ONCHAINDIVERS_API_KEY='<redacted>'
+export W3E_HL_CH_USER='<redacted>'
+export W3E_HL_CH_PASS='<redacted>'
+```
+
+Use placeholders in docs and examples only.
+
+For bearer API calls, prefer ephemeral shell variables over inline literals:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $ONCHAINDIVERS_API_KEY" \
+  -H 'Content-Type: application/json' \
+  https://db-access-test.onchaindivers.com/v1/polymarket/query \
+  -d '{"query":"SELECT 1"}'
+```
+
+For direct ClickHouse HTTP access, use readonly users only.
+
+## Practical Workflow
+
+### 1) Confirm access first
+
+Do not assume stored creds are valid just because local code mentions W3E.
+
+Start with tiny verification queries:
+
+```sql
+SELECT count() AS rows FROM raw_event_meta
+SELECT count() AS rows FROM raw_market_meta
+SELECT count() AS rows FROM polymarket_order_filled_v3
+```
+
+For Hyperliquid:
+
+```sql
+SELECT count() AS rows FROM agg_fulfilled_order
+```
+
+For Solana:
+
+```sql
+SELECT count() AS rows FROM solana_blocks
+```
+
+If auth is flaky, re-check whether you are using the intended endpoint, header format, and freshest key.
+
+### 2) Discover schema from the live system
+
+Docs may show simplified names such as `markets`, `tokens`, `fills`, or `fundings`, while the live warehouse can expose different physical tables.
+
+Prefer:
+
+```sql
+SELECT name
+FROM system.tables
+WHERE database = currentDatabase()
+ORDER BY name
+```
+
+If that fails through the bearer endpoint, fall back to:
+- docs pages for conceptual orientation,
+- known good tables from prior validation,
+- or direct ClickHouse access where available.
+
+### 3) Use the warehouse in three layers
+
+For Polymarket, the most useful pattern is:
+- `raw_event_meta` → event-level framing
+- `raw_market_meta` → market-level metadata
+- `polymarket_order_filled_v3` → real fills / executed prices
+
+This is the right path when validating claims about overpriced or underpriced volatility, monthly BTC structures, or entry timing.
+
+### 4) Build from metadata to fills
+
+Do not start with abstract strategy talk. First identify the actual markets, then join to fills.
+
+Good sequence:
+1. find candidate BTC monthly markets in metadata,
+2. inspect titles / slugs / end dates,
+3. only then pull fills for those markets,
+4. compare executed prices and realized outcomes.
+
+## Known Reality-Check on Table Names
+
+Based on practical use, these names are the reliable starting points.
+
+### Polymarket
+
+Use these first:
+- `raw_event_meta`
+- `raw_market_meta`
+- `polymarket_order_filled_v3`
+
+### Hyperliquid
+
+Useful starting points:
+- `agg_fulfilled_order`
+- `raw_node_fills_by_block`
+- `view_perpetual_wallet`
+- `view_wallet_position`
+- `dxn_funding`
+- `perp_asset_meta`
+- `perp_asset_stats`
+- `spot_asset_meta`
+- `spot_pair_meta`
+
+### Solana
+
+Useful starting points:
+- `solana_blocks`
+- `tx_timestamps`
+- `jito_tips`
+- `pumpfun_token_creation`
+- `pumpfun_all_swaps`
+- `pumpswap_all_swaps`
+- `raydium_all_swaps`
+- `meteora_swaps`
+- `meteora_dynamic_bonding_swaps`
+- `pfamm_migrations`
+- `max_caps`
+
+## First Polymarket Query Pattern
+
+When the user wants **monthly BTC markets**, start with metadata discovery, not fills.
+
+Example shape:
+
+```sql
+SELECT
+  event_id,
+  market_id,
+  event_title,
+  market_question,
+  slug,
+  end_date,
+  active,
+  closed
+FROM raw_market_meta
+WHERE lower(event_title) LIKE '%bitcoin%'
+   OR lower(event_title) LIKE '%btc%'
+   OR lower(market_question) LIKE '%bitcoin%'
+   OR lower(market_question) LIKE '%btc%'
+ORDER BY end_date DESC
+LIMIT 200
+```
+
+Then narrow to monthly-expiry style wording such as:
+- `end of month`
+- `by may 31`
+- `in may`
+- `monthly`
+- or explicit month/year references in titles and slugs.
+
+After that, pull fills from `polymarket_order_filled_v3` only for the shortlisted markets.
+
+## Query Style Guidelines
+
+- Prefer `SELECT` and `WITH` only
+- Keep first queries cheap and inspectable
+- Use `LIMIT` during discovery
+- Add explicit `ORDER BY` so outputs are reproducible
+- Save intermediate candidate IDs before running heavy fill queries
+- When comparing strategies, use **executed fill prices**, not just quoted probabilities
+
+## Common Pitfalls
+
+1. **Trusting docs over reality.**
+   If docs say `fills` but the live table is `agg_fulfilled_order`, trust the live system.
+
+2. **Assuming a local codebase means current access works.**
+   Old helper scripts can survive long after creds rotate.
+
+3. **Leaking keys in shell history or commits.**
+   Use env vars and placeholders only.
+
+4. **Jumping directly into strategy conclusions.**
+   First prove the market set and entry prices you are talking about actually existed.
+
+5. **Using abstract volatility narratives instead of actual fill data.**
+   For Polymarket research, the fill table is where the truth starts.
+
+## Verification Checklist
+
+- [ ] Access verified with a tiny live query
+- [ ] No secrets printed or committed
+- [ ] Physical table names confirmed from live system or previously verified evidence
+- [ ] Metadata query run before fill query
+- [ ] Analysis grounded in actual rows, not only docs or intuition
+- [ ] If docs and schema disagree, the discrepancy is called out explicitly
+
+## Supporting Reference
+
+See `references/example-queries.md` for sanitized curl + SQL snippets covering Polymarket, Hyperliquid, and Solana.

--- a/skills/research/onchaindivers-w3e/SKILL.md
+++ b/skills/research/onchaindivers-w3e/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: onchaindivers-w3e
 description: "Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hyperliquid, or Solana research without exposing credentials."
-version: 1.0.0
+version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -211,6 +211,57 @@ After that, pull fills from `polymarket_order_filled_v3` only for the shortliste
 - Add explicit `ORDER BY` so outputs are reproducible
 - Save intermediate candidate IDs before running heavy fill queries
 - When comparing strategies, use **executed fill prices**, not just quoted probabilities
+
+## Practical PM Microstructure Notes
+
+These points came from practical trading discussion and are worth preserving as hypotheses / implementation constraints, not as proven alpha.
+
+### 1) Entry quality can destroy most of the edge
+
+A common failure mode is assuming the theoretical edge survives market-order entry. In practice, shallow books can move the fill from something like `0.70` to `0.73`, which can compress a nominal `~5%` edge down to `~1–2%`.
+
+Implication: when evaluating a PM strategy, model **actual reachable fills**, not just top-of-book snapshots or event probabilities.
+
+### 2) Marketable limit orders are often better than pure market orders
+
+For these setups, speed is often less important than preserving price.
+
+Useful execution pattern:
+- place a **marketable limit** at the worst acceptable price,
+- let the instantly available size fill,
+- leave the rest resting in the book,
+- monitor whether the original alpha still exists,
+- cancel and unwind filled inventory if the delta / thesis moves away.
+
+This is especially relevant around balanced prices like `0.45–0.55`, where preserving a few cents matters a lot.
+
+### 3) Partial-maker execution can help fees and realized entry
+
+A marketable limit can behave better than a blunt market order because:
+- part of the order may execute immediately,
+- part may rest as maker,
+- effective fees can be lower,
+- realized entry may stay closer to the intended threshold.
+
+### 4) Book-update streams may contain duplicates
+
+When reconstructing order-book or event streams, expect duplicate updates by hash and/or server timestamp. Deduplication is part of the research problem, not an optional cleanup step.
+
+### 5) Monitoring across many BTC expiries/time windows increases opportunity count
+
+One research idea worth checking empirically: monitoring BTC markets across many expiries / time windows can produce a larger event set, making systematic placement through the book more realistic than judging the opportunity from one isolated market.
+
+Do **not** treat this as validated alpha without fill-level evidence.
+
+### 6) Narrow-loss-range structures must be tested against real fills
+
+A proposed framing from the notes: structure straddle / volatility exposure so that loss is concentrated in a narrow central band, then rebalance the rest. This kind of idea must be tested against:
+- actual PM fills,
+- available size,
+- duplicate-book noise,
+- and real execution latency.
+
+If you cannot show the realized fills, you do not yet know whether the structure works.
 
 ## Common Pitfalls
 

--- a/skills/research/onchaindivers-w3e/SKILL.md
+++ b/skills/research/onchaindivers-w3e/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: onchaindivers-w3e
 description: "Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hyperliquid, or Solana research without exposing credentials."
-version: 1.1.0
+version: 1.0.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -212,56 +212,7 @@ After that, pull fills from `polymarket_order_filled_v3` only for the shortliste
 - Save intermediate candidate IDs before running heavy fill queries
 - When comparing strategies, use **executed fill prices**, not just quoted probabilities
 
-## Practical PM Microstructure Notes
 
-These points came from practical trading discussion and are worth preserving as hypotheses / implementation constraints, not as proven alpha.
-
-### 1) Entry quality can destroy most of the edge
-
-A common failure mode is assuming the theoretical edge survives market-order entry. In practice, shallow books can move the fill from something like `0.70` to `0.73`, which can compress a nominal `~5%` edge down to `~1–2%`.
-
-Implication: when evaluating a PM strategy, model **actual reachable fills**, not just top-of-book snapshots or event probabilities.
-
-### 2) Marketable limit orders are often better than pure market orders
-
-For these setups, speed is often less important than preserving price.
-
-Useful execution pattern:
-- place a **marketable limit** at the worst acceptable price,
-- let the instantly available size fill,
-- leave the rest resting in the book,
-- monitor whether the original alpha still exists,
-- cancel and unwind filled inventory if the delta / thesis moves away.
-
-This is especially relevant around balanced prices like `0.45–0.55`, where preserving a few cents matters a lot.
-
-### 3) Partial-maker execution can help fees and realized entry
-
-A marketable limit can behave better than a blunt market order because:
-- part of the order may execute immediately,
-- part may rest as maker,
-- effective fees can be lower,
-- realized entry may stay closer to the intended threshold.
-
-### 4) Book-update streams may contain duplicates
-
-When reconstructing order-book or event streams, expect duplicate updates by hash and/or server timestamp. Deduplication is part of the research problem, not an optional cleanup step.
-
-### 5) Monitoring across many BTC expiries/time windows increases opportunity count
-
-One research idea worth checking empirically: monitoring BTC markets across many expiries / time windows can produce a larger event set, making systematic placement through the book more realistic than judging the opportunity from one isolated market.
-
-Do **not** treat this as validated alpha without fill-level evidence.
-
-### 6) Narrow-loss-range structures must be tested against real fills
-
-A proposed framing from the notes: structure straddle / volatility exposure so that loss is concentrated in a narrow central band, then rebalance the rest. This kind of idea must be tested against:
-- actual PM fills,
-- available size,
-- duplicate-book noise,
-- and real execution latency.
-
-If you cannot show the realized fills, you do not yet know whether the structure works.
 
 ## Common Pitfalls
 

--- a/skills/research/onchaindivers-w3e/references/example-queries.md
+++ b/skills/research/onchaindivers-w3e/references/example-queries.md
@@ -1,0 +1,139 @@
+# OnchainDivers / W3E Example Queries
+
+All examples below are **sanitized**. Replace placeholders with your own env vars at runtime. Do not paste real credentials into repo files, chat logs, or commits.
+
+## Bearer API pattern
+
+```bash
+export ONCHAINDIVERS_API_KEY='***'
+```
+
+### Polymarket: access smoke test
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $ONCHAINDIVERS_API_KEY" \
+  -H 'Content-Type: application/json' \
+  https://db-access-test.onchaindivers.com/v1/polymarket/query \
+  -d '{"query":"SELECT count() AS rows FROM raw_event_meta"}'
+```
+
+### Solana: access smoke test
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $ONCHAINDIVERS_API_KEY" \
+  -H 'Content-Type: application/json' \
+  https://db-access-test.onchaindivers.com/v1/solana/query \
+  -d '{"query":"SELECT count() AS rows FROM solana_blocks"}'
+```
+
+### Hyperliquid: access smoke test
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $ONCHAINDIVERS_API_KEY" \
+  -H 'Content-Type: application/json' \
+  https://db-access-test.onchaindivers.com/v1/hyperliquid/query \
+  -d '{"query":"SELECT count() AS rows FROM agg_fulfilled_order"}'
+```
+
+## Direct ClickHouse HTTP pattern
+
+Use readonly users only.
+
+```bash
+export W3E_HL_CH_USER='<readonly-user>'
+export W3E_HL_CH_PASS='<readonly-pass>'
+export W3E_HL_CH_HOST='example.host'
+export W3E_HL_CH_PORT='28123'
+```
+
+```bash
+curl -sS \
+  --user "$W3E_HL_CH_USER:$W3E_HL_CH_PASS" \
+  "http://$W3E_HL_CH_HOST:$W3E_HL_CH_PORT/?database=hyperliquid&default_format=JSONEachRow" \
+  --data-binary 'SELECT count() AS rows FROM agg_fulfilled_order'
+```
+
+## Schema discovery
+
+If supported by the endpoint, try:
+
+```sql
+SELECT name
+FROM system.tables
+WHERE database = currentDatabase()
+ORDER BY name
+```
+
+If that fails through bearer mode, fall back to known-good tables and docs.
+
+## Polymarket: discover BTC monthly candidates
+
+```sql
+SELECT
+  event_id,
+  market_id,
+  event_title,
+  market_question,
+  slug,
+  end_date,
+  active,
+  closed
+FROM raw_market_meta
+WHERE lower(event_title) LIKE '%bitcoin%'
+   OR lower(event_title) LIKE '%btc%'
+   OR lower(market_question) LIKE '%bitcoin%'
+   OR lower(market_question) LIKE '%btc%'
+ORDER BY end_date DESC
+LIMIT 200
+```
+
+Then narrow the candidate set by month wording before touching the fill table.
+
+## Polymarket: pull fills after market discovery
+
+The exact join keys can vary across warehouse revisions, so inspect columns first if needed. Keep the first fill query narrow:
+
+```sql
+SELECT *
+FROM polymarket_order_filled_v3
+WHERE market_id IN ('<candidate-market-id-1>', '<candidate-market-id-2>')
+ORDER BY timestamp DESC
+LIMIT 200
+```
+
+## Hyperliquid: funding or fill research
+
+Start with cheap samples:
+
+```sql
+SELECT *
+FROM dxn_funding
+ORDER BY time DESC
+LIMIT 50
+```
+
+```sql
+SELECT *
+FROM agg_fulfilled_order
+ORDER BY time DESC
+LIMIT 50
+```
+
+## Solana: general block-level sanity check
+
+```sql
+SELECT *
+FROM solana_blocks
+ORDER BY slot DESC
+LIMIT 10
+```
+
+## Notes
+
+- Prefer `SELECT` / `WITH` only
+- Use `LIMIT` aggressively during discovery
+- Record schema mismatches between docs and live tables in your notes
+- Keep analysis grounded in real fills and metadata, not just conceptual narratives

--- a/skills/research/onchaindivers-w3e/references/example-queries.md
+++ b/skills/research/onchaindivers-w3e/references/example-queries.md
@@ -104,39 +104,7 @@ ORDER BY timestamp DESC
 LIMIT 200
 ```
 
-## Polymarket: inspect whether book/event updates need dedup
 
-If your downstream strategy uses book updates or event-stream reconstruction, explicitly check for duplicate-like rows by stable identifiers and timestamps instead of assuming a clean stream.
-
-Generic pattern:
-
-```sql
-WITH grouped AS (
-  SELECT
-    <event_hash_or_key> AS k,
-    <server_timestamp_column> AS ts,
-    count() AS n
-  FROM <book_or_event_table>
-  GROUP BY 1, 2
-)
-SELECT *
-FROM grouped
-WHERE n > 1
-ORDER BY n DESC
-LIMIT 50
-```
-
-Adapt the placeholder columns / table to the actual schema you discover.
-
-## Polymarket execution research notes
-
-When you evaluate a trading idea, preserve these distinctions in your notebook:
-- theoretical edge from model / probability mismatch,
-- top-of-book visible price,
-- actual reachable fill,
-- and realized blended fill after partial execution.
-
-In practice, the gap between `intended entry` and `actual fill` can be the difference between a seemingly strong edge and a weak one.
 
 ## Hyperliquid: funding or fill research
 

--- a/skills/research/onchaindivers-w3e/references/example-queries.md
+++ b/skills/research/onchaindivers-w3e/references/example-queries.md
@@ -104,6 +104,40 @@ ORDER BY timestamp DESC
 LIMIT 200
 ```
 
+## Polymarket: inspect whether book/event updates need dedup
+
+If your downstream strategy uses book updates or event-stream reconstruction, explicitly check for duplicate-like rows by stable identifiers and timestamps instead of assuming a clean stream.
+
+Generic pattern:
+
+```sql
+WITH grouped AS (
+  SELECT
+    <event_hash_or_key> AS k,
+    <server_timestamp_column> AS ts,
+    count() AS n
+  FROM <book_or_event_table>
+  GROUP BY 1, 2
+)
+SELECT *
+FROM grouped
+WHERE n > 1
+ORDER BY n DESC
+LIMIT 50
+```
+
+Adapt the placeholder columns / table to the actual schema you discover.
+
+## Polymarket execution research notes
+
+When you evaluate a trading idea, preserve these distinctions in your notebook:
+- theoretical edge from model / probability mismatch,
+- top-of-book visible price,
+- actual reachable fill,
+- and realized blended fill after partial execution.
+
+In practice, the gap between `intended entry` and `actual fill` can be the difference between a seemingly strong edge and a weak one.
+
 ## Hyperliquid: funding or fill research
 
 Start with cheap samples:

--- a/website/docs/reference/polymarket-monthly-research-notes.md
+++ b/website/docs/reference/polymarket-monthly-research-notes.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 7
+title: "Polymarket Monthly Research Notes"
+description: "Execution-aware notes and hypotheses for monthly BTC / Polymarket research"
+---
+
+# Polymarket Monthly Research Notes
+
+These are research notes from practical discussion around PM monthly markets and adjacent execution questions.
+
+They are **not** part of the `onchaindivers-w3e` skill contract.
+They belong in docs / knowledge base because they are strategy and microstructure notes, not instructions for how to use W3E itself.
+
+## Status
+
+Treat everything here as:
+
+- a working hypothesis,
+- a research constraint,
+- or an execution caveat.
+
+Do **not** treat these notes as validated alpha without fill-level evidence.
+
+## Core idea
+
+One possible direction is to monitor many BTC monthly / expiry / time-window markets instead of reasoning from one isolated market.
+
+Why this matters:
+
+- more events may create more placement opportunities,
+- strategy viability may depend on breadth, not one-off setups,
+- opportunity count and execution quality have to be measured together.
+
+## Main execution lesson
+
+The biggest warning from the discussion is simple:
+
+**paper edge is not real edge unless the fill survives execution.**
+
+Example framing:
+
+- intended entry: `0.70`
+- realized fill: `0.73`
+- nominal edge: about `5%`
+- realized edge after bad fill: maybe only `1–2%`
+
+So the correct object to model is not just:
+
+- market probability,
+- or top-of-book quote,
+
+but instead:
+
+- actual reachable fill,
+- blended fill after partial execution,
+- fees,
+- and inventory left resting in the book.
+
+## Practical execution hypotheses
+
+### Marketable limit orders may dominate pure market orders
+
+For these setups, speed is often less important than preserving price.
+
+A useful pattern to test:
+
+1. place a **marketable limit** at the worst acceptable entry,
+2. let immediately available size fill,
+3. leave the remainder resting,
+4. monitor whether the alpha still exists,
+5. cancel or unwind if the thesis degrades.
+
+This is especially important around balanced levels like `0.45–0.55`, where a few cents of slippage can erase much of the expected edge.
+
+### Partial-maker execution may improve realized economics
+
+A marketable limit can outperform a blunt market order because:
+
+- some size may execute immediately,
+- some size may rest as maker,
+- effective fees may improve,
+- blended entry may stay closer to the target threshold.
+
+## Data-quality warning
+
+If research depends on book updates or event-stream reconstruction, assume duplicates are possible.
+
+Potential duplicate dimensions:
+
+- event hash / update key,
+- server timestamp,
+- repeated book snapshots carrying the same economic state.
+
+Deduplication is part of the research problem, not optional cleanup.
+
+## Structure ideas that still need validation
+
+One strategy framing mentioned in discussion:
+
+- shape straddle / vol exposure so that losses are concentrated in a narrow central band,
+- then rebalance the rest.
+
+This is not enough on its own.
+It must be checked against:
+
+- real PM fills,
+- available size,
+- duplicate-book noise,
+- real execution latency,
+- and blended post-fee entry.
+
+If the analysis cannot show realized fills, the structure is still unproven.
+
+## What to measure in research notebooks
+
+Keep these fields separate:
+
+- theoretical edge from model / probability mismatch,
+- visible top-of-book price,
+- actual reachable fill,
+- blended realized fill,
+- fees,
+- remaining unfilled inventory,
+- post-entry thesis drift.
+
+## Generic dedup query pattern
+
+```sql
+WITH grouped AS (
+  SELECT
+    <event_hash_or_key> AS k,
+    <server_timestamp_column> AS ts,
+    count() AS n
+  FROM <book_or_event_table>
+  GROUP BY 1, 2
+)
+SELECT *
+FROM grouped
+WHERE n > 1
+ORDER BY n DESC
+LIMIT 50
+```
+
+Adapt placeholders to the actual schema.
+
+## Bottom line
+
+The main takeaway is:
+
+**for PM monthly research, execution-aware fill data is the unit of truth.**
+
+Without real fill analysis, apparent edge may just be microstructure illusion.

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -163,6 +163,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`arxiv`](/user-guide/skills/bundled/research/research-arxiv) | Search arXiv papers by keyword, author, category, or ID. | `research/arxiv` |
 | [`blogwatcher`](/user-guide/skills/bundled/research/research-blogwatcher) | Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool. | `research/blogwatcher` |
 | [`llm-wiki`](/user-guide/skills/bundled/research/research-llm-wiki) | Karpathy's LLM Wiki: build/query interlinked markdown KB. | `research/llm-wiki` |
+| [`onchaindivers-w3e`](/user-guide/skills/bundled/research/research-onchaindivers-w3e) | Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hyperliquid, or Solana research without exposing credentials. | `research/onchaindivers-w3e` |
 | [`polymarket`](/user-guide/skills/bundled/research/research-polymarket) | Query Polymarket: markets, prices, orderbooks, history. | `research/polymarket` |
 | [`research-paper-writing`](/user-guide/skills/bundled/research/research-research-paper-writing) | Write ML papers for NeurIPS/ICML/ICLR: design→submit. | `research/research-paper-writing` |
 

--- a/website/docs/user-guide/skills/bundled/research/research-onchaindivers-w3e.md
+++ b/website/docs/user-guide/skills/bundled/research/research-onchaindivers-w3e.md
@@ -1,0 +1,261 @@
+---
+title: "Onchaindivers W3E"
+sidebar_label: "Onchaindivers W3E"
+description: "Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hyperliquid, or Solana research without exposing credentials"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Onchaindivers W3E
+
+Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hyperliquid, or Solana research without exposing credentials.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/research/onchaindivers-w3e` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `research`, `clickhouse`, `onchaindivers`, `w3e`, `polymarket`, `hyperliquid`, `solana` |
+| Related skills | [`polymarket`](/docs/user-guide/skills/bundled/research/research-polymarket), [`arxiv`](/docs/user-guide/skills/bundled/research/research-arxiv) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# OnchainDivers / W3E Research Access
+
+## Overview
+
+Use this skill when the user wants practical research on **Polymarket**, **Hyperliquid**, or **Solana** using the hosted OnchainDivers / W3E data warehouse instead of only public REST endpoints.
+
+This workflow is optimized for:
+- quick access validation,
+- safe handling of bearer keys and readonly ClickHouse credentials,
+- schema discovery,
+- writing real SQL against the warehouse,
+- and staying honest when docs/examples diverge from the actual tables.
+
+The main lesson: **treat the docs as a map, not as ground truth**. Verify real table names and row availability with live queries before building analysis on top.
+
+## When to Use
+
+- User already has OnchainDivers / W3E access and wants live data checks
+- User wants research on Polymarket fills, market metadata, or event metadata
+- User wants Hyperliquid fills / funding / wallet state from a warehouse
+- User wants Solana research from curated tables instead of raw RPC scraping
+- You need repeatable SQL-backed evidence, not hand-wavy market commentary
+
+Do **not** use this skill when:
+- public Polymarket REST data is enough,
+- the user wants trading execution,
+- or credentials are unavailable and no public fallback exists.
+
+## Safe Credential Handling
+
+Never commit or print real secrets into repo files, chat summaries, skills, or Git history.
+
+Preferred pattern:
+
+```bash
+export ONCHAINDIVERS_API_KEY='<redacted>'
+export W3E_HL_CH_USER='<redacted>'
+export W3E_HL_CH_PASS='<redacted>'
+```
+
+Use placeholders in docs and examples only.
+
+For bearer API calls, prefer ephemeral shell variables over inline literals:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $ONCHAINDIVERS_API_KEY" \
+  -H 'Content-Type: application/json' \
+  https://db-access-test.onchaindivers.com/v1/polymarket/query \
+  -d '{"query":"SELECT 1"}'
+```
+
+For direct ClickHouse HTTP access, use readonly users only.
+
+## Practical Workflow
+
+### 1) Confirm access first
+
+Do not assume stored creds are valid just because local code mentions W3E.
+
+Start with tiny verification queries:
+
+```sql
+SELECT count() AS rows FROM raw_event_meta
+SELECT count() AS rows FROM raw_market_meta
+SELECT count() AS rows FROM polymarket_order_filled_v3
+```
+
+For Hyperliquid:
+
+```sql
+SELECT count() AS rows FROM agg_fulfilled_order
+```
+
+For Solana:
+
+```sql
+SELECT count() AS rows FROM solana_blocks
+```
+
+If auth is flaky, re-check whether you are using the intended endpoint, header format, and freshest key.
+
+### 2) Discover schema from the live system
+
+Docs may show simplified names such as `markets`, `tokens`, `fills`, or `fundings`, while the live warehouse can expose different physical tables.
+
+Prefer:
+
+```sql
+SELECT name
+FROM system.tables
+WHERE database = currentDatabase()
+ORDER BY name
+```
+
+If that fails through the bearer endpoint, fall back to:
+- docs pages for conceptual orientation,
+- known good tables from prior validation,
+- or direct ClickHouse access where available.
+
+### 3) Use the warehouse in three layers
+
+For Polymarket, the most useful pattern is:
+- `raw_event_meta` → event-level framing
+- `raw_market_meta` → market-level metadata
+- `polymarket_order_filled_v3` → real fills / executed prices
+
+This is the right path when validating claims about overpriced or underpriced volatility, monthly BTC structures, or entry timing.
+
+### 4) Build from metadata to fills
+
+Do not start with abstract strategy talk. First identify the actual markets, then join to fills.
+
+Good sequence:
+1. find candidate BTC monthly markets in metadata,
+2. inspect titles / slugs / end dates,
+3. only then pull fills for those markets,
+4. compare executed prices and realized outcomes.
+
+## Known Reality-Check on Table Names
+
+Based on practical use, these names are the reliable starting points.
+
+### Polymarket
+
+Use these first:
+- `raw_event_meta`
+- `raw_market_meta`
+- `polymarket_order_filled_v3`
+
+### Hyperliquid
+
+Useful starting points:
+- `agg_fulfilled_order`
+- `raw_node_fills_by_block`
+- `view_perpetual_wallet`
+- `view_wallet_position`
+- `dxn_funding`
+- `perp_asset_meta`
+- `perp_asset_stats`
+- `spot_asset_meta`
+- `spot_pair_meta`
+
+### Solana
+
+Useful starting points:
+- `solana_blocks`
+- `tx_timestamps`
+- `jito_tips`
+- `pumpfun_token_creation`
+- `pumpfun_all_swaps`
+- `pumpswap_all_swaps`
+- `raydium_all_swaps`
+- `meteora_swaps`
+- `meteora_dynamic_bonding_swaps`
+- `pfamm_migrations`
+- `max_caps`
+
+## First Polymarket Query Pattern
+
+When the user wants **monthly BTC markets**, start with metadata discovery, not fills.
+
+Example shape:
+
+```sql
+SELECT
+  event_id,
+  market_id,
+  event_title,
+  market_question,
+  slug,
+  end_date,
+  active,
+  closed
+FROM raw_market_meta
+WHERE lower(event_title) LIKE '%bitcoin%'
+   OR lower(event_title) LIKE '%btc%'
+   OR lower(market_question) LIKE '%bitcoin%'
+   OR lower(market_question) LIKE '%btc%'
+ORDER BY end_date DESC
+LIMIT 200
+```
+
+Then narrow to monthly-expiry style wording such as:
+- `end of month`
+- `by may 31`
+- `in may`
+- `monthly`
+- or explicit month/year references in titles and slugs.
+
+After that, pull fills from `polymarket_order_filled_v3` only for the shortlisted markets.
+
+## Query Style Guidelines
+
+- Prefer `SELECT` and `WITH` only
+- Keep first queries cheap and inspectable
+- Use `LIMIT` during discovery
+- Add explicit `ORDER BY` so outputs are reproducible
+- Save intermediate candidate IDs before running heavy fill queries
+- When comparing strategies, use **executed fill prices**, not just quoted probabilities
+
+## Common Pitfalls
+
+1. **Trusting docs over reality.**
+   If docs say `fills` but the live table is `agg_fulfilled_order`, trust the live system.
+
+2. **Assuming a local codebase means current access works.**
+   Old helper scripts can survive long after creds rotate.
+
+3. **Leaking keys in shell history or commits.**
+   Use env vars and placeholders only.
+
+4. **Jumping directly into strategy conclusions.**
+   First prove the market set and entry prices you are talking about actually existed.
+
+5. **Using abstract volatility narratives instead of actual fill data.**
+   For Polymarket research, the fill table is where the truth starts.
+
+## Verification Checklist
+
+- [ ] Access verified with a tiny live query
+- [ ] No secrets printed or committed
+- [ ] Physical table names confirmed from live system or previously verified evidence
+- [ ] Metadata query run before fill query
+- [ ] Analysis grounded in actual rows, not only docs or intuition
+- [ ] If docs and schema disagree, the discrepancy is called out explicitly
+
+## Supporting Reference
+
+See `references/example-queries.md` for sanitized curl + SQL snippets covering Polymarket, Hyperliquid, and Solana.

--- a/website/docs/user-guide/skills/bundled/research/research-onchaindivers-w3e.md
+++ b/website/docs/user-guide/skills/bundled/research/research-onchaindivers-w3e.md
@@ -16,7 +16,7 @@ Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hype
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/research/onchaindivers-w3e` |
-| Version | `1.0.0` |
+| Version | `1.1.0` |
 | Author | Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -229,6 +229,57 @@ After that, pull fills from `polymarket_order_filled_v3` only for the shortliste
 - Add explicit `ORDER BY` so outputs are reproducible
 - Save intermediate candidate IDs before running heavy fill queries
 - When comparing strategies, use **executed fill prices**, not just quoted probabilities
+
+## Practical PM Microstructure Notes
+
+These points came from practical trading discussion and are worth preserving as hypotheses / implementation constraints, not as proven alpha.
+
+### 1) Entry quality can destroy most of the edge
+
+A common failure mode is assuming the theoretical edge survives market-order entry. In practice, shallow books can move the fill from something like `0.70` to `0.73`, which can compress a nominal `~5%` edge down to `~1–2%`.
+
+Implication: when evaluating a PM strategy, model **actual reachable fills**, not just top-of-book snapshots or event probabilities.
+
+### 2) Marketable limit orders are often better than pure market orders
+
+For these setups, speed is often less important than preserving price.
+
+Useful execution pattern:
+- place a **marketable limit** at the worst acceptable price,
+- let the instantly available size fill,
+- leave the rest resting in the book,
+- monitor whether the original alpha still exists,
+- cancel and unwind filled inventory if the delta / thesis moves away.
+
+This is especially relevant around balanced prices like `0.45–0.55`, where preserving a few cents matters a lot.
+
+### 3) Partial-maker execution can help fees and realized entry
+
+A marketable limit can behave better than a blunt market order because:
+- part of the order may execute immediately,
+- part may rest as maker,
+- effective fees can be lower,
+- realized entry may stay closer to the intended threshold.
+
+### 4) Book-update streams may contain duplicates
+
+When reconstructing order-book or event streams, expect duplicate updates by hash and/or server timestamp. Deduplication is part of the research problem, not an optional cleanup step.
+
+### 5) Monitoring across many BTC expiries/time windows increases opportunity count
+
+One research idea worth checking empirically: monitoring BTC markets across many expiries / time windows can produce a larger event set, making systematic placement through the book more realistic than judging the opportunity from one isolated market.
+
+Do **not** treat this as validated alpha without fill-level evidence.
+
+### 6) Narrow-loss-range structures must be tested against real fills
+
+A proposed framing from the notes: structure straddle / volatility exposure so that loss is concentrated in a narrow central band, then rebalance the rest. This kind of idea must be tested against:
+- actual PM fills,
+- available size,
+- duplicate-book noise,
+- and real execution latency.
+
+If you cannot show the realized fills, you do not yet know whether the structure works.
 
 ## Common Pitfalls
 

--- a/website/docs/user-guide/skills/bundled/research/research-onchaindivers-w3e.md
+++ b/website/docs/user-guide/skills/bundled/research/research-onchaindivers-w3e.md
@@ -16,7 +16,7 @@ Use when querying OnchainDivers / W3E hosted warehouse data for Polymarket, Hype
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/research/onchaindivers-w3e` |
-| Version | `1.1.0` |
+| Version | `1.0.0` |
 | Author | Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -230,56 +230,7 @@ After that, pull fills from `polymarket_order_filled_v3` only for the shortliste
 - Save intermediate candidate IDs before running heavy fill queries
 - When comparing strategies, use **executed fill prices**, not just quoted probabilities
 
-## Practical PM Microstructure Notes
 
-These points came from practical trading discussion and are worth preserving as hypotheses / implementation constraints, not as proven alpha.
-
-### 1) Entry quality can destroy most of the edge
-
-A common failure mode is assuming the theoretical edge survives market-order entry. In practice, shallow books can move the fill from something like `0.70` to `0.73`, which can compress a nominal `~5%` edge down to `~1–2%`.
-
-Implication: when evaluating a PM strategy, model **actual reachable fills**, not just top-of-book snapshots or event probabilities.
-
-### 2) Marketable limit orders are often better than pure market orders
-
-For these setups, speed is often less important than preserving price.
-
-Useful execution pattern:
-- place a **marketable limit** at the worst acceptable price,
-- let the instantly available size fill,
-- leave the rest resting in the book,
-- monitor whether the original alpha still exists,
-- cancel and unwind filled inventory if the delta / thesis moves away.
-
-This is especially relevant around balanced prices like `0.45–0.55`, where preserving a few cents matters a lot.
-
-### 3) Partial-maker execution can help fees and realized entry
-
-A marketable limit can behave better than a blunt market order because:
-- part of the order may execute immediately,
-- part may rest as maker,
-- effective fees can be lower,
-- realized entry may stay closer to the intended threshold.
-
-### 4) Book-update streams may contain duplicates
-
-When reconstructing order-book or event streams, expect duplicate updates by hash and/or server timestamp. Deduplication is part of the research problem, not an optional cleanup step.
-
-### 5) Monitoring across many BTC expiries/time windows increases opportunity count
-
-One research idea worth checking empirically: monitoring BTC markets across many expiries / time windows can produce a larger event set, making systematic placement through the book more realistic than judging the opportunity from one isolated market.
-
-Do **not** treat this as validated alpha without fill-level evidence.
-
-### 6) Narrow-loss-range structures must be tested against real fills
-
-A proposed framing from the notes: structure straddle / volatility exposure so that loss is concentrated in a narrow central band, then rebalance the rest. This kind of idea must be tested against:
-- actual PM fills,
-- available size,
-- duplicate-book noise,
-- and real execution latency.
-
-If you cannot show the realized fills, you do not yet know whether the structure works.
 
 ## Common Pitfalls
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -327,6 +327,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/research/research-arxiv',
                     'user-guide/skills/bundled/research/research-blogwatcher',
                     'user-guide/skills/bundled/research/research-llm-wiki',
+                    'user-guide/skills/bundled/research/research-onchaindivers-w3e',
                     'user-guide/skills/bundled/research/research-polymarket',
                     'user-guide/skills/bundled/research/research-research-paper-writing',
                   ],


### PR DESCRIPTION
## Summary
- add a bundled research skill for OnchainDivers / W3E warehouse access
- document safe credential handling with no secrets committed
- add sanitized example queries and generated skill docs

## Notes
- intentionally uses placeholders / env vars only
- includes practical caveats about schema-vs-doc mismatches for Polymarket, Hyperliquid, and Solana