### PR TITLE
fix(volcengine): strip XML attribute fragments from tool_use.name (#33007)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1664,6 +1664,27 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if not tool_name:
         return None
 
+    # VolcEngine api/plan workaround (issue #33007): the endpoint's
+    # protocol-translation layer occasionally leaks raw XML attribute
+    # fragments into tool_use.name, e.g.
+    #   `terminal" parameter="command" string="true`
+    #   `execute_code" parameter="code" string="true`
+    #   `session_search" parameter="session_id" string="true`
+    # We trim at the first unambiguous XML/quote character so the rest
+    # of the repair pipeline (lowercase / snake_case / fuzzy match)
+    # can resolve the cleaned name to a real tool.
+    #
+    # Crucially we DO NOT split on whitespace: legitimate inputs like
+    # "write file" must keep flowing through ``_norm`` -> ``write_file``
+    # (covered by test_space_to_underscore in
+    # tests/run_agent/test_repair_tool_call_name.py).
+    for _xml_sep in ('"', "'", "<", ">"):
+        _idx = tool_name.find(_xml_sep)
+        if _idx > 0:
+            tool_name = tool_name[:_idx]
+    if not tool_name:
+        return None
+
     def _norm(s: str) -> str:
         return s.lower().replace("-", "_").replace(" ", "_")
 

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -25,6 +25,8 @@ VALID = {
     "read_file",
     "write_file",
     "terminal",
+    "execute_code",
+    "session_search",
 }
 
 
@@ -115,3 +117,72 @@ class TestEdgeCases:
     def test_very_long_name_does_not_match_by_accident(self, repair):
         # Fuzzy match should not claim a tool for something obviously unrelated.
         assert repair("ThisIsNotRemotelyARealToolName_tool") is None
+
+
+class TestVolcEngineXmlPollution:
+    """Regression coverage for #33007 — VolcEngine ``api/plan`` endpoint
+    leaks raw XML attribute fragments into ``tool_use.name``.
+
+    Observed in production with the ``anthropic_messages`` API mode:
+
+        terminal" parameter="command" string="true
+        execute_code" parameter="code" string="true
+        session_search" parameter="session_id" string="true
+
+    The fix trims at the first ``"``/``'``/``<``/``>`` so the rest of
+    the repair pipeline can resolve the cleaned name to a real tool.
+    """
+
+    def test_terminal_with_xml_attribute_pollution(self, repair):
+        # Exact pattern from the bug report (terminal call).
+        polluted = 'terminal" parameter="command" string="true'
+        assert repair(polluted) == "terminal"
+
+    def test_execute_code_with_xml_attribute_pollution(self, repair):
+        polluted = 'execute_code" parameter="code" string="true'
+        assert repair(polluted) == "execute_code"
+
+    def test_session_search_with_xml_attribute_pollution(self, repair):
+        polluted = 'session_search" parameter="session_id" string="true'
+        assert repair(polluted) == "session_search"
+
+    def test_camel_case_tool_with_xml_pollution(self, repair):
+        # If the polluted prefix is CamelCase / suffixed, the rest of
+        # the pipeline (CamelCase -> snake_case, _tool strip) still runs.
+        polluted = 'BrowserClick_tool" parameter="selector" string="true'
+        assert repair(polluted) == "browser_click"
+
+    def test_tool_name_with_trailing_quote_only(self, repair):
+        # Minimal leak — just a stray trailing quote, no full attribute.
+        assert repair('terminal"') == "terminal"
+
+    def test_tool_name_with_angle_bracket_pollution(self, repair):
+        # Defensive — same root cause, raw '<' bleeding through.
+        assert repair("terminal<parameter=command") == "terminal"
+
+    def test_tool_name_with_single_quote_pollution(self, repair):
+        # Defensive — same root cause, single-quoted attribute style.
+        assert repair("terminal' parameter='command' string='true") == "terminal"
+
+    def test_clean_tool_name_unaffected_by_sanitizer(self, repair):
+        # Pure passthrough — no XML/quote chars, no change.
+        assert repair("execute_code") == "execute_code"
+        assert repair("session_search") == "session_search"
+
+    def test_space_separated_name_still_normalizes(self, repair):
+        # Critical: the XML strip must NOT consume whitespace, or the
+        # legitimate ``"write file" -> write_file`` repair path breaks.
+        assert repair("write file") == "write_file"
+
+    def test_pollution_with_unknown_tool_root_still_fails(self, repair):
+        # Sanitizer must not mask invalid tool names by laundering them
+        # through the cleaner.
+        polluted = 'no_such_tool" parameter="x" string="true'
+        assert repair(polluted) is None
+
+    def test_leading_quote_falls_through_to_fuzzy_match(self, repair):
+        # Sanitizer only trims when the XML char is at idx > 0 — a
+        # name that *starts* with a quote is left untouched so the
+        # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
+        # recover the obvious target.
+        assert repair('"terminal"') == "terminal"


### PR DESCRIPTION
## Summary

VolcEngine's `api/plan` endpoint (used via `api_mode: anthropic_messages`) occasionally emits raw XML attribute fragments inside `tool_use.name`. The corruption happens server-side in the provider's protocol-translation layer — it converts the model's native XML-style tool emission into Anthropic Messages `tool_use` blocks but only splits at the first whitespace inside the opening tag, so given:

```xml
<terminal parameter="command" string="true">…</terminal>
```

…it serializes the block as:

```json
{"type": "tool_use", "name": "terminal\" parameter=\"command\" string=\"true", "input": {…}}
```

Hermes correctly trusts `tc.function.name` (it comes from the SDK's parsed `tool_use` field), so the polluted name propagates straight into `repair_tool_call`, which has no rule for stripping XML attribute fragments. Result: **every** tool call fails, runs 3 retries, and aborts as partial.

This patch adds a minimal sanitizer at the very top of `repair_tool_call` that trims at the first `"`, `'`, `<`, or `>` character (when `idx > 0`), then lets the rest of the existing pipeline (lowercase / snake_case / fuzzy match) resolve the cleaned name.

## Before / After

| Endpoint response (`tool_use.name`) | Before | After |
|---|---|---|
| `terminal" parameter="command" string="true` | ❌ Unknown tool → 3 retries → partial abort | ✅ Routes to `terminal` |
| `execute_code" parameter="code" string="true` | ❌ Unknown tool → 3 retries → partial abort | ✅ Routes to `execute_code` |
| `session_search" parameter="session_id" string="true` | ❌ Unknown tool → 3 retries → partial abort | ✅ Routes to `session_search` |
| `BrowserClick_tool" parameter="selector" string="true` | ❌ Unknown tool | ✅ Routes to `browser_click` |
| `terminal"` (minimal leak) | ❌ Unknown tool | ✅ Routes to `terminal` |
| `terminal` (clean) | ✅ Routes | ✅ Routes (unchanged) |
| `"write file"` (multi-word, legitimate) | ✅ → `write_file` | ✅ → `write_file` (unchanged) |
| `no_such_tool" parameter="x" string="true` | ❌ None | ❌ None (invalid root still rejected) |

## Root Cause

This is a **VolcEngine `api/plan` server-side bug, not a Hermes bug**. Their endpoint's XML→Anthropic-tool-use translator stops parsing the opening tag at whitespace rather than at the closing `>`, so everything after the tool name leaks into the `name` field of the emitted `tool_use` block. The pattern is uniform across all tools (`terminal`, `execute_code`, `session_search`) which is the smoking gun that this is a server-side translation bug, not anything model-specific.

The reporter cannot reach VolcEngine to file the upstream bug, and their CodingPlan subscription has no alternative endpoint to switch to, so a defensive fix in Hermes is the only realistic mitigation for affected users.

## Minimal Repro

```yaml
# config.yaml
model:
  default: claude-opus-4-7
  provider: volcengine
providers:
  volcengine:
    name: VolcEngine
    base_url: https://ark.cn-beijing.volces.com/api/plan
    api_key: <YOUR_ARK_KEY>
    api_mode: anthropic_messages
```

Send any message that requires a tool call (e.g. via the Telegram gateway: `"run ls for me"`). Every turn fails with `Unknown tool '<name>" parameter="..." string="true'`.

## Architecture / Why `repair_tool_call`

`repair_tool_call` in `agent/agent_runtime_helpers.py` is the single chokepoint every tool name passes through before the agent decides whether to dispatch or to emit `Unknown tool`. It already normalizes case, separators, CamelCase, and `_tool` suffixes for #14784, with a fuzzy-match fallback. Adding the XML strip here:

1. Keeps the fix in **one place** instead of leaking provider-specific logic into multiple adapters.
2. Composes naturally with the existing normalizations (CamelCase + XML pollution mix already covered by `test_camel_case_tool_with_xml_pollution`).
3. Keeps the repair pipeline the central safety net — exactly what it's designed for.
4. Adds zero cost on the happy path (one `find()` per separator, all return `-1`).

**Crucial design choice:** the sanitizer triggers on `"`, `'`, `<`, `>` only — never on whitespace. Splitting on whitespace would break the existing `"write file" → write_file` repair path (verified by `test_space_to_underscore`, which still passes).

## Tests

11 new regression cases in `tests/run_agent/test_repair_tool_call_name.py::TestVolcEngineXmlPollution`:

- `test_terminal_with_xml_attribute_pollution` — exact pattern from the bug report
- `test_execute_code_with_xml_attribute_pollution` — second observed tool
- `test_session_search_with_xml_attribute_pollution` — third observed tool
- `test_camel_case_tool_with_xml_pollution` — combined CamelCase + XML leak
- `test_tool_name_with_trailing_quote_only` — minimal-leak case
- `test_tool_name_with_angle_bracket_pollution` — defensive `<` variant
- `test_tool_name_with_single_quote_pollution` — defensive `'` variant
- `test_clean_tool_name_unaffected_by_sanitizer` — pure passthrough
- `test_space_separated_name_still_normalizes` — guards the `"write file" → write_file` path
- `test_pollution_with_unknown_tool_root_still_fails` — sanitizer doesn't launder invalid roots
- `test_leading_quote_falls_through_to_fuzzy_match` — `idx > 0` guard documented

**Without** the fix: 6/11 new tests **FAIL** (verified via `git stash`).
**With** the fix: 29/29 pass in the file (11 new + 18 pre-existing #14784 regression tests preserved).

## Local Checks

```bash
$ pytest tests/run_agent/test_repair_tool_call_name.py -q
29 passed in 0.48s

$ pytest tests/run_agent/test_repair_tool_call_name.py \
         tests/run_agent/test_repair_tool_call_arguments.py \
         tests/run_agent/test_streaming_tool_call_repair.py -q
62 passed in 0.68s

$ ruff check agent/agent_runtime_helpers.py tests/run_agent/test_repair_tool_call_name.py
All checks passed!
```

## Scope

- ✅ Touches **only** `agent/agent_runtime_helpers.py::repair_tool_call` and one test file.
- ✅ No provider/adapter code changed — keeps the fix portable across every entry point that resolves a tool name.
- ✅ Zero behavior change on the happy path or any pre-existing #14784 / #14784-style emission.

Fixes #33007
