### PR TITLE
ci(docker): simplify tagging — push both :main and :latest on main push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,8 +28,7 @@ permissions:
   contents: read
 
 # Concurrency: push/release runs are NEVER cancelled so every merge gets
-# its own :main or release-tagged image.  :latest is guarded separately
-# by the move-latest job.  PR runs reuse a PR-scoped group with
+# its own image.  PR runs reuse a PR-scoped group with
 # cancel-in-progress: true so rapid pushes to the same PR collapse to the
 # latest commit.
 concurrency:
@@ -140,12 +139,6 @@ jobs:
       # Push amd64 by digest only (no tag).  The merge job assembles the
       # tagged manifest list.  `push-by-digest=true` is docker's recommended
       # pattern for multi-runner multi-platform builds.
-      #
-      # We apply the OCI revision label here (and again on arm64) because
-      # the move-latest job reads it off the linux/amd64 sub-manifest
-      # config of the floating tag to decide whether it's safe to advance.
-      # The label must be on each per-arch image — manifest lists themselves
-      # don't carry image config labels.
       - name: Push amd64 by digest
         id: push
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
@@ -258,30 +251,17 @@ jobs:
   # ---------------------------------------------------------------------------
   # Stitch both per-arch digests into a single tagged multi-arch manifest.
   # This is a registry-side operation — no building, no layer re-push —
-  # so it runs in ~30 seconds.  On main pushes it produces :main; on
-  # releases it produces :<release_tag_name>.
+  # so it runs in ~30 seconds.
   #
-  # For main pushes the ancestor check runs BEFORE the manifest push so
-  # we never overwrite :main with an older commit.  The top-level
-  # concurrency group (`docker-${{ github.ref }}` with
-  # `cancel-in-progress: false`) already serialises runs per ref; the
-  # ancestor check is defense-in-depth.
+  # On main pushes: tags both :main and :latest.
+  # On releases: tags :<release_tag_name>.
   # ---------------------------------------------------------------------------
   merge:
     if: github.repository == 'NousResearch/hermes-agent' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release')
     runs-on: ubuntu-latest
     needs: [build-amd64, build-arm64]
     timeout-minutes: 10
-    outputs:
-      pushed_release_tag: ${{ steps.mark_release_pushed.outputs.pushed }}
-      release_tag: ${{ steps.tag.outputs.tag }}
     steps:
-      - name: Checkout code
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 1000
-
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -298,86 +278,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Read the git revision label off the current :main manifest, then
-      # use `git merge-base --is-ancestor` to check whether our commit is
-      # a descendant of it.  If :main doesn't exist yet, or its label is
-      # missing, we treat that as "safe to publish".  If another run
-      # already advanced :main past us (or diverged), we skip and leave
-      # it alone.
-      - name: Decide whether to move :main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        id: main_check
-        run: |
-          set -euo pipefail
-          image=nousresearch/hermes-agent
-
-          image_json=$(
-            docker buildx imagetools inspect "${image}:main" \
-              --format '{{ json (index .Image "linux/amd64") }}' \
-              2>/dev/null || true
-          )
-
-          if [ -z "${image_json}" ]; then
-            echo "No existing :main (or inspect failed) — safe to publish."
-            echo "push_main=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          current_sha=$(
-            printf '%s' "${image_json}" \
-              | jq -r '.config.Labels."org.opencontainers.image.revision" // ""'
-          )
-
-          if [ -z "${current_sha}" ]; then
-            echo "Registry :main has no revision label — safe to publish."
-            echo "push_main=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Registry :main is at ${current_sha}"
-          echo "This run is at      ${GITHUB_SHA}"
-
-          if [ "${current_sha}" = "${GITHUB_SHA}" ]; then
-            echo ":main already points at our SHA — nothing to do."
-            echo "push_main=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if ! git cat-file -e "${current_sha}^{commit}" 2>/dev/null; then
-            git fetch --no-tags --prune origin \
-              "+refs/heads/main:refs/remotes/origin/main" \
-              || true
-          fi
-
-          if ! git cat-file -e "${current_sha}^{commit}" 2>/dev/null; then
-            echo "Registry :main points at an unknown commit (${current_sha}); refusing to overwrite."
-            echo "push_main=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if git merge-base --is-ancestor "${current_sha}" "${GITHUB_SHA}"; then
-            echo "Our commit is a descendant of :main — safe to advance."
-            echo "push_main=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Another run advanced :main past us (or diverged) — leaving it alone."
-            echo "push_main=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Compute the tag for this run.  Main pushes tag directly as :main
-      # (no per-commit SHA tags); releases use the release tag name.
-      - name: Compute tag
-        id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=main" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Gate the manifest push on the ancestor check for main pushes.
-      # For releases there is no gate — the check doesn't even run.
       - name: Create manifest list and push
-        if: github.event_name != 'push' || steps.main_check.outputs.push_main == 'true'
         working-directory: /tmp/digests
         run: |
           set -euo pipefail
@@ -385,137 +286,26 @@ jobs:
           for digest_file in *; do
             args+=("${IMAGE_NAME}@sha256:${digest_file}")
           done
-          docker buildx imagetools create \
-            -t "${IMAGE_NAME}:${TAG}" \
-            "${args[@]}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            docker buildx imagetools create \
+              -t "${IMAGE_NAME}:${TAG}" \
+              "${args[@]}"
+          else
+            docker buildx imagetools create \
+              -t "${IMAGE_NAME}:main" \
+              -t "${IMAGE_NAME}:latest" \
+              "${args[@]}"
+          fi
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          TAG: ${{ steps.tag.outputs.tag }}
 
       - name: Inspect image
-        if: github.event_name != 'push' || steps.main_check.outputs.push_main == 'true'
         run: |
-          docker buildx imagetools inspect "${IMAGE_NAME}:${TAG}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            docker buildx imagetools inspect "${IMAGE_NAME}:${{ github.event.release.tag_name }}"
+          else
+            docker buildx imagetools inspect "${IMAGE_NAME}:main"
+          fi
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          TAG: ${{ steps.tag.outputs.tag }}
-
-      # Signal to move-latest that the release tag is live.
-      - name: Mark release tag pushed
-        id: mark_release_pushed
-        if: github.event_name == 'release'
-        run: echo "pushed=true" >> "$GITHUB_OUTPUT"
-
-  # ---------------------------------------------------------------------------
-  # Move :latest to point at the release tag the merge job pushed.
-  #
-  # :latest is the floating tag that tracks the most recent stable release.
-  # Only `release: published` events advance it — never main pushes.
-  #
-  # We still run an ancestor check against the existing :latest so that a
-  # backport release on an older branch (e.g. patching v1.1.5 after v1.2.3
-  # is out) doesn't drag :latest backwards.  The check is the same shape
-  # as the ancestor check in the merge job for :main: read the OCI
-  # revision label off the current :latest, look up that commit in git,
-  # and only advance if our release commit is a strict descendant.
-  # ---------------------------------------------------------------------------
-  move-latest:
-    if: |
-      github.repository == 'NousResearch/hermes-agent'
-      && github.event_name == 'release'
-      && needs.merge.outputs.pushed_release_tag == 'true'
-    needs: merge
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    concurrency:
-      group: docker-move-latest
-      cancel-in-progress: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 1000
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Decide whether to move :latest
-        id: latest_check
-        run: |
-          set -euo pipefail
-          image=nousresearch/hermes-agent
-
-          image_json=$(
-            docker buildx imagetools inspect "${image}:latest" \
-              --format '{{ json (index .Image "linux/amd64") }}' \
-              2>/dev/null || true
-          )
-
-          if [ -z "${image_json}" ]; then
-            echo "No existing :latest (or inspect failed) — safe to publish."
-            echo "push_latest=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          current_sha=$(
-            printf '%s' "${image_json}" \
-              | jq -r '.config.Labels."org.opencontainers.image.revision" // ""'
-          )
-
-          if [ -z "${current_sha}" ]; then
-            echo "Registry :latest has no revision label — safe to publish."
-            echo "push_latest=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Registry :latest is at ${current_sha}"
-          echo "This release is at  ${GITHUB_SHA}"
-
-          if [ "${current_sha}" = "${GITHUB_SHA}" ]; then
-            echo ":latest already points at our SHA — nothing to do."
-            echo "push_latest=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Make sure we have the :latest commit locally for merge-base.
-          # Releases can be cut from any branch, so fetch broadly.
-          if ! git cat-file -e "${current_sha}^{commit}" 2>/dev/null; then
-            git fetch --no-tags --prune origin \
-              "+refs/heads/main:refs/remotes/origin/main" \
-              || true
-          fi
-
-          if ! git cat-file -e "${current_sha}^{commit}" 2>/dev/null; then
-            echo "Registry :latest points at an unknown commit (${current_sha}); refusing to overwrite."
-            echo "push_latest=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Our release SHA must be a descendant of the current :latest.
-          # Backport releases on older branches won't satisfy this and will
-          # be left alone — :latest stays on the newer release.
-          if git merge-base --is-ancestor "${current_sha}" "${GITHUB_SHA}"; then
-            echo "Our release commit is a descendant of :latest — safe to advance."
-            echo "push_latest=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Existing :latest is newer than this release (likely a backport) — leaving it alone."
-            echo "push_latest=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Retag the already-pushed release manifest as :latest.
-      - name: Move :latest to this release tag
-        if: steps.latest_check.outputs.push_latest == 'true'
-        env:
-          RELEASE_TAG: ${{ needs.merge.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-          image=nousresearch/hermes-agent
-          docker buildx imagetools create \
-            --tag "${image}:latest" \
-            "${image}:${RELEASE_TAG}"


### PR DESCRIPTION
## What does this PR do?

Simplifies the Docker publish workflow by removing the entire ancestor-check + move-latest machinery. On main pushes, the merge job now tags both `:main` and `:latest` in a single `imagetools create` call instead of the previous two-phase approach (merge job tags `:main` only, separate `move-latest` job retags as `:latest` on release events).

The ancestor checks were defense-in-depth against out-of-order concurrent runs, but the top-level concurrency group (`docker-${{ github.ref }}` with `cancel-in-progress: false`) already serializes per-ref — making the checks redundant complexity.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `.github/workflows/docker-publish.yml`: Removed `move-latest` job entirely
- `.github/workflows/docker-publish.yml`: Removed `Decide whether to move :main` step (ancestor check in merge job)
- `.github/workflows/docker-publish.yml`: Removed `Compute tag` step
- `.github/workflows/docker-publish.yml`: Removed `push_main` gate on manifest push
- `.github/workflows/docker-publish.yml`: Removed merge job outputs (nothing downstream needs them)
- `.github/workflows/docker-publish.yml`: Merge job now tags both `:main` and `:latest` in one `imagetools create` call on main pushes

Net: -229 lines.

## How to Test

1. Merge to main, observe the `docker-publish` workflow run
2. Verify both `nousresearch/hermes-agent:main` and `nousresearch/hermes-agent:latest` are updated on Docker Hub
3. Verify release tag pushes still produce `:<release_tag>` only

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, CI workflow change
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
