### PR TITLE
fix: suppress repeated corrupt kanban backups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5543,6 +5543,9 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                disabled_fingerprint = disabled_corrupt_boards.get(slug)
+                if disabled_fingerprint == _board_db_fingerprint(slug):
+                    continue
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -954,6 +954,8 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
+_CORRUPT_BACKUP_LOCK = threading.RLock()
+_CORRUPT_BACKUPS: dict[tuple[str, int, int], Optional[Path]] = {}
 
 
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
@@ -1007,7 +1009,7 @@ def _validate_sqlite_header(path: Path) -> None:
     )
 
 
-class KanbanDbCorruptError(RuntimeError):
+class KanbanDbCorruptError(sqlite3.DatabaseError):
     """Raised when an existing kanban DB file fails integrity checks.
 
     Fail-closed guard against silent recreation of a corrupt board file,
@@ -1074,6 +1076,35 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     return candidate
 
 
+def _corrupt_db_fingerprint(path: Path) -> tuple[str, int, int]:
+    """Return a process-local fingerprint for a corrupt DB's current bytes."""
+    resolved = path.resolve()
+    stat = resolved.stat()
+    return (str(resolved), stat.st_mtime_ns, stat.st_size)
+
+
+def _backup_corrupt_db_once(path: Path) -> Optional[Path]:
+    """Preserve a corrupt DB once per unchanged file fingerprint.
+
+    Gateway dispatcher, health probes, CLI retries, and cron tasks may all try
+    to open the same malformed board DB. Re-copying identical bytes on every
+    attempt creates backup spam and makes a single corruption look like many
+    new incidents. If the underlying DB changes, the fingerprint changes and we
+    preserve the new bytes separately.
+    """
+    try:
+        fingerprint = _corrupt_db_fingerprint(path)
+    except OSError:
+        return _backup_corrupt_db(path)
+    with _CORRUPT_BACKUP_LOCK:
+        existing = _CORRUPT_BACKUPS.get(fingerprint)
+        if existing is not None and existing.exists():
+            return existing
+        backup = _backup_corrupt_db(path)
+        _CORRUPT_BACKUPS[fingerprint] = backup
+        return backup
+
+
 def _guard_existing_db_is_healthy(path: Path) -> None:
     """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
 
@@ -1128,7 +1159,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         reason = f"sqlite refused to open file: {exc}"
     if reason is None:
         return
-    backup = _backup_corrupt_db(resolved)
+    backup = _backup_corrupt_db_once(resolved)
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3189,6 +3189,56 @@ def test_connect_refuses_corrupt_existing_file(tmp_path):
         kb.connect(db_path=db_path)
 
 
+def test_corrupt_db_error_is_sqlite_database_error():
+    """Gateway dispatcher catches sqlite3.DatabaseError to disable corrupt boards.
+
+    If KanbanDbCorruptError is only a RuntimeError, the dispatcher logs a full
+    traceback every tick and never records the board as disabled.
+    """
+    assert issubclass(kb.KanbanDbCorruptError, sqlite3.DatabaseError)
+
+
+def test_repeated_corrupt_existing_file_reuses_first_backup(tmp_path):
+    """Repeated probes of the same corrupt DB must not create backup spam.
+
+    The gateway has several periodic paths that may attempt to open a board.
+    Once one path preserved a specific corrupt file fingerprint, later opens in
+    the same process should raise with that same backup path until the DB file
+    changes.
+    """
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    assert first.value.backup_path == second.value.backup_path
+    backups = sorted(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert backups == [first.value.backup_path]
+
+
+def test_changed_corrupt_existing_file_gets_new_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+
+    # Change the underlying corrupt DB fingerprint; that should be preserved
+    # separately so operators have the latest broken bytes too.
+    db_path.write_bytes(db_path.read_bytes() + b"changed")
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    assert first.value.backup_path != second.value.backup_path
+    backups = set(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert backups == {first.value.backup_path, second.value.backup_path}
+
+
 def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
     """A transient lock during the probe must not produce a .corrupt backup
     and must not be reported as :class:`KanbanDbCorruptError`. Raw sqlite

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -327,6 +327,28 @@ def test_dispatcher_tick_does_not_call_init_db(kanban_home, monkeypatch):
     )
 
 
+def test_gateway_dispatcher_health_probe_skips_disabled_corrupt_boards():
+    """The ready-queue health probe must not re-open disabled corrupt boards.
+
+    The dispatch tick already fingerprints and disables a corrupt board. The
+    later health probe runs every tick too; if it ignores that disabled set, it
+    keeps opening the same malformed DB and creates another .corrupt backup.
+    """
+    import inspect
+    from gateway.run import GatewayRunner
+
+    src = inspect.getsource(GatewayRunner._kanban_dispatcher_watcher)
+    ready_src = src.split("def _ready_nonempty", 1)[1].split(
+        "# Auto-decompose:", 1
+    )[0]
+
+    assert "disabled_corrupt_boards.get(slug)" in ready_src
+    assert "_board_db_fingerprint(slug)" in ready_src
+    assert ready_src.index("disabled_corrupt_boards.get(slug)") < ready_src.index(
+        "_kb.connect(board=slug)"
+    )
+
+
 @pytest.mark.asyncio
 async def test_notifier_skips_subscription_owned_by_other_profile(kanban_home):
     """Each gateway keeps its watcher on, but only the subscribing profile claims."""


### PR DESCRIPTION
## Summary
- make KanbanDbCorruptError a sqlite3.DatabaseError so gateway dispatcher corrupt-board handling can disable the board
- cache corrupt DB backups per unchanged file fingerprint to avoid repeated .corrupt backup spam
- skip already-disabled corrupt boards in dispatcher ready-queue health probes

## Tests
- python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_notify.py -q

## Operational context
Observed a malformed board DB causing repeated backup/log spam from multiple gateway tick paths. This preserves the first backup for a specific corrupt file fingerprint and retries only after the DB file changes.

Fixes #32593
