### PR TITLE
feat(gateway): add channel model bindings

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -868,6 +868,14 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "channel_model_bindings" in platform_cfg:
+                    channel_model_bindings = platform_cfg["channel_model_bindings"]
+                    if isinstance(channel_model_bindings, dict):
+                        bridged["channel_model_bindings"] = {
+                            str(k): v for k, v in channel_model_bindings.items()
+                        }
+                    else:
+                        bridged["channel_model_bindings"] = channel_model_bindings
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1187,6 +1187,11 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Per-channel model binding resolved by the platform adapter (e.g.
+    # platform channel_model_bindings). Applied as the default runtime for
+    # this session unless /model has set a session-scoped override.
+    channel_model_binding: Optional[dict[str, str]] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the
@@ -1443,6 +1448,60 @@ def resolve_channel_prompt(
         prompt = str(prompt).strip()
         if prompt:
             return prompt
+    return None
+
+
+def _coerce_channel_model_binding(value: Any) -> dict[str, str] | None:
+    """Normalize a channel model binding value from YAML/platform config."""
+    if isinstance(value, str):
+        model = value.strip()
+        return {"model": model} if model else None
+    if not isinstance(value, dict):
+        return None
+
+    allowed_keys = {"model", "provider", "base_url", "api_mode"}
+    binding: dict[str, str] = {}
+    for key in allowed_keys:
+        raw = value.get(key)
+        if raw is None:
+            continue
+        text = str(raw).strip()
+        if text:
+            binding[key] = text
+    return binding if binding.get("model") or binding.get("provider") else None
+
+
+def resolve_channel_model_binding(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> dict[str, str] | None:
+    """Resolve a per-channel model binding from platform config.
+
+    Looks up ``channel_model_bindings`` in the adapter's ``config.extra`` dict.
+    Prefers an exact match on *channel_id*; falls back to *parent_id* so
+    forum/thread/topic children inherit parent-channel defaults.
+
+    Supported config format::
+
+        channel_model_bindings:
+          "1234567890":
+            provider: openrouter
+            model: openrouter/auto
+          "9876543210": anthropic/claude-sonnet-4
+
+    Returns a normalized binding dict, or None if no usable binding exists.
+    """
+    bindings = config_extra.get("channel_model_bindings") or {}
+    if not isinstance(bindings, dict):
+        return None
+
+    for key in (channel_id, parent_id):
+        if not key:
+            continue
+        binding = _coerce_channel_model_binding(bindings.get(str(key)))
+        if binding:
+            return binding
     return None
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -23,6 +23,7 @@ from urllib.parse import urlsplit
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
+_MISSING = object()
 
 # Audio file extensions Hermes recognizes for native audio delivery.
 # Kept in sync with tools/send_message_tool.py and cron/scheduler.py via
@@ -1492,16 +1493,32 @@ def resolve_channel_model_binding(
 
     Returns a normalized binding dict, or None if no usable binding exists.
     """
-    bindings = config_extra.get("channel_model_bindings") or {}
+    bindings = config_extra.get("channel_model_bindings", _MISSING)
+    if bindings is _MISSING or bindings is None:
+        return None
     if not isinstance(bindings, dict):
+        logger.warning(
+            "Ignoring malformed channel_model_bindings config: expected mapping, got %s",
+            type(bindings).__name__,
+        )
         return None
 
     for key in (channel_id, parent_id):
         if not key:
             continue
-        binding = _coerce_channel_model_binding(bindings.get(str(key)))
+        binding_key = str(key)
+        raw_binding = bindings.get(binding_key, _MISSING)
+        if raw_binding is _MISSING:
+            continue
+        binding = _coerce_channel_model_binding(raw_binding)
         if binding:
             return binding
+        logger.warning(
+            "Ignoring malformed channel_model_bindings entry for channel %s: "
+            "expected non-empty model string or mapping with model/provider, got %s",
+            binding_key,
+            type(raw_binding).__name__,
+        )
     return None
 
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2189,10 +2189,19 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=thread_ts,
         )
 
-        # Per-channel ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt, resolve_channel_skills
+        # Per-channel ephemeral prompt/model binding
+        from gateway.platforms.base import (
+            resolve_channel_model_binding,
+            resolve_channel_prompt,
+            resolve_channel_skills,
+        )
         _channel_prompt = resolve_channel_prompt(
             self.config.extra, channel_id, None,
+        )
+        _channel_model_binding = resolve_channel_model_binding(
+            self.config.extra,
+            thread_ts or channel_id,
+            channel_id if thread_ts else None,
         )
         _auto_skill = resolve_channel_skills(
             self.config.extra, channel_id, None,
@@ -2224,6 +2233,7 @@ class SlackAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=thread_ts if thread_ts != ts else None,
             channel_prompt=_channel_prompt,
+            channel_model_binding=_channel_model_binding,
             reply_to_text=reply_to_text,
             auto_skill=_auto_skill,
         )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5758,10 +5758,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     or None
                 )
 
-        # Per-channel/topic ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt
+        # Per-channel/topic ephemeral prompt/model binding
+        from gateway.platforms.base import resolve_channel_model_binding, resolve_channel_prompt
         _chat_id_str = str(chat.id)
         _channel_prompt = resolve_channel_prompt(
+            self.config.extra,
+            thread_id_str or _chat_id_str,
+            _chat_id_str if thread_id_str else None,
+        )
+        _channel_model_binding = resolve_channel_model_binding(
             self.config.extra,
             thread_id_str or _chat_id_str,
             _chat_id_str if thread_id_str else None,
@@ -5778,6 +5783,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            channel_model_binding=_channel_model_binding,
             timestamp=message.date,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1036,6 +1036,7 @@ from gateway.platforms.base import (
     MessageType,
     _reply_anchor_for_event,
     merge_pending_message_event,
+    resolve_channel_model_binding,
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -1098,6 +1099,11 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
+    return _runtime_to_agent_kwargs(runtime)
+
+
+def _runtime_to_agent_kwargs(runtime: dict) -> dict:
+    """Convert a resolved runtime-provider bundle into AIAgent kwargs."""
     return {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
@@ -1107,6 +1113,40 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+
+
+def _resolve_channel_binding_runtime_kwargs(binding: dict[str, str]) -> dict:
+    """Resolve runtime credentials for a channel model binding's provider.
+
+    Unlike the global runtime resolver, an explicit channel provider should not
+    silently fall back to another provider when credentials are missing — that
+    would make the binding appear to work while using the wrong backend.
+    """
+    provider = (binding.get("provider") or "").strip()
+    base_url = (binding.get("base_url") or "").strip() or None
+    target_model = (binding.get("model") or "").strip() or None
+    if not provider:
+        return {}
+
+    from hermes_cli.runtime_provider import (
+        resolve_runtime_provider,
+        format_runtime_provider_error,
+    )
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=provider,
+            explicit_base_url=base_url,
+            target_model=target_model,
+        )
+    except Exception as exc:
+        raise RuntimeError(format_runtime_provider_error(exc)) from exc
+
+    kwargs = _runtime_to_agent_kwargs(runtime)
+    runtime_model = runtime.get("model")
+    if runtime_model:
+        kwargs["model"] = runtime_model
+    return kwargs
 
 
 def _try_resolve_fallback_provider() -> dict | None:
@@ -2348,14 +2388,45 @@ class GatewayRunner:
                 return None
         return None
 
+    def _resolve_source_channel_model_binding(
+        self,
+        source: Optional[SessionSource],
+    ) -> dict[str, str] | None:
+        """Best-effort channel binding lookup for synthetic platform events.
+
+        Normal adapter events carry the resolved binding on ``MessageEvent``.
+        Synthetic events such as goal continuations may only have a
+        ``SessionSource``; look up the same config here so durable channel
+        bindings still apply.
+        """
+        if not source or not source.platform:
+            return None
+        adapter = getattr(self, "adapters", {}).get(source.platform)
+        extra = getattr(getattr(adapter, "config", None), "extra", None)
+        if not isinstance(extra, dict):
+            return None
+        channel_id = str(source.thread_id or source.chat_id or "")
+        parent_id = str(source.parent_chat_id or "") or None
+        if not parent_id and source.thread_id and source.chat_id:
+            chat_id = str(source.chat_id)
+            if chat_id and chat_id != channel_id:
+                parent_id = chat_id
+        if not channel_id:
+            return None
+        return resolve_channel_model_binding(extra, channel_id, parent_id)
+
     def _resolve_session_agent_runtime(
         self,
         *,
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
         user_config: Optional[dict] = None,
+        channel_model_binding: Optional[dict[str, str]] = None,
     ) -> tuple[str, dict]:
-        """Resolve model/runtime for a session, honoring session-scoped /model overrides.
+        """Resolve model/runtime for a session.
+
+        Precedence is: explicit session-scoped ``/model`` override, then an
+        event's channel model binding, then gateway/global defaults.
 
         If the session override already contains a complete provider bundle
         (provider/api_key/base_url/api_mode), prefer it directly instead of
@@ -2398,7 +2469,17 @@ class GatewayRunner:
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        channel_binding = channel_model_binding if isinstance(channel_model_binding, dict) else None
+        if channel_binding is None:
+            channel_binding = self._resolve_source_channel_model_binding(source)
+        channel_provider = (channel_binding.get("provider") or "").strip() if channel_binding else ""
+        binding_runtime = None
+
+        if channel_binding and channel_provider and not override:
+            binding_runtime = _resolve_channel_binding_runtime_kwargs(channel_binding)
+            runtime_kwargs = binding_runtime
+        else:
+            runtime_kwargs = _resolve_runtime_agent_kwargs()
         runtime_model = runtime_kwargs.pop("model", None)
         if runtime_model:
             logger.info(
@@ -2407,6 +2488,40 @@ class GatewayRunner:
                 runtime_model,
             )
             model = runtime_model
+
+        if channel_binding and not override:
+            binding_runtime_model = str(runtime_model).strip() if runtime_model else ""
+            if not channel_provider:
+                binding_runtime = _resolve_channel_binding_runtime_kwargs(channel_binding)
+                if binding_runtime:
+                    runtime_kwargs = binding_runtime
+                    binding_runtime_model = str(runtime_kwargs.pop("model", None) or "").strip()
+            binding_model = (channel_binding.get("model") or "").strip()
+            if not binding_model and binding_runtime_model:
+                binding_model = str(binding_runtime_model).strip()
+            if not binding_model and (channel_binding.get("provider") or "").strip():
+                try:
+                    from hermes_cli.models import get_default_model_for_provider
+
+                    binding_model = get_default_model_for_provider(
+                        (channel_binding.get("provider") or "").strip()
+                    ) or ""
+                except Exception:
+                    binding_model = ""
+            if binding_model:
+                logger.info(
+                    "Channel model binding applied: session=%s %s -> %s provider=%s",
+                    resolved_session_key or "",
+                    model,
+                    binding_model,
+                    channel_binding.get("provider") or runtime_kwargs.get("provider"),
+                )
+                model = binding_model
+            for key in ("provider", "base_url", "api_mode"):
+                val = (channel_binding.get(key) or "").strip()
+                if val:
+                    runtime_kwargs[key] = val
+
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
@@ -7106,6 +7221,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_model_binding=event.channel_model_binding,
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
@@ -7133,6 +7249,7 @@ class GatewayRunner:
                             source=event.source,
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
+                            channel_model_binding=event.channel_model_binding,
                         )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
@@ -7155,6 +7272,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_model_binding=event.channel_model_binding,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
@@ -8420,6 +8538,7 @@ class GatewayRunner:
                         source=source,
                         session_key=session_key,
                         user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
+                        channel_model_binding=event.channel_model_binding,
                     )
                     _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
                     _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
@@ -8523,6 +8642,7 @@ class GatewayRunner:
                             source=source,
                             session_key=session_key,
                             user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
+                            channel_model_binding=event.channel_model_binding,
                         )
                         if _hyg_runtime.get("api_key"):
                             _hyg_msgs = [
@@ -8748,6 +8868,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                channel_model_binding=event.channel_model_binding,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -10230,6 +10351,11 @@ class GatewayRunner:
             current_provider = override.get("provider", current_provider)
             current_base_url = override.get("base_url", current_base_url)
             current_api_key = override.get("api_key", current_api_key)
+        elif isinstance(getattr(event, "channel_model_binding", None), dict):
+            channel_binding = event.channel_model_binding or {}
+            current_model = channel_binding.get("model") or current_model
+            current_provider = channel_binding.get("provider") or current_provider
+            current_base_url = channel_binding.get("base_url") or current_base_url
 
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
@@ -10692,6 +10818,7 @@ class GatewayRunner:
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
+            channel_model_binding=event.channel_model_binding,
         )
         
         # Let the normal message handler process it
@@ -10813,6 +10940,7 @@ class GatewayRunner:
                     source=event.source,
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
+                    channel_model_binding=event.channel_model_binding,
                 )
                 self._enqueue_fifo(_quick_key, kickoff_event, adapter)
             except Exception as exc:
@@ -15804,6 +15932,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        channel_model_binding: Optional[dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -16522,6 +16651,7 @@ class GatewayRunner:
                     source=source,
                     session_key=session_key,
                     user_config=user_config,
+                    channel_model_binding=channel_model_binding,
                 )
                 logger.debug(
                     "run_agent resolved: model=%s provider=%s session=%s",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1472,6 +1472,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "channel_model_bindings": {},  # Per-channel model/provider bindings
     },
 
     # Discord platform settings (gateway mode)
@@ -1485,6 +1486,7 @@ DEFAULT_CONFIG = {
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        "channel_model_bindings": {},  # Per-channel model/provider bindings (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require
         # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also
@@ -1525,6 +1527,7 @@ DEFAULT_CONFIG = {
     "telegram": {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+        "channel_model_bindings": {},  # Per-chat/topic model/provider bindings (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
     },
 
@@ -1534,6 +1537,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "channel_model_bindings": {},  # Per-channel model/provider bindings
     },
 
     # Matrix platform settings (gateway mode)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3506,6 +3506,7 @@ class DiscordAdapter(BasePlatformAdapter):
             source=source,
             raw_message=interaction,
             channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
+            channel_model_binding=self._resolve_channel_model_binding(channel_id, parent_id or None),
         )
 
     # ------------------------------------------------------------------
@@ -3583,6 +3584,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
+        _channel_model_binding = self._resolve_channel_model_binding(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
@@ -3590,6 +3592,7 @@ class DiscordAdapter(BasePlatformAdapter):
             raw_message=interaction,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_model_binding=_channel_model_binding,
         )
         await self.handle_message(event)
 
@@ -3609,6 +3612,15 @@ class DiscordAdapter(BasePlatformAdapter):
         """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
+    def _resolve_channel_model_binding(
+        self,
+        channel_id: str,
+        parent_id: str | None = None,
+    ) -> dict[str, str] | None:
+        """Resolve a Discord per-channel model binding, exact channel before parent."""
+        from gateway.platforms.base import resolve_channel_model_binding
+        return resolve_channel_model_binding(self.config.extra, channel_id, parent_id)
 
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""
@@ -4837,6 +4849,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
+        _channel_model_binding = self._resolve_channel_model_binding(_chan_id, _parent_id or None)
 
         reply_to_id = None
         reply_to_text = None
@@ -4858,6 +4871,7 @@ class DiscordAdapter(BasePlatformAdapter):
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_model_binding=_channel_model_binding,
             channel_context=_channel_context,
         )
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -851,10 +851,15 @@ class MattermostAdapter(BasePlatformAdapter):
             thread_id=thread_id,
         )
 
-        # Per-channel ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt
+        # Per-channel ephemeral prompt/model binding
+        from gateway.platforms.base import resolve_channel_model_binding, resolve_channel_prompt
         _channel_prompt = resolve_channel_prompt(
             self.config.extra, channel_id, None,
+        )
+        _channel_model_binding = resolve_channel_model_binding(
+            self.config.extra,
+            thread_id or channel_id,
+            channel_id if thread_id else None,
         )
 
         msg_event = MessageEvent(
@@ -866,6 +871,7 @@ class MattermostAdapter(BasePlatformAdapter):
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
             channel_prompt=_channel_prompt,
+            channel_model_binding=_channel_model_binding,
         )
 
         await self.handle_message(msg_event)

--- a/tests/gateway/test_channel_model_bindings.py
+++ b/tests/gateway/test_channel_model_bindings.py
@@ -1,5 +1,6 @@
 """Tests for channel_model_bindings resolution and runtime application."""
 
+import logging
 import sys
 import types
 from types import SimpleNamespace
@@ -105,11 +106,28 @@ class TestResolveChannelModelBindings:
         adapter.config.extra = {"channel_model_bindings": {"100": "openrouter/auto"}}
         assert adapter._resolve_channel_model_binding("100") == {"model": "openrouter/auto"}
 
-    def test_blank_or_invalid_bindings_are_ignored(self):
+    def test_malformed_bindings_root_warns_and_is_ignored(self, caplog):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_model_bindings": ["bad"]}
+
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.base"):
+            assert adapter._resolve_channel_model_binding("100") is None
+
+        assert "Ignoring malformed channel_model_bindings config" in caplog.text
+        assert "expected mapping, got list" in caplog.text
+
+    def test_blank_or_invalid_bindings_warn_and_are_ignored(self, caplog):
         adapter = _make_adapter()
         adapter.config.extra = {"channel_model_bindings": {"100": "   ", "200": ["bad"]}}
-        assert adapter._resolve_channel_model_binding("100") is None
-        assert adapter._resolve_channel_model_binding("200") is None
+
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.base"):
+            assert adapter._resolve_channel_model_binding("100") is None
+            assert adapter._resolve_channel_model_binding("200") is None
+
+        assert "Ignoring malformed channel_model_bindings entry for channel 100" in caplog.text
+        assert "got str" in caplog.text
+        assert "Ignoring malformed channel_model_bindings entry for channel 200" in caplog.text
+        assert "got list" in caplog.text
 
     def test_build_slash_event_sets_channel_model_binding(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_channel_model_bindings.py
+++ b/tests/gateway/test_channel_model_bindings.py
@@ -1,0 +1,553 @@
+"""Tests for channel_model_bindings resolution and runtime application."""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    discord_mod = types.ModuleType("discord")
+    setattr(discord_mod, "Intents", MagicMock())
+    getattr(discord_mod, "Intents").default.return_value = MagicMock()
+    setattr(discord_mod, "DMChannel", type("DMChannel", (), {}))
+    setattr(discord_mod, "Thread", type("Thread", (), {}))
+    setattr(discord_mod, "ForumChannel", type("ForumChannel", (), {}))
+    setattr(discord_mod, "Interaction", object)
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+def _make_adapter():
+    _ensure_discord_mock()
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    return adapter
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="12345",
+        chat_type="thread",
+        user_id="user-1",
+    )
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._session_key_for_source = lambda source: "agent:main:discord:thread:12345"
+    return runner
+
+
+class TestResolveChannelModelBindings:
+    def test_no_bindings_returns_none(self):
+        adapter = _make_adapter()
+        assert adapter._resolve_channel_model_binding("123") is None
+
+    def test_match_by_channel_id_with_provider_and_model(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_model_bindings": {
+                "100": {"provider": "openrouter", "model": "openrouter/auto"}
+            }
+        }
+        assert adapter._resolve_channel_model_binding("100") == {
+            "provider": "openrouter",
+            "model": "openrouter/auto",
+        }
+
+    def test_match_by_parent_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_model_bindings": {
+                "200": {"provider": "anthropic", "model": "claude-sonnet-4-6"}
+            }
+        }
+        assert adapter._resolve_channel_model_binding("999", parent_id="200") == {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+        }
+
+    def test_exact_channel_overrides_parent(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_model_bindings": {
+                "999": {"provider": "openrouter", "model": "openrouter/auto"},
+                "200": {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+            }
+        }
+        assert adapter._resolve_channel_model_binding("999", parent_id="200") == {
+            "provider": "openrouter",
+            "model": "openrouter/auto",
+        }
+
+    def test_string_value_is_model_shorthand(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_model_bindings": {"100": "openrouter/auto"}}
+        assert adapter._resolve_channel_model_binding("100") == {"model": "openrouter/auto"}
+
+    def test_blank_or_invalid_bindings_are_ignored(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_model_bindings": {"100": "   ", "200": ["bad"]}}
+        assert adapter._resolve_channel_model_binding("100") is None
+        assert adapter._resolve_channel_model_binding("200") is None
+
+    def test_build_slash_event_sets_channel_model_binding(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_model_bindings": {
+                "321": {"provider": "openrouter", "model": "openrouter/auto"}
+            }
+        }
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+
+        event = adapter._build_slash_event(interaction, "/model")
+
+        assert event.channel_model_binding == {
+            "provider": "openrouter",
+            "model": "openrouter/auto",
+        }
+
+    @pytest.mark.asyncio
+    async def test_dispatch_thread_session_inherits_parent_channel_model_binding(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_model_bindings": {
+                "200": {"provider": "openrouter", "model": "openrouter/auto"}
+            }
+        }
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter._get_effective_topic = MagicMock(return_value=None)
+        adapter.handle_message = AsyncMock()
+
+        interaction = SimpleNamespace(
+            guild=SimpleNamespace(name="Wetlands"),
+            channel=SimpleNamespace(id=200, parent=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+
+        await adapter._dispatch_thread_session(interaction, "999", "new-thread", "hello")
+
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        assert dispatched_event.channel_model_binding == {
+            "provider": "openrouter",
+            "model": "openrouter/auto",
+        }
+
+
+def test_config_bridges_discord_channel_model_bindings(monkeypatch, tmp_path):
+    import yaml
+    from gateway.config import load_gateway_config
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "discord": {
+                    "enabled": True,
+                    "channel_model_bindings": {
+                        1234567890: {
+                            "provider": "openrouter",
+                            "model": "openrouter/auto",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = load_gateway_config()
+
+    discord_extra = config.platforms[Platform.DISCORD].extra
+    assert discord_extra["channel_model_bindings"] == {
+        "1234567890": {"provider": "openrouter", "model": "openrouter/auto"}
+    }
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "platform"),
+    [
+        ("slack", Platform.SLACK),
+        ("telegram", Platform.TELEGRAM),
+        ("mattermost", Platform.MATTERMOST),
+    ],
+)
+def test_config_bridges_channel_model_bindings_for_channel_platforms(
+    platform_name, platform, monkeypatch, tmp_path
+):
+    import yaml
+    from gateway.config import load_gateway_config
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                platform_name: {
+                    "enabled": True,
+                    "channel_model_bindings": {
+                        "channel-1": {
+                            "provider": "openrouter",
+                            "model": "openrouter/auto",
+                        },
+                        "channel-2": "anthropic/claude-sonnet-4",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = load_gateway_config()
+
+    assert config.platforms[platform].extra["channel_model_bindings"] == {
+        "channel-1": {"provider": "openrouter", "model": "openrouter/auto"},
+        "channel-2": "anthropic/claude-sonnet-4",
+    }
+
+
+def test_channel_model_binding_applies_provider_and_model(monkeypatch):
+    runner = _make_runner()
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "global-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_channel_binding_runtime_kwargs",
+        lambda binding: {
+            "provider": binding["provider"],
+            "api_key": "channel-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=_make_source(),
+        session_key="agent:main:discord:thread:12345",
+        user_config={},
+        channel_model_binding={"provider": "openrouter", "model": "openrouter/auto"},
+    )
+
+    assert model == "openrouter/auto"
+    assert runtime["provider"] == "openrouter"
+    assert runtime["api_key"] == "channel-key"
+    assert runtime["base_url"] == "https://openrouter.ai/api/v1"
+
+
+def test_channel_provider_binding_uses_runtime_default_model(monkeypatch):
+    runner = _make_runner()
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: pytest.fail("global runtime should not resolve before a provider-bound channel"),
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_channel_binding_runtime_kwargs",
+        lambda binding: {
+            "provider": binding["provider"],
+            "api_key": "custom-key",
+            "base_url": "https://example.test/v1",
+            "api_mode": "chat_completions",
+            "model": "custom-default-model",
+        },
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=_make_source(),
+        session_key="agent:main:discord:thread:12345",
+        user_config={},
+        channel_model_binding={"provider": "custom:test"},
+    )
+
+    assert model == "custom-default-model"
+    assert runtime["provider"] == "custom:test"
+    assert "model" not in runtime
+
+
+def test_channel_binding_runtime_resolution_uses_bound_model(monkeypatch):
+    seen = {}
+
+    def fake_resolve_runtime_provider(**kwargs):
+        seen.update(kwargs)
+        return {
+            "provider": kwargs["requested"],
+            "api_key": "channel-key",
+            "base_url": kwargs["explicit_base_url"],
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        SimpleNamespace(
+            resolve_runtime_provider=fake_resolve_runtime_provider,
+            format_runtime_provider_error=lambda exc: str(exc),
+        ),
+    )
+
+    runtime = gateway_run._resolve_channel_binding_runtime_kwargs(
+        {
+            "provider": "opencode-zen",
+            "model": "anthropic/claude-sonnet-4",
+            "base_url": "https://opencode.ai/zen",
+        }
+    )
+
+    assert seen == {
+        "requested": "opencode-zen",
+        "explicit_base_url": "https://opencode.ai/zen",
+        "target_model": "anthropic/claude-sonnet-4",
+    }
+    assert runtime["provider"] == "opencode-zen"
+
+
+def test_channel_binding_runtime_resolution_preserves_provider_default_model(monkeypatch):
+    def fake_resolve_runtime_provider(**kwargs):
+        assert kwargs == {
+            "requested": "custom:test",
+            "explicit_base_url": None,
+            "target_model": None,
+        }
+        return {
+            "provider": "custom:test",
+            "api_key": "channel-key",
+            "base_url": "https://example.test/v1",
+            "api_mode": "chat_completions",
+            "model": "custom-default-model",
+        }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        SimpleNamespace(
+            resolve_runtime_provider=fake_resolve_runtime_provider,
+            format_runtime_provider_error=lambda exc: str(exc),
+        ),
+    )
+
+    runtime = gateway_run._resolve_channel_binding_runtime_kwargs({"provider": "custom:test"})
+
+    assert runtime["provider"] == "custom:test"
+    assert runtime["model"] == "custom-default-model"
+
+
+def test_synthetic_event_source_can_resolve_channel_binding(monkeypatch):
+    runner = _make_runner()
+    runner.adapters = {  # type: ignore[assignment]
+        Platform.DISCORD: SimpleNamespace(
+            config=SimpleNamespace(
+                extra={
+                    "channel_model_bindings": {
+                        "parent-1": {"provider": "openrouter", "model": "openrouter/auto"}
+                    }
+                }
+            )
+        )
+    }
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="thread-1",
+        chat_type="thread",
+        thread_id="thread-1",
+        parent_chat_id="parent-1",
+        user_id="user-1",
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "global-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_channel_binding_runtime_kwargs",
+        lambda binding: {
+            "provider": binding["provider"],
+            "api_key": "channel-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source,
+        session_key="agent:main:discord:thread:thread-1",
+        user_config={},
+        channel_model_binding=None,
+    )
+
+    assert model == "openrouter/auto"
+    assert runtime["provider"] == "openrouter"
+
+
+@pytest.mark.parametrize("platform", [Platform.SLACK, Platform.TELEGRAM, Platform.MATTERMOST])
+def test_synthetic_event_source_resolves_non_discord_channel_binding(platform, monkeypatch):
+    runner = _make_runner()
+    setattr(
+        runner,
+        "adapters",
+        {
+            platform: SimpleNamespace(
+                config=SimpleNamespace(
+                    extra={
+                        "channel_model_bindings": {
+                            "parent-channel": {
+                                "provider": "openrouter",
+                                "model": "openrouter/auto",
+                            }
+                        }
+                    }
+                )
+            )
+        },
+    )
+    source = SessionSource(
+        platform=platform,
+        chat_id="parent-channel",
+        chat_type="thread",
+        thread_id="thread-1",
+        user_id="user-1",
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "global-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_channel_binding_runtime_kwargs",
+        lambda binding: {
+            "provider": binding["provider"],
+            "api_key": "channel-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source,
+        session_key=f"agent:main:{platform.value}:thread:thread-1",
+        user_config={},
+        channel_model_binding=None,
+    )
+
+    assert model == "openrouter/auto"
+    assert runtime["provider"] == "openrouter"
+
+
+def test_session_model_override_wins_over_channel_binding(monkeypatch):
+    runner = _make_runner()
+    session_key = "agent:main:discord:thread:12345"
+    runner._session_model_overrides[session_key] = {
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "chat_completions",
+    }
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_key": "global-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_channel_binding_runtime_kwargs",
+        lambda binding: pytest.fail("channel binding should not be resolved when /model override exists"),
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=_make_source(),
+        session_key=session_key,
+        user_config={},
+        channel_model_binding={"provider": "openrouter", "model": "openrouter/auto"},
+    )
+
+    assert model == "claude-sonnet-4-6"
+    assert runtime["provider"] == "anthropic"
+    assert runtime["base_url"] == "https://api.anthropic.com"
+
+
+@pytest.mark.asyncio
+async def test_retry_preserves_channel_model_binding(monkeypatch):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_key_for_source = lambda source: "agent:main:discord:thread:12345"
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1", last_prompt_tokens=10),
+        load_transcript=lambda session_id: [
+            {"role": "user", "content": "original message"},
+            {"role": "assistant", "content": "old reply"},
+        ],
+        rewrite_transcript=MagicMock(),
+    )
+    runner._handle_message = AsyncMock(return_value="ok")
+
+    event = MessageEvent(
+        text="/retry",
+        message_type=gateway_run.MessageType.COMMAND,
+        source=_make_source(),
+        raw_message=SimpleNamespace(),
+        channel_model_binding={"provider": "openrouter", "model": "openrouter/auto"},
+    )
+
+    result = await runner._handle_retry_command(event)
+
+    assert result == "ok"
+    retried_event = runner._handle_message.await_args.args[0]
+    assert retried_event.channel_model_binding == {
+        "provider": "openrouter",
+        "model": "openrouter/auto",
+    }

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -316,6 +316,7 @@ discord:
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
   channel_prompts: {}             # Per-channel ephemeral system prompts
+  channel_model_bindings: {}      # Per-channel model/provider bindings
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
     everyone: false               # @everyone / @here pings (default: false)
     roles: false                  # @role pings (default: false)
@@ -442,6 +443,35 @@ Behavior:
 - Exact thread/channel ID matches win.
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
+
+#### `discord.channel_model_bindings`
+
+**Type:** mapping — **Default:** `{}`
+
+Per-channel model/provider bindings that choose the default model runtime for matching Discord channels or threads. This same `channel_model_bindings` shape is also supported by Slack, Telegram, and Mattermost. This is durable config: unlike `/model`, it survives `/reset` and gateway restarts. An explicit session-scoped `/model` switch still takes precedence until that session is reset.
+
+```yaml
+discord:
+  channel_model_bindings:
+    "1234567890":
+      provider: openrouter
+      model: openrouter/auto
+    "9876543210":
+      provider: anthropic
+      model: claude-sonnet-4-6
+    "5555555555": openrouter/auto  # shorthand for model-only binding
+```
+
+Supported fields:
+- `model`: model ID passed to the provider.
+- `provider`: provider slug (for example `openrouter`, `anthropic`, `openai-codex`, or `custom:<name>`). Credentials are resolved through the normal Hermes auth/env/config paths; do not put API keys here.
+- `base_url`: optional provider base URL override.
+- `api_mode`: optional API mode override.
+
+Behavior:
+- Exact thread/channel ID matches win.
+- If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
+- Session-scoped `/model` overrides win over channel bindings. `/new`, `/reset`, auto-reset, or gateway restart clears the session override, revealing the channel binding again.
 
 #### `discord.history_backfill`
 

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -325,6 +325,24 @@ mattermost:
 
 Keys are Mattermost channel IDs (find them in the channel URL or via the API). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
 
+## Per-Channel Model Bindings
+
+Set durable default models/providers for specific Mattermost channels or threads. `/model` still wins for the current session; `/new`, `/reset`, auto-reset, or gateway restart clears that session override and reveals the channel binding again.
+
+```yaml
+mattermost:
+  channel_model_bindings:
+    "channel_id_abc123":
+      provider: openrouter
+      model: openrouter/auto
+    "channel_id_def456":
+      provider: anthropic
+      model: claude-sonnet-4-6
+    "channel_id_casual": openrouter/auto  # shorthand for model-only binding
+```
+
+Supported fields: `model`, `provider`, `base_url`, and `api_mode`. If only `provider` is set, Hermes uses that provider runtime's configured/default model. Thread-specific keys are checked first; otherwise Mattermost threads inherit their parent channel's binding.
+
 ## Security
 
 :::warning

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -565,6 +565,24 @@ slack:
 
 Keys are Slack channel IDs (find them via channel details → "About" → scroll to bottom). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
 
+## Per-Channel Model Bindings
+
+Set durable default models/providers for specific Slack channels or threads. `/model` still wins for the current session; `/new`, `/reset`, auto-reset, or gateway restart clears that session override and reveals the channel binding again.
+
+```yaml
+slack:
+  channel_model_bindings:
+    "C01RESEARCH":
+      provider: openrouter
+      model: openrouter/auto
+    "C02ENGINEERING":
+      provider: anthropic
+      model: claude-sonnet-4-6
+    "C03CASUAL": openrouter/auto  # shorthand for model-only binding
+```
+
+Supported fields: `model`, `provider`, `base_url`, and `api_mode`. If only `provider` is set, Hermes uses that provider runtime's configured/default model. Thread-specific keys are checked first; otherwise Slack threads inherit their parent channel's binding.
+
 ## Per-Channel Skill Bindings
 
 Auto-load a skill whenever a new session starts in a specific channel or DM. Unlike per-channel prompts (which are injected on every turn), skill bindings inject the skill content as a user message at **session start** — it becomes part of the conversation history and does not need to be reloaded on subsequent turns.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1174,6 +1174,24 @@ Keys are chat IDs (groups/supergroups) or forum topic IDs. For forum groups, top
 
 Numeric YAML keys are automatically normalized to strings.
 
+## Per-Channel Model Bindings
+
+Set durable default models/providers for specific Telegram groups or forum topics. `/model` still wins for the current session; `/new`, `/reset`, auto-reset, or gateway restart clears that session override and reveals the channel binding again.
+
+```yaml
+telegram:
+  channel_model_bindings:
+    "-1001234567890":
+      provider: openrouter
+      model: openrouter/auto
+    "42":
+      provider: anthropic
+      model: claude-sonnet-4-6
+    "99": openrouter/auto  # shorthand for model-only binding
+```
+
+Keys are chat IDs or forum topic IDs, matching `channel_prompts`. Topic-specific bindings win; topics without an explicit entry inherit the parent group binding. Supported fields: `model`, `provider`, `base_url`, and `api_mode`. If only `provider` is set, Hermes uses that provider runtime's configured/default model.
+
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
## Summary
- Adds durable `channel_model_bindings` config for per-channel/thread/topic model and provider defaults.
- Supports Discord, Slack, Telegram, and Mattermost, matching the existing per-channel prompt/binding surfaces on those platforms.
- Resolves exact thread/topic/channel bindings first, then parent bindings for child threads/topics.
- Keeps `/model` session overrides higher priority than channel bindings.
- Propagates bindings through adapter events plus queued/retry/synthetic `SessionSource` paths so runtime selection does not get lost.
- Documents the config shape and adds gateway regression coverage.
- Warns on malformed `channel_model_bindings` config so typos do not silently fall back to the global model.

## Why
Messaging deployments commonly use different channels for different work. A single global model forces users to overpay for casual channels or manually run `/model` in every new thread/topic. This PR makes channel defaults durable in config while preserving explicit per-session `/model` intent.

## Config example
```yaml
discord:
  channel_model_bindings:
    "1234567890":
      provider: openrouter
      model: openrouter/auto

slack:
  channel_model_bindings:
    "C01RESEARCH":
      provider: anthropic
      model: claude-sonnet-4-6

telegram:
  channel_model_bindings:
    "-1001234567890": openrouter/auto
    "42":
      provider: openrouter
      model: openrouter/auto

mattermost:
  channel_model_bindings:
    "channel_id_abc123":
      provider: anthropic
      model: claude-sonnet-4-6
```

Supported fields are `model`, `provider`, `base_url`, and `api_mode`. If a binding only specifies `provider`, Hermes uses that provider runtime's configured/default model. If it specifies `model`, the explicit binding model wins over the provider default.

## Related issues / PRs
- Partially addresses #1955 and #21637.
- Follow-up to the closed duplicate proposal #17834.
- Compared with #1991: this keeps the scope to model/provider routing and avoids bundling system prompts into a broad new `channel_overrides` abstraction, because `channel_prompts` already exists.
- Compared with #21476: this supports provider-aware bindings, current bundled/plugin platform paths, non-Discord platforms, synthetic/retry source fallback, and docs/tests against the current gateway shape.
- Compared with #7737: this is a first-class config surface rather than attaching model selection to `channel_skill_bindings`, so it works for channels that do not bind skills.

## Testing
Platform tested: macOS 26.3.1.

- `scripts/run_tests.sh tests/gateway/test_channel_model_bindings.py`
- `scripts/run_tests.sh tests/gateway/test_channel_model_bindings.py tests/gateway/test_discord_channel_prompts.py tests/gateway/test_discord_channel_skills.py tests/gateway/test_discord_model_picker.py tests/gateway/test_discord_slash_commands.py tests/gateway/test_slack_channel_skills.py tests/gateway/test_config.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_mattermost.py`
- `python -m py_compile gateway/config.py gateway/platforms/base.py gateway/run.py hermes_cli/config.py plugins/platforms/discord/adapter.py gateway/platforms/slack.py gateway/platforms/telegram.py plugins/platforms/mattermost/adapter.py tests/gateway/test_channel_model_bindings.py`
- `python -m ruff check gateway/config.py gateway/platforms/base.py gateway/run.py hermes_cli/config.py plugins/platforms/discord/adapter.py gateway/platforms/slack.py gateway/platforms/telegram.py plugins/platforms/mattermost/adapter.py tests/gateway/test_channel_model_bindings.py`
- `python scripts/check-windows-footguns.py --diff origin/main`
- `git diff --check`

