### PR TITLE
fix(agent): keep credential pools scoped to active provider

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -559,6 +559,18 @@ def recover_with_credential_pool(
     pool = agent._credential_pool
     if pool is None:
         return False, has_retried_429
+    raw_pool_provider = getattr(pool, "provider", "")
+    raw_current_provider = getattr(agent, "provider", "")
+    pool_provider = raw_pool_provider.strip().lower() if isinstance(raw_pool_provider, str) else ""
+    current_provider = raw_current_provider.strip().lower() if isinstance(raw_current_provider, str) else ""
+    if pool_provider and current_provider and pool_provider != current_provider:
+        _ra().logger.warning(
+            "Skipping credential-pool recovery for provider mismatch "
+            "(pool=%s, current=%s)",
+            pool_provider,
+            current_provider,
+        )
+        return False, has_retried_429
 
     effective_reason = classified_reason
     if effective_reason is None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1038,6 +1038,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
+        try:
+            from agent.credential_pool import load_pool
+
+            fb_pool = load_pool(fb_provider)
+            agent._credential_pool = fb_pool if fb_pool and fb_pool.has_credentials() else None
+        except Exception as exc:
+            logger.debug("Could not load credential pool for fallback %s: %s", fb_provider, exc)
+            agent._credential_pool = None
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True

--- a/run_agent.py
+++ b/run_agent.py
@@ -263,6 +263,11 @@ def _pool_may_recover_from_rate_limit(
     """
     if pool is None:
         return False
+    raw_pool_provider = getattr(pool, "provider", "")
+    pool_provider = raw_pool_provider.strip().lower() if isinstance(raw_pool_provider, str) else ""
+    current_provider = provider.strip().lower() if isinstance(provider, str) else ""
+    if pool_provider and current_provider and pool_provider != current_provider:
+        return False
     if not pool.has_available():
         return False
     # CloudCode / Gemini CLI quotas are account-wide — all pool entries share

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -232,3 +232,46 @@ class TestPoolRotationCycle:
         )
         assert recovered is False
         assert has_retried is False
+
+    def test_provider_mismatch_does_not_mutate_stale_pool(self):
+        """A fallback provider error must not exhaust the primary provider pool."""
+        from run_agent import AIAgent
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+        pool = MagicMock()
+        pool.provider = "openai-codex"
+        agent.provider = "openrouter"
+        agent._credential_pool = pool
+
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=402, has_retried_429=False
+        )
+
+        assert recovered is False
+        assert has_retried is False
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+    def test_provider_match_still_rotates_pool(self):
+        """The provider guard must not block normal same-provider rotation."""
+        from run_agent import AIAgent
+
+        with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+            agent = AIAgent()
+        next_entry = MagicMock()
+        next_entry.id = "next"
+        pool = MagicMock()
+        pool.provider = "openrouter"
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+        agent.provider = "openrouter"
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=402, has_retried_429=False
+        )
+
+        assert recovered is True
+        assert has_retried is False
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None)
+        agent._swap_credential.assert_called_once_with(next_entry)

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -7,6 +7,8 @@ advancement through multiple providers.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
@@ -34,6 +36,14 @@ def _mock_client(base_url="https://openrouter.ai/api/v1", api_key="fb-key"):
     mock.base_url = base_url
     mock.api_key = api_key
     return mock
+
+
+@pytest.fixture(autouse=True)
+def _stub_fallback_pool_load():
+    empty_pool = MagicMock()
+    empty_pool.has_credentials.return_value = False
+    with patch("agent.credential_pool.load_pool", return_value=empty_pool):
+        yield
 
 
 # ── Chain initialisation ──────────────────────────────────────────────────
@@ -116,6 +126,48 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.model == "glm-4.7"
             assert agent._fallback_index == 2
+
+    def test_fallback_replaces_stale_credential_pool(self):
+        fbs = [{"provider": "zai", "model": "glm-5.1"}]
+        agent = _make_agent(fallback_model=fbs)
+        stale_pool = MagicMock()
+        stale_pool.provider = "openai-codex"
+        agent._credential_pool = stale_pool
+        fallback_pool = MagicMock()
+        fallback_pool.provider = "zai"
+        fallback_pool.has_credentials.return_value = True
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(base_url="https://api.z.ai/api/paas/v4/"), "glm-5.1"),
+            ),
+            patch("agent.credential_pool.load_pool", return_value=fallback_pool),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.provider == "zai"
+            assert agent._credential_pool is fallback_pool
+
+    def test_fallback_clears_pool_when_target_has_no_credentials(self):
+        fbs = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        agent = _make_agent(fallback_model=fbs)
+        stale_pool = MagicMock()
+        stale_pool.provider = "openai-codex"
+        agent._credential_pool = stale_pool
+        empty_pool = MagicMock()
+        empty_pool.provider = "openrouter"
+        empty_pool.has_credentials.return_value = False
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(base_url="https://openrouter.ai/api/v1"), "anthropic/claude-sonnet-4"),
+            ),
+            patch("agent.credential_pool.load_pool", return_value=empty_pool),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.provider == "openrouter"
+            assert agent._credential_pool is None
 
     def test_all_exhausted_returns_false(self):
         fbs = [{"provider": "openai", "model": "gpt-4o"}]
@@ -213,6 +265,17 @@ class TestPoolRotationRoom:
     def test_two_credentials_available_returns_true(self):
         """With >1 credentials and at least one available, rotate instead of fallback."""
         assert _pool_may_recover_from_rate_limit(_pool(2)) is True
+
+    def test_mismatched_provider_pool_returns_false(self):
+        """A stale primary pool must not block fallback-provider failover."""
+        pool = _pool(2)
+        pool.provider = "openai-codex"
+        assert _pool_may_recover_from_rate_limit(pool, provider="openrouter") is False
+
+    def test_matching_provider_pool_still_returns_true(self):
+        pool = _pool(2)
+        pool.provider = "openrouter"
+        assert _pool_may_recover_from_rate_limit(pool, provider="openrouter") is True
 
     def test_multiple_credentials_all_in_cooldown_returns_false(self):
         """All credentials cooling down — fall back rather than wait."""


### PR DESCRIPTION
## What changed

- Reload or clear `agent._credential_pool` when provider fallback activation switches to a new provider.
- Skip credential-pool recovery when the loaded pool provider does not match the agent's current provider.
- Treat a provider-mismatched pool as unable to recover rate-limit/billing failures, so a stale primary pool cannot block fallback-chain advancement.
- Add regression coverage for:
  - fallback replacing an `openai-codex` pool with the fallback provider pool,
  - fallback clearing the pool when the target provider has no credentials,
  - mismatched pools not mutating primary credentials on fallback `402`/`429`-style failures,
  - same-provider credential-pool rotation still working.

## Why

Fixes #33088.

When `openai-codex` failed and Hermes activated a fallback provider, the in-memory credential pool could still point at the primary provider. If the fallback provider then returned an exhaustion-style error, Hermes could mark the primary provider's credential as exhausted. Confirmed repros include:

- `openai-codex` primary + `zai` fallback returning `429` code `1113`
- `openai-codex` primary + `openrouter` fallback returning `402`

This made a healthy Codex OAuth credential appear rate-limited or billing-exhausted even though the error came from the fallback provider.

## Testing

- `git diff --check`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m py_compile run_agent.py agent/agent_runtime_helpers.py agent/chat_completion_helpers.py tests/agent/test_credential_pool_routing.py tests/run_agent/test_provider_fallback.py`
- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py tests/agent/test_credential_pool_routing.py`
  - 38 passed
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery tests/run_agent/test_run_agent.py::TestFallbackAnthropicProvider tests/run_agent/test_run_agent.py::TestFallbackSetsOAuthFlag tests/run_agent/test_run_agent.py::TestRunConversation::test_empty_response_triggers_fallback_provider tests/run_agent/test_run_agent.py::TestRunConversation::test_empty_response_fallback_also_empty_returns_empty tests/run_agent/test_run_agent.py::TestRunConversation::test_partial_stream_recovery_preempts_prior_turn_fallback -q`
  - 19 passed, 1 warning
- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py tests/agent/test_credential_pool_routing.py tests/run_agent/test_credential_pool_interrupt.py tests/run_agent/test_codex_xai_oauth_recovery.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_init_fallback_on_exhausted_pool.py`
  - 119 passed

## Manual validation

- Original local repro was validated on macOS: after clearing the stale exhausted state, direct `openai-codex` / `gpt-5.5` succeeded (`hermes -z ... --provider openai-codex -m gpt-5.5` returned `OK`), confirming the observed `429` was not a Codex rate-limit condition.
- I did not run the live fallback failure path again from this clean checkout to avoid intentionally exhausting or mutating real provider auth state; the regression tests reproduce the state-transition bug without touching live credentials.

## Tested platforms

- macOS, Python 3.11 Hermes venv

## Risk / compatibility

- Runtime behavior only changes credential-pool handling when provider identities differ.
- Same-provider rotation and refresh paths are covered by existing and new tests.
- If provider aliases are later expanded, the comparison may need to share a central provider-normalization helper; current tested repros use canonical `openai-codex`, `zai`, and `openrouter` provider ids.
