### PR TITLE
fix: support markdown media attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|tar|gz|tgz|bz2|xz|docx?|odt|rtf|xlsx?|xls|ods|pptx?|ppt|odp|key|txt|md|markdown|csv|tsv|json|xml|ya?ml|toml|ini|cfg|log|html?|py|sh|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -161,6 +161,46 @@ async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sen
     adapter.send_voice.assert_not_awaited()
 
 
+def test_extract_media_accepts_markdown_document_tags():
+    media, cleaned = BasePlatformAdapter.extract_media(
+        "Plan file:\nMEDIA:/home/wikish/.hermes/plans/example-plan.md"
+    )
+
+    assert media == [("/home/wikish/.hermes/plans/example-plan.md", False)]
+    assert "MEDIA:" not in cleaned
+    assert "example-plan.md" not in cleaned
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_routes_markdown_media_tag_to_document_sender(tmp_path, monkeypatch):
+    event = _event(thread_id="topic-1")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "plan.md")
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}),
+        f"MEDIA:{media_file}",
+        event,
+        adapter,
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path=str(media_file),
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_voice.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_streaming_delivery_routes_non_voice_telegram_ogg_media_tag_to_document_sender(tmp_path, monkeypatch):
     event = _event(thread_id="topic-1")


### PR DESCRIPTION
## Summary

- Allow Telegram/gateway `MEDIA:` tags to reference Markdown and common document/code/archive files.
- Add regression coverage for Markdown document extraction.
- Add streaming Telegram delivery coverage so Markdown `MEDIA:` tags route to document upload instead of being left as plain text.

## Why

`MEDIA:/path/to/file.md` was ignored because the gateway parser allowlist did not include `.md`. This caused Markdown plans to appear as plain text paths instead of Telegram document attachments.

## Test Plan

- `python -m pytest tests/gateway/test_tts_media_routing.py::test_extract_media_accepts_markdown_document_tags tests/gateway/test_tts_media_routing.py::test_streaming_delivery_routes_markdown_media_tag_to_document_sender -q -o 'addopts='`
- `python -m pytest tests/gateway/test_tts_media_routing.py tests/gateway/test_extract_local_files.py tests/tools/test_send_message_telegram_proxy.py -q -o 'addopts='`
- `git diff --check -- gateway/platforms/base.py tests/gateway/test_tts_media_routing.py`
