### PR TITLE
fix(memory/holographic): normalize CJK prefetch queries

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -7,6 +7,7 @@ Jaccard similarity reranking and trust-weighted scoring.
 from __future__ import annotations
 
 import math
+import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -593,29 +594,57 @@ class FactRetriever:
           - strips FTS5 special characters from each token
           - OR-joins the survivors
 
-        If nothing remains (pathological query), falls back to the raw
-        query so the caller sees zero results instead of a SQL error.
+        If nothing remains after filtering, safely quotes each cleaned raw token
+        and preserves FTS5's implicit-AND fallback semantics.
         """
         if not query:
             return ""
+        # Remove controls and terminal question scaffolding conservatively.
+        # Do not split every occurrence of Chinese particle characters: they
+        # are also part of ordinary words such as ``目的地`` and ``的确``.
+        query = query.replace("\x00", " ").strip()
+        query = re.sub(r"[？?！!。．.]+$", "", query)
+        query = re.sub(r"(?:是什么|是什麼|怎么样|怎麼樣|如何)$", "", query)
+        query = re.sub(r"[吗嗎呢吧啊呀]$", "", query)
+        # Split a likely possessive 的 only when both sides have meaningful
+        # length. Avoid the common lexical word ``的确``.
+        query = re.sub(
+            r"([A-Za-z0-9_]+|[\u3400-\u9fff\uf900-\ufaff]{2,})"
+            r"(?<!目)的(?=(?!确)[\u3400-\u9fff\uf900-\ufaff]{2,})",
+            r"\1 ",
+            query,
+        )
+        query = re.sub(
+            r"(?<=[A-Za-z0-9_])(?=[\u3400-\u9fff\uf900-\ufaff])"
+            r"|(?<=[\u3400-\u9fff\uf900-\ufaff])(?=[A-Za-z0-9_])",
+            " ",
+            query,
+        )
         # Strip FTS5 operator characters from EACH token to avoid
         # accidentally creating a malformed query.
-        _FTS_SPECIAL = '"()*^:-+'
+        _FTS_SPECIAL = '\"()*^:-+'
         tokens: list[str] = []
+        fallback_tokens: list[str] = []
         for raw in query.lower().split():
-            cleaned = raw.strip(".,;:!?\"'()[]{}#@<>") .translate(
+            cleaned = raw.strip(".,;:!?\"'()[]{}#@<>？！，。；：") .translate(
                 str.maketrans("", "", _FTS_SPECIAL)
             )
+            if not cleaned:
+                continue
+            fallback_tokens.append(f'"{cleaned}"')
             if len(cleaned) < 2:
                 continue
             if cleaned in cls._FTS_STOPWORDS:
                 continue
             # FTS5 phrase-literal each token to ensure no special chars
-            # sneak through as operators.
-            tokens.append(f'"{cleaned}"')
+            # sneak through as operators. unicode61 keeps a contiguous CJK
+            # clause as one token, so use a prefix query for CJK phrases: a
+            # term such as ``支付链路`` can then match ``支付链路在运营手册``
+            # without changing the index or English-token semantics.
+            suffix = "*" if re.search(r"[\u3400-\u9fff\uf900-\ufaff]", cleaned) else ""
+            tokens.append(f'"{cleaned}"{suffix}')
         if not tokens:
-            # Fallback: raw query (likely returns 0, but never crashes)
-            return query
+            return " ".join(fallback_tokens) if fallback_tokens else '""'
         return " OR ".join(tokens)
 
     @staticmethod

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -26,8 +26,8 @@ from plugins.memory.holographic.store import MemoryStore
         ("what happened with the deployment rollback", {"happened", "deployment", "rollback"}),
         # single content word passes through
         ("compaction", {"compaction"}),
-        # all stopwords → falls back to raw
-        ("the and of", None),  # None = sentinel for fallback-to-raw
+        # all stopwords → safely quoted implicit-AND fallback
+        ("the and of", {"the", "and", "of"}),
         # empty string → empty output
         ("", ""),
         # FTS5 operator characters stripped
@@ -43,16 +43,37 @@ def test_sanitize_fts_query_extracts_content_tokens(query, expected_tokens):
         assert result == ""
         return
 
-    if expected_tokens is None:
-        # Pathological case: all stopwords — should fall back to raw query
-        assert result == query
-        return
-
     # OR-joined phrase literals: `"tok1" OR "tok2" OR ...`
     # Extract the tokens between quotes, order-independent.
     import re
     matches = re.findall(r'"([^"]+)"', result)
     assert set(matches) == expected_tokens, f"got {result!r}"
+
+
+def test_sanitize_fts_query_splits_contiguous_cjk_question_scaffolding():
+    assert FactRetriever._sanitize_fts_query("课程平台的支付链路是什么？") == (
+        '"课程平台"* OR "支付链路"*'
+    )
+
+
+def test_sanitize_fts_query_splits_mixed_language_boundaries():
+    assert FactRetriever._sanitize_fts_query("Hermes的部署状态是什么？") == (
+        '"hermes" OR "部署状态"*'
+    )
+
+
+def test_sanitize_fts_query_does_not_split_cjk_words_containing_particle_chars():
+    assert FactRetriever._sanitize_fts_query("目的地是什么？") == '"目的地"*'
+    assert FactRetriever._sanitize_fts_query("有目的地前往北京吗？") == (
+        '"有目的地前往北京"*'
+    )
+    assert FactRetriever._sanitize_fts_query("的确如此") == '"的确如此"*'
+
+
+def test_sanitize_fts_query_preserves_english_token_behavior():
+    assert FactRetriever._sanitize_fts_query("deployment rollback") == (
+        '"deployment" OR "rollback"'
+    )
 
 
 def test_sanitize_fts_query_never_crashes_on_fts5_specials():
@@ -64,6 +85,7 @@ def test_sanitize_fts_query_never_crashes_on_fts5_specials():
         "test^2 query",
         "test:colon query",
         "test-hyphen query",
+        "\x00OR",
         "a" * 1000,  # long query
     ]
     for q in problematic:
@@ -93,6 +115,18 @@ def retriever_with_facts(tmp_path):
         content="Venice.ai advertises availableContextTokens inside model_spec.",
         category="tool",
     )
+    store.add_fact(
+        content="课程平台支付链路在运营手册里有唯一记录。检索关键词：课程平台 支付链路",
+        category="project",
+    )
+    store.add_fact(
+        content="Hermes的部署状态正常。检索关键词：Hermes 部署状态",
+        category="project",
+    )
+    store.add_fact(
+        content="C language and R language are both supported.",
+        category="tool",
+    )
     retriever = FactRetriever(store=store)
     yield retriever
     store.close()
@@ -119,10 +153,42 @@ def test_prefetch_single_keyword_still_works(retriever_with_facts):
     assert "Compaction" in results[0]["content"] or "compaction" in results[0]["content"].lower()
 
 
+def test_retriever_normalizes_cjk_question_against_indexable_keywords(
+    retriever_with_facts,
+):
+    results = retriever_with_facts.search("课程平台的支付链路是什么？")
+
+    assert any("支付链路" in result["content"] for result in results)
+
+
+def test_memory_store_search_facts_recalls_mixed_language_question(
+    retriever_with_facts,
+):
+    results = retriever_with_facts.store.search_facts("Hermes的部署状态是什么？")
+
+    assert any("Hermes 部署状态" in result["content"] for result in results)
+
+
+def test_memory_store_search_facts_quotes_operator_only_fallback(
+    retriever_with_facts,
+):
+    assert retriever_with_facts.store.search_facts("OR") == []
+
+
+def test_memory_store_search_facts_handles_nul_fallback(retriever_with_facts):
+    assert retriever_with_facts.store.search_facts("\x00OR") == []
+
+
+def test_short_token_fallback_preserves_implicit_and_semantics(retriever_with_facts):
+    results = retriever_with_facts.store.search_facts("c r")
+
+    assert any("C language and R language" in result["content"] for result in results)
+
+
 def test_prefetch_stopword_only_query_empty(retriever_with_facts):
     """Pure stopword queries return zero results but don't crash."""
     # Pass to _sanitize_fts_query directly first so we know what happens
-    assert FactRetriever._sanitize_fts_query("the and of") == "the and of"
+    assert FactRetriever._sanitize_fts_query("the and of") == '"the" "and" "of"'
     # search() handles the likely-zero-hit case gracefully
     results = retriever_with_facts.search("the and of")
     # Either zero results or it errored-gracefully to [] — both are fine


### PR DESCRIPTION
## Summary

Normalize CJK and mixed-language natural-language queries in the shared Holographic FTS sanitizer.

This is a current-`main` rewrite following maintainer review. The normalization now lives in `FactRetriever._sanitize_fts_query`, so both retriever prefetch and direct `MemoryStore.search_facts()` use the same path. The old provider-only candidate pipeline is removed.

## Changes

- conservatively remove terminal Chinese question scaffolding
- split ASCII/CJK boundaries and likely possessive `的` boundaries without breaking words such as `目的地` or `的确`
- use quoted FTS5 prefix terms for CJK query phrases
- preserve existing English content-token OR behavior
- safely handle operator-only, short-token, stopword-only, and NUL-containing fallback queries
- preserve implicit-AND semantics for short-token fallback instead of collapsing it into one phrase
- add shared-path regressions for both `FactRetriever` and `MemoryStore.search_facts()`

This patch is query-side normalization only; it does not change or migrate the existing FTS5 `unicode61` index. Tests use natural CJK fact text plus explicit indexable search keywords, matching the current fact-writing/indexing model rather than claiming arbitrary CJK substring search.

## Test plan

```bash
python -m pytest tests/plugins/memory/test_holographic_retrieval.py -q
python -m pytest tests/plugins/memory -q
python -m ruff check plugins/memory/holographic/retrieval.py \
  tests/plugins/memory/test_holographic_retrieval.py
git diff --check
```

Observed locally:

```text
19 passed
469 passed
```

Ruff, compileall, and diff check passed.
