### PR TITLE
fix(codex): recover null-output Responses turns

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -286,6 +286,37 @@ def grok_supports_reasoning_effort(model: str) -> bool:
     return any(name.startswith(prefix) for prefix in _GROK_EFFORT_CAPABLE_PREFIXES)
 
 
+# OpenAI model families that accept the Responses API ``reasoning`` config and
+# ``include: ["reasoning.encrypted_content"]``. The codex OAuth backend only
+# serves these (gpt-5.x / codex-*), but the *direct* OpenAI endpoint also
+# serves non-reasoning models (gpt-4.1, gpt-4o, ...) on the Responses API —
+# those reject ``include`` with HTTP 400 "Encrypted content is not supported
+# with this model." Mirrors hermes_cli.models._AZURE_FOUNDRY_RESPONSES_PREFIXES.
+_OPENAI_RESPONSES_REASONING_PREFIXES = (
+    "codex",   # codex-*, codex-mini
+    "gpt-5",   # gpt-5, gpt-5.x, gpt-5-codex, gpt-5.x-codex
+    "o1",      # o1, o1-preview, o1-mini
+    "o3",      # o3, o3-mini
+    "o4",      # o4, o4-mini
+)
+
+
+def openai_responses_supports_reasoning(model: str) -> bool:
+    """Return True when an OpenAI Responses-API model accepts reasoning/include.
+
+    Used to gate ``reasoning`` + ``include:["reasoning.encrypted_content"]`` on
+    the direct-OpenAI / codex Responses path. Non-reasoning models (gpt-4.1,
+    gpt-4o, gpt-4-turbo, ...) return False so we omit those params instead of
+    triggering HTTP 400. Conservative: an unknown model returns False.
+    """
+    name = (model or "").strip().lower()
+    if not name:
+        return False
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    return any(name.startswith(prefix) for prefix in _OPENAI_RESPONSES_REASONING_PREFIXES)
+
+
 _CONTEXT_LENGTH_KEYS = (
     "context_length",
     "context_window",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -168,15 +168,27 @@ class ResponsesApiTransport(ProviderTransport):
             if grok_supports_reasoning_effort(model):
                 kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:
+            from agent.model_metadata import openai_responses_supports_reasoning
+
             if is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
-            else:
+            elif is_codex_backend or openai_responses_supports_reasoning(model):
+                # The codex OAuth backend only serves reasoning models and its
+                # contract requires reasoning replay, so always send these for
+                # it. The direct OpenAI Responses endpoint also serves
+                # non-reasoning models (gpt-4.1, gpt-4o, ...) — gate those on
+                # the model so we don't send params they reject.
                 kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
                 kwargs["include"] = (
                     ["reasoning.encrypted_content"] if replay_encrypted_reasoning else []
                 )
+            # else: a non-reasoning OpenAI model (gpt-4.1, gpt-4o, ...) reached
+            # the Responses API — e.g. as a fallback target on the direct
+            # api.openai.com endpoint. Omit reasoning/include entirely; sending
+            # include=["reasoning.encrypted_content"] returns HTTP 400
+            # "Encrypted content is not supported with this model."
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -447,6 +447,28 @@ class TestBuildApiKwargsCodex:
         kwargs = agent._build_api_kwargs(messages)
         assert "reasoning.encrypted_content" in kwargs.get("include", [])
 
+    def test_omits_reasoning_include_for_direct_openai_non_reasoning_model(self, monkeypatch):
+        """gpt-4.1 on the direct OpenAI Responses endpoint (e.g. a fallback
+        target) must NOT receive reasoning/include — they 400 with "Encrypted
+        content is not supported with this model." Regression for the codex→
+        gpt-4.1 fallback failure."""
+        agent = _make_agent(monkeypatch, "custom", api_mode="codex_responses",
+                            base_url="https://api.openai.com/v1", model="gpt-4.1")
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "reasoning" not in kwargs
+        assert "include" not in kwargs
+
+    def test_includes_reasoning_for_direct_openai_reasoning_model(self, monkeypatch):
+        """gpt-5.x on the direct OpenAI Responses endpoint still gets
+        reasoning/include — only non-reasoning models are gated out."""
+        agent = _make_agent(monkeypatch, "custom", api_mode="codex_responses",
+                            base_url="https://api.openai.com/v1", model="gpt-5.4")
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["reasoning"]["effort"] == "medium"
+        assert "reasoning.encrypted_content" in kwargs.get("include", [])
+
     def test_tools_converted_to_responses_format(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
                             base_url="https://chatgpt.com/backend-api/codex")


### PR DESCRIPTION
## Summary
- recover Codex Responses turns that return null output by falling back through the existing create-stream path
- gate encrypted reasoning replay/include behavior to reasoning-capable models
- add Grok 4.3 context metadata and regression coverage for Codex/XAI provider parity

## Test Plan
- python -m pytest tests/run_agent/test_codex_xai_oauth_recovery.py tests/run_agent/test_provider_parity.py -v --tb=short -o 'addopts='

🤖 Generated with Hermes Agent