### PR TITLE
fix: reduce compaction and tool-output regressions

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1539,6 +1539,25 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
             return messages
 
+        # Auto-compression attempts inside the summary-failure cooldown are
+        # known no-ops before they start: _generate_summary() would return
+        # None without calling the LLM. Abort here, before the lossy tool-output
+        # pruning pre-pass, so a failed/no-op compression attempt preserves the
+        # transcript byte-for-byte. Manual /compress (force=True) already
+        # cleared the cooldown above and can proceed normally.
+        if not force and time.monotonic() < self._summary_failure_cooldown_until:
+            self._last_summary_skipped_by_cooldown = True
+            self._last_summary_dropped_count = 0
+            self._last_summary_fallback_used = False
+            self._last_compress_aborted = True
+            if not self.quiet_mode:
+                logger.warning(
+                    "Summary generation skipped — aborting compression "
+                    "(summary failure cooldown is active). Message history "
+                    "preserved unchanged until the next /compress or /new."
+                )
+            return messages
+
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
 
         # Phase 1: Prune old tool results (cheap, no LLM call)

--- a/scripts/provider_stall_audit.py
+++ b/scripts/provider_stall_audit.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Aggregate-only classifier for Hermes provider stall symptoms.
+
+The script deliberately reports counts and input file paths only. It does not
+print raw log lines, prompts, messages, tool payloads, session ids, or user ids.
+
+Usage:
+    python scripts/provider_stall_audit.py \
+        --logs-dir ~/.hermes/logs \
+        --state-db ~/.hermes/state.db \
+        --start-date 2026-05-25 --end-date 2026-05-27
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+DATE_RE = re.compile(r"(20\d\d-\d\d-\d\d)")
+LEVEL_RE = re.compile(r"\b(WARNING|ERROR|CRITICAL)\b", re.IGNORECASE)
+SESSION_ID_RE = re.compile(r"\[(?P<session>[A-Za-z0-9_:-]{8,})\]")
+
+PROVIDER_STALL_RE = re.compile(
+    # Keep this intentionally narrow: broad ``provider.*timeout`` searches are
+    # exactly what made prior audits count meta-discussion and follow-on errors
+    # as runtime provider stalls. Generic timeouts are counted separately.
+    r"non-streaming api call stale for (?P<seconds>\d+(?:\.\d+)?)s",
+    re.IGNORECASE,
+)
+TIMEOUT_RE = re.compile(r"\b(?:timeout|timed out|TimeoutError)\b", re.IGNORECASE)
+COMPRESSION_FAILURE_RE = re.compile(
+    r"(?:compression|compress|summary|summar(?:y|ies)).*"
+    r"(?:fail|failed|failure|unavailable|timed out|timeout|no auxiliary|below .*threshold)|"
+    r"(?:no auxiliary llm provider for compression)",
+    re.IGNORECASE,
+)
+DISCORD_RESPONSE_RE = re.compile(
+    r"response ready:\s*platform=discord\b.*?\btime=(?P<seconds>\d+(?:\.\d+)?)s",
+    re.IGNORECASE,
+)
+DISCORD_SEND_FAILURE_RE = re.compile(
+    r"\[Discord\].*(?:failed to send|send failure|rate limited|failed to register|auto-thread creation failed)",
+    re.IGNORECASE,
+)
+SESSION_PROVIDER_MENTION_RE = re.compile(
+    r"\b(?:provider(?:_300s| stalls?| stale)?|300s|non-streaming api call stale|stale events?)\b",
+    re.IGNORECASE,
+)
+SESSION_META_RE = re.compile(
+    r"\b(?:audit|report|regex|mentions?|meta(?:-discussion)?|classifier|symptom|metric|count|evidence)\b",
+    re.IGNORECASE,
+)
+
+DEFAULT_LOG_GLOBS = ("*.log", "*.log.[0-9]*")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--logs-dir", type=Path, default=Path.home() / ".hermes" / "logs")
+    parser.add_argument(
+        "--state-db",
+        type=Path,
+        action="append",
+        default=[],
+        help="Hermes state.db to scan for aggregate session-content mentions; repeatable.",
+    )
+    parser.add_argument("--start-date", help="Inclusive YYYY-MM-DD filter.")
+    parser.add_argument("--end-date", help="Inclusive YYYY-MM-DD filter.")
+    parser.add_argument(
+        "--discord-slow-threshold-seconds",
+        type=float,
+        default=60.0,
+        help="Threshold for Discord response-ready latency symptoms.",
+    )
+    parser.add_argument(
+        "--provider-stale-threshold-seconds",
+        type=float,
+        default=300.0,
+        help="Threshold for direct provider stale-call log lines.",
+    )
+    parser.add_argument(
+        "--include-session-content-mentions",
+        action="store_true",
+        help="Count session-message symptom mentions separately from direct runtime logs.",
+    )
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    return parser.parse_args()
+
+
+def in_date_range(date: str, start: str | None, end: str | None) -> bool:
+    if date == "unknown":
+        return start is None and end is None
+    if start and date < start:
+        return False
+    if end and date > end:
+        return False
+    return True
+
+
+def date_from_log_line(line: str) -> str:
+    match = DATE_RE.search(line)
+    return match.group(1) if match else "unknown"
+
+
+def date_from_epoch(value: float | int | None) -> str:
+    if value is None:
+        return "unknown"
+    return datetime.fromtimestamp(float(value), tz=timezone.utc).strftime("%Y-%m-%d")
+
+
+def source_from_log_path(path: Path) -> str:
+    name = path.name
+    if name.startswith("gateway"):
+        return "gateway_log"
+    if name.startswith("agent"):
+        return "agent_log"
+    if name.startswith("errors"):
+        return "errors_log"
+    return "other_log"
+
+
+def nested_counter() -> defaultdict[str, defaultdict[str, defaultdict[str, int]]]:
+    return defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+
+
+def bump(counts: dict[str, Any], category: str, date: str, source: str, amount: int = 1) -> None:
+    counts[category][date][source] += amount
+
+
+def log_event_key(category: str, date: str, source: str, line: str, extra: str = "") -> tuple[str, ...]:
+    """Return a privacy-safe in-memory key for duplicate rotated-log events."""
+    timestamp = line[:23] if DATE_RE.search(line[:23]) else date
+    session_match = SESSION_ID_RE.search(line)
+    session_key = session_match.group("session") if session_match else "no-session"
+    return (category, date, source, timestamp, session_key, extra)
+
+
+def bump_once(
+    counts: dict[str, Any],
+    seen_events: set[tuple[str, ...]],
+    category: str,
+    date: str,
+    source: str,
+    line: str,
+    extra: str = "",
+) -> None:
+    key = log_event_key(category, date, source, line, extra)
+    if key in seen_events:
+        return
+    seen_events.add(key)
+    bump(counts, category, date, source)
+
+
+def scan_logs(
+    logs_dir: Path,
+    start_date: str | None,
+    end_date: str | None,
+    discord_slow_threshold_seconds: float,
+    provider_stale_threshold_seconds: float,
+) -> tuple[dict[str, Any], list[str]]:
+    counts: dict[str, Any] = nested_counter()
+    input_files: list[str] = []
+    seen_paths: set[Path] = set()
+    seen_events: set[tuple[str, ...]] = set()
+    for glob in DEFAULT_LOG_GLOBS:
+        for path in sorted(logs_dir.glob(glob)):
+            if path in seen_paths or not path.is_file():
+                continue
+            seen_paths.add(path)
+            input_files.append(str(path))
+            source = source_from_log_path(path)
+            with path.open("r", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    date = date_from_log_line(line)
+                    if not in_date_range(date, start_date, end_date):
+                        continue
+
+                    provider_match = PROVIDER_STALL_RE.search(line)
+                    if provider_match:
+                        seconds_text = provider_match.groupdict().get("seconds")
+                        if seconds_text is None or float(seconds_text) >= provider_stale_threshold_seconds:
+                            bump_once(
+                                counts,
+                                seen_events,
+                                "direct_provider_stalls",
+                                date,
+                                source,
+                                line,
+                                extra=seconds_text or "",
+                            )
+
+                    if TIMEOUT_RE.search(line):
+                        bump_once(counts, seen_events, "timeout_lines", date, source, line)
+
+                    if COMPRESSION_FAILURE_RE.search(line):
+                        bump_once(
+                            counts,
+                            seen_events,
+                            "compression_summary_failures",
+                            date,
+                            source,
+                            line,
+                        )
+
+                    discord_match = DISCORD_RESPONSE_RE.search(line)
+                    if discord_match and float(discord_match.group("seconds")) >= discord_slow_threshold_seconds:
+                        bump_once(
+                            counts,
+                            seen_events,
+                            "discord_slow_responses",
+                            date,
+                            source,
+                            line,
+                            extra=discord_match.group("seconds"),
+                        )
+                    if DISCORD_SEND_FAILURE_RE.search(line):
+                        bump_once(counts, seen_events, "discord_send_failures", date, source, line)
+    return counts, input_files
+
+
+def has_session_schema(conn: sqlite3.Connection) -> bool:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    names = {row[0] for row in rows}
+    return {"sessions", "messages"}.issubset(names)
+
+
+def scan_session_mentions(
+    state_dbs: Iterable[Path], start_date: str | None, end_date: str | None
+) -> tuple[dict[str, Any], list[str]]:
+    counts: dict[str, Any] = nested_counter()
+    input_files: list[str] = []
+    for db_path in state_dbs:
+        if not db_path.exists() or not db_path.is_file():
+            continue
+        input_files.append(str(db_path))
+        uri = f"file:{db_path}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        try:
+            if not has_session_schema(conn):
+                continue
+            query = """
+                SELECT s.source, m.role, m.content, m.tool_name, m.timestamp
+                FROM messages m
+                JOIN sessions s ON s.id = m.session_id
+                WHERE m.content IS NOT NULL
+                  AND (
+                    m.content LIKE '%provider%'
+                    OR m.content LIKE '%300s%'
+                    OR m.content LIKE '%stale%'
+                    OR m.content LIKE '%non-streaming API call stale%'
+                  )
+            """
+            for source, role, content, tool_name, timestamp in conn.execute(query):
+                date = date_from_epoch(timestamp)
+                if not in_date_range(date, start_date, end_date):
+                    continue
+                text = content or ""
+                if not SESSION_PROVIDER_MENTION_RE.search(text):
+                    continue
+                source_label = str(source or "unknown")
+                if role == "tool" or tool_name:
+                    category = "session_tool_log_mentions"
+                elif SESSION_META_RE.search(text):
+                    category = "session_meta_discussion_mentions"
+                else:
+                    category = "session_unclassified_provider_mentions"
+                bump(counts, category, date, source_label)
+        finally:
+            conn.close()
+    return counts, input_files
+
+
+def freeze(value: Any) -> Any:
+    if isinstance(value, defaultdict):
+        value = dict(value)
+    if isinstance(value, dict):
+        return {key: freeze(value[key]) for key in sorted(value)}
+    return value
+
+
+def merge_counts(base: dict[str, Any], extra: dict[str, Any]) -> None:
+    for category, by_date in extra.items():
+        for date, by_source in by_date.items():
+            for source, count in by_source.items():
+                bump(base, category, date, source, count)
+
+
+def totals_by_category(counts: dict[str, Any]) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for category, by_date in counts.items():
+        totals[category] = sum(sum(by_source.values()) for by_source in by_date.values())
+    return dict(sorted(totals.items()))
+
+
+def main() -> int:
+    args = parse_args()
+    counts, log_files = scan_logs(
+        logs_dir=args.logs_dir.expanduser(),
+        start_date=args.start_date,
+        end_date=args.end_date,
+        discord_slow_threshold_seconds=args.discord_slow_threshold_seconds,
+        provider_stale_threshold_seconds=args.provider_stale_threshold_seconds,
+    )
+    session_files: list[str] = []
+    if args.include_session_content_mentions:
+        session_counts, session_files = scan_session_mentions(
+            [path.expanduser() for path in args.state_db], args.start_date, args.end_date
+        )
+        merge_counts(counts, session_counts)
+
+    frozen_counts = freeze(counts)
+    output = {
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "scope": {
+            "start_date": args.start_date,
+            "end_date": args.end_date,
+            "discord_slow_threshold_seconds": args.discord_slow_threshold_seconds,
+            "provider_stale_threshold_seconds": args.provider_stale_threshold_seconds,
+        },
+        "privacy": "aggregate counts and input file paths only; raw messages/prompts/log lines are never emitted",
+        "input_files": {
+            "logs": sorted(log_files),
+            "state_dbs": sorted(session_files),
+        },
+        "counts": frozen_counts,
+        "totals_by_category": totals_by_category(frozen_counts),
+    }
+    print(json.dumps(output, indent=2 if args.pretty else None, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,6 +1,9 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+from copy import deepcopy
+
 import pytest
+from typing import Any
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
@@ -84,6 +87,9 @@ class TestCompress:
         # increments the count even on summary failure.
         compressor.compress(msgs)
         assert compressor.compression_count == 1
+        # Force the legacy fallback path again instead of the new cooldown abort
+        # path; cooldown abort behavior has its own preservation regression test.
+        compressor._summary_failure_cooldown_until = 0.0
         compressor.compress(msgs)
         assert compressor.compression_count == 2
 
@@ -782,6 +788,61 @@ class TestSummaryFailureTrackingForGatewayWarning:
         c._summary_failure_cooldown_until = 0.0
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             c.compress(msgs)
+        assert c._last_summary_fallback_used is False
+        assert c._last_summary_dropped_count == 0
+
+    def test_cooldown_skips_abort_without_static_fallback_loss(self):
+        """Auto-compress during summary cooldown must preserve messages exactly.
+
+        The first failure may use the legacy static fallback in default mode,
+        but subsequent automatic attempts inside the cooldown are known not to
+        even call the summarizer. Treat those as an abort so retry loops do not
+        repeatedly replace middle context with unsummarized placeholders. That
+        abort must happen before lossy tool-output pruning too, otherwise old
+        tool output can still be deduped/truncated during a failed no-op.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=1,
+                summary_target_ratio=0.10,
+            )
+        c.tail_token_budget = 30
+
+        msgs: list[dict[str, Any]] = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "head"},
+        ]
+        for i in range(8):
+            msgs.extend([
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": f"call_{i}",
+                            "function": {"name": "terminal", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": f"call_{i}", "content": "x" * 5000},
+                {"role": "user", "content": f"mid {i}"},
+            ])
+        msgs.append({"role": "assistant", "content": "tail"})
+        original_msgs = deepcopy(msgs)
+
+        import time as _time
+        c._summary_failure_cooldown_until = _time.monotonic() + 999.0
+
+        with patch("agent.context_compressor.call_llm") as mock_call_llm:
+            result = c.compress(msgs)
+
+        mock_call_llm.assert_not_called()
+        assert result == original_msgs
+        assert msgs == original_msgs
+        assert c._last_compress_aborted is True
         assert c._last_summary_fallback_used is False
         assert c._last_summary_dropped_count == 0
 

--- a/tests/scripts/test_provider_stall_audit.py
+++ b/tests/scripts/test_provider_stall_audit.py
@@ -1,0 +1,121 @@
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "provider_stall_audit.py"
+
+
+def run_audit(*args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_provider_stall_audit_aggregates_logs_without_raw_payloads(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    secretish_payload = "user prompt says provider 300s audit meta discussion"
+    (logs / "errors.log").write_text(
+        "\n".join(
+            [
+                "2026-05-25 01:02:03,000 WARNING [20260525_aaa] agent.chat_completion_helpers: Non-streaming API call stale for 300s (threshold 300s). model=gpt-5.5 context=~123 tokens. Killing connection.",
+                "2026-05-25 01:03:03,000 WARNING tools.delegate_tool: Subagent 12 timed out after 600.0s",
+                "2026-05-26 01:04:03,000 WARNING agent.conversation_compression: No auxiliary LLM provider for compression — summaries will be unavailable.",
+                f"2026-05-26 01:05:03,000 INFO gateway.run: inbound message: platform=discord msg='{secretish_payload}'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (logs / "gateway.log").write_text(
+        "\n".join(
+            [
+                "2026-05-25 02:02:03,000 INFO gateway.run: response ready: platform=discord chat=123 time=61.0s api_calls=2 response=9 chars",
+                "2026-05-25 02:03:03,000 WARNING gateway.platforms.discord: [Discord] Failed to send follow-up chunk to forum thread 123: rate limited",
+                "2026-05-26 02:02:03,000 INFO gateway.run: response ready: platform=discord chat=123 time=59.9s api_calls=1 response=9 chars",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    output = run_audit("--logs-dir", str(logs), "--start-date", "2026-05-25", "--end-date", "2026-05-26")
+
+    assert output["totals_by_category"] == {
+        "compression_summary_failures": 1,
+        "direct_provider_stalls": 1,
+        "discord_send_failures": 1,
+        "discord_slow_responses": 1,
+        "timeout_lines": 1,
+    }
+    assert output["counts"]["direct_provider_stalls"]["2026-05-25"]["errors_log"] == 1
+    assert output["counts"]["discord_slow_responses"]["2026-05-25"]["gateway_log"] == 1
+    serialized = json.dumps(output)
+    assert secretish_payload not in serialized
+    assert "Non-streaming API call stale" not in serialized
+
+
+def test_provider_stall_audit_keeps_session_meta_mentions_separate(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "agent.log").write_text("", encoding="utf-8")
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                started_at REAL NOT NULL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL
+            );
+            """
+        )
+        conn.execute("INSERT INTO sessions (id, source, started_at) VALUES ('s1', 'cli', 1779667200)")
+        conn.execute("INSERT INTO sessions (id, source, started_at) VALUES ('s2', 'discord', 1779667200)")
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, tool_name, timestamp) VALUES (?, ?, ?, ?, ?)",
+            ("s1", "assistant", "audit report says provider_300s mentions can be meta", None, 1779667200),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, tool_name, timestamp) VALUES (?, ?, ?, ?, ?)",
+            ("s2", "tool", "provider stale line observed in a tool payload", "terminal", 1779667200),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    output = run_audit(
+        "--logs-dir",
+        str(logs),
+        "--state-db",
+        str(db),
+        "--include-session-content-mentions",
+        "--start-date",
+        "2026-05-25",
+        "--end-date",
+        "2026-05-25",
+    )
+
+    assert output["totals_by_category"] == {
+        "session_meta_discussion_mentions": 1,
+        "session_tool_log_mentions": 1,
+    }
+    assert output["counts"]["session_meta_discussion_mentions"]["2026-05-25"]["cli"] == 1
+    assert output["counts"]["session_tool_log_mentions"]["2026-05-25"]["discord"] == 1
+    serialized = json.dumps(output)
+    assert "audit report says" not in serialized
+    assert "provider stale line" not in serialized

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -16,7 +16,9 @@ from hermes_state import SessionDB
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
     _HIDDEN_SESSION_SOURCES,
+    _MAX_MESSAGE_CONTENT_CHARS,
     _format_timestamp,
+    _shape_message,
     session_search,
 )
 
@@ -102,6 +104,17 @@ class TestSchema:
 class TestHiddenSources:
     def test_tool_source_hidden(self):
         assert "tool" in _HIDDEN_SESSION_SOURCES
+
+
+class TestMessageShaping:
+    def test_long_message_content_is_bounded(self):
+        content = "x" * (_MAX_MESSAGE_CONTENT_CHARS + 500)
+        shaped = _shape_message({"id": 1, "role": "tool", "content": content})
+
+        assert shaped["content_truncated"] is True
+        assert shaped["original_content_chars"] == len(content)
+        assert "session_search content truncated" in shaped["content"]
+        assert len(shaped["content"]) < len(content)
 
 
 class TestFormatTimestamp:

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -373,6 +373,88 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
+    def test_repeated_view_same_task_returns_dedup_stub(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "big-skill", body="x" * 5000)
+            first = json.loads(skill_view("big-skill", task_id="dedup-session"))
+            second = json.loads(skill_view("big-skill", task_id="dedup-session"))
+
+        assert first["success"] is True
+        assert "content" in first
+        assert second["success"] is True
+        assert second["dedup"] is True
+        assert second["content_returned"] is False
+        assert "content" not in second
+
+    def test_repeated_reference_view_same_task_returns_dedup_stub(self, tmp_path):
+        skills_tool_module._skill_view_dedup.clear()
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "ref-skill")
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "api.md").write_text("# API Docs\n" + "x" * 5000)
+            first = json.loads(
+                skill_view(
+                    "ref-skill",
+                    file_path="references/api.md",
+                    task_id="ref-dedup-session",
+                )
+            )
+            second = json.loads(
+                skill_view(
+                    "ref-skill",
+                    file_path="references/api.md",
+                    task_id="ref-dedup-session",
+                )
+            )
+
+        assert "content" in first
+        assert second["dedup"] is True
+        assert second["file"] == "references/api.md"
+        assert "content" not in second
+
+    def test_dedup_uses_content_digest_not_mtime(self, tmp_path):
+        skills_tool_module._skill_view_dedup.clear()
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "fresh-skill", body="first body")
+            skill_md = skill_dir / "SKILL.md"
+            first = json.loads(skill_view("fresh-skill", task_id="fresh-session"))
+            stat = skill_md.stat()
+            skill_md.write_text(skill_md.read_text().replace("first body", "second body"))
+            os.utime(skill_md, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+            second = json.loads(skill_view("fresh-skill", task_id="fresh-session"))
+
+        assert "first body" in first["content"]
+        assert second["success"] is True
+        assert second.get("dedup") is not True
+        assert "second body" in second["content"]
+
+    def test_dedup_key_includes_preprocessing_config(self, tmp_path):
+        skills_tool_module._skill_view_dedup.clear()
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_preprocessing.load_skills_config",
+                side_effect=[
+                    {"template_vars": True, "inline_shell": False},
+                    {"template_vars": False, "inline_shell": False},
+                ],
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "render-skill",
+                body="session=${HERMES_SESSION_ID}; dir=${HERMES_SKILL_DIR}",
+            )
+            first = json.loads(skill_view("render-skill", task_id="render-session"))
+            second = json.loads(skill_view("render-skill", task_id="render-session"))
+
+        assert first["success"] is True
+        assert "session=render-session" in first["content"]
+        assert second["success"] is True
+        assert second.get("dedup") is not True
+        assert "session=${HERMES_SESSION_ID}" in second["content"]
+
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -38,6 +38,27 @@ from typing import Any, Dict, List, Optional, Union
 # so they don't clutter the user's session history.
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
+# Bound individual message bodies returned by discovery/scroll.  A single
+# historical tool result or pasted log can otherwise make one search response
+# tens of thousands of characters even though the caller only needs enough
+# context to decide whether to scroll further.
+_MAX_MESSAGE_CONTENT_CHARS = 2_000
+
+
+def _truncate_message_content(content: Any) -> Any:
+    """Return *content* capped for session-search result payloads."""
+    if not isinstance(content, str) or len(content) <= _MAX_MESSAGE_CONTENT_CHARS:
+        return content
+    omitted = len(content) - _MAX_MESSAGE_CONTENT_CHARS
+    head = _MAX_MESSAGE_CONTENT_CHARS // 2
+    tail = _MAX_MESSAGE_CONTENT_CHARS - head
+    return (
+        content[:head]
+        + f"\n\n... [session_search content truncated: {omitted} chars omitted; "
+        + "use the message id to orient follow-up lookup if exact text is needed] ...\n\n"
+        + content[-tail:]
+    )
+
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
@@ -88,12 +109,17 @@ def _resolve_to_parent(db, session_id: str) -> str:
 
 def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[str, Any]:
     """Slim a message row for the tool response. Keeps content even if empty."""
+    original_content = m.get("content")
+    shaped_content = _truncate_message_content(original_content)
     entry = {
         "id": m.get("id"),
         "role": m.get("role"),
-        "content": m.get("content"),
+        "content": shaped_content,
         "timestamp": m.get("timestamp"),
     }
+    if isinstance(original_content, str) and shaped_content != original_content:
+        entry["content_truncated"] = True
+        entry["original_content_chars"] = len(original_content)
     if m.get("tool_name"):
         entry["tool_name"] = m.get("tool_name")
     if m.get("tool_calls"):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -68,10 +68,12 @@ Usage:
 
 import json
 import logging
+import hashlib
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
 import re
+import threading
 from enum import Enum
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Set, Tuple
@@ -106,6 +108,79 @@ _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona"}
 )
 _secret_capture_callback = None
+
+# Per-session duplicate-load guard.  Skills are often mandatory context, but
+# loading the same large SKILL.md repeatedly in one agent run is pure payload
+# bloat.  When task_id is provided by the dispatcher, return a tiny unchanged
+# stub on exact repeated loads of the same unchanged skill/file.
+_skill_view_dedup_lock = threading.Lock()
+_skill_view_dedup: dict[tuple[Any, ...], str] = {}
+
+
+def _normalized_skill_preprocess_config(
+    preprocess: bool,
+    skill_dir: Path | None,
+    skills_cfg: dict | None,
+) -> tuple[Any, ...]:
+    """Return render-affecting inputs for skill_view dedup scoping."""
+    if not preprocess:
+        return (False, None, None, None, None)
+    cfg = skills_cfg if isinstance(skills_cfg, dict) else {}
+    try:
+        inline_shell_timeout = int(cfg.get("inline_shell_timeout", 10) or 10)
+    except (TypeError, ValueError):
+        inline_shell_timeout = 10
+    return (
+        True,
+        str(skill_dir.resolve()) if skill_dir else None,
+        bool(cfg.get("template_vars", True)),
+        bool(cfg.get("inline_shell", False)),
+        inline_shell_timeout,
+    )
+
+
+def _skill_view_dedup_status(
+    *,
+    task_id: str | None,
+    source_path: Path,
+    file_path: str | None,
+    preprocess: bool,
+    skill_dir: Path | None,
+    skills_cfg: dict | None,
+    content: str,
+    name: str,
+) -> dict[str, Any] | None:
+    """Return a lightweight duplicate-load response, or record this load."""
+    if not task_id:
+        return None
+    try:
+        resolved = str(source_path.resolve())
+    except OSError:
+        return None
+    content_digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    key = (
+        str(task_id),
+        resolved,
+        file_path or "",
+        *_normalized_skill_preprocess_config(preprocess, skill_dir, skills_cfg),
+    )
+    with _skill_view_dedup_lock:
+        previous_digest = _skill_view_dedup.get(key)
+        _skill_view_dedup[key] = content_digest
+    if previous_digest is not None and previous_digest == content_digest:
+        return {
+            "success": True,
+            "name": name,
+            "status": "unchanged",
+            "message": (
+                "Skill content unchanged since the earlier skill_view result "
+                "in this conversation; refer to that instead of reloading it."
+            ),
+            "path": resolved,
+            "dedup": True,
+            "content_returned": False,
+        }
+    return None
 
 
 def load_env() -> Dict[str, str]:
@@ -820,25 +895,45 @@ def _serve_plugin_skill(
         banner = ""
 
     rendered_content = content
+    skills_cfg: dict | None = None
     if preprocess:
         try:
-            from agent.skill_preprocessing import preprocess_skill_content
+            from agent.skill_preprocessing import (
+                load_skills_config,
+                preprocess_skill_content,
+            )
 
+            skills_cfg = load_skills_config()
             rendered_content = preprocess_skill_content(
                 content,
                 skill_md.parent,
                 session_id=session_id,
+                skills_cfg=skills_cfg,
             )
         except Exception:
             logger.debug(
                 "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
             )
 
+    response_content = f"{banner}{rendered_content}" if banner else rendered_content
+    dedup_result = _skill_view_dedup_status(
+        task_id=session_id,
+        source_path=skill_md,
+        file_path=None,
+        preprocess=preprocess,
+        skill_dir=skill_md.parent,
+        skills_cfg=skills_cfg,
+        content=response_content,
+        name=f"{namespace}:{bare}",
+    )
+    if dedup_result is not None:
+        return json.dumps(dedup_result, ensure_ascii=False)
+
     return json.dumps(
         {
             "success": True,
             "name": f"{namespace}:{bare}",
-            "content": f"{banner}{rendered_content}" if banner else rendered_content,
+            "content": response_content,
             "description": description,
             "linked_files": None,
             "readiness_status": SkillReadinessStatus.AVAILABLE.value,
@@ -1208,6 +1303,22 @@ def skill_view(
                     ensure_ascii=False,
                 )
 
+            dedup_result = _skill_view_dedup_status(
+                task_id=task_id,
+                source_path=target_file,
+                file_path=file_path,
+                # Linked files are returned raw today, so normalize their render
+                # context as non-preprocessed even if the caller left preprocess=True.
+                preprocess=False,
+                skill_dir=skill_dir,
+                skills_cfg=None,
+                content=content,
+                name=name,
+            )
+            if dedup_result is not None:
+                dedup_result["file"] = file_path
+                return json.dumps(dedup_result, ensure_ascii=False)
+
             return json.dumps(
                 {
                     "success": True,
@@ -1365,19 +1476,38 @@ def skill_view(
                 )
 
         rendered_content = content
+        skills_cfg: dict | None = None
         if preprocess:
             try:
-                from agent.skill_preprocessing import preprocess_skill_content
+                from agent.skill_preprocessing import (
+                    load_skills_config,
+                    preprocess_skill_content,
+                )
 
+                skills_cfg = load_skills_config()
                 rendered_content = preprocess_skill_content(
                     content,
                     skill_dir,
                     session_id=task_id,
+                    skills_cfg=skills_cfg,
                 )
             except Exception:
                 logger.debug(
                     "Could not preprocess skill content for %s", skill_name, exc_info=True
                 )
+
+        dedup_result = _skill_view_dedup_status(
+            task_id=task_id,
+            source_path=skill_md,
+            file_path=None,
+            preprocess=preprocess,
+            skill_dir=skill_dir,
+            skills_cfg=skills_cfg,
+            content=rendered_content,
+            name=skill_name,
+        )
+        if dedup_result is not None:
+            return json.dumps(dedup_result, ensure_ascii=False)
 
         result = {
             "success": True,


### PR DESCRIPTION
## Summary
- Preserve context-compression abort behavior during summary cooldown so failed no-op attempts do not prune tool output
- Bound high-volume session search and skill view payloads for long-running sessions
- Add provider stall audit script coverage

## Scope
Includes only the approved compression/token/simplification files. This branch is based on current origin/main and does not include the separate incident-fix commit c2def539b.

## Test plan
- git diff --check -- agent/context_compressor.py tests/agent/test_context_compressor.py tools/session_search_tool.py tests/tools/test_session_search.py tools/skills_tool.py tests/tools/test_skills_tool.py scripts/provider_stall_audit.py tests/scripts/test_provider_stall_audit.py
- python -m pytest tests/agent/test_context_compressor.py tests/tools/test_session_search.py tests/tools/test_skills_tool.py tests/scripts/test_provider_stall_audit.py -q -o 'addopts='\n- python -m py_compile scripts/provider_stall_audit.py