### PR TITLE
fix(tui): pass HERMES_HOME to child processes

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -59,6 +59,33 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_env_for_child_process_preserves_explicit_hermes_home(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", "/tmp/hermes-explicit")
+
+    assert server._env_for_child_process()["HERMES_HOME"] == "/tmp/hermes-explicit"
+
+
+def test_env_for_child_process_pins_active_non_default_profile(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "bob"
+    profile_home.mkdir(parents=True)
+    (root / "active_profile").write_text("bob", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    assert server._env_for_child_process()["HERMES_HOME"] == str(profile_home)
+
+
+def test_env_for_child_process_defaults_to_root_when_profile_missing(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    root.mkdir(parents=True)
+    (root / "active_profile").write_text("missing", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    assert server._env_for_child_process()["HERMES_HOME"] == str(root)
+
+
 def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
     redact_module = types.ModuleType("agent.redact")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -181,6 +181,34 @@ sys.stdout = sys.stderr
 _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 
 
+def _env_for_child_process() -> dict[str, str]:
+    """Return a subprocess env with HERMES_HOME pinned.
+
+    TUI users can launch the Node app directly, bypassing hermes_cli.main's
+    early profile bootstrap. If the sticky active_profile is non-default and
+    HERMES_HOME is absent, child Python processes must still inherit the
+    profile home or imports that call get_hermes_home() fall back to ~/.hermes.
+    """
+    env = os.environ.copy()
+    if env.get("HERMES_HOME", "").strip():
+        return env
+
+    root = Path.home() / ".hermes"
+    try:
+        active = (root / "active_profile").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        active = ""
+
+    if active and active != "default":
+        profile_home = root / "profiles" / active
+        if profile_home.is_dir():
+            env["HERMES_HOME"] = str(profile_home)
+            return env
+
+    env["HERMES_HOME"] = str(root)
+    return env
+
+
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
@@ -208,7 +236,7 @@ class _SlashWorker:
             text=True,
             bufsize=1,
             cwd=os.getcwd(),
-            env=os.environ.copy(),
+            env=_env_for_child_process(),
         )
         threading.Thread(target=self._drain_stdout, daemon=True).start()
         threading.Thread(target=self._drain_stderr, daemon=True).start()

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { GatewayClient } from '../gatewayClient.js'
+import { GatewayClient, resolveHermesHomeForSpawn } from '../gatewayClient.js'
 
 interface ListenerEntry {
   callback: (event: any) => void
@@ -303,6 +307,7 @@ describe('GatewayClient websocket attach mode', () => {
     process.env.HERMES_TUI_GATEWAY_URL = secretUrl
     ;(globalThis as { WebSocket?: unknown }).WebSocket = class ThrowingWebSocket extends FakeWebSocket {
       constructor(url: string) {
+        super(url)
         throw new TypeError(`Invalid URL: ${url}`)
       }
     } as unknown as typeof WebSocket
@@ -390,5 +395,40 @@ describe('GatewayClient websocket attach mode', () => {
     expect(tail).not.toContain('token=secret')
 
     gw.kill()
+  })
+})
+
+describe('resolveHermesHomeForSpawn', () => {
+  let tempHome: string
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), 'hermes-home-spawn-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempHome, { force: true, recursive: true })
+  })
+
+  it('preserves an explicit HERMES_HOME', () => {
+    expect(resolveHermesHomeForSpawn({ HERMES_HOME: '/explicit/profile' }, tempHome)).toBe('/explicit/profile')
+  })
+
+  it('pins child env to the sticky active non-default profile', () => {
+    const root = join(tempHome, '.hermes')
+    const profileHome = join(root, 'profiles', 'bob')
+
+    mkdirSync(profileHome, { recursive: true })
+    writeFileSync(join(root, 'active_profile'), 'bob')
+
+    expect(resolveHermesHomeForSpawn({}, tempHome)).toBe(profileHome)
+  })
+
+  it('falls back to default home when the sticky profile is missing or default', () => {
+    const root = join(tempHome, '.hermes')
+
+    mkdirSync(root, { recursive: true })
+    writeFileSync(join(root, 'active_profile'), 'default')
+
+    expect(resolveHermesHomeForSpawn({}, tempHome)).toBe(root)
   })
 })

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1,7 +1,8 @@
 import { type ChildProcess, spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { existsSync } from 'node:fs'
-import { delimiter, resolve } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
 import type { GatewayEvent } from './gatewayTypes.js'
@@ -60,6 +61,32 @@ const resolvePython = (root: string) => {
   ].find(p => p && existsSync(p))
 
   return hit || (process.platform === 'win32' ? 'python' : 'python3')
+}
+
+export const resolveHermesHomeForSpawn = (env: NodeJS.ProcessEnv = process.env, homeDir = homedir()) => {
+  const existing = env.HERMES_HOME?.trim()
+
+  if (existing) {
+    return existing
+  }
+
+  const root = join(homeDir, '.hermes')
+
+  try {
+    const active = readFileSync(join(root, 'active_profile'), 'utf8').trim()
+
+    if (active && active !== 'default' && /^[a-z0-9][a-z0-9_-]{0,63}$/.test(active)) {
+      const profileHome = join(root, 'profiles', active)
+
+      if (existsSync(profileHome)) {
+        return profileHome
+      }
+    }
+  } catch {
+    // Missing/corrupt active_profile means classic/default profile.
+  }
+
+  return root
 }
 
 const asGatewayEvent = (value: unknown): GatewayEvent | null =>
@@ -332,6 +359,7 @@ export class GatewayClient extends EventEmitter {
     const env = { ...process.env }
     const pyPath = env.PYTHONPATH?.trim()
 
+    env.HERMES_HOME = resolveHermesHomeForSpawn(env)
     env.PYTHONPATH = pyPath ? `${root}${delimiter}${pyPath}` : root
     this.startReadyTimer(python, cwd)
     this.proc = spawn(python, ['-m', 'tui_gateway.entry'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] })


### PR DESCRIPTION
## Summary
- pass an explicit HERMES_HOME into TUI-spawned gateway child processes
- resolve the active non-default profile home when HERMES_HOME is unset
- apply the same child-process env guard inside the Python TUI gateway slash-worker spawner

## Why
When the active profile is non-default (for example `bob`) but HERMES_HOME is not set, subprocesses fall back to `~/.hermes` and write data into the default profile. The spawner should pin HERMES_HOME so child processes inherit the correct profile directory.

## Tests
- `cd ui-tui && npm exec eslint src/gatewayClient.ts src/__tests__/gatewayClient.test.ts`
- `cd ui-tui && npm test -- gatewayClient.test.ts`
- `uv run --extra dev pytest -q tests/test_tui_gateway_server.py -k 'env_for_child_process'`
