### PR TITLE
Fixes: Hermes fallback issue with kimi-for-coding -- anthropic_messages endpoint returning 404

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1027,6 +1027,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             and base_url_host_matches(fb_base_url, "amazonaws.com")
         ):
             fb_api_mode = "bedrock_converse"
+        else:
+            # Fallback: use the same URL-based detection that
+            # determine_api_mode() and _resolve_explicit_runtime() use
+            # for direct provider switches.  This catches endpoints like
+            # Kimi's ``api.kimi.com/coding`` (Anthropic Messages) that
+            # the inline heuristics above miss.  See #22548.
+            from hermes_cli.runtime_provider import _detect_api_mode_for_url
+            detected = _detect_api_mode_for_url(fb_base_url)
+            if detected:
+                fb_api_mode = detected
 
         old_model = agent.model
 


### PR DESCRIPTION
**Problem statement:**
In Hermes-Agent, when configured primary model fails and Hermes-Agent falls back to secondary, here my configuration is kimi-for-coding, the fallback path uses chat_completions (OpenAI client) against api.kimi.com/coding,  which speaks Anthropic Messages → HTTP 404.

Direct provider switches (hermes chat --provider kimi-coding) work correctly because it calls determine_api_mode() / _detect_api_mode_for_url().

**Root Cause**
Try_activate_fallback() in agent/chat_completion_helpers.py has inline api_mode heuristics that miss api.kimi.com/coding (Anthropic Messages).

**Fix**
Add a final else branch that calls _detect_api_mode_for_url() as a fallback detector, matching the behavior of explicit model switches.

Verification
    - Kimi fallback: api_mode = anthropic_messages ✅
    - OpenAI fallback: api_mode = codex_responses ✅
    - DeepSeek fallback: api_mode = chat_completions ✅


- [ x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

