### PR TITLE
fix(codex): recover null terminal stream output

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -188,10 +188,55 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     # returns empty output (e.g. chatgpt.com backend-api sends
     # response.incomplete instead of response.completed).
     agent._codex_streamed_text_parts: list = []
+
+    def _synthesize_response_from_stream(
+        collected_output_items: list,
+        *,
+        allow_text: bool,
+    ):
+        output = None
+        if collected_output_items:
+            output = list(collected_output_items)
+            logger.debug(
+                "Codex stream: recovered %d output items after SDK terminal-response parse failure",
+                len(collected_output_items),
+            )
+        elif allow_text and agent._codex_streamed_text_parts:
+            assembled = "".join(agent._codex_streamed_text_parts)
+            output = [SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )]
+            logger.debug(
+                "Codex stream: synthesized output after SDK terminal-response parse failure "
+                "from %d text deltas (%d chars)",
+                len(agent._codex_streamed_text_parts), len(assembled),
+            )
+        if not output:
+            return None
+        return SimpleNamespace(
+            id=None,
+            object="response",
+            status="completed",
+            model=api_kwargs.get("model"),
+            output=output,
+            output_text=None,
+            usage=None,
+            incomplete_details=None,
+            error=None,
+        )
+
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        # Recovery synthesis must only use bytes/items from the active
+        # attempt. A failed first stream can emit partial text before the SDK
+        # raises; do not prepend that stale text to a later retry's response.
+        agent._codex_streamed_text_parts = []
+        has_tool_calls = False
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
                 for event in stream:
@@ -248,10 +293,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         )
                 final_response = stream.get_final_response()
                 # PATCH: ChatGPT Codex backend streams valid output items
-                # but get_final_response() can return an empty output list.
+                # but get_final_response() can return an empty or null output.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -330,6 +375,28 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 logger.debug(
                     "Responses stream %s; falling back to create(stream=True). %s err=%s",
                     "rejected before response.created" if prelude_error else "did not emit response.completed",
+                    agent._client_log_context(),
+                    err_text,
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
+        except TypeError as exc:
+            # The ChatGPT Codex backend may emit a terminal response with
+            # ``output: null``. Some OpenAI SDK versions try to iterate that
+            # field while handling the SSE terminal event, raising before
+            # ``get_final_response()`` can return. Recover from the items/text
+            # already streamed, matching the empty-output backfill above.
+            err_text = str(exc)
+            if "NoneType" in err_text and "iterable" in err_text:
+                recovered = _synthesize_response_from_stream(
+                    collected_output_items,
+                    allow_text=not has_tool_calls,
+                )
+                if recovered is not None:
+                    return recovered
+                logger.debug(
+                    "Responses stream terminal response had output=None and no collected output; "
+                    "falling back to create(stream=True). %s err=%s",
                     agent._client_log_context(),
                     err_text,
                 )
@@ -414,7 +481,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -186,6 +186,35 @@ class _FakeCreateStream:
         self.closed = True
 
 
+class _FakeStreamRaisesAfterEvents:
+    def __init__(self, events, error):
+        self._events = list(events)
+        self._error = error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+        raise self._error
+
+    def get_final_response(self):
+        raise AssertionError("get_final_response should not be reached")
+
+
+class _FakeResponsesStreamWithEvents(_FakeResponsesStream):
+    def __init__(self, events, *, final_response=None, final_error=None):
+        super().__init__(final_response=final_response, final_error=final_error)
+        self._events = list(events)
+
+    def __iter__(self):
+        return iter(self._events)
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -421,6 +450,36 @@ def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):
     assert response.output[0].content[0].text == "stream ok"
 
 
+def test_run_codex_stream_retry_synthesizes_only_current_attempt_text(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        if calls["stream"] == 1:
+            return _FakeResponsesStreamWithEvents(
+                [SimpleNamespace(type="response.output_text.delta", delta="stale")],
+                final_error=RuntimeError("Didn't receive a `response.completed` event."),
+            )
+        return _FakeResponsesStreamWithEvents(
+            [SimpleNamespace(type="response.output_text.delta", delta="fresh")],
+            final_response=SimpleNamespace(output=None, status="completed"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls["stream"] == 2
+    assert response is not None
+    assert response.output[0].content[0].text == "fresh"
+
+
 def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"stream": 0, "create": 0}
@@ -482,6 +541,54 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_when_sdk_rejects_null_terminal_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _FakeStreamRaisesAfterEvents(
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="ok"),
+            ],
+            TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "ok"
+
+
+def test_codex_create_stream_fallback_backfills_null_terminal_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.output_text.delta", delta="fallback ok"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(output=None, status="completed"),
+            ),
+        ]
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=lambda **kwargs: create_stream,
+        )
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert create_stream.closed is True
+    assert response.output[0].content[0].text == "fallback ok"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
Summary:
- Recover gracefully when Codex terminal stream output is null.
- Add regression coverage for Codex Responses terminal stream handling.

Test plan:
- Not run in this step; local tests were already completed before commit.