### PR TITLE
fix(memory): synchronous OpenViking prefetch with current turn's query

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -519,15 +519,44 @@ class OpenVikingMemoryProvider(MemoryProvider):
             )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Return prefetched results from the background thread."""
+        """Search OpenViking synchronously with the CURRENT turn's query.
+
+        Also drains any stale background prefetch result (previous turn's
+        topic) — the synchronous search with *this* turn's query always
+        wins.  This fixes the architectural misunderstanding where the
+        agent was always getting context about the wrong topic.
+        """
+        if not self._client:
+            return ""
+
+        # Drain the stale background prefetch result (previous turn's topic)
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
-            result = self._prefetch_result
             self._prefetch_result = ""
-        if not result:
-            return ""
-        return f"## OpenViking Context\n{result}"
+
+        # Synchronous search with THIS turn's query — not last turn's
+        try:
+            resp = self._client.post("/api/v1/search/find", {
+                "query": query,
+                "top_k": 5,
+            })
+            result = resp.get("result", {})
+            parts = []
+            for ctx_type in ("memories", "resources"):
+                items = result.get(ctx_type, [])
+                for item in items[:3]:
+                    uri = item.get("uri", "")
+                    abstract = item.get("abstract", "")
+                    score = item.get("score", 0)
+                    if abstract and score >= 0.35:
+                        parts.append(f"- [{score:.2f}] {abstract} ({uri})")
+            if parts:
+                return "## OpenViking Context\n" + "\n".join(parts)
+        except Exception as e:
+            logger.debug("OpenViking synchronous prefetch failed: %s", e)
+
+        return ""
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Fire a background search to pre-load relevant context."""


### PR DESCRIPTION
## Problem

The OpenViking memory provider's `prefetch()` method ignores its `query` parameter entirely. 
It returns background-thread results from `queue_prefetch()` which fired at the **end of 
the previous turn** — meaning automatic memory context is always about the wrong topic.

```
Turn N (user asks about AWS):
  Agent responds → background thread searches OV for "AWS" → stores in cache

Turn N+1 (user asks about CSS):
  Agent starts → pulls cache → injects results about "AWS"
  The query "CSS" is literally ignored
```

First turn of every session gets zero context. Every subsequent turn gets stale context 
from the previous topic. The model can manually call `viking_search` to compensate, 
but the automatic recall that fires on every turn is working against it.

This was identified and analyzed in detail by @hammerhoundai in 
[volcengine/OpenViking#2253](https://github.com/volcengine/OpenViking/discussions/2253), 
which documents the full comparison against Claude Code's synchronous recall approach.

### Evidence from source

The `prefetch()` method in `plugins/memory/openviking/__init__.py`:

```python
def prefetch(self, query: str, ...) -> str:
    # The query parameter? Completely ignored.
    # Just returns whatever the background thread found.
    with self._prefetch_lock:
        result = self._prefetch_result
    return f"## OpenViking Context\n{result}"
```

`queue_prefetch()` fires at end of turn N with query "AWS", stores in `_prefetch_result`. 
`prefetch()` at start of turn N+1 with query "CSS" returns the "AWS" result. The API 
signature takes a `query` parameter but the OpenViking provider throws it away.

## Fix

`prefetch()` now does a synchronous `POST /api/v1/search/find` with the **current** 
turn's `query` parameter — matching how Claude Code's plugin works. The stale 
background-thread cache is drained (discarded).

Three changes:

1. **Uses the actual query** — `prefetch(query="CSS")` searches for "CSS", not "AWS"
2. **Score threshold** — minimum 0.35 (matches Claude Code's plugin), filters noise
3. **Clean early return** — returns `""` when no client configured

`queue_prefetch()` is unchanged — it still fires background searches at end of turn 
for pre-warming, but `prefetch()` no longer consumes those results.

## How to test

1. Start Hermes with OpenViking memory provider configured
2. Turn 1: ask a question about topic A — note that first turn gets no context (expected)
3. Turn 2: ask about topic B — verify `## OpenViking Context` contains results about B, not A
4. Turn 3: ask about topic C — verify context follows C, not B

## Tested on

- WSL2 (Ubuntu 26.04), Hermes v0.14.0, OpenViking v0.3.21
- Python 3.11.15, httpx
- Verified: syntax check passes, plugin loads without errors

## Related

- [volcengine/OpenViking#2253](https://github.com/volcengine/OpenViking/discussions/2253) — root cause analysis and comparison with Claude Code
- Hermes issue #9973 — related (prefetch cache lost on gateway AIAgent recreation) but different problem. This fix addresses *relevance*, not *availability*.
