### PR TITLE
fix(kanban): fix interaction between max_spawn and max_in_progress

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -626,7 +626,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_disp.add_argument("--dry-run", action="store_true",
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
-                        help="Cap concurrently-running task workers (defaults to config)")
+                        help="Cap new worker spawns this dispatch pass (defaults to config)")
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
@@ -641,7 +641,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_daemon.add_argument("--interval", type=float, default=60.0,
                           help="Seconds between dispatch ticks (default: 60)")
     p_daemon.add_argument("--max", type=int, default=None,
-                          help="Cap concurrently-running task workers (defaults to config)")
+                          help="Cap new worker spawns per dispatch tick (defaults to config)")
     p_daemon.add_argument("--failure-limit", type=int,
                           default=kb.DEFAULT_SPAWN_FAILURE_LIMIT)
     p_daemon.add_argument("--pidfile", default=None,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -626,7 +626,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_disp.add_argument("--dry-run", action="store_true",
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
-                        help="Cap number of spawns this pass")
+                        help="Cap concurrently-running task workers (defaults to config)")
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
@@ -641,7 +641,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_daemon.add_argument("--interval", type=float, default=60.0,
                           help="Seconds between dispatch ticks (default: 60)")
     p_daemon.add_argument("--max", type=int, default=None,
-                          help="Cap number of spawns per tick")
+                          help="Cap concurrently-running task workers (defaults to config)")
     p_daemon.add_argument("--failure-limit", type=int,
                           default=kb.DEFAULT_SPAWN_FAILURE_LIMIT)
     p_daemon.add_argument("--pidfile", default=None,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6052,13 +6052,17 @@ def dispatch_once(
     failures the task is auto-blocked with the last error as its reason —
     prevents the dispatcher from thrashing forever on an unfixable task.
 
-    ``max_spawn`` is a **live concurrency cap**, not a per-tick spawn budget:
-    it counts tasks already in ``status='running'`` plus this tick's spawns
-    against the limit. So ``max_spawn=4`` means "at most 4 workers running
-    at any time across the whole board" — matching the gateway's stated
-    intent ("limit concurrent kanban tasks"). With a per-tick interpretation
-    a 60-second tick interval could grow concurrency by N every minute on a
-    busy board and accumulate without bound.
+    ``max_spawn`` is a **per-dispatch spawn budget**: it limits how many new
+    workers this dispatcher tick may launch, independent of workers that were
+    already in ``status='running'`` before the tick started.
+
+    ``max_in_progress`` is the **live concurrency cap**: it counts tasks
+    already in ``status='running'`` plus this tick's spawns against the limit.
+    So ``max_in_progress=4`` means "at most 4 workers running at any time
+    across the whole board".
+
+    When both are set, the dispatcher spawns at most
+    ``min(max_spawn, max_in_progress - currently_running)`` workers this tick.
 
     ``spawn_fn`` defaults to ``_default_spawn``. Tests pass a stub.
     ``board`` pins workspace/log/db resolution for this tick to a specific
@@ -6093,15 +6097,8 @@ def dispatch_once(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
-    # Count tasks already running so max_spawn enforces concurrency rather
-    # than a per-tick spawn budget. See the docstring above for the full
-    # rationale; the short version is that a 60-second tick interval with a
-    # per-tick budget of N would grow concurrency by N every tick on a busy
-    # board, since "running" tasks aren't reclaimed by completion alone —
-    # they sit in status='running' until the worker calls
-    # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
     running_count = 0
-    if max_spawn is not None:
+    if max_in_progress is not None:
         running_count = int(
             conn.execute(
                 "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
@@ -6117,16 +6114,16 @@ def dispatch_once(
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
     # pile up and time out.
+    spawn_budget = max_spawn
     if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        if in_progress >= max_in_progress:
+        if running_count >= max_in_progress:
             return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
+        # ``max_spawn`` is a per-tick budget while ``max_in_progress`` is the
+        # live cap including already-running tasks. Only the remaining live
+        # capacity may be used for fresh spawns this tick.
+        remaining = max_in_progress - running_count
+        if spawn_budget is None or spawn_budget > remaining:
+            spawn_budget = remaining
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -6165,7 +6162,7 @@ def dispatch_once(
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
     for row in ready_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if spawn_budget is not None and spawned >= spawn_budget:
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -6341,16 +6338,16 @@ def dispatch_once(
     # sdlc-review skill) that verifies the PR and either merges (→ done)
     # or rejects (→ back to running for the worker to fix).
     #
-    # Same concurrency model as ready dispatch: review spawns count
-    # against max_spawn alongside ready tasks, so the total number of
-    # running workers stays bounded.
+    # Same concurrency model as ready dispatch: review spawns consume the same
+    # per-tick spawn budget as ready tasks, while max_in_progress still counts
+    # already-running workers plus both ready/review spawns this tick.
     review_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'review' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     for row in review_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if spawn_budget is not None and spawned >= spawn_budget:
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -155,6 +155,7 @@ AUTHOR_MAP = {
     "cipherframe@users.noreply.github.com": "CipherFrame",
     "donovan-yohan@users.noreply.github.com": "donovan-yohan",
     "121752779+jacevys@users.noreply.github.com": "jacevys",
+    "loicnico96@gmail.com": "loicnico96",
     "me@promplate.dev": "CNSeniorious000",
     "yichengqiao21@gmail.com": "YarrowQiao",
     "erhanyasarx@gmail.com": "erhnysr",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1559,14 +1559,41 @@ def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawna
         assert kb.get_task(conn, t).claim_lock is None
 
 
-def test_dispatch_max_spawn_counts_existing_running_tasks(
+def test_dispatch_max_spawn_limits_only_new_spawns(
     kanban_home, all_assignees_spawnable
 ):
-    """max_spawn is a live concurrency cap, not a per-tick spawn cap.
+    """max_spawn is a per-dispatch budget, not a cap on already-running work."""
+    spawns = []
 
-    Without counting tasks already in ``running``, every dispatcher tick can
-    launch up to ``max_spawn`` more workers while previous workers are still
-    alive. Long-running boards then accumulate unbounded worker subprocesses.
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        running_a = kb.create_task(conn, title="running-a", assignee="alice")
+        running_b = kb.create_task(conn, title="running-b", assignee="bob")
+        ready_a = kb.create_task(conn, title="ready-a", assignee="carol")
+        ready_b = kb.create_task(conn, title="ready-b", assignee="dave")
+        ready_c = kb.create_task(conn, title="ready-c", assignee="erin")
+        kb.claim_task(conn, running_a)
+        kb.claim_task(conn, running_b)
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=2)
+
+        assert len(res.spawned) == 2
+        assert spawns == [ready_a, ready_b]
+        assert kb.get_task(conn, ready_a).status == "running"
+        assert kb.get_task(conn, ready_b).status == "running"
+        assert kb.get_task(conn, ready_c).status == "ready"
+
+
+def test_dispatch_max_spawn_and_max_in_progress_share_remaining_capacity(
+    kanban_home, all_assignees_spawnable
+):
+    """The live cap and per-tick budget should compose without double-counting.
+
+    With two workers already running and ``max_in_progress=4``, the dispatcher
+    should still be able to launch two more workers this tick when
+    ``max_spawn`` allows it.
     """
     spawns = []
 
@@ -1576,38 +1603,24 @@ def test_dispatch_max_spawn_counts_existing_running_tasks(
     with kb.connect() as conn:
         running_a = kb.create_task(conn, title="running-a", assignee="alice")
         running_b = kb.create_task(conn, title="running-b", assignee="bob")
-        ready = kb.create_task(conn, title="ready", assignee="carol")
+        ready_a = kb.create_task(conn, title="ready-a", assignee="carol")
+        ready_b = kb.create_task(conn, title="ready-b", assignee="dave")
+        ready_c = kb.create_task(conn, title="ready-c", assignee="erin")
         kb.claim_task(conn, running_a)
         kb.claim_task(conn, running_b)
 
-        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=2)
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            max_spawn=8,
+            max_in_progress=4,
+        )
 
-        assert res.spawned == []
-        assert spawns == []
-        assert kb.get_task(conn, ready).status == "ready"
-
-
-def test_dispatch_max_spawn_fills_remaining_capacity(
-    kanban_home, all_assignees_spawnable
-):
-    """When below cap, dispatch only fills available worker slots."""
-    spawns = []
-
-    def fake_spawn(task, workspace):
-        spawns.append(task.id)
-
-    with kb.connect() as conn:
-        running = kb.create_task(conn, title="running", assignee="alice")
-        ready_a = kb.create_task(conn, title="ready-a", assignee="bob")
-        ready_b = kb.create_task(conn, title="ready-b", assignee="carol")
-        kb.claim_task(conn, running)
-
-        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=2)
-
-        assert len(res.spawned) == 1
-        assert spawns == [ready_a]
+        assert len(res.spawned) == 2
+        assert spawns == [ready_a, ready_b]
         assert kb.get_task(conn, ready_a).status == "running"
-        assert kb.get_task(conn, ready_b).status == "ready"
+        assert kb.get_task(conn, ready_b).status == "running"
+        assert kb.get_task(conn, ready_c).status == "ready"
 
 
 def test_dispatch_reclaims_stale_before_spawning(kanban_home):


### PR DESCRIPTION
## Problem

`max_spawn` and `max_in_progress` are both documented in-code as doing the same "max concurrent workers" cap, even each doing the exact same SQL query independently. This seems to have been introduced when `max_spawn` was changed to the current concurrent-worker meaning, while a new field was added in parallel.
- This is redundant, confusing, poorly documented
- There is effectively no more config for "max spawns per dispatch" (which can still be useful)
- This duplicates work and logic inside dispatch, in particular the same SQL query potentially running twice
- If both are set, the current logic is incorrect and may double-count running tasks, resulting in no workers spawned when there could be (see below)

## Proposed change

- keep `max_in_progress` as the live running-worker cap
- revert `max_spawn` to per-dispatch spawn budget as it originally was
- fix the dispatcher so those two limits compose without double-counting already-running tasks
- clarify the CLI help text for `kanban dispatch --max` / `kanban daemon --max`

## Why this still matters
Current `main` already fixed the older "CLI falls back to unbounded dispatch when `--max` is omitted" problem.

What still remained was the limit interaction bug:
- when `max_in_progress` is set, the dispatcher rewrites `max_spawn` to the remaining live capacity
- the ready/review loops then compare `running_count + spawned >= max_spawn`
- that counts already-running tasks twice and can produce zero spawns even when capacity remains

Example reproduced locally before this refresh:
- 2 tasks already `running`
- `max_in_progress=4`
- `max_spawn=8`
- expected: spawn 2 more tasks
- previous behavior: spawn 0

This refresh keeps the newer split-cap design instead of collapsing the settings:
- `max_spawn` limits **new spawns this tick**
- `max_in_progress` limits **total running workers including existing ones**

## What changed
- `dispatch_once()` now computes a per-tick `spawn_budget` and caps it by remaining `max_in_progress` capacity when both settings are present
- ready and review dispatch both consume that same per-tick budget
- CLI help text now describes `--max` as a spawn-budget cap rather than a live worker cap
- regression tests now cover:
  - `max_spawn` limiting only new spawns
  - `max_spawn` + `max_in_progress` sharing remaining capacity without double-counting

## Validation
- `pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_cli.py`
  - 264 passed

## Notes
- kept the contributor attribution mapping commit because the branch still introduces `loicnico96@gmail.com` in rewritten history
- left the newer CLI passthrough / per-profile-cap work intact and rebased this fix around it instead of reviving the older `max_workers` collapse approach
