### PR TITLE
fix(codex): recover from NoneType stream finalizer errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3060,6 +3060,24 @@ class AIAgent:
         message = str(error).strip().lower()
         return "expected ident at line" in message
 
+    def _is_provider_runtime_type_error(self, error: BaseException) -> bool:
+        """Return True for provider-side TypeErrors that should retry.
+
+        The Codex / openai-codex stack sometimes raises ``TypeError:
+        'NoneType' object is not iterable`` during response assembly even when
+        the request itself is valid.  That is provider/runtime failure, not a
+        local programming bug, so it should not be treated as a fatal client
+        error.
+        """
+        if getattr(self, "api_mode", None) != "codex_responses":
+            return False
+        if getattr(self, "provider", None) != "openai-codex":
+            return False
+        if not isinstance(error, TypeError):
+            return False
+        err_text = str(error)
+        return "NoneType" in err_text and "iterable" in err_text
+
     def _log_stream_retry(
         self,
         *,
@@ -7090,6 +7108,42 @@ class AIAgent:
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)
 
+    def _synthesize_codex_response_from_stream_events(
+        self,
+        *,
+        api_kwargs: dict,
+        collected_output_items: list,
+        collected_text_parts: list,
+        has_tool_calls: bool,
+    ) -> Any | None:
+        """Build a minimal Responses-like object from already-seen stream events.
+
+        The Codex backend sometimes emits valid stream events but the SDK's final
+        response reconstruction blows up with a TypeError ('NoneType' is not
+        iterable) or returns an empty output container.  When that happens, the
+        stream contents we already collected are enough to hand the caller a
+        usable response object without re-entering the broken parser.
+        """
+        if collected_output_items:
+            return SimpleNamespace(
+                output=list(collected_output_items),
+                status="completed",
+                model=api_kwargs.get("model"),
+            )
+        if collected_text_parts and not has_tool_calls:
+            assembled = "".join(collected_text_parts)
+            return SimpleNamespace(
+                output=[SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text=assembled)],
+                )],
+                status="completed",
+                model=api_kwargs.get("model"),
+            )
+        return None
+
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
@@ -7155,30 +7209,51 @@ class AIAgent:
                                 sum(len(p) for p in self._codex_streamed_text_parts),
                                 self._client_log_context(),
                             )
-                    final_response = stream.get_final_response()
+                    try:
+                        final_response = stream.get_final_response()
+                    except TypeError as exc:
+                        err_text = str(exc)
+                        if "NoneType" in err_text and "iterable" in err_text:
+                            logger.warning(
+                                "Codex Responses stream finalization hit TypeError (%s); "
+                                "synthesizing from collected stream events. %s",
+                                err_text,
+                                self._client_log_context(),
+                            )
+                            synthesized = self._synthesize_codex_response_from_stream_events(
+                                api_kwargs=api_kwargs,
+                                collected_output_items=collected_output_items,
+                                collected_text_parts=self._codex_streamed_text_parts,
+                                has_tool_calls=has_tool_calls,
+                            )
+                            if synthesized is not None:
+                                return synthesized
+                            return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+                        raise
                     # PATCH: ChatGPT Codex backend streams valid output items
                     # but get_final_response() can return an empty output list.
                     # Backfill from collected items or synthesize from deltas.
                     _out = getattr(final_response, "output", None)
                     if isinstance(_out, list) and not _out:
-                        if collected_output_items:
-                            final_response.output = list(collected_output_items)
-                            logger.debug(
-                                "Codex stream: backfilled %d output items from stream events",
-                                len(collected_output_items),
-                            )
-                        elif self._codex_streamed_text_parts and not has_tool_calls:
-                            assembled = "".join(self._codex_streamed_text_parts)
-                            final_response.output = [SimpleNamespace(
-                                type="message",
-                                role="assistant",
-                                status="completed",
-                                content=[SimpleNamespace(type="output_text", text=assembled)],
-                            )]
-                            logger.debug(
-                                "Codex stream: synthesized output from %d text deltas (%d chars)",
-                                len(self._codex_streamed_text_parts), len(assembled),
-                            )
+                        synthesized = self._synthesize_codex_response_from_stream_events(
+                            api_kwargs=api_kwargs,
+                            collected_output_items=collected_output_items,
+                            collected_text_parts=self._codex_streamed_text_parts,
+                            has_tool_calls=has_tool_calls,
+                        )
+                        if synthesized is not None:
+                            final_response = synthesized
+                            if collected_output_items:
+                                logger.debug(
+                                    "Codex stream: backfilled %d output items from stream events",
+                                    len(collected_output_items),
+                                )
+                            else:
+                                assembled = "".join(self._codex_streamed_text_parts)
+                                logger.debug(
+                                    "Codex stream: synthesized output from %d text deltas (%d chars)",
+                                    len(self._codex_streamed_text_parts), len(assembled),
+                                )
                     return final_response
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
                 if attempt < max_stream_retries:
@@ -7293,23 +7368,25 @@ class AIAgent:
                     # Backfill empty output from collected stream events
                     _out = getattr(terminal_response, "output", None)
                     if isinstance(_out, list) and not _out:
-                        if collected_output_items:
-                            terminal_response.output = list(collected_output_items)
-                            logger.debug(
-                                "Codex fallback stream: backfilled %d output items",
-                                len(collected_output_items),
-                            )
-                        elif collected_text_deltas:
-                            assembled = "".join(collected_text_deltas)
-                            terminal_response.output = [SimpleNamespace(
-                                type="message", role="assistant",
-                                status="completed",
-                                content=[SimpleNamespace(type="output_text", text=assembled)],
-                            )]
-                            logger.debug(
-                                "Codex fallback stream: synthesized from %d deltas (%d chars)",
-                                len(collected_text_deltas), len(assembled),
-                            )
+                        synthesized = self._synthesize_codex_response_from_stream_events(
+                            api_kwargs=api_kwargs,
+                            collected_output_items=collected_output_items,
+                            collected_text_parts=collected_text_deltas,
+                            has_tool_calls=False,
+                        )
+                        if synthesized is not None:
+                            terminal_response = synthesized
+                            if collected_output_items:
+                                logger.debug(
+                                    "Codex fallback stream: backfilled %d output items",
+                                    len(collected_output_items),
+                                )
+                            else:
+                                assembled = "".join(collected_text_deltas)
+                                logger.debug(
+                                    "Codex fallback stream: synthesized from %d deltas (%d chars)",
+                                    len(collected_text_deltas), len(assembled),
+                                )
                     return terminal_response
         finally:
             close_fn = getattr(stream_or_response, "close", None)
@@ -7319,6 +7396,14 @@ class AIAgent:
                 except Exception:
                     pass
 
+        synthesized = self._synthesize_codex_response_from_stream_events(
+            api_kwargs=api_kwargs,
+            collected_output_items=collected_output_items,
+            collected_text_parts=collected_text_deltas,
+            has_tool_calls=False,
+        )
+        if synthesized is not None:
+            return synthesized
         if terminal_response is not None:
             return terminal_response
         raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
@@ -14603,6 +14688,7 @@ class AIAgent:
                             api_error, (UnicodeEncodeError, json.JSONDecodeError)
                         )
                         and not self._is_provider_stream_parse_error(api_error)
+                        and not self._is_provider_runtime_type_error(api_error)
                         # ssl.SSLError (and its subclass SSLCertVerificationError)
                         # inherits from OSError *and* ValueError via Python MRO,
                         # so the isinstance(ValueError) check above would

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -188,6 +188,27 @@ class _FakeCreateStream:
         self.closed = True
 
 
+class _FakeResponsesStreamWithEvents:
+    def __init__(self, *, events=None, final_response=None, final_error=None):
+        self._events = list(events or [])
+        self._final_response = final_response
+        self._final_error = final_error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_response(self):
+        if self._final_error is not None:
+            raise self._final_error
+        return self._final_response
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -396,6 +417,63 @@ def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_mo
     assert "reasoning" not in kwargs
     assert "include" not in kwargs
     assert "prompt_cache_key" not in kwargs
+
+
+def test_run_codex_stream_synthesizes_after_typeerror_finalization(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+    events = [
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="stream synthesis ok")],
+            ),
+        )
+    ]
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStreamWithEvents(
+            events=events,
+            final_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("fallback should not be used")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls["stream"] == 1
+    assert calls["create"] == 0
+    assert response is not None
+    assert getattr(response, "output", None)
+    assert response.output[0].content[0].text == "stream synthesis ok"
+
+
+def test_run_codex_provider_runtime_typeerror_is_retryable(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    assert agent.provider == "openai-codex"
+    assert agent._is_provider_runtime_type_error(
+        TypeError("'NoneType' object is not iterable")
+    )
+    assert not agent._is_provider_runtime_type_error(
+        TypeError("unsupported operand type(s) for +: 'NoneType' and 'int'")
+    )
+    assert not agent._is_provider_runtime_type_error(
+        ValueError("'NoneType' object is not iterable")
+    )
 
 
 def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Adds a targeted recovery path for the Codex Responses stream finalization failure where the provider/backend yields `TypeError: 'NoneType' object is not iterable`. Hermes now treats that provider/runtime shape as retryable and synthesizes a minimal final response from already-collected stream events instead of aborting the request.

## Related Issue

Fixes #33237

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added provider-scoped TypeError classification in `run_agent.py` for the Codex Responses path.
- Added a stream-event synthesis fallback when final response reconstruction fails on `NoneType` iterable errors.
- Added regression coverage in `tests/run_agent/test_run_agent_codex_responses.py`.

## How to Test

1. Run the Codex Responses regression test file.
2. Reproduce the Codex stream finalization path with a backend that returns `response.completed` / `output: null`.
3. Confirm Hermes now completes the turn instead of fataling out.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact per CONTRIBUTING.md

## Verification

- `python3 -m py_compile run_agent.py` passes in the PR checkout.
- Smoke-tested the two regression helpers against the PR checkout with the Hermes runtime Python:
  - `_is_provider_runtime_type_error(...)` returns true only for `openai-codex` + `codex_responses` + `TypeError("'NoneType' object is not iterable")`.
  - `_synthesize_codex_response_from_stream_events(...)` returns a minimal Responses-like object from collected text deltas and collected output items.
- Applied the same fix to a local Homebrew-installed Hermes runtime and verified a real one-shot call succeeds: `hermes -z 'Reply with OK only.' --ignore-rules -t ''` returned `OK`.

## Screenshots / Logs

- Full targeted pytest is still blocked in this checkout because `scripts/run_tests.sh` cannot find a discoverable virtualenv and the system/runtime Pythons do not have `pytest` installed.

