### PR TITLE
[codex] Harden Responses streaming fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -441,6 +441,23 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
+def _is_none_iterable_type_error(exc: TypeError) -> bool:
+    msg = str(exc)
+    return "NoneType" in msg and "not iterable" in msg
+
+
+class _NullResponsesStreamError(RuntimeError):
+    """The SDK/provider returned no iterable stream object."""
+
+
+def _ensure_responses_stream(stream: Any, *, path: str) -> Any:
+    if stream is None:
+        raise _NullResponsesStreamError(
+            f"{path} returned None instead of an iterable Responses stream."
+        )
+    return stream
+
+
 def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     """Headers required to avoid Cloudflare 403s on chatgpt.com/backend-api/codex.
 
@@ -791,31 +808,101 @@ class _CodexCompletionsAdapter:
             collected_output_items: List[Any] = []
             collected_text_deltas: List[str] = []
             has_function_calls = False
+
+            def _collect_stream_event(_event: Any) -> Optional[Any]:
+                nonlocal has_function_calls
+                _check_cancelled()
+                _etype = getattr(_event, "type", "")
+                if _etype == "response.output_item.done":
+                    _done = getattr(_event, "item", None)
+                    if _done is not None:
+                        collected_output_items.append(_done)
+                elif "output_text.delta" in _etype:
+                    _delta = getattr(_event, "delta", "")
+                    if _delta:
+                        collected_text_deltas.append(_delta)
+                elif "function_call" in _etype:
+                    has_function_calls = True
+
+                if _etype not in {"response.completed", "response.incomplete", "response.failed"}:
+                    return None
+                return getattr(_event, "response", None)
+
+            def _consume_create_stream() -> Any:
+                create_kwargs = dict(resp_kwargs)
+                create_kwargs["stream"] = True
+                stream_or_response = self._client.responses.create(**create_kwargs)
+                if stream_or_response is None:
+                    raise RuntimeError(
+                        "Codex auxiliary Responses create(stream=True) returned "
+                        "None instead of a response stream."
+                    )
+                if hasattr(stream_or_response, "output"):
+                    return stream_or_response
+                terminal_response = None
+                try:
+                    for _event in stream_or_response:
+                        maybe_terminal = _collect_stream_event(_event)
+                        if maybe_terminal is not None:
+                            terminal_response = maybe_terminal
+                            return terminal_response
+                finally:
+                    close_fn = getattr(stream_or_response, "close", None)
+                    if callable(close_fn):
+                        try:
+                            close_fn()
+                        except Exception:
+                            pass
+                if terminal_response is not None:
+                    return terminal_response
+                raise RuntimeError(
+                    "Codex auxiliary Responses create(stream=True) did not emit "
+                    "a terminal response."
+                )
+
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
-            with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
+            try:
+                stream_cm = _ensure_responses_stream(
+                    self._client.responses.stream(**resp_kwargs),
+                    path="Codex auxiliary Responses stream",
+                )
+                with stream_cm as stream:
+                    stream = _ensure_responses_stream(
+                        stream,
+                        path="Codex auxiliary Responses stream.__enter__()",
+                    )
+                    for _event in stream:
+                        _collect_stream_event(_event)
                     _check_cancelled()
-                    _etype = getattr(_event, "type", "")
-                    if _etype == "response.output_item.done":
-                        _done = getattr(_event, "item", None)
-                        if _done is not None:
-                            collected_output_items.append(_done)
-                    elif "output_text.delta" in _etype:
-                        _delta = getattr(_event, "delta", "")
-                        if _delta:
-                            collected_text_deltas.append(_delta)
-                    elif "function_call" in _etype:
-                        has_function_calls = True
-                _check_cancelled()
-                final = stream.get_final_response()
+                    final = stream.get_final_response()
+            except _NullResponsesStreamError:
+                logger.debug(
+                    "Codex auxiliary Responses stream returned no iterable; "
+                    "falling back to create(stream=True)."
+                )
+                final = _consume_create_stream()
+            except TypeError as exc:
+                if not _is_none_iterable_type_error(exc):
+                    raise
+                logger.debug(
+                    "Codex auxiliary Responses stream had no iterable; "
+                    "falling back to create(stream=True)."
+                )
+                final = _consume_create_stream()
+
+            if final is None:
+                raise RuntimeError(
+                    "Codex auxiliary Responses stream returned None instead "
+                    "of a final response."
+                )
 
             # Backfill empty output from collected stream events
             _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
+            if not _output:
                 if collected_output_items:
                     final.output = list(collected_output_items)
                     logger.debug(

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -25,6 +25,52 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+class _NullResponsesStreamError(RuntimeError):
+    """The SDK/provider returned no iterable stream object."""
+
+
+def _is_none_iterable_type_error(exc: TypeError) -> bool:
+    """Return True for SDK stream internals failing on a missing iterator."""
+    msg = str(exc)
+    return "NoneType" in msg and "not iterable" in msg
+
+
+def _ensure_responses_stream(stream: Any, *, path: str) -> Any:
+    if stream is None:
+        raise _NullResponsesStreamError(
+            f"{path} returned None instead of an iterable Responses stream."
+        )
+    return stream
+
+
+def _run_codex_non_stream_create_fallback(
+    agent,
+    api_kwargs: dict,
+    active_client: Any,
+    *,
+    reason: str,
+):
+    """Final recovery path when both SDK streaming surfaces are unusable."""
+    logger.debug(
+        "Codex Responses stream fallback failed (%s); trying non-stream create(). %s",
+        reason,
+        agent._client_log_context(),
+    )
+    non_stream_kwargs = dict(api_kwargs)
+    non_stream_kwargs.pop("stream", None)
+    non_stream_kwargs = agent._get_transport().preflight_kwargs(
+        non_stream_kwargs,
+        allow_stream=False,
+    )
+    response = active_client.responses.create(**non_stream_kwargs)
+    if response is None:
+        raise RuntimeError(
+            "Responses create() non-stream fallback returned None instead of "
+            "a response."
+        )
+    return response
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -192,7 +238,15 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
         try:
-            with active_client.responses.stream(**api_kwargs) as stream:
+            stream_cm = _ensure_responses_stream(
+                active_client.responses.stream(**api_kwargs),
+                path="Responses.stream()",
+            )
+            with stream_cm as stream:
+                stream = _ensure_responses_stream(
+                    stream,
+                    path="Responses.stream().__enter__()",
+                )
                 for event in stream:
                     agent._touch_activity("receiving stream response")
                     if agent._interrupt_requested:
@@ -245,7 +299,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if not _out:
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -277,6 +331,42 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 continue
             logger.debug(
                 "Codex Responses stream transport failed; falling back to create(stream=True). %s error=%s",
+                agent._client_log_context(),
+                exc,
+            )
+            return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+        except _NullResponsesStreamError as exc:
+            if attempt < max_stream_retries:
+                logger.debug(
+                    "Codex Responses stream returned no iterable stream (attempt %s/%s); retrying. %s error=%s",
+                    attempt + 1,
+                    max_stream_retries + 1,
+                    agent._client_log_context(),
+                    exc,
+                )
+                continue
+            logger.debug(
+                "Codex Responses stream returned no iterable stream; falling back to create(stream=True). %s error=%s",
+                agent._client_log_context(),
+                exc,
+            )
+            return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+        except TypeError as exc:
+            if not _is_none_iterable_type_error(exc):
+                raise
+            if attempt < max_stream_retries:
+                logger.debug(
+                    "Codex Responses stream failed with a missing internal iterator "
+                    "(attempt %s/%s); retrying. %s error=%s",
+                    attempt + 1,
+                    max_stream_retries + 1,
+                    agent._client_log_context(),
+                    exc,
+                )
+                continue
+            logger.debug(
+                "Codex Responses stream failed with a missing internal iterator; "
+                "falling back to create(stream=True). %s error=%s",
                 agent._client_log_context(),
                 exc,
             )
@@ -339,6 +429,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
     fallback_kwargs["stream"] = True
     fallback_kwargs = agent._get_transport().preflight_kwargs(fallback_kwargs, allow_stream=True)
     stream_or_response = active_client.responses.create(**fallback_kwargs)
+    if stream_or_response is None:
+        return _run_codex_non_stream_create_fallback(
+            agent,
+            api_kwargs,
+            active_client,
+            reason="create(stream=True) returned None",
+        )
 
     # Compatibility shim for mocks or providers that still return a concrete response.
     if hasattr(stream_or_response, "output"):
@@ -408,7 +505,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if not _out:
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(
@@ -427,6 +524,15 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                             len(collected_text_deltas), len(assembled),
                         )
                 return terminal_response
+    except TypeError as exc:
+        if not _is_none_iterable_type_error(exc):
+            raise
+        return _run_codex_non_stream_create_fallback(
+            agent,
+            api_kwargs,
+            active_client,
+            reason="create(stream=True) iterator was missing",
+        )
     finally:
         close_fn = getattr(stream_or_response, "close", None)
         if callable(close_fn):
@@ -437,7 +543,12 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
 
     if terminal_response is not None:
         return terminal_response
-    raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
+    return _run_codex_non_stream_create_fallback(
+        agent,
+        api_kwargs,
+        active_client,
+        reason="create(stream=True) did not emit a terminal response",
+    )
 
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2404,6 +2404,126 @@ class TestCodexAuxiliaryAdapterTimeout:
 
         assert time.monotonic() - started < 0.14
 
+    def test_stream_context_returning_none_falls_back_to_create_stream(self):
+        class NullEnteringStream:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeResponses:
+            def __init__(self):
+                self.calls = {"stream": 0, "create": 0}
+
+            def stream(self, **kwargs):
+                self.calls["stream"] += 1
+                return NullEnteringStream()
+
+            def create(self, **kwargs):
+                self.calls["create"] += 1
+                assert kwargs.get("stream") is True
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="fallback summary")],
+                    )],
+                    usage=None,
+                )
+
+        fake_responses = FakeResponses()
+        fake_client = SimpleNamespace(responses=fake_responses)
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize this"}])
+
+        assert fake_responses.calls == {"stream": 1, "create": 1}
+        assert response.choices[0].message.content == "fallback summary"
+
+    def test_gpt55_chatgpt_auxiliary_uses_sdk_stream_when_stream_succeeds(self):
+        class WorkingStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="Hermes status check")],
+                    )],
+                    usage=None,
+                )
+
+        class FakeResponses:
+            def __init__(self):
+                self.calls = {"stream": 0, "create": 0}
+
+            def stream(self, **kwargs):
+                self.calls["stream"] += 1
+                assert kwargs["model"] == "gpt-5.5"
+                return WorkingStream()
+
+            def create(self, **kwargs):
+                self.calls["create"] += 1
+                raise AssertionError("responses.create(stream=True) should only run after stream failure")
+
+        fake_responses = FakeResponses()
+        fake_client = SimpleNamespace(
+            responses=fake_responses,
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize this"}])
+
+        assert fake_responses.calls == {"stream": 1, "create": 0}
+        assert response.choices[0].message.content == "Hermes status check"
+
+    def test_stream_none_iterable_falls_back_to_create_stream(self):
+        class BrokenStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        class FakeResponses:
+            def __init__(self):
+                self.calls = {"stream": 0, "create": 0}
+
+            def stream(self, **kwargs):
+                self.calls["stream"] += 1
+                return BrokenStream()
+
+            def create(self, **kwargs):
+                self.calls["create"] += 1
+                assert kwargs.get("stream") is True
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="fallback title")],
+                    )],
+                    usage=None,
+                )
+
+        fake_responses = FakeResponses()
+        fake_client = SimpleNamespace(responses=fake_responses)
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5-codex")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize this"}])
+
+        assert fake_responses.calls == {"stream": 1, "create": 1}
+        assert response.choices[0].message.content == "fallback title"
+
 
 # ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -174,6 +174,25 @@ class _FakeResponsesStream:
         return self._final_response
 
 
+class _NullEnteringResponsesStream:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _TypeErroringResponsesStream:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        raise TypeError("'NoneType' object is not iterable")
+
+
 class _FakeCreateStream:
     def __init__(self, events):
         self._events = list(events)
@@ -181,6 +200,17 @@ class _FakeCreateStream:
 
     def __iter__(self):
         return iter(self._events)
+
+    def close(self):
+        self.closed = True
+
+
+class _TypeErroringCreateStream:
+    def __init__(self):
+        self.closed = False
+
+    def __iter__(self):
+        raise TypeError("'NoneType' object is not iterable")
 
     def close(self):
         self.closed = True
@@ -479,6 +509,188 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_uses_sdk_stream_for_codex_gpt55_when_stream_succeeds(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.model = "gpt-5.5"
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        assert kwargs["model"] == "gpt-5.5"
+        return _FakeResponsesStream(final_response=_codex_message_response("sdk stream ok"))
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        raise AssertionError("responses.create(stream=True) should only run after stream failure")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+    kwargs = dict(_codex_request_kwargs(), model="gpt-5.5")
+
+    response = agent._run_codex_stream(kwargs)
+
+    assert calls == {"stream": 1, "create": 0}
+    assert response.output[0].content[0].text == "sdk stream ok"
+
+
+def test_run_codex_create_stream_fallback_backfills_none_terminal_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"create": 0}
+    message_item = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="done item ok")],
+    )
+    terminal_response = SimpleNamespace(output=None, status="completed")
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(type="response.completed", response=terminal_response),
+        ]
+    )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert calls["create"] == 1
+    assert create_stream.closed is True
+    assert response.output == [message_item]
+    assert response.output[0].content[0].text == "done item ok"
+
+
+def test_run_codex_stream_falls_back_when_stream_context_returns_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _NullEnteringResponsesStream()
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        assert kwargs.get("stream") is True
+        return _codex_message_response("null stream fallback ok")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls == {"stream": 2, "create": 1}
+    assert response.output[0].content[0].text == "null stream fallback ok"
+
+
+def test_run_codex_stream_falls_back_when_sdk_stream_iterator_is_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _TypeErroringResponsesStream()
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        assert kwargs.get("stream") is True
+        return _codex_message_response("none iterator fallback ok")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls == {"stream": 2, "create": 1}
+    assert response.output[0].content[0].text == "none iterator fallback ok"
+
+
+def test_run_codex_create_stream_fallback_uses_non_stream_when_stream_response_is_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = []
+
+    def _fake_create(**kwargs):
+        calls.append(dict(kwargs))
+        if len(calls) == 1:
+            assert kwargs.get("stream") is True
+            return None
+        assert "stream" not in kwargs
+        return _codex_message_response("non-stream fallback ok")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert len(calls) == 2
+    assert response.output[0].content[0].text == "non-stream fallback ok"
+
+
+def test_run_codex_create_stream_fallback_uses_non_stream_when_iterator_is_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = []
+    broken_stream = _TypeErroringCreateStream()
+
+    def _fake_create(**kwargs):
+        calls.append(dict(kwargs))
+        if len(calls) == 1:
+            assert kwargs.get("stream") is True
+            return broken_stream
+        assert "stream" not in kwargs
+        return _codex_message_response("iterator non-stream fallback ok")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert len(calls) == 2
+    assert broken_stream.closed is True
+    assert response.output[0].content[0].text == "iterator non-stream fallback ok"
+
+
+def test_run_codex_create_non_stream_fallback_none_response_raises_clear_error(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"create": 0}
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return None
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=_fake_create,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="create\\(\\) non-stream fallback returned None"):
+        agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert calls["create"] == 2
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

- Add defensive guards when `responses.stream()` returns no context manager or enters to no iterable stream.
- Fall back to `responses.create(stream=True)` when the SDK stream path is unusable or raises the observed `NoneType` iterator failure.
- Backfill missing/empty terminal response output from streamed output items or text deltas in the main Codex runtime and auxiliary Codex adapter.

## Why

Some Responses-compatible backends can stream useful events while the SDK stream helper fails to provide a usable final stream/final output. Hermes previously surfaced this as generic failures such as `'NoneType' object is not iterable` or as empty final output even though stream events contained the assistant message.

This keeps the normal SDK stream path as the default and only uses the create-stream fallback after a concrete stream failure, avoiding model-specific or backend-specific bypass logic.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python3 -m py_compile agent/codex_runtime.py agent/auxiliary_client.py tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py`
- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py` (`70/70` passed)
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py` (`175/175` passed)

## Notes

The branch intentionally excludes proxy, auth, Cloudflare, and provider-routing diagnostics. Those were useful during local diagnosis but are not part of this narrow resilience fix.
