### PR TITLE
fix(codex): surface tool-progress + interim commentary on codex_app_server runtime (#33200)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -21,9 +21,284 @@ import logging
 import os
 import time
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Codex app-server → Hermes UI bridge (#33200)
+#
+# The codex_app_server runtime hands the entire turn to a subprocess and
+# bypasses the normal Hermes tool loop. Without this bridge gateway
+# adapters (Discord, Telegram, TUI) never see live tool-progress bubbles
+# or interim assistant commentary while codex is working — the user just
+# stares at a quiet channel until the final answer lands. The bridge
+# translates raw codex JSON-RPC notifications into the same three agent
+# callbacks the standard runtime fires:
+#   - tool_progress_callback("tool.started"|"tool.completed", name, ...)
+#   - _fire_stream_delta(text) for streaming agentMessage chunks
+#   - _emit_interim_assistant_message({...}) for completed agentMessages
+# ---------------------------------------------------------------------------
+
+# Codex item types that map to a Hermes tool_call in the projector (and
+# therefore deserve a tool_progress bubble pair). The projector lives in
+# agent/transports/codex_event_projector.py — keep these in sync so the
+# tool name shown in the UI matches the name recorded in messages.
+_CODEX_TOOL_ITEM_TYPES = frozenset(
+    {"commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall"}
+)
+
+
+def _codex_item_to_tool_name(item: dict) -> str:
+    """Synthetic Hermes tool name for a codex item. Mirrors
+    CodexEventProjector so the progress bubble and the projected
+    tool_calls entry use the same identifier."""
+    item_type = item.get("type") or ""
+    if item_type == "commandExecution":
+        return "exec_command"
+    if item_type == "fileChange":
+        return "apply_patch"
+    if item_type == "mcpToolCall":
+        server = item.get("server") or "mcp"
+        tool = item.get("tool") or "unknown"
+        return f"mcp.{server}.{tool}"
+    if item_type == "dynamicToolCall":
+        return item.get("tool") or "dynamic"
+    return item_type or "unknown"
+
+
+def _codex_item_to_args(item: dict) -> dict:
+    """Args dict surfaced to tool_progress_callback("tool.started", ...).
+    Mirrors the projector's _project_command / _project_file_change /
+    _project_mcp_tool_call / _project_dynamic_tool_call shapes."""
+    item_type = item.get("type") or ""
+    if item_type == "commandExecution":
+        return {"command": item.get("command") or "",
+                "cwd": item.get("cwd") or ""}
+    if item_type == "fileChange":
+        return {"changes": [
+            {"kind": (c.get("kind") or {}).get("type") or "update",
+             "path": c.get("path") or ""}
+            for c in (item.get("changes") or []) if isinstance(c, dict)
+        ]}
+    if item_type in {"mcpToolCall", "dynamicToolCall"}:
+        args = item.get("arguments") or {}
+        return args if isinstance(args, dict) else {"arguments": args}
+    return {}
+
+
+def _codex_item_to_preview(item: dict) -> Any:
+    """Short human-readable preview for the tool.started bubble. Returns
+    None when no useful preview is available (Hermes' UI tolerates None)."""
+    item_type = item.get("type") or ""
+    if item_type == "commandExecution":
+        cmd = item.get("command") or ""
+        return cmd[:120] if cmd else None
+    if item_type == "fileChange":
+        paths = [c.get("path") for c in (item.get("changes") or [])
+                 if isinstance(c, dict) and c.get("path")]
+        if not paths:
+            return None
+        preview = ", ".join(paths[:3])
+        if len(paths) > 3:
+            preview += f", +{len(paths) - 3} more"
+        return preview
+    if item_type in {"mcpToolCall", "dynamicToolCall"}:
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict) or not args:
+            return None
+        try:
+            return json.dumps(args, ensure_ascii=False)[:120]
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _codex_item_completion_payload(item: dict) -> tuple[str, bool]:
+    """Return (result_text, is_error) for a completed codex tool item.
+    Mirrors the projector's tool-result content so the bubble shows the
+    same outcome string that ends up in the messages list."""
+    item_type = item.get("type") or ""
+    if item_type == "commandExecution":
+        out = item.get("aggregatedOutput") or ""
+        exit_code = item.get("exitCode")
+        is_error = bool(exit_code is not None and exit_code != 0)
+        if is_error:
+            out = f"[exit {exit_code}]\n{out}"
+        return out, is_error
+    if item_type == "fileChange":
+        status = item.get("status") or "unknown"
+        n = len(item.get("changes") or [])
+        return (
+            f"apply_patch status={status}, {n} change(s)",
+            status not in {"completed", "applied", "success"},
+        )
+    if item_type == "mcpToolCall":
+        error = item.get("error")
+        if error:
+            return (
+                f"[error] {json.dumps(error, ensure_ascii=False)[:1000]}",
+                True,
+            )
+        result = item.get("result")
+        return (
+            json.dumps(result, ensure_ascii=False)[:4000]
+            if result is not None else "",
+            False,
+        )
+    if item_type == "dynamicToolCall":
+        content_items = item.get("contentItems") or []
+        if isinstance(content_items, list) and content_items:
+            return (
+                json.dumps(content_items, ensure_ascii=False)[:4000],
+                not bool(item.get("success", True)),
+            )
+        success = item.get("success", True)
+        return f"success={success}", not bool(success)
+    return "", False
+
+
+def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
+    """Build an ``on_event`` callback that wires codex app-server JSON-RPC
+    notifications into Hermes' gateway UI callbacks.
+
+    Returns a single-argument callable suitable for
+    ``CodexAppServerSession(on_event=...)``.
+
+    Translation map:
+      * ``item/started`` for tool-shaped items → ``tool_progress_callback(
+        "tool.started", name, preview, args)``
+      * ``item/completed`` for tool-shaped items → ``tool_progress_callback(
+        "tool.completed", name, None, None, duration=..., is_error=...,
+        result=...)``
+      * ``item/agentMessage/delta`` → ``_fire_stream_delta(text)`` so chat
+        adapters can render the assistant's reply as it streams.
+      * ``item/reasoning/delta`` → ``_fire_reasoning_delta(text)``
+      * ``item/completed`` for ``agentMessage`` →
+        ``_emit_interim_assistant_message({"role": "assistant",
+        "content": text})``. The gateway's ``already_streamed`` check
+        dedupes against any text the stream-delta callback already
+        rendered for the same message.
+
+    All callback invocations are guarded — a buggy display callback must
+    not tear down the codex turn loop. Errors are logged at DEBUG so the
+    notification stream keeps flowing regardless.
+    """
+    # item_id -> (tool_name, args, started_wall_time). Populated on
+    # item/started and consumed on item/completed so duration is correct
+    # even when codex doesn't report durationMs.
+    started: dict[str, tuple[str, dict, float]] = {}
+
+    def _fire_tool_started(item: dict) -> None:
+        item_id = item.get("id") or ""
+        name = _codex_item_to_tool_name(item)
+        args = _codex_item_to_args(item)
+        if item_id:
+            started[item_id] = (name, args, time.monotonic())
+        cb = getattr(agent, "tool_progress_callback", None)
+        if cb is None:
+            return
+        try:
+            cb("tool.started", name, _codex_item_to_preview(item), args)
+        except Exception:
+            logger.debug(
+                "tool_progress_callback raised on tool.started for %s",
+                name, exc_info=True,
+            )
+
+    def _fire_tool_completed(item: dict) -> None:
+        item_id = item.get("id") or ""
+        name = _codex_item_to_tool_name(item)
+        prior = started.pop(item_id, None)
+        # Prefer codex's own durationMs when present so the bubble shows
+        # exact tool wall-time; fall back to our started timestamp; fall
+        # back to None if we never saw an item/started (some codex
+        # versions only emit completed for fast items).
+        duration: Any = None
+        codex_ms = item.get("durationMs")
+        if isinstance(codex_ms, (int, float)) and codex_ms >= 0:
+            duration = codex_ms / 1000.0
+        elif prior is not None:
+            duration = time.monotonic() - prior[2]
+        result, is_error = _codex_item_completion_payload(item)
+        cb = getattr(agent, "tool_progress_callback", None)
+        if cb is None:
+            return
+        try:
+            cb("tool.completed", name, None, None,
+               duration=duration, is_error=is_error, result=result)
+        except Exception:
+            logger.debug(
+                "tool_progress_callback raised on tool.completed for %s",
+                name, exc_info=True,
+            )
+
+    def _fire_text_delta(params: dict) -> None:
+        text = params.get("delta") or params.get("text") or ""
+        if not isinstance(text, str) or not text:
+            return
+        fn = getattr(agent, "_fire_stream_delta", None)
+        if fn is None:
+            return
+        try:
+            fn(text)
+        except Exception:
+            logger.debug("_fire_stream_delta raised", exc_info=True)
+
+    def _fire_reasoning_delta(params: dict) -> None:
+        text = params.get("delta") or params.get("text") or ""
+        if not isinstance(text, str) or not text:
+            return
+        fn = getattr(agent, "_fire_reasoning_delta", None)
+        if fn is None:
+            return
+        try:
+            fn(text)
+        except Exception:
+            logger.debug("_fire_reasoning_delta raised", exc_info=True)
+
+    def _fire_agent_message_completed(item: dict) -> None:
+        text = item.get("text") or ""
+        if not isinstance(text, str) or not text.strip():
+            return
+        emit = getattr(agent, "_emit_interim_assistant_message", None)
+        if emit is None:
+            return
+        try:
+            emit({"role": "assistant", "content": text})
+        except Exception:
+            logger.debug(
+                "_emit_interim_assistant_message raised", exc_info=True,
+            )
+
+    def on_event(note: dict) -> None:
+        if not isinstance(note, dict):
+            return
+        method = note.get("method") or ""
+        params = note.get("params") or {}
+        if not isinstance(params, dict):
+            params = {}
+        if method == "item/agentMessage/delta":
+            _fire_text_delta(params)
+            return
+        if method == "item/reasoning/delta":
+            _fire_reasoning_delta(params)
+            return
+        item = params.get("item")
+        if not isinstance(item, dict):
+            return
+        item_type = item.get("type") or ""
+        if method == "item/started" and item_type in _CODEX_TOOL_ITEM_TYPES:
+            _fire_tool_started(item)
+            return
+        if method == "item/completed":
+            if item_type in _CODEX_TOOL_ITEM_TYPES:
+                _fire_tool_completed(item)
+            elif item_type == "agentMessage":
+                _fire_agent_message_completed(item)
+
+    return on_event
 
 
 def run_codex_app_server_turn(
@@ -533,4 +808,5 @@ __all__ = [
     "run_codex_stream",
     "run_codex_create_stream_fallback",
     "_consume_codex_event_stream",
+    "make_codex_app_server_event_bridge",
 ]

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -332,9 +332,16 @@ def run_codex_app_server_turn(
             approval_callback = _get_approval_callback()
         except Exception:
             approval_callback = None
+        # Bridge codex JSON-RPC notifications (item/started, item/completed,
+        # item/agentMessage/delta, ...) into Hermes' gateway UI callbacks
+        # (tool_progress_callback, _fire_stream_delta,
+        # _emit_interim_assistant_message). Without this, Discord/Telegram
+        # users see no live tool-progress or interim commentary while
+        # codex_app_server is running — only the final answer (#33200).
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            on_event=make_codex_app_server_event_bridge(agent),
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -1,0 +1,574 @@
+"""Regression tests for the codex_app_server → Hermes UI event bridge.
+
+Pin the translation of codex JSON-RPC notifications into agent callbacks
+(`tool_progress_callback`, `_fire_stream_delta`, `_fire_reasoning_delta`,
+`_emit_interim_assistant_message`) so Discord/Telegram/TUI continue to
+surface live tool-progress bubbles and interim assistant commentary when
+the active provider runs on `openai_runtime: codex_app_server` (#33200).
+
+Each test drives `make_codex_app_server_event_bridge(agent)` directly with
+fixture notifications that mirror codex 0.130.0's `item/*` shape and
+asserts the right agent callback fired with the right arguments. The
+bridge is deliberately small (~150 lines of pure dict mapping) so the
+tests can stay focused on the wire format ↔ callback contract.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.codex_runtime import (
+    _codex_item_completion_payload,
+    _codex_item_to_args,
+    _codex_item_to_preview,
+    _codex_item_to_tool_name,
+    make_codex_app_server_event_bridge,
+)
+
+
+def _make_stub_agent() -> SimpleNamespace:
+    """Minimal stand-in for AIAgent that records every callback fire."""
+    return SimpleNamespace(
+        tool_progress_callback=MagicMock(name="tool_progress_callback"),
+        _fire_stream_delta=MagicMock(name="_fire_stream_delta"),
+        _fire_reasoning_delta=MagicMock(name="_fire_reasoning_delta"),
+        _emit_interim_assistant_message=MagicMock(
+            name="_emit_interim_assistant_message"
+        ),
+    )
+
+
+def _item_started(item: dict) -> dict:
+    return {"method": "item/started", "params": {"item": item}}
+
+
+def _item_completed(item: dict) -> dict:
+    return {"method": "item/completed", "params": {"item": item}}
+
+
+# ---------- name / args / preview / result mapping ----------
+
+
+class TestCodexItemToToolName:
+    def test_command_execution_maps_to_exec_command(self):
+        assert _codex_item_to_tool_name(
+            {"type": "commandExecution"}
+        ) == "exec_command"
+
+    def test_file_change_maps_to_apply_patch(self):
+        assert _codex_item_to_tool_name(
+            {"type": "fileChange"}
+        ) == "apply_patch"
+
+    def test_mcp_tool_call_includes_server_and_tool(self):
+        assert _codex_item_to_tool_name(
+            {"type": "mcpToolCall", "server": "fs", "tool": "read_file"}
+        ) == "mcp.fs.read_file"
+
+    def test_mcp_tool_call_falls_back_when_fields_missing(self):
+        assert _codex_item_to_tool_name(
+            {"type": "mcpToolCall"}
+        ) == "mcp.mcp.unknown"
+
+    def test_dynamic_tool_call_uses_tool_field(self):
+        assert _codex_item_to_tool_name(
+            {"type": "dynamicToolCall", "tool": "web_search"}
+        ) == "web_search"
+
+    def test_unknown_type_returns_type_string(self):
+        assert _codex_item_to_tool_name(
+            {"type": "plan"}
+        ) == "plan"
+
+    def test_missing_type_returns_unknown_sentinel(self):
+        assert _codex_item_to_tool_name({}) == "unknown"
+
+
+class TestCodexItemToArgs:
+    def test_command_execution_args_carry_cwd_and_command(self):
+        args = _codex_item_to_args({
+            "type": "commandExecution",
+            "command": "ls -la",
+            "cwd": "/tmp",
+        })
+        assert args == {"command": "ls -la", "cwd": "/tmp"}
+
+    def test_file_change_args_normalize_changes(self):
+        args = _codex_item_to_args({
+            "type": "fileChange",
+            "changes": [
+                {"path": "/a.py", "kind": {"type": "add"}},
+                {"path": "/b.py", "kind": {"type": "update"}},
+                "not-a-dict",
+            ],
+        })
+        assert args == {
+            "changes": [
+                {"kind": "add", "path": "/a.py"},
+                {"kind": "update", "path": "/b.py"},
+            ]
+        }
+
+    def test_mcp_tool_call_returns_arguments_dict(self):
+        args = _codex_item_to_args({
+            "type": "mcpToolCall", "arguments": {"q": "x"}
+        })
+        assert args == {"q": "x"}
+
+    def test_non_dict_arguments_get_wrapped(self):
+        args = _codex_item_to_args({
+            "type": "dynamicToolCall", "arguments": ["a", "b"],
+        })
+        assert args == {"arguments": ["a", "b"]}
+
+
+class TestCodexItemToPreview:
+    def test_command_preview_truncated(self):
+        long_cmd = "echo " + "x" * 500
+        preview = _codex_item_to_preview({
+            "type": "commandExecution", "command": long_cmd
+        })
+        assert preview is not None
+        assert len(preview) <= 120
+
+    def test_file_change_preview_lists_first_three_paths(self):
+        preview = _codex_item_to_preview({
+            "type": "fileChange",
+            "changes": [
+                {"path": f"/p{i}.py", "kind": {"type": "update"}}
+                for i in range(5)
+            ],
+        })
+        assert "/p0.py" in preview and "/p2.py" in preview
+        assert "+2 more" in preview
+
+    def test_file_change_no_paths_returns_none(self):
+        assert _codex_item_to_preview({
+            "type": "fileChange", "changes": [{}]
+        }) is None
+
+    def test_mcp_args_preview_is_json(self):
+        preview = _codex_item_to_preview({
+            "type": "mcpToolCall", "arguments": {"q": "hello"},
+        })
+        assert preview is not None
+        assert "hello" in preview
+
+    def test_empty_args_returns_none(self):
+        assert _codex_item_to_preview({"type": "mcpToolCall"}) is None
+
+
+class TestCodexItemCompletionPayload:
+    def test_command_success_returns_aggregated_output(self):
+        result, is_error = _codex_item_completion_payload({
+            "type": "commandExecution",
+            "exitCode": 0,
+            "aggregatedOutput": "hello\nworld\n",
+        })
+        assert result == "hello\nworld\n"
+        assert is_error is False
+
+    def test_command_nonzero_exit_marks_error(self):
+        result, is_error = _codex_item_completion_payload({
+            "type": "commandExecution",
+            "exitCode": 2,
+            "aggregatedOutput": "boom",
+        })
+        assert "[exit 2]" in result
+        assert "boom" in result
+        assert is_error is True
+
+    def test_file_change_completed_status_not_error(self):
+        result, is_error = _codex_item_completion_payload({
+            "type": "fileChange",
+            "status": "completed",
+            "changes": [{"path": "/a"}],
+        })
+        assert "completed" in result
+        assert is_error is False
+
+    def test_mcp_tool_error_is_error(self):
+        result, is_error = _codex_item_completion_payload({
+            "type": "mcpToolCall",
+            "error": {"message": "nope"},
+        })
+        assert "[error]" in result
+        assert is_error is True
+
+    def test_dynamic_tool_failure_is_error(self):
+        result, is_error = _codex_item_completion_payload({
+            "type": "dynamicToolCall",
+            "success": False,
+        })
+        assert "False" in result
+        assert is_error is True
+
+
+# ---------- bridge: dispatch contracts ----------
+
+
+class TestStreamDeltaDispatch:
+    def test_agent_message_delta_fires_stream_delta(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "hello "}})
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "world"}})
+        assert agent._fire_stream_delta.call_count == 2
+        assert agent._fire_stream_delta.call_args_list[0].args == ("hello ",)
+        assert agent._fire_stream_delta.call_args_list[1].args == ("world",)
+
+    def test_empty_delta_is_skipped(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge({"method": "item/agentMessage/delta", "params": {"delta": ""}})
+        bridge({"method": "item/agentMessage/delta", "params": {}})
+        agent._fire_stream_delta.assert_not_called()
+
+    def test_text_field_used_when_delta_missing(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"text": "fallback"}})
+        agent._fire_stream_delta.assert_called_once_with("fallback")
+
+    def test_reasoning_delta_fires_reasoning_callback(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge({"method": "item/reasoning/delta",
+                "params": {"delta": "thinking..."}})
+        agent._fire_reasoning_delta.assert_called_once_with("thinking...")
+        agent._fire_stream_delta.assert_not_called()
+
+
+class TestToolProgressDispatch:
+    def test_command_started_fires_tool_started(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "commandExecution",
+            "id": "exec-1",
+            "command": "ls /tmp",
+            "cwd": "/tmp",
+        }))
+        agent.tool_progress_callback.assert_called_once()
+        call = agent.tool_progress_callback.call_args
+        assert call.args[0] == "tool.started"
+        assert call.args[1] == "exec_command"
+        assert "ls /tmp" in call.args[2]  # preview
+        assert call.args[3] == {"command": "ls /tmp", "cwd": "/tmp"}
+
+    def test_command_completed_fires_tool_completed_with_result(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "commandExecution",
+            "id": "exec-2",
+            "command": "echo hi",
+            "cwd": "/tmp",
+        }))
+        bridge(_item_completed({
+            "type": "commandExecution",
+            "id": "exec-2",
+            "exitCode": 0,
+            "aggregatedOutput": "hi\n",
+            "durationMs": 42,
+        }))
+        # tool.started then tool.completed
+        assert agent.tool_progress_callback.call_count == 2
+        completed = agent.tool_progress_callback.call_args_list[1]
+        assert completed.args[0] == "tool.completed"
+        assert completed.args[1] == "exec_command"
+        assert completed.args[2] is None  # preview unused on completion
+        assert completed.args[3] is None  # args unused on completion
+        assert completed.kwargs["duration"] == pytest.approx(0.042)
+        assert completed.kwargs["is_error"] is False
+        assert completed.kwargs["result"] == "hi\n"
+
+    def test_nonzero_exit_marks_completion_error(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "commandExecution",
+            "id": "exec-3",
+            "exitCode": 127,
+            "aggregatedOutput": "not found",
+        }))
+        call = agent.tool_progress_callback.call_args
+        assert call.args[0] == "tool.completed"
+        assert call.kwargs["is_error"] is True
+        assert "[exit 127]" in call.kwargs["result"]
+
+    def test_apply_patch_started_and_completed(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "fileChange",
+            "id": "fc-1",
+            "changes": [
+                {"path": "/a.py", "kind": {"type": "add"}},
+                {"path": "/b.py", "kind": {"type": "update"}},
+            ],
+        }))
+        bridge(_item_completed({
+            "type": "fileChange",
+            "id": "fc-1",
+            "status": "completed",
+            "changes": [{"path": "/a.py"}, {"path": "/b.py"}],
+        }))
+        names = [
+            c.args[1] for c in agent.tool_progress_callback.call_args_list
+        ]
+        assert names == ["apply_patch", "apply_patch"]
+        completed = agent.tool_progress_callback.call_args_list[1]
+        assert completed.kwargs["is_error"] is False
+        assert "2 change(s)" in completed.kwargs["result"]
+
+    def test_mcp_tool_uses_namespaced_tool_name(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "mcpToolCall",
+            "id": "mcp-1",
+            "server": "fs",
+            "tool": "list_dir",
+            "arguments": {"path": "/tmp"},
+        }))
+        call = agent.tool_progress_callback.call_args
+        assert call.args[1] == "mcp.fs.list_dir"
+        # Preview should be a json render of the args
+        assert "/tmp" in call.args[2]
+
+    def test_dynamic_tool_uses_tool_field_as_name(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "dynamicToolCall",
+            "id": "dyn-1",
+            "tool": "web_search",
+            "arguments": {"query": "hermes"},
+        }))
+        bridge(_item_completed({
+            "type": "dynamicToolCall",
+            "id": "dyn-1",
+            "tool": "web_search",
+            "success": True,
+            "contentItems": [{"text": "results"}],
+        }))
+        names = [
+            c.args[1] for c in agent.tool_progress_callback.call_args_list
+        ]
+        assert names == ["web_search", "web_search"]
+        completed = agent.tool_progress_callback.call_args_list[1]
+        assert completed.kwargs["is_error"] is False
+        assert "results" in completed.kwargs["result"]
+
+    def test_duration_falls_back_to_wall_time_when_codex_missing_ms(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "commandExecution",
+            "id": "exec-4",
+            "command": "sleep 0",
+        }))
+        bridge(_item_completed({
+            "type": "commandExecution",
+            "id": "exec-4",
+            "exitCode": 0,
+            "aggregatedOutput": "",
+            # no durationMs
+        }))
+        completed = agent.tool_progress_callback.call_args_list[1]
+        assert completed.kwargs["duration"] is not None
+        assert completed.kwargs["duration"] >= 0
+
+    def test_unknown_started_item_type_is_silent(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({"type": "plan", "id": "p-1"}))
+        agent.tool_progress_callback.assert_not_called()
+
+
+class TestAgentMessageInterimDispatch:
+    def test_completed_agent_message_emits_interim(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-1",
+            "text": "I'll check the config first.",
+        }))
+        agent._emit_interim_assistant_message.assert_called_once_with(
+            {"role": "assistant", "content": "I'll check the config first."}
+        )
+
+    def test_empty_text_does_not_emit_interim(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage", "id": "am-2", "text": "   ",
+        }))
+        bridge(_item_completed({
+            "type": "agentMessage", "id": "am-3", "text": ""
+        }))
+        agent._emit_interim_assistant_message.assert_not_called()
+
+    def test_completed_agent_message_does_not_fire_tool_progress(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage", "id": "am-4", "text": "hi",
+        }))
+        agent.tool_progress_callback.assert_not_called()
+
+
+class TestBridgeRobustness:
+    def test_non_dict_notification_is_ignored(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge("not-a-dict")  # type: ignore[arg-type]
+        bridge(None)  # type: ignore[arg-type]
+        bridge(123)  # type: ignore[arg-type]
+        agent.tool_progress_callback.assert_not_called()
+        agent._fire_stream_delta.assert_not_called()
+        agent._emit_interim_assistant_message.assert_not_called()
+
+    def test_missing_params_is_ignored(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge({"method": "item/started"})
+        bridge({"method": "item/completed"})
+        agent.tool_progress_callback.assert_not_called()
+
+    def test_callback_exceptions_do_not_propagate(self):
+        # Buggy display callbacks must not tear down the codex turn loop.
+        agent = _make_stub_agent()
+        agent.tool_progress_callback.side_effect = RuntimeError("boom")
+        agent._fire_stream_delta.side_effect = RuntimeError("boom")
+        agent._emit_interim_assistant_message.side_effect = RuntimeError("boom")
+        bridge = make_codex_app_server_event_bridge(agent)
+        # All three paths must swallow exceptions silently.
+        bridge(_item_started({
+            "type": "commandExecution", "id": "exec-x", "command": "ls",
+        }))
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "x"}})
+        bridge(_item_completed({
+            "type": "agentMessage", "id": "am-x", "text": "hi",
+        }))
+
+    def test_agent_without_callbacks_is_a_noop(self):
+        # Mirrors gateway-less / cron contexts where the agent never had
+        # the display callbacks set. Bridge must not raise.
+        agent = SimpleNamespace()  # bare — none of the callbacks exist
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "commandExecution", "id": "exec-y", "command": "ls",
+        }))
+        bridge(_item_completed({
+            "type": "commandExecution", "id": "exec-y",
+            "exitCode": 0, "aggregatedOutput": "",
+        }))
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "x"}})
+        bridge({"method": "item/reasoning/delta",
+                "params": {"delta": "x"}})
+        bridge(_item_completed({
+            "type": "agentMessage", "id": "am", "text": "hi",
+        }))
+
+    def test_silent_methods_do_not_fire_anything(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        for method in ("turn/started", "turn/completed", "thread/started",
+                       "item/commandExecution/outputDelta"):
+            bridge({"method": method, "params": {}})
+        agent.tool_progress_callback.assert_not_called()
+        agent._fire_stream_delta.assert_not_called()
+        agent._fire_reasoning_delta.assert_not_called()
+        agent._emit_interim_assistant_message.assert_not_called()
+
+
+# ---------- end-to-end: bridge is wired in run_codex_app_server_turn ----------
+
+
+class TestBridgeWiredInRuntime:
+    """Verify run_codex_app_server_turn actually constructs the session
+    with `on_event=<bridge>`. This is the integration guard that prevents
+    a future refactor from dropping the bridge wiring and silently
+    regressing Discord/Telegram live progress visibility."""
+
+    def test_session_constructor_receives_on_event(self, monkeypatch):
+        from agent import codex_runtime
+
+        captured: dict = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def run_turn(self, user_input, **_):
+                from agent.transports.codex_app_server_session import TurnResult
+                return TurnResult(
+                    final_text="done",
+                    projected_messages=[],
+                    tool_iterations=0,
+                    turn_id="t1",
+                    thread_id="th1",
+                )
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+
+        # Minimal stub agent — the runtime only touches a handful of
+        # attributes and we mock the heavy ones to keep the test fast.
+        agent = SimpleNamespace(
+            session_cwd=None,
+            _codex_session=None,
+            tool_progress_callback=MagicMock(),
+            _fire_stream_delta=MagicMock(),
+            _fire_reasoning_delta=MagicMock(),
+            _emit_interim_assistant_message=MagicMock(),
+            _iters_since_skill=0,
+            _skill_nudge_interval=0,
+            valid_tool_names=set(),
+            _sync_external_memory_for_turn=lambda **_: None,
+            _spawn_background_review=lambda **_: None,
+        )
+
+        codex_runtime.run_codex_app_server_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t",
+        )
+
+        assert "on_event" in captured, (
+            "run_codex_app_server_turn must pass on_event=<bridge> to the "
+            "session — without it the gateway sees no live progress (#33200)"
+        )
+        assert callable(captured["on_event"]), (
+            "on_event must be the bridge callable, not None or a sentinel"
+        )
+
+        # And the bridge must actually drive the agent's callbacks when
+        # fed a representative notification.
+        captured["on_event"](_item_started({
+            "type": "commandExecution",
+            "id": "wired-1",
+            "command": "ls",
+        }))
+        agent.tool_progress_callback.assert_called_once()
+        assert agent.tool_progress_callback.call_args.args[0] == "tool.started"
+        assert agent.tool_progress_callback.call_args.args[1] == "exec_command"


### PR DESCRIPTION
## What does this PR do?

Restores live tool-progress bubbles and interim assistant commentary on Discord / Telegram / TUI when the active provider runs on `openai_runtime: codex_app_server`. Fixes the silent-channel UX described in #33200.

The `codex_app_server` runtime hands the entire turn to a subprocess and short-circuits the normal Hermes tool loop, so `tool_progress_callback`, `_fire_stream_delta` and `_emit_interim_assistant_message` never fire while codex is working — only the final answer lands. `CodexAppServerSession` has always exposed a raw `on_event` hook, but `run_codex_app_server_turn` simply never supplied one.

This PR ships the missing bridge in three small commits:

1. **`feat(codex)` — mapping helpers + bridge factory.** Four pure-dict helpers translate codex `item/*` payloads into the Hermes-shape (tool name, args, preview, result+is_error), then `make_codex_app_server_event_bridge(agent)` wraps them into a single `on_event(note)` callable. Tool names match `CodexEventProjector` so the progress bubble and the projected `tool_calls` entry agree on the identifier.

2. **`fix(codex)` — wire the bridge into the runtime.** Pass `on_event=make_codex_app_server_event_bridge(agent)` when constructing the per-session `CodexAppServerSession`. ~7-line change, no other behaviour shift.

3. **`test(codex)` — 42 regression tests.** Pin the mapping contract per type, the dispatch contract per Codex event, defensive paths (non-dict notifications, missing params, raising callbacks, agents without callbacks), and one integration guard that asserts `run_codex_app_server_turn` actually wires the bridge — so a future refactor can't silently regress this again.

## Related Issue

Fixes #33200

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_runtime.py` — adds `_codex_item_to_tool_name` / `_codex_item_to_args` / `_codex_item_to_preview` / `_codex_item_completion_payload` plus `make_codex_app_server_event_bridge(agent)`, then wires `on_event=` into `CodexAppServerSession` inside `run_codex_app_server_turn`. Exports the factory in `__all__`.
- `tests/agent/test_codex_app_server_event_bridge.py` — **42 new tests** across `TestCodexItemToToolName`, `TestCodexItemToArgs`, `TestCodexItemToPreview`, `TestCodexItemCompletionPayload`, `TestStreamDeltaDispatch`, `TestToolProgressDispatch`, `TestAgentMessageInterimDispatch`, `TestBridgeRobustness`, and `TestBridgeWiredInRuntime`.

### Translation map

| Codex notification | Hermes callback |
| --- | --- |
| `item/started` for `commandExecution` / `fileChange` / `mcpToolCall` / `dynamicToolCall` | `tool_progress_callback("tool.started", name, preview, args)` |
| `item/completed` for same | `tool_progress_callback("tool.completed", name, None, None, duration=…, is_error=…, result=…)` |
| `item/agentMessage/delta` | `_fire_stream_delta(text)` |
| `item/reasoning/delta` | `_fire_reasoning_delta(text)` |
| `item/completed` for `agentMessage` | `_emit_interim_assistant_message({"role": "assistant", "content": text})` |

`_emit_interim_assistant_message` already calls `_interim_content_was_streamed` to set `already_streamed=True` when the stream-delta path showed the same text, so adapters stay dedup-safe.

Backwards compatible — `CodexAppServerSession(on_event=...)` has always been an optional kwarg; tests and cron / non-interactive contexts that never set the agent callbacks see no change (the bridge is a no-op when the agent has no callbacks registered).

## How to Test

```bash
# New bridge suite (42 tests)
python3 -m pytest tests/agent/test_codex_app_server_event_bridge.py -v

# Full codex_app_server test pass (122 existing + 42 new = 164 tests)
python3 -m pytest \
    tests/run_agent/test_codex_app_server_integration.py \
    tests/agent/transports/test_codex_app_server_session.py \
    tests/agent/transports/test_codex_event_projector.py \
    tests/agent/transports/test_codex_app_server_runtime.py \
    tests/agent/test_codex_app_server_event_bridge.py
# expected: 164 passed
```

End-to-end behaviour after the fix, on a turn that runs a shell command:

```
> user: list /tmp
< Discord channel (live):
    🛠 exec_command  ls /tmp
    …
    ✅ exec_command (0.04s)
    [interim] I'll inspect the directory contents.
    [final] /tmp contains foo, bar, baz.
```

Before the fix, the same turn produced one final message and no live signal of any kind.

## Checklist

- [x] Conventional Commits (`feat(codex):`, `fix(codex):`, `test(codex):`)
- [x] 3 focused commits, single author (xxxigm)
- [x] 42 new tests pass; 122 existing codex_app_server tests pass; full agent suite confirms no new failures
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12
- [x] No new config keys, no schema change, no platform-specific calls
- [x] Bridge is a no-op when the agent has no callbacks registered (cron / gateway-less paths)
