### PR TITLE
fix: update DeepSeek pricing to post-promotion permanent rates (May 2026)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -350,36 +350,55 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         pricing_version="anthropic-pricing-2026-05",
     ),
     # DeepSeek
+    # deepseek-chat / deepseek-reasoner are now aliases for v4-flash
+    # non-thinking and thinking modes respectively (same pricing).
+    # deepseek-v4-pro: permanent price = 1/4 of original (was 75% off
+    # promo ending 2026-05-31, now permanent per footnote (3)).
+    # Cache hit pricing = 1/10 of launch price per footnote (2).
+    # Source: https://api-docs.deepseek.com/quick_start/pricing
     (
         "deepseek",
         "deepseek-chat",
     ): PricingEntry(
         input_cost_per_million=Decimal("0.14"),
         output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-05-27",
     ),
     (
         "deepseek",
         "deepseek-reasoner",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.55"),
-        output_cost_per_million=Decimal("2.19"),
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-05-27",
+    ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-05-27",
     ),
     (
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.74"),
-        output_cost_per_million=Decimal("3.48"),
-        cache_read_cost_per_million=Decimal("0.0145"),
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.003625"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-05-27",
     ),
     # Google Gemini
     (

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -207,9 +207,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 1.74
-    assert float(entry.output_cost_per_million) == 3.48
-    assert float(entry.cache_read_cost_per_million) == 0.0145
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.003625
 
 
 def test_deepseek_v4_pro_estimate_usage_cost():
@@ -222,5 +222,5 @@ def test_deepseek_v4_pro_estimate_usage_cost():
 
     assert result.status == "estimated"
     assert result.amount_usd is not None
-    # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
-    assert float(result.amount_usd) == 3.48
+    # 1M input × $0.435/M + 500K output × $0.87/M = $0.435 + $0.435 = $0.87
+    assert float(result.amount_usd) == 0.87


### PR DESCRIPTION
## What changed

DeepSeek API pricing was updated. This PR syncs `_OFFICIAL_DOCS_PRICING` with the live docs at https://api-docs.deepseek.com/quick_start/pricing

### `deepseek-v4-pro` — permanent 1/4 price cut

Per footnote (3), the 75% off promotion ends 2026-05-31 and becomes the **permanent** price:

| Field | Old | New |
|---|---|---|
| Input (cache miss) | $1.74/M | **$0.435/M** |
| Output | $3.48/M | **$0.87/M** |
| Cache hit | $0.0145/M | **$0.003625/M** |

### `deepseek-v4-flash` — new entry

This model was entirely missing from the table:

| Field | Price |
|---|---|
| Input (cache miss) | $0.14/M |
| Output | $0.28/M |
| Cache hit | $0.0028/M |

### `deepseek-chat` / `deepseek-reasoner`

Per footnote (1), these are now aliases for v4-flash non-thinking/thinking modes. Updated from stale pricing ($0.55/$2.19 for reasoner) to match v4-flash pricing. Added `cache_read_cost_per_million`.

### Cache hit pricing

Footnote (2) states all cache hit prices were reduced to 1/10 of launch price from 2026-04-26. Added `cache_read_cost_per_million` to all entries.

## Verification

All values extracted from the live docs page table on 2026-05-27. Corresponding test assertions updated.