### PR TITLE
fix(auxiliary): treat zero timeouts as disabled

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4535,14 +4535,22 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
 
 
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
-    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
+    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*.
+    
+    Zero or negative values are treated as "disabled timeout override" and return
+    the default, since passing timeout=0 to OpenAI/httpx SDKs can cause immediate
+    connection failures (zero timeout behaves like an already-expired deadline).
+    """
     if not task:
         return default
     task_config = _get_auxiliary_task_config(task)
     raw = task_config.get("timeout")
     if raw is not None:
         try:
-            return float(raw)
+            val = float(raw)
+            # Normalize: 0 or negative means "use default" (disabled timeout override)
+            if val > 0:
+                return val
         except (ValueError, TypeError):
             pass
     return default


### PR DESCRIPTION
Fixes #33227

## Problem
When `auxiliary.{task}.timeout` is configured as `0`, Hermes forwards `timeout=0` into the provider SDK request kwargs. For OpenAI/httpx-compatible SDKs, zero timeout behaves like an already-expired deadline, causing auxiliary calls (context compression, etc.) to fail immediately with connection errors.

## Solution
Normalize auxiliary timeout values in `_get_task_timeout()`:
- `None` → use default
- `0` or negative → use default (disabled timeout override)
- positive values → forward unchanged

## Changes
- Added check `val > 0` before returning timeout value
- Updated docstring to document the normalization behavior

## Testing
- Configure `auxiliary.compression.timeout: 0`
- Trigger context compression
- Verify compression uses default timeout instead of failing immediately