### PR TITLE
fix(slack): rehydrate thread context after restart

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -481,6 +481,14 @@ class SlackAdapter(BasePlatformAdapter):
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
+        # Persistent sessions survive gateway restarts, but this in-memory
+        # adapter state does not. Track successful full-thread injections so
+        # the first ordinary reply after a restart can rehydrate an existing
+        # session without prepending the entire Slack thread on every turn.
+        # Keys follow shared-vs-per-user thread session scoping, and are only
+        # recorded after a non-empty fetch so transient API/empty results retry.
+        self._thread_context_injected_threads: set = set()
+        self._THREAD_CONTEXT_INJECTED_MAX = 5000
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active Assistant statuses by (team_id, channel_id, thread_ts)
@@ -3353,8 +3361,9 @@ class SlackAdapter(BasePlatformAdapter):
             (bot_uid and f"<@{bot_uid}>" in routing_text)
             or self._slack_message_matches_mention_patterns(routing_text)
         )
-        event_thread_ts = event.get("thread_ts")
+        event_thread_ts = str(event.get("thread_ts") or "")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        active_thread_session: Optional[bool] = None
 
         if not is_one_to_one_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
@@ -3372,6 +3381,13 @@ class SlackAdapter(BasePlatformAdapter):
             elif self._slack_strict_mention() and not is_mentioned:
                 return  # Strict mode: ignore until @-mentioned again
             elif not is_mentioned:
+                if is_thread_reply:
+                    active_thread_session = self._has_active_session_for_thread(
+                        channel_id=channel_id,
+                        thread_ts=event_thread_ts,
+                        user_id=user_id,
+                        team_id=team_id,
+                    )
                 reply_to_bot_thread = (
                     is_thread_reply and event_thread_ts in self._bot_message_ts
                 )
@@ -3379,16 +3395,10 @@ class SlackAdapter(BasePlatformAdapter):
                     event_thread_ts is not None
                     and event_thread_ts in self._mentioned_threads
                 )
-                has_session = is_thread_reply and self._has_active_session_for_thread(
-                    channel_id=channel_id,
-                    thread_ts=event_thread_ts,
-                    user_id=user_id,
-                    team_id=team_id,
-                )
                 if (
                     not reply_to_bot_thread
                     and not in_mentioned_thread
-                    and not has_session
+                    and not active_thread_session
                 ):
                     return
 
@@ -3408,22 +3418,48 @@ class SlackAdapter(BasePlatformAdapter):
                     for t in to_remove:
                         self._mentioned_threads.discard(t)
 
-        # When entering a thread for the first time (no existing session),
-        # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
-            channel_id=channel_id,
-            thread_ts=event_thread_ts,
-            user_id=user_id,
-            team_id=team_id,
-        ):
+        # Fetch context on first entry and rehydrate an already-active
+        # persistent session once after each gateway restart. Explicit mentions
+        # remain a fresh intent signal and always refresh Slack-side context;
+        # this preserves strict-mention behavior without making ordinary
+        # non-strict replies repeatedly inject the full thread.
+        if is_thread_reply and active_thread_session is None:
+            active_thread_session = self._has_active_session_for_thread(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+                team_id=team_id,
+            )
+        thread_injection_key = f"{team_id}:{channel_id}:{event_thread_ts}"
+        store_cfg = getattr(getattr(self, "_session_store", None), "config", None)
+        if getattr(store_cfg, "thread_sessions_per_user", False):
+            thread_injection_key = f"{thread_injection_key}:{user_id}"
+        should_fetch_thread_context = is_thread_reply and (
+            is_mentioned
+            or not active_thread_session
+            or thread_injection_key not in self._thread_context_injected_threads
+        )
+        if should_fetch_thread_context:
             thread_context = await self._fetch_thread_context(
                 channel_id=channel_id,
                 thread_ts=event_thread_ts,
                 current_ts=ts,
                 team_id=team_id,
+                force_refresh=is_mentioned,
             )
             if thread_context:
                 text = thread_context + text
+                self._thread_context_injected_threads.add(thread_injection_key)
+                if (
+                    len(self._thread_context_injected_threads)
+                    > self._THREAD_CONTEXT_INJECTED_MAX
+                ):
+                    excess = (
+                        len(self._thread_context_injected_threads)
+                        - self._THREAD_CONTEXT_INJECTED_MAX // 2
+                    )
+                    for old_key in list(self._thread_context_injected_threads)[:excess]:
+                        self._thread_context_injected_threads.discard(old_key)
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -4293,15 +4329,15 @@ class SlackAdapter(BasePlatformAdapter):
         current_ts: str,
         team_id: str = "",
         limit: int = 30,
+        force_refresh: bool = False,
     ) -> str:
         """Fetch recent thread messages to provide context when the bot is
-        mentioned mid-thread for the first time.
+        mentioned mid-thread or a persistent session needs restart recovery.
 
-        This method is only called when there is NO active session for the
-        thread (guarded at the call site by _has_active_session_for_thread).
-        That guard ensures thread messages are prepended only on the very
-        first turn — after that the session history already holds them, so
-        there is no duplication across subsequent turns.
+        The call site limits ordinary replies to first-entry/no-session cases
+        and one successful rehydration per process/session scope. Explicit
+        mentions pass ``force_refresh=True`` so newer Slack replies are not
+        hidden by the short-lived API cache.
 
         Results are cached for _THREAD_CACHE_TTL seconds per thread to avoid
         hammering conversations.replies (Tier 3, ~50 req/min).
@@ -4312,7 +4348,11 @@ class SlackAdapter(BasePlatformAdapter):
         cache_key = f"{channel_id}:{thread_ts}:{team_id}"
         now = time.monotonic()
         cached = self._thread_context_cache.get(cache_key)
-        if cached and (now - cached.fetched_at) < self._THREAD_CACHE_TTL:
+        if (
+            not force_refresh
+            and cached
+            and (now - cached.fetched_at) < self._THREAD_CACHE_TTL
+        ):
             return cached.content
 
         try:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1361,6 +1361,176 @@ class TestBangPrefixCommands:
 
 
 # ---------------------------------------------------------------------------
+# TestSlackThreadContextRehydration
+# ---------------------------------------------------------------------------
+
+
+class TestSlackThreadContextRehydration:
+    """Restart recovery must not turn into repeated full-thread injection."""
+
+    def _make_thread_event(
+        self,
+        *,
+        text="continue",
+        ts="1234567890.000002",
+        user="U_USER",
+    ):
+        return {
+            "text": text,
+            "user": user,
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": ts,
+            "thread_ts": "1111111111.000001",
+        }
+
+    def _prepare_adapter(self, adapter, *, per_user=False, strict_mention=False):
+        adapter.config.extra["strict_mention"] = strict_mention
+        adapter._team_bot_user_ids = {"T123": "U_BOT"}
+        adapter._channel_team = {"C123": "T123"}
+        adapter._has_active_session_for_thread = MagicMock(return_value=True)
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="parent")
+        adapter._user_name_cache = {
+            ("T123", "U_USER"): "User",
+            ("T123", "U_OTHER"): "Other",
+        }
+        adapter._session_store = MagicMock(
+            config=MagicMock(thread_sessions_per_user=per_user)
+        )
+
+    @pytest.mark.asyncio
+    async def test_active_session_rehydrates_once_after_restart(self, adapter):
+        self._prepare_adapter(adapter)
+        adapter._fetch_thread_context = AsyncMock(
+            return_value="[Thread context]\nearlier details\n[End]\n\n"
+        )
+
+        await adapter._handle_slack_message(self._make_thread_event())
+        first_event = adapter.handle_message.await_args.args[0]
+
+        adapter.handle_message.reset_mock()
+        await adapter._handle_slack_message(
+            self._make_thread_event(text="ordinary follow-up", ts="1234567890.000003")
+        )
+        second_event = adapter.handle_message.await_args.args[0]
+
+        adapter._fetch_thread_context.assert_awaited_once_with(
+            channel_id="C123",
+            thread_ts="1111111111.000001",
+            current_ts="1234567890.000002",
+            team_id="T123",
+            force_refresh=False,
+        )
+        assert first_event.text.startswith("[Thread context]\nearlier details")
+        assert second_event.text == "ordinary follow-up"
+
+    @pytest.mark.asyncio
+    async def test_empty_rehydration_retries_next_reply(self, adapter):
+        self._prepare_adapter(adapter)
+        adapter._fetch_thread_context = AsyncMock(
+            side_effect=["", "[Thread context]\nrecovered\n[End]\n\n"]
+        )
+
+        await adapter._handle_slack_message(self._make_thread_event())
+        await adapter._handle_slack_message(
+            self._make_thread_event(text="retry", ts="1234567890.000003")
+        )
+
+        assert adapter._fetch_thread_context.await_count == 2
+        assert adapter.handle_message.await_args.args[0].text.startswith(
+            "[Thread context]\nrecovered"
+        )
+
+    @pytest.mark.asyncio
+    async def test_shared_thread_rehydration_is_deduped_across_users(self, adapter):
+        self._prepare_adapter(adapter, per_user=False)
+        adapter._fetch_thread_context = AsyncMock(
+            return_value="[Thread context]\nshared\n[End]\n\n"
+        )
+
+        await adapter._handle_slack_message(self._make_thread_event(user="U_USER"))
+        adapter.handle_message.reset_mock()
+        await adapter._handle_slack_message(
+            self._make_thread_event(
+                text="other user reply",
+                ts="1234567890.000003",
+                user="U_OTHER",
+            )
+        )
+
+        adapter._fetch_thread_context.assert_awaited_once()
+        assert adapter.handle_message.await_args.args[0].text == "other user reply"
+
+    @pytest.mark.asyncio
+    async def test_per_user_thread_sessions_rehydrate_independently(self, adapter):
+        self._prepare_adapter(adapter, per_user=True)
+        adapter._fetch_thread_context = AsyncMock(
+            return_value="[Thread context]\nshared\n[End]\n\n"
+        )
+
+        await adapter._handle_slack_message(self._make_thread_event(user="U_USER"))
+        await adapter._handle_slack_message(
+            self._make_thread_event(
+                text="other user reply",
+                ts="1234567890.000003",
+                user="U_OTHER",
+            )
+        )
+
+        assert adapter._fetch_thread_context.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_strict_explicit_mentions_still_refresh_context(self, adapter):
+        self._prepare_adapter(adapter, strict_mention=True)
+        adapter._fetch_thread_context = AsyncMock(
+            side_effect=[
+                "[Thread context]\nfirst snapshot\n[End]\n\n",
+                "[Thread context]\nupdated snapshot\n[End]\n\n",
+            ]
+        )
+
+        await adapter._handle_slack_message(
+            self._make_thread_event(text="<@U_BOT> refresh")
+        )
+        await adapter._handle_slack_message(
+            self._make_thread_event(
+                text="<@U_BOT> refresh again",
+                ts="1234567890.000003",
+            )
+        )
+
+        assert adapter._fetch_thread_context.await_count == 2
+        assert all(
+            awaited.kwargs["force_refresh"] is True
+            for awaited in adapter._fetch_thread_context.await_args_list
+        )
+        assert adapter.handle_message.await_args.args[0].text.startswith(
+            "[Thread context]\nupdated snapshot"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ordinary_followups_never_repeat_successful_rehydration(self, adapter):
+        self._prepare_adapter(adapter)
+        adapter._fetch_thread_context = AsyncMock(
+            return_value="[Thread context]\nonce\n[End]\n\n"
+        )
+
+        for index in range(4):
+            await adapter._handle_slack_message(
+                self._make_thread_event(
+                    text=f"reply {index}",
+                    ts=f"1234567890.00000{index + 2}",
+                )
+            )
+
+        adapter._fetch_thread_context.assert_awaited_once()
+        delivered = [awaited.args[0].text for awaited in adapter.handle_message.await_args_list]
+        assert delivered[0].startswith("[Thread context]\nonce")
+        assert delivered[1:] == ["reply 1", "reply 2", "reply 3"]
+
+
+# ---------------------------------------------------------------------------
 # TestIncomingDocumentHandling
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -504,6 +504,72 @@ class TestSlackThreadContext:
         assert context == ""
 
     @pytest.mark.asyncio
+    async def test_api_empty_thread_is_not_cached_and_retries(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(
+            side_effect=[
+                {"messages": []},
+                {
+                    "messages": [
+                        {"ts": "1000.0", "user": "U1", "text": "Parent"},
+                        {"ts": "1000.2", "user": "U1", "text": "Current"},
+                    ]
+                },
+            ]
+        )
+        adapter._user_name_cache = {("T1", "U1"): "Alice"}
+
+        first = await adapter._fetch_thread_context(
+            channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"
+        )
+        second = await adapter._fetch_thread_context(
+            channel_id="C1", thread_ts="1000.0", current_ts="1000.2", team_id="T1"
+        )
+
+        assert first == ""
+        assert "Alice: Parent" in second
+        assert mock_client.conversations_replies.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_bypasses_nonempty_context_cache(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(
+            side_effect=[
+                {
+                    "messages": [
+                        {"ts": "1000.0", "user": "U1", "text": "Old parent"},
+                        {"ts": "1000.1", "user": "U1", "text": "Current"},
+                    ]
+                },
+                {
+                    "messages": [
+                        {"ts": "1000.0", "user": "U1", "text": "Old parent"},
+                        {"ts": "1000.15", "user": "U1", "text": "New reply"},
+                        {"ts": "1000.2", "user": "U1", "text": "Current"},
+                    ]
+                },
+            ]
+        )
+        adapter._user_name_cache = {("T1", "U1"): "Alice"}
+
+        first = await adapter._fetch_thread_context(
+            channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"
+        )
+        refreshed = await adapter._fetch_thread_context(
+            channel_id="C1",
+            thread_ts="1000.0",
+            current_ts="1000.2",
+            team_id="T1",
+            force_refresh=True,
+        )
+
+        assert "New reply" not in first
+        assert "New reply" in refreshed
+        assert mock_client.conversations_replies.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_api_failure_returns_empty(self):
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]


### PR DESCRIPTION
## Summary
- port restart rehydration from the obsolete Slack adapter into `plugins/platforms/slack/adapter.py` on current `main`
- rehydrate an active persistent thread session once per gateway process/session scope, marking success only after non-empty context
- preserve shared-thread dedupe and `thread_sessions_per_user` isolation
- refresh Slack context on explicit thread mentions (including strict-mention mode) while preventing repeated full-thread injection on ordinary follow-ups
- bypass the short-lived thread-context cache for explicit mentions so newer replies are visible

## Test Plan
- `.venv/bin/python -m pytest tests/gateway/test_slack.py::TestSlackThreadContextRehydration tests/gateway/test_slack_approval_buttons.py::TestSlackThreadContext::test_api_empty_thread_is_not_cached_and_retries tests/gateway/test_slack_approval_buttons.py::TestSlackThreadContext::test_force_refresh_bypasses_nonempty_context_cache -q -o 'addopts='` — 8 passed
- `.venv/bin/python -m pytest tests/gateway/test_slack*.py -q -o 'addopts='` — 449 passed (52 existing runtime warnings)
- `.venv/bin/ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py` — passed
- `git diff --check` — passed

## Notes
This branch was rebuilt on current upstream `main`; the obsolete `gateway/platforms/slack.py` changes are no longer present.
