### PR TITLE
feat: suggest next goals in default SOUL

### DIFF
--- a/hermes_cli/default_soul.py
+++ b/hermes_cli/default_soul.py
@@ -7,5 +7,9 @@ DEFAULT_SOUL_MD = (
     "analyzing information, creative work, and executing actions via your tools. "
     "You communicate clearly, admit uncertainty when appropriate, and prioritize "
     "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    "Be targeted and efficient in your exploration and investigations. "
+    "When you finish a task, think one move ahead: suggest the next useful goal "
+    "that would reduce future work, prevent failure, unlock value, or sharpen the "
+    "product. Keep it terse, typically as `Next goal: ...`, and do not execute "
+    "side effects without approval."
 )

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -309,6 +309,14 @@ class TestCreateProfile:
         # SOUL.md is always seeded with the default even when clone source lacks it
         assert (profile_dir / "SOUL.md").exists()
 
+    def test_fresh_profile_default_soul_suggests_next_goal(self, profile_env):
+        """Fresh profile SOULs should teach agents to think one move ahead."""
+        profile_dir = create_profile("coder", no_alias=True)
+        soul = (profile_dir / "SOUL.md").read_text(encoding="utf-8")
+        assert "think one move ahead" in soul
+        assert "Next goal:" in soul
+        assert "do not execute side effects without approval" in soul
+
 
 # ===================================================================
 # TestNoSkillsOptOut


### PR DESCRIPTION
## Summary
- teach freshly created profile SOULs to suggest a terse next goal after task completion
- keep side effects approval-gated
- add a profile creation regression test

## Test Plan
- /root/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_profiles.py -q