### PR TITLE
fix(webhook): scope GitHub delivery dedup by route

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -501,15 +501,22 @@ class WebhookAdapter(BasePlatformAdapter):
             for k, v in self._seen_deliveries.items()
             if now - v < self._idempotency_ttl
         }
-        if delivery_id in self._seen_deliveries:
+        dedup_key = f"{route_name}:{delivery_id}"
+        if dedup_key in self._seen_deliveries:
             logger.info(
-                "[webhook] Skipping duplicate delivery %s", delivery_id
+                "[webhook] Skipping duplicate delivery %s on route %s",
+                delivery_id,
+                route_name,
             )
             return web.json_response(
-                {"status": "duplicate", "delivery_id": delivery_id},
+                {
+                    "status": "duplicate",
+                    "delivery_id": delivery_id,
+                    "route": route_name,
+                },
                 status=200,
             )
-        self._seen_deliveries[delivery_id] = now
+        self._seen_deliveries[dedup_key] = now
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we


### PR DESCRIPTION
  ## Changes Made

  `gateway/platforms/webhook.py`: scope the GitHub delivery idempotency dedup by `(route_name, delivery_id)` instead of bare `delivery_id`.

  Before:
  ```python
  if delivery_id in self._seen_deliveries: ...
  self._seen_deliveries[delivery_id] = now

  After:
  dedup_key = f"{route_name}:{delivery_id}"
  if dedup_key in self._seen_deliveries: ...
  self._seen_deliveries[dedup_key] = now

  How to Test

  1. Configure two webhook routes subscribed to the same GitHub event type. For example, two distinct routes both listening to pull_request.
  2. Trigger a pull_request event (e.g. open a PR on a repo subscribed to both routes).
  3. Without the fix: GitHub sends a single delivery to both routes, but Hermes silently drops the second route's invocation as "duplicate delivery" because the dedup key is the bare
  delivery id.
  4. With the fix: both routes process the delivery independently, each maintaining its own dedup namespace. Retries to the same route are still deduplicated correctly within the existing
  _idempotency_ttl window.

  Checklist

  Code

  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits (fix(webhook): ...)
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass — N/A (no existing tests for this dedup path)
  - [ ] I've added tests for my changes — not added; the dedup state is private to the adapter instance and the regression scenario requires two routes + idempotency TTL semantics. Happy to
   add a test if maintainers point me at the right harness.
  - [x] I've tested on my platform: Debian 13 (Linux containerized deployment)

  Documentation & Housekeeping

  - [x] I've updated relevant documentation — N/A (internal dedup logic, no public behavior documented)
  - [x] I've updated cli-config.yaml.example — N/A (no config keys added)
  - [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (pure Python string operation, no platform-specific code paths)
  - [x] I've updated tool descriptions/schemas — N/A (no tool changes)

  Screenshots / Logs

  Observed in production (two webhook routes subscribed to the same pull_request event):

  INFO gateway.platforms.webhook: [webhook] POST event=pull_request route=route-a delivery=ebb65ef0-591c-11f1-9885-0fb6f1ba36fa
  INFO gateway.platforms.webhook: [webhook] POST event=pull_request route=route-b delivery=ebb65ef0-591c-11f1-9885-0fb6f1ba36fa
  INFO gateway.platforms.webhook: [webhook] Skipping duplicate delivery ebb65ef0-591c-11f1-9885-0fb6f1ba36fa

  The second route was silently dropped despite being a legitimate distinct subscription. After the patch, both routes process the delivery independently.