### PR TITLE
fix: patch Responses API parse_response to handle empty/None output field

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -42,6 +42,21 @@ def _load_openai_cls() -> type:
     if _OPENAI_CLS_CACHE is None:
         from openai import OpenAI as _cls
         _OPENAI_CLS_CACHE = _cls
+        # Apply Responses API parse_response monkey patch to handle empty/None output fields
+        try:
+            import openai.lib._parsing._responses as responses_parsing
+            _orig_parse_response = responses_parsing.parse_response
+
+            def _patched_parse_response(*args, **kwargs):
+                response = kwargs.get("response")
+                if response is not None:
+                    if getattr(response, "output", None) is None:
+                        response.output = []
+                return _orig_parse_response(*args, **kwargs)
+
+            responses_parsing.parse_response = _patched_parse_response
+        except Exception:
+            pass
     return _OPENAI_CLS_CACHE
 
 


### PR DESCRIPTION
This PR fixes a `TypeError: 'NoneType' object is not iterable` in the `openai` SDK when utilizing Codex/Responses backends where `response.output` is returned as `None` (for instance, on the final `response.completed` event).

We apply a runtime monkey-patch to `openai.lib._parsing._responses.parse_response` inside `_load_openai_cls()` to default `response.output` to `[]` when `None`, preventing the crash.