### PR TITLE
fix: remove unused imports flagged by ruff F401 in gateway/ and tools/

### DIFF
--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -26,7 +26,6 @@ piecemeal, the footer is sent as a separate trailing message via
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -113,3 +113,32 @@ class TestLintWorkflow:
             pytest.fail(f"lint.yml is not valid YAML: {exc}")
         assert isinstance(parsed, dict)
         assert "jobs" in parsed
+
+
+class TestGatewayLintRegression:
+    """Gateway-level lint regression guards.
+
+    Each test asserts zero violations of a *specific* rule in a *specific*
+    gateway file.  See test-driven-development skill for the pattern.
+    """
+
+    TARGET = REPO_ROOT / "gateway" / "runtime_footer.py"
+
+    def test_runtime_footer_zero_f401_violations(self):
+        """gateway/runtime_footer.py must have zero F401 (unused-import) violations."""
+        import subprocess
+        import sys
+
+        assert self.TARGET.exists(), f"Target file not found: {self.TARGET}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", str(self.TARGET)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"{self.TARGET} has F401 violation(s):\n{result.stdout}" + (
+                f"\n{result.stderr}" if result.stderr else ""
+            )
+        )

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -142,3 +142,32 @@ class TestGatewayLintRegression:
                 f"\n{result.stderr}" if result.stderr else ""
             )
         )
+
+
+class TestToolsLintRegression:
+    """Tools-level lint regression guards.
+
+    Each test asserts zero violations of a *specific* rule in a *specific*
+    tools file.  See test-driven-development skill for the pattern.
+    """
+
+    TARGET = REPO_ROOT / "tools" / "memory_tool.py"
+
+    def test_memory_tool_zero_f401_violations(self):
+        """tools/memory_tool.py must have zero F401 (unused-import) violations."""
+        import subprocess
+        import sys
+
+        assert self.TARGET.exists(), f"Target file not found: {self.TARGET}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", str(self.TARGET)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"{self.TARGET} has F401 violation(s):\n{result.stdout}" + (
+                f"\n{result.stderr}" if result.stderr else ""
+            )
+        )

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,7 +26,6 @@ Design:
 import json
 import logging
 import os
-import re
 import tempfile
 import time
 from contextlib import contextmanager


### PR DESCRIPTION
## Summary

Remove unused `from pathlib import Path` from `gateway/runtime_footer.py`
flagged by ruff F401. Add a regression test asserting zero F401 violations.

## TDD Verification
- [x] RED: Test written and verified to fail (ruff returned exit code 1 with the expected violation)
- [x] GREEN: Fix applied, regression test passes
- [x] Full test_lint_config.py suite: 6/6 passed

## Changes
- `gateway/runtime_footer.py`: Remove unused `from pathlib import Path` import
- `tests/test_lint_config.py`: Add `TestGatewayLintRegression.test_runtime_footer_zero_f401_violations`

---
## CI Note
> This PR was created by an automated agent. CI may not trigger automatically
because commits were pushed via a PAT without `actions: write` scope. If checks
are pending, please trigger CI manually via `gh workflow run ci --ref fix/gateway-runtime-footer-f401-20260527`.
The label `needs-review` could not be added to this upstream PR due to admin-level
restrictions on the labels API — the fork PR #67 carries this label.

## Changes in this tick (2026-05-27)
- `tools/memory_tool.py`: Remove unused `import re` flagged by ruff F401
- `tests/test_lint_config.py`: Add `TestToolsLintRegression.test_memory_tool_zero_f401_violations` regression test
