### PR TITLE
fix(auth): expand ${VAR} references in .env before seeding credential pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1832,6 +1832,10 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     def _get_env_prefer_dotenv(key: str) -> str:
         env_file = load_env()
         val = env_file.get(key) or os.environ.get(key) or ""
+        # Expand ${VAR} / $VAR references so that .env entries like
+        # ANTHROPIC_API_KEY=${OPENAI_API_KEY} resolve to the actual value
+        # instead of seeding the literal "${OPENAI_API_KEY}" into the pool.
+        val = os.path.expandvars(val)
         return val.strip()
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -97,6 +97,44 @@ class TestCredentialPoolSeedsFromDotEnv:
             e.access_token == "sk-or-dotenv-abc" for e in entries
         )
 
+    def test_dotenv_var_reference_expansion(self, isolated_hermes_home, monkeypatch):
+        """${VAR} references in .env must be expanded before seeding the pool.
+
+        Regression test for #20310: .env with ANTHROPIC_API_KEY=${OPENAI_API_KEY}
+        was seeding the literal string "${OPENAI_API_KEY}" into the pool.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-expanded-real-key")
+        _write_env_file(isolated_hermes_home, ANTHROPIC_API_KEY="${OPENAI_API_KEY}")
+        assert "ANTHROPIC_API_KEY" not in os.environ
+
+        from agent.credential_pool import _seed_from_env
+        entries = []
+        changed, active_sources = _seed_from_env("anthropic", entries)
+
+        assert changed is True
+        assert "env:ANTHROPIC_API_KEY" in active_sources
+        assert any(
+            e.access_token == "sk-expanded-real-key"
+            and e.source == "env:ANTHROPIC_API_KEY"
+            for e in entries
+        ), f"Expected expanded key, got: {[(e.source, e.access_token) for e in entries]}"
+
+    def test_dotenv_unresolved_var_stays_literal(self, isolated_hermes_home):
+        """${VAR} referencing a nonexistent env var stays as-is (fail-open)."""
+        _write_env_file(isolated_hermes_home, DEEPSEEK_API_KEY="${NONEXISTENT_VAR_XYZ}")
+        assert "NONEXISTENT_VAR_XYZ" not in os.environ
+
+        from agent.credential_pool import _seed_from_env
+        entries = []
+        changed, active_sources = _seed_from_env("deepseek", entries)
+
+        assert changed is True
+        # os.path.expandvars leaves ${NONEXISTENT_VAR_XYZ} unchanged
+        assert any(
+            e.access_token == "${NONEXISTENT_VAR_XYZ}"
+            for e in entries
+        ), f"Expected literal unresolved var, got: {[(e.source, e.access_token) for e in entries]}"
+
     def test_empty_dotenv_no_entries(self, isolated_hermes_home):
         """No .env file, no env vars → no entries seeded (and no crash)."""
         from agent.credential_pool import _seed_from_env


### PR DESCRIPTION
## What does this PR do?

When `~/.hermes/.env` uses variable references like `ANTHROPIC_API_KEY=${OPENAI_API_KEY}`, the credential pool seeds the **literal string** `${OPENAI_API_KEY}` into `auth.json` instead of the expanded value. Auxiliary tasks (title generation, compression, etc.) then send that raw string as the `x-api-key` header, causing 401 errors.
### Root Cause

`_get_env_prefer_dotenv()` in `agent/credential_pool.py` calls `load_env()` which parses `.env` as raw `key=value` without shell-style variable interpolation. Since it prefers `.env` values over `os.environ`, the unexpanded `${VAR}` string wins over the correctly expanded value in the environment.

## Related Issue

Fixes #20310

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `_get_env_prefer_dotenv()` in `agent/credential_pool.py:1832` (callers: `_seed_from_env` → `load_pool`)
- Blast radius: LOW (single helper function, credential seeding only)
- Related patterns: `load_env()` in `hermes_cli/config.py:4609` (parses `.env` raw, no interpolation)