### PR TITLE
fix(feishu): render markdown tables and code blocks via CardKit 2.0 cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -157,6 +157,11 @@ _MARKDOWN_HINT_RE = re.compile(
 # Detect markdown tables: a line starting with | followed by a separator line.
 # Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
+# GFM table: a row of |cells| followed by a separator row (---|:---|...)
+_TABLE_MARKDOWN_RE = re.compile(r"^\|.+\|.*\n\|[-: |]+\|", re.MULTILINE)
+# Multi-line fenced code block (opening fence + 2+ content lines + closing fence)
+# Empty or 1-line blocks render fine in post/md; route 2+ content lines to CardKit 2.0.
+_CODE_BLOCK_RE = re.compile(r"^```[^\n]*\n(.*\n){2,}```", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -1788,40 +1793,64 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
-                try:
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type=msg_type,
-                        payload=payload,
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
-                        raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                if (
-                    msg_type == "post"
-                    and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
-                ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                last_response = response
+                for msg_type, payload in self._build_outbound_messages(chunk):
+                    try:
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type=msg_type,
+                            payload=payload,
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    except Exception as exc:
+                        if msg_type == "interactive":
+                            logger.warning("[Feishu] Interactive card send failed (exc=%r); falling back to plain text", exc)
+                            response = await self._feishu_send_with_retry(
+                                chat_id=chat_id,
+                                msg_type="text",
+                                payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                                reply_to=reply_to,
+                                metadata=metadata,
+                            )
+                        elif msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                            raise
+                        else:
+                            logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                            response = await self._feishu_send_with_retry(
+                                chat_id=chat_id,
+                                msg_type="text",
+                                payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                                reply_to=reply_to,
+                                metadata=metadata,
+                            )
+                    if msg_type == "interactive" and not self._response_succeeded(response):
+                        _resp_code = getattr(response, "code", None)
+                        _resp_msg = getattr(response, "msg", None)
+                        logger.warning(
+                            "[Feishu] Interactive card rejected by API (code=%s msg=%r); falling back to plain text",
+                            _resp_code, _resp_msg,
+                        )
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    if (
+                        msg_type == "post"
+                        and not self._response_succeeded(response)
+                        and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    ):
+                        logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    last_response = response
 
             return self._finalize_send_result(last_response, "send failed")
         except Exception as exc:
@@ -4373,17 +4402,103 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
+    # Feishu CardKit 2.0 limits the total number of GFM tables across the
+    # entire card (sum of all markdown elements) to 5. Exceeding this triggers
+    # ErrCode 11310 ("card table number over limit") and the API rejects the
+    # whole card. Verified empirically 2026-05-27: a single element with 6
+    # tables fails; two elements with 4+2 tables also fail; five tables in any
+    # element layout succeed. The only safe workaround is splitting content
+    # into multiple cards when it has > 5 tables.
+    _CARD_MAX_TABLES = 5
+
+    @staticmethod
+    def _split_content_by_table_limit(content: str, max_tables: int) -> List[str]:
+        """Split markdown content so each chunk has at most max_tables tables.
+
+        Splits between sections (paragraph blocks) so the heading and lead-in
+        prose owning each table travel with the table rather than being
+        orphaned in the previous chunk. The cut goes at the first paragraph
+        boundary after the previous table block ends — that is the start of
+        the section that owns the next table.
+
+        Content with <= max_tables tables is returned as a single-element list.
+        """
+        # Find all table start positions (start of the header row)
+        table_starts = [m.start() for m in _TABLE_MARKDOWN_RE.finditer(content)]
+        if len(table_starts) <= max_tables:
+            return [content]
+
+        chunks: List[str] = []
+        chunk_start = 0
+        for i in range(max_tables, len(table_starts), max_tables):
+            split_pos = table_starts[i]
+            prev_table_end = table_starts[i - 1]
+            # Walk forward from the previous table's start to find where its
+            # block ends (first blank line after the table body).
+            block_end = content.find("\n\n", prev_table_end)
+            if 0 <= block_end < split_pos:
+                # Cut at the first paragraph boundary after the previous table —
+                # this leaves the next table's section heading + lead-in prose
+                # with the next chunk.
+                cut = block_end + 2
+            else:
+                # Fallback: nearest single newline before the next table.
+                newline_pos = content.rfind("\n", chunk_start, split_pos)
+                cut = newline_pos + 1 if newline_pos >= chunk_start else split_pos
+
+            chunk = content[chunk_start:cut].strip()
+            if chunk:
+                chunks.append(chunk)
+            chunk_start = cut
+
+        # Remaining content
+        tail = content[chunk_start:].strip()
+        if tail:
+            chunks.append(tail)
+
+        return chunks if chunks else [content]
+
+    def _build_card_payload(self, content: str) -> str:
+        """Build a CardKit 2.0 interactive card payload with markdown content.
+
+        Caller must ensure the content has at most _CARD_MAX_TABLES tables —
+        use _build_outbound_messages() to handle splitting at the message level.
+        """
+        card = {
+            "schema": "2.0",
+            "config": {"wide_screen_mode": True},
+            "body": {
+                "elements": [
+                    {"tag": "markdown", "content": content}
+                ]
+            },
+        }
+        return json.dumps(card, ensure_ascii=False)
+
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Route GFM tables and multi-line code blocks to CardKit 2.0 interactive
+        # messages, which render markdown properly (tables, code blocks, links).
+        # Short code blocks (1 content line) and plain markdown stay in post/md.
+        if _TABLE_MARKDOWN_RE.search(content) or _CODE_BLOCK_RE.search(content):
+            return "interactive", self._build_card_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
+
+    def _build_outbound_messages(self, content: str) -> List[tuple[str, str]]:
+        """Return a list of (msg_type, payload) entries to send for content.
+
+        Most content yields a single entry. When the content has more than
+        _CARD_MAX_TABLES GFM tables, it is split into multiple cards because
+        Feishu rejects cards with > 5 tables (ErrCode 11310).
+        """
+        # Count tables once up front so we don't pay regex cost for typical short msgs
+        table_count = sum(1 for _ in _TABLE_MARKDOWN_RE.finditer(content))
+        if table_count <= self._CARD_MAX_TABLES:
+            return [self._build_outbound_payload(content)]
+        chunks = self._split_content_by_table_limit(content, self._CARD_MAX_TABLES)
+        return [self._build_outbound_payload(chunk) for chunk in chunks]
 
     async def _send_uploaded_file_message(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4944,3 +4944,148 @@ class TestChatLockEviction(unittest.TestCase):
                 held.release()
 
         asyncio.run(_run())
+
+
+class TestCardTableLimitSplitting(unittest.TestCase):
+    """Verify Feishu CardKit table-count splitting (ErrCode 11310 workaround).
+
+    Feishu rejects any interactive card whose total GFM table count exceeds
+    _CARD_MAX_TABLES (5, verified empirically). When content has more tables,
+    we split it into multiple cards before sending — splitting markdown
+    elements within a single card does NOT bypass the limit (it is per-card,
+    not per-element).
+    """
+
+    def _make_table(self, idx: int) -> str:
+        return (
+            f"\n\n### 表格 {idx}\n\n"
+            "| A | B | C |\n"
+            "|---|---|---|\n"
+            "| 1 | 2 | 3 |\n"
+            "| 4 | 5 | 6 |\n"
+        )
+
+    def _count_tables(self, card: dict) -> int:
+        """Count GFM tables across all markdown elements of a card."""
+        from gateway.platforms.feishu import _TABLE_MARKDOWN_RE
+
+        return sum(
+            len(_TABLE_MARKDOWN_RE.findall(el["content"]))
+            for el in card["body"]["elements"]
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_table_routes_to_interactive_card(self):
+        """含 GFM 表格的内容应路由到 CardKit 2.0 交互卡片，而非 text/post。"""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload = adapter._build_outbound_payload(
+            "## 标题\n" + self._make_table(1)
+        )
+        self.assertEqual(msg_type, "interactive")
+        card = json.loads(payload)
+        self.assertEqual(card["schema"], "2.0")
+        self.assertEqual(card["body"]["elements"][0]["tag"], "markdown")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_multiline_code_block_routes_to_interactive_card(self):
+        """多行围栏代码块在 post/md 中会被截断，应路由到交互卡片。"""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "输出：\n```python\nprint('a')\nprint('b')\nprint('c')\n```"
+        msg_type, payload = adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "interactive")
+        card = json.loads(payload)
+        self.assertIn("```python", card["body"]["elements"][0]["content"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_under_limit_yields_single_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "## 标题\n" + "".join(self._make_table(i + 1) for i in range(5))
+        messages = adapter._build_outbound_messages(content)
+
+        self.assertEqual(len(messages), 1)
+        msg_type, payload = messages[0]
+        self.assertEqual(msg_type, "interactive")
+        card = json.loads(payload)
+        # All 5 tables go into one element of one card.
+        self.assertEqual(len(card["body"]["elements"]), 1)
+        self.assertEqual(self._count_tables(card), 5)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_over_limit_yields_multiple_cards(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        # 6 tables — must be split into 2 cards (5 + 1) because per-card cap is 5.
+        content = "## 标题\n" + "".join(self._make_table(i + 1) for i in range(6))
+        messages = adapter._build_outbound_messages(content)
+
+        self.assertEqual(len(messages), 2)
+        for msg_type, _ in messages:
+            self.assertEqual(msg_type, "interactive")
+
+        first = json.loads(messages[0][1])
+        second = json.loads(messages[1][1])
+        # First card carries 5 tables, second carries the remaining 1.
+        self.assertEqual(self._count_tables(first), 5)
+        self.assertEqual(self._count_tables(second), 1)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_far_over_limit_splits_into_three_cards(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        # 12 tables → 3 cards (5 + 5 + 2).
+        content = "## 标题\n" + "".join(self._make_table(i + 1) for i in range(12))
+        messages = adapter._build_outbound_messages(content)
+
+        self.assertEqual(len(messages), 3)
+        table_counts = [self._count_tables(json.loads(p)) for _, p in messages]
+        self.assertEqual(table_counts, [5, 5, 2])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_tables_returns_post_or_text(self):
+        """Tables-only logic doesn't disturb non-table routing."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        messages = adapter._build_outbound_messages("just plain text")
+        self.assertEqual(len(messages), 1)
+        msg_type, _ = messages[0]
+        self.assertEqual(msg_type, "text")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_prose_between_tables_stays_with_following_table(self):
+        """Splitting must happen at table boundaries, not mid-paragraph."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        parts = []
+        for i in range(6):
+            parts.append(f"\n\n这是第 {i + 1} 段说明文字。")
+            parts.append(self._make_table(i + 1))
+        content = "## 标题" + "".join(parts)
+        messages = adapter._build_outbound_messages(content)
+
+        self.assertEqual(len(messages), 2)
+        first_content = json.loads(messages[0][1])["body"]["elements"][0]["content"]
+        second_content = json.loads(messages[1][1])["body"]["elements"][0]["content"]
+        # Tables 1..5 live in card 1, table 6 in card 2 — each table's
+        # preceding prose travels with it (no orphaned paragraphs).
+        for i in range(1, 6):
+            self.assertIn(f"第 {i} 段说明文字", first_content)
+            self.assertIn(f"### 表格 {i}", first_content)
+        self.assertIn("第 6 段说明文字", second_content)
+        self.assertIn("### 表格 6", second_content)


### PR DESCRIPTION
Closes #9549. Closes #19035. Supersedes #23861.

## Problem

Feishu's post-type `md` element does not render GFM tables and truncates multi-line fenced code blocks. The current behaviour ([#20275](https://github.com/NousResearch/hermes-agent/pull/20275), force-text fallback) avoids the blank-message symptom but leaks raw markdown source to the user — pipes, separators and code fences are visible as plain text.

#23861 partially addressed this by routing tables/code blocks to CardKit 2.0, but it does not handle the per-card table count limit (see below) and stalled in review. This PR is a more complete take.

## Approach

Route content containing GFM tables or multi-line fenced code blocks to CardKit 2.0 interactive messages (`schema: 2.0`, `tag: markdown`), which render both natively. Plain markdown without tables/code stays in `post/md` as before.

Falls back to plain text when the interactive card is rejected (bot lacks card permission, malformed payload, etc.) so failures degrade gracefully — no regression vs current behaviour for misconfigured bots.

## ErrCode 11310: per-card table cap

CardKit 2.0 caps the total number of GFM tables across an **entire card** at 5. Exceeding this triggers `ErrCode 11310` (`card table number over limit`) and the API rejects the whole card.

The cap is per-CARD, not per-element — verified empirically against the live Feishu API on 2026-05-27:

| layout | result |
|---|---|
| 1 element × 5 tables | ✓ |
| 1 element × 6 tables | ✗ 11310 |
| 2 elements × (4+2) tables | ✗ 11310 |
| 2 elements × (5+1) tables | ✗ 11310 |
| 5 elements × 1 table each | ✓ |
| 8 elements × 1 table each | ✗ 11310 |

When content has more than 5 tables, `_build_outbound_messages()` splits it into multiple cards and `send()` iterates the resulting `(msg_type, payload)` list. Splits cut at section boundaries — the first paragraph break after the previous table block ends — so each table's heading and lead-in prose travel into the same card as the table itself, rather than being orphaned in the previous chunk.

## Tests

`tests/gateway/test_feishu.py::TestCardTableLimitSplitting` (7 cases):

- table content routes to interactive card (not text)
- single card for ≤5 tables
- two cards for 6 tables (5 + 1)
- three cards for 12 tables (5 + 5 + 2)
- non-table content keeps post/text routing untouched
- prose between tables stays with the following table at split points
- multi-line fenced code block routes to interactive card

Full test suite (`tests/gateway/test_feishu.py`): 208 passed.

## Migration notes

- Bots without card-send permission silently fall back to plain text (existing fallback path, extended for the interactive case). No new permission required vs `post/md`.
- `edit_message` remains on the single-payload path; streaming edits do not currently produce > 5 tables in a single chunk in practice.
- The single-content-line code block case (e.g. `` ```json\n{"x":1}\n``` ``) intentionally stays in `post/md` because it renders fine there — only blocks with two or more code lines route to the interactive card. This preserves the existing `test_send_splits_fenced_code_blocks_into_separate_post_rows` behaviour.
