### PR TITLE
fix(docker): install python-is-python3 so bare `python` resolves in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # hermes process, the dashboard, and per-profile gateways.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates curl python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
+    ca-certificates curl python3 python-is-python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------- s6-overlay install ----------


### PR DESCRIPTION
## Summary

Drop a `/usr/bin/python → python3` symlink into the Docker image so bare `python` works.

## Root cause

Debian 13 ships only `python3` — no `python` symlink. When the agent emits bash commands using bare `python` (which models do frequently from their training prior), every such call fails inside the container with:

```
/usr/bin/bash: python: command not found
Tool terminal returned error … exit_code 127
```

The agent then retries with different approaches, sessions take longer, and `agent.log` fills with WARNING noise.

## Changes

- `Dockerfile`: add `python-is-python3` to the apt install line on the supervisor stage.

`python-is-python3` is the standard Debian package that drops a `/usr/bin/python → python3` symlink. Roughly 30 KB. Zero behavior change for anything that already calls `python3` directly; transparent fix for everything else.

## Validation

| | Before | After |
|---|---|---|
| `which python` inside container | not found | `/usr/bin/python` |
| `python --version` | `command not found` (127) | `Python 3.13.x` |
| Agent terminal calls using bare `python` | exit 127, retry loop | run normally |

cc @benbarclay

Fixes #33178
