### PR TITLE
fix(telegram): lazy-install python-telegram-bot in standalone send path

### DIFF
--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -155,3 +155,53 @@ class TestSendTelegramStandaloneProxy:
         assert "get_updates_request" not in call_kwargs
         httpx_request_factory.assert_not_called()
         bot.send_message.assert_awaited_once()
+
+
+class TestTelegramStandaloneLazyDeps:
+    """The standalone Telegram send path should lazy-install missing SDK deps."""
+
+    def test_missing_telegram_sdk_invokes_lazy_deps_then_reimports(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the initial Telegram import fails, call lazy_deps.ensure for
+        platform.telegram and retry the import instead of returning a manual
+        pip-install error immediately.
+        """
+        import builtins
+        from tools import send_message_tool
+
+        for name in list(sys.modules):
+            if name == "telegram" or name.startswith("telegram."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+
+        bot_factory = MagicMock()
+        httpx_request_factory = MagicMock()
+        installed = False
+        ensure_calls: list[tuple[str, bool]] = []
+
+        def fake_ensure(feature: str, prompt: bool = True) -> None:
+            nonlocal installed
+            ensure_calls.append((feature, prompt))
+            installed = True
+            _install_telegram_mock_with_request(
+                monkeypatch,
+                bot_factory,
+                httpx_request_factory,
+            )
+
+        monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+
+        original_import = builtins.__import__
+
+        def fake_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):
+            if (name == "telegram" or name.startswith("telegram.")) and not installed:
+                raise ImportError("No module named 'telegram'")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        Bot, ParseMode = send_message_tool._import_telegram_send_deps()
+
+        assert ensure_calls == [("platform.telegram", False)]
+        assert Bot is bot_factory
+        assert ParseMode.MARKDOWN_V2 == "MarkdownV2"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -810,6 +810,35 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
+def _import_telegram_send_deps():
+    """Import Telegram SDK pieces needed by the standalone send path.
+
+    The gateway adapter already lazy-installs ``platform.telegram`` when the
+    Telegram SDK is absent.  The out-of-process send_message tool must do the
+    same so ``hermes send --to telegram ...`` works from CLI/cron sessions
+    without asking users to run pip manually.
+    """
+    try:
+        from telegram import Bot
+        from telegram.constants import ParseMode
+        return Bot, ParseMode
+    except ImportError as first_error:
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("platform.telegram", prompt=False)
+        except Exception as install_error:
+            raise ImportError(
+                "python-telegram-bot is not installed and automatic lazy install failed"
+            ) from install_error
+
+        try:
+            from telegram import Bot
+            from telegram.constants import ParseMode
+            return Bot, ParseMode
+        except ImportError:
+            raise first_error
+
+
 async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
@@ -819,8 +848,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     instead, bypassing MarkdownV2 conversion.
     """
     try:
-        from telegram import Bot
-        from telegram.constants import ParseMode
+        Bot, ParseMode = _import_telegram_send_deps()
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
         # Inspired by github.com/ashaney — PR #1568.


### PR DESCRIPTION
## What

Extract the Telegram SDK import in the out-of-process `send_message` tool into a `_import_telegram_send_deps()` helper: try the import, and on `ImportError` call `lazy_deps.ensure("platform.telegram", prompt=False)` and retry, re-raising the original error if the install still fails.

## Why

`hermes send --to telegram ...` from CLI/cron sessions currently fails with a bare `ImportError` when `python-telegram-bot` isn't installed, forcing a manual pip install. This brings the standalone send path to parity with the other platforms in the same file — `_send_slack` already lazy-installs via `ensure_and_bind("platform.slack", ...)`, and adapter-based platforms inherit the gateway adapters' lazy-install. Telegram was the only standalone `_send_*` path doing a bare direct import.

## Tests

Adds `TestTelegramStandaloneLazyDeps` covering the install-then-reimport path (mocks the failed import, asserts `lazy_deps.ensure("platform.telegram", prompt=False)` is invoked once, then the retry succeeds). Full file passes (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
