### PR TITLE
fix(stream): preserve thread routing on fallback + add timeout to Mattermost _api_put

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -800,6 +800,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
+                    reply_to=self._initial_reply_to_id,
                     metadata=self.metadata,
                 )
                 if result.success:

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -152,7 +152,8 @@ class MattermostAdapter(BasePlatformAdapter):
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.put(
-                url, headers=self._headers(), json=payload
+                url, headers=self._headers(), json=payload,
+                timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
                 if resp.status >= 400:
                     body = await resp.text()


### PR DESCRIPTION
## Summary

Two bug fixes that cause silent message loss in Mattermost threads.

### 1. `stream_consumer.py`: `_send_fallback_final()` drops `reply_to`

When a stream message overflows the platform limit and falls back to chunked sends, `_send_fallback_final()` calls `adapter.send()` **without** the `reply_to` parameter:

```python
# Current (broken):
result = await self.adapter.send(
    chat_id=self.chat_id,
    content=chunk,
    metadata=self.metadata,
)
```

This means fallback chunks go to the channel root instead of the thread, making them appear as standalone messages (or invisible on thread-only views). The fix adds `reply_to=self._initial_reply_to_id`, consistent with `_send_new_chunk()` which already passes `reply_to_id` correctly.

**Impact:** Thread conversations where long responses trigger overflow will have missing or misrouted messages.

### 2. `mattermost/adapter.py`: `_api_put()` missing timeout

`_api_get()` and `_api_post()` both set `timeout=aiohttp.ClientTimeout(total=30)`, but `_api_put()` has no timeout. When the HTTP connection pool is disrupted (e.g., WebSocket instability), the PUT request hangs indefinitely or throws `asyncio.TimeoutError` — whose `str()` returns an empty string `""`. This produces unhelpful log entries like:

```
Stream send/edit error: 
```

The fix adds the same 30s timeout to `_api_put()`.

**Impact:** Message edits silently hang or fail with no diagnostic information when the network is unstable.

## Testing

- Verified on local Mattermost instance with `mattermost-enhancer` plugin
- Fallback messages now correctly appear in threads
- `_api_put` timeout produces clear error messages: `"edit timeout (30s)"` instead of empty string
- Patch script `hermes-patches.sh` updated with both fixes for persistence across upgrades