### PR TITLE
fix(codex): recover from SDK none-output iterator crash

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -281,7 +281,35 @@ def _consume_codex_event_stream(
     terminal_error: Any = None
     saw_terminal = False
 
-    for event in event_iter:
+    event_iter = iter(event_iter)
+    while True:
+        try:
+            event = next(event_iter)
+        except StopIteration:
+            break
+        except TypeError as exc:
+            # The OpenAI SDK's streamed Responses iterator still runs its own
+            # accumulator while yielding SSE events. When chatgpt.com emits a
+            # terminal snapshot whose ``response.output`` is ``null``, the SDK
+            # trips over ``for output in response.output`` and raises
+            # ``TypeError: 'NoneType' object is not iterable`` *after* earlier
+            # ``response.output_item.done`` / ``response.output_text.delta``
+            # events have already arrived. If we have recoverable streamed
+            # state, synthesize the final response from that state instead of
+            # letting a local parse bug poison credential-pool health.
+            if "not iterable" not in str(exc):
+                raise
+            if not collected_output_items and not collected_text_deltas:
+                raise
+            logger.debug(
+                "Codex Responses iterator hit SDK None-output TypeError; "
+                "recovering from streamed state (items=%d, chars=%d)",
+                len(collected_output_items),
+                sum(len(p) for p in collected_text_deltas),
+            )
+            saw_terminal = True
+            terminal_status = terminal_status or "completed"
+            break
         if on_event is not None:
             try:
                 on_event(event)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2914,7 +2914,11 @@ def run_conversation(
                 if is_client_error:
                     # Try fallback before aborting — a different provider
                     # may not have the same issue (rate limit, auth, etc.)
-                    agent._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                    _err_kind = agent._nonretryable_error_kind(status_code, api_error)
+                    agent._emit_status(
+                        f"⚠️ Non-retryable error ({_err_kind}): "
+                        f"{agent._summarize_api_error(api_error)} — trying fallback..."
+                    )
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -2925,10 +2929,10 @@ def run_conversation(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,
                         )
                     agent._emit_status(
-                        f"❌ Non-retryable error (HTTP {status_code}): "
+                        f"❌ Non-retryable error ({_err_kind}): "
                         f"{agent._summarize_api_error(api_error)}"
                     )
-                    agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
+                    agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error ({_err_kind}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
                     # Actionable guidance for common auth errors

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import threading
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
@@ -100,15 +101,38 @@ CONCLUDE_SCHEMA = {
     "name": "mem0_conclude",
     "description": (
         "Store a durable fact about the user. Stored verbatim (no LLM extraction). "
-        "Use for explicit preferences, corrections, or decisions."
+        "Use for explicit preferences, corrections, decisions, or operational facts. "
+        "Optional metadata lets callers separate preferences, doctrine, facts, and history."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "conclusion": {"type": "string", "description": "The fact to store."},
+            "memory_class": {
+                "type": "string",
+                "enum": ["preference", "doctrine", "factual", "temporal"],
+                "description": "Optional class override for the stored memory.",
+            },
+            "time_scope": {
+                "type": "string",
+                "enum": ["current", "past", "future", "timeless"],
+                "description": "Optional time-scope override for the stored memory.",
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Optional extra metadata stored alongside the memory.",
+            },
         },
         "required": ["conclusion"],
     },
+}
+
+_EXPLICIT_PREFIX_RE = re.compile(r"^\[(?:PREF|RULE|FACT|HIST)(?:/(?:CURRENT|PAST|FUTURE|TIMELESS))?\]\s*")
+_MEMORY_CLASS_PREFIX = {
+    "preference": "PREF",
+    "doctrine": "RULE",
+    "factual": "FACT",
+    "temporal": "HIST",
 }
 
 
@@ -127,10 +151,12 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = "hermes-user"
         self._agent_id = "hermes"
         self._rerank = True
+        self._sync_turn_mode = "full"
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
         self._sync_thread = None
+        self._write_thread = None
         # Circuit breaker state
         self._consecutive_failures = 0
         self._breaker_open_until = 0.0
@@ -163,6 +189,7 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
+            {"key": "sync_turn_mode", "description": "Automatic turn-to-memory extraction mode", "default": "full", "choices": ["full", "off"]},
         ]
 
     def _get_client(self):
@@ -208,10 +235,25 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
         self._agent_id = self._config.get("agent_id", "hermes")
         self._rerank = self._config.get("rerank", True)
+        if "sync_turn_mode" in self._config:
+            self._sync_turn_mode = str(self._config.get("sync_turn_mode", "full") or "full").strip().lower()
+        elif self._config.get("sync_turns") is False:
+            self._sync_turn_mode = "off"
+        else:
+            self._sync_turn_mode = "full"
+        if self._sync_turn_mode not in {"full", "off"}:
+            self._sync_turn_mode = "full"
 
     def _read_filters(self) -> Dict[str, Any]:
         """Filters for search/get_all — scoped to user only for cross-session recall."""
         return {"user_id": self._user_id}
+
+    def _scoped_read_filters(self) -> Dict[str, Any]:
+        """Fallback filters for stores that only return agent-scoped memories."""
+        filters = self._read_filters().copy()
+        if self._agent_id:
+            filters["agent_id"] = self._agent_id
+        return filters
 
     def _write_filters(self) -> Dict[str, Any]:
         """Filters for add — scoped to user + agent for attribution."""
@@ -226,6 +268,107 @@ class Mem0MemoryProvider(MemoryProvider):
             return response
         return []
 
+    @staticmethod
+    def _strip_explicit_prefix(text: str) -> str:
+        return _EXPLICIT_PREFIX_RE.sub("", (text or "").strip())
+
+    @classmethod
+    def _normalize_memory_class(cls, value: Optional[str], *, target: str = "memory", content: str = "") -> str:
+        raw = str(value or "").strip().lower()
+        aliases = {
+            "pref": "preference",
+            "preference": "preference",
+            "user": "preference",
+            "rule": "doctrine",
+            "doctrine": "doctrine",
+            "policy": "doctrine",
+            "fact": "factual",
+            "factual": "factual",
+            "current_fact": "factual",
+            "history": "temporal",
+            "historical": "temporal",
+            "temporal": "temporal",
+            "past": "temporal",
+        }
+        if raw in aliases:
+            return aliases[raw]
+        if target == "user":
+            return "preference"
+        base = cls._strip_explicit_prefix(content).lower()
+        if re.search(r"\b(do not|don't|never|must|should|unless|only if|expected to|keep .* on)\b", base):
+            return "doctrine"
+        if re.search(r"\b(previously|earlier|before|used to|was changed|retired|on 20\d{2}-\d{2}-\d{2}|as of)\b", base):
+            return "temporal"
+        return "factual"
+
+    @staticmethod
+    def _normalize_time_scope(value: Optional[str], content: str = "") -> str:
+        raw = str(value or "").strip().lower()
+        aliases = {
+            "current": "current",
+            "now": "current",
+            "present": "current",
+            "past": "past",
+            "previous": "past",
+            "historical": "past",
+            "future": "future",
+            "planned": "future",
+            "timeless": "timeless",
+            "rule": "timeless",
+        }
+        if raw in aliases:
+            return aliases[raw]
+        base = Mem0MemoryProvider._strip_explicit_prefix(content).lower()
+        if re.search(r"\b(plan|planned|later|upcoming|will|future)\b", base):
+            return "future"
+        if re.search(r"\b(always|never|must|should|unless|only if|expected to)\b", base):
+            return "timeless"
+        if re.search(r"\b(previously|earlier|before|used to|was|were|retired|on 20\d{2}-\d{2}-\d{2}|as of)\b", base):
+            return "past"
+        return "current"
+
+    @classmethod
+    def _decorate_explicit_memory(
+        cls,
+        content: str,
+        *,
+        target: str = "memory",
+        memory_class: Optional[str] = None,
+        time_scope: Optional[str] = None,
+    ) -> str:
+        base = cls._strip_explicit_prefix(content)
+        memory_class_norm = cls._normalize_memory_class(memory_class, target=target, content=base)
+        time_scope_norm = cls._normalize_time_scope(time_scope, base)
+        prefix = _MEMORY_CLASS_PREFIX.get(memory_class_norm, "FACT")
+        if memory_class_norm == "preference":
+            return f"[{prefix}] {base}"
+        return f"[{prefix}/{time_scope_norm.upper()}] {base}"
+
+    @classmethod
+    def _build_explicit_metadata(
+        cls,
+        *,
+        target: str,
+        content: str,
+        memory_class: Optional[str] = None,
+        time_scope: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        source: str = "mem0_conclude",
+        action: str = "add",
+    ) -> Dict[str, Any]:
+        merged = dict(metadata or {})
+        merged.setdefault("memory_target", target)
+        merged.setdefault("source", source)
+        merged.setdefault("write_action", action)
+        merged["memory_class"] = cls._normalize_memory_class(memory_class, target=target, content=content)
+        merged["time_scope"] = cls._normalize_time_scope(time_scope, content)
+        merged["explicit_memory"] = True
+        return merged
+
+    @classmethod
+    def _format_memory_for_display(cls, text: str) -> str:
+        return cls._strip_explicit_prefix(text)
+
     def system_prompt_block(self) -> str:
         return (
             "# Mem0 Memory\n"
@@ -233,6 +376,30 @@ class Mem0MemoryProvider(MemoryProvider):
             "Use mem0_search to find memories, mem0_conclude to store facts, "
             "mem0_profile for a full overview."
         )
+
+    def _search_with_fallback(self, client: Any, *, query: str, rerank: bool, top_k: int) -> list:
+        """Search user-wide first, then fall back to agent-scoped reads if empty."""
+        results = self._unwrap_results(client.search(
+            query=query,
+            filters=self._read_filters(),
+            rerank=rerank,
+            top_k=top_k,
+        ))
+        if results or not self._agent_id:
+            return results
+        return self._unwrap_results(client.search(
+            query=query,
+            filters=self._scoped_read_filters(),
+            rerank=rerank,
+            top_k=top_k,
+        ))
+
+    def _get_all_with_fallback(self, client: Any) -> list:
+        """Load user-wide memories first, then fall back to agent-scoped reads if empty."""
+        memories = self._unwrap_results(client.get_all(filters=self._read_filters()))
+        if memories or not self._agent_id:
+            return memories
+        return self._unwrap_results(client.get_all(filters=self._scoped_read_filters()))
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
@@ -251,16 +418,16 @@ class Mem0MemoryProvider(MemoryProvider):
         def _run():
             try:
                 client = self._get_client()
-                results = self._unwrap_results(client.search(
+                results = self._search_with_fallback(
+                    client,
                     query=query,
-                    filters=self._read_filters(),
                     rerank=self._rerank,
                     top_k=5,
-                ))
+                )
                 if results:
-                    lines = [r.get("memory", "") for r in results if r.get("memory")]
+                    lines = [self._format_memory_for_display(r.get("memory", "")) for r in results if r.get("memory")]
                     with self._prefetch_lock:
-                        self._prefetch_result = "\n".join(f"- {l}" for l in lines)
+                        self._prefetch_result = "\n".join(f"- {l}" for l in lines if l)
                 self._record_success()
             except Exception as e:
                 self._record_failure()
@@ -272,6 +439,8 @@ class Mem0MemoryProvider(MemoryProvider):
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
         if self._is_breaker_open():
+            return
+        if self._sync_turn_mode == "off":
             return
 
         def _sync():
@@ -310,12 +479,12 @@ class Mem0MemoryProvider(MemoryProvider):
 
         if tool_name == "mem0_profile":
             try:
-                memories = self._unwrap_results(client.get_all(filters=self._read_filters()))
+                memories = self._get_all_with_fallback(client)
                 self._record_success()
                 if not memories:
                     return json.dumps({"result": "No memories stored yet."})
-                lines = [m.get("memory", "") for m in memories if m.get("memory")]
-                return json.dumps({"result": "\n".join(lines), "count": len(lines)})
+                lines = [self._format_memory_for_display(m.get("memory", "")) for m in memories if m.get("memory")]
+                return json.dumps({"result": "\n".join(l for l in lines if l), "count": len(lines)})
             except Exception as e:
                 self._record_failure()
                 return tool_error(f"Failed to fetch profile: {e}")
@@ -327,16 +496,23 @@ class Mem0MemoryProvider(MemoryProvider):
             rerank = args.get("rerank", False)
             top_k = min(int(args.get("top_k", 10)), 50)
             try:
-                results = self._unwrap_results(client.search(
+                results = self._search_with_fallback(
+                    client,
                     query=query,
-                    filters=self._read_filters(),
                     rerank=rerank,
                     top_k=top_k,
-                ))
+                )
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                items = [{"memory": r.get("memory", ""), "score": r.get("score", 0)} for r in results]
+                items = [
+                    {
+                        "memory": self._format_memory_for_display(r.get("memory", "")),
+                        "score": r.get("score", 0),
+                        "metadata": r.get("metadata", {}),
+                    }
+                    for r in results
+                ]
                 return json.dumps({"results": items, "count": len(items)})
             except Exception as e:
                 self._record_failure()
@@ -347,21 +523,89 @@ class Mem0MemoryProvider(MemoryProvider):
             if not conclusion:
                 return tool_error("Missing required parameter: conclusion")
             try:
+                explicit_text = self._decorate_explicit_memory(
+                    conclusion,
+                    target="memory",
+                    memory_class=args.get("memory_class"),
+                    time_scope=args.get("time_scope"),
+                )
+                explicit_metadata = self._build_explicit_metadata(
+                    target="memory",
+                    content=conclusion,
+                    memory_class=args.get("memory_class"),
+                    time_scope=args.get("time_scope"),
+                    metadata=args.get("metadata") if isinstance(args.get("metadata"), dict) else None,
+                    source="mem0_conclude",
+                    action="add",
+                )
                 client.add(
-                    [{"role": "user", "content": conclusion}],
+                    [{"role": "user", "content": explicit_text}],
                     **self._write_filters(),
                     infer=False,
+                    metadata=explicit_metadata,
                 )
                 self._record_success()
-                return json.dumps({"result": "Fact stored."})
+                return json.dumps({
+                    "result": "Fact stored.",
+                    "stored": self._format_memory_for_display(explicit_text),
+                    "memory_class": explicit_metadata.get("memory_class"),
+                    "time_scope": explicit_metadata.get("time_scope"),
+                })
             except Exception as e:
                 self._record_failure()
                 return tool_error(f"Failed to store: {e}")
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror built-in memory writes to Mem0 using explicit classification metadata."""
+        if self._is_breaker_open():
+            return
+        if action not in {"add", "replace"} or not (content or "").strip():
+            return
+
+        def _write():
+            try:
+                client = self._get_client()
+                explicit_text = self._decorate_explicit_memory(
+                    content,
+                    target=target,
+                    memory_class=(metadata or {}).get("memory_class") if isinstance(metadata, dict) else None,
+                    time_scope=(metadata or {}).get("time_scope") if isinstance(metadata, dict) else None,
+                )
+                explicit_metadata = self._build_explicit_metadata(
+                    target=target,
+                    content=content,
+                    memory_class=(metadata or {}).get("memory_class") if isinstance(metadata, dict) else None,
+                    time_scope=(metadata or {}).get("time_scope") if isinstance(metadata, dict) else None,
+                    metadata=metadata,
+                    source="builtin_memory_tool",
+                    action=action,
+                )
+                client.add(
+                    [{"role": "user", "content": explicit_text}],
+                    **self._write_filters(),
+                    infer=False,
+                    metadata=explicit_metadata,
+                )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Mem0 on_memory_write failed: %s", e)
+
+        if self._write_thread and self._write_thread.is_alive():
+            self._write_thread.join(timeout=2.0)
+        self._write_thread = threading.Thread(target=_write, daemon=True, name="mem0-memwrite")
+        self._write_thread.start()
+
     def shutdown(self) -> None:
-        for t in (self._prefetch_thread, self._sync_thread):
+        for t in (self._prefetch_thread, self._sync_thread, self._write_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
         with self._client_lock:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1563,6 +1563,18 @@ class AIAgent:
         prefix = f"HTTP {status_code}: " if status_code else ""
         return f"{prefix}{raw[:500]}"
 
+    @staticmethod
+    def _nonretryable_error_kind(status_code, api_error) -> str:
+        """Short label for a non-retryable failure.
+
+        Returns ``HTTP <code>`` when an HTTP status is present, otherwise the
+        exception class name. This avoids misleading labels like ``HTTP None``
+        for local parse or transport failures.
+        """
+        if status_code:
+            return f"HTTP {status_code}"
+        return type(api_error).__name__
+
     def _mask_api_key_for_logs(self, key: Any) -> Optional[str]:
         # Azure Foundry Entra ID bearer providers are callables — never
         # invoke them in log paths; identify the auth surface instead.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2591,6 +2591,35 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
 
         assert response.choices[0].message.content == "aux survived"
 
+    def test_recovers_when_sdk_iterator_raises_none_output_typeerror(self):
+        """Recover from streamed items when the SDK iterator crashes post-stream."""
+        output_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="aux recovered")],
+        )
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=output_item),
+        ]
+
+        class _BrokenCreateStream:
+            def __iter__(self):
+                for event in events:
+                    yield event
+                raise TypeError("'NoneType' object is not iterable")
+            def close(self): pass
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                return _BrokenCreateStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize"}])
+
+        assert response.choices[0].message.content == "aux recovered"
+
 
 # ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -12,19 +12,29 @@ from plugins.memory.mem0 import Mem0MemoryProvider
 class FakeClientV2:
     """Fake Mem0 client that returns v2-style dict responses and captures call kwargs."""
 
-    def __init__(self, search_results=None, all_results=None):
+    def __init__(self, search_results=None, all_results=None, search_results_sequence=None, all_results_sequence=None):
         self._search_results = search_results or {"results": []}
         self._all_results = all_results or {"results": []}
+        self._search_results_sequence = list(search_results_sequence or [])
+        self._all_results_sequence = list(all_results_sequence or [])
         self.captured_search = {}
         self.captured_get_all = {}
+        self.search_calls = []
+        self.get_all_calls = []
         self.captured_add = []
 
     def search(self, **kwargs):
         self.captured_search = kwargs
+        self.search_calls.append(kwargs)
+        if self._search_results_sequence:
+            return self._search_results_sequence.pop(0)
         return self._search_results
 
     def get_all(self, **kwargs):
         self.captured_get_all = kwargs
+        self.get_all_calls.append(kwargs)
+        if self._all_results_sequence:
+            return self._all_results_sequence.pop(0)
         return self._all_results
 
     def add(self, messages, **kwargs):
@@ -48,7 +58,7 @@ class TestMem0FiltersV2:
         return provider
 
     def test_search_uses_filters(self, monkeypatch):
-        client = FakeClientV2()
+        client = FakeClientV2(search_results={"results": [{"memory": "hello", "score": 0.9}]})
         provider = self._make_provider(monkeypatch, client)
 
         provider.handle_tool_call("mem0_search", {"query": "hello", "top_k": 3, "rerank": False})
@@ -61,7 +71,7 @@ class TestMem0FiltersV2:
         assert "user_id" not in {k for k in client.captured_search if k != "filters"}
 
     def test_profile_uses_filters(self, monkeypatch):
-        client = FakeClientV2()
+        client = FakeClientV2(all_results={"results": [{"memory": "alpha"}]})
         provider = self._make_provider(monkeypatch, client)
 
         provider.handle_tool_call("mem0_profile", {})
@@ -70,7 +80,7 @@ class TestMem0FiltersV2:
         assert "user_id" not in {k for k in client.captured_get_all if k != "filters"}
 
     def test_prefetch_uses_filters(self, monkeypatch):
-        client = FakeClientV2()
+        client = FakeClientV2(search_results={"results": [{"memory": "hello"}]})
         provider = self._make_provider(monkeypatch, client)
 
         provider.queue_prefetch("hello")
@@ -96,13 +106,17 @@ class TestMem0FiltersV2:
         client = FakeClientV2()
         provider = self._make_provider(monkeypatch, client)
 
-        provider.handle_tool_call("mem0_conclude", {"conclusion": "user likes dark mode"})
+        result = json.loads(provider.handle_tool_call("mem0_conclude", {"conclusion": "user likes dark mode"}))
 
         assert len(client.captured_add) == 1
         call = client.captured_add[0]
         assert call["user_id"] == "u123"
         assert call["agent_id"] == "hermes"
         assert call["infer"] is False
+        assert call["messages"][0]["content"] == "[FACT/CURRENT] user likes dark mode"
+        assert call["metadata"]["memory_class"] == "factual"
+        assert call["metadata"]["time_scope"] == "current"
+        assert result["stored"] == "user likes dark mode"
 
     def test_read_filters_no_agent_id(self):
         """Read filters should use user_id only — cross-session recall across agents."""
@@ -110,6 +124,54 @@ class TestMem0FiltersV2:
         provider._user_id = "u123"
         provider._agent_id = "hermes"
         assert provider._read_filters() == {"user_id": "u123"}
+
+    def test_search_falls_back_to_agent_scope_when_user_wide_empty(self, monkeypatch):
+        client = FakeClientV2(
+            search_results_sequence=[
+                {"results": []},
+                {"results": [{"memory": "agent memory", "score": 0.8}]},
+            ]
+        )
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call("mem0_search", {"query": "hello", "top_k": 3}))
+
+        assert result["count"] == 1
+        assert len(client.search_calls) == 2
+        assert client.search_calls[0]["filters"] == {"user_id": "u123"}
+        assert client.search_calls[1]["filters"] == {"user_id": "u123", "agent_id": "hermes"}
+
+    def test_profile_falls_back_to_agent_scope_when_user_wide_empty(self, monkeypatch):
+        client = FakeClientV2(
+            all_results_sequence=[
+                {"results": []},
+                {"results": [{"memory": "agent memory"}]},
+            ]
+        )
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call("mem0_profile", {}))
+
+        assert result["count"] == 1
+        assert len(client.get_all_calls) == 2
+        assert client.get_all_calls[0]["filters"] == {"user_id": "u123"}
+        assert client.get_all_calls[1]["filters"] == {"user_id": "u123", "agent_id": "hermes"}
+
+    def test_prefetch_falls_back_to_agent_scope_when_user_wide_empty(self, monkeypatch):
+        client = FakeClientV2(
+            search_results_sequence=[
+                {"results": []},
+                {"results": [{"memory": "agent memory"}]},
+            ]
+        )
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.queue_prefetch("hello")
+        provider._prefetch_thread.join(timeout=2)
+
+        assert len(client.search_calls) == 2
+        assert client.search_calls[0]["filters"] == {"user_id": "u123"}
+        assert client.search_calls[1]["filters"] == {"user_id": "u123", "agent_id": "hermes"}
 
     def test_write_filters_include_agent_id(self):
         """Write filters should include agent_id for attribution."""
@@ -225,3 +287,101 @@ class TestMem0Defaults:
         provider.initialize("test")
 
         assert provider._agent_id == "hermes"
+
+    def test_default_sync_turn_mode_full(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+
+        assert provider._sync_turn_mode == "full"
+
+    def test_legacy_sync_turns_false_maps_to_off(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(json.dumps({"sync_turns": False}))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+
+        assert provider._sync_turn_mode == "off"
+
+
+class TestMem0ExplicitMemoryFormatting:
+    def test_decorate_preference_memory(self):
+        assert Mem0MemoryProvider._decorate_explicit_memory(
+            "User prefers concise responses.",
+            target="user",
+        ) == "[PREF] User prefers concise responses."
+
+    def test_decorate_doctrine_memory(self):
+        assert Mem0MemoryProvider._decorate_explicit_memory(
+            "OpenClaw is retired and should be ignored unless live Hermes residue still matters.",
+            target="memory",
+        ).startswith("[RULE/TIMELESS]")
+
+    def test_format_memory_for_display_strips_prefix(self):
+        assert Mem0MemoryProvider._format_memory_for_display(
+            "[FACT/PAST] Previously Dockerized apps were hosted locally."
+        ) == "Previously Dockerized apps were hosted locally."
+
+    def test_on_memory_write_mirrors_explicit_metadata(self, monkeypatch):
+        client = FakeClientV2()
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+
+        provider.on_memory_write(
+            "add",
+            "user",
+            "User prefers concise responses.",
+            metadata={"tool_name": "memory", "platform": "telegram"},
+        )
+        assert provider._write_thread is not None
+        provider._write_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+        call = client.captured_add[0]
+        assert call["messages"][0]["content"] == "[PREF] User prefers concise responses."
+        assert call["metadata"]["memory_class"] == "preference"
+        assert call["metadata"]["time_scope"] == "current"
+        assert call["metadata"]["source"] == "builtin_memory_tool"
+
+
+class TestMem0SyncTurnMode:
+    def _make_provider(self, monkeypatch, client, tmp_path, sync_turn_mode="full"):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mem0_cfg = tmp_path / "mem0.json"
+        mem0_cfg.write_text(json.dumps({"sync_turn_mode": sync_turn_mode}))
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_sync_turn_mode_off_skips_turn_write(self, monkeypatch, tmp_path):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client, tmp_path, sync_turn_mode="off")
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+
+        assert provider._sync_thread is None
+        assert client.captured_add == []
+
+    def test_sync_turn_mode_full_preserves_existing_behavior(self, monkeypatch, tmp_path):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client, tmp_path, sync_turn_mode="full")
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+        assert provider._sync_thread is not None
+        provider._sync_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+        call = client.captured_add[0]
+        assert call["user_id"] == "u123"
+        assert call["agent_id"] == "hermes"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5632,3 +5632,15 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+
+def test_nonretryable_error_kind_surfaces_exception_type_without_status():
+    """Transport/parse failures with no status must not render as HTTP None."""
+    assert (
+        AIAgent._nonretryable_error_kind(
+            None, TypeError("'NoneType' object is not iterable")
+        )
+        == "TypeError"
+    )
+    assert AIAgent._nonretryable_error_kind(0, ValueError("bad")) == "ValueError"
+    assert AIAgent._nonretryable_error_kind(404, RuntimeError("nope")) == "HTTP 404"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -161,12 +161,16 @@ class _FakeCreateStream:
     tests use this to drive it through the same code paths the wire does.
     """
 
-    def __init__(self, events):
+    def __init__(self, events, *, iter_error=None):
         self._events = list(events)
+        self._iter_error = iter_error
         self.closed = False
 
     def __iter__(self):
-        return iter(self._events)
+        for event in self._events:
+            yield event
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def close(self):
         self.closed = True
@@ -529,6 +533,48 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.status == "completed"
     assert response.output == [output_item]
     assert response.usage.total_tokens == 11
+
+
+def test_run_codex_stream_recovers_after_sdk_none_output_typeerror(monkeypatch):
+    """If the SDK iterator crashes after streamed items arrived, recover from them.
+
+    ``responses.create(stream=True)`` still runs the OpenAI SDK's internal
+    accumulator while yielding SSE events. When chatgpt.com sends a terminal
+    snapshot with ``response.output = null``, the iterator can raise
+    ``TypeError: 'NoneType' object is not iterable`` after earlier
+    ``response.output_item.done`` events were already delivered. The runtime
+    must synthesize the final response from those streamed items instead of
+    surfacing a local parse failure.
+    """
+    agent = _build_agent(monkeypatch)
+    tool_call_item = SimpleNamespace(
+        type="function_call",
+        call_id="call_123",
+        name="lookup_weather",
+        arguments='{"city":"Lahore"}',
+    )
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=tool_call_item),
+        ],
+        iter_error=TypeError("'NoneType' object is not iterable"),
+    )
+
+    def _fake_create(**kwargs):
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response is not None
+    assert create_stream.closed is True
+    assert response.status == "completed"
+    assert response.output == [tool_call_item]
+    assert response.output_text == ""
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

Fix the remaining `openai-codex` streamed Responses crash when the OpenAI SDK
raises `TypeError: 'NoneType' object is not iterable` after `chatgpt.com`
returns a terminal snapshot with `response.output = null`.

This supersedes the old branch-level fix in #33138. That PR targeted the
pre-`agent/codex_runtime.py` layout; the current mainline still hits the same
SDK iterator crash because `responses.create(stream=True)` continues to run the
SDK accumulator while yielding events.

Fixes #33237.

## What changed

- recover inside `agent/codex_runtime._consume_codex_event_stream()` when the
  SDK iterator raises the null-output `TypeError` after streamed
  `response.output_item.done` / `response.output_text.delta` events already
  arrived
- preserve tool-call turns as well as plain-text turns by synthesizing the
  final response from the streamed state already collected before the crash
- apply the same protection to auxiliary Codex calls automatically, because
  they share `_consume_codex_event_stream()`
- replace misleading `HTTP None` fallback messaging with the actual exception
  class and summarized error text (`TypeError`, etc.)

## Why this is still needed after the raw-event migration

The current code correctly avoids reconstructing content from
`response.completed.response.output`, but the OpenAI SDK's streamed iterator
still performs its own accumulator work internally while we iterate over
`responses.create(stream=True)`. That means the SDK can still throw the
null-output `TypeError` *after* Hermes has already received valid streamed
items. The right Hermes-side fix is therefore to recover from the streamed
state instead of assuming raw iteration is structurally immune.

## Verification

Ran locally with the project venv:

- `./venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -k 'null_output or none_output_typeerror'`
- `./venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -k 'NullOutputRecovery or none_output_typeerror'`
- `./venv/bin/python -m pytest tests/run_agent/test_run_agent.py -k 'nonretryable_error_kind'`

All passed.
