### PR TITLE
fix(cron): cap LLM job iterations separately

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -29,7 +29,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -975,6 +975,65 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script execution failed: {exc}"
 
 
+_DEFAULT_CRON_MAX_ITERATIONS = 30
+
+
+def _coerce_cron_max_iterations(raw: Any, source: str) -> int | None:
+    if raw in (None, ""):
+        return None
+    if isinstance(raw, bool):
+        logger.warning(
+            "Invalid %s cron max_iterations=%r; using safe default %d",
+            source,
+            raw,
+            _DEFAULT_CRON_MAX_ITERATIONS,
+        )
+        return _DEFAULT_CRON_MAX_ITERATIONS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s cron max_iterations=%r; using safe default %d",
+            source,
+            raw,
+            _DEFAULT_CRON_MAX_ITERATIONS,
+        )
+        return _DEFAULT_CRON_MAX_ITERATIONS
+    if value > 0:
+        return value
+    logger.warning(
+        "Invalid %s cron max_iterations=%r; using safe default %d",
+        source,
+        raw,
+        _DEFAULT_CRON_MAX_ITERATIONS,
+    )
+    return _DEFAULT_CRON_MAX_ITERATIONS
+
+
+def _resolve_cron_max_iterations(cfg: dict | None) -> int:
+    """Return the tool-calling iteration cap for LLM-backed cron jobs.
+
+    Gateway/user chat sessions can legitimately use a high ``agent.max_turns``
+    value, but the gateway cron ticker is a single background loop. If a
+    recurring cron job inherits a huge chat cap (for example 500), one noisy
+    LLM-backed run can occupy the ticker for close to an hour and make unrelated
+    due jobs look stalled. Cron therefore has its own conservative default,
+    overridable explicitly via ``cron.max_iterations`` or
+    ``HERMES_CRON_MAX_ITERATIONS``.
+    """
+    env_value = _coerce_cron_max_iterations(os.getenv("HERMES_CRON_MAX_ITERATIONS", "").strip(), "env")
+    if env_value is not None:
+        return env_value
+
+    cron_cfg = (cfg or {}).get("cron") if isinstance(cfg, dict) else None
+    raw_config_value = cron_cfg.get("max_iterations") if isinstance(cron_cfg, dict) else None
+    config_value = _coerce_cron_max_iterations(raw_config_value, "config")
+    if config_value is not None:
+        return config_value
+
+    return _DEFAULT_CRON_MAX_ITERATIONS
+
+
 def _parse_wake_gate(script_output: str) -> bool:
     """Parse the last non-empty stdout line of a cron job's pre-check script
     as a wake gate.
@@ -1486,14 +1545,15 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
-        _cfg = {}
+        _cfg: dict = {}
         try:
             import yaml
             _cfg_path = str(_get_hermes_home() / "config.yaml")
             if os.path.exists(_cfg_path):
                 with open(_cfg_path, encoding="utf-8") as _f:
-                    _cfg = yaml.safe_load(_f) or {}
-                _cfg = _expand_env_vars(_cfg)
+                    _loaded_cfg = yaml.safe_load(_f) or {}
+                _expanded_cfg = _expand_env_vars(_loaded_cfg) if isinstance(_loaded_cfg, dict) else {}
+                _cfg = _expanded_cfg if isinstance(_expanded_cfg, dict) else {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
                     if isinstance(_model_cfg, str):
@@ -1534,8 +1594,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        # Max iterations: cron has its own conservative cap. Do not inherit
+        # a large interactive/gateway ``agent.max_turns`` value by default — a
+        # single long LLM-backed recurring job can otherwise monopolize the
+        # gateway cron ticker and delay unrelated due jobs.
+        max_iterations = _resolve_cron_max_iterations(_cfg if isinstance(_cfg, dict) else {})
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1637,6 +1637,11 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Maximum tool-calling iterations for LLM-backed cron jobs. This is
+        # intentionally separate from agent.max_turns so a high interactive
+        # chat cap cannot let one recurring job monopolize the scheduler tick.
+        # Also overridable via HERMES_CRON_MAX_ITERATIONS env var.
+        "max_iterations": 30,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -314,3 +314,101 @@ class TestSysPathOrdering:
         """hermes_constants should be importable from cron context."""
         from hermes_constants import get_hermes_home
         assert callable(get_hermes_home)
+
+
+class TestCronRunLimits:
+    def test_default_max_iterations_is_capped_below_gateway_agent_max_turns(self, monkeypatch):
+        """Cron LLM jobs should not inherit a very large gateway/chat max_turns value.
+
+        Regression for scheduler starvation: a recurring LLM-backed cron job inherited
+        agent.max_turns=500 from config.yaml and ran 80+ tool/API turns for ~1h, holding
+        the cron ticker and delaying unrelated jobs. Default cron runs need a bounded
+        iteration cap unless a cron-specific override is set.
+        """
+        from cron.scheduler import _resolve_cron_max_iterations
+
+        monkeypatch.delenv("HERMES_CRON_MAX_ITERATIONS", raising=False)
+        cfg = {"agent": {"max_turns": 500}}
+
+        assert _resolve_cron_max_iterations(cfg) <= 50
+        assert _resolve_cron_max_iterations(cfg) == 30
+
+    def test_cron_max_iterations_can_be_overridden_in_cron_config(self, monkeypatch):
+        from cron.scheduler import _resolve_cron_max_iterations
+
+        monkeypatch.delenv("HERMES_CRON_MAX_ITERATIONS", raising=False)
+        cfg = {"agent": {"max_turns": 500}, "cron": {"max_iterations": 12}}
+
+        assert _resolve_cron_max_iterations(cfg) == 12
+
+    def test_invalid_cron_max_iterations_falls_back_to_safe_default(self, monkeypatch):
+        from cron.scheduler import _resolve_cron_max_iterations
+
+        monkeypatch.delenv("HERMES_CRON_MAX_ITERATIONS", raising=False)
+        for invalid_value in ("bogus", True):
+            cfg = {"agent": {"max_turns": 500}, "cron": {"max_iterations": invalid_value}}
+
+            assert _resolve_cron_max_iterations(cfg) == 30
+
+    def test_non_mapping_cron_config_falls_back_to_safe_default(self, monkeypatch):
+        from cron.scheduler import _resolve_cron_max_iterations
+
+        monkeypatch.delenv("HERMES_CRON_MAX_ITERATIONS", raising=False)
+        cfg = {"agent": {"max_turns": 500}, "cron": "bad"}
+
+        assert _resolve_cron_max_iterations(cfg) == 30
+
+    def test_env_cron_max_iterations_override_wins(self, monkeypatch):
+        from cron.scheduler import _resolve_cron_max_iterations
+
+        monkeypatch.setenv("HERMES_CRON_MAX_ITERATIONS", "9")
+        cfg = {"agent": {"max_turns": 500}, "cron": {"max_iterations": 12}}
+
+        assert _resolve_cron_max_iterations(cfg) == 9
+
+    def test_run_job_passes_resolved_cron_max_iterations_to_agent(self, tmp_path, monkeypatch):
+        import sys
+        import cron.scheduler as sched
+
+        observed: dict = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                observed["max_iterations"] = kwargs.get("max_iterations")
+
+            def run_conversation(self, *_args, **_kwargs):
+                return {"final_response": "done", "messages": []}
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 0.0}
+
+        fake_mod = type(sys)("run_agent")
+        fake_mod.AIAgent = FakeAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+
+        from hermes_cli import runtime_provider as _rtp
+        monkeypatch.setattr(
+            _rtp,
+            "resolve_runtime_provider",
+            lambda **_kwargs: {
+                "provider": "test",
+                "api_key": "k",
+                "base_url": "http://test.local",
+                "api_mode": "chat_completions",
+            },
+        )
+        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+        monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+        monkeypatch.setenv("HERMES_CRON_MAX_ITERATIONS", "7")
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("agent:\n  max_turns: 500\ncron:\n  max_iterations: 12\n")
+        monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+
+        success, _output, response, error = sched.run_job({"id": "abc", "name": "limit-job"})
+
+        assert success is True, f"run_job failed: error={error!r} response={response!r}"
+        assert observed["max_iterations"] == 7

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -115,6 +115,17 @@ Each cron job runs in a completely fresh agent session:
 - The prompt must be self-contained — cron jobs cannot ask clarifying questions
 - The `cronjob` toolset is disabled (recursion guard)
 
+### LLM Iteration Limit
+
+LLM-backed cron jobs use a cron-specific tool-calling iteration cap instead of
+inheriting the interactive `agent.max_turns` setting. The default is `30`, and it
+can be overridden with `cron.max_iterations` in `config.yaml` or the
+`HERMES_CRON_MAX_ITERATIONS` environment variable. The environment variable wins.
+
+This separation prevents one noisy recurring job from monopolizing the gateway
+cron ticker when a user has intentionally configured a high chat/session turn
+limit for interactive work.
+
 ## Skill-Backed Jobs
 
 A cron job can attach one or more skills via the `skills` field. At execution time:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -522,6 +522,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_CRON_TIMEOUT` | Inactivity timeout for cron job agent runs in seconds (default: `600`). The agent can run indefinitely while actively calling tools or receiving stream tokens — this only triggers when idle. Set to `0` for unlimited. |
 | `HERMES_CRON_SCRIPT_TIMEOUT` | Timeout for pre-run scripts attached to cron jobs in seconds (default: `120`). Override for scripts that need longer execution (e.g., randomized delays for anti-bot timing). Also configurable via `cron.script_timeout_seconds` in `config.yaml`. |
 | `HERMES_CRON_MAX_PARALLEL` | Max cron jobs run in parallel per tick (default: `4`). |
+| `HERMES_CRON_MAX_ITERATIONS` | Max tool-calling iterations for LLM-backed cron jobs (default: `30`). Also configurable via `cron.max_iterations` in `config.yaml`; the environment variable wins. This is intentionally separate from `agent.max_turns` so high interactive chat limits do not let one recurring job monopolize the scheduler tick. |
 
 ## Agent Behavior
 


### PR DESCRIPTION
## Summary
- add a cron-specific `max_iterations` cap for LLM-backed scheduled jobs
- stop cron runs from inheriting large interactive `agent.max_turns` values by default
- document `cron.max_iterations` / `HERMES_CRON_MAX_ITERATIONS` and cover default, override, invalid, and run-job propagation paths

## Why
A high interactive turn limit is useful in chat, but a recurring cron job inheriting it can monopolize the gateway cron ticker and delay unrelated due jobs. Cron should have a conservative scheduler-safe default unless the operator explicitly opts into a higher cron-specific limit.

## Test Plan
- [x] `python -m pytest tests/cron/test_cron_inactivity_timeout.py::TestCronRunLimits -q -o 'addopts='` -> 6 passed
- [x] `python -m pytest tests/cron/test_cron_inactivity_timeout.py -q -o 'addopts='` -> 17 passed
- [x] `python -m py_compile cron/scheduler.py tests/cron/test_cron_inactivity_timeout.py hermes_cli/config.py` -> passed
- [x] `git diff --check` -> passed
- [x] broader cron signal: `python -m pytest tests/cron/test_cron_inactivity_timeout.py tests/cron/test_scheduler.py -q -o 'addopts='` -> 142 passed, 3 failed in existing Matrix delivery-target expectations unrelated to this diff (`thread_id` / extra Matrix home channel pollution)

## Notes
- This intentionally changes the default for LLM-backed cron jobs: operators who need a higher cron cap can set `cron.max_iterations` or `HERMES_CRON_MAX_ITERATIONS`.
- Fork PR workflows are waiting for upstream authorization, so GitHub Actions currently show `action_required` with no runnable jobs.
