### PR TITLE
auth(xai-oauth): cross-profile shared token store, race fix

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3694,6 +3694,18 @@ def _save_xai_oauth_tokens(
             state["redirect_uri"] = redirect_uri
         _save_provider_state(auth_store, "xai-oauth", state)
         _save_auth_store(auth_store)
+    # Mirror the freshly-rotated tokens to the cross-profile shared store so
+    # sibling profiles can pick them up via :func:`_merge_shared_xai_oauth_state`
+    # on their next refresh attempt — instead of reusing their own (now
+    # server-side-consumed) refresh_token and getting the family revoked.
+    # Best-effort: any failure is logged and swallowed, the local save above
+    # remains the source of truth.
+    _write_shared_xai_state(
+        tokens,
+        discovery=discovery,
+        redirect_uri=redirect_uri,
+        last_refresh=last_refresh,
+    )
 
 
 def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
@@ -4007,16 +4019,57 @@ def resolve_xai_oauth_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_xai_oauth_tokens(_lock=False)
+        # Cross-profile serialization: hold the shared xAI store lock for the
+        # whole "re-read → maybe-merge → maybe-refresh → persist" cycle so
+        # two profiles can't both consume the same single-use refresh_token.
+        # Persistence helpers called below (``_save_xai_oauth_tokens`` and
+        # the terminal-failure quarantine block) acquire ``_auth_store_lock``
+        # internally and briefly. Lock ordering exception, mirroring
+        # ``_try_import_shared_nous_state`` — see ``_xai_shared_store_lock``.
+        shared_lock_timeout = max(
+            float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0
+        )
+        with _xai_shared_store_lock(timeout_seconds=shared_lock_timeout):
+            # Re-read local under the shared lock: another in-process caller
+            # may have refreshed while we waited on the lock, in which case
+            # the existing logic below correctly sees the fresh access_token
+            # and skips the HTTP refresh.
+            data = _read_xai_oauth_tokens()
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
             discovery = dict(data.get("discovery") or {})
             token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
             redirect_uri = str(data.get("redirect_uri", "") or "").strip()
+
+            # If a sibling profile refreshed while we waited on the lock,
+            # the shared store has fresher tokens. Merge them in and persist
+            # locally — avoids burning our own refresh_token (which is now
+            # server-side-consumed because the sibling's refresh rotated it)
+            # and skips the HTTP round trip entirely.
+            merge_state: Dict[str, Any] = {
+                "tokens": tokens,
+                "last_refresh": data.get("last_refresh"),
+                "discovery": discovery,
+                "redirect_uri": redirect_uri,
+            }
+            if _merge_shared_xai_oauth_state(merge_state):
+                tokens = dict(merge_state["tokens"])
+                access_token = str(tokens.get("access_token", "") or "").strip()
+                discovery = dict(merge_state.get("discovery") or {})
+                token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
+                redirect_uri = str(merge_state.get("redirect_uri") or "")
+                _save_xai_oauth_tokens(
+                    tokens,
+                    discovery=discovery if discovery else None,
+                    redirect_uri=redirect_uri,
+                    last_refresh=merge_state.get("last_refresh"),
+                )
+
             should_refresh = bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
+                should_refresh = _xai_access_token_is_expiring(
+                    access_token, refresh_skew_seconds
+                )
             if should_refresh:
                 if not token_endpoint:
                     token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
@@ -4054,6 +4107,11 @@ def resolve_xai_oauth_runtime_credentials(
                             logger.debug(
                                 "xAI OAuth: failed to persist quarantined state: %s", _save_exc,
                             )
+                        # Wipe the shared store too — leaving these dead
+                        # tokens in <hermes-root>/shared/xai_auth.json would
+                        # poison every sibling profile that's still running
+                        # against the same family revocation.
+                        _clear_shared_xai_state(reason=exc.code or "xai_refresh_failed")
                     raise
 
     base_url = _xai_validate_inference_base_url(
@@ -4532,6 +4590,268 @@ def _clear_shared_nous_state(reason: str) -> None:
         _oauth_trace("nous_shared_store_cleared", reason=reason)
     except Exception as exc:
         logger.debug("Failed to clear shared Nous auth store: %s", exc)
+
+
+# =============================================================================
+# Shared xAI OAuth token store — same idea as the Nous shared store above, but
+# for xAI tokens. Without this, every profile that picks ``model.provider:
+# xai-oauth`` keeps its OWN copy of the rotating refresh_token in its
+# profile-local auth.json. xAI uses single-use rotating refresh tokens: when
+# profile A refreshes, the server mints a new pair and invalidates the old
+# refresh_token; if profile B still holds the old one and refreshes, xAI
+# treats it as a reuse attempt and revokes the entire token family for both
+# profiles. The shared store gives every profile under the same hermes-root
+# a single authoritative copy of the latest tokens plus a cross-profile file
+# lock that serializes refreshes so siblings can't race on the single-use
+# token.
+#
+# File lives at ``${HERMES_SHARED_AUTH_DIR}/xai_auth.json``, defaulting to
+# ``<hermes-root>/shared/xai_auth.json`` (same dir Nous's shared store uses).
+# Written on successful login and on every runtime refresh. If the stored
+# refresh_token does go stale server-side (e.g. user re-logs in from
+# another machine), :func:`resolve_xai_oauth_runtime_credentials` clears
+# the shared store on terminal failure so the dead token doesn't survive
+# to poison other profiles.
+# =============================================================================
+
+XAI_SHARED_STORE_FILENAME = "xai_auth.json"
+_xai_shared_lock_holder = threading.local()
+
+
+def _xai_shared_auth_dir() -> Path:
+    """Resolve the directory that holds the shared xAI OAuth token store.
+
+    Mirrors :func:`_nous_shared_auth_dir`: honors ``HERMES_SHARED_AUTH_DIR``
+    so tests can redirect to a tmp path, defaults to
+    ``<hermes-root>/shared/`` for normal installs.
+    """
+    override = os.getenv("HERMES_SHARED_AUTH_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "shared"
+
+
+def _xai_shared_store_path() -> Path:
+    path = _xai_shared_auth_dir() / XAI_SHARED_STORE_FILENAME
+    # Seat belt: same as :func:`_nous_shared_store_path`. Pytest must redirect
+    # ``HERMES_SHARED_AUTH_DIR`` to a tmp_path or this raises rather than
+    # silently corrupt the real user's shared store.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        from hermes_constants import get_default_hermes_root
+        real_home_shared = (
+            get_default_hermes_root() / "shared" / XAI_SHARED_STORE_FILENAME
+        ).resolve(strict=False)
+        try:
+            resolved = path.resolve(strict=False)
+        except Exception:
+            resolved = path
+        if resolved == real_home_shared:
+            raise RuntimeError(
+                f"Refusing to touch real user shared xAI auth store during test run: "
+                f"{path}. Set HERMES_SHARED_AUTH_DIR to a tmp_path in your test fixture."
+            )
+    return path
+
+
+@contextmanager
+def _xai_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Cross-profile lock for the shared xAI OAuth store.
+
+    Lock ordering: this lock is acquired ALONE for the entire refresh +
+    persistence cycle inside
+    :func:`resolve_xai_oauth_runtime_credentials`, so concurrent profiles
+    can't race on the single-use refresh_token. The persistence helpers
+    called inside (``_save_xai_oauth_tokens``, the terminal-failure
+    quarantine block) acquire ``_auth_store_lock`` internally and briefly.
+    Callers must NOT hold ``_auth_store_lock`` when acquiring this one —
+    mirrors the exception documented on :func:`_nous_shared_store_lock`.
+    """
+    try:
+        lock_path = _xai_shared_store_path().with_suffix(".lock")
+    except RuntimeError:
+        # No HERMES_HOME yet (pre-setup): fall through without locking.
+        yield
+        return
+
+    with _file_lock(
+        lock_path,
+        _xai_shared_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared xAI auth lock",
+    ):
+        yield
+
+
+def _write_shared_xai_state(
+    tokens: Dict[str, Any],
+    *,
+    discovery: Optional[Dict[str, Any]] = None,
+    redirect_uri: str = "",
+    last_refresh: Optional[str] = None,
+) -> None:
+    """Persist xAI OAuth tokens to the shared store.
+
+    Best-effort: any failure is swallowed after logging. The shared store
+    is a sync layer across profiles; the per-profile auth.json remains the
+    source of truth.
+    """
+    access_token = (
+        str(tokens.get("access_token", "") or "").strip()
+        if isinstance(tokens, dict)
+        else ""
+    )
+    refresh_token = (
+        str(tokens.get("refresh_token", "") or "").strip()
+        if isinstance(tokens, dict)
+        else ""
+    )
+    if not refresh_token or not access_token:
+        # Nothing worth sharing across profiles.
+        return
+
+    shared = {
+        "_schema": 1,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": str(tokens.get("token_type") or "Bearer"),
+        "id_token": str(tokens.get("id_token") or ""),
+        "expires_in": tokens.get("expires_in"),
+        "discovery": dict(discovery) if discovery else {},
+        "redirect_uri": redirect_uri or "",
+        "last_refresh": last_refresh
+        or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        with _xai_shared_store_lock():
+            path = _xai_shared_store_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
+            secure_parent_dir(path)
+            tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+            # Atomic 0o600 create — closes the TOCTOU window where
+            # write_text + post-write chmod briefly exposed refresh_token
+            # at process umask. Mirrors :func:`_write_shared_nous_state`.
+            fd = os.open(
+                str(tmp),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(json.dumps(shared, indent=2, sort_keys=True))
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp, path)
+            finally:
+                try:
+                    if tmp.exists():
+                        tmp.unlink()
+                except OSError:
+                    pass
+        _oauth_trace(
+            "xai_shared_store_written",
+            path=str(path),
+            refresh_token_fp=_token_fingerprint(refresh_token),
+        )
+    except Exception as exc:
+        logger.debug("Failed to write shared xAI auth store: %s", exc)
+
+
+def _read_shared_xai_state() -> Optional[Dict[str, Any]]:
+    """Return the shared xAI OAuth state if present and well-formed.
+
+    ``None`` means the file is missing, unreadable, malformed, or lacks
+    required fields — callers fall through to whatever they have locally.
+    """
+    try:
+        path = _xai_shared_store_path()
+    except RuntimeError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        logger.debug("Shared xAI auth store at %s is unreadable: %s", path, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    refresh_token = payload.get("refresh_token")
+    access_token = payload.get("access_token")
+    if not (isinstance(refresh_token, str) and refresh_token.strip()):
+        return None
+    if not (isinstance(access_token, str) and access_token.strip()):
+        return None
+    return payload
+
+
+def _clear_shared_xai_state(reason: str) -> None:
+    """Remove the shared xAI OAuth store after a terminal token failure."""
+    try:
+        with _xai_shared_store_lock():
+            path = _xai_shared_store_path()
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        _oauth_trace("xai_shared_store_cleared", reason=reason)
+    except Exception as exc:
+        logger.debug("Failed to clear shared xAI auth store: %s", exc)
+
+
+def _merge_shared_xai_oauth_state(state: Dict[str, Any]) -> bool:
+    """If the shared store has fresher xAI tokens than ``state``, copy
+    them in and return True.
+
+    ``state`` matches the shape returned by :func:`_read_xai_oauth_tokens`
+    (with a ``tokens`` sub-dict, ``last_refresh``, ``discovery``,
+    ``redirect_uri``). The merge mutates ``state`` in place.
+
+    "Fresher" means the shared store's ``refresh_token`` differs from
+    local — the most reliable cross-profile signal, since xAI rotates
+    the refresh_token on every successful refresh and the shared store
+    is written by every refresh path.
+    """
+    shared = _read_shared_xai_state()
+    if not shared:
+        return False
+
+    shared_refresh = str(shared.get("refresh_token") or "").strip()
+    if not shared_refresh:
+        return False
+
+    tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else {}
+    local_refresh = (
+        str(tokens.get("refresh_token") or "").strip()
+        if isinstance(tokens, dict)
+        else ""
+    )
+    if shared_refresh == local_refresh:
+        # No new refresh_token in the shared store.
+        return False
+
+    # Apply the shared tokens. We preserve the local state shape (a mutable
+    # ``tokens`` dict at the top level + sibling ``last_refresh``,
+    # ``discovery``, ``redirect_uri``).
+    new_tokens = dict(tokens) if isinstance(tokens, dict) else {}
+    new_tokens["access_token"] = shared.get("access_token", "")
+    new_tokens["refresh_token"] = shared_refresh
+    if shared.get("token_type"):
+        new_tokens["token_type"] = shared["token_type"]
+    if shared.get("id_token"):
+        new_tokens["id_token"] = shared["id_token"]
+    if shared.get("expires_in") is not None:
+        new_tokens["expires_in"] = shared["expires_in"]
+    state["tokens"] = new_tokens
+    if shared.get("last_refresh"):
+        state["last_refresh"] = shared["last_refresh"]
+    if shared.get("discovery"):
+        state.setdefault("discovery", dict(shared["discovery"]))
+    if shared.get("redirect_uri"):
+        state.setdefault("redirect_uri", shared["redirect_uri"])
+    return True
 
 
 def _is_terminal_nous_refresh_error(exc: Exception) -> bool:

--- a/tests/hermes_cli/test_auth_xai_shared_store.py
+++ b/tests/hermes_cli/test_auth_xai_shared_store.py
@@ -1,0 +1,360 @@
+"""Unit tests for the xAI shared OAuth token store.
+
+Mirrors the Nous shared-store tests in
+``tests/hermes_cli/test_auth_nous_provider.py`` — same fixture conventions,
+same seat-belt expectations. The shared store is what stops two profiles
+that both pick ``model.provider: xai-oauth`` from racing on xAI's
+single-use rotating refresh_token (which otherwise revokes the entire
+token family the moment the second profile's refresh attempt hits the
+already-consumed token).
+"""
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def shared_store_env(tmp_path, monkeypatch):
+    """Redirect HERMES_SHARED_AUTH_DIR to a tmp_path.
+
+    Required for every test that touches the shared xAI store — the
+    in-auth.py seat belt refuses to touch the real user's shared store
+    under pytest, so tests that forget this fixture fail loudly instead
+    of corrupting real state.
+    """
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    return shared_dir
+
+
+def _shared_payload(
+    *,
+    refresh_token: str = "rt-current",
+    access_token: str = "at-current",
+) -> dict:
+    """A complete shared-store payload as the writer would emit it."""
+    return {
+        "_schema": 1,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "Bearer",
+        "id_token": "id-tok",
+        "expires_in": 3600,
+        "discovery": {"token_endpoint": "https://api.x.ai/oauth2/token"},
+        "redirect_uri": "http://127.0.0.1:8765/callback",
+        "last_refresh": "2026-05-27T00:00:00Z",
+        "updated_at": "2026-05-27T00:00:00+00:00",
+    }
+
+
+def _local_state(*, refresh_token: str = "rt-local") -> dict:
+    """A profile-local xAI OAuth state as :func:`_read_xai_oauth_tokens` returns."""
+    return {
+        "tokens": {
+            "access_token": "at-local",
+            "refresh_token": refresh_token,
+            "token_type": "Bearer",
+            "id_token": "id-local",
+            "expires_in": 3600,
+        },
+        "last_refresh": "2026-05-20T00:00:00Z",
+        "discovery": {"token_endpoint": "https://api.x.ai/oauth2/token"},
+        "redirect_uri": "http://127.0.0.1:8765/callback",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Seat belt + path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_shared_store_seat_belt_refuses_real_home_under_pytest(monkeypatch):
+    """Without HERMES_SHARED_AUTH_DIR override, the seat belt must trip.
+
+    Mirrors the Nous seat belt: forgetting to redirect this store in a
+    test must fail loudly instead of silently writing to the user's real
+    ``~/.hermes/shared/`` across CI runs.
+    """
+    from hermes_cli.auth import _xai_shared_store_path
+
+    monkeypatch.delenv("HERMES_SHARED_AUTH_DIR", raising=False)
+
+    with pytest.raises(RuntimeError, match="shared xAI auth store"):
+        _xai_shared_store_path()
+
+
+def test_shared_store_honors_env_override(tmp_path, monkeypatch):
+    """HERMES_SHARED_AUTH_DIR must redirect the path."""
+    from hermes_cli.auth import XAI_SHARED_STORE_FILENAME, _xai_shared_store_path
+
+    custom_dir = tmp_path / "custom_shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(custom_dir))
+
+    path = _xai_shared_store_path()
+    assert path == custom_dir / XAI_SHARED_STORE_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Read: missing / malformed / incomplete
+# ---------------------------------------------------------------------------
+
+
+def test_shared_store_read_missing_returns_none(shared_store_env):
+    """Missing file → ``_read_shared_xai_state()`` returns None."""
+    from hermes_cli.auth import _read_shared_xai_state
+
+    assert _read_shared_xai_state() is None
+
+
+def test_shared_store_read_malformed_returns_none(shared_store_env):
+    """Non-JSON content → None, not an exception."""
+    from hermes_cli.auth import _read_shared_xai_state, _xai_shared_store_path
+
+    path = _xai_shared_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ not json")
+
+    assert _read_shared_xai_state() is None
+
+
+def test_shared_store_read_missing_required_fields_returns_none(shared_store_env):
+    """Payload without refresh_token → None (nothing worth importing)."""
+    from hermes_cli.auth import _read_shared_xai_state, _xai_shared_store_path
+
+    path = _xai_shared_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"_schema": 1, "access_token": "abc"}))
+
+    assert _read_shared_xai_state() is None
+
+
+# ---------------------------------------------------------------------------
+# Write
+# ---------------------------------------------------------------------------
+
+
+def test_shared_store_write_and_read_roundtrip(shared_store_env):
+    """Write → read must preserve refresh_token + the OAuth metadata
+    we'll need to skip discovery on the next refresh."""
+    from hermes_cli.auth import (
+        _read_shared_xai_state,
+        _write_shared_xai_state,
+        _xai_shared_store_path,
+    )
+
+    tokens = {
+        "access_token": "at-rolled",
+        "refresh_token": "rt-rolled",
+        "token_type": "Bearer",
+        "id_token": "id-rolled",
+        "expires_in": 3600,
+    }
+    _write_shared_xai_state(
+        tokens,
+        discovery={"token_endpoint": "https://api.x.ai/oauth2/token"},
+        redirect_uri="http://127.0.0.1:8765/callback",
+        last_refresh="2026-05-27T07:00:00Z",
+    )
+
+    path = _xai_shared_store_path()
+    assert path.is_file()
+
+    # 0o600 where the platform supports it.
+    mode = path.stat().st_mode & 0o777
+    assert mode in {stat.S_IRUSR | stat.S_IWUSR, 0o644}
+
+    loaded = _read_shared_xai_state()
+    assert loaded is not None
+    assert loaded["refresh_token"] == "rt-rolled"
+    assert loaded["access_token"] == "at-rolled"
+    assert loaded["token_type"] == "Bearer"
+    assert loaded["id_token"] == "id-rolled"
+    assert loaded["expires_in"] == 3600
+    assert loaded["discovery"] == {
+        "token_endpoint": "https://api.x.ai/oauth2/token",
+    }
+    assert loaded["last_refresh"] == "2026-05-27T07:00:00Z"
+
+
+def test_shared_store_write_skips_when_refresh_token_missing(shared_store_env):
+    """Write is a no-op when refresh_token is absent (nothing to share)."""
+    from hermes_cli.auth import _write_shared_xai_state, _xai_shared_store_path
+
+    _write_shared_xai_state(
+        {"access_token": "at", "refresh_token": ""},
+        last_refresh="2026-05-27T00:00:00Z",
+    )
+
+    assert not _xai_shared_store_path().is_file()
+
+
+def test_shared_store_write_skips_when_access_token_missing(shared_store_env):
+    """Write is a no-op when access_token is absent (incomplete pair)."""
+    from hermes_cli.auth import _write_shared_xai_state, _xai_shared_store_path
+
+    _write_shared_xai_state(
+        {"access_token": "", "refresh_token": "rt"},
+        last_refresh="2026-05-27T00:00:00Z",
+    )
+
+    assert not _xai_shared_store_path().is_file()
+
+
+# ---------------------------------------------------------------------------
+# Clear
+# ---------------------------------------------------------------------------
+
+
+def test_shared_store_clear_removes_file(shared_store_env):
+    """``_clear_shared_xai_state`` deletes the file (idempotent if absent)."""
+    from hermes_cli.auth import (
+        _clear_shared_xai_state,
+        _write_shared_xai_state,
+        _xai_shared_store_path,
+    )
+
+    _write_shared_xai_state(
+        {"access_token": "at", "refresh_token": "rt"},
+        last_refresh="2026-05-27T00:00:00Z",
+    )
+    assert _xai_shared_store_path().is_file()
+
+    _clear_shared_xai_state(reason="test")
+    assert not _xai_shared_store_path().is_file()
+
+    # Idempotent — a second clear on an already-absent file must not raise.
+    _clear_shared_xai_state(reason="test_again")
+
+
+# ---------------------------------------------------------------------------
+# Merge — the cross-profile import path
+# ---------------------------------------------------------------------------
+
+
+def test_merge_no_op_when_refresh_token_matches(shared_store_env):
+    """Shared and local agree → merge is a no-op, returns False."""
+    from hermes_cli.auth import (
+        _merge_shared_xai_oauth_state,
+        _xai_shared_store_path,
+    )
+
+    path = _xai_shared_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_shared_payload(refresh_token="rt-same")))
+
+    state = _local_state(refresh_token="rt-same")
+    snapshot = json.loads(json.dumps(state))
+
+    changed = _merge_shared_xai_oauth_state(state)
+
+    assert changed is False
+    assert state == snapshot
+
+
+def test_merge_copies_fresher_shared_tokens_into_state(shared_store_env):
+    """Shared has a different (rotated) refresh_token → merge copies it
+    plus the matching access_token into the local state and returns True.
+    """
+    from hermes_cli.auth import (
+        _merge_shared_xai_oauth_state,
+        _xai_shared_store_path,
+    )
+
+    path = _xai_shared_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            _shared_payload(
+                refresh_token="rt-rolled",
+                access_token="at-rolled",
+            )
+        )
+    )
+
+    state = _local_state(refresh_token="rt-stale")
+
+    changed = _merge_shared_xai_oauth_state(state)
+
+    assert changed is True
+    assert state["tokens"]["refresh_token"] == "rt-rolled"
+    assert state["tokens"]["access_token"] == "at-rolled"
+    # Other token fields propagate too.
+    assert state["tokens"]["token_type"] == "Bearer"
+    assert state["tokens"]["expires_in"] == 3600
+    # last_refresh follows the shared store's clock.
+    assert state["last_refresh"] == "2026-05-27T00:00:00Z"
+
+
+def test_merge_returns_false_when_shared_missing(shared_store_env):
+    """No shared file → merge is a no-op, returns False."""
+    from hermes_cli.auth import _merge_shared_xai_oauth_state
+
+    state = _local_state(refresh_token="rt-local")
+    snapshot = json.loads(json.dumps(state))
+
+    assert _merge_shared_xai_oauth_state(state) is False
+    assert state == snapshot
+
+
+# ---------------------------------------------------------------------------
+# Integration: _save_xai_oauth_tokens mirrors to shared
+# ---------------------------------------------------------------------------
+
+
+def test_save_xai_oauth_tokens_mirrors_to_shared_store(
+    tmp_path, monkeypatch, shared_store_env,
+):
+    """``_save_xai_oauth_tokens`` must populate BOTH per-profile auth.json
+    AND the shared store so a sibling profile picking ``xai-oauth`` next
+    sees the rotated tokens instead of re-using its stale refresh_token.
+    This is the cross-profile race fix.
+    """
+    from hermes_cli.auth import (
+        _read_shared_xai_state,
+        _save_xai_oauth_tokens,
+        _xai_shared_store_path,
+    )
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_xai_oauth_tokens(
+        {
+            "access_token": "at-1",
+            "refresh_token": "rt-1",
+            "token_type": "Bearer",
+            "id_token": "id-1",
+            "expires_in": 3600,
+        },
+        discovery={"token_endpoint": "https://api.x.ai/oauth2/token"},
+        redirect_uri="http://127.0.0.1:8765/callback",
+        last_refresh="2026-05-27T07:00:00Z",
+    )
+
+    # Local auth.json should exist with the tokens.
+    auth_path = hermes_home / "auth.json"
+    assert auth_path.is_file()
+    local = json.loads(auth_path.read_text())
+    assert (
+        local["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "rt-1"
+    )
+
+    # Shared store should mirror them.
+    shared_path = _xai_shared_store_path()
+    assert shared_path.is_file()
+    shared = _read_shared_xai_state()
+    assert shared is not None
+    assert shared["refresh_token"] == "rt-1"
+    assert shared["access_token"] == "at-1"
+    assert shared["last_refresh"] == "2026-05-27T07:00:00Z"


### PR DESCRIPTION
## Problem

xAI uses single-use rotating refresh tokens — every successful refresh mints a new pair and the previous `refresh_token` is immediately invalid server-side. When two profiles under the same hermes-root both pick `model.provider: xai-oauth`, each keeps an INDEPENDENT copy of the rotating `refresh_token` in its profile-local `auth.json`; there's no cross-profile sync.

The race:

1. Profile A's token nears expiry → posts `refresh_token R1` → xAI mints `R2`, invalidates `R1`, A stores `R2`.
2. Profile B still has `R1` cached locally → posts `R1` → xAI sees reuse → revokes the entire token family.
3. Both profiles end up with `last_auth_error.code == "xai_refresh_failed"`, `relogin_required: True` — and the user discovers it later when a tool (`x_search`, xAI TTS, etc.) silently disappears from the schema because `check_x_search_requirements()` returns False.

Real users hit this with no warning. The diagnostic in the field is the `"Refresh token has been revoked"` `last_auth_error.message` on a profile that never did anything "wrong" — it just happened to wake up after a sibling refreshed.

## Fix

Same pattern as the existing Nous shared store (`_nous_shared_store_*` + `_try_import_shared_nous_state`): a single authoritative copy of the OAuth tokens at `<hermes-root>/shared/xai_auth.json` plus a cross-profile file lock that serializes refreshes so siblings can't race on the single-use token.

### New helpers (mirror Nous)

- `_xai_shared_auth_dir` / `_xai_shared_store_path` — same `HERMES_SHARED_AUTH_DIR` override and pytest seat belt as Nous.
- `_xai_shared_store_lock` — file lock at `xai_auth.json.lock`. Held alone for the entire refresh+persist cycle (lock-ordering exception, documented in the docstring, just like `_try_import_shared_nous_state` does for Nous).
- `_write_shared_xai_state` — atomic `O_EXCL` `0o600` write via `secure_parent_dir` + tmp + rename. Skips when `refresh_token` or `access_token` is empty.
- `_read_shared_xai_state` — `None` on missing / malformed / incomplete payload.
- `_clear_shared_xai_state` — wipe after terminal failure so dead tokens don't poison siblings.
- `_merge_shared_xai_oauth_state` — copy fresher shared tokens into a profile-local state when shared's `refresh_token` differs from local's. Returns True iff the state changed.

### Wiring

- **`_save_xai_oauth_tokens`** now mirrors the rotated pair to the shared store after the per-profile `auth.json` write. Failures in the shared write are logged and swallowed — the local save remains the source of truth.
- **`resolve_xai_oauth_runtime_credentials`** now performs its refresh path under `_xai_shared_store_lock` instead of `_auth_store_lock`. Inside the lock it:
  - re-reads the per-profile state,
  - merges fresher shared tokens in and persists them locally (skipping the HTTP refresh entirely if a sibling has rotated since this profile last looked),
  - only then makes the actual HTTP refresh call,
  - on terminal failure (`invalid_grant` / `xai_refresh_failed`), clears the shared store in addition to the per-profile quarantine, so a sibling doesn't inherit dead tokens.
- `_auth_store_lock` is no longer held across the HTTP refresh — persistence helpers acquire it briefly and internally.

### Lock ordering invariant

Following the existing documented exception on `_nous_shared_store_lock`: the runtime refresh path holds the shared lock **alone** for the whole refresh + persist cycle (callers must not enter it with `_auth_store_lock` already held). The persistence helpers (`_save_xai_oauth_tokens`, the terminal-failure quarantine block) acquire `_auth_store_lock` internally and briefly.

## Tests

`tests/hermes_cli/test_auth_xai_shared_store.py` (13 cases, all passing):

- Seat belt rejects real home under pytest (mirrors Nous test).
- `HERMES_SHARED_AUTH_DIR` redirect honored.
- `_read_shared_xai_state` returns `None` for missing / malformed / incomplete payload.
- Write + read round-trip preserves `refresh_token` / `access_token` / `token_type` / `id_token` / `expires_in` / `discovery` / `last_refresh`.
- File mode is `0o600` where the platform supports `chmod`.
- Write skipped when `refresh_token` or `access_token` is empty.
- `_clear_shared_xai_state` removes the file and is idempotent on already-absent files.
- `_merge_shared_xai_oauth_state` no-op when refresh_tokens match.
- `_merge_shared_xai_oauth_state` copies fresher shared tokens in when refresh_tokens differ.
- `_merge_shared_xai_oauth_state` returns False when shared store is missing.
- Integration: `_save_xai_oauth_tokens` mirrors to both per-profile `auth.json` and the shared store.

Conventions match `test_auth_nous_provider.py`'s shared-store tests — `shared_store_env` fixture redirecting `HERMES_SHARED_AUTH_DIR` to `tmp_path`.

## Regression coverage

Full `tests/hermes_cli/test_auth_xai_oauth_provider.py` + `test_xai_oauth_pkce_token_exchange.py` + `test_auth_nous_provider.py` suites still green: **154/154 passed in 8.72s**.

```
python -m pytest tests/hermes_cli/test_auth_xai_oauth_provider.py \
                 tests/hermes_cli/test_xai_oauth_pkce_token_exchange.py \
                 tests/hermes_cli/test_auth_nous_provider.py -q
```

## Out of scope

- MCP-server-style per-tool toggling for xAI tools.
- Concurrent-thread race test — the `_file_lock` primitive is already covered by Nous's existing suite; the new tests exercise the integration points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)