### PR TITLE
[codex] Preserve context in execute_code RPC threads

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -15,6 +15,7 @@ Run with:  python -m pytest tests/test_code_execution.py -v
 import pytest
 # pytestmark removed — tests run fine (61 pass, ~99s)
 
+import contextvars
 import json
 import os
 
@@ -835,6 +836,52 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
             ))
         self.assertEqual(result["status"], "success")
         self.assertIn("fallback ok", result["output"])
+
+    @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+    def test_rpc_thread_preserves_contextvars(self):
+        """Sandbox tool calls should inherit the agent turn context."""
+        from tools.approval import (
+            get_current_session_key,
+            reset_current_session_key,
+            set_current_session_key,
+        )
+
+        marker_var = contextvars.ContextVar("execute_code_rpc_marker", default="missing")
+        marker_token = marker_var.set("marker-value")
+        session_token = set_current_session_key("rpc-context-session")
+        seen = []
+
+        def fake_handle(tool_name, tool_args, task_id=None):
+            seen.append({
+                "marker": marker_var.get(),
+                "session_key": get_current_session_key(default="missing"),
+                "task_id": task_id,
+                "tool": tool_name,
+            })
+            return json.dumps({"ok": True, "path": tool_args.get("path")})
+
+        code = (
+            "from hermes_tools import read_file\n"
+            "print(read_file('/tmp/context-check.txt'))\n"
+        )
+        try:
+            with patch("model_tools.handle_function_call", side_effect=fake_handle):
+                result = json.loads(execute_code(
+                    code,
+                    task_id="test-rpc-context",
+                    enabled_tools=["read_file"],
+                ))
+        finally:
+            reset_current_session_key(session_token)
+            marker_var.reset(marker_token)
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(seen, [{
+            "marker": "marker-value",
+            "session_key": "rpc-context-session",
+            "task_id": "test-rpc-context",
+            "tool": "read_file",
+        }])
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -29,6 +29,7 @@ Remote execution additionally requires Python 3 in the terminal backend.
 """
 
 import base64
+import contextvars
 import functools
 import json
 import logging
@@ -434,6 +435,16 @@ def _call(tool_name, args):
 
 # Terminal parameters that must not be used from ephemeral sandbox scripts
 _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
+
+
+def _context_thread_target(target, *args):
+    """Return a thread target that preserves the caller's ContextVars."""
+    ctx = contextvars.copy_context()
+
+    def _run():
+        return ctx.run(target, *args)
+
+    return _run
 
 
 def _rpc_server_loop(
@@ -906,8 +917,8 @@ def _execute_remote(
 
         # Start RPC polling thread
         rpc_thread = threading.Thread(
-            target=_rpc_poll_loop,
-            args=(
+            target=_context_thread_target(
+                _rpc_poll_loop,
                 env, f"{sandbox_dir}/rpc", effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event,
@@ -1153,8 +1164,8 @@ def execute_code(
         server_sock.listen(1)
 
         rpc_thread = threading.Thread(
-            target=_rpc_server_loop,
-            args=(
+            target=_context_thread_target(
+                _rpc_server_loop,
                 server_sock, task_id, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools,
             ),


### PR DESCRIPTION
Disclaimer: this is a fully-automated contribution trying to expand on the success of #30432.

Fixes #33057.

## Summary

This preserves Hermes session/approval context when `execute_code` sandbox scripts call back into Hermes tools through the parent-process RPC bridge.

## Root Cause

`execute_code` starts raw `threading.Thread` workers for its RPC paths:

- the local Unix-domain-socket RPC server thread;
- the remote file-polling RPC thread.

Raw Python threads start with an empty `contextvars.Context`. That means any `ContextVar` bound around the agent turn, including approval/session routing state, is not visible when the sandbox calls back into `model_tools.handle_function_call(...)`.

For approval-sensitive flows, that is the wrong boundary: a sandboxed script can call `hermes_tools.terminal(...)`, and the resulting terminal approval checks need the same session context as the agent turn that launched `execute_code`.

## What Changed

- Added a small `_context_thread_target(...)` helper in `tools/code_execution_tool.py`.
- Wrapped both execute-code RPC thread targets in `contextvars.copy_context().run(...)`.
- Added regression coverage proving a sandbox tool call sees:
  - an arbitrary parent `ContextVar`;
  - the approval session key from `tools.approval`;
  - the original execute-code `task_id`.

## Relationship To #30893

#30893 guards the `execute_code` entry point in gateway approval contexts: the script itself must be approved before it starts.

This PR is complementary. It keeps the already-running sandbox's RPC tool calls attached to the same turn context, so approval/session-sensitive tool dispatch inside `execute_code` does not fall back to missing or stale context.

## Validation

- `.venv/bin/ruff check tools/code_execution_tool.py tests/tools/test_code_execution.py`
- `.venv/bin/python -m py_compile tools/code_execution_tool.py tests/tools/test_code_execution.py`
- `.venv/bin/python -m pytest tests/tools/test_code_execution.py::TestExecuteCodeEdgeCases::test_rpc_thread_preserves_contextvars -q --tb=short`
- `.venv/bin/python -m pytest tests/tools/test_code_execution.py -q --tb=short`

Note: the focused/full `execute_code` pytest runs were executed outside my local Codex filesystem sandbox because the sandbox blocks Unix-domain-socket bind with `PermissionError: [Errno 1] Operation not permitted`. The same tests pass when run in the normal local environment.
