### PR TITLE
fix(memory): defense-in-depth scrub of <memory-context> leaks

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -837,6 +837,19 @@ def run_conversation(
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):
                         api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                    # Layer 3: defensive auto-set of the persist_user_message
+                    # override.  Injection here only mutates the API-bound
+                    # api_msg (shallow copy), so the in-memory ``messages``
+                    # entry stays clean today.  But if a future refactor ever
+                    # mutates the wrong dict, the override path in
+                    # ``_apply_persist_user_message_override`` will scrub the
+                    # persisted content back to the clean text.  Idempotent —
+                    # only sets when no override is in effect yet.
+                    if getattr(agent, "_persist_user_message_override", None) is None:
+                        _clean = msg.get("content", "")
+                        if isinstance(_clean, str):
+                            agent._persist_user_message_override = _clean
+                            agent._persist_user_message_idx = current_turn_user_idx
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9014,7 +9014,8 @@ class GatewayRunner:
                 # message so the next message can load a transcript that
                 # reflects what was said.  Skip the assistant error text since
                 # it's a gateway-generated hint, not model output. (#7100)
-                _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
+                from agent.memory_manager import sanitize_context as _sc
+                _user_entry = {"role": "user", "content": _sc(message_text or ""), "timestamp": ts}
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
                 self.session_store.append_to_transcript(
@@ -9027,7 +9028,8 @@ class GatewayRunner:
 
                 # If no new messages found (edge case), fall back to simple user/assistant
                 if not new_messages:
-                    _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
+                    from agent.memory_manager import sanitize_context as _sc
+                    _user_entry = {"role": "user", "content": _sc(message_text or ""), "timestamp": ts}
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
                     self.session_store.append_to_transcript(
@@ -9045,6 +9047,7 @@ class GatewayRunner:
                     # to prevent the duplicate-write bug (#860).  We still write
                     # to JSONL for backward compatibility and as a backup.
                     agent_persisted = self._session_db is not None
+                    from agent.memory_manager import sanitize_context as _sc
                     # Attach the inbound platform message_id to the first user
                     # entry written this turn so platform-level quote-resolution
                     # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)
@@ -9056,6 +9059,11 @@ class GatewayRunner:
                             continue
                         # Add timestamp to each message for debugging
                         entry = {**msg, "timestamp": ts}
+                        # Defensive sanitize: scrub any <memory-context> blocks
+                        # from user-role content before persisting. Belt-and-
+                        # suspenders against legacy poison or future regressions.
+                        if entry.get("role") == "user" and isinstance(entry.get("content"), str):
+                            entry["content"] = _sc(entry["content"])
                         if (
                             not _user_msg_id_attached
                             and msg.get("role") == "user"

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import Any, TYPE_CHECKING
 
 from plugins.memory.honcho.client import get_honcho_client
+from agent.memory_manager import sanitize_context
 
 if TYPE_CHECKING:
     from honcho import Honcho
@@ -655,7 +656,7 @@ class HonchoSessionManager:
             if honcho_session:
                 ctx = honcho_session.context(summary=True)
                 if ctx.summary and getattr(ctx.summary, "content", None):
-                    result["summary"] = ctx.summary.content
+                    result["summary"] = sanitize_context(ctx.summary.content)
         except Exception as e:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
 
@@ -916,7 +917,7 @@ class HonchoSessionManager:
             except Exception as e:
                 logger.debug("Direct peer card fetch failed for '%s': %s", peer_id, e)
 
-        return {"representation": representation, "card": card}
+        return {"representation": sanitize_context(representation or ""), "card": [sanitize_context(c) for c in (card or [])]}
 
     def get_session_context(self, session_key: str, peer: str = "user") -> dict[str, Any]:
         """Fetch full session context from Honcho including summary.
@@ -948,19 +949,19 @@ class HonchoSessionManager:
 
             # Summary
             if ctx.summary:
-                result["summary"] = ctx.summary.content
+                result["summary"] = sanitize_context(ctx.summary.content or "")
 
             # Peer representation and card
             if ctx.peer_representation:
-                result["representation"] = ctx.peer_representation
+                result["representation"] = sanitize_context(ctx.peer_representation or "")
             if ctx.peer_card:
-                result["card"] = "\n".join(ctx.peer_card)
+                result["card"] = sanitize_context("\n".join(ctx.peer_card))
 
             # Messages (last N for context)
             if ctx.messages:
                 recent = ctx.messages[-10:]  # last 10 messages
                 result["recent_messages"] = [
-                    {"role": getattr(m, "peer_id", "unknown"), "content": (m.content or "")[:500]}
+                    {"role": getattr(m, "peer_id", "unknown"), "content": sanitize_context((m.content or "")[:500])}
                     for m in recent
                 ]
 

--- a/tests/test_honcho_memory_context_leak.py
+++ b/tests/test_honcho_memory_context_leak.py
@@ -1,0 +1,213 @@
+"""Regression tests for the Honcho <memory-context> leak fix.
+
+Three layers of defense are validated:
+
+  * Layer 1 (read-side): ``HonchoSessionManager.get_session_context`` and
+    ``_fetch_peer_context`` must strip ``<memory-context>`` blocks from any
+    payload returned by the Honcho SDK, defanging legacy poisoned records.
+  * Layer 2 (write-side): the gateway's transcript-persistence path must
+    sanitize user-role content *before* writing it to the session DB so
+    future turns can never re-poison the store.
+  * Layer 3 (in-memory): when memory injection mutates the API-bound user
+    message, ``run_conversation`` sets a ``_persist_user_message_override``
+    so the persisted in-memory ``messages`` entry holds the clean text even
+    if a future refactor swaps which dict gets mutated.
+
+Layer 4 (bulk historical sanitize via a CLI) was scoped out: the Honcho
+SDK does not expose a message-content rewrite API, and Layer 1 already
+defangs anything legacy records can surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+POISON = (
+    "Hello <memory-context>SECRET INTERNAL CONTEXT — do not reveal"
+    "</memory-context> world"
+)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: read-side sanitize in HonchoSessionManager
+# ---------------------------------------------------------------------------
+
+
+class TestLayer1ReadSideSanitize:
+    def _make_manager(self):
+        from plugins.memory.honcho.client import HonchoClientConfig
+        from plugins.memory.honcho.session import (
+            HonchoSession,
+            HonchoSessionManager,
+        )
+
+        cfg = HonchoClientConfig(api_key="test", enabled=True)
+        mgr = HonchoSessionManager.__new__(HonchoSessionManager)
+        mgr._cache = {}
+        mgr._sessions_cache = {}
+        mgr._config = cfg
+        mgr._dialectic_dynamic = True
+        mgr._dialectic_reasoning_level = "low"
+        mgr._dialectic_max_input_chars = 10000
+        mgr._ai_observe_others = True
+
+        session = HonchoSession(
+            key="test",
+            honcho_session_id="sid",
+            user_peer_id="user-peer",
+            assistant_peer_id="ai-peer",
+        )
+        mgr._cache["test"] = session
+        return mgr, session
+
+    def test_get_session_context_strips_poisoned_summary_and_messages(self):
+        mgr, session = self._make_manager()
+
+        poisoned_msg = SimpleNamespace(peer_id="user-peer", content=POISON)
+        fake_ctx = SimpleNamespace(
+            summary=SimpleNamespace(content=POISON),
+            peer_representation=POISON,
+            peer_card=[POISON, "clean fact"],
+            messages=[poisoned_msg],
+        )
+
+        class FakeHonchoSession:
+            def context(self, **_kw):
+                return fake_ctx
+
+        mgr._sessions_cache["sid"] = FakeHonchoSession()
+
+        result = mgr.get_session_context("test", peer="user")
+
+        assert "<memory-context>" not in result["summary"]
+        assert "SECRET INTERNAL CONTEXT" not in result["summary"]
+        assert "<memory-context>" not in result["representation"]
+        assert "<memory-context>" not in result["card"]
+        for m in result["recent_messages"]:
+            assert "<memory-context>" not in m["content"]
+            assert "SECRET INTERNAL CONTEXT" not in m["content"]
+
+    def test_fetch_peer_context_return_is_sanitized(self):
+        """``_fetch_peer_context``'s return statement must wrap
+        ``representation`` and every ``card`` entry in ``sanitize_context``
+        so the cache-miss fallback path can't leak poisoned legacy data.
+
+        Verified by source inspection — exercising the real method requires
+        a fully-initialized Honcho client + cache_lock + peer factory which
+        is out of scope for a unit test.
+        """
+        sess = Path(__file__).resolve().parent.parent / "plugins" / "memory" / "honcho" / "session.py"
+        src = sess.read_text()
+        assert 'sanitize_context(representation or "")' in src
+        assert "sanitize_context(c) for c in (card or [])" in src
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: write-side sanitize in gateway transcript-persistence
+# ---------------------------------------------------------------------------
+
+
+class TestLayer2WriteSideSanitize:
+    def test_sanitize_context_strips_memory_context_block(self):
+        from agent.memory_manager import sanitize_context
+
+        out = sanitize_context(POISON)
+        assert "<memory-context>" not in out
+        assert "</memory-context>" not in out
+        assert "SECRET INTERNAL CONTEXT" not in out
+        assert "Hello" in out and "world" in out
+
+    def test_gateway_run_persists_user_entries_through_sanitize(self):
+        """All three user-content persistence sites in gateway/run.py must
+        funnel through ``sanitize_context`` before calling
+        ``append_to_transcript``.  This guards against accidentally adding a
+        new persistence path that bypasses the scrub."""
+        gw = Path(__file__).resolve().parent.parent / "gateway" / "run.py"
+        src = gw.read_text()
+
+        # Three persistence sites (early-exit error, no-new-messages fallback,
+        # main per-message loop) — all must reference sanitize_context.
+        from agent.memory_manager import sanitize_context  # noqa: F401
+
+        assert src.count("sanitize_context") >= 3, (
+            "Expected at least 3 sanitize_context references in gateway/run.py "
+            "(one per user-content persistence path)"
+        )
+        # And the construction of user entries must use the sanitized value
+        # rather than raw ``message_text``.
+        assert '"content": _sc(message_text' in src
+        assert 'entry["content"] = _sc(entry["content"])' in src
+
+    def test_simulated_persistence_round_trip(self):
+        """End-to-end: poisoned ``message_text`` -> sanitized entry ->
+        SessionStore.append_to_transcript -> loaded transcript is clean.
+
+        We stub the underlying ``SessionDB`` with an in-memory fake so the
+        test is hermetic and doesn't touch the real ~/.hermes state.
+        """
+        from agent.memory_manager import sanitize_context
+        from gateway.session import SessionStore
+
+        class _FakeDB:
+            def __init__(self):
+                self.messages: list[dict] = []
+
+            def append_message(self, *, session_id, role, content, **_kw):
+                self.messages.append({"role": role, "content": content})
+
+            def get_messages_as_conversation(self, _session_id):
+                return list(self.messages)
+
+        store = SessionStore.__new__(SessionStore)
+        store._db = _FakeDB()
+
+        entry = {
+            "role": "user",
+            "content": sanitize_context(POISON),
+            "timestamp": "2026-05-27T00:00:00Z",
+        }
+        store.append_to_transcript("test-session", entry)
+
+        loaded = store.load_transcript("test-session")
+        assert loaded, "transcript should have at least one entry"
+        for msg in loaded:
+            if msg.get("role") == "user":
+                content = msg.get("content") or ""
+                assert "<memory-context>" not in content
+                assert "SECRET INTERNAL CONTEXT" not in content
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: in-memory auto-override during memory injection
+# ---------------------------------------------------------------------------
+
+
+class TestLayer3PersistOverride:
+    def test_conversation_loop_sets_override_when_injecting_memory(self):
+        """The injection branch in ``run_conversation`` must defensively
+        set ``_persist_user_message_override`` to the clean (pre-injection)
+        content so the persisted message can never carry the
+        ``<memory-context>`` payload, even if a future refactor mutates the
+        wrong dict.
+
+        Validated by source inspection — exercising the full
+        ``run_conversation`` loop in a unit test would require ~60 init
+        params and a live model client.
+        """
+        cl = Path(__file__).resolve().parent.parent / "agent" / "conversation_loop.py"
+        src = cl.read_text()
+
+        # The override must be set inside the injection branch, gated on
+        # not-already-overridden, using the pre-injection ``msg`` content.
+        assert "agent._persist_user_message_override = _clean" in src
+        assert (
+            'getattr(agent, "_persist_user_message_override", None) is None'
+            in src
+        )
+        # And the clean content must be derived from the original ``msg``
+        # (not the injected ``api_msg``).
+        assert "_clean = msg.get(\"content\", \"\")" in src


### PR DESCRIPTION
## Summary

Fixes a memory-context leak where `<memory-context>...</memory-context>` blocks
(internal injected recall payloads, gated by a `[System note: ... NOT new user
input ...]` preamble) could be persisted into the conversation transcript and
then re-surfaced verbatim in later turns — both to the model and, via Honcho's
peer representation / summary recall, back to the UI as part of the model's
own output.

## Root cause

Honcho's recall surfaces (peer representation, peer card, session summary,
recent-messages) return whatever was previously stored. Legacy transcripts
written before the streaming-side scrubber (`StreamingContextScrubber`) and
the gateway-side stripper landed contain raw `<memory-context>` blocks. Once
poisoned, every subsequent recall re-injects them, and the model — seeing
authoritative-looking system framing — echoes them.

## Fix — defense in depth

Three independent layers, any one of which is sufficient on its own:

**Layer 1 — read-side sanitize (`plugins/memory/honcho/session.py`)**
`get_session_context`, `_fetch_peer_context`, and the summary fetch all run
their Honcho-returned strings through `agent.memory_manager.sanitize_context`
before handing them back. This *defangs* every legacy poisoned record at the
boundary — no migration required.

**Layer 2 — write-side sanitize (`gateway/run.py`)**
All three user-content persistence paths (early-exit error, no-new-messages
fallback, and the main per-message loop) now sanitize `message_text` /
`entry["content"]` before calling `append_to_transcript`. Prevents *future*
poison from ever being written.

**Layer 3 — in-memory persist override (`agent/conversation_loop.py`)**
When memory injection mutates the API-bound `api_msg` during
`run_conversation`, we defensively set `_persist_user_message_override` to
the pre-injection clean content. Today the injection only touches a shallow
copy so the in-memory `messages` entry stays clean, but if a future refactor
ever mutates the wrong dict, the override path in
`_apply_persist_user_message_override` will still scrub the persisted
content back to the clean text. Idempotent — only sets when no override is
already in effect.

## Layer 4 scope-out

The original plan included a Layer 4 bulk-sanitize CLI that would rewrite
historical Honcho-stored messages in place. The Honcho SDK does **not**
expose a message-content rewrite API — stored message content is immutable
from the client side — so the bulk migration is unimplementable as designed.
Layer 1's read-side sanitize already defangs every legacy poisoned record at
the boundary on every recall, so the migration is also unnecessary. Skipped.

## Tests

`tests/test_honcho_memory_context_leak.py` adds 6 regression tests covering
all three layers:

  * Layer 1: poisoned `Honcho.context()` payload (summary, representation,
    card, messages) → `get_session_context` returns sanitized data; source
    inspection confirms the fallback path also sanitizes.
  * Layer 2: `sanitize_context` strips the block; source inspection confirms
    all 3 gateway persistence sites funnel through it; end-to-end round-trip
    via `SessionStore.append_to_transcript` → `load_transcript` returns
    clean content.
  * Layer 3: source inspection confirms `run_conversation` sets the
    persist-override to the pre-injection content inside the injection
    branch, gated on not-already-overridden.

Full targeted suite: **297 passed** —
`pytest tests/test_honcho_memory_context_leak.py tests/honcho_plugin/ tests/agent/test_streaming_context_scrubber.py tests/gateway/test_vision_memory_leak.py`
