### PR TITLE
feat(cli): config-driven Telegram menu ordering (priority + promote-to-top)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -555,6 +555,29 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Telegram bot menu ordering (optional). Telegram's BotCommand menu is
+  # capped (~30 entries), so with many skills these knobs control which appear
+  # and in what order. Both default off (skills sort alphabetically after the
+  # core commands), so omitting them keeps current behavior.
+  #
+  # platform_menu_promote_to_top: skills listed here jump ABOVE the core
+  #   commands to the very top of the menu, and reserve slots so they survive
+  #   the cap. Use for your most-tapped skills. Names match the skill key
+  #   (e.g. "file", "partnership-radar").
+  # platform_menu_priority: orders the remaining skill tier (listed skills
+  #   first in order; the rest fall back to alphabetical). Handy for clustering
+  #   cron/scheduled skills.
+  #
+  # platform_menu_promote_to_top:
+  #   telegram:
+  #     - file
+  #     - remember
+  #     - pdf
+  # platform_menu_priority:
+  #   telegram:
+  #     - daily-briefing
+  #     - weekly-review
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -730,7 +730,48 @@ def _collect_gateway_skill_entries(
             str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
         )
         skill_cmds = get_skill_commands()
-        for cmd_key in sorted(skill_cmds):
+        # Skill ordering: read optional priority list from
+        # ``skills.platform_menu_priority.<platform>`` in config.yaml. Skills
+        # listed there appear first in the menu in the listed order; the
+        # remainder fall back to alphabetical. Names in the priority list are
+        # matched against the raw skill key after leading-slash stripping but
+        # before platform-specific sanitization, so config can use natural names.
+        # Combine priority + promote_to_top into one sort key. promote_to_top
+        # names need to survive the slot cap (alphabetical position can push
+        # them out when total skill count exceeds remaining_slots), so they
+        # get the highest priority rank. The post-collection extractor in
+        # telegram_menu_commands moves them to the top of the menu.
+        _priority_list: list[str] = []
+        _promote_list: list[str] = []
+        try:
+            from hermes_cli.config import read_raw_config
+            _cfg = read_raw_config()
+            _skills_cfg = _cfg.get("skills") or {}
+            _priority_list = list(
+                (_skills_cfg.get("platform_menu_priority") or {})
+                .get(platform) or []
+            )
+            _promote_list = list(
+                (_skills_cfg.get("platform_menu_promote_to_top") or {})
+                .get(platform) or []
+            )
+        except Exception:
+            _priority_list = []
+            _promote_list = []
+        # promote first (rank 0..M-1), then priority (rank M..M+N-1), then alpha.
+        # Dedupe in case the same name appears in both lists.
+        _combined: list[str] = list(_promote_list)
+        for _n in _priority_list:
+            if _n not in _combined:
+                _combined.append(_n)
+        _priority_index = {n: i for i, n in enumerate(_combined)}
+        _priority_cap = len(_priority_index)
+
+        def _skill_sort_key(cmd_key: str) -> tuple[int, str]:
+            raw = cmd_key.lstrip("/")
+            return (_priority_index.get(raw, _priority_cap), raw)
+
+        for cmd_key in sorted(skill_cmds, key=_skill_sort_key):
             info = skill_cmds[cmd_key]
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
@@ -789,10 +830,34 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
     """
     core_commands = _prioritize_telegram_menu_commands(list(telegram_bot_commands()))
     reserved_names = {n for n, _ in core_commands}
+
+    # Read promote_to_top BEFORE the collector so we can reserve slots for the
+    # promoted skills even when core_commands alone exceed max_commands (the
+    # Telegram BotCommand menu is hard-capped at 30 by current bot policy, and
+    # core_commands can exceed that). Without this reservation, max_slots=0
+    # and the promote logic never sees its targets.
+    _promote_order: dict[str, int] = {}
+    try:
+        from hermes_cli.config import read_raw_config
+        _cfg = read_raw_config()
+        _promote_list = list(
+            ((_cfg.get("skills") or {})
+             .get("platform_menu_promote_to_top") or {})
+            .get("telegram") or []
+        )
+        _promote_order = {
+            _sanitize_telegram_name(n): i for i, n in enumerate(_promote_list)
+        }
+    except Exception:
+        _promote_order = {}
+
     all_commands = list(core_commands)
     hidden_core_count = max(0, len(all_commands) - max_commands)
 
-    remaining_slots = max(0, max_commands - len(all_commands))
+    # Reserve at least len(_promote_order) slots so promoted skills survive the
+    # collector cap. Without this, when core_commands >= max_commands,
+    # remaining_slots = 0 and the configured pinned skills never reach entries.
+    remaining_slots = max(len(_promote_order), max_commands - len(all_commands))
     entries, hidden_count = _collect_gateway_skill_entries(
         platform="telegram",
         max_slots=remaining_slots,
@@ -800,8 +865,17 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
         desc_limit=40,
         sanitize_name=_sanitize_telegram_name,
     )
-    # Drop the cmd_key — Telegram only needs (name, desc) pairs.
-    all_commands.extend((n, d) for n, d, _k in entries)
+
+    promoted: list[tuple[str, str]] = []
+    rest: list[tuple[str, str]] = []
+    for n, d, _k in entries:
+        if n in _promote_order:
+            promoted.append((n, d))
+        else:
+            rest.append((n, d))
+    promoted.sort(key=lambda nd: _promote_order.get(nd[0], len(_promote_order)))
+
+    all_commands = list(promoted) + list(core_commands) + list(rest)
     return all_commands[:max_commands], hidden_count + hidden_core_count
 
 


### PR DESCRIPTION
## What does this PR do?

Telegram caps the BotCommand menu (~30 entries). With many skills installed, you can't currently ensure your most-used skills appear — the alphabetical fallback pushes them out, and core commands alone can fill the cap. This adds two **optional** config keys under `skills:` to control skill ordering in the Telegram menu.

Both keys default off — **with neither set, behavior is unchanged** (skills sort alphabetically after the core commands), so this is fully backward-compatible.

## Related Issue

No existing issue — happy to open one if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`hermes_cli/commands.py`**
  - `_collect_gateway_skill_entries`: reads `skills.platform_menu_priority.<platform>` and `skills.platform_menu_promote_to_top.<platform>`, builds a combined sort key (promoted first, then priority list, then alphabetical). Promoted names get the top rank so they survive the slot cap.
  - `telegram_menu_commands`: reads `platform_menu_promote_to_top`, **reserves slots** for promoted skills (otherwise, when core commands alone meet the cap, `remaining_slots = 0` and pinned skills never reach the menu), then reassembles as `[promoted] + [core] + [rest]`.
- **`cli-config.yaml.example`**: documents both keys under `skills:` with examples.

## How to Test

1. Add to `config.yaml`:
   ```yaml
   skills:
     platform_menu_promote_to_top:
       telegram: [file, remember, pdf]
   ```
2. Restart the gateway.
3. The Telegram menu's first entries are now `file`, `remember`, `pdf` (above core commands). Remove the key → menu reverts to the default order.

Verified live on a production Hermes (macOS): a 10-skill promote list produced exactly those 10 as the first 10 `getMyCommands` entries; removing the keys restored the default alphabetical order.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs (no duplicate)
- [x] PR contains only changes related to this feature
- [ ] `pytest tests/ -q` — *not run in this fork clone (deps not installed). The change is config-gated and backward-compatible, and I verified the menu behavior live. Glad to add unit tests in `tests/hermes_cli/test_commands.py` on request (or if you point me at the preferred mocking pattern for `get_skill_commands`/`read_raw_config`).*
- [ ] Added tests — see note above
- [x] Tested on macOS (live)

### Documentation & Housekeeping
- [x] Updated `cli-config.yaml.example` (the two new keys)
- [x] No other docs change needed — N/A
- [x] No CONTRIBUTING/AGENTS change — N/A
- [x] Cross-platform considered — pure-Python config read + sort, no platform-specific calls
- [x] No tool schema change — N/A