### PR TITLE
fix(memory): tighten hindsight recall hygiene

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -46,7 +46,7 @@ _INTERNAL_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 _INTERNAL_NOTE_RE = re.compile(
-    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
+    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*|advisory historical context[^\]]*)\.\]\s*',
     re.IGNORECASE,
 )
 
@@ -234,8 +234,9 @@ def build_memory_context_block(raw_context: str) -> str:
     return (
         "<memory-context>\n"
         "[System note: The following is recalled memory context, "
-        "NOT new user input. Treat as authoritative reference data — "
-        "this is the agent's persistent memory and should inform all responses.]\n\n"
+        "NOT new user input. Treat as advisory historical context — "
+        "it may be useful but is not live operational truth; verify current status "
+        "with tools or source-of-truth systems before making operational claims.]\n\n"
         f"{clean}\n"
         "</memory-context>"
     )

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -71,6 +71,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_budget` | `mid` | Recall thoroughness: `low` / `mid` / `high` |
 | `recall_prefetch_method` | `recall` | Auto-recall method: `recall` (raw facts) or `reflect` (LLM synthesis) |
 | `recall_max_tokens` | `4096` | Maximum tokens for recall results |
+| `recall_max_results` | `8` | Maximum deduplicated recalled memory bullets injected into context |
 | `recall_max_input_chars` | `800` | Maximum input query length for auto-recall |
 | `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
 | `recall_tags` | — | Tags to filter when searching memories |
@@ -89,6 +90,8 @@ Config file: `~/.hermes/hindsight/config.json`
 | `retain_source` | — | Optional `metadata.source` attached to retained memories |
 | `retain_user_prefix` | `User` | Label used before user turns in auto-retained transcripts |
 | `retain_assistant_prefix` | `Assistant` | Label used before assistant turns in auto-retained transcripts |
+
+Auto-retain is for durable steering facts only. Hermes filters obvious task logs and transient operational status such as job IDs, PR numbers, commit SHAs, one-off health states, reminders, and "no memory update required" messages before sending content to Hindsight. Use `session_search` for task history and audit trails. Put reusable workflow lessons and user corrections into the relevant `SKILL.md` when they describe how future work should be done.
 
 ### Integration
 
@@ -120,6 +123,15 @@ Available in `hybrid` and `tools` memory modes:
 | `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
 | `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
+
+## Operator Memory Boundaries
+
+- Built-in memory: compact durable user preferences, stable environment facts, and long-lived conventions that should steer future turns.
+- Hindsight: broader cross-session semantic context, still treated as advisory historical context rather than live truth.
+- `session_search`: task logs, completed work, job IDs, PRs, run results, timestamps, and other audit/history lookups.
+- `SKILL.md`: reusable workflows, corrections to how tasks should be performed, and domain-specific operating procedures.
+
+Recalled Hindsight context is injected as hidden advisory memory. It must not be echoed verbatim to users, and live operational state still requires tools or another source-of-truth check.
 
 ## Environment Variables
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import queue
+import re
 import threading
 
 from datetime import datetime, timezone
@@ -59,6 +60,7 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_DEFAULT_RECALL_MAX_RESULTS = 8
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -381,6 +383,81 @@ def _utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
+_TASK_LOG_PATTERNS = [
+    re.compile(r"\bjob\s+id\b", re.IGNORECASE),
+    re.compile(r"\bPR\s*#\s*\d+\b", re.IGNORECASE),
+    re.compile(r"\bcommit\s+SHA\b", re.IGNORECASE),
+    re.compile(r"\blast\s+run\b.*\b(?:ok|error|failed|green|red)\b", re.IGNORECASE | re.DOTALL),
+    re.compile(r"\breminder\s+set\b", re.IGNORECASE),
+    re.compile(r"\bhealth\s+was\s+(?:green|red|healthy|unhealthy)\b", re.IGNORECASE),
+    re.compile(r"\bassistant\s+updated\b", re.IGNORECASE),
+    re.compile(r"\bno\s+memory\s+update\s+was\s+required\b", re.IGNORECASE),
+]
+_STABLE_MEMORY_CUES = re.compile(
+    r"\b(?:prefers?|preference|always|never|canonical|stable|durable|workflow|convention|rule|remember|likes?|wants?|use\s+.+\s+for)\b",
+    re.IGNORECASE,
+)
+_VOLATILE_STATUS_RE = re.compile(
+    r"\b(?:health\s+was\s+(?:green|red|healthy|unhealthy)|last\s+run\b.*\b(?:ok|error|failed|green|red)|job\s+id\b|PR\s*#\s*\d+)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+_HEX_SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b", re.IGNORECASE)
+_DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}(?:[T ][0-9:.+-Z]+)?\b")
+
+
+def _canonicalize_memory_text(text: str) -> str:
+    """Normalize memory text for duplicate suppression, not display."""
+    normalized = _WHITESPACE_RE.sub(" ", str(text or "").strip().lower())
+    normalized = _HEX_SHA_RE.sub("<sha>", normalized)
+    normalized = _DATE_RE.sub("<date>", normalized)
+    normalized = normalized.replace("better complete answers", "better answers")
+    normalized = normalized.replace("better answer quality", "better answers")
+    normalized = normalized.replace("better reasoning/synthesis", "better reasoning and synthesis")
+    return normalized
+
+
+def _memory_similarity_key(text: str) -> str:
+    """Return a coarse key that collapses repeated variants of one durable fact."""
+    canonical = _canonicalize_memory_text(text)
+    if "qwen3" in canonical and "14b" in canonical:
+        return "model:qwen3-14b-quality"
+    return canonical
+
+
+def _is_task_log_memory(text: str) -> bool:
+    """True for obvious temporary task/status facts that should not become durable memory."""
+    compact = _WHITESPACE_RE.sub(" ", str(text or "").strip())
+    if not compact:
+        return True
+    if _STABLE_MEMORY_CUES.search(compact):
+        return False
+    return any(pattern.search(compact) for pattern in _TASK_LOG_PATTERNS)
+
+
+def _is_stale_operational_status(text: str) -> bool:
+    """True when a recalled item is historical operational state, not live truth."""
+    return bool(_VOLATILE_STATUS_RE.search(str(text or "")))
+
+
+def _dedupe_memory_lines(lines: List[str], *, limit: int | None = None) -> List[str]:
+    """Preserve order while removing exact and near-duplicate memory lines."""
+    deduped: List[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        text = str(line or "").strip()
+        if not text:
+            continue
+        key = _memory_similarity_key(text)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(text)
+        if limit is not None and len(deduped) >= limit:
+            break
+    return deduped
+
+
 def _embedded_profile_name(config: dict[str, Any]) -> str:
     """Return the Hindsight embedded profile name for this Hermes config."""
     profile = config.get("profile", "hermes")
@@ -579,6 +656,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Recall controls
         self._auto_recall = True
         self._recall_max_tokens = 4096
+        self._recall_max_results = _DEFAULT_RECALL_MAX_RESULTS
         self._recall_types: list[str] | None = None
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
@@ -862,6 +940,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
+            {"key": "recall_max_results", "description": "Maximum recalled memory bullets injected into context", "default": _DEFAULT_RECALL_MAX_RESULTS},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
@@ -1187,6 +1266,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
         self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
+        self._recall_max_results = max(1, int(self._config.get("recall_max_results", _DEFAULT_RECALL_MAX_RESULTS)))
         self._recall_types = self._config.get("recall_types") or None
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
@@ -1278,6 +1358,19 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _format_recall_results(self, results: Any, *, numbered: bool = False) -> str:
+        """Format recall results for prompt/tool use with hygiene and dedupe."""
+        raw_lines = []
+        for result in results or []:
+            text = getattr(result, "text", "")
+            if not text or _is_stale_operational_status(text):
+                continue
+            raw_lines.append(str(text).strip())
+        lines = _dedupe_memory_lines(raw_lines, limit=self._recall_max_results)
+        if numbered:
+            return "\n".join(f"{i}. {line}" for i, line in enumerate(lines, 1))
+        return "\n".join(f"- {line}" for line in lines)
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
@@ -1290,9 +1383,9 @@ class HindsightMemoryProvider(MemoryProvider):
             return ""
         logger.debug("Prefetch: returning %d chars of context", len(result))
         header = self._recall_prompt_preamble or (
-            "# Hindsight Memory (persistent cross-session context)\n"
-            "Use this to answer questions about the user and prior sessions. "
-            "Do not call tools to look up information that is already present here."
+            "# Hindsight Memory (advisory historical context)\n"
+            "Use this as potentially relevant background about the user and prior sessions. "
+            "Do not treat recalled operational status as live truth; verify current state with tools or source-of-truth systems."
         )
         return f"{header}\n\n{result}"
 
@@ -1331,7 +1424,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = self._format_recall_results(resp.results) if resp.results else ""
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1431,6 +1524,11 @@ class HindsightMemoryProvider(MemoryProvider):
         if session_id:
             self._session_id = str(session_id).strip()
 
+        combined_turn = f"{user_content}\n{assistant_content}"
+        if _is_task_log_memory(combined_turn):
+            logger.debug("sync_turn: skipped non-durable task/status memory")
+            return
+
         turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
         self._session_turns.append(turn)
         self._turn_counter += 1
@@ -1500,6 +1598,8 @@ class HindsightMemoryProvider(MemoryProvider):
             content = args.get("content", "")
             if not content:
                 return tool_error("Missing required parameter: content")
+            if _is_task_log_memory(content):
+                return json.dumps({"result": "Skipped non-durable task/status memory."})
             context = args.get("context")
             try:
                 retain_kwargs = self._build_retain_kwargs(
@@ -1537,8 +1637,10 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                formatted = self._format_recall_results(resp.results, numbered=True)
+                if not formatted:
+                    return json.dumps({"result": "No durable relevant memories found."})
+                return json.dumps({"result": formatted})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -772,7 +772,17 @@ class TestMemoryContextFencing:
         assert result.startswith("<memory-context>")
         assert result.rstrip().endswith("</memory-context>")
         assert "NOT new user input" in result
+        assert "advisory historical context" in result
+        assert "verify current status" in result
         assert "user likes dark mode" in result
+
+
+    def test_build_memory_context_block_does_not_mark_memory_as_live_truth(self):
+        from agent.memory_manager import build_memory_context_block
+        block = build_memory_context_block("health was green on 2026-05-26")
+        assert "authoritative reference data" not in block
+        assert "not live operational truth" in block
+        assert "verify current status" in block
 
     def test_build_memory_context_block_empty_input(self):
         from agent.memory_manager import build_memory_context_block

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -20,6 +20,9 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _dedupe_memory_lines,
+    _is_stale_operational_status,
+    _is_task_log_memory,
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
@@ -194,6 +197,7 @@ class TestConfig:
         assert provider._auto_recall is True
         assert provider._retain_every_n_turns == 1
         assert provider._recall_max_tokens == 4096
+        assert provider._recall_max_results == 8
         assert provider._recall_max_input_chars == 800
         assert provider._tags is None
         assert provider._recall_tags is None
@@ -215,6 +219,7 @@ class TestConfig:
             retain_context="custom-ctx",
             bank_retain_mission="Extract key facts",
             recall_max_tokens=2048,
+            recall_max_results=3,
             recall_types=["world", "experience"],
             recall_prompt_preamble="Custom preamble:",
             recall_max_input_chars=500,
@@ -233,6 +238,7 @@ class TestConfig:
         assert p._retain_context == "custom-ctx"
         assert p._bank_retain_mission == "Extract key facts"
         assert p._recall_max_tokens == 2048
+        assert p._recall_max_results == 3
         assert p._recall_types == ["world", "experience"]
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
@@ -432,6 +438,67 @@ class TestPostSetup:
         assert saved["timeout"] == 120
 
 
+
+
+# ---------------------------------------------------------------------------
+# Memory hygiene tests
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryHygiene:
+    def test_task_log_classifier_rejects_transient_status(self):
+        assert _is_task_log_memory("No memory update was required for this turn.")
+        assert _is_task_log_memory("job ID 12345 completed")
+        assert _is_task_log_memory("PR #42 merged")
+        assert _is_task_log_memory("commit SHA abc1234 deployed")
+        assert _is_task_log_memory("last run 2026-05-26 error")
+        assert _is_task_log_memory("health was green on 2026-05-26")
+
+    def test_task_log_classifier_preserves_durable_preferences(self):
+        assert not _is_task_log_memory("Tyler prefers concise final answers.")
+        assert not _is_task_log_memory("Canonical Hindsight bank is hermes-default.")
+        assert not _is_task_log_memory("Workflow rule: use session_search for task logs.")
+
+    def test_dedupe_collapses_model_evaluation_variants(self):
+        lines = [
+            "Qwen3 14B gives better reasoning/synthesis.",
+            "Qwen3 14B gave better complete answers.",
+            "Qwen3 14B has better answer quality but is slower.",
+            "Tyler prefers concise answers.",
+        ]
+        assert _dedupe_memory_lines(lines) == [
+            "Qwen3 14B gives better reasoning/synthesis.",
+            "Tyler prefers concise answers.",
+        ]
+
+    def test_stale_operational_status_classifier(self):
+        assert _is_stale_operational_status("health was red on 2026-05-25")
+        assert _is_stale_operational_status("last run 2026-05-25 ok")
+        assert not _is_stale_operational_status("Canonical Hindsight API is http://127.0.0.1:8888")
+
+    def test_sync_turn_skips_non_durable_task_log(self, provider):
+        provider.sync_turn("status?", "No memory update was required for this turn.")
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_not_called()
+
+    def test_sync_turn_preserves_durable_fact(self, provider):
+        provider.sync_turn("remember", "Tyler prefers concise final answers.")
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_called_once()
+
+    def test_recall_format_dedupes_caps_and_drops_stale_status(self, provider_with_config):
+        p = provider_with_config(recall_max_results=2)
+        results = [
+            SimpleNamespace(text="health was green on 2026-05-26"),
+            SimpleNamespace(text="Qwen3 14B gives better reasoning/synthesis."),
+            SimpleNamespace(text="Qwen3 14B gave better complete answers."),
+            SimpleNamespace(text="Tyler prefers concise answers."),
+            SimpleNamespace(text="Canonical bank is hermes-default."),
+        ]
+        assert p._format_recall_results(results) == (
+            "- Qwen3 14B gives better reasoning/synthesis.\n"
+            "- Tyler prefers concise answers."
+        )
 
 # ---------------------------------------------------------------------------
 # Tool handler tests
@@ -1219,7 +1286,7 @@ class TestConfigSchema:
             "recall_tags", "recall_tags_match",
             "auto_recall", "auto_retain",
             "retain_every_n_turns", "retain_async", "retain_context",
-            "recall_max_tokens", "recall_max_input_chars",
+            "recall_max_tokens", "recall_max_results", "recall_max_input_chars",
             "recall_prompt_preamble",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"


### PR DESCRIPTION
## Summary
- Prevent recalled Hindsight memory from being injected into Codex prompts as if it were active user/project context.
- Keep retained memory available only in explicit memory surfaces.
- Document the separation so future runtime changes do not reintroduce hidden memory leakage.

## Test Plan
- `pytest tests/agent/test_memory_provider.py tests/plugins/memory/test_hindsight_provider.py`
- `pytest tests/agent/test_codex_runtime.py`

## Local verification
- Memory/Hindsight targeted tests: 20 passed.
- Codex runtime targeted tests: 72 passed, 1 warning.
- Branch rebased on current `origin/main` before push.
