### PR TITLE
fix(slack): truncate message in edit_message to prevent msg_too_long

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -881,6 +881,11 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             formatted = self.format_message(content)
+            # Slack's chat.update has the same ~40k char limit as postMessage.
+            # Unlike send() we can't split into multiple messages (we're
+            # editing an existing one), so truncate to fit.
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            formatted = chunks[0] if chunks else formatted
             await self._get_client(chat_id).chat_update(
                 channel=chat_id,
                 ts=message_id,


### PR DESCRIPTION
## Summary
- `edit_message()` in the Slack adapter passed full formatted content to `chat.update` without length checking, unlike `send()` which already calls `truncate_message()`
- When agent responses exceed Slack's ~40k char limit, the API returns `msg_too_long`, surfacing as an error to the user even though the response was generated successfully
- Added `truncate_message()` call in `edit_message` to match the behavior of `send()`

## Test plan
- [ ] Send a message to the Slack bot that triggers a very long response (e.g. ask it to generate a long document)
- [ ] Verify the edited message is truncated instead of failing with `msg_too_long`
- [ ] Verify normal-length edit_message calls still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)