### PR TITLE
fix: strip oversized item ids from Responses API replay (#10788)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -435,8 +435,17 @@ def _chat_messages_to_responses_input(
                             "status": _normalize_responses_message_status(raw_item.get("status")),
                             "content": normalized_content_parts,
                         }
+                        # Strip oversized message item ids (>64 chars) on
+                        # replay — the Responses API rejects them with HTTP
+                        # 400 string_above_max_length.  With store=false the
+                        # server cannot resolve the id anyway; the phase
+                        # field (preserved below) is what matters for cache.
                         item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
+                        if (
+                            isinstance(item_id, str)
+                            and item_id.strip()
+                            and len(item_id.strip()) <= 64
+                        ):
                             replay_item["id"] = item_id.strip()
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
@@ -690,7 +699,13 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 "content": normalized_content,
             }
             item_id = item.get("id")
-            if isinstance(item_id, str) and item_id.strip():
+            if (
+                isinstance(item_id, str)
+                and item_id.strip()
+                and len(item_id.strip()) <= 64
+            ):
+                # Only pass through short ids — oversized ids from
+                # Codex (408+ chars) cause HTTP 400 on replay.
                 normalized_item["id"] = item_id.strip()
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
@@ -1069,8 +1084,13 @@ def _normalize_codex_response(
                     "content": [{"type": "output_text", "text": message_text}],
                 }
                 item_id = getattr(item, "id", None)
-                if isinstance(item_id, str) and item_id:
+                if isinstance(item_id, str) and item_id and len(item_id) <= 64:
                     raw_message_item["id"] = item_id
+                elif isinstance(item_id, str) and len(item_id) > 64:
+                    logger.debug(
+                        "Dropping oversized message item id (%d chars) during capture",
+                        len(item_id),
+                    )
                 if normalized_phase:
                     raw_message_item["phase"] = normalized_phase
                 message_items_raw.append(raw_message_item)
@@ -1098,8 +1118,13 @@ def _normalize_codex_response(
                         item_id,
                     )
                     continue
-                if isinstance(item_id, str) and item_id:
+                if isinstance(item_id, str) and item_id and len(item_id) <= 64:
                     raw_item["id"] = item_id
+                elif isinstance(item_id, str) and len(item_id) > 64:
+                    logger.debug(
+                        "Dropping oversized reasoning item id (%d chars) during capture",
+                        len(item_id),
+                    )
                 # Capture summary — required by the API when replaying reasoning items
                 summary = getattr(item, "summary", None)
                 if isinstance(summary, list):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
 
-from agent.codex_responses_adapter import _normalize_codex_response
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _normalize_codex_response,
+    _preflight_codex_input_items,
+)
 
 
 def test_normalize_codex_response_drops_transient_rs_tmp_reasoning_items():
@@ -61,3 +65,182 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
     assert assistant_message.content == ""
     assert assistant_message.reasoning == "still thinking"
     assert assistant_message.codex_reasoning_items is None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for oversized message/reasoning item IDs (>64 chars)
+# See upstream issue #10788 — HTTP 400 string_above_max_length on replay.
+# ---------------------------------------------------------------------------
+
+_LONG_ID = "msg_" + "a" * 412  # 416 chars, same length observed in #10788
+_SHORT_ID = "msg_" + "b" * 55   # 59 chars, within limit
+
+
+def test_capture_normalization_drops_oversized_message_item_id():
+    """_normalize_codex_response must NOT store message item ids >64 chars."""
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="message",
+                id=_LONG_ID,
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="hello")],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == "hello"
+    # The captured codex_message_items must NOT contain the oversized id
+    items = assistant_message.codex_message_items
+    assert items is not None and len(items) == 1
+    assert "id" not in items[0]
+
+
+def test_capture_normalization_preserves_short_message_item_id():
+    """Short ids (<=64 chars) should pass through capture normally."""
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="message",
+                id=_SHORT_ID,
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="ok")],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+    items = assistant_message.codex_message_items
+    assert items[0]["id"] == _SHORT_ID
+
+
+def test_capture_normalization_drops_oversized_reasoning_item_id():
+    """_normalize_codex_response must NOT store reasoning item ids >64 chars."""
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id=_LONG_ID,
+                encrypted_content="opaque-blob",
+                summary=[SimpleNamespace(text="thinking")],
+            ),
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="done")],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+    items = assistant_message.codex_reasoning_items
+    assert len(items) == 1
+    assert "id" not in items[0]
+
+
+def test_replay_strips_oversized_message_item_id():
+    """_chat_messages_to_responses_input must strip message item ids >64 chars
+    from the replay payload so the Responses API never sees them."""
+    messages = [
+        {
+            "role": "user",
+            "content": "hi",
+        },
+        {
+            "role": "assistant",
+            "content": "hello",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "hello"}],
+                    "id": _LONG_ID,
+                    "phase": "response.123",
+                },
+            ],
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+    # Find the replayed message item
+    replayed = [i for i in items if i.get("type") == "message" and i.get("role") == "assistant"]
+    assert len(replayed) == 1
+    assert "id" not in replayed[0]
+    # Phase must still be present (cache-critical)
+    assert replayed[0].get("phase") == "response.123"
+
+
+def test_replay_preserves_short_message_item_id():
+    """Short ids (<=64 chars) should survive replay."""
+    messages = [
+        {
+            "role": "user",
+            "content": "hi",
+        },
+        {
+            "role": "assistant",
+            "content": "hello",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "hello"}],
+                    "id": _SHORT_ID,
+                    "phase": "response.456",
+                },
+            ],
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+    replayed = [i for i in items if i.get("type") == "message" and i.get("role") == "assistant"]
+    assert replayed[0]["id"] == _SHORT_ID
+
+
+def test_preflight_strips_oversized_message_item_id():
+    """_preflight_codex_input_items must strip message item ids >64 chars."""
+    raw_items = [
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "hello"}],
+            "id": _LONG_ID,
+            "phase": "response.789",
+        },
+    ]
+
+    normalized = _preflight_codex_input_items(raw_items)
+    assistant_items = [i for i in normalized if i.get("role") == "assistant"]
+    assert len(assistant_items) == 1
+    assert "id" not in assistant_items[0]
+    assert assistant_items[0].get("phase") == "response.789"
+
+
+def test_preflight_preserves_short_message_item_id():
+    """Short ids (<=64 chars) should survive preflight."""
+    raw_items = [
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "hello"}],
+            "id": _SHORT_ID,
+            "phase": "response.012",
+        },
+    ]
+
+    normalized = _preflight_codex_input_items(raw_items)
+    assistant_items = [i for i in normalized if i.get("role") == "assistant"]
+    assert assistant_items[0]["id"] == _SHORT_ID


### PR DESCRIPTION
## Problem

The Codex Responses API rejects item `id` fields longer than 64 characters with:

```
HTTP 400: Invalid 'input[101].id': string too long. Expected a string with maximum length 64, but got a string with length 416 instead.
```

Some Codex endpoints return opaque message/reasoning item ids of 400+ characters that break multi-turn replay on subsequent turns. This has been reported in #10788.

## Solution

Three-layer defense — strip/drop oversized ids rather than truncating:

### 1. Capture (`_normalize_codex_response`)
Drop oversized ids (message + reasoning items) at ingest so they never enter the conversation history. Log at DEBUG level when dropping.

### 2. Replay (`_chat_messages_to_responses_input`)  
Strip oversized ids from replayed message items. The `phase` field is preserved in all cases — with `store=false` the server cannot resolve the id anyway, so `phase` is the cache-critical field.

### 3. Preflight (`_preflight_codex_input_items`)
Guard normalized items before they reach the API — strip oversized ids from message items.

## Why strip instead of truncate/hash?

- Stripping is the simplest correct fix: the API never needs the `id` with `store=false`
- The `phase` field carries all cache-relevant information
- Hash-based approaches (PR #17318) introduce unnecessary complexity and conflict with main
- Truncation (`[:64]`) risks colliding ids

## Tests

7 regression tests covering all three layers:
- Capture: drop oversized message id, preserve short message id, drop oversized reasoning id
- Replay: strip oversized message id (phase preserved), preserve short message id
- Preflight: strip oversized message id (phase preserved), preserve short message id

All 90 existing `codex_responses` tests continue to pass.

## Related

- Closes #10788
- Supersedes #27143 (closed — similar approach but incomplete)
- Alternative to #17318 (open — hash-based, conflicts with main)