### PR TITLE
fix(codex): treat tool-call stream events as tool turns

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,13 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _is_codex_tool_call_event(event_type: Any) -> bool:
+    """Return True for Responses events that indicate a tool-call turn."""
+    if not isinstance(event_type, str):
+        return False
+    return "function_call" in event_type or "tool_call" in event_type
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -326,9 +333,9 @@ def _consume_codex_event_stream(
                             logger.debug("Codex stream on_text_delta raised", exc_info=True)
             continue
 
-        if "function_call" in event_type:
+        if _is_codex_tool_call_event(event_type):
             has_tool_calls = True
-            # fall through — function_call items still get added on output_item.done
+            # fall through — tool-call items still get added on output_item.done
 
         if "reasoning" in event_type and "delta" in event_type:
             reasoning_text = _event_field(event, "delta", "")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2592,6 +2592,41 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
         assert response.choices[0].message.content == "aux survived"
 
 
+    @pytest.mark.parametrize(
+        "event_type",
+        ["response.tool_call.delta", "response.custom_tool_call.delta"],
+    )
+    def test_does_not_synthesize_text_after_tool_call_event(self, event_type):
+        """Auxiliary recovery should not turn tool-call deltas into text."""
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_text.delta", delta="incidental aux text"),
+            SimpleNamespace(type=event_type),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(
+                status="completed",
+                id="resp_tool_call_null_output",
+                output=None,
+                usage=None,
+            )),
+        ]
+
+        class _NullOutputCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                return _NullOutputCreateStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize"}])
+
+        assert response.choices[0].message.content is None
+        assert response.choices[0].message.tool_calls is None
+
+
 # ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -531,6 +531,51 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.usage.total_tokens == 11
 
 
+@pytest.mark.parametrize(
+    "event_type",
+    ["response.tool_call.delta", "response.custom_tool_call.delta"],
+)
+def test_run_codex_stream_does_not_synthesize_text_after_tool_call_event(monkeypatch, event_type):
+    """Tool/custom-tool events should suppress leaked text synthesis.
+
+    Codex-compatible backends may emit incidental output_text deltas around a
+    tool-call turn and then finish with ``response.output = null``.  When the
+    only tool indicator is a generic/custom tool event, the recovery path must
+    not convert those incidental deltas into an assistant message.
+    """
+    agent = _build_agent(monkeypatch)
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_text.delta", delta="incidental text"),
+            SimpleNamespace(type=event_type),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    id="resp_tool_call_null_output",
+                    status="completed",
+                    output=None,
+                    usage=None,
+                ),
+            ),
+        ]
+    )
+
+    def _fake_create(**kwargs):
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert create_stream.closed is True
+    assert response.output == []
+    assert response.output_text == "incidental text"
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary
- Treat `tool_call` / `custom_tool_call` Responses stream events as tool-turn indicators during Codex stream recovery.
- Prevent incidental `output_text.delta` fragments from being synthesized into assistant messages when a generic/custom tool-call turn ends with `response.output = null`.
- Add focused regression coverage for both the main Codex stream path and the auxiliary Codex client path.

## Context
#32963 fixed the main Codex `output=null` crash from #11179. This is a smaller follow-up for one remaining edge case: null-output recovery currently suppresses text synthesis only after `function_call` events. Codex-compatible streams can also signal tool turns through `tool_call` / `custom_tool_call` events, so those should be treated the same way.

This intentionally avoids re-opening the broader duplicate fix from #32918 and only keeps the narrower hardening that was not fully covered by #32963.

## Test plan
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_does_not_synthesize_text_after_tool_call_event tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterNullOutputRecovery::test_does_not_synthesize_text_after_tool_call_event -q`
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py -q`

Result: `249 passed, 1 warning`