### PR TITLE
fix: apply root-level provider/base_url fallback in _get_model_config()

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -198,7 +198,15 @@ def _get_model_config() -> Dict[str, Any]:
                 cfg["default"] = detected
         return cfg
     if isinstance(model_cfg, str) and model_cfg.strip():
-        return {"default": model_cfg.strip()}
+        cfg = {"default": model_cfg.strip()}
+        # Mirror load_cli_config's root-level provider/base_url fallback
+        # so that users with legacy flat configs (model: <name> + provider: <name>)
+        # get consistent provider resolution across CLI and runtime paths.
+        if config.get("provider"):
+            cfg["provider"] = config["provider"]
+        if config.get("base_url"):
+            cfg["base_url"] = config["base_url"]
+        return cfg
     return {}
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2657,3 +2657,83 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+# ── _get_model_config root-level provider/base_url fallback ──────────
+
+
+def test_get_model_config_string_model_with_root_provider(monkeypatch):
+    """String model + root-level provider → provider injected into result."""
+    monkeypatch.setattr(
+        rp, "load_config",
+        lambda: {"model": "deepseek-v4-flash", "provider": "deepseek"},
+    )
+
+    cfg = rp._get_model_config()
+
+    assert cfg["default"] == "deepseek-v4-flash"
+    assert cfg["provider"] == "deepseek"
+
+
+def test_get_model_config_string_model_with_root_base_url(monkeypatch):
+    """String model + root-level base_url → base_url injected into result."""
+    monkeypatch.setattr(
+        rp, "load_config",
+        lambda: {
+            "model": "deepseek-v4-flash",
+            "base_url": "https://api.deepseek.com",
+        },
+    )
+
+    cfg = rp._get_model_config()
+
+    assert cfg["default"] == "deepseek-v4-flash"
+    assert cfg["base_url"] == "https://api.deepseek.com"
+
+
+def test_get_model_config_string_model_with_both_roots(monkeypatch):
+    """String model + both root-level keys → both injected."""
+    monkeypatch.setattr(
+        rp, "load_config",
+        lambda: {
+            "model": "deepseek-v4-flash",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com",
+        },
+    )
+
+    cfg = rp._get_model_config()
+
+    assert cfg["default"] == "deepseek-v4-flash"
+    assert cfg["provider"] == "deepseek"
+    assert cfg["base_url"] == "https://api.deepseek.com"
+
+
+def test_get_model_config_string_model_no_roots_is_unchanged(monkeypatch):
+    """String model without root-level keys — original behavior preserved."""
+    monkeypatch.setattr(
+        rp, "load_config",
+        lambda: {"model": "deepseek-v4-flash"},
+    )
+
+    cfg = rp._get_model_config()
+
+    assert cfg == {"default": "deepseek-v4-flash"}
+
+
+def test_get_model_config_dict_model_is_unchanged(monkeypatch):
+    """Dict model format — no change (dict path already has provider)."""
+    monkeypatch.setattr(
+        rp, "load_config",
+        lambda: {
+            "model": {
+                "default": "claude-sonnet-4-6",
+                "provider": "anthropic",
+            },
+            "provider": "deepseek",  # should NOT leak into dict model path
+        },
+    )
+
+    cfg = rp._get_model_config()
+
+    assert cfg["default"] == "claude-sonnet-4-6"
+    assert cfg["provider"] == "anthropic"  # from dict, not rootprovider/base_url fallback in _get_model_config())


### PR DESCRIPTION
## Problem

When a user's config.yaml uses the flat string format:

```yaml
model: deepseek-v4-flash
provider: deepseek
```

`load_cli_config()` in cli.py correctly reads the root-level `provider` and merges it into the model dict. However, `_get_model_config()` in `hermes_cli/runtime_provider.py` re-reads the raw config independently and returns only `{"default": model_name}` for string-format models, silently dropping the root-level provider and base_url.

## Impact

Five independent code paths call `_get_model_config()`:
- `resolve_requested_provider()` (line 362)
- `_resolve_runtime_from_pool_entry()` (line 229)
- `_resolve_openrouter_runtime()` (line 630)
- `resolve_runtime_provider()` main path (line 1115)
- Azure Foundry path (line 1094)

Downstream callers checking `model_cfg.get("provider")` receive None, triggering auto-detection which may route to the wrong provider (e.g. OpenRouter instead of DeepSeek), resulting in HTTP 401.

## Fix

Mirror `load_cli_config`'s root-level fallback inside `_get_model_config()`, reading `provider` and `base_url` from the raw config when model is a plain string.

## Tests

5 new tests added:
- String model + root provider → provider injected
- String model + root base_url → base_url injected
- String model + both root keys → both injected
- String model, no roots → no change (regression guard)
- Dict model format → no change (dict path not polluted by root keys)

All 115 tests in test_runtime_provider_resolution.py pass (110 existing + 5 new).