### PR TITLE
fix(agent): sync `manual:device_code` Codex pool entries from auth.json

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -508,11 +508,12 @@ class CredentialPool:
         though fresh credentials are sitting on disk — and every request
         fails with "no available entries (all exhausted or empty)".
 
-        Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
-        auth.json shadow to sync from.
+        Mirrors the Nous/Anthropic resync paths above.  Applies to both
+        auto-seeded ("device_code") and user-added ("manual:device_code")
+        entries; env/API-key-sourced entries have no auth.json shadow to
+        sync from.
         """
-        if self.provider != "openai-codex" or entry.source != "device_code":
+        if self.provider != "openai-codex" or entry.source not in {"device_code", "manual:device_code"}:
             return entry
         try:
             with _auth_store_lock():
@@ -1186,7 +1187,7 @@ class CredentialPool:
             # frozen behind last_error_reset_at (can be hours in the
             # future for ChatGPT weekly windows).
             if (self.provider == "openai-codex"
-                    and entry.source == "device_code"
+                    and entry.source in {"device_code", "manual:device_code"}
                     and entry.last_status == STATUS_EXHAUSTED):
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2289,6 +2289,195 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     assert available == []
 
 
+def _codex_auth_store_with_manual_pool_entry(
+    singleton_access: str,
+    singleton_refresh: str,
+    pool_access: str,
+    pool_refresh: str,
+    *,
+    pool_status: "str | None" = None,
+    pool_error_code: "int | None" = None,
+    pool_reset_at: "float | None" = None,
+) -> dict:
+    """Build an auth.json with a singleton + a *manual* pool entry.
+
+    Mirrors the on-disk shape produced when the user has previously run
+    ``hermes auth`` -> Add credential for openai-codex, which writes the
+    pool entry with ``source="manual:device_code"`` while subsequent
+    refreshes write to the ``providers["openai-codex"]`` singleton.
+    """
+    entry: dict = {
+        "id": "manual-1",
+        "label": "openai-codex-oauth-1",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": pool_access,
+        "refresh_token": pool_refresh,
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    if pool_status is not None:
+        entry["last_status"] = pool_status
+        entry["last_status_at"] = time.time()
+        entry["last_error_code"] = pool_error_code
+        entry["last_error_reset_at"] = pool_reset_at
+    return {
+        "version": 1,
+        "active_provider": "openai-codex",
+        "providers": {
+            "openai-codex": {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": singleton_access,
+                    "refresh_token": singleton_refresh,
+                    "id_token": "id-" + singleton_access,
+                },
+                "last_refresh": "2026-05-27T08:12:17Z",
+            }
+        },
+        "credential_pool": {
+            "openai-codex": [entry],
+        },
+    }
+
+
+def test_sync_codex_entry_adopts_newer_tokens_for_manual_source(tmp_path, monkeypatch):
+    """Manually-added Codex pool entries must also sync from auth.json.
+
+    Regression: previously the sync gate required ``entry.source ==
+    "device_code"``, so entries created by ``hermes auth`` -> Add
+    credential (which use ``source="manual:device_code"``) silently
+    diverged from the singleton tokens after every refresh.  Once the
+    pool entry's access_token went stale, every chat-mode request 401d
+    while the singleton-backed paths kept working -- leaving the user
+    with a half-broken install that was very hard to diagnose.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        _codex_auth_store_with_manual_pool_entry(
+            singleton_access="access-NEW",
+            singleton_refresh="refresh-NEW",
+            pool_access="access-OLD",
+            pool_refresh="refresh-OLD",
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = next(
+        e for e in pool._entries if e.source == "manual:device_code"
+    )
+    assert entry.access_token == "access-OLD"
+
+    synced = pool._sync_codex_entry_from_auth_store(entry)
+    assert synced is not entry
+    assert synced.access_token == "access-NEW"
+    assert synced.refresh_token == "refresh-NEW"
+    assert synced.last_status is None
+    assert synced.last_error_code is None
+
+
+def test_codex_manual_exhausted_entry_recovers_via_auth_store_sync(
+    tmp_path, monkeypatch
+):
+    """Full recovery path: an exhausted ``manual:device_code`` entry
+    must be revived by ``_available_entries`` once auth.json holds
+    fresh tokens -- the same way auto-seeded ``device_code`` entries
+    already do.
+
+    Without this, ``hermes auth`` re-login left the pool entry frozen
+    behind ``last_error_reset_at`` (often hours into the future for
+    Codex 429 weekly-window patterns), so every request continued to
+    fail with "no available entries (all exhausted or empty)" until
+    the cooldown elapsed naturally.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    now = time.time()
+    _write_auth_store(
+        tmp_path,
+        _codex_auth_store_with_manual_pool_entry(
+            singleton_access="access-FRESH",
+            singleton_refresh="refresh-FRESH",
+            pool_access="access-OLD",
+            pool_refresh="refresh-OLD",
+            pool_status=STATUS_EXHAUSTED,
+            pool_error_code=401,
+            pool_reset_at=now + 3600,
+        ),
+    )
+
+    pool = load_pool("openai-codex")
+    available = pool._available_entries(clear_expired=True, refresh=False)
+    # load_pool may also auto-seed a separate device_code entry
+    # from the singleton.  What matters here is that the manual entry
+    # is no longer quarantined and now carries the fresh tokens.
+    manual = [e for e in available if e.source == "manual:device_code"]
+    assert len(manual) == 1, [e.source for e in available]
+    assert manual[0].access_token == "access-FRESH"
+    assert manual[0].refresh_token == "refresh-FRESH"
+    assert manual[0].last_status is None
+    assert manual[0].last_error_reset_at is None
+
+
+
+
+def test_codex_manual_and_seeded_entries_stay_consistent_after_sync(
+    tmp_path, monkeypatch
+):
+    """Coexisting ``manual:device_code`` and ``device_code`` entries must
+    converge on the singleton's fresh tokens after sync.
+
+    ``_upsert_entry`` keys on the exact source string, so a manual entry
+    and an auto-seeded entry live side-by-side in the pool without
+    deduplicating.  Once this PR's sync widens to admit
+    ``manual:device_code``, both should end up holding the same tokens
+    -- not silently diverge -- when ``_available_entries`` runs.
+
+    Both entries are pre-populated explicitly here so the test is
+    independent of singleton auto-seeding behavior.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    now = time.time()
+    payload = _codex_auth_store_with_manual_pool_entry(
+        singleton_access="access-FRESH",
+        singleton_refresh="refresh-FRESH",
+        pool_access="access-OLD",
+        pool_refresh="refresh-OLD",
+        pool_status=STATUS_EXHAUSTED,
+        pool_error_code=401,
+        pool_reset_at=now + 3600,
+    )
+    # Add an explicit auto-seeded entry alongside the manual one so the
+    # invariant we assert does not depend on load_pool's seeding path.
+    payload["credential_pool"]["openai-codex"].append({
+        "id": "seeded-1",
+        "label": "device_code",
+        "auth_type": "oauth",
+        "priority": 1,
+        "source": "device_code",
+        "access_token": "access-FRESH",
+        "refresh_token": "refresh-FRESH",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    })
+    _write_auth_store(tmp_path, payload)
+
+    pool = load_pool("openai-codex")
+    available = pool._available_entries(clear_expired=True, refresh=False)
+
+    manual = [e for e in available if e.source == "manual:device_code"]
+    seeded = [e for e in available if e.source == "device_code"]
+    assert manual, [e.source for e in available]
+    assert seeded, [e.source for e in available]
+    assert manual[0].access_token == seeded[0].access_token == "access-FRESH"
+    assert manual[0].refresh_token == seeded[0].refresh_token == "refresh-FRESH"
+
+
 # ---------------------------------------------------------------------------
 # xAI OAuth terminal error quarantine
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(agent): sync `manual:device_code` Codex pool entries from `auth.json`

## Summary

When a user adds a Codex credential via `hermes auth` → *Add credential* → `openai-codex`, the resulting pool entry is tagged `source="manual:device_code"`. The pool's auto-resync gate only matches the exact string `"device_code"`, so manually-added entries never adopt fresh tokens that `hermes auth` (or any other client) writes to the `providers["openai-codex"]` singleton.

Once the manual entry's `access_token` goes stale, the next request 401s. The pool then tries to refresh using the entry's `refresh_token`, but OAuth refresh tokens are single-use and the singleton path has typically already consumed it — so refresh fails with `refresh_token_reused`, the entry is marked terminally exhausted, and every subsequent chat-mode request fails with *"no available entries (all exhausted or empty)"*. Meanwhile singleton-backed code paths (`hermes -z`, gateway init, the auxiliary client) keep working because they read the fresh tokens directly from `providers["openai-codex"]`. The two modes silently diverge, which makes the failure hard to diagnose — `hermes -z` keeps replying while `hermes chat` 401s on the same install with the same account.

## Root cause

Two gates in `agent/credential_pool.py` exclude `manual:device_code` entries from the auth-store resync flow:

```python
# agent/credential_pool.py:514 (inside _sync_codex_entry_from_auth_store)
if self.provider != "openai-codex" or entry.source != "device_code":
    return entry

# agent/credential_pool.py:1187 (inside _available_entries)
if (self.provider == "openai-codex"
        and entry.source == "device_code"
        and entry.last_status == STATUS_EXHAUSTED):
    synced = self._sync_codex_entry_from_auth_store(entry)
```

The same file already establishes the right idiom at line 1608, where it accepts both source strings as a set:

```python
if entry.source not in {"device_code", "manual:device_code"}
```

This PR aligns the two sync gates with that precedent.

## Fix

Both gates now accept `{"device_code", "manual:device_code"}`. No new helper introduced — staying consistent with the existing set-literal pattern keeps the diff to two one-line edits. The docstring of `_sync_codex_entry_from_auth_store` is updated to reflect the broader scope.

## Repro

1. Run `hermes auth` → *Add credential* → `openai-codex`, complete the device-code flow. This writes a pool entry with `source="manual:device_code"`.
2. Sign into ChatGPT/Codex from any other client (Codex CLI, VS Code extension, or ChatGPT desktop/web on the same account). This invalidates the refresh token stored in the pool entry server-side.
3. Run `hermes auth` again → *Add credential* → `openai-codex`. Fresh tokens land in `providers["openai-codex"]` (the singleton), but the pool entry still holds the consumed pair.
4. `hermes -z "hi"` → works (singleton path).
5. `hermes chat -q "hi"` → 401, then *"no available entries (all exhausted or empty)"*.

After this PR: step 5 succeeds because the pool entry adopts the fresh singleton tokens on next `_available_entries` call.

## Tests

Three regression tests added to `tests/agent/test_credential_pool.py`:

- `test_sync_codex_entry_adopts_newer_tokens_for_manual_source` — exercises `_sync_codex_entry_from_auth_store` directly on a `manual:device_code` entry with stale tokens; asserts the fresh singleton tokens are adopted.
- `test_codex_manual_exhausted_entry_recovers_via_auth_store_sync` — full recovery flow through `_available_entries`; asserts the exhausted manual entry recovers when the singleton holds fresh tokens.
- `test_codex_manual_and_seeded_entries_stay_consistent_after_sync` — coexistence guard: when both a `manual:device_code` entry and a singleton-seeded `device_code` entry are present, asserts both converge on the singleton's tokens (no silent divergence between them).

The first two fail on `main` without the fix and pass with it. The third documents the expected post-fix invariant for the two-entry shape that real users produce in practice.

```
$ pytest tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py \
         tests/run_agent/test_credential_pool_interrupt.py \
         tests/run_agent/test_init_fallback_on_exhausted_pool.py \
         tests/hermes_cli/test_auth_codex_provider.py \
         tests/tools/test_credential_pool_env_fallback.py
111 passed, 1 warning in 6.65s
```

Manual verification on the affected install:

- `hermes -z "hi"` — succeeded both before and after (singleton path, unaffected).
- `hermes chat -q "hi"` — failed with 401 → terminal exhaustion before; succeeds after.
- Gateway + WhatsApp adapter — running cleanly after the fix.

## Risk

Low. The change widens an existing gate to admit one additional well-known source string that is already produced inside the same codebase (the `manual:` prefix is created by `hermes auth add`). The set-literal idiom already exists in the same file (line 1608). The sync function itself is unchanged — it still only writes when `auth.json` tokens actually differ from the pool entry, and it only clears exhausted status when adopting newer tokens. No new code paths, no new I/O.

## Scope

`openai-codex` only. The PR addresses the exact-match gate at the two sync sites — the cleanup at line 1036 (terminal-refresh quarantine) intentionally only removes singleton-seeded entries and is correct as-is.

## Platforms tested

- Linux x86_64, Debian 12, Python 3.11.15
