### PR TITLE
fix(docker): discover agent-browser Chromium binary at boot

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -188,4 +188,47 @@ if [ -d "$INSTALL_DIR/skills" ]; then
         || echo "[stage2] Warning: skills_sync.py failed; continuing"
 fi
 
+# --- Discover agent-browser's Chromium binary ---
+# The image's Dockerfile runs `npx playwright install chromium`, which
+# populates ``$PLAYWRIGHT_BROWSERS_PATH`` (=/opt/hermes/.playwright) with
+# a ``chromium_headless_shell-<build>/chrome-headless-shell-linux64/``
+# directory. agent-browser (the runtime CLI Hermes spawns for the
+# browser tool) doesn't recognise this layout in its own cache scan and
+# fails with "Auto-launch failed: Chrome not found" — even though the
+# binary is right there (#15697).
+#
+# Fix: locate the binary at boot and export ``AGENT_BROWSER_EXECUTABLE_PATH``
+# via /run/s6/container_environment so the `with-contenv` shebang on
+# main-wrapper.sh propagates it into the supervised ``hermes`` process
+# and thence to agent-browser subprocesses.
+#
+# - Skipped when the user has already set ``AGENT_BROWSER_EXECUTABLE_PATH``
+#   (lets users override with a system Chrome install).
+# - Filename-matched (not path-matched): the chromium dir contains many
+#   shared libraries (libGLESv2.so, libEGL.so, ...) which inherit the
+#   executable bit from Playwright's tarball but are NOT browser binaries.
+#   We only accept files whose basename is chrome / chromium /
+#   chrome-headless-shell / chromium-browser. Compare PR #18635's earlier
+#   ``find | grep -Ei 'chrome|chromium'`` which would match the path
+#   ``.../chrome-headless-shell-linux64/libGLESv2.so`` and pick a .so.
+# - Quietly skipped when $PLAYWRIGHT_BROWSERS_PATH doesn't exist (e.g.
+#   custom builds that strip Playwright).
+if [ -z "${AGENT_BROWSER_EXECUTABLE_PATH:-}" ] && \
+        [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && \
+        [ -d "$PLAYWRIGHT_BROWSERS_PATH" ]; then
+    browser_bin=$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f -executable \
+        \( -name 'chrome' -o -name 'chromium' \
+           -o -name 'chrome-headless-shell' -o -name 'chromium-browser' \) \
+        2>/dev/null | head -n 1)
+    if [ -n "$browser_bin" ]; then
+        echo "[stage2] Found agent-browser Chromium binary: $browser_bin"
+        # Write to s6's container_environment so with-contenv picks it
+        # up for all supervised services (main-hermes, dashboard, etc.).
+        # Idempotent: each boot overwrites with the current path.
+        printf '%s' "$browser_bin" > /run/s6/container_environment/AGENT_BROWSER_EXECUTABLE_PATH
+    else
+        echo "[stage2] Warning: no Chromium binary under $PLAYWRIGHT_BROWSERS_PATH; browser tool may fail"
+    fi
+fi
+
 echo "[stage2] Setup complete; starting user services"


### PR DESCRIPTION
## What does this PR do?

In the Hermes Docker image, the browser tool fails on first use with:

```
✗ Auto-launch failed: Chrome not found. Checked:
  - agent-browser cache: ~/.agent-browser/browsers
  - System Chrome installations
  - Puppeteer browser cache
  - Playwright browser cache
Run `agent-browser install` to download Chrome, or use --executable-path.
```

even though the Dockerfile already runs `npx playwright install chromium` and the binary lives at `/opt/hermes/.playwright/chromium_headless_shell-1223/chrome-headless-shell-linux64/chrome-headless-shell`.

The Dockerfile's `ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright` would normally let Playwright/agent-browser find the binary, but modern `playwright install` lays it down as `chromium_headless_shell-<build>/` and agent-browser's own cache walker doesn't recognise that directory shape — it only matches Playwright's older `chromium-<build>/` layout.

Fix: at boot, scan `$PLAYWRIGHT_BROWSERS_PATH` for the actual executable and export `AGENT_BROWSER_EXECUTABLE_PATH` via `/run/s6/container_environment` so the `with-contenv` shebang on `main-wrapper.sh` propagates it to the supervised `hermes` process and downstream `agent-browser` subprocesses.

## Empirical reproduction

```
$ docker run --rm hermes-agent:main sh -c '
    mkdir -p /tmp/h && export HOME=/tmp/h && cd /tmp/h
    npx -y agent-browser snapshot --url about:blank'
✗ Auto-launch failed: Chrome not found.    # ← bug
```

After this PR:

```
$ docker run --rm hermes-agent:fix sh -c '
    mkdir -p /tmp/h && export HOME=/tmp/h && cd /tmp/h
    npx -y agent-browser snapshot --url about:blank'
[stage2] Found agent-browser Chromium binary: /opt/hermes/.playwright/chromium_headless_shell-1223/chrome-headless-shell-linux64/chrome-headless-shell
[stage2] Setup complete; starting user services
(empty page)                                # ← agent-browser launched, scraped about:blank
```

## Related Issue

Fixes #15697
Closes #18635 (salvages — see attribution below)

## Salvage notes (vs. #18635)

@jackey8616 identified this exact bug in #18635 and proposed the right approach (export `AGENT_BROWSER_EXECUTABLE_PATH` after a `find` under `$PLAYWRIGHT_BROWSERS_PATH`). This PR carries that idea forward with two corrections:

1. **Retargeted** to `docker/stage2-hook.sh` (the s6-overlay cont-init script where boot-time env setup belongs). `docker/entrypoint.sh` is now a thin shim that just forwards to stage2 — env exports there don't propagate to s6-supervised services.
2. **Corrected find command.** The original PR's `find -type f -executable | grep -Ei 'chrome|chromium'` matches by path, not basename — and the chromium dir's name (`chrome-headless-shell-linux64`) contains `chrome`, so it would select `libGLESv2.so` (the first executable .so) as the browser binary. This PR matches by basename against the actual binary names: `chrome`, `chromium`, `chrome-headless-shell`, `chromium-browser`.
3. **Uses s6-overlay's `container_environment`** so the env var propagates through `with-contenv` to all supervised services, not just the cont-init shell.

Original credit retained via `Co-authored-by:`.

## How to Test

```
docker build -t hermes-agent:test .

# Bug fix:
docker run --rm hermes-agent:test sh -c '
    mkdir -p /tmp/h && export HOME=/tmp/h && cd /tmp/h
    npx -y agent-browser snapshot --url about:blank'
# Expect: '(empty page)' instead of 'Auto-launch failed: Chrome not found'

# User override respected:
docker run --rm -e AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome \
    hermes-agent:test sh -c 'echo $AGENT_BROWSER_EXECUTABLE_PATH'
# Expect: /usr/bin/google-chrome  (stage2 didn't override it)

# Regression: --version still works
docker run --rm hermes-agent:test --version
# Expect: Hermes Agent v...

# Regression: custom HERMES_HOME still works (PR #33078)
docker run --rm -e HERMES_HOME=/custom/h/.hermes hermes-agent:test --version 2>&1 | \
    grep -c 'mkdir: cannot create'
# Expect: 0

# Regression: UID remap still chowns ui-tui (PR #33045)
docker run --rm -e HERMES_UID=12345 hermes-agent:test sh -c \
    'stat -c %U /opt/hermes/ui-tui'
# Expect: hermes
```

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (salvage of #18635)
- [x] My PR contains **only** changes related to this fix
- [x] I've tested on my platform: Linux 7.0.10-arch1-1 / Docker
- [x] shellcheck clean
- N/A: pytest (Docker-only change, no Python touched)
