### PR TITLE
fix(slack): fail closed for interactive approval callbacks

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2395,16 +2395,17 @@ class SlackAdapter(BasePlatformAdapter):
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
 
-        # Authorization — reuse the exec-approval allowlist.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
-                    user_name, user_id,
-                )
-                return
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+            thread_id=message.get("thread_ts") or msg_ts,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized slash-confirm click by %s (%s) - ignoring",
+                user_name, user_id,
+            )
+            return
 
         # Parse session_key|confirm_id back out
         if "|" not in value:
@@ -2496,15 +2497,17 @@ class SlackAdapter(BasePlatformAdapter):
         # Only authorized users may click approval buttons.  Button clicks
         # bypass the normal message auth flow in gateway/run.py, so we must
         # check here as well.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized approval click by %s (%s) — ignoring",
-                    user_name, user_id,
-                )
-                return
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+            thread_id=message.get("thread_ts") or msg_ts,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized approval click by %s (%s) - ignoring",
+                user_name, user_id,
+            )
+            return
 
         # Map action_id to approval choice
         choice_map = {
@@ -2573,6 +2576,55 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("Failed to resolve gateway approval from Slack button: %s", exc)
 
         # (approval state already consumed by atomic pop above)
+
+    def _is_interactive_user_authorized(
+        self,
+        user_id: str,
+        *,
+        channel_id: str = "",
+        user_name: str = "",
+        thread_id: Optional[str] = None,
+    ) -> bool:
+        """Return whether a Slack button caller may resolve gated prompts."""
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return False
+
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if callable(auth_fn):
+            try:
+                source = self.build_source(
+                    chat_id=str(channel_id or normalized_user_id),
+                    chat_name=str(channel_id or normalized_user_id),
+                    chat_type="dm" if str(channel_id).startswith("D") else "group",
+                    user_id=normalized_user_id,
+                    user_name=str(user_name).strip() if user_name else None,
+                    thread_id=str(thread_id) if thread_id else None,
+                )
+                return bool(auth_fn(source))
+            except Exception:
+                logger.debug(
+                    "[Slack] Falling back to env-only interactive auth for user %s",
+                    normalized_user_id,
+                    exc_info=True,
+                )
+
+        if os.getenv("SLACK_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+            return True
+
+        slack_allowlist = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+        if not slack_allowlist and not global_allowlist:
+            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+
+        allowed_ids = set()
+        if slack_allowlist:
+            allowed_ids.update(uid.strip() for uid in slack_allowlist.split(",") if uid.strip())
+        if global_allowlist:
+            allowed_ids.update(uid.strip() for uid in global_allowlist.split(",") if uid.strip())
+
+        return "*" in allowed_ids or normalized_user_id in allowed_ids
 
     # ----- Thread context fetching -----
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -153,7 +153,8 @@ class TestSlackApprovalAction:
     """Test the approval button click handler."""
 
     @pytest.mark.asyncio
-    async def test_resolves_approval(self):
+    async def test_resolves_approval(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_APPROVER")
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = False
 
@@ -167,7 +168,7 @@ class TestSlackApprovalAction:
                 ],
             },
             "channel": {"id": "C1"},
-            "user": {"name": "norbert"},
+            "user": {"name": "norbert", "id": "U_APPROVER"},
         }
         action = {
             "action_id": "hermes_approve_once",
@@ -189,7 +190,8 @@ class TestSlackApprovalAction:
         assert "Approved once by norbert" in update_kwargs["text"]
 
     @pytest.mark.asyncio
-    async def test_prevents_double_click(self):
+    async def test_prevents_double_click(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_APPROVER")
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = True  # Already resolved
 
@@ -197,7 +199,7 @@ class TestSlackApprovalAction:
         body = {
             "message": {"ts": "1234.5678", "blocks": []},
             "channel": {"id": "C1"},
-            "user": {"name": "norbert"},
+            "user": {"name": "norbert", "id": "U_APPROVER"},
         }
         action = {
             "action_id": "hermes_approve_once",
@@ -212,7 +214,8 @@ class TestSlackApprovalAction:
         mock_resolve.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_deny_action(self):
+    async def test_deny_action(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_APPROVER")
         adapter = _make_adapter()
         adapter._approval_resolved["1.2"] = False
 
@@ -222,7 +225,7 @@ class TestSlackApprovalAction:
                 {"type": "section", "text": {"type": "mrkdwn", "text": "cmd"}},
             ]},
             "channel": {"id": "C1"},
-            "user": {"name": "alice"},
+            "user": {"name": "alice", "id": "U_APPROVER"},
         }
         action = {"action_id": "hermes_deny", "value": "session-key"}
 
@@ -235,6 +238,170 @@ class TestSlackApprovalAction:
         mock_resolve.assert_called_once_with("session-key", "deny")
         update_kwargs = mock_client.chat_update.call_args[1]
         assert "Denied by alice" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_denies_approval_when_no_allowlist(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        adapter = _make_adapter()
+        adapter._approval_resolved["1.2"] = False
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.2", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_INTRUDER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+        assert adapter._approval_resolved["1.2"] is False
+
+    @pytest.mark.asyncio
+    async def test_global_allowlist_permits_approval(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_APPROVER")
+
+        adapter = _make_adapter()
+        adapter._approval_resolved["1.2"] = False
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.2", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_APPROVER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+        adapter._team_clients["T1"].chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        mock_resolve.assert_called_once_with("session-key", "once")
+
+    @pytest.mark.asyncio
+    async def test_global_allowlist_mismatch_denies_approval(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_APPROVER")
+
+        adapter = _make_adapter()
+        adapter._approval_resolved["1.2"] = False
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.2", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_INTRUDER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+
+
+class TestSlackSlashConfirmAction:
+    """Test slash-confirm button authorization."""
+
+    @pytest.mark.asyncio
+    async def test_global_allowlist_permits_slash_confirm(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_APPROVER")
+
+        adapter = _make_adapter()
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "1234.5678",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "confirm text"}},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_APPROVER"},
+        }
+        action = {"action_id": "hermes_confirm_once", "value": "session-key|confirm-1"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock, return_value=None) as mock_resolve:
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        mock_resolve.assert_awaited_once_with("session-key", "confirm-1", "once")
+        mock_client.chat_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_global_allowlist_mismatch_denies_slash_confirm(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_APPROVER")
+
+        adapter = _make_adapter()
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_INTRUDER"},
+        }
+        action = {"action_id": "hermes_confirm_once", "value": "session-key|confirm-1"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+
+
+class TestSlackInteractiveAuth:
+    """Test shared Slack interactive auth helper."""
+
+    def test_runner_auth_is_used_before_env_fallback(self):
+        class Runner:
+            def __init__(self):
+                self.sources = []
+
+            def _is_user_authorized(self, source):
+                self.sources.append(source)
+                return source.user_id == "U_APPROVER"
+
+            async def handle(self, _event):
+                return None
+
+        adapter = _make_adapter()
+        runner = Runner()
+        adapter._message_handler = runner.handle
+
+        assert adapter._is_interactive_user_authorized(
+            "U_APPROVER",
+            channel_id="C1",
+            user_name="owner",
+            thread_id="1234.5678",
+        ) is True
+        assert adapter._is_interactive_user_authorized("U_INTRUDER", channel_id="C1") is False
+        assert runner.sources[0].platform == Platform.SLACK
+        assert runner.sources[0].chat_id == "C1"
+        assert runner.sources[0].user_id == "U_APPROVER"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fix Slack interactive approval authorization so Block Kit callbacks cannot resolve gated prompts unless the clicking user is authorized.

Slack approval and slash-confirm button handlers bypass the normal gateway message dispatch path, so they must enforce authorization locally. The previous callback checks only consulted `SLACK_ALLOWED_USERS` when it was non-empty, which made an empty platform allowlist behave like allow-all for button clicks.

This PR adds a shared Slack interactive auth helper that:

- delegates to `GatewayRunner._is_user_authorized()` when available
- preserves approved runner behavior such as global allowlists and pairing
- falls back to `SLACK_ALLOWED_USERS` / `GATEWAY_ALLOWED_USERS`
- honors explicit allow-all flags
- fails closed when no allowlist or allow-all is configured

## Security Impact

This closes an external-surface auth gap where an unauthorized Slack user who could see a Block Kit approval prompt could click an approval or slash-confirm button and resolve the pending action.

Affected surfaces:

- dangerous command approval buttons
- destructive slash-confirm buttons

This aligns Slack callbacks with the gateway trust model: session IDs and callback payloads are routing data, not authorization.

## Tests


uv --cache-dir .uv-cache run --with pytest --with pytest-asyncio pytest -o addopts= tests/gateway/test_slack_approval_buttons.py -q
uv --cache-dir .uv-cache run --with pytest --with pytest-asyncio pytest -o addopts= tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_slack_channel_skills.py tests/gateway/test_slack_approval_buttons.py -q
uv --cache-dir .uv-cache run --with pytest --with pytest-asyncio pytest -o addopts= tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_allowlist_startup_check.py -q
uv --cache-dir .uv-cache run --with ruff ruff check gateway/platforms/slack.py tests/gateway/test_slack_approval_buttons.py
git diff --check

### Results:

Slack approval tests: 29 passed
Full Slack gateway test set: 281 passed
Gateway allowlist tests: 34 passed
Ruff: passed
Diff check: passed