### PR TITLE
fix: preserve gateway update completion notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6831,7 +6831,7 @@ class GatewayRunner:
                 prompt_path = _hermes_home / ".update_prompt.json"
                 try:
                     tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text(response_text)
+                    tmp.write_text(response_text, encoding="utf-8")
                     tmp.replace(response_path)
                     prompt_path.unlink(missing_ok=True)
                 except OSError as e:
@@ -6851,7 +6851,7 @@ class GatewayRunner:
                 prompt_path = _hermes_home / ".update_prompt.json"
                 try:
                     tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text("")
+                    tmp.write_text("", encoding="utf-8")
                     tmp.replace(response_path)
                     prompt_path.unlink(missing_ok=True)
                     logger.info(
@@ -13952,6 +13952,10 @@ class GatewayRunner:
         pending_path = _hermes_home / ".update_pending.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
+        sentinel_path = _hermes_home / ".update_in_progress"
+        logs_dir = _hermes_home / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        transcript_path = logs_dir / f"safe-update-{datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
         session_key = self._session_key_for_source(event.source)
         pending = {
             "platform": event.source.platform.value,
@@ -13959,12 +13963,15 @@ class GatewayRunner:
             "user_id": event.source.user_id,
             "session_key": session_key,
             "timestamp": datetime.now().isoformat(),
+            "sentinel_path": str(sentinel_path),
+            "transcript_path": str(transcript_path),
         }
         if event.source.thread_id:
             pending["thread_id"] = event.source.thread_id
         _tmp_pending = pending_path.with_suffix(".tmp")
-        _tmp_pending.write_text(json.dumps(pending))
+        _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
         _tmp_pending.replace(pending_path)
+        sentinel_path.write_text(datetime.now().isoformat(), encoding="utf-8")
         exit_code_path.unlink(missing_ok=True)
 
         # Spawn `hermes update --gateway` detached so it survives gateway restart.
@@ -14003,20 +14010,31 @@ class GatewayRunner:
                     import os, subprocess, sys
                     output_path = sys.argv[1]
                     exit_code_path = sys.argv[2]
-                    cmd = sys.argv[3:]
+                    transcript_path = sys.argv[3]
+                    cmd = sys.argv[4:]
                     env = dict(os.environ)
                     env["PYTHONUNBUFFERED"] = "1"
-                    with open(output_path, "wb") as f:
-                        proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
+                    env["PYTHONUTF8"] = "1"
+                    env["PYTHONIOENCODING"] = "utf-8"
+                    with open(output_path, "wb") as out, open(transcript_path, "ab") as transcript:
+                        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+                        assert proc.stdout is not None
+                        for chunk in iter(lambda: proc.stdout.read(8192), b""):
+                            if not chunk:
+                                break
+                            out.write(chunk)
+                            out.flush()
+                            transcript.write(chunk)
+                            transcript.flush()
                         rc = proc.wait()
-                    with open(exit_code_path, "w") as f:
+                    with open(exit_code_path, "w", encoding="utf-8") as f:
                         f.write(str(rc))
                     """
                 ).strip()
                 subprocess.Popen(
                     [
                         sys.executable, "-c", helper,
-                        str(output_path), str(exit_code_path),
+                        str(output_path), str(exit_code_path), str(transcript_path),
                         *hermes_cmd, "update", "--gateway",
                     ],
                     stdout=subprocess.DEVNULL,
@@ -14053,6 +14071,8 @@ class GatewayRunner:
                     )
         except Exception as e:
             pending_path.unlink(missing_ok=True)
+            sentinel_path.unlink(missing_ok=True)
+            output_path.unlink(missing_ok=True)
             exit_code_path.unlink(missing_ok=True)
             return t("gateway.update.start_failed", error=e)
 
@@ -14091,6 +14111,8 @@ class GatewayRunner:
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
         prompt_path = _hermes_home / ".update_prompt.json"
+        sentinel_path = _hermes_home / ".update_in_progress"
+        transcript_path: Optional[Path] = None
 
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
@@ -14103,11 +14125,13 @@ class GatewayRunner:
         for path in (claimed_path, pending_path):
             if path.exists():
                 try:
-                    pending = json.loads(path.read_text())
+                    pending = json.loads(path.read_text(encoding="utf-8"))
                     platform_str = pending.get("platform")
                     chat_id = pending.get("chat_id")
                     session_key = pending.get("session_key")
                     thread_id = pending.get("thread_id")
+                    transcript_raw = pending.get("transcript_path")
+                    transcript_path = Path(transcript_raw) if transcript_raw else None
                     metadata = {"thread_id": thread_id} if thread_id else None
                     if platform_str and chat_id:
                         platform = Platform(platform_str)
@@ -14128,7 +14152,7 @@ class GatewayRunner:
                     return
                 await asyncio.sleep(poll_interval)
             if (pending_path.exists() or claimed_path.exists()) and not exit_code_path.exists():
-                exit_code_path.write_text("124")
+                exit_code_path.write_text("124", encoding="utf-8")
                 await self._send_update_notification()
             return
 
@@ -14166,7 +14190,7 @@ class GatewayRunner:
                 # Read any remaining output
                 if output_path.exists():
                     try:
-                        content = output_path.read_text()
+                        content = output_path.read_text(encoding="utf-8", errors="replace")
                         if len(content) > bytes_sent:
                             buffer += content[bytes_sent:]
                             bytes_sent = len(content)
@@ -14176,14 +14200,15 @@ class GatewayRunner:
 
                 # Send final status
                 try:
-                    exit_code_raw = exit_code_path.read_text().strip() or "1"
+                    exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
                     exit_code = int(exit_code_raw)
+                    transcript_note = f"\n\nTranscript: `{transcript_path}`" if transcript_path else ""
                     if exit_code == 0:
-                        await adapter.send(chat_id, "✅ Hermes update finished.", metadata=metadata)
+                        await adapter.send(chat_id, f"✅ Hermes update finished.{transcript_note}", metadata=metadata)
                     else:
                         await adapter.send(
                             chat_id,
-                            "❌ Hermes update failed (exit code {}).".format(exit_code),
+                            "❌ Hermes update failed (exit code {}).{}".format(exit_code, transcript_note),
                             metadata=metadata,
                         )
                     logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
@@ -14192,7 +14217,7 @@ class GatewayRunner:
 
                 # Cleanup
                 for p in (pending_path, claimed_path, output_path,
-                          exit_code_path, prompt_path):
+                          exit_code_path, prompt_path, sentinel_path):
                     p.unlink(missing_ok=True)
                 (_hermes_home / ".update_response").unlink(missing_ok=True)
                 self._update_prompt_pending.pop(session_key, None)
@@ -14201,7 +14226,7 @@ class GatewayRunner:
             # Check for new output
             if output_path.exists():
                 try:
-                    content = output_path.read_text()
+                    content = output_path.read_text(encoding="utf-8", errors="replace")
                     if len(content) > bytes_sent:
                         buffer += content[bytes_sent:]
                         bytes_sent = len(content)
@@ -14219,7 +14244,7 @@ class GatewayRunner:
             if (prompt_path.exists() and session_key
                     and not self._update_prompt_pending.get(session_key)):
                 try:
-                    prompt_data = json.loads(prompt_path.read_text())
+                    prompt_data = json.loads(prompt_path.read_text(encoding="utf-8"))
                     prompt_text = prompt_data.get("prompt", "")
                     default = prompt_data.get("default", "")
                     if prompt_text:
@@ -14266,7 +14291,7 @@ class GatewayRunner:
         # Timeout
         if not exit_code_path.exists():
             logger.warning("Update watcher timed out after %.0fs", timeout)
-            exit_code_path.write_text("124")
+            exit_code_path.write_text("124", encoding="utf-8")
             await _flush_buffer()
             try:
                 await adapter.send(
@@ -14277,7 +14302,7 @@ class GatewayRunner:
             except Exception:
                 pass
             for p in (pending_path, claimed_path, output_path,
-                      exit_code_path, prompt_path):
+                      exit_code_path, prompt_path, sentinel_path):
                 p.unlink(missing_ok=True)
             (_hermes_home / ".update_response").unlink(missing_ok=True)
             self._update_prompt_pending.pop(session_key, None)
@@ -14285,89 +14310,121 @@ class GatewayRunner:
     async def _send_update_notification(self) -> bool:
         """If an update finished, notify the user.
 
-        Returns False when the update is still running so a caller can retry
-        later. Returns True after a definitive send/skip decision.
-
-        This is the legacy notification path used when the streaming watcher
-        cannot resolve the adapter (e.g. after a gateway restart where the
-        platform hasn't reconnected yet).
+        Returns False when the update is still running or delivery should be
+        retried later. Returns True after a definitive send/skip decision.
         """
         pending_path = _hermes_home / ".update_pending.json"
         claimed_path = _hermes_home / ".update_pending.claimed.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
+        sentinel_path = _hermes_home / ".update_in_progress"
 
         if not pending_path.exists() and not claimed_path.exists():
             return False
 
-        cleanup = True
-        active_pending_path = claimed_path
+        claimed = False
+
+        def _restore_claim_for_retry() -> None:
+            try:
+                if claimed_path.exists():
+                    claimed_path.replace(pending_path)
+            except OSError as restore_err:
+                logger.warning("Failed to restore update pending marker for retry: %s", restore_err)
+
         try:
             if pending_path.exists():
                 try:
                     pending_path.replace(claimed_path)
+                    claimed = True
                 except FileNotFoundError:
                     if not claimed_path.exists():
                         return True
             elif not claimed_path.exists():
                 return True
 
-            pending = json.loads(claimed_path.read_text())
+            try:
+                pending = json.loads(claimed_path.read_text(encoding="utf-8"))
+            except Exception as e:
+                logger.warning("Post-update notification discarded malformed marker: %s", e)
+                claimed_path.unlink(missing_ok=True)
+                pending_path.unlink(missing_ok=True)
+                return True
+
             platform_str = pending.get("platform")
             chat_id = pending.get("chat_id")
             thread_id = pending.get("thread_id")
+            transcript_raw = pending.get("transcript_path")
+            transcript_path = Path(transcript_raw) if transcript_raw else None
 
             if not exit_code_path.exists():
                 logger.info("Update notification deferred: update still running")
-                cleanup = False
-                active_pending_path = pending_path
-                claimed_path.replace(pending_path)
+                _restore_claim_for_retry()
                 return False
 
-            exit_code_raw = exit_code_path.read_text().strip() or "1"
+            exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
             exit_code = int(exit_code_raw)
 
-            # Read the captured update output
             output = ""
             if output_path.exists():
-                output = output_path.read_text()
+                output = output_path.read_text(encoding="utf-8", errors="replace")
 
-            # Resolve adapter
-            platform = Platform(platform_str)
-            adapter = self.adapters.get(platform)
-
-            if adapter and chat_id:
-                metadata = {"thread_id": thread_id} if thread_id else None
-                # Strip ANSI escape codes for clean display
-                output = re.sub(r'\x1b\[[0-9;]*m', '', output).strip()
-                if output:
-                    if len(output) > 3500:
-                        output = "…" + output[-3500:]
-                    if exit_code == 0:
-                        msg = f"✅ Hermes update finished.\n\n```\n{output}\n```"
-                    else:
-                        msg = f"❌ Hermes update failed.\n\n```\n{output}\n```"
-                elif exit_code == 0:
-                    msg = "✅ Hermes update finished successfully."
-                else:
-                    msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
-                await adapter.send(chat_id, msg, metadata=metadata)
-                logger.info(
-                    "Sent post-update notification to %s:%s (exit=%s)",
-                    platform_str,
-                    chat_id,
-                    exit_code,
-                )
-        except Exception as e:
-            logger.warning("Post-update notification failed: %s", e)
-        finally:
-            if cleanup:
-                active_pending_path.unlink(missing_ok=True)
+            try:
+                platform = Platform(platform_str)
+            except Exception as e:
+                logger.warning("Post-update notification discarded invalid platform %r: %s", platform_str, e)
                 claimed_path.unlink(missing_ok=True)
+                pending_path.unlink(missing_ok=True)
                 output_path.unlink(missing_ok=True)
                 exit_code_path.unlink(missing_ok=True)
+                sentinel_path.unlink(missing_ok=True)
+                return True
 
-        return True
+            adapter = self.adapters.get(platform)
+            if not adapter or not chat_id:
+                logger.warning(
+                    "Post-update notification deferred: adapter/chat unavailable for %s:%s",
+                    platform_str,
+                    chat_id,
+                )
+                _restore_claim_for_retry()
+                return False
+
+            metadata = {"thread_id": thread_id} if thread_id else None
+            output = re.sub(r'\x1b\[[0-9;]*m', '', output).strip()
+            transcript_note = f"\n\nTranscript: `{transcript_path}`" if transcript_path else ""
+            if output:
+                if len(output) > 3500:
+                    output = "…" + output[-3500:]
+                if exit_code == 0:
+                    msg = f"✅ Hermes update finished.{transcript_note}\n\n```\n{output}\n```"
+                else:
+                    msg = f"❌ Hermes update failed.{transcript_note}\n\n```\n{output}\n```"
+            elif exit_code == 0:
+                msg = f"✅ Hermes update finished successfully.{transcript_note}"
+            else:
+                msg = f"❌ Hermes update failed.{transcript_note}\nCheck the gateway logs or run `hermes update` manually for details."
+
+            result = await adapter.send(chat_id, msg, metadata=metadata)
+            if result is not None and getattr(result, "success", True) is False:
+                raise RuntimeError(getattr(result, "error", "send returned success=False"))
+            logger.info(
+                "Sent post-update notification to %s:%s (exit=%s)",
+                platform_str,
+                chat_id,
+                exit_code,
+            )
+
+            claimed_path.unlink(missing_ok=True)
+            pending_path.unlink(missing_ok=True)
+            output_path.unlink(missing_ok=True)
+            exit_code_path.unlink(missing_ok=True)
+            sentinel_path.unlink(missing_ok=True)
+            return True
+        except Exception as e:
+            logger.warning("Post-update notification failed: %s", e)
+            if claimed:
+                _restore_claim_for_retry()
+            return False
 
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13956,6 +13956,23 @@ class GatewayRunner:
         logs_dir = _hermes_home / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         transcript_path = logs_dir / f"safe-update-{datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
+
+        if sentinel_path.exists():
+            pending_exists = pending_path.exists() or (_hermes_home / ".update_pending.claimed.json").exists()
+            if exit_code_path.exists() and pending_exists:
+                notified = await self._send_update_notification()
+                if notified:
+                    return "⚕ Previous Hermes update result was delivered. Run `/update` again if you want to start another update."
+                self._schedule_update_notification_watch()
+                return "⚕ Previous Hermes update finished, but its notification is still pending retry. I will keep watching it."
+            if not exit_code_path.exists() and pending_exists:
+                self._schedule_update_notification_watch()
+                return "⚕ Hermes update is already in progress. I will keep watching it and report when it finishes."
+            if not pending_exists:
+                sentinel_path.unlink(missing_ok=True)
+                if exit_code_path.exists():
+                    exit_code_path.unlink(missing_ok=True)
+
         session_key = self._session_key_for_source(event.source)
         pending = {
             "platform": event.source.platform.value,
@@ -14044,13 +14061,15 @@ class GatewayRunner:
             else:
                 hermes_cmd_str = " ".join(shlex.quote(part) for part in hermes_cmd)
                 update_cmd = (
-                    f"PYTHONUNBUFFERED=1 {hermes_cmd_str} update --gateway"
-                    f" > {shlex.quote(str(output_path))} 2>&1; "
+                    f"PYTHONUNBUFFERED=1 PYTHONUTF8=1 PYTHONIOENCODING=utf-8 "
+                    f"{hermes_cmd_str} update --gateway 2>&1 "
+                    f"| tee -a {shlex.quote(str(transcript_path))} > {shlex.quote(str(output_path))}; "
                     # Avoid `status=$?`: `status` is a read-only special parameter
                     # in zsh, and this command string is copied/reused in macOS/zsh
                     # operator wrappers. Keep the template zsh-safe even though this
-                    # specific subprocess currently runs under bash.
-                    f"rc=$?; printf '%s' \"$rc\" > {shlex.quote(str(exit_code_path))}"
+                    # specific subprocess currently runs under bash. PIPESTATUS is
+                    # bash-specific, and this command is explicitly run via bash.
+                    f"rc=${{PIPESTATUS[0]}}; printf '%s' \"$rc\" > {shlex.quote(str(exit_code_path))}"
                 )
                 setsid_bin = shutil.which("setsid")
                 if setsid_bin:
@@ -14214,6 +14233,11 @@ class GatewayRunner:
                     logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
                 except Exception as e:
                     logger.warning("Update final notification failed: %s", e)
+                    # Preserve markers/output/exit code and retry while the
+                    # watcher is alive rather than losing the final update
+                    # result on a transient platform send failure.
+                    await asyncio.sleep(poll_interval)
+                    continue
 
                 # Cleanup
                 for p in (pending_path, claimed_path, output_path,
@@ -14348,6 +14372,9 @@ class GatewayRunner:
                 logger.warning("Post-update notification discarded malformed marker: %s", e)
                 claimed_path.unlink(missing_ok=True)
                 pending_path.unlink(missing_ok=True)
+                output_path.unlink(missing_ok=True)
+                exit_code_path.unlink(missing_ok=True)
+                sentinel_path.unlink(missing_ok=True)
                 return True
 
             platform_str = pending.get("platform")
@@ -14390,7 +14417,7 @@ class GatewayRunner:
                 return False
 
             metadata = {"thread_id": thread_id} if thread_id else None
-            output = re.sub(r'\x1b\[[0-9;]*m', '', output).strip()
+            output = re.sub(r'\x1b\[[0-9;]*[A-Za-z]', '', output).strip()
             transcript_note = f"\n\nTranscript: `{transcript_path}`" if transcript_path else ""
             if output:
                 if len(output) > 3500:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -306,6 +306,9 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
         "hermes_cli/main.py -p",
         "hermes gateway",
         "gateway/run.py",
+        "cli.py --gateway",
+        "cli.py\" --gateway",
+        "cli.py' --gateway",
     ]
     current_home = str(get_hermes_home().resolve())
     current_profile_arg = _profile_arg(current_home)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6440,7 +6440,7 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
         "id": str(_uuid.uuid4()),
     }
     tmp = prompt_path.with_suffix(".tmp")
-    tmp.write_text(_json.dumps(payload))
+    tmp.write_text(_json.dumps(payload), encoding="utf-8")
     tmp.replace(prompt_path)
 
     # Poll for response
@@ -6448,7 +6448,7 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
     while _time.monotonic() < deadline:
         if response_path.exists():
             try:
-                answer = response_path.read_text().strip()
+                answer = response_path.read_text(encoding="utf-8", errors="replace").strip()
                 response_path.unlink(missing_ok=True)
                 prompt_path.unlink(missing_ok=True)
                 return answer if answer else default

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -274,7 +274,11 @@ class TestHandleUpdateCommand:
         call_args = mock_popen.call_args[0][0]
         assert call_args[0] == "/usr/bin/setsid"
         assert call_args[1] == "bash"
-        assert ".update_exit_code" in call_args[-1]
+        update_cmd = call_args[-1]
+        assert ".update_exit_code" in update_cmd
+        assert "safe-update-" in update_cmd
+        assert "tee -a" in update_cmd
+        assert "PIPESTATUS[0]" in update_cmd
         assert "Starting Hermes update" in result
 
     @pytest.mark.asyncio
@@ -313,6 +317,8 @@ class TestHandleUpdateCommand:
         assert call_args[0] == "bash"
         assert "nohup" not in call_args[2]
         assert ".update_exit_code" in call_args[2]
+        assert "safe-update-" in call_args[2]
+        assert "tee -a" in call_args[2]
         # start_new_session=True should be in kwargs
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("start_new_session") is True
@@ -355,6 +361,100 @@ class TestHandleUpdateCommand:
         assert "transcript_path" in json.loads((hermes_home / ".update_pending.json").read_text(encoding="utf-8"))
         assert any("safe-update-" in str(part) for part in argv)
         assert "--gateway" in argv
+
+    @pytest.mark.asyncio
+    async def test_update_already_running_does_not_spawn_second_update(self, tmp_path):
+        """A fresh update sentinel blocks duplicate /update runs from overwriting markers."""
+        runner = _make_runner()
+        event = _make_event()
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".update_in_progress").write_text("now", encoding="utf-8")
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram", "chat_id": "111", "user_id": "222",
+        }), encoding="utf-8")
+
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", return_value="/usr/bin/hermes"), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        assert "already in progress" in result
+        mock_popen.assert_not_called()
+        assert (hermes_home / ".update_pending.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_update_completed_sentinel_retries_notification_without_spawning(self, tmp_path):
+        """A completed preserved update is retried instead of overwritten by a new /update."""
+        runner = _make_runner()
+        event = _make_event()
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".update_in_progress").write_text("now", encoding="utf-8")
+        (hermes_home / ".update_exit_code").write_text("0", encoding="utf-8")
+        (hermes_home / ".update_output.txt").write_text("done", encoding="utf-8")
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram", "chat_id": "111", "user_id": "222",
+        }), encoding="utf-8")
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", side_effect=lambda x: "/usr/bin/hermes" if x == "hermes" else "/usr/bin/setsid"), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        assert "Previous Hermes update result was delivered" in result
+        mock_adapter.send.assert_called_once()
+        mock_popen.assert_not_called()
+        assert not (hermes_home / ".update_pending.json").exists()
+        assert not (hermes_home / ".update_exit_code").exists()
+        assert not (hermes_home / ".update_in_progress").exists()
+
+    @pytest.mark.asyncio
+    async def test_stale_sentinel_without_markers_is_ignored(self, tmp_path):
+        """A lone stale sentinel should not permanently block future /update runs."""
+        runner = _make_runner()
+        event = _make_event()
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".update_in_progress").write_text("stale", encoding="utf-8")
+
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", side_effect=lambda x: "/usr/bin/hermes" if x == "hermes" else "/usr/bin/setsid"), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        assert "Starting Hermes update" in result
+        mock_popen.assert_called_once()
+        assert (hermes_home / ".update_pending.json").exists()
 
     @pytest.mark.asyncio
     async def test_popen_failure_cleans_up(self, tmp_path):
@@ -572,7 +672,7 @@ class TestSendUpdateNotification:
         pending = {"platform": "telegram", "chat_id": "111", "user_id": "222"}
         (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
         (hermes_home / ".update_output.txt").write_text(
-            "\x1b[32m✓ Code updated!\x1b[0m\n\x1b[1mDone\x1b[0m"
+            "\x1b[32m✓ Code updated!\x1b[0m\n\x1b[2K\x1b[1mDone\x1b[0m"
         )
         (hermes_home / ".update_exit_code").write_text("0")
 
@@ -718,14 +818,23 @@ class TestSendUpdateNotification:
         hermes_home.mkdir()
 
         pending_path = hermes_home / ".update_pending.json"
-        pending_path.write_text("{corrupt json!!")
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        sentinel_path = hermes_home / ".update_in_progress"
+        pending_path.write_text("{corrupt json!!", encoding="utf-8")
+        output_path.write_text("stale output", encoding="utf-8")
+        exit_code_path.write_text("0", encoding="utf-8")
+        sentinel_path.write_text("stale sentinel", encoding="utf-8")
 
         with patch("gateway.run._hermes_home", hermes_home):
             # Should not raise
             await runner._send_update_notification()
 
-        # File should be cleaned up
+        # Corrupt lifecycle files should be cleaned up rather than leaving a stale sentinel.
         assert not pending_path.exists()
+        assert not output_path.exists()
+        assert not exit_code_path.exists()
+        assert not sentinel_path.exists()
 
     @pytest.mark.asyncio
     async def test_no_adapter_for_platform(self, tmp_path):

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -209,10 +209,14 @@ class TestHandleUpdateCommand:
 
         pending_path = hermes_home / ".update_pending.json"
         assert pending_path.exists()
-        data = json.loads(pending_path.read_text())
+        data = json.loads(pending_path.read_text(encoding="utf-8"))
         assert data["platform"] == "telegram"
         assert data["chat_id"] == "99999"
         assert "timestamp" in data
+        assert data["sentinel_path"].endswith(".update_in_progress")
+        assert "safe-update-" in data["transcript_path"]
+        assert data["transcript_path"].endswith(".log")
+        assert (hermes_home / ".update_in_progress").exists()
         assert not (hermes_home / ".update_exit_code").exists()
 
     @pytest.mark.asyncio
@@ -261,6 +265,7 @@ class TestHandleUpdateCommand:
         mock_popen = MagicMock()
         with patch("gateway.run._hermes_home", hermes_home), \
              patch("gateway.run.__file__", fake_file), \
+             patch("gateway.run.sys.platform", "linux"), \
              patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
              patch("subprocess.Popen", mock_popen):
             result = await runner._handle_update_command(event)
@@ -298,6 +303,7 @@ class TestHandleUpdateCommand:
 
         with patch("gateway.run._hermes_home", hermes_home), \
              patch("gateway.run.__file__", fake_file), \
+             patch("gateway.run.sys.platform", "linux"), \
              patch("shutil.which", side_effect=which_no_setsid), \
              patch("subprocess.Popen", mock_popen):
             result = await runner._handle_update_command(event)
@@ -311,6 +317,44 @@ class TestHandleUpdateCommand:
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("start_new_session") is True
         assert "Starting Hermes update" in result
+
+
+    @pytest.mark.asyncio
+    async def test_windows_update_helper_forces_utf8_and_transcript(self, tmp_path):
+        """Windows update helper forces UTF-8 and writes a durable transcript."""
+        import sys
+        runner = _make_runner()
+        event = _make_event()
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("gateway.run.sys.platform", "win32"), \
+             patch("shutil.which", return_value="/usr/bin/hermes"), \
+             patch("hermes_cli._subprocess_compat.windows_detach_popen_kwargs", return_value={}), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        assert "Starting Hermes update" in result
+        argv = mock_popen.call_args[0][0]
+        helper = argv[2]
+        assert argv[0] == sys.executable
+        assert argv[1] == "-c"
+        assert 'env["PYTHONUNBUFFERED"] = "1"' in helper
+        assert 'env["PYTHONUTF8"] = "1"' in helper
+        assert 'env["PYTHONIOENCODING"] = "utf-8"' in helper
+        assert "transcript_path" in json.loads((hermes_home / ".update_pending.json").read_text(encoding="utf-8"))
+        assert any("safe-update-" in str(part) for part in argv)
+        assert "--gateway" in argv
 
     @pytest.mark.asyncio
     async def test_popen_failure_cleans_up(self, tmp_path):
@@ -486,6 +530,38 @@ class TestSendUpdateNotification:
 
         assert mock_adapter.send.call_args.kwargs["metadata"] == {"thread_id": "777"}
 
+
+    @pytest.mark.asyncio
+    async def test_send_notification_reads_output_as_utf8_when_locale_charmap(self, tmp_path, monkeypatch):
+        """Post-update notifier reads UTF-8 output explicitly on Windows/charmap locales."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram", "chat_id": "111", "user_id": "222",
+        }), encoding="utf-8")
+        output_path.write_bytes("→ Fetching updates...\n✅ Done\n".encode("utf-8"))
+        exit_code_path.write_text("0", encoding="utf-8")
+
+        orig_read_text = Path.read_text
+        def fail_if_output_read_without_encoding(self, *args, **kwargs):
+            if self == output_path and kwargs.get("encoding") is None:
+                raise UnicodeDecodeError("charmap", b"\x81", 0, 1, "character maps to <undefined>")
+            return orig_read_text(self, *args, **kwargs)
+        monkeypatch.setattr(Path, "read_text", fail_if_output_read_without_encoding)
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._send_update_notification()
+
+        assert result is True
+        mock_adapter.send.assert_called_once()
+        assert "Fetching updates" in mock_adapter.send.call_args[0][1]
+
     @pytest.mark.asyncio
     async def test_strips_ansi_codes(self, tmp_path):
         """ANSI escape codes are removed from output."""
@@ -605,33 +681,34 @@ class TestSendUpdateNotification:
         assert not exit_code_path.exists()
 
     @pytest.mark.asyncio
-    async def test_cleans_up_on_error(self, tmp_path):
-        """Files are cleaned up even if notification fails."""
+    async def test_restores_pending_marker_on_send_error_for_retry(self, tmp_path):
+        """Transient send failures preserve marker/output files for retry."""
         runner = _make_runner()
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
 
         pending_path = hermes_home / ".update_pending.json"
+        claimed_path = hermes_home / ".update_pending.claimed.json"
         output_path = hermes_home / ".update_output.txt"
         exit_code_path = hermes_home / ".update_exit_code"
         pending_path.write_text(json.dumps({
             "platform": "telegram", "chat_id": "111", "user_id": "222",
-        }))
-        output_path.write_text("✓ Done")
-        exit_code_path.write_text("0")
+        }), encoding="utf-8")
+        output_path.write_text("✓ Done", encoding="utf-8")
+        exit_code_path.write_text("0", encoding="utf-8")
 
-        # Adapter send raises
         mock_adapter = AsyncMock()
         mock_adapter.send.side_effect = RuntimeError("network error")
         runner.adapters = {Platform.TELEGRAM: mock_adapter}
 
         with patch("gateway.run._hermes_home", hermes_home):
-            await runner._send_update_notification()
+            result = await runner._send_update_notification()
 
-        # Files should still be cleaned up (finally block)
-        assert not pending_path.exists()
-        assert not output_path.exists()
-        assert not exit_code_path.exists()
+        assert result is False
+        assert pending_path.exists()
+        assert not claimed_path.exists()
+        assert output_path.exists()
+        assert exit_code_path.exists()
 
     @pytest.mark.asyncio
     async def test_handles_corrupt_pending_file(self, tmp_path):
@@ -674,9 +751,9 @@ class TestSendUpdateNotification:
 
         # send should not have been called (wrong platform)
         mock_adapter.send.assert_not_called()
-        # Files should still be cleaned up
-        assert not pending_path.exists()
-        assert not exit_code_path.exists()
+        # Adapter-unavailable is retryable; markers/output are preserved.
+        assert pending_path.exists()
+        assert exit_code_path.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -228,6 +228,7 @@ class TestUpdateCommandGatewayFlag:
         mock_popen = MagicMock()
         with patch("gateway.run._hermes_home", hermes_home), \
              patch("gateway.run.__file__", fake_file), \
+             patch("gateway.run.sys.platform", "linux"), \
              patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
              patch("subprocess.Popen", mock_popen):
             result = await runner._handle_update_command(event)
@@ -286,6 +287,42 @@ class TestWatchUpdateProgress:
         # Should have sent at least the output and a success message
         assert mock_adapter.send.call_count >= 1
         all_sent = " ".join(str(c) for c in mock_adapter.send.call_args_list)
+        assert "update finished" in all_sent.lower()
+
+
+    @pytest.mark.asyncio
+    async def test_reads_update_output_as_utf8_when_locale_charmap(self, tmp_path, monkeypatch):
+        """Watcher reads UTF-8 update output explicitly, avoiding Windows charmap decode failures."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending = {
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": "agent:main:telegram:dm:111",
+        }
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps(pending), encoding="utf-8")
+        output_path.write_bytes("→ Fetching updates...\n✅ Done\n".encode("utf-8"))
+        exit_code_path.write_text("0", encoding="utf-8")
+
+        orig_read_text = Path.read_text
+        def fail_if_output_read_without_encoding(self, *args, **kwargs):
+            if self == output_path and kwargs.get("encoding") is None:
+                raise UnicodeDecodeError("charmap", b"\x81", 0, 1, "character maps to <undefined>")
+            return orig_read_text(self, *args, **kwargs)
+        monkeypatch.setattr(Path, "read_text", fail_if_output_read_without_encoding)
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(poll_interval=0.1, stream_interval=0.1, timeout=5.0)
+
+        all_sent = " ".join(str(c) for c in mock_adapter.send.call_args_list)
+        assert "Fetching updates" in all_sent
         assert "update finished" in all_sent.lower()
 
     @pytest.mark.asyncio
@@ -395,9 +432,15 @@ class TestWatchUpdateProgress:
         pending_path = hermes_home / ".update_pending.json"
         output_path = hermes_home / ".update_output.txt"
         exit_code_path = hermes_home / ".update_exit_code"
-        pending_path.write_text(json.dumps(pending))
-        output_path.write_text("done\n")
-        exit_code_path.write_text("0")
+        sentinel_path = hermes_home / ".update_in_progress"
+        transcript_path = hermes_home / "logs" / "safe-update-test.log"
+        transcript_path.parent.mkdir()
+        pending["transcript_path"] = str(transcript_path)
+        pending_path.write_text(json.dumps(pending), encoding="utf-8")
+        output_path.write_text("done\n", encoding="utf-8")
+        exit_code_path.write_text("0", encoding="utf-8")
+        sentinel_path.write_text("now", encoding="utf-8")
+        transcript_path.write_text("durable", encoding="utf-8")
 
         mock_adapter = AsyncMock()
         runner.adapters = {Platform.TELEGRAM: mock_adapter}
@@ -412,6 +455,8 @@ class TestWatchUpdateProgress:
         assert not pending_path.exists()
         assert not output_path.exists()
         assert not exit_code_path.exists()
+        assert not sentinel_path.exists()
+        assert transcript_path.exists()
 
     @pytest.mark.asyncio
     async def test_failure_exit_code(self, tmp_path):

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -238,7 +238,8 @@ class TestUpdateCommandGatewayFlag:
         cmd_string = call_args[-1] if isinstance(call_args, list) else str(call_args)
         assert "--gateway" in cmd_string
         assert "PYTHONUNBUFFERED" in cmd_string
-        assert "rc=$?" in cmd_string
+        assert "tee -a" in cmd_string
+        assert "PIPESTATUS[0]" in cmd_string
         assert "status=$?" not in cmd_string
         assert "stream progress" in result
 
@@ -457,6 +458,75 @@ class TestWatchUpdateProgress:
         assert not exit_code_path.exists()
         assert not sentinel_path.exists()
         assert transcript_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_final_send_failure_preserves_markers_for_retry(self, tmp_path):
+        """A transient final-send failure must not lose update completion markers."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {"platform": "telegram", "chat_id": "111", "user_id": "222",
+                   "session_key": "agent:main:telegram:dm:111"}
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        sentinel_path = hermes_home / ".update_in_progress"
+        pending_path.write_text(json.dumps(pending), encoding="utf-8")
+        output_path.write_text("done\n", encoding="utf-8")
+        exit_code_path.write_text("0", encoding="utf-8")
+        sentinel_path.write_text("now", encoding="utf-8")
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send.side_effect = RuntimeError("network down")
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(
+                poll_interval=0.1,
+                stream_interval=0.2,
+                timeout=5.0,
+            )
+
+        assert pending_path.exists()
+        assert output_path.exists()
+        assert exit_code_path.exists()
+        assert sentinel_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_final_send_failure_retries_in_same_watcher(self, tmp_path):
+        """A transient final-send failure is retried by the active watcher."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {"platform": "telegram", "chat_id": "111", "user_id": "222",
+                   "session_key": "agent:main:telegram:dm:111"}
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        sentinel_path = hermes_home / ".update_in_progress"
+        pending_path.write_text(json.dumps(pending), encoding="utf-8")
+        output_path.write_text("done\n", encoding="utf-8")
+        exit_code_path.write_text("0", encoding="utf-8")
+        sentinel_path.write_text("now", encoding="utf-8")
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send.side_effect = [RuntimeError("network down"), None]
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(
+                poll_interval=0.1,
+                stream_interval=0.2,
+                timeout=5.0,
+            )
+
+        assert mock_adapter.send.call_count >= 2
+        assert not pending_path.exists()
+        assert not output_path.exists()
+        assert not exit_code_path.exists()
+        assert not sentinel_path.exists()
 
     @pytest.mark.asyncio
     async def test_failure_exit_code(self, tmp_path):

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -9,6 +9,26 @@ import hermes_cli.gateway_windows as gateway_windows
 import hermes_cli.setup as setup
 
 
+def test_windows_pid_scan_detects_legacy_cli_gateway(monkeypatch):
+    """Status/restart scans should still see older cli.py --gateway watchdog launches."""
+    class Result:
+        returncode = 0
+        stdout = (
+            "CommandLine=C:\\Projects\\Hermes\\.venv\\Scripts\\pythonw.exe "
+            "\"C:\\Projects\\Hermes\\cli.py\" --gateway\n"
+            "ProcessId=1234\n\n"
+        )
+
+    monkeypatch.setattr(gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_filter_venv_launcher_stubs", lambda pids: pids)
+    monkeypatch.setattr(gateway, "_profile_arg", lambda *args, **kwargs: "")
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: "wmic" if name == "wmic" else None)
+    monkeypatch.setattr(gateway.subprocess, "run", lambda *args, **kwargs: Result())
+
+    assert gateway._scan_gateway_pids(set()) == [1234]
+
+
 @pytest.mark.parametrize(
     "detail",
     [
@@ -61,6 +81,10 @@ def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, 
     argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
 
     assert argv[:3] == [str(base_pythonw), "-m", "hermes_cli.main"]
+    assert argv[-2:] == ["gateway", "run"]
+    joined = " ".join(argv)
+    assert "cli.py" not in joined
+    assert "--gateway" not in argv
     assert cwd == str(project)
     assert env_overlay["VIRTUAL_ENV"] == str(project / "venv")
     assert str(project) in env_overlay["PYTHONPATH"].split(gateway_windows.os.pathsep)


### PR DESCRIPTION
## Summary
- prevent duplicate gateway /update runs from overwriting lifecycle markers
- preserve completion markers when final notification delivery transiently fails
- retry final update notifications and clean stale/corrupt marker files
- keep safe-update transcript output while preserving the update process exit code

## Test Plan
- .venv/Scripts/python.exe -m pytest tests/gateway/test_update_command.py tests/gateway/test_update_streaming.py -q --timeout-method=thread