### PR TITLE
docker: add chromium-hermes symlink after playwright install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ ENV npm_config_install_links=false
 
 RUN npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
+    ln -sf "$(find /opt/hermes/.playwright -name chrome -path '*/chrome-linux/chrome' | head -1)" /usr/local/bin/chromium-hermes && \
     (cd web && npm install --prefer-offline --no-audit) && \
     (cd ui-tui && npm install --prefer-offline --no-audit) && \
     npm cache clean --force


### PR DESCRIPTION
## Summary

After `npx playwright install --with-deps chromium --only-shell`, creates a stable symlink at `/usr/local/bin/chromium-hermes` pointing to the installed Chromium binary.

This allows users to set `AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium-hermes` in their Docker environment and get a working, version-independent path to Chromium — without needing to know the exact versioned path under `$PLAYWRIGHT_BROWSERS_PATH`.

## Changes

- Single `ln -sf` added to the existing npm/playwright `RUN` block (no new layer, no extra packages)
- Replaces an earlier approach that duplicated the playwright install via `uv pip` and added `xvfb`/`xauth` — the `--only-shell` install already installed by npm is sufficient and doesn't require an X display

## Test plan

- [ ] Build the Docker image and verify `/usr/local/bin/chromium-hermes` resolves to the Playwright-managed Chromium binary
- [ ] Set `AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium-hermes` and confirm browser tools work

🤖 Generated with [Claude Code](https://claude.com/claude-code)