### PR TITLE
fix(gateway): merge Telegram startup media into text turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30,6 +30,7 @@ import dataclasses
 import inspect
 import json
 import logging
+import math
 import os
 import re
 import shlex
@@ -4994,6 +4995,121 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # follow-ups is far beyond any realistic conversational backlog while
     # still small enough to never threaten memory.
     _BUSY_QUEUE_MAX_PENDING = 32
+
+    @staticmethod
+    def _event_has_image_media(event: Optional[MessageEvent]) -> bool:
+        if event is None:
+            return False
+        media_urls = getattr(event, "media_urls", None) or []
+        if not media_urls:
+            return False
+        if getattr(event, "message_type", None) == MessageType.PHOTO:
+            return True
+        media_types = getattr(event, "media_types", None) or []
+        return any(str(mtype).startswith("image/") for mtype in media_types)
+
+    def _pop_adapter_pending_image_event(
+        self, adapter: Any, session_key: str
+    ) -> Optional[MessageEvent]:
+        pending_messages = getattr(adapter, "_pending_messages", None)
+        if not pending_messages:
+            return None
+        pending_event = pending_messages.get(session_key)
+        if not self._event_has_image_media(pending_event):
+            return None
+        return pending_messages.pop(session_key, None)
+
+    @staticmethod
+    def _adapter_declared_method(adapter: Any, name: str) -> Optional[Callable[..., Any]]:
+        try:
+            inspect.getattr_static(adapter, name)
+        except AttributeError:
+            return None
+        method = getattr(adapter, name, None)
+        return method if callable(method) else None
+
+    @staticmethod
+    def _startup_media_grace_seconds() -> float:
+        raw = os.getenv("HERMES_TELEGRAM_STARTUP_MEDIA_GRACE_SECONDS", "1.0")
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = 1.0
+        if not math.isfinite(value):
+            value = 1.0
+        return max(0.0, min(value, 3.0))
+
+    async def _merge_startup_media_followups(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        session_key: str,
+    ) -> MessageEvent:
+        """Merge Telegram media that arrived while a text turn was starting.
+
+        Telegram short-text batches intentionally flush quickly, while photo
+        batches wait longer to collect albums/bursts. A back-to-back
+        "question text" + screenshot send can therefore start an agent turn
+        before the screenshot reaches the normal image routing path. Just
+        before prompt preparation, steal any pending Telegram image follow-up
+        for the same session and fold it into the current user event.
+        """
+        if (
+            source.platform != Platform.TELEGRAM
+            or event.message_type != MessageType.TEXT
+            or self._event_has_image_media(event)
+        ):
+            return event
+
+        adapter = self.adapters.get(source.platform)
+        if adapter is None:
+            return event
+
+        grace = self._startup_media_grace_seconds()
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + grace
+        merged_count = 0
+        pop_startup_media_event = self._adapter_declared_method(
+            adapter, "pop_startup_media_event"
+        )
+        has_startup_media_pending = self._adapter_declared_method(
+            adapter, "has_startup_media_pending"
+        )
+
+        while True:
+            incoming = self._pop_adapter_pending_image_event(adapter, session_key)
+            if incoming is None and pop_startup_media_event is not None:
+                try:
+                    incoming = pop_startup_media_event(session_key)
+                except Exception:
+                    logger.debug("Telegram startup media pop failed", exc_info=True)
+                    incoming = None
+
+            if incoming is not None:
+                slot = {session_key: event}
+                merge_pending_message_event(slot, session_key, incoming)
+                event = slot[session_key]
+                merged_count += len(getattr(incoming, "media_urls", None) or [])
+                continue
+
+            has_pending = False
+            if has_startup_media_pending is not None:
+                try:
+                    has_pending = bool(has_startup_media_pending(session_key))
+                except Exception:
+                    logger.debug("Telegram startup media pending check failed", exc_info=True)
+                    has_pending = False
+            if not has_pending or loop.time() >= deadline:
+                break
+            await asyncio.sleep(min(0.05, max(0.0, deadline - loop.time())))
+
+        if merged_count:
+            logger.info(
+                "Merged %d Telegram startup image(s) into text turn for session %s",
+                merged_count,
+                session_key,
+            )
+        return event
 
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self._adapter_for_source(event.source)
@@ -10997,6 +11113,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
+        event = await self._merge_startup_media_followups(event, source, session_key)
         message_text = await self._prepare_inbound_message_text(
             event=event,
             source=source,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -77,6 +77,7 @@ from gateway.platforms.base import (
     cache_video_from_bytes,
     cache_document_from_bytes,
     resolve_proxy_url,
+    merge_pending_message_event,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
@@ -391,6 +392,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
+        self._media_downloads_in_progress_by_session: Dict[str, int] = {}
         # Buffer rapid text messages so Telegram client-side splits of long
         # messages are aggregated into a single MessageEvent.  Lower defaults
         # (0.3s / 1.0s instead of 0.6s / 2.0s) let short replies stream
@@ -7231,6 +7233,117 @@ class TelegramAdapter(BasePlatformAdapter):
     # Photo batching
     # ------------------------------------------------------------------
 
+    def _event_session_key(self, event: MessageEvent) -> str:
+        """Return the gateway session key used by text/photo batching."""
+        from gateway.session import build_session_key
+
+        return build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+
+    def _track_media_download_start(self, event: MessageEvent) -> str:
+        """Mark a Telegram image download that may belong to a nearby text turn."""
+        session_key = self._event_session_key(event)
+        counts = getattr(self, "_media_downloads_in_progress_by_session", None)
+        if counts is None:
+            counts = {}
+            self._media_downloads_in_progress_by_session = counts
+        counts[session_key] = counts.get(session_key, 0) + 1
+        return session_key
+
+    def _track_media_download_done(self, session_key: Optional[str]) -> None:
+        if not session_key:
+            return
+        counts = getattr(self, "_media_downloads_in_progress_by_session", None)
+        if not counts:
+            return
+        remaining = counts.get(session_key, 0) - 1
+        if remaining > 0:
+            counts[session_key] = remaining
+        else:
+            counts.pop(session_key, None)
+
+    def has_startup_media_pending(self, session_key: str) -> bool:
+        """Whether Telegram has image work that can still join a starting text turn."""
+        if not session_key:
+            return False
+        counts = getattr(self, "_media_downloads_in_progress_by_session", None) or {}
+        if counts.get(session_key, 0) > 0:
+            return True
+        prefix = f"{session_key}:"
+        for key in getattr(self, "_pending_photo_batches", {}) or {}:
+            if key == f"{session_key}:photo-burst" or key.startswith(prefix + "album:"):
+                return True
+        for event in (getattr(self, "_media_group_events", {}) or {}).values():
+            try:
+                if self._event_session_key(event) == session_key:
+                    return True
+            except Exception:
+                continue
+        return False
+
+    @staticmethod
+    def _event_has_image_media(event: MessageEvent) -> bool:
+        media_urls = getattr(event, "media_urls", None) or []
+        if not media_urls:
+            return False
+        media_types = getattr(event, "media_types", None) or []
+        if getattr(event, "message_type", None) == MessageType.PHOTO:
+            return True
+        return any(str(mtype).startswith("image/") for mtype in media_types)
+
+    def _merge_startup_media_events(
+        self,
+        merged_by_session: Dict[str, MessageEvent],
+        session_key: str,
+        event: MessageEvent,
+    ) -> None:
+        if not self._event_has_image_media(event):
+            return
+        merge_pending_message_event(merged_by_session, session_key, event)
+
+    def pop_startup_media_event(self, session_key: str) -> Optional[MessageEvent]:
+        """Consume buffered Telegram image batches that can join a starting text turn."""
+        if not session_key:
+            return None
+
+        merged_by_session: Dict[str, MessageEvent] = {}
+        pending_photo_batches = getattr(self, "_pending_photo_batches", None) or {}
+        pending_photo_tasks = getattr(self, "_pending_photo_batch_tasks", None) or {}
+        photo_keys = [
+            key for key in list(pending_photo_batches.keys())
+            if key == f"{session_key}:photo-burst"
+            or key.startswith(f"{session_key}:album:")
+        ]
+        for key in photo_keys:
+            event = pending_photo_batches.pop(key, None)
+            task = pending_photo_tasks.pop(key, None)
+            if task is not None and not task.done():
+                task.cancel()
+            if event is not None:
+                self._merge_startup_media_events(merged_by_session, session_key, event)
+
+        media_group_events = getattr(self, "_media_group_events", None) or {}
+        media_group_tasks = getattr(self, "_media_group_tasks", None) or {}
+        group_ids = []
+        for group_id, event in list(media_group_events.items()):
+            try:
+                if self._event_session_key(event) == session_key:
+                    group_ids.append(group_id)
+            except Exception:
+                continue
+        for group_id in group_ids:
+            event = media_group_events.pop(group_id, None)
+            task = media_group_tasks.pop(group_id, None)
+            if task is not None and not task.done():
+                task.cancel()
+            if event is not None:
+                self._merge_startup_media_events(merged_by_session, session_key, event)
+
+        return merged_by_session.get(session_key)
+
     def _photo_batch_key(self, event: MessageEvent, msg: Message) -> str:
         """Return a batching key for Telegram photos/albums."""
         from gateway.session import build_session_key
@@ -7330,6 +7443,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Download photo to local image cache so the vision tool can access it
         # even after Telegram's ephemeral file URLs expire (~1 hour).
         if msg.photo:
+            image_download_session_key = self._track_media_download_start(event)
             try:
                 # msg.photo is a list of PhotoSize sorted by size; take the largest
                 photo = msg.photo[-1]
@@ -7359,6 +7473,8 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache photo: %s", e, exc_info=True)
                 await self._surface_media_cache_failure(msg, event, "photo", e)
+            finally:
+                self._track_media_download_done(image_download_session_key)
 
         # Download voice/audio messages to cache for STT transcription
         if msg.voice:
@@ -7458,31 +7574,35 @@ class TelegramAdapter(BasePlatformAdapter):
                 # payload is actually an image, route it through the image cache
                 # and batching path instead of rejecting it as a document.
                 if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
-                    file_obj = await doc.get_file()
-                    image_bytes = await file_obj.download_as_bytearray()
-                    image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                    image_download_session_key = self._track_media_download_start(event)
                     try:
-                        cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
-                    except ValueError as e:
-                        logger.warning("[Telegram] Failed to cache image document: %s", e, exc_info=True)
-                        event.text = (
-                            f"Image document '{original_filename or doc_mime or ext or 'unknown'}' "
-                            "could not be read as an image."
-                        )
-                        await self.handle_message(event)
-                        return
+                        file_obj = await doc.get_file()
+                        image_bytes = await file_obj.download_as_bytearray()
+                        image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                        try:
+                            cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
+                        except ValueError as e:
+                            logger.warning("[Telegram] Failed to cache image document: %s", e, exc_info=True)
+                            event.text = (
+                                f"Image document '{original_filename or doc_mime or ext or 'unknown'}' "
+                                "could not be read as an image."
+                            )
+                            await self.handle_message(event)
+                            return
 
-                    event.message_type = MessageType.PHOTO
-                    event.media_urls = [cached_path]
-                    event.media_types = [doc_mime if doc_mime.startswith("image/") else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")]
-                    logger.info("[Telegram] Cached user image-document at %s", cached_path)
+                        event.message_type = MessageType.PHOTO
+                        event.media_urls = [cached_path]
+                        event.media_types = [doc_mime if doc_mime.startswith("image/") else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")]
+                        logger.info("[Telegram] Cached user image-document at %s", cached_path)
 
-                    media_group_id = getattr(msg, "media_group_id", None)
-                    if media_group_id:
-                        await self._queue_media_group_event(str(media_group_id), event)
-                    else:
-                        batch_key = self._photo_batch_key(event, msg)
-                        self._enqueue_photo_event(batch_key, event)
+                        media_group_id = getattr(msg, "media_group_id", None)
+                        if media_group_id:
+                            await self._queue_media_group_event(str(media_group_id), event)
+                        else:
+                            batch_key = self._photo_batch_key(event, msg)
+                            self._enqueue_photo_event(batch_key, event)
+                    finally:
+                        self._track_media_download_done(image_download_session_key)
                     return
 
                 if not ext and doc.mime_type:

--- a/tests/gateway/test_telegram_text_photo_startup_merge.py
+++ b/tests/gateway/test_telegram_text_photo_startup_merge.py
@@ -1,0 +1,153 @@
+import asyncio
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class _DummyTask:
+    def __init__(self):
+        self.cancelled = False
+
+    def done(self):
+        return False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="273403055",
+        chat_type="dm",
+        user_id="273403055",
+        user_name="Maxim E.",
+        thread_id="363402",
+    )
+
+
+def _text_event(source: SessionSource) -> MessageEvent:
+    return MessageEvent(
+        text="Is this a real study?",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+
+def _photo_event(source: SessionSource, path: str = "/tmp/alcohol-study.jpg") -> MessageEvent:
+    return MessageEvent(
+        text="",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=[path],
+        media_types=["image/jpeg"],
+    )
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    adapter.config = PlatformConfig(enabled=True, token="fake")
+    adapter._pending_messages = {}
+    adapter._pending_photo_batches = {}
+    adapter._pending_photo_batch_tasks = {}
+    adapter._media_group_events = {}
+    adapter._media_group_tasks = {}
+    adapter._media_downloads_in_progress_by_session = {}
+    return adapter
+
+
+def _make_runner(adapter: TelegramAdapter) -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda **_: "native"
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_gateway_merges_buffered_photo_batch_before_image_routing():
+    source = _source()
+    session_key = build_session_key(source)
+    adapter = _make_adapter()
+    runner = _make_runner(adapter)
+    task = _DummyTask()
+    adapter._pending_photo_batches[f"{session_key}:photo-burst"] = _photo_event(source)
+    adapter._pending_photo_batch_tasks[f"{session_key}:photo-burst"] = task
+
+    event = await runner._merge_startup_media_followups(
+        _text_event(source),
+        source,
+        session_key,
+    )
+    message_text = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+        session_key=session_key,
+    )
+
+    assert message_text == "Is this a real study?"
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == ["/tmp/alcohol-study.jpg"]
+    assert runner._consume_pending_native_image_paths(session_key) == ["/tmp/alcohol-study.jpg"]
+    assert adapter._pending_photo_batches == {}
+    assert task.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_waits_for_in_progress_photo_download(monkeypatch):
+    source = _source()
+    session_key = build_session_key(source)
+    adapter = _make_adapter()
+    runner = _make_runner(adapter)
+    adapter._media_downloads_in_progress_by_session[session_key] = 1
+    monkeypatch.setenv("HERMES_TELEGRAM_STARTUP_MEDIA_GRACE_SECONDS", "0.2")
+
+    async def finish_download():
+        await asyncio.sleep(0.02)
+        adapter._pending_photo_batches[f"{session_key}:photo-burst"] = _photo_event(
+            source,
+            "/tmp/late-photo.jpg",
+        )
+        adapter._media_downloads_in_progress_by_session.pop(session_key, None)
+
+    producer = asyncio.create_task(finish_download())
+    event = await runner._merge_startup_media_followups(
+        _text_event(source),
+        source,
+        session_key,
+    )
+    await producer
+
+    assert event.message_type == MessageType.PHOTO
+    assert event.text == "Is this a real study?"
+    assert event.media_urls == ["/tmp/late-photo.jpg"]
+    assert adapter._pending_photo_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_merges_priority_queued_photo_followup():
+    source = _source()
+    session_key = build_session_key(source)
+    adapter = _make_adapter()
+    runner = _make_runner(adapter)
+    adapter._pending_messages[session_key] = _photo_event(source, "/tmp/queued-photo.jpg")
+
+    event = await runner._merge_startup_media_followups(
+        _text_event(source),
+        source,
+        session_key,
+    )
+
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == ["/tmp/queued-photo.jpg"]
+    assert session_key not in adapter._pending_messages


### PR DESCRIPTION
## What does this PR do?

Fixes a Telegram cross-modal startup race where a short text message can start an agent turn before a same-session photo finishes downloading and flushing from the photo batch buffer.

The runner now gives Telegram text-only events a short bounded chance to merge same-session image followups before preparing prompt text and native image routing. This preserves the text fast path for normal text-only messages while preventing image-backed questions from becoming text-only turns.

## Related Issue

Fixes #33270

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: tracks in-progress same-session image downloads and exposes a helper to pop/merge startup photo-burst and media-group buffers.
- `gateway/run.py`: merges same-session Telegram image followups into text-only events before prompt preparation and image routing, including a bounded grace window controlled by `HERMES_TELEGRAM_STARTUP_MEDIA_GRACE_SECONDS`.
- `tests/gateway/test_telegram_text_photo_startup_merge.py`: covers buffered photo batches, in-progress photo downloads, and image followups already queued by the active-session pending path.

## How to Test

1. Send a short Telegram text question to a cold or just-starting session.
2. Immediately send a photo/image that provides the question context.
3. Confirm the first agent turn includes the text and image, and native image routing sees the image before the agent invocation.

Focused regression commands run:

```bash
/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/gateway/test_telegram_text_photo_startup_merge.py tests/gateway/test_telegram_photo_interrupts.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_telegram_text_batch_perf.py tests/gateway/test_native_image_buffer_isolation.py
# 23 passed, 1 warning in 3.63s

/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_max_doc_bytes.py tests/gateway/test_telegram_caption_merge.py tests/gateway/test_telegram_text_photo_startup_merge.py
# 60 passed, 1 warning in 5.46s

/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/gateway/test_telegram_text_photo_startup_merge.py
# 3 passed, 1 warning in 0.77s

/usr/local/lib/hermes-agent/venv/bin/python -m ruff check gateway/run.py gateway/platforms/telegram.py tests/gateway/test_telegram_text_photo_startup_merge.py
# All checks passed!

/usr/local/lib/hermes-agent/venv/bin/python -m py_compile gateway/run.py gateway/platforms/telegram.py tests/gateway/test_telegram_text_photo_startup_merge.py
```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — gateway/Telegram async logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Sanitized failing order from the production session:

```text
15:11:54.430 Flushing text batch ... (26 chars)
15:11:54.432 inbound message ... msg='Это реальное исследование?'
15:11:54.554 Cached user photo at /root/.hermes/image_cache/...
15:11:55.376 Flushing photo batch ... with 1 image(s)
15:11:55.996 conversation turn ... history=0 msg='Это реальное исследование?'
```

The image was cached locally but did not reach image routing before the turn started.
