### PR TITLE
fix(auxiliary): treat zero timeouts as disabled

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2572,7 +2572,7 @@ def _retry_same_provider_sync(
     temperature: Optional[float],
     max_tokens: Optional[int],
     tools: Optional[list],
-    effective_timeout: float,
+    effective_timeout: Optional[float],
     effective_extra_body: dict,
 ) -> Any:
     if task == "vision":
@@ -2629,7 +2629,7 @@ async def _retry_same_provider_async(
     temperature: Optional[float],
     max_tokens: Optional[int],
     tools: Optional[list],
-    effective_timeout: float,
+    effective_timeout: Optional[float],
     effective_extra_body: dict,
 ) -> Any:
     if task == "vision":
@@ -4490,6 +4490,27 @@ def _resolve_task_provider_model(
 _DEFAULT_AUX_TIMEOUT = 30.0
 
 
+def _normalize_aux_timeout(value: Any) -> Optional[float]:
+    """Normalize auxiliary request timeouts.
+
+    Hermes config uses ``0`` to mean "no per-request timeout override" for
+    auxiliary tasks.  The OpenAI/httpx stack treats a raw ``timeout=0`` as
+    an already-expired deadline, which makes context compression fail fast
+    with a misleading ``Connection error``.  Keep positive timeouts unchanged
+    and convert zero/negative values to ``None`` before request kwargs are
+    assembled.
+    """
+    if value is None:
+        return None
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return None
+    if timeout <= 0:
+        return None
+    return timeout
+
+
 def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     """Return the config dict for auxiliary.<task>, or {} when unavailable.
 
@@ -4534,18 +4555,22 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config
 
 
-def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
+def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> Optional[float]:
     """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
     if not task:
-        return default
+        return _normalize_aux_timeout(default)
     task_config = _get_auxiliary_task_config(task)
     raw = task_config.get("timeout")
     if raw is not None:
+        normalized = _normalize_aux_timeout(raw)
+        if normalized is not None or str(raw).strip() in {"0", "0.0", "-0", "-0.0"}:
+            return normalized
         try:
-            return float(raw)
-        except (ValueError, TypeError):
+            if float(raw) <= 0:
+                return None
+        except (TypeError, ValueError):
             pass
-    return default
+    return _normalize_aux_timeout(default)
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:
@@ -4633,7 +4658,7 @@ def _build_call_kwargs(
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
     tools: Optional[list] = None,
-    timeout: float = 30.0,
+    timeout: Optional[float] = 30.0,
     extra_body: Optional[dict] = None,
     base_url: Optional[str] = None,
 ) -> dict:
@@ -4641,8 +4666,11 @@ def _build_call_kwargs(
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,
-        "timeout": timeout,
     }
+
+    normalized_timeout = _normalize_aux_timeout(timeout)
+    if normalized_timeout is not None:
+        kwargs["timeout"] = normalized_timeout
 
     fixed_temperature = _fixed_temperature_for_model(model, base_url)
     if fixed_temperature is OMIT_TEMPERATURE:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -24,6 +24,7 @@ from agent.auxiliary_client import (
     _is_payment_error,
     _is_rate_limit_error,
     _normalize_aux_provider,
+    _get_task_timeout,
     _try_payment_fallback,
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
@@ -2487,6 +2488,49 @@ class TestVisionAutoSkipsKimiCoding:
 
 
 class TestCodexAuxiliaryAdapterTimeout:
+    def test_config_timeout_zero_normalizes_to_none(self):
+        config = {"auxiliary": {"compression": {"timeout": 0}}}
+
+        with patch("hermes_cli.config.load_config", return_value=config):
+            assert _get_task_timeout("compression") is None
+
+    def test_config_negative_timeout_normalizes_to_none(self):
+        config = {"auxiliary": {"compression": {"timeout": -1}}}
+
+        with patch("hermes_cli.config.load_config", return_value=config):
+            assert _get_task_timeout("compression") is None
+
+    def test_build_call_kwargs_omits_raw_timeout_zero(self):
+        kwargs = _build_call_kwargs(
+            provider="openai-codex",
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "summarize this"}],
+            timeout=0,
+        )
+
+        assert "timeout" not in kwargs
+
+    def test_explicit_call_llm_timeout_zero_does_not_forward_zero(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="summary"))]
+        )
+        client = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "gpt-5.5"),
+        ):
+            result = call_llm(
+                provider="openai-codex",
+                model="gpt-5.5",
+                messages=[{"role": "user", "content": "summarize this"}],
+                timeout=0,
+            )
+
+        assert result is response
+        assert "timeout" not in client.chat.completions.create.call_args.kwargs
+
     def test_forwards_timeout_to_responses_create(self):
         message_item = SimpleNamespace(
             type="message",


### PR DESCRIPTION
## Summary

- Normalize auxiliary task timeouts before building provider request kwargs
- Treat zero and negative auxiliary timeout values as disabled per-request timeout overrides
- Preserve positive timeout forwarding/enforcement behavior
- Add regression coverage for config-derived and explicit zero timeout paths

## Why

`auxiliary.<task>.timeout: 0` is a natural way to express a disabled per-request timeout override, but the auxiliary client was forwarding raw `timeout=0` into provider SDK calls. OpenAI/httpx-compatible SDK paths can interpret that as an already-expired deadline, which makes context compression fail immediately with a generic connection error.

## Test Plan

- `python -m pytest -q -o addopts='' tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout`
- `python -m pytest -q -o addopts='' tests/agent/test_auxiliary_client.py`

Closes #33227