### PR TITLE
fix(tools): recognize api.deepseek.com as deepseek provider in delegate_task

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2398,6 +2398,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         elif base_url_hostname(configured_base_url) == "api.anthropic.com":
             provider = "anthropic"
             api_mode = "anthropic_messages"
+        elif base_url_hostname(configured_base_url) == "api.deepseek.com":
+            provider = "deepseek"
+            # api_mode already correctly detected by _detect_api_mode_for_url
+            # for /anthropic-suffix endpoints (anthropic_messages)
         elif "api.kimi.com/coding" in base_lower:
             provider = "custom"
             api_mode = "anthropic_messages"


### PR DESCRIPTION
## Bug

`delegate_task` returns HTTP 404 when using DeepSeek with the Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`).

Reported in #26210, with root cause analysis by @flowioo confirming the issue is in `_resolve_delegation_credentials()` in `tools/delegate_tool.py`.

## Root Cause

When `delegation.base_url` is configured, `_resolve_delegation_credentials` correctly detects `api_mode=anthropic_messages` via `_detect_api_mode_for_url()` (line 2391), but then forces `provider='custom'` at line 2390 — overwriting the user's configured `delegation.provider: deepseek`. The resulting provider mismatch (`deepseek` parent → `custom` child) triggers the api_mode inheritance bug: the child agent sends OpenAI-format requests to the Anthropic-format endpoint, which returns 404.

The existing host-recognition chain (lines 2398-2403) handles `api.anthropic.com` and `api.kimi.com/coding`, but has no entry for `api.deepseek.com`.

## Fix

Add `api.deepseek.com` as a recognized host, setting `provider='deepseek'` while preserving the already-correct `api_mode` detection from `_detect_api_mode_for_url`.

Change: 4 lines added in `tools/delegate_tool.py` (between lines 2400-2403).

## Testing

- Verified `_detect_api_mode_for_url` returns `anthropic_messages` for the deepseek anthropic endpoint
- Verified `base_url_hostname` returns `api.deepseek.com`
- 32 relevant delegate_task tests pass (14 failures are pre-existing `ModuleNotFoundError: dotenv` in clean clone, unrelated to this change)
- Tested on WSL2 (Linux)

Fixes #26210. The broader cross-provider api_mode inheritance issue (addressed in closed PR #25369) may still affect other providers, but this fix resolves the DeepSeek-specific case.

---

*Note: I am not a professional coder. This fix was generated by Munin (AI) based on analysis of #26210, the root cause identified by @flowioo, and source code tracing. Tested on a clean clone. Happy to make any changes maintainers request.*
