### PR TITLE
fix(weixin): skip content dedup for approval commands

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1392,10 +1392,19 @@ class WeixinAdapter(BasePlatformAdapter):
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
         if text:
-            content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
-            if self._dedup.is_duplicate(content_key):
-                logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
-                return
+            # Skip content dedup for approval commands — user may send
+            # duplicate /approve or /deny in quick succession for sequential
+            # dangerous commands and we must not silently eat the second one.
+            stripped = text.strip().lower()
+            is_approval_cmd = any(
+                stripped == cmd or stripped.startswith(cmd + " ")
+                for cmd in ("/approve", "/deny", "/always", "/cancel")
+            )
+            if not is_approval_cmd:
+                content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
+                if self._dedup.is_duplicate(content_key):
+                    logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
+                    return
 
         chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)
         if chat_type == "group":


### PR DESCRIPTION
## Problem

When the user sends multiple `/approve` or `/deny` commands in quick succession (e.g. approving sequential dangerous sudo commands), the content-fingerprint dedup (MD5) in `WeixinAdapter._process_message` silently drops the second identical message within the 5-minute TTL window.

## Fix

Skip the content-fingerprint dedup for known approval commands (`/approve`, `/deny`, `/always`, `/cancel`) so repeated approvals always reach the gateway handler.

## Testing

- Sequential `sudo systemctl stop` and `sudo systemctl restart` commands now both properly prompt for approval
- Second `/approve` response is no longer silently discarded