### PR TITLE
fix: honor fallback api_mode overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -770,6 +770,120 @@ def init_agent(
     # Claude uses its own timeout path and is not covered here.
     _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
 
+    # Resolve the OpenAI-wire primary before selecting the transport-specific
+    # initialization branch.  If its credentials are unavailable, a fallback
+    # entry may select a different transport (notably anthropic_messages), so
+    # that selection must happen before the branch below rather than inside
+    # the OpenAI client setup block.
+    _pre_resolved_client = None
+    if (
+        agent.api_mode not in {"anthropic_messages", "bedrock_converse"}
+        and agent.provider != "moa"
+        and not (api_key and base_url)
+    ):
+        from agent.auxiliary_client import resolve_provider_client
+
+        _pre_resolved_client, _ = resolve_provider_client(
+            agent.provider or "auto",
+            model=agent.model,
+            raw_codex=True,
+        )
+        if _pre_resolved_client is None:
+            _explicit = (agent.provider or "").strip().lower()
+            if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
+                _env_hint = f"{_explicit.upper()}_API_KEY"
+                try:
+                    from hermes_cli.auth import PROVIDER_REGISTRY
+
+                    _pcfg = PROVIDER_REGISTRY.get(_explicit)
+                    if _pcfg and _pcfg.api_key_env_vars:
+                        _env_hint = _pcfg.api_key_env_vars[0]
+                except Exception:
+                    pass
+
+                if isinstance(fallback_model, list):
+                    _fb_entries = [
+                        entry
+                        for entry in fallback_model
+                        if isinstance(entry, dict)
+                        and entry.get("provider")
+                        and entry.get("model")
+                    ]
+                elif (
+                    isinstance(fallback_model, dict)
+                    and fallback_model.get("provider")
+                    and fallback_model.get("model")
+                ):
+                    _fb_entries = [fallback_model]
+                else:
+                    _fb_entries = []
+
+                from hermes_cli.fallback_config import (
+                    resolve_fallback_client,
+                    resolve_fallback_transport,
+                )
+
+                for _fb in _fb_entries:
+                    _fb_client, _fb_model, _fb_api_mode = (
+                        resolve_fallback_client(_fb, raw_codex=True)
+                    )
+                    if _fb_client is None:
+                        continue
+
+                    agent.provider = str(_fb["provider"]).strip().lower()
+                    agent.model = _fb_model or str(_fb["model"]).strip()
+                    agent.base_url = str(_fb_client.base_url)
+                    agent.api_mode = resolve_fallback_transport(
+                        validated_api_mode=_fb_api_mode,
+                        provider=agent.provider,
+                        model_requires_responses=(
+                            agent._provider_model_requires_responses_api(
+                                agent.model,
+                                provider=agent.provider,
+                            )
+                        ),
+                        base_url=agent.base_url,
+                        is_azure=agent._is_azure_openai_url(agent.base_url),
+                    )
+                    # The initial policy was computed for the unavailable
+                    # primary. Re-evaluate it before any request so a native
+                    # Anthropic fallback keeps the same cache-control contract
+                    # as a fallback activated during a live conversation.
+                    (
+                        agent._use_prompt_caching,
+                        agent._use_native_cache_layout,
+                    ) = agent._anthropic_prompt_cache_policy(
+                        provider=agent.provider,
+                        base_url=agent.base_url,
+                        api_mode=agent.api_mode,
+                        model=agent.model,
+                    )
+                    agent._fallback_activated = True
+                    _provider_timeout = get_provider_request_timeout(
+                        agent.provider,
+                        agent.model,
+                    )
+                    _pre_resolved_client = _fb_client
+
+                    # Native transports initialize below from the selected
+                    # fallback's credentials and endpoint. OpenAI-wire modes
+                    # reuse the already-resolved client in the implicit-auth
+                    # branch so provider-specific headers survive.
+                    if agent.api_mode in {
+                        "anthropic_messages",
+                        "bedrock_converse",
+                    }:
+                        api_key = _fb_client.api_key
+                        base_url = str(_fb_client.base_url)
+                    break
+
+                if _pre_resolved_client is None:
+                    raise RuntimeError(
+                        f"Provider '{_explicit}' is set in config.yaml but no API key "
+                        f"was found. Set the {_env_hint} environment "
+                        f"variable, or switch to a different provider with `hermes model`."
+                    )
+
     if agent.api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
         # Bedrock + Claude → use AnthropicBedrock SDK for full feature parity
@@ -983,10 +1097,9 @@ def init_agent(
                 except Exception:
                     pass
         else:
-            # No explicit creds — use the centralized provider router
-            from agent.auxiliary_client import resolve_provider_client
-            _routed_client, _ = resolve_provider_client(
-                agent.provider or "auto", model=agent.model, raw_codex=True)
+            # No explicit creds — reuse the preflight router result. Fallback
+            # selection already happened before transport branching above.
+            _routed_client = _pre_resolved_client
             if _routed_client is not None:
                 client_kwargs = {
                     "api_key": _routed_client.api_key,
@@ -1006,75 +1119,12 @@ def init_agent(
                 if _routed_headers:
                     client_kwargs["default_headers"] = dict(_routed_headers)
             else:
-                # When the user explicitly chose a non-OpenRouter provider
-                # but no credentials were found, fail fast with a clear
-                # message instead of silently routing through OpenRouter.
-                _explicit = (agent.provider or "").strip().lower()
-                if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
-                    # Look up the actual env var name from the provider
-                    # config — some providers use non-standard names
-                    # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
-                    _env_hint = f"{_explicit.upper()}_API_KEY"
-                    try:
-                        from hermes_cli.auth import PROVIDER_REGISTRY
-                        _pcfg = PROVIDER_REGISTRY.get(_explicit)
-                        if _pcfg and _pcfg.api_key_env_vars:
-                            _env_hint = _pcfg.api_key_env_vars[0]
-                    except Exception:
-                        pass
-                    # --- Init-time fallback (#17929) ---
-                    _fb_entries = []
-                    if isinstance(fallback_model, list):
-                        _fb_entries = [
-                            f for f in fallback_model
-                            if isinstance(f, dict) and f.get("provider") and f.get("model")
-                        ]
-                    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-                        _fb_entries = [fallback_model]
-                    _fb_resolved = False
-                    for _fb in _fb_entries:
-                        _fb_explicit_key = (_fb.get("api_key") or "").strip() or None
-                        if not _fb_explicit_key:
-                            _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
-                            if _fb_key_env:
-                                _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
-                        _fb_client, _fb_model = resolve_provider_client(
-                            _fb["provider"], model=_fb["model"], raw_codex=True,
-                            explicit_base_url=_fb.get("base_url"),
-                            explicit_api_key=_fb_explicit_key,
-                        )
-                        if _fb_client is not None:
-                            agent.provider = _fb["provider"]
-                            agent.model = _fb_model or _fb["model"]
-                            agent._fallback_activated = True
-                            client_kwargs = {
-                                "api_key": _fb_client.api_key,
-                                "base_url": str(_fb_client.base_url),
-                            }
-                            if _provider_timeout is not None:
-                                client_kwargs["timeout"] = _provider_timeout
-                            _fb_headers = getattr(_fb_client, "_custom_headers", None)
-                            if not _fb_headers:
-                                _fb_headers = getattr(_fb_client, "default_headers", None)
-                            if not _fb_headers:
-                                _fb_headers = getattr(_fb_client, "_default_headers", None)
-                            if _fb_headers:
-                                client_kwargs["default_headers"] = dict(_fb_headers)
-                            _fb_resolved = True
-                            break
-                    if not _fb_resolved:
-                        raise RuntimeError(
-                            f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_env_hint} environment "
-                            f"variable, or switch to a different provider with `hermes model`."
-                        )
-                if not getattr(agent, "_fallback_activated", False):
-                    # No provider configured — reject with a clear message.
-                    raise RuntimeError(
-                        "No LLM provider configured. Run `hermes model` to "
-                        "select a provider, or run `hermes setup` for first-time "
-                        "configuration."
-                    )
+                # No provider configured — reject with a clear message.
+                raise RuntimeError(
+                    "No LLM provider configured. Run `hermes model` to "
+                    "select a provider, or run `hermes setup` for first-time "
+                    "configuration."
+                )
         
         agent._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -35,7 +35,7 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
 )
 from tools.terminal_tool import is_persistent_env
-from utils import base_url_host_matches, base_url_hostname, env_float, env_int
+from utils import base_url_host_matches, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
@@ -1421,27 +1421,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # raw_codex=True because the main agent needs direct responses.stream()
     # access for Codex providers.
     try:
-        from agent.auxiliary_client import resolve_provider_client
-        # Pass base_url and api_key from fallback config so custom
-        # endpoints (e.g. Ollama Cloud) resolve correctly instead of
-        # falling through to OpenRouter defaults.
-        fb_base_url_hint = (fb.get("base_url") or "").strip() or None
-        fb_api_key_hint = (fb.get("api_key") or "").strip() or None
-        if not fb_api_key_hint:
-            # key_env and api_key_env are both documented aliases (see
-            # _normalize_custom_provider_entry in hermes_cli/config.py).
-            fb_key_env = (fb.get("key_env") or fb.get("api_key_env") or "").strip()
-            if fb_key_env:
-                fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
-        # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
-        # when no explicit key is in the fallback config. Host match
-        # (not substring) — see GHSA-76xc-57q6-vm5m.
-        if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
-            fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
-        fb_client, _resolved_fb_model = resolve_provider_client(
-            fb_provider, model=fb_model, raw_codex=True,
-            explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+        from hermes_cli.fallback_config import (
+            resolve_fallback_client,
+            resolve_fallback_transport,
+        )
+
+        fb_client, _resolved_fb_model, fb_api_mode_hint = (
+            resolve_fallback_client(fb, raw_codex=True)
+        )
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -1458,43 +1445,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # The validated entry hint wins. With no valid hint, reuse the same
+        # provider/URL transport resolver as initial runtime setup, followed by
+        # the agent's model-specific Responses API rule.
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
-            fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
+        fb_api_mode = resolve_fallback_transport(
+            validated_api_mode=fb_api_mode_hint,
             provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+            model_requires_responses=agent._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ),
+            base_url=fb_base_url,
+            is_azure=_fb_is_azure,
+        )
 
         old_model = agent.model
         old_provider = agent.provider

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3030,6 +3030,7 @@ def run_job(
             resolve_runtime_provider,
             format_runtime_provider_error,
         )
+        from hermes_cli.fallback_config import resolve_fallback_runtime
         from hermes_cli.auth import AuthError
 
         # F8 runtime backstop: never resolve a stored provider/base_url pair that
@@ -3059,12 +3060,7 @@ def run_job(
             runtime = None
             for entry in fb_list:
                 try:
-                    fb_kwargs = {"requested": entry.get("provider")}
-                    if entry.get("base_url"):
-                        fb_kwargs["explicit_base_url"] = entry["base_url"]
-                    if entry.get("api_key"):
-                        fb_kwargs["explicit_api_key"] = entry["api_key"]
-                    runtime = resolve_runtime_provider(**fb_kwargs)
+                    runtime = resolve_fallback_runtime(entry)
                     logger.info("Job '%s': fallback resolved to %s", job_id, runtime.get("provider"))
                     break
                 except Exception as fb_exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1972,7 +1972,7 @@ def _credential_pool_for_provider(provider: Optional[str]):
 
 def _try_resolve_fallback_provider() -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
-    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.fallback_config import resolve_fallback_runtime
     try:
         import yaml as _y
         cfg_path = _hermes_home / "config.yaml"
@@ -1985,18 +1985,7 @@ def _try_resolve_fallback_provider() -> dict | None:
             return None
         for entry in fb_list:
             try:
-                explicit_api_key = entry.get("api_key")
-                if not explicit_api_key:
-                    key_env = str(
-                        entry.get("key_env") or entry.get("api_key_env") or ""
-                    ).strip()
-                    if key_env:
-                        explicit_api_key = os.getenv(key_env, "").strip() or None
-                runtime = resolve_runtime_provider(
-                    requested=entry.get("provider"),
-                    explicit_base_url=entry.get("base_url"),
-                    explicit_api_key=explicit_api_key,
-                )
+                runtime = resolve_fallback_runtime(entry)
                 # Log the literal `provider` key from config, not the resolved
                 # runtime category — an Ollama fallback resolves through the
                 # OpenAI-compatible path and would otherwise be logged as

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -49,6 +49,7 @@ class CLIAgentSetupMixin:
         # Primary provider auth failed — try fallback providers before giving up.
         if runtime is None and _primary_exc is not None:
             from hermes_cli.auth import AuthError
+            from hermes_cli.fallback_config import resolve_fallback_runtime
             if isinstance(_primary_exc, AuthError):
                 _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
                 for _fb in _fb_chain:
@@ -57,7 +58,7 @@ class CLIAgentSetupMixin:
                     if not _fb_provider or not _fb_model:
                         continue
                     try:
-                        runtime = resolve_runtime_provider(requested=_fb_provider)
+                        runtime = resolve_fallback_runtime(_fb)
                         logger.warning(
                             "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
                             _primary_exc, _fb_provider, _fb_model,

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -4,11 +4,162 @@ from __future__ import annotations
 
 from typing import Any
 
+from agent.secret_scope import get_secret as _get_secret
+from utils import base_url_host_matches, base_url_hostname
+
+
+_FALLBACK_API_MODES = frozenset({
+    "chat_completions",
+    "codex_responses",
+    "anthropic_messages",
+    "bedrock_converse",
+})
+
 
 def _normalized_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
     return value.strip().rstrip("/")
+
+
+def normalize_fallback_api_mode(value: Any) -> str | None:
+    """Return a supported in-process fallback transport, or ``None``.
+
+    ``runtime_provider._parse_api_mode`` owns config-level normalization
+    (including whitespace/case handling).  Fallback activation narrows that
+    set to transports an already-running agent can switch to; the
+    ``codex_app_server`` runtime is a whole-process mode rather than an
+    in-process provider transport.
+    """
+
+    from hermes_cli.runtime_provider import _parse_api_mode
+
+    parsed = _parse_api_mode(value)
+    return parsed if parsed in _FALLBACK_API_MODES else None
+
+
+def fallback_entry_hints(entry: dict[str, Any]) -> dict[str, Any]:
+    """Normalize resolver inputs shared by every fallback entry consumer."""
+
+    provider = str(entry.get("provider") or "").strip()
+    model = str(entry.get("model") or "").strip()
+    base_url = _normalized_base_url(entry.get("base_url")) or None
+
+    raw_api_key = entry.get("api_key")
+    api_key = raw_api_key.strip() if isinstance(raw_api_key, str) else None
+    api_key = api_key or None
+    if not api_key:
+        key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+        if key_env:
+            api_key = (_get_secret(key_env, "") or "").strip() or None
+
+    # Ollama Cloud supports the documented provider-wide key without making
+    # users repeat it in every fallback entry.  Keep the hostname check exact
+    # so an attacker-controlled lookalike cannot receive the credential.
+    if base_url and not api_key and base_url_host_matches(base_url, "ollama.com"):
+        api_key = (_get_secret("OLLAMA_API_KEY", "") or "").strip() or None
+
+    return {
+        "provider": provider,
+        "model": model,
+        "base_url": base_url,
+        "api_key": api_key,
+        "api_mode": normalize_fallback_api_mode(entry.get("api_mode")),
+    }
+
+
+def resolve_fallback_client(
+    entry: dict[str, Any],
+    *,
+    raw_codex: bool = False,
+) -> tuple[Any | None, str | None, str | None]:
+    """Resolve a fallback client plus its validated explicit transport hint."""
+
+    from agent.auxiliary_client import resolve_provider_client
+
+    hints = fallback_entry_hints(entry)
+    kwargs: dict[str, Any] = {
+        "model": hints["model"],
+        "raw_codex": raw_codex,
+        "explicit_base_url": hints["base_url"] or "",
+        "explicit_api_key": hints["api_key"] or "",
+    }
+    if hints["api_mode"]:
+        kwargs["api_mode"] = hints["api_mode"]
+    client, resolved_model = resolve_provider_client(hints["provider"], **kwargs)
+    return client, resolved_model, hints["api_mode"]
+
+
+def resolve_fallback_runtime(entry: dict[str, Any]) -> dict[str, Any]:
+    """Resolve credentials/runtime and apply a validated entry transport.
+
+    Invalid non-empty ``api_mode`` values are treated exactly like an absent
+    hint: they are not forwarded and the runtime resolver's provider, URL,
+    and target-model heuristics remain authoritative.
+    """
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    hints = fallback_entry_hints(entry)
+    kwargs: dict[str, Any] = {
+        "requested": hints["provider"],
+        "target_model": hints["model"],
+    }
+    if hints["base_url"]:
+        kwargs["explicit_base_url"] = hints["base_url"]
+    if hints["api_key"]:
+        kwargs["explicit_api_key"] = hints["api_key"]
+
+    runtime = resolve_runtime_provider(**kwargs)
+    if hints["api_mode"]:
+        runtime = dict(runtime)
+        runtime["api_mode"] = hints["api_mode"]
+    return runtime
+
+
+def resolve_fallback_transport(
+    *,
+    validated_api_mode: str | None,
+    provider: str,
+    model_requires_responses: bool,
+    base_url: str,
+    is_azure: bool,
+) -> str:
+    """Resolve the effective transport after a fallback client is built."""
+
+    if validated_api_mode:
+        return validated_api_mode
+
+    from hermes_cli.providers import determine_api_mode
+    from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+    # Start from the provider's declared transport without passing the URL:
+    # determine_api_mode() intentionally accepts legacy substring URL matches
+    # for known providers, which would misclassify lookalike hosts such as
+    # api.anthropic.com.attacker.test.  The runtime URL detector below parses
+    # hostnames and paths exactly, matching the primary-provider path.
+    detected = determine_api_mode(provider, "")
+    if detected != "chat_completions":
+        return detected
+
+    # Azure OpenAI serves GPT-5.x through chat/completions, not Responses.
+    if is_azure:
+        return "chat_completions"
+
+    url_detected = _detect_api_mode_for_url(base_url)
+    if url_detected:
+        return url_detected
+
+    hostname = base_url_hostname(base_url)
+    if (
+        hostname.startswith("bedrock-runtime.")
+        and base_url_host_matches(base_url, "amazonaws.com")
+    ):
+        return "bedrock_converse"
+
+    if model_requires_responses:
+        return "codex_responses"
+    return "chat_completions"
 
 
 def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -172,6 +172,43 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
     assert shell.agent is not None
 
 
+def test_runtime_auth_fallback_honors_entry_api_mode(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        if kwargs.get("requested") == "openai-codex":
+            raise AuthError("Codex token expired")
+        assert kwargs.get("target_model") == "claude-sonnet-4-6"
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://proxy.example/anthropic",
+            "api_key": "fallback-key",
+            "source": "fallback",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _runtime_resolve,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.requested_provider = "openai-codex"
+    shell._fallback_model = [{
+        "provider": "custom:krill",
+        "model": "claude-sonnet-4-6",
+        "api_mode": "anthropic_messages",
+    }]
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.api_mode == "anthropic_messages"
+    assert shell.model == "claude-sonnet-4-6"
+
+
 def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     cli = _import_cli()
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2032,6 +2032,52 @@ class TestRunJobConfigEnvVarExpansion:
         models = [e.get("model") for e in fb if isinstance(e, dict)]
         assert models == ["gpt-4o-mini", "claude-sonnet-4-6"]
 
+    def test_initial_auth_fallback_honors_entry_api_mode(self, tmp_path):
+        from hermes_cli.auth import AuthError
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  provider: openai-codex\n"
+            "  default: gpt-5\n"
+            "fallback_providers:\n"
+            "  - provider: custom:krill\n"
+            "    model: claude-sonnet-4-6\n"
+            "    api_mode: anthropic_messages\n"
+        )
+        job = {"id": "fb-mode", "name": "fallback mode", "prompt": "hi"}
+        fake_db = MagicMock()
+
+        def _resolve(**kwargs):
+            if kwargs.get("requested") is None:
+                raise AuthError("primary token expired")
+            assert kwargs.get("target_model") == "claude-sonnet-4-6"
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://proxy.example/anthropic",
+                "provider": "custom",
+                "api_mode": "chat_completions",
+            }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=_resolve,
+             ), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert mock_agent_cls.call_args.kwargs["api_mode"] == "anthropic_messages"
+
     def test_unexpanded_ref_passthrough_when_var_unset(self, tmp_path, monkeypatch):
         """When the env var is not set, the literal ${VAR} is kept verbatim (not crashed)."""
         (tmp_path / "config.yaml").write_text("model: ${_HERMES_TEST_CRON_UNSET_VAR}\n")

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -113,3 +113,79 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         assert calls == ["openrouter", "nous"]
         assert result["provider"] == "nous"
         assert result["model"] == "Hermes-4"
+
+    def test_fallback_providers_api_mode_overrides_runtime_mode(self, tmp_path, monkeypatch):
+        """gateway auth fallback honors per-entry api_mode from fallback_providers."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "fallback_providers:\n"
+            "  - provider: custom:krill\n"
+            "    model: deepseek-v4-pro\n"
+            "    api_mode: anthropic_messages\n"
+        )
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        def _mock_resolve(**kwargs):
+            assert kwargs.get("requested") == "custom:krill"
+            assert kwargs.get("target_model") == "deepseek-v4-pro"
+            return {
+                "api_key": "krill-key",
+                "base_url": "https://api.krill-ai.com/coding/v1",
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _try_resolve_fallback_provider
+
+            result = _try_resolve_fallback_provider()
+
+        assert result is not None
+        assert result["provider"] == "custom"
+        assert result["model"] == "deepseek-v4-pro"
+        assert result["api_mode"] == "anthropic_messages"
+
+    def test_invalid_fallback_api_mode_preserves_runtime_heuristic(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "fallback_providers:\n"
+            "  - provider: custom:krill\n"
+            "    model: claude-sonnet-4-6\n"
+            "    base_url: https://api.anthropic.com/v1\n"
+            "    api_mode: anthropic_message\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        def _mock_resolve(**kwargs):
+            assert kwargs == {
+                "requested": "custom:krill",
+                "target_model": "claude-sonnet-4-6",
+                "explicit_base_url": "https://api.anthropic.com/v1",
+            }
+            return {
+                "api_key": "krill-key",
+                "base_url": "https://api.anthropic.com/v1",
+                "provider": "custom",
+                "api_mode": "anthropic_messages",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _try_resolve_fallback_provider
+
+            result = _try_resolve_fallback_provider()
+
+        assert result is not None
+        assert result["api_mode"] == "anthropic_messages"

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -186,11 +186,18 @@ fallback_providers:
     )
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *,
+        requested=None,
+        target_model=None,
+        explicit_base_url=None,
+        explicit_api_key=None,
+    ):
         if requested in {None, "", "openai-codex"}:
             from hermes_cli.auth import AuthError
             raise AuthError("No Codex credentials stored. Run `hermes auth` to authenticate.")
         assert requested == "openrouter"
+        assert target_model == "minimax/minimax-m2.7"
         return {
             "api_key": "sk-openrouter",
             "base_url": "https://openrouter.ai/api/v1",
@@ -235,8 +242,15 @@ fallback_providers:
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setenv("MY_FALLBACK_KEY", "env-secret")
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *,
+        requested=None,
+        target_model=None,
+        explicit_base_url=None,
+        explicit_api_key=None,
+    ):
         assert requested == "custom"
+        assert target_model == "fallback-model"
         assert explicit_base_url == "https://fallback.example/v1"
         assert explicit_api_key == "env-secret"
         return {
@@ -260,4 +274,3 @@ fallback_providers:
     assert runtime_kwargs["api_key"] == "env-secret"
     assert runtime_kwargs["base_url"] == "https://fallback.example/v1"
     assert runtime_kwargs["model"] == "fallback-model"
-

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,0 +1,83 @@
+"""Focused tests for shared fallback-provider config resolution."""
+
+import pytest
+
+from agent import secret_scope
+from hermes_cli.fallback_config import (
+    fallback_entry_hints,
+    resolve_fallback_transport,
+)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.anthropic.com.attacker.test/v1",
+        "https://api.openai.com.attacker.test/v1",
+    ],
+)
+def test_fallback_transport_rejects_provider_host_lookalikes(base_url):
+    assert resolve_fallback_transport(
+        validated_api_mode=None,
+        provider="openrouter",
+        model_requires_responses=False,
+        base_url=base_url,
+        is_azure=False,
+    ) == "chat_completions"
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        ("https://api.anthropic.com/v1", "anthropic_messages"),
+        ("https://api.openai.com/v1", "codex_responses"),
+        (
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "bedrock_converse",
+        ),
+    ],
+)
+def test_fallback_transport_keeps_exact_endpoint_detection(base_url, expected):
+    assert resolve_fallback_transport(
+        validated_api_mode=None,
+        provider="openrouter",
+        model_requires_responses=False,
+        base_url=base_url,
+        is_azure=False,
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    ("entry", "scope"),
+    [
+        (
+            {
+                "provider": "custom:scoped",
+                "model": "test-model",
+                "key_env": "FALLBACK_TEST_API_KEY",
+            },
+            {"FALLBACK_TEST_API_KEY": "profile-key"},
+        ),
+        (
+            {
+                "provider": "ollama",
+                "model": "test-model",
+                "base_url": "https://ollama.com/v1",
+            },
+            {"OLLAMA_API_KEY": "profile-key"},
+        ),
+    ],
+)
+def test_fallback_entry_hints_read_credentials_from_active_scope(
+    monkeypatch,
+    entry,
+    scope,
+):
+    for name in scope:
+        monkeypatch.setenv(name, "another-profile-key")
+
+    token = secret_scope.set_secret_scope(scope)
+    try:
+        assert fallback_entry_hints(entry)["api_key"] == "profile-key"
+    finally:
+        secret_scope.reset_secret_scope(token)

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -5,6 +5,11 @@ from unittest.mock import patch, MagicMock
 from run_agent import AIAgent
 
 
+@pytest.fixture(autouse=True)
+def _isolate_agent_logs(tmp_path, monkeypatch):
+    monkeypatch.setattr("run_agent._hermes_home", tmp_path)
+
+
 def _make_tool_defs():
     return [{"type": "function", "function": {"name": "web_search",
              "description": "search", "parameters": {"type": "object", "properties": {}}}}]
@@ -67,3 +72,96 @@ def test_init_raises_when_no_fallback_configured():
                 skip_memory=True,
                 fallback_model=None,
             )
+
+
+def test_init_fallback_selects_explicit_anthropic_transport():
+    fb = _mock_client(base_url="https://proxy.example/anthropic")
+    calls = []
+
+    def fake_resolve(provider, model=None, raw_codex=False, **kwargs):
+        calls.append((provider, kwargs))
+        if provider == "custom:krill":
+            return fb, "claude-sonnet-4-6"
+        return None, None
+
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        side_effect=fake_resolve,
+    ), patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=MagicMock(),
+    ), patch(
+        "run_agent.get_tool_definitions",
+        return_value=_make_tool_defs(),
+    ), patch(
+        "run_agent.check_toolset_requirements",
+        return_value={},
+    ):
+        agent = AIAgent(
+            provider="alibaba-coding-plan",
+            model="qwen3.6-plus",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{
+                "provider": "custom:krill",
+                "model": "claude-sonnet-4-6",
+                "api_mode": "anthropic_messages",
+            }],
+        )
+
+    fallback_kwargs = next(kwargs for provider, kwargs in calls if provider == "custom:krill")
+    assert fallback_kwargs["api_mode"] == "anthropic_messages"
+    assert agent.api_mode == "anthropic_messages"
+    assert agent._anthropic_client is not None
+    assert agent.client is None
+    assert agent._use_prompt_caching is True
+    assert agent._use_native_cache_layout is True
+
+
+def test_init_invalid_fallback_mode_uses_endpoint_heuristic():
+    fb = _mock_client(base_url="https://api.anthropic.com/v1")
+    calls = []
+
+    def fake_resolve(provider, model=None, raw_codex=False, **kwargs):
+        calls.append((provider, kwargs))
+        if provider == "custom:krill":
+            return fb, "claude-sonnet-4-6"
+        return None, None
+
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        side_effect=fake_resolve,
+    ), patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=MagicMock(),
+    ), patch(
+        "run_agent.get_tool_definitions",
+        return_value=_make_tool_defs(),
+    ), patch(
+        "run_agent.check_toolset_requirements",
+        return_value={},
+    ):
+        agent = AIAgent(
+            provider="alibaba-coding-plan",
+            model="qwen3.6-plus",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{
+                "provider": "custom:krill",
+                "model": "claude-sonnet-4-6",
+                "base_url": "https://api.anthropic.com/v1",
+                "api_mode": "anthropic_message",
+            }],
+        )
+
+    fallback_kwargs = next(kwargs for provider, kwargs in calls if provider == "custom:krill")
+    assert "api_mode" not in fallback_kwargs
+    assert agent.api_mode == "anthropic_messages"
+    assert agent._anthropic_client is not None
+    assert agent.client is None

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -33,6 +33,11 @@ from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _isolate_run_agent_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_agent, "_hermes_home", tmp_path)
+
+
 def _make_tool_defs(*names: str) -> list:
     """Build minimal tool definition list accepted by AIAgent.__init__."""
     return [
@@ -6800,6 +6805,70 @@ class TestFallbackAnthropicProvider:
         assert result is True
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
+
+    def test_fallback_entry_api_mode_hint_sets_anthropic_messages(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {
+            "provider": "custom:krill",
+            "model": "deepseek-v4-pro",
+            "api_mode": "anthropic_messages",
+        }
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.krill-ai.com/coding/v1"
+        mock_client.api_key = "***"
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)) as mock_resolve,
+            patch("agent.anthropic_adapter.build_anthropic_client") as mock_build,
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=None),
+        ):
+            mock_build.return_value = MagicMock()
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert mock_resolve.call_args.kwargs["api_mode"] == "anthropic_messages"
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._anthropic_client is not None
+        assert agent.client is None
+
+    def test_invalid_fallback_api_mode_is_absent_and_url_heuristic_runs(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {
+            "provider": "custom:krill",
+            "model": "claude-sonnet-4-6",
+            "api_mode": "anthropic_message",
+        }
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.anthropic.com/v1"
+        mock_client.api_key = "***"
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_client, None),
+            ) as mock_resolve,
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "agent.anthropic_adapter.resolve_anthropic_token",
+                return_value=None,
+            ),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert "api_mode" not in mock_resolve.call_args.kwargs
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._anthropic_client is not None
+        assert agent.client is None
 
 
 def test_aiagent_uses_copilot_acp_client():

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8848,6 +8848,39 @@ class TestResolveRuntimeWithFallback:
         )
         assert result == fallback_runtime
 
+    def test_auth_fallback_honors_entry_api_mode(self, monkeypatch):
+        from hermes_cli.auth import AuthError
+
+        def fake_resolve(**kwargs):
+            if kwargs.get("requested") == "openai-codex":
+                raise AuthError("No Codex credentials stored")
+            assert kwargs.get("target_model") == "claude-sonnet-4-6"
+            return {
+                "provider": "custom",
+                "api_key": "fb-tok",
+                "api_mode": "chat_completions",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve,
+        )
+        monkeypatch.setattr(
+            server,
+            "_load_fallback_model",
+            lambda: [{
+                "provider": "custom:krill",
+                "model": "claude-sonnet-4-6",
+                "api_mode": "anthropic_messages",
+            }],
+        )
+
+        result = server._resolve_runtime_with_fallback(
+            {"requested": "openai-codex"},
+        )
+
+        assert result["api_mode"] == "anthropic_messages"
+
     def test_auth_error_all_fallbacks_fail_raises(self, monkeypatch):
         """When all fallbacks also fail, re-raise the original AuthError."""
         from hermes_cli.auth import AuthError

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4474,6 +4474,7 @@ def _resolve_runtime_with_fallback(
     ``fallback_model`` chain before giving up.
     """
     from hermes_cli.auth import AuthError
+    from hermes_cli.fallback_config import resolve_fallback_runtime
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
     kwargs = resolve_kwargs or {}
@@ -4488,12 +4489,7 @@ def _resolve_runtime_with_fallback(
             if not fb_provider:
                 continue
             try:
-                fb_kwargs: dict = {"requested": fb_provider}
-                if entry.get("base_url"):
-                    fb_kwargs["explicit_base_url"] = entry["base_url"]
-                if entry.get("api_key"):
-                    fb_kwargs["explicit_api_key"] = entry["api_key"]
-                runtime = resolve_runtime_provider(**fb_kwargs)
+                runtime = resolve_fallback_runtime(entry)
                 import logging
 
                 logging.getLogger(__name__).warning(


### PR DESCRIPTION
## What does this PR do?

Honors explicit `fallback_providers[].api_mode` when Hermes activates a fallback provider.

Custom providers can declare `api_mode: anthropic_messages`, `api_mode: chat_completions`, or another transport mode, but fallback activation currently recomputes transport from provider/base URL/model heuristics. For Anthropic-compatible gateways whose URL does not end in `/anthropic`, the fallback can resolve credentials correctly while leaving the agent runtime in the wrong transport mode.

This PR makes the fallback entry's explicit `api_mode` authoritative in the in-agent failover path and applies the same per-entry precedence in the gateway auth fallback path.

Closest related PRs checked:

- #16346, #24631, and #29749 cover the same fallback `api_mode` class in the agent/runtime path.
- #33140 was closed as another duplicate of this class.
- This PR keeps the gateway auth fallback path coverage as the differentiator, so `gateway/run.py::_try_resolve_fallback_provider()` also preserves the per-entry `api_mode` hint.

## Related Issue

Partially addresses #33062 for fallback provider entries that declare an explicit `api_mode`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`
  - Passes the fallback entry's explicit `api_mode` through provider client resolution.
  - Keeps existing provider/base URL/model heuristics as the fallback behavior when no explicit `api_mode` is configured.
- `gateway/run.py`
  - Applies the same per-entry `api_mode` precedence while resolving gateway auth fallback providers.
- `tests/run_agent/test_run_agent.py`
  - Adds regression coverage for Anthropic Messages fallback activation.
- `tests/gateway/test_auth_fallback.py`
  - Adds regression coverage for gateway auth fallback preserving per-entry `api_mode`.

## How to Test

1. Configure a fallback provider entry that explicitly sets a transport mode, for example:

```yaml
fallback_providers:
  - provider: custom:anthropic-facade
    model: claude-compatible-model
    base_url: https://example.com/v1
    api_mode: anthropic_messages
```

2. Trigger fallback activation from a failing primary provider.
3. Verify the fallback runtime keeps the configured `api_mode` instead of recomputing transport from provider/base URL/model heuristics.
4. Run the targeted regression tests:

```bash
python -m pytest tests/run_agent/test_run_agent.py::TestFallbackAnthropicProvider \
                 tests/gateway/test_auth_fallback.py \
                 -q -o 'addopts='
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS with the targeted tests above; GitHub CI is green

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression command:

```text
$ python -m pytest tests/run_agent/test_run_agent.py::TestFallbackAnthropicProvider tests/gateway/test_auth_fallback.py -q -o 'addopts='
```

Current GitHub CI for this PR is green, including tests, e2e, ruff enforcement, nix checks, build jobs, attribution, and supply-chain scan.
