### PR TITLE
fix(dashboard-auth): honour X-Forwarded-Prefix in login page provider buttons

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -350,15 +350,18 @@ auth gate (not recommended on untrusted networks).</p>
 """
 
 
-def render_login_html(*, next_path: str = "") -> str:
+def render_login_html(*, next_path: str = "", prefix: str = "") -> str:
     """Return the full HTML for ``GET /login``.
 
-    ``next_path`` — when set, the post-login landing path the user
-    originally requested. Threaded into each provider button's ``href``
-    as a ``next=`` query parameter so the OAuth round trip carries it
-    end-to-end. The caller (``routes.login_page``) is responsible for
-    validating ``next_path`` against the same-origin rules before we
-    emit it; we still HTML-escape it as defence in depth.
+    Args:
+        next_path: When set, the post-login landing path the user
+            originally requested. Threaded into each provider button's ``href``
+            as a ``next=`` query parameter so the OAuth round trip carries it
+            end-to-end. The caller (``routes.login_page``) is responsible for
+            validating ``next_path`` against the same-origin rules before we
+            emit it; we still HTML-escape it as defence in depth.
+        prefix: The X-Forwarded-Prefix (e.g., "/hermes") to prepend to URLs.
+            Used when the dashboard is behind a reverse proxy.
     """
     providers = list_providers()
     if not providers:
@@ -374,11 +377,15 @@ def render_login_html(*, next_path: str = "") -> str:
     else:
         next_qs = ""
 
+    # Normalise the prefix (ensure it starts with "/" and has no trailing slash)
+    from hermes_cli.dashboard_auth.prefix import normalise_prefix
+    normalized_prefix = normalise_prefix(prefix)
+
     buttons = []
     for p in providers:
         buttons.append(
             f'      <a class="provider-btn" '
-            f'href="/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
+            f'href="{html.escape(normalized_prefix, quote=True)}/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
             f'Sign in with {html.escape(p.display_name)}</a>'
         )
     return _LOGIN_HTML_TEMPLATE.format(provider_buttons="\n".join(buttons))

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -132,8 +132,10 @@ async def login_page(request: Request) -> HTMLResponse:
     next_path = _validate_post_login_target(
         request.query_params.get("next", "")
     )
+    # Get the X-Forwarded-Prefix header for reverse proxy deployments
+    prefix = _prefix(request)
     return HTMLResponse(
-        render_login_html(next_path=next_path),
+        render_login_html(next_path=next_path, prefix=prefix),
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
     )
 

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -438,6 +438,71 @@ class TestRenderLoginHtmlNext:
 
 
 # ---------------------------------------------------------------------------
+# Unit-level coverage: render_login_html respects X-Forwarded-Prefix
+# ---------------------------------------------------------------------------
+
+
+class TestRenderLoginHtmlPrefix:
+    """Cover ``render_login_html`` prefix parameter for reverse proxy deployments.
+
+    When the dashboard is served behind a reverse proxy at a path prefix
+    (e.g. /hermes), the X-Forwarded-Prefix header tells the backend the prefix.
+    The login page buttons must include this prefix in their hrefs so the OAuth
+    flow stays under the same path.
+    """
+
+    def setup_method(self):
+        clear_providers()
+        register_provider(StubAuthProvider())
+
+    def teardown_method(self):
+        clear_providers()
+
+    def test_no_prefix_emits_root_path(self):
+        """Empty prefix produces root-relative /auth/login (unchanged behaviour)."""
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        html_out = render_login_html()
+        assert 'href="/auth/login?provider=stub"' in html_out
+
+    def test_valid_prefix_prepended(self):
+        """A valid prefix like /hermes is prepended to the button href."""
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        html_out = render_login_html(prefix="/hermes")
+        assert 'href="/hermes/auth/login?provider=stub"' in html_out
+
+    def test_prefix_without_leading_slash_normalised(self):
+        """Prefix without leading slash is normalised to have one."""
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        html_out = render_login_html(prefix="hermes")
+        assert 'href="/hermes/auth/login?provider=stub"' in html_out
+
+    def test_prefix_with_trailing_slash_normalised(self):
+        """Prefix with trailing slash has it stripped."""
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        html_out = render_login_html(prefix="/hermes/")
+        assert 'href="/hermes/auth/login?provider=stub"' in html_out
+
+    def test_malicious_prefix_normalised_to_empty(self):
+        """Malicious prefix values are rejected and fall back to no prefix."""
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+
+        # Path traversal attempt
+        html_out = render_login_html(prefix="/../etc/passwd")
+        assert 'href="/auth/login?provider=stub"' in html_out
+
+        # Double slash attempt
+        html_out = render_login_html(prefix="//injected")
+        assert 'href="/auth/login?provider=stub"' in html_out
+
+    def test_prefix_with_next_path(self):
+        """Prefix works together with next_path parameter."""
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        html_out = render_login_html(prefix="/hermes", next_path="/sessions")
+        assert "provider=stub&next=%2Fsessions" in html_out
+        assert 'href="/hermes/auth/login?' in html_out
+
+
+# ---------------------------------------------------------------------------
 # Unit-level coverage: /auth/login persists next= into the PKCE cookie
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes the login page's OAuth provider buttons to honour the `X-Forwarded-Prefix` header when the dashboard is served behind a reverse proxy at a path prefix (e.g. `/hermes`).

Previously, clicking a "Sign in with …" button on `/login` always generated `href="/auth/login?provider=…"` — a root-relative path that bypasses the proxy prefix. Under `X-Forwarded-Prefix: /hermes`, the correct URL should be `/hermes/auth/login?provider=…`. This mirrors the prefix-awareness already implemented in `web_server.py` (SPA mount), `routes.py` (OAuth redirect_uri), `cookies.py` (Path attribute), and `middleware.py` (gate login_url) — the login page's button HTML was the only surface that missed it.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_auth/login_page.py`: Added `prefix` parameter to `render_login_html()`. The prefix is normalised via the existing `normalise_prefix()` helper from `prefix.py` (strips trailing slashes, rejects `..` / injection characters) and prepended to the `/auth/login` href in each provider button.
- `hermes_cli/dashboard_auth/routes.py`: In the `login_page()` route handler, extract the prefix with `_prefix(request)` (which reads `X-Forwarded-Prefix`) and pass it to `render_login_html()`.

## How to Test

1. Deploy the dashboard behind a reverse proxy that sets `X-Forwarded-Prefix: /hermes` (e.g. Caddy or nginx with `strip_prefix` + `header_set X-Forwarded-Prefix /hermes`).
2. Navigate to `/hermes/login` and inspect the "Sign in with …" button hrefs — they should read `/hermes/auth/login?provider=…` instead of `/auth/login?provider=…`.
3. Without a reverse proxy (no `X-Forwarded-Prefix` header), the hrefs should remain `/auth/login?provider=…` (no prefix prepended, behaviour unchanged).
4. Verify the existing test suite passes: `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_401_reauth.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

*(Not applicable — this is a bug fix, not a new skill.)*

## Screenshots / Logs

N/A — the change affects generated HTML href attributes and is best verified by inspecting the button URLs in the login page source under a reverse proxy setup.