### PR TITLE
fix(codex): opt-out user-facing emit on TTFB watchdog hits

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -271,6 +271,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # signal). The marker advances on *any* event (see codex_runtime), so
     # reasoning-only / tool-call-only turns are not mistaken for a stall.
     # Operators can tune via HERMES_CODEX_TTFB_TIMEOUT_SECONDS (0 disables).
+    # User-facing emit on each kill is opt-out via
+    # HERMES_CODEX_TTFB_EMIT_PER_HIT=0: default preserves the silent-hang
+    # hint behavior, while operators running with a healthy
+    # agent.api_max_retries budget can defer all user notification to the
+    # conversation_loop's max-retries-exhausted path. The file logger.warning
+    # is always emitted for diagnostics regardless of this flag.
     _ttfb_enabled = agent.api_mode == "codex_responses"
     try:
         _ttfb_timeout = float(os.getenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "45"))
@@ -278,6 +284,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
         _ttfb_timeout = 45.0
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
+    _ttfb_emit_per_hit = os.getenv(
+        "HERMES_CODEX_TTFB_EMIT_PER_HIT", "1"
+    ).strip().lower() not in {"0", "false", "no", "off"}
     if _ttfb_enabled:
         # Reset before the worker starts so a marker left over from a previous
         # call on this agent can't be misread as first-byte for this one.
@@ -327,18 +336,19 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 "loop can reconnect.",
                 _elapsed, _ttfb_timeout, api_kwargs.get("model", "unknown"),
             )
-            if _silent_hint:
-                agent._emit_status(
-                    f"⚠️ No first byte from provider in {int(_elapsed)}s "
-                    f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Reconnecting. {_silent_hint}"
-                )
-            else:
-                agent._emit_status(
-                    f"⚠️ No first byte from provider in {int(_elapsed)}s "
-                    f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Reconnecting."
-                )
+            if _ttfb_emit_per_hit:
+                if _silent_hint:
+                    agent._emit_status(
+                        f"⚠️ No first byte from provider in {int(_elapsed)}s "
+                        f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"Reconnecting. {_silent_hint}"
+                    )
+                else:
+                    agent._emit_status(
+                        f"⚠️ No first byte from provider in {int(_elapsed)}s "
+                        f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"Reconnecting."
+                    )
             try:
                 _close_request_client_once("codex_ttfb_kill")
             except Exception:

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -148,6 +148,56 @@ def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
         stop["flag"] = True
 
 
+def test_ttfb_emit_per_hit_opt_out_silences_user_surface(tmp_path, monkeypatch):
+    """HERMES_CODEX_TTFB_EMIT_PER_HIT=0 must suppress the per-hit
+    ``_emit_status`` call so transient TTFB kills are silent on the user
+    surface (Discord, etc.) while the file ``logger.warning`` and the
+    ``TimeoutError`` remain intact. Use when ``agent.api_max_retries`` is
+    high enough that retries reliably auto-recover and the per-kill warning
+    would only be noise."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_CODEX_TTFB_EMIT_PER_HIT", "0")
+
+    closes: list = []
+    statuses: list[str] = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(agent, "_emit_status", lambda msg: statuses.append(msg))
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent, "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    stop = {"flag": False}
+
+    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+        deadline = time.time() + 30
+        while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
+            time.sleep(0.02)
+        raise RuntimeError("connection closed")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_hang)
+
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+        # The watchdog still kills the connection — only the user-facing
+        # emit is suppressed.
+        assert "codex_ttfb_kill" in closes
+        assert "TTFB" in str(excinfo.value)
+        # No status pushed to Discord / platform.
+        assert statuses == [], f"expected no _emit_status calls, got {statuses!r}"
+    finally:
+        stop["flag"] = True
+
+
 def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
     """Once a stream event has arrived, a generation that runs past the TTFB
     cutoff is NOT killed by the watchdog — it completes normally."""


### PR DESCRIPTION
## Summary

Add `HERMES_CODEX_TTFB_EMIT_PER_HIT` (default `1`) so operators with a healthy `agent.api_max_retries` budget can defer user-facing notification to the conversation_loop's max-retries-exhausted path.

## Problem

The `chatgpt.com/backend-api/codex` endpoint has an intermittent failure mode where it accepts the TLS connection but emits zero SSE events. This is well-documented upstream and OPEN:

- [openai/codex#13245](https://github.com/openai/codex/issues/13245) — exact URL match: "Stream disconnected before completion: error sending request for url (https://chatgpt.com/backend-api/codex/responses)"
- [openai/codex#9727](https://github.com/openai/codex/issues/9727) — "idle timeout waiting for SSE" variant
- [community.openai.com Feb 8 2026](https://community.openai.com/t/bug-codex-stream-disconnected-before-completion-on-backend-api-codex-responses-feb-8-2026/1373656) — longstanding, no OpenAI fix

The TTFB watchdog correctly catches this and triggers a fast reconnect. Under sustained `gpt-5.5` load (Hub-Discord production: ~30k context prompt, frequent calls), I measured **roughly one TTFB-hit every 5-10 minutes**. With `agent.api_max_retries: 3` (the codebase default), every observed hit auto-recovered on attempt 2 with latency 2.7-3 s — the user never sees a failed conversation.

What the user *does* see is a steady stream of `⚠️ No first byte from provider in 45s … Reconnecting` warnings in Discord, including the actionable silent-hang hint. Same hint, every 5-10 minutes, for what is effectively a transient blip. This is the noise this PR addresses.

## Solution

Gate the per-hit `_emit_status` calls behind `HERMES_CODEX_TTFB_EMIT_PER_HIT`. **Default is `1` — no behavior change unless operators opt in.**

When set to `0` / `false` / `no` / `off`:
- `logger.warning` still records the kill to the file log (diagnostics preserved)
- The connection is still killed via `codex_ttfb_kill`
- The `TimeoutError` is still raised so the retry loop can recover
- The `_silent_hint`-aware `_emit_status` is **suppressed**
- User-facing notice is then handled by the existing `conversation_loop` max-retries-exhausted emit at `Max retries (N) exhausted — trying fallback`

This preserves the silent-hang hint for the deployment shape where it's most useful (interactive sessions, low retry budget) while giving operators with a healthy retry budget a way to silence transient blips.

## Live Verification

Production Hub gateway, observed window 2026-05-27 12:30-12:38 (8 min, env=0):
- 1 TTFB hit at 12:32:44 (model=gpt-5.5, real Discord session)
- Retry succeeded at 12:33:02 (latency 6.6 s)
- 27 successful gpt-5.5 completions in the same window
- **0 user-facing emits** from the TTFB path

## Test plan

- [x] `tests/agent/test_codex_ttfb_watchdog.py::test_ttfb_emit_per_hit_opt_out_silences_user_surface` — new test, asserts env=0 suppresses emit while preserving kill + TimeoutError
- [x] `tests/agent/test_codex_ttfb_watchdog.py::test_ttfb_includes_silent_hang_hint_for_gpt_5_5` — existing test continues to pass with default env (proves no behavior change when env unset)
- [x] All 5 tests in `test_codex_ttfb_watchdog.py` pass locally

## Backward compatibility

Strict opt-in. Existing deployments see no change. The default emit-per-hit behavior including the silent-hang hint is preserved exactly.