### PR TITLE
fix(api-server): forward request extra_body to providers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -164,6 +164,62 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
+def _merge_extra_body(
+    base: Optional[Dict[str, Any]],
+    addition: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Merge provider-specific request body fields with request precedence."""
+    merged: Dict[str, Any] = dict(base or {})
+    for key, value in dict(addition or {}).items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = {**current, **value}
+        else:
+            merged[key] = value
+    return merged
+
+
+_TOP_LEVEL_EXTRA_BODY_OBJECT_FIELDS = frozenset({
+    "chat_template_kwargs",
+    "vllm_xargs",
+})
+
+
+def _extract_request_extra_body(
+    body: Dict[str, Any],
+) -> tuple[Dict[str, Any], Optional[str]]:
+    """Extract OpenAI-compatible provider-specific request fields.
+
+    OpenAI SDK ``extra_body`` values are serialized into the JSON body.  For
+    provider-specific passthrough, this adapter accepts either an explicit
+    nested ``extra_body`` object or allow-listed top-level provider extension
+    objects produced by SDK ``extra_body={...}`` calls.
+    """
+    request_extra_body: Dict[str, Any] = {}
+
+    raw_extra_body = body.get("extra_body")
+    if raw_extra_body is not None:
+        if not isinstance(raw_extra_body, dict):
+            return {}, "'extra_body' must be an object"
+        request_extra_body.update(raw_extra_body)
+
+    for field in sorted(_TOP_LEVEL_EXTRA_BODY_OBJECT_FIELDS):
+        raw_value = body.get(field)
+        if raw_value is None:
+            continue
+        if not isinstance(raw_value, dict):
+            return {}, f"'{field}' must be an object"
+        existing_value = request_extra_body.get(field)
+        if existing_value is not None and not isinstance(existing_value, dict):
+            return {}, f"'extra_body.{field}' must be an object"
+        request_extra_body[field] = _merge_extra_body(
+            existing_value,
+            raw_value,
+        )
+
+    return request_extra_body, None
+
+
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
 ) -> str:
@@ -1754,6 +1810,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        request_extra_body: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1774,6 +1831,9 @@ class APIServerAdapter(BasePlatformAdapter):
         routing).  When set — and no session ``/model`` override exists for
         this session — its model/provider/api_key/base_url override the
         global defaults for this agent instance only.
+
+        ``request_extra_body`` carries per-request OpenAI-compatible provider
+        extension fields into ``request_overrides.extra_body``.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1786,6 +1846,15 @@ class APIServerAdapter(BasePlatformAdapter):
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        if request_extra_body:
+            runtime_kwargs = dict(runtime_kwargs or {})
+            request_overrides = dict(runtime_kwargs.get("request_overrides") or {})
+            existing_extra_body = request_overrides.get("extra_body")
+            request_overrides["extra_body"] = _merge_extra_body(
+                existing_extra_body if isinstance(existing_extra_body, dict) else {},
+                request_extra_body,
+            )
+            runtime_kwargs["request_overrides"] = request_overrides
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
@@ -2661,6 +2730,10 @@ class APIServerAdapter(BasePlatformAdapter):
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
 
+        request_extra_body, extra_body_err = _extract_request_extra_body(body)
+        if extra_body_err:
+            return web.json_response(_openai_error(extra_body_err), status=400)
+
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
             return web.json_response(
@@ -2865,6 +2938,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                request_extra_body=request_extra_body,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2885,11 +2959,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                request_extra_body=request_extra_body,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(
+                body,
+                keys=[
+                    "model",
+                    "messages",
+                    "tools",
+                    "tool_choice",
+                    "stream",
+                    "extra_body",
+                    "chat_template_kwargs",
+                    "vllm_xargs",
+                ],
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -3802,6 +3889,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        request_extra_body, extra_body_err = _extract_request_extra_body(body)
+        if extra_body_err:
+            return web.json_response(_openai_error(extra_body_err), status=400)
+
         raw_input = body.get("input")
         if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
@@ -3949,6 +4040,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                request_extra_body=request_extra_body,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -3983,13 +4075,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                request_extra_body=request_extra_body,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=[
+                    "input",
+                    "instructions",
+                    "previous_response_id",
+                    "conversation",
+                    "model",
+                    "tools",
+                    "extra_body",
+                    "chat_template_kwargs",
+                    "vllm_xargs",
+                ],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -4632,6 +4735,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        request_extra_body: Optional[Dict[str, Any]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4642,6 +4746,9 @@ class APIServerAdapter(BasePlatformAdapter):
         *route* is an optional ``model_routes`` entry (resolved from the
         request's ``model`` field) that overrides the global model/provider
         for this specific request.
+
+        *request_extra_body* carries per-request provider extension fields
+        into the underlying OpenAI-compatible provider call.
 
         If *agent_ref* is a one-element list, the AIAgent instance is stored
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
@@ -4673,6 +4780,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        request_extra_body=request_extra_body,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent
@@ -4790,6 +4898,10 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        request_extra_body, extra_body_err = _extract_request_extra_body(body)
+        if extra_body_err:
+            return web.json_response(_openai_error(extra_body_err), status=400)
 
         raw_input = body.get("input")
         if not raw_input:
@@ -4922,6 +5034,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_progress_callback=event_cb,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        request_extra_body=request_extra_body,
                     )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,7 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _IdempotencyCache,
     _derive_chat_session_id,
+    _extract_request_extra_body,
     _redact_api_error_text,
     check_api_server_requirements,
     cors_middleware,
@@ -280,6 +281,61 @@ class TestIdempotencyCache:
 
 
 # ---------------------------------------------------------------------------
+# Request extra_body extraction
+# ---------------------------------------------------------------------------
+
+
+class TestRequestExtraBody:
+    def test_extracts_nested_extra_body_and_top_level_provider_extensions(self):
+        extra_body, err = _extract_request_extra_body({
+            "model": "hermes-agent",
+            "extra_body": {
+                "tags": ["hermes"],
+                "chat_template_kwargs": {"enable_thinking": False},
+                "vllm_xargs": {"temperature_floor": 0.0},
+            },
+            "chat_template_kwargs": {"top_k": 4},
+            "vllm_xargs": {"lang_guard": "ko_en"},
+        })
+
+        assert err is None
+        assert extra_body == {
+            "tags": ["hermes"],
+            "chat_template_kwargs": {
+                "enable_thinking": False,
+                "top_k": 4,
+            },
+            "vllm_xargs": {
+                "temperature_floor": 0.0,
+                "lang_guard": "ko_en",
+            },
+        }
+
+    def test_rejects_non_object_extra_body(self):
+        extra_body, err = _extract_request_extra_body({"extra_body": "bad"})
+
+        assert extra_body == {}
+        assert err == "'extra_body' must be an object"
+
+    def test_rejects_non_object_top_level_provider_extension(self):
+        extra_body, err = _extract_request_extra_body({
+            "chat_template_kwargs": "bad",
+        })
+
+        assert extra_body == {}
+        assert err == "'chat_template_kwargs' must be an object"
+
+    def test_rejects_non_object_nested_provider_extension_merge_target(self):
+        extra_body, err = _extract_request_extra_body({
+            "extra_body": {"chat_template_kwargs": "bad"},
+            "chat_template_kwargs": {"top_k": 4},
+        })
+
+        assert extra_body == {}
+        assert err == "'extra_body.chat_template_kwargs' must be an object"
+
+
+# ---------------------------------------------------------------------------
 # Adapter initialization
 # ---------------------------------------------------------------------------
 
@@ -478,6 +534,67 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["model"] == "primary/model"
 
+    def test_create_agent_merges_request_extra_body(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openai-compatible",
+                "base_url": "https://example.test/v1",
+                "request_overrides": {
+                    "service_tier": "auto",
+                    "extra_body": {
+                        "tags": ["hermes"],
+                        "chat_template_kwargs": {"enable_thinking": False},
+                        "vllm_xargs": {"temperature_floor": 0.0},
+                    },
+                },
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "local")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: {}),
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 90)
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        adapter._create_agent(
+            session_id="api-session",
+            request_extra_body={
+                "chat_template_kwargs": {"top_k": 4},
+                "vllm_xargs": {"lang_guard": "ko_en"},
+                "custom": True,
+            },
+        )
+
+        assert captured["request_overrides"] == {
+            "service_tier": "auto",
+            "extra_body": {
+                "tags": ["hermes"],
+                "chat_template_kwargs": {
+                    "enable_thinking": False,
+                    "top_k": 4,
+                },
+                "vllm_xargs": {
+                    "temperature_floor": 0.0,
+                    "lang_guard": "ko_en",
+                },
+                "custom": True,
+            },
+        }
+
 
 # ---------------------------------------------------------------------------
 # Auth checking
@@ -656,6 +773,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
         "/api/platforms/{platform}/events",
         adapter._handle_platform_event_callback,
     )
+    app.router.add_post("/v1/runs", adapter._handle_runs)
     return app
 
 
@@ -717,6 +835,26 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+
+    @pytest.mark.asyncio
+    async def test_run_agent_forwards_request_extra_body(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent) as create_agent:
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+                request_extra_body={"vllm_xargs": {"lang_guard": "ko_en"}},
+            )
+
+        assert create_agent.call_args.kwargs["request_extra_body"] == {
+            "vllm_xargs": {"lang_guard": "ko_en"},
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1253,6 +1391,37 @@ class TestChatCompletionsEndpoint:
             data = await resp.json()
             assert data["object"] == "chat.completion"
             assert data["choices"][0]["message"]["content"] == mock_result["final_response"]
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_forwards_request_extra_body(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "extra_body": {
+                            "tags": ["hermes"],
+                            "vllm_xargs": {"temperature_floor": 0.0},
+                        },
+                        "vllm_xargs": {"lang_guard": "ko_en"},
+                    },
+                )
+
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["request_extra_body"] == {
+                "tags": ["hermes"],
+                "vllm_xargs": {
+                    "temperature_floor": 0.0,
+                    "lang_guard": "ko_en",
+                },
+            }
 
     @pytest.mark.asyncio
     async def test_stream_task_done_callback_enqueues_eos_for_chat_completions(self, adapter):
@@ -1891,6 +2060,31 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+
+    @pytest.mark.asyncio
+    async def test_responses_forwards_request_extra_body(self, adapter):
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Hello",
+                        "vllm_xargs": {"lang_guard": "ko_en"},
+                    },
+                )
+
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["request_extra_body"] == {
+                "vllm_xargs": {"lang_guard": "ko_en"},
+            }
 
     @pytest.mark.asyncio
     async def test_successful_response_with_array_input(self, adapter):
@@ -2720,6 +2914,49 @@ class TestResponsesStreaming:
         stored = adapter._response_store.get(response_id)
         assert stored is not None, "snapshot must survive client disconnect"
         assert stored["response"]["status"] == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# /v1/runs endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRunsEndpoint:
+    @pytest.mark.asyncio
+    async def test_runs_forwards_request_extra_body(self, adapter):
+        agent_created = asyncio.Event()
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+
+        def _fake_create_agent(*args, **kwargs):
+            agent_created.set()
+            return mock_agent
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=_fake_create_agent) as create_agent:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Hello",
+                        "vllm_xargs": {"lang_guard": "ko_en"},
+                    },
+                )
+                assert resp.status == 202
+                data = await resp.json()
+
+                await asyncio.wait_for(agent_created.wait(), timeout=1)
+                assert create_agent.call_args.kwargs["request_extra_body"] == {
+                    "vllm_xargs": {"lang_guard": "ko_en"},
+                }
+
+                task = adapter._active_run_tasks.get(data["run_id"])
+                if task is not None:
+                    await asyncio.wait_for(task, timeout=1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Preserves request-level provider-specific OpenAI-compatible fields when the API server creates provider calls.

OpenAI SDK `extra_body` values are serialized into the request JSON body rather than sent as a nested SDK-only field. Before this change, the API server parsed the OpenAI-compatible request, reconstructed an `AIAgent`, and dropped those provider-specific fields before the model request was built. That meant callers could not pass backend extensions such as vLLM `vllm_xargs` through `/v1/chat/completions`, `/v1/responses`, or `/v1/runs`.

This PR extracts request-level `extra_body` and top-level `vllm_xargs`, merges them into `request_overrides.extra_body`, and forwards the result to the provider call. Hermes does not interpret provider-specific keys; it only preserves them for the OpenAI-compatible backend.

Existing open PRs checked for overlap: #30224, #21554, and #26517. Those cover gateway turn override preservation, config-level provider `extra_body`, and fallback-provider `extra_body`; this PR is limited to API server request-level passthrough.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Added request extra body extraction for explicit nested `extra_body` and SDK-produced top-level `vllm_xargs`.
  - Merges request-level provider fields into `runtime_kwargs["request_overrides"]["extra_body"]` with request values taking precedence.
  - Forwards request extra body through `/v1/chat/completions`, `/v1/responses`, and `/v1/runs`.
  - Includes `extra_body` and `vllm_xargs` in idempotency fingerprints.
- `tests/gateway/test_api_server.py`
  - Added extraction and merge coverage.
  - Added endpoint coverage for chat completions, responses, and runs forwarding.

## How to Test

1. Run focused API server tests:
   ```bash
   uv run pytest tests/gateway/test_api_server.py -q --timeout-method=thread
   ```
   Result on Windows 11: `162 passed, 1 skipped`.

2. Run lint and Windows compatibility checks:
   ```bash
   uv run ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
   uv run python scripts/check-windows-footguns.py gateway/platforms/api_server.py tests/gateway/test_api_server.py
   ```
   Result: both passed.

3. Run a manual API server smoke test on an alternate localhost port, POSTing `/v1/chat/completions` with top-level `vllm_xargs` and asserting it reaches `request_extra_body`.
   Result on Ubuntu/DGX Spark, Python 3.11: `manual_api_server_smoke: passed`.

4. Run the full suite with the project test wrapper:
   ```bash
   scripts/run_tests.sh
   ```
   Result on Ubuntu/DGX Spark, Python 3.11: `1219 files, 26558 tests passed, 0 failed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 and Ubuntu/DGX Spark (aarch64, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

This is request-construction logic covered by tests. Full-suite summary:

```text
=== Summary: 1219 files, 26558 tests passed, 0 failed (100% complete) in 170.5s (40 workers) ===
```