### PR TITLE
fix: harden kanban sqlite writes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -953,7 +953,15 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
+_WRITE_LOCKS_LOCK = threading.RLock()
+_WRITE_LOCKS: dict[str, threading.RLock] = {}
 _SQLITE_HEADER = b"SQLite format 3\x00"
+
+
+class KanbanConnection(sqlite3.Connection):
+    """SQLite connection annotated with its resolved Kanban DB path."""
+
+    hermes_kanban_db_path: str | None = None
 
 
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
@@ -1168,9 +1176,16 @@ def connect(
     # via _INITIALIZED_PATHS so it only runs once per process per path.
     _guard_existing_db_is_healthy(path)
     resolved = str(path.resolve())
-    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
+    conn = sqlite3.connect(
+        str(path),
+        isolation_level=None,
+        timeout=30,
+        factory=KanbanConnection,
+    )
     try:
+        conn.hermes_kanban_db_path = resolved
         conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout=30000")
         with _INIT_LOCK:
             # WAL activation can take an exclusive lock while SQLite creates the
             # sidecar files for a fresh database. Keep it in the same process-local
@@ -1473,15 +1488,34 @@ def write_txn(conn: sqlite3.Connection):
     Use for any multi-statement write (creating a task + link, claiming a
     task + recording an event, etc.).  A claim CAS inside this context is
     atomic -- at most one concurrent writer can succeed.
+
+    Same-process writers for the same board DB also serialize through a
+    per-database Python ``RLock`` before asking SQLite for its writer lock.
+    SQLite still remains the cross-process authority, but this avoids local
+    gateway/notifier/CLI threads stampeding the same connection family.
     """
-    conn.execute("BEGIN IMMEDIATE")
-    try:
-        yield conn
-    except Exception:
-        conn.execute("ROLLBACK")
-        raise
-    else:
-        conn.execute("COMMIT")
+    lock = _write_lock_for_connection(conn)
+    with lock:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        else:
+            conn.execute("COMMIT")
+
+
+def _write_lock_for_connection(conn: sqlite3.Connection) -> threading.RLock:
+    db_path = getattr(conn, "hermes_kanban_db_path", None)
+    if not db_path:
+        return threading.RLock()
+    with _WRITE_LOCKS_LOCK:
+        lock = _WRITE_LOCKS.get(db_path)
+        if lock is None:
+            lock = threading.RLock()
+            _WRITE_LOCKS[db_path] = lock
+        return lock
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2120,8 +2120,14 @@ def test_connect_falls_back_to_delete_on_locking_protocol(kanban_home, caplog):
             return super().execute(sql, *args, **kwargs)
 
     def wal_blocking_connect(*args, **kwargs):
+        factory = kwargs.pop("factory", _WalBlockingConnection)
+        class _WalBlockingKanbanConnection(factory):  # type: ignore[misc, valid-type]
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode=wal" in sql.lower().replace(" ", ""):
+                    raise _sqlite3.OperationalError("locking protocol")
+                return super().execute(sql, *args, **kwargs)
         return real_connect(
-            *args, factory=_WalBlockingConnection, **kwargs
+            *args, factory=_WalBlockingKanbanConnection, **kwargs
         )
 
     with _patch("hermes_cli.kanban_db.sqlite3.connect", side_effect=wal_blocking_connect):
@@ -3233,6 +3239,31 @@ def test_init_db_allows_missing_then_healthy(tmp_path):
     with kb.connect(db_path=db_path) as conn:
         tasks = kb.list_tasks(conn)
     assert [t.title for t in tasks] == ["keeps"]
+
+
+def test_connect_sets_explicit_busy_timeout(tmp_path):
+    """Kanban connections should set SQLite's busy handler explicitly.
+
+    Passing timeout=... to sqlite3.connect is easy to miss during future
+    refactors. Keep an explicit PRAGMA so every connection advertises the same
+    cross-process writer wait budget.
+    """
+    import inspect
+
+    src = inspect.getsource(kb.connect)
+    assert "PRAGMA busy_timeout" in src
+
+    with kb.connect(db_path=tmp_path / "kanban.db") as conn:
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] >= 30_000
+
+
+def test_write_txn_uses_per_database_python_lock():
+    """Same-process writers should serialize before hitting SQLite locks."""
+    import inspect
+
+    src = inspect.getsource(kb.write_txn)
+    assert "_write_lock_for_connection" in src
+    assert src.index("with lock") < src.index('conn.execute("BEGIN IMMEDIATE")')
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an explicit `PRAGMA busy_timeout=30000` to every Kanban DB connection
- annotate Kanban SQLite connections with the resolved board DB path
- serialize same-process write transactions through a per-board Python `RLock` before `BEGIN IMMEDIATE`
- keep the existing SQLite WAL/rollback-journal fallback as the cross-process authority

## Tests
- `python -m pytest tests/hermes_cli/test_kanban_db.py::test_connect_sets_explicit_busy_timeout tests/hermes_cli/test_kanban_db.py::test_write_txn_uses_per_database_python_lock -q`
- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_notify.py -q`

## Context
Follow-up hardening after a real Kanban board DB corruption/recovery incident. This does not replace SQLite's locking; it prevents local gateway/notifier/CLI threads from stampeding the same board DB and makes the cross-process busy wait explicit.

Fixes #32532
Refs #31158
