### PR TITLE
feat(tools): add CAMOFOX_API_KEY support for remote Camofox authentication

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2487,6 +2487,14 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "tool",
     },
+    "CAMOFOX_API_KEY": {
+        "description": "API key for remote Camofox browser server authentication",
+        "prompt": "Camofox API key",
+        "url": "https://github.com/jo-inc/camofox-browser",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": True,
+        "category": "tool",
+    },
     "FAL_KEY": {
         "description": "FAL API key for image and video generation",
         "prompt": "FAL API key",

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tools.browser_camofox import (
+    _camofox_headers,
     camofox_back,
     camofox_click,
     camofox_close,
@@ -324,6 +325,58 @@ class TestCamofoxVisionConfig:
         assert result["analysis"] == "Default camofox screenshot analysis"
         assert mock_llm.call_args.kwargs["temperature"] == 0.1
         assert mock_llm.call_args.kwargs["timeout"] == 120.0
+
+
+# ---------------------------------------------------------------------------
+# API key header
+# ---------------------------------------------------------------------------
+
+
+class TestCamofoxApiKeyHeader:
+    def test_headers_return_bearer_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_API_KEY", "test-secret-key")
+        headers = _camofox_headers()
+        assert headers == {"Authorization": "Bearer test-secret-key"}
+
+    def test_headers_empty_when_key_unset(self, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
+        assert _camofox_headers() == {}
+
+    def test_headers_empty_when_key_blank(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_API_KEY", "   ")
+        assert _camofox_headers() == {}
+
+    def test_post_request_includes_auth_header(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("CAMOFOX_API_KEY", "my-api-key")
+
+        captured = {}
+
+        def _capture_post(url, json=None, timeout=None, headers=None):
+            captured["headers"] = headers
+            return _mock_response(json_data={"ok": True, "url": "https://example.com"})
+
+        with patch("tools.browser_camofox.requests.post", side_effect=_capture_post):
+            from tools.browser_camofox import _post
+            _post("/tabs/test1/navigate", {"userId": "u1", "url": "https://example.com"})
+
+        assert captured.get("headers") == {"Authorization": "Bearer my-api-key"}
+
+    def test_get_request_includes_auth_header(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("CAMOFOX_API_KEY", "my-api-key")
+
+        captured = {}
+
+        def _capture_get(url, params=None, timeout=None, headers=None):
+            captured["headers"] = headers
+            return _mock_response(json_data={"snapshot": "", "refsCount": 0})
+
+        with patch("tools.browser_camofox.requests.get", side_effect=_capture_get):
+            from tools.browser_camofox import _get
+            _get("/tabs/test2/snapshot", params={"userId": "u2"})
+
+        assert captured.get("headers") == {"Authorization": "Bearer my-api-key"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -151,7 +151,7 @@ class TestManagedPersistenceMode:
 
         requests_seen = []
 
-        def _capture_post(url, json=None, timeout=None):
+        def _capture_post(url, json=None, timeout=None, headers=None):
             requests_seen.append(json)
             return _mock_response(
                 json_data={"tabId": "tab-1", "url": "https://example.com"}
@@ -171,7 +171,7 @@ class TestManagedPersistenceMode:
 
         requests_seen = []
 
-        def _capture_post(url, json=None, timeout=None):
+        def _capture_post(url, json=None, timeout=None, headers=None):
             requests_seen.append(json)
             return _mock_response(
                 json_data={"tabId": f"tab-{len(requests_seen)}", "url": "https://example.com"}

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -48,6 +48,14 @@ _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
 
 
+def _camofox_headers() -> Dict[str, str]:
+    """Return request headers with API key, if configured."""
+    api_key = os.getenv("CAMOFOX_API_KEY", "").strip()
+    if not api_key:
+        return {}
+    return {"Authorization": f"Bearer {api_key}"}
+
+
 def get_camofox_url() -> str:
     """Return the configured Camofox server URL, or empty string."""
     return os.getenv("CAMOFOX_URL", "").rstrip("/")
@@ -73,7 +81,7 @@ def check_camofox_available() -> bool:
     if not url:
         return False
     try:
-        resp = requests.get(f"{url}/health", timeout=5)
+        resp = requests.get(f"{url}/health", timeout=5, headers=_camofox_headers())
         if resp.status_code == 200 and not _vnc_url_checked:
             try:
                 data = resp.json()
@@ -254,6 +262,7 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     if session["tab_id"]:
         return session
     base = get_camofox_url()
+    headers = _camofox_headers()
     resp = requests.post(
         f"{base}/tabs",
         json={
@@ -262,6 +271,7 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
             "url": url,
         },
         timeout=_DEFAULT_TIMEOUT,
+        headers=headers,
     )
     resp.raise_for_status()
     data = resp.json()
@@ -300,7 +310,8 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """POST JSON to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.post(url, json=body, timeout=timeout)
+    headers = _camofox_headers()
+    resp = requests.post(url, json=body, timeout=timeout, headers=headers)
     resp.raise_for_status()
     return resp.json()
 
@@ -308,7 +319,8 @@ def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
 def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """GET from camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    headers = _camofox_headers()
+    resp = requests.get(url, params=params, timeout=timeout, headers=headers)
     resp.raise_for_status()
     return resp.json()
 
@@ -316,7 +328,8 @@ def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dic
 def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> requests.Response:
     """GET from camofox and return raw response (for binary data)."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    headers = _camofox_headers()
+    resp = requests.get(url, params=params, timeout=timeout, headers=headers)
     resp.raise_for_status()
     return resp
 
@@ -324,7 +337,8 @@ def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) ->
 def _delete(path: str, body: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """DELETE to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout)
+    headers = _camofox_headers()
+    resp = requests.delete(url, json=body, timeout=timeout, headers=headers)
     resp.raise_for_status()
     return resp.json()
 


### PR DESCRIPTION
## Summary

- Add `Authorization: Bearer` header to all Camofox HTTP requests when `CAMOFOX_API_KEY` is set
- Register `CAMOFOX_API_KEY` in `OPTIONAL_ENV_VARS` so it appears in the setup wizard
- Add 5 new tests for header behavior, update 2 existing tests for the new `headers` kwarg

## What changed and why

Remote Camofox deployments need a way to authenticate API requests. This adds support for `CAMOFOX_API_KEY` — when set, all HTTP calls (`_post`, `_get`, `_get_raw`, `_delete`, `check_camofox_available`, `_ensure_tab`) include an `Authorization: Bearer <key>` header.

## Changes

| File | Change |
|------|--------|
| `tools/browser_camofox.py` | Add `_camofox_headers()` helper, apply to all 6 HTTP call sites |
| `hermes_cli/config.py` | Register `CAMOFOX_API_KEY` in `OPTIONAL_ENV_VARS` |
| `tests/tools/test_browser_camofox.py` | Add `TestCamofoxApiKeyHeader` class (5 tests) |
| `tests/tools/test_browser_camofox_persistence.py` | Update 2 mock signatures to accept `headers` kwarg |

## How to test

```bash
# Without API key — headers dict is empty (no-op)
echo "CAMOFOX_URL=http://localhost:9377" >> ~/.hermes/.env

# With API key — Authorization: Bearer header is included
echo "CAMOFOX_API_KEY=your-secret-key" >> ~/.hermes/.env

# Run the test suite
source venv/bin/activate
scripts/run_tests.sh tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_persistence.py
```

All 55 tests pass on Linux.

Closes #20476