### PR TITLE
fix(gateway/feishu): wire channel_prompts into MessageEvent

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3017,6 +3017,15 @@ class FeishuAdapter(BasePlatformAdapter):
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
         )
+        # Per-channel ephemeral system prompt (matches telegram / yuanbao behavior).
+        # Lets users restrict the bot's role in a specific Feishu group via
+        # `channel_prompts: {<chat_id>: "<prompt>"}` in PlatformConfig.extra.
+        from gateway.platforms.base import resolve_channel_prompt
+        _channel_prompt = resolve_channel_prompt(
+            self.config.extra,
+            chat_id,
+            None,
+        )
         normalized = MessageEvent(
             text=text,
             message_type=inbound_type,
@@ -3028,6 +3037,7 @@ class FeishuAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
             timestamp=datetime.now(),
+            channel_prompt=_channel_prompt,
         )
         await self._dispatch_inbound_event(normalized)
 


### PR DESCRIPTION
## Problem

`channel_prompts` (per-chat ephemeral system prompt configured in
`PlatformConfig.extra`) is honored by the **telegram** and **yuanbao**
adapters but silently ignored by the **feishu** adapter.

The config loads correctly into `PlatformConfig.extra` (verified via
`load_gateway_config()`), but `FeishuAdapter` never calls
`resolve_channel_prompt()` and never passes `channel_prompt=` into the
`MessageEvent(...)` constructor. As a result, users who configure

```yaml
feishu:
  channel_prompts:
    oc_xxxxx: |
      你只能在这个群里做X，其它请求拒答。
```

see the bot continue answering off-topic in that chat — the
per-channel prompt is loaded but never injected at the agent layer.

## Fix

Mirror the telegram pattern (`gateway/platforms/telegram.py:5366-5372,5384`):
- import and call `resolve_channel_prompt(self.config.extra, chat_id, None)`
  in the inbound normalization path
- attach the result via `channel_prompt=` on the `MessageEvent`
  constructor

## Scope

- Single file, +10 lines.
- No new dependencies.
- No behavior change for Feishu deployments without `channel_prompts`
  configured (`resolve_channel_prompt` returns `None` and the
  `MessageEvent.channel_prompt` field is already `Optional[str] = None`
  by default in `gateway/platforms/base.py:982`).

## Test plan

Verified locally on a real Feishu group:

1. Configured `channel_prompts: {<group_chat_id>: "<role-restricting prompt>"}` in `PlatformConfig.extra`.
2. Before patch: bot answered off-topic questions in the configured
   group despite the prompt.
3. After patch: bot follows the per-channel prompt (refuses off-topic
   requests with the configured template; honors on-topic requests
   normally). DM behavior unchanged.

## Related

Same pattern that telegram (`telegram.py:5366`) and yuanbao
(`yuanbao.py:2633`) already follow.
