### PR TITLE
fix(agent): roll back switch_model state when client rebuild fails

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1361,91 +1361,125 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     old_model = agent.model
     old_provider = agent.provider
 
-    # Clear the per-config context_length override so the new model's
-    # actual context window is resolved via get_model_context_length()
-    # instead of inheriting the stale value from the previous model.
-    agent._config_context_length = None
+    # Snapshot the pre-swap state of every field this function mutates
+    # before the client build completes. If the rebuild raises (bad API
+    # key, network error, MiniMax OAuth failure, etc.) we restore these
+    # so the agent stays internally consistent — without this, the swap
+    # below would leave ``agent.model``/``agent.provider`` already
+    # pointing at the new combo while ``agent.client`` (or
+    # ``agent._anthropic_client``) still belongs to the old provider,
+    # producing the torn state reported in #33175 where the next turn
+    # hits a model/provider mismatch (e.g. HTTP 400 "model not supported
+    # on this provider").
+    _rollback = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": agent.api_key,
+        "_config_context_length": getattr(agent, "_config_context_length", None),
+        "client": getattr(agent, "client", None),
+        "_client_kwargs": dict(getattr(agent, "_client_kwargs", {}) or {}),
+        "_anthropic_api_key": getattr(agent, "_anthropic_api_key", None),
+        "_anthropic_base_url": getattr(agent, "_anthropic_base_url", None),
+        "_anthropic_client": getattr(agent, "_anthropic_client", None),
+        "_is_anthropic_oauth": getattr(agent, "_is_anthropic_oauth", False),
+        "_use_prompt_caching": getattr(agent, "_use_prompt_caching", False),
+        "_use_native_cache_layout": getattr(agent, "_use_native_cache_layout", False),
+    }
+    _committed = False
 
-    # ── Swap core runtime fields ──
-    agent.model = new_model
-    agent.provider = new_provider
-    # Use new base_url when provided; only fall back to current when the
-    # new provider genuinely has no endpoint (e.g. native SDK providers).
-    # Without this guard the old provider's URL (e.g. Ollama's localhost
-    # address) would persist silently after switching to a cloud provider
-    # that returns an empty base_url string.
-    if base_url:
-        agent.base_url = base_url
-    agent.api_mode = api_mode
-    # Invalidate transport cache — new api_mode may need a different transport
-    if hasattr(agent, "_transport_cache"):
-        agent._transport_cache.clear()
-    if api_key:
-        agent.api_key = api_key
+    try:
+        # Clear the per-config context_length override so the new model's
+        # actual context window is resolved via get_model_context_length()
+        # instead of inheriting the stale value from the previous model.
+        agent._config_context_length = None
 
-    # ── Build new client ──
-    if api_mode == "anthropic_messages":
-        from agent.anthropic_adapter import (
-            build_anthropic_client,
-            resolve_anthropic_token,
-            _is_oauth_token,
+        # ── Swap core runtime fields ──
+        agent.model = new_model
+        agent.provider = new_provider
+        # Use new base_url when provided; only fall back to current when the
+        # new provider genuinely has no endpoint (e.g. native SDK providers).
+        # Without this guard the old provider's URL (e.g. Ollama's localhost
+        # address) would persist silently after switching to a cloud provider
+        # that returns an empty base_url string.
+        if base_url:
+            agent.base_url = base_url
+        agent.api_mode = api_mode
+        # Invalidate transport cache — new api_mode may need a different transport
+        if hasattr(agent, "_transport_cache"):
+            agent._transport_cache.clear()
+        if api_key:
+            agent.api_key = api_key
+
+        # ── Build new client ──
+        if api_mode == "anthropic_messages":
+            from agent.anthropic_adapter import (
+                build_anthropic_client,
+                resolve_anthropic_token,
+                _is_oauth_token,
+            )
+            # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
+            # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own
+            # API key — falling back would send Anthropic credentials to third-party endpoints.
+            _is_native_anthropic = new_provider == "anthropic"
+            effective_key = (api_key or agent.api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or agent.api_key or "")
+
+            # MiniMax OAuth: swap static string for a per-request callable token
+            # provider so the rebuilt client survives 15-min token expiry. See
+            # the matching block in agent_init.py for the full rationale.
+            if new_provider == "minimax-oauth" and isinstance(effective_key, str) and effective_key:
+                try:
+                    from hermes_cli.auth import build_minimax_oauth_token_provider
+                    effective_key = build_minimax_oauth_token_provider()
+                except Exception as _mm_exc:  # noqa: BLE001
+                    import logging as _logging
+                    _logging.getLogger(__name__).warning(
+                        "MiniMax OAuth: failed to install per-request token provider "
+                        "on switch (%s); using static bearer.",
+                        _mm_exc,
+                    )
+
+            agent.api_key = effective_key
+            agent._anthropic_api_key = effective_key
+            agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
+            agent._anthropic_client = build_anthropic_client(
+                effective_key, agent._anthropic_base_url,
+                timeout=get_provider_request_timeout(agent.provider, agent.model),
+            )
+            agent._is_anthropic_oauth = _is_oauth_token(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
+            agent.client = None
+            agent._client_kwargs = {}
+        else:
+            effective_key = api_key or agent.api_key
+            effective_base = base_url or agent.base_url
+            agent._client_kwargs = {
+                "api_key": effective_key,
+                "base_url": effective_base,
+            }
+            _sm_timeout = get_provider_request_timeout(agent.provider, agent.model)
+            if _sm_timeout is not None:
+                agent._client_kwargs["timeout"] = _sm_timeout
+            agent.client = agent._create_openai_client(
+                dict(agent._client_kwargs),
+                reason="switch_model",
+                shared=True,
+            )
+
+        # ── Re-evaluate prompt caching ──
+        agent._use_prompt_caching, agent._use_native_cache_layout = (
+            agent._anthropic_prompt_cache_policy(
+                provider=new_provider,
+                base_url=agent.base_url,
+                api_mode=api_mode,
+                model=new_model,
+            )
         )
-        # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
-        # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own
-        # API key — falling back would send Anthropic credentials to third-party endpoints.
-        _is_native_anthropic = new_provider == "anthropic"
-        effective_key = (api_key or agent.api_key or resolve_anthropic_token() or "") if _is_native_anthropic else (api_key or agent.api_key or "")
-
-        # MiniMax OAuth: swap static string for a per-request callable token
-        # provider so the rebuilt client survives 15-min token expiry. See
-        # the matching block in agent_init.py for the full rationale.
-        if new_provider == "minimax-oauth" and isinstance(effective_key, str) and effective_key:
-            try:
-                from hermes_cli.auth import build_minimax_oauth_token_provider
-                effective_key = build_minimax_oauth_token_provider()
-            except Exception as _mm_exc:  # noqa: BLE001
-                import logging as _logging
-                _logging.getLogger(__name__).warning(
-                    "MiniMax OAuth: failed to install per-request token provider "
-                    "on switch (%s); using static bearer.",
-                    _mm_exc,
-                )
-
-        agent.api_key = effective_key
-        agent._anthropic_api_key = effective_key
-        agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
-        agent._anthropic_client = build_anthropic_client(
-            effective_key, agent._anthropic_base_url,
-            timeout=get_provider_request_timeout(agent.provider, agent.model),
-        )
-        agent._is_anthropic_oauth = _is_oauth_token(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
-        agent.client = None
-        agent._client_kwargs = {}
-    else:
-        effective_key = api_key or agent.api_key
-        effective_base = base_url or agent.base_url
-        agent._client_kwargs = {
-            "api_key": effective_key,
-            "base_url": effective_base,
-        }
-        _sm_timeout = get_provider_request_timeout(agent.provider, agent.model)
-        if _sm_timeout is not None:
-            agent._client_kwargs["timeout"] = _sm_timeout
-        agent.client = agent._create_openai_client(
-            dict(agent._client_kwargs),
-            reason="switch_model",
-            shared=True,
-        )
-
-    # ── Re-evaluate prompt caching ──
-    agent._use_prompt_caching, agent._use_native_cache_layout = (
-        agent._anthropic_prompt_cache_policy(
-            provider=new_provider,
-            base_url=agent.base_url,
-            api_mode=api_mode,
-            model=new_model,
-        )
-    )
+        _committed = True
+    finally:
+        if not _committed:
+            for _attr, _val in _rollback.items():
+                setattr(agent, _attr, _val)
 
     # ── LM Studio: preload before probing context length ──
     agent._ensure_lmstudio_runtime_loaded()

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -1,0 +1,185 @@
+"""Regression tests for #33175: ``switch_model`` must restore the agent's
+pre-swap state when the client rebuild fails partway through.
+
+Before the fix, ``agent.model`` and ``agent.provider`` were updated several
+lines before the client rebuild ran, so any exception during the rebuild
+(bad API key, network error, MiniMax OAuth failure, import failure) left
+the agent with the *new* model/provider names against the *old* client.
+The next turn would hit a model/provider mismatch (e.g. HTTP 400
+"claude-sonnet-4-6 is not supported on openai-codex").
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_chat_completions_agent() -> AIAgent:
+    """Build a minimal AIAgent for chat_completions tests."""
+    agent = AIAgent.__new__(AIAgent)
+
+    agent.model = "claude-sonnet-4-6"
+    agent.provider = "anthropic"
+    agent.base_url = "https://api.anthropic.com"
+    agent.api_key = "old-key"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="old_client")
+    agent._client_kwargs = {
+        "api_key": "old-key",
+        "base_url": "https://api.anthropic.com",
+    }
+    agent.context_compressor = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._anthropic_client = None
+    agent._is_anthropic_oauth = False
+    agent._cached_system_prompt = "cached"
+    agent._config_context_length = None
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._create_openai_client = MagicMock(name="_create_openai_client")
+    return agent
+
+
+def _make_anthropic_agent() -> AIAgent:
+    """Build a minimal AIAgent currently on chat_completions, about to switch
+    into anthropic_messages — the path used by the issue reporter (codex →
+    anthropic-style provider)."""
+    agent = AIAgent.__new__(AIAgent)
+
+    agent.model = "gpt-5"
+    agent.provider = "openai-codex"
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    agent.api_key = "old-codex-key"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="old_codex_client")
+    agent._client_kwargs = {
+        "api_key": "old-codex-key",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    agent.context_compressor = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._anthropic_client = None
+    agent._is_anthropic_oauth = False
+    agent._cached_system_prompt = "cached"
+    agent._config_context_length = None
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    return agent
+
+
+def _snapshot(agent: AIAgent) -> dict:
+    return {
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": agent.api_key,
+        "client": agent.client,
+        "_client_kwargs": dict(agent._client_kwargs),
+        "_anthropic_api_key": agent._anthropic_api_key,
+        "_anthropic_base_url": agent._anthropic_base_url,
+        "_anthropic_client": agent._anthropic_client,
+        "_is_anthropic_oauth": agent._is_anthropic_oauth,
+        "_config_context_length": agent._config_context_length,
+        "_use_prompt_caching": agent._use_prompt_caching,
+        "_use_native_cache_layout": agent._use_native_cache_layout,
+    }
+
+
+def test_chat_completions_client_failure_rolls_back_state():
+    """Bad credentials at ``_create_openai_client`` time must leave the
+    agent on the old provider, model, base_url, and client — not in a
+    torn state with new model/provider against the stale client."""
+    agent = _make_chat_completions_agent()
+    before = _snapshot(agent)
+
+    agent._create_openai_client = MagicMock(
+        name="_create_openai_client",
+        side_effect=RuntimeError("bad credentials"),
+    )
+
+    with pytest.raises(RuntimeError, match="bad credentials"):
+        agent.switch_model(
+            new_model="x-ai/grok-4",
+            new_provider="openrouter",
+            api_key="bad-key",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+        )
+
+    after = _snapshot(agent)
+    assert after == before, (
+        "switch_model must restore pre-swap state on client-build failure; "
+        f"diverged fields: {[k for k in before if before[k] != after[k]]}"
+    )
+
+
+def test_anthropic_client_failure_rolls_back_state():
+    """Anthropic-side rebuild failure (e.g. ``build_anthropic_client``
+    raising on a malformed token) must roll back to the old provider."""
+    agent = _make_anthropic_agent()
+    before = _snapshot(agent)
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        side_effect=ConnectionError("network error"),
+    ), patch(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        return_value="sk-ant-x",
+    ), patch(
+        "agent.anthropic_adapter._is_oauth_token",
+        return_value=False,
+    ):
+        with pytest.raises(ConnectionError, match="network error"):
+            agent.switch_model(
+                new_model="claude-sonnet-4-6",
+                new_provider="anthropic",
+                api_key="sk-ant-x",
+                base_url="https://api.anthropic.com",
+                api_mode="anthropic_messages",
+            )
+
+    after = _snapshot(agent)
+    assert after == before, (
+        "switch_model must restore pre-swap state on anthropic-client-build "
+        f"failure; diverged fields: {[k for k in before if before[k] != after[k]]}"
+    )
+
+
+def test_successful_switch_commits_new_state():
+    """Happy path: when the client rebuild succeeds, the new state must
+    persist (no regression from the rollback wrapper)."""
+    agent = _make_chat_completions_agent()
+    new_client = MagicMock(name="new_client")
+    agent._create_openai_client = MagicMock(return_value=new_client)
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._ensure_lmstudio_runtime_loaded = MagicMock()
+
+    agent.switch_model(
+        new_model="x-ai/grok-4",
+        new_provider="openrouter",
+        api_key="or-key",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+
+    assert agent.model == "x-ai/grok-4"
+    assert agent.provider == "openrouter"
+    assert agent.base_url == "https://openrouter.ai/api/v1"
+    assert agent.api_mode == "chat_completions"
+    assert agent.api_key == "or-key"
+    assert agent.client is new_client


### PR DESCRIPTION
## What does this PR do?

`agent_runtime_helpers.switch_model()` swapped `agent.model`,
`agent.provider`, `agent.base_url`, and `agent.api_mode` several lines
*before* the new client was built. Any exception during the rebuild —
bad API key, network error, MiniMax OAuth failure, or import failure —
left the agent in a torn state: the new model/provider against the
*old* client. The next turn then hit a model/provider mismatch (e.g.
HTTP 400 `"claude-sonnet-4-6 is not supported on openai-codex"`).

The fix snapshots every field this function mutates before the swap
(`model`, `provider`, `base_url`, `api_mode`, `api_key`, `client`,
`_client_kwargs`, `_config_context_length`, the four `_anthropic_*`
fields, and the two prompt-caching flags), wraps the swap + client
rebuild + prompt-cache policy evaluation in `try`/`finally`, and
restores the snapshot on any uncommitted failure. The exception
continues to propagate so callers (`model_switch.switch_model`, the
TUI/CLI `/model` handlers) keep seeing the failure — the only change is
that the agent is now internally consistent when they do.

## Related Issue

Fixes #33175

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py` — snapshot pre-swap state, wrap the
  mutating section in `try`/`finally` with a `_committed` flag,
  restore the snapshot when the body raises before completing. No
  behaviour change on the happy path.
- `tests/run_agent/test_switch_model_rollback.py` — three new tests:
  chat_completions rebuild failure restores all state, anthropic
  rebuild failure restores all state, happy-path commit still applies
  the new state.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_switch_model_rollback.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_switch_model_fallback_prune.py tests/hermes_cli/test_model_switch_variant_tags.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_model_switch_opencode_anthropic.py tests/gateway/test_model_command_flat_string_config.py -v` — 49 passed locally.
2. Regression guard: temporarily revert the production change and rerun
   `tests/run_agent/test_switch_model_rollback.py`; the two failure-path
   tests fail with exactly the torn-state symptom described in #33175
   (`model`, `provider`, `api_mode`, `base_url`, `_anthropic_*` all
   stuck on the new values).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, behaviour is unchanged on the happy path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python state-management change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Contract Protected

**Invariant**: after `switch_model()` returns, either (a) the new model,
provider, base_url, api_mode, api_key, and matching client are all
committed together, or (b) all of them are still on the old values.
There is no observable intermediate state where the model name and the
client object disagree.

**Known-bad inputs covered by tests**:
- chat_completions path: `_create_openai_client` raises (bad
  credentials, network error, transport build failure).
- anthropic_messages path: `build_anthropic_client` raises
  (`ConnectionError`, `AuthenticationError`, import failure).

**Negative case**: the happy-path test confirms the new state is
committed when no exception is raised — the rollback wrapper does not
silently swallow successful swaps.

**Sibling code paths**: `_try_activate_fallback()` in `run_agent.py`
mirrors the same client-swap logic for the fallback case (see the
"mirrors `_try_activate_fallback`" note in this function's docstring).
That path is turn-scoped and resets each turn, so torn state is less
visible there, but it would benefit from the same rollback discipline
in a follow-up — intentionally left out of this PR's scope to keep the
diff small and focused on the reported symptom. Happy to widen if
preferred.