### PR TITLE
fix(gateway): add 1s cooldown after --replace cleanup to prevent restart death spiral

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18224,6 +18224,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                     logger.info("Released %d stale scoped lock(s) from old gateway.", _released)
             except Exception:
                 pass
+            # Cooldown: give the kernel a moment to release the old
+            # gateway's listening sockets and file descriptors before
+            # we try to claim them for ourselves. Without this, a
+            # SIGKILL'd gateway can leave resources in TIME_WAIT that
+            # block the new instance from binding, creating a
+            # restart-death-spiral when the process supervisor
+            # immediately respawns us.
+            time.sleep(1.0)
         else:
             hermes_home = str(get_hermes_home())
             logger.error(


### PR DESCRIPTION
When gateway dies and Relay restarts it, the old sockets may still be in TIME_WAIT. New instance crashes on bind → death spiral. A 1s sleep after --replace cleanup fixes this.