### PR TITLE
fix(agent): read custom model.base_url/api_key in _resolve_auto cron path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3125,10 +3125,26 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None
-        if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
-            resolved_provider = "custom"
-            explicit_base_url = runtime_base_url
-            explicit_api_key = runtime_api_key or None
+        explicit_api_mode = runtime_api_mode or None
+        if main_provider == "custom" or main_provider.startswith("custom:"):
+            if runtime_base_url:
+                resolved_provider = "custom"
+                explicit_base_url = runtime_base_url
+                explicit_api_key = runtime_api_key or None
+            else:
+                # No session-level runtime override (cron jobs, gateway
+                # background tasks). Resolve ``model.base_url`` /
+                # ``model.api_key`` from config.yaml via the canonical
+                # custom-runtime helper so aux calls hit the user's
+                # configured endpoint instead of dropping to the Step-2
+                # fallback chain with the wrong credentials.
+                cfg_base, cfg_key, cfg_mode = _resolve_custom_runtime()
+                if cfg_base:
+                    resolved_provider = "custom"
+                    explicit_base_url = cfg_base
+                    explicit_api_key = cfg_key or None
+                    if cfg_mode and not explicit_api_mode:
+                        explicit_api_mode = cfg_mode
         elif runtime_api_key:
             # Pin auxiliary to the same api_key as the active main chat session
             # so that a working key is reused instead of re-selecting from the pool
@@ -3148,7 +3164,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
                 main_model,
                 explicit_base_url=explicit_base_url,
                 explicit_api_key=explicit_api_key,
-                api_mode=runtime_api_mode or None,
+                api_mode=explicit_api_mode,
             )
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -161,6 +161,118 @@ class TestResolveAutoMainFirst:
         assert mock_resolve.call_args.args[0] == "anthropic"
         assert mock_resolve.call_args.args[1] == "runtime-model"
 
+    def test_custom_provider_no_runtime_reads_config_base_url(self):
+        """Cron/background path: `custom` provider with no runtime override
+        must resolve ``model.base_url`` and ``model.api_key`` from config
+        via ``_resolve_custom_runtime`` instead of dropping them and
+        falling through to the Step-2 fallback chain (#33333).
+        """
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="custom",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="some-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            return_value=("https://endpoint.example.com/v1", "sk-cfg-key", None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve:
+            mock_client = MagicMock()
+            mock_resolve.return_value = (mock_client, "some-model")
+
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto()
+
+        assert client is mock_client
+        assert model == "some-model"
+        # Provider resolved to "custom"; base_url and api_key forwarded from config
+        assert mock_resolve.call_args.args[0] == "custom"
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://endpoint.example.com/v1"
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] == "sk-cfg-key"
+
+    def test_custom_provider_no_runtime_forwards_api_mode(self):
+        """When `_resolve_custom_runtime` reports an api_mode (e.g.
+        anthropic_messages for a Zhipu/MiniMax gateway), the cron-path
+        fallback must forward it to ``resolve_provider_client`` so the
+        Anthropic transport is selected.
+        """
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="custom",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="claude-sonnet-4",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            return_value=("https://gateway.example.com/anthropic", "sk-cfg", "anthropic_messages"),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve:
+            mock_resolve.return_value = (MagicMock(), "claude-sonnet-4")
+
+            from agent.auxiliary_client import _resolve_auto
+
+            _resolve_auto()
+
+        assert mock_resolve.call_args.kwargs["api_mode"] == "anthropic_messages"
+
+    def test_custom_provider_no_runtime_no_config_falls_to_chain(self):
+        """If no runtime override AND no config-level custom base_url, the
+        cron-path code MUST NOT pass an empty `custom` to
+        ``resolve_provider_client`` — it should leave Step-1 unsuccessful
+        and let the Step-2 fallback chain handle it.
+        """
+        chain_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="custom",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="some-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            return_value=(None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_openrouter",
+            return_value=(chain_client, "google/gemini-3-flash-preview"),
+        ):
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto()
+
+        assert client is chain_client
+
+    def test_custom_provider_with_runtime_override_unchanged(self):
+        """When a session-level runtime override is present, the existing
+        behavior must be preserved — runtime values win over the config
+        fallback path added for #33333.
+        """
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="custom",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="cfg-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+        ) as mock_cfg, patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve:
+            mock_resolve.return_value = (MagicMock(), "cfg-model")
+
+            from agent.auxiliary_client import _resolve_auto
+
+            _resolve_auto(main_runtime={
+                "provider": "custom",
+                "model": "cfg-model",
+                "base_url": "https://session-runtime.example.com/v1",
+                "api_key": "sk-session",
+                "api_mode": "",
+            })
+
+        # Runtime path used — config helper NOT consulted
+        mock_cfg.assert_not_called()
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://session-runtime.example.com/v1"
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] == "sk-session"
+
 
 # ── Vision — resolve_vision_provider_client ─────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

In `agent/auxiliary_client.py::_resolve_auto`, Step 1 gated the
`custom` / `custom:<name>` branch on `runtime_base_url` being truthy.
When no session-level runtime override is present — the steady state
for cron jobs and gateway background tasks (curator runs,
session_search indexing, title generation triggered by incoming
messages, etc.) — `explicit_base_url` and `explicit_api_key` stayed
`None`, so `resolve_provider_client(\"custom\", ..., explicit_base_url=None, explicit_api_key=None)`
failed to construct a client. Execution fell through to the Step-2
aggregator chain (OpenRouter → Nous → custom → Codex → API-key
providers), billing aux tasks against the wrong subscription or
401/403'ing outright when no aggregator credentials were configured.

The fix consults the existing `_resolve_custom_runtime()` helper —
the canonical config-then-env resolver that Step 2's
`_try_custom_endpoint()` already uses — to fill in `base_url` /
`api_key` / `api_mode` from `config.yaml > model.*` when
`runtime_base_url` is empty. Session-level runtime values still win
when present; non-custom providers are unaffected.

Mirrors Step 2's `_try_custom_endpoint` precedence: `runtime > cfg (_resolve_custom_runtime) > env`. The same canonical resolver `resolve_runtime_provider(requested=\"custom\")` is the source of truth in both steps now.

## Related Issue

Fixes #33333

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py` — `_resolve_auto` now consults `_resolve_custom_runtime()` for the custom-provider branch when `runtime_base_url` is empty; tracks `api_mode` in a local so the config-derived `anthropic_messages` / `codex_responses` value can be forwarded to `resolve_provider_client`.
- `tests/agent/test_auxiliary_main_first.py` — adds 4 regression tests for `_resolve_auto` covering the cron/background path: (a) config base_url/api_key are forwarded, (b) config-side `api_mode` is forwarded for Anthropic-compatible gateways, (c) no-config-and-no-runtime falls through to the chain, (d) runtime-override path still wins.

## How to Test

Reproduction (from issue body) — without the fix returns `(None, None)`; with the fix returns the custom client:
```python
from agent.auxiliary_client import _resolve_auto
client, model = _resolve_auto(main_runtime=None)
print(f\"client={client}, model={model}\")
```

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio \\
  python3 -m pytest tests/agent/test_auxiliary_main_first.py -v
```
Expected: 19 passed including 4 new \`test_custom_provider_no_runtime_*\` / \`test_custom_provider_with_runtime_override_unchanged\` cases.

Adjacent regression check:
```
uv run --with pytest --with pytest-xdist --with pytest-asyncio \\
  python3 -m pytest tests/agent/test_auxiliary_client.py \\
    tests/agent/test_auxiliary_named_custom_providers.py \\
    tests/agent/test_auxiliary_client_anthropic_custom.py \\
    tests/agent/test_auxiliary_client_azure_foundry.py \\
    tests/agent/test_auxiliary_config_bridge.py \\
    tests/agent/test_auxiliary_transport_autodetect.py \\
    tests/agent/test_minimax_auxiliary_url.py
```
Expected: 267 passed (no regressions in adjacent custom-provider / config-bridge / transport-autodetect / minimax suites).

Regression guard verified manually: stashing the production change makes the two new positive tests fail (`assert None == 'anthropic_messages'`, missing `explicit_base_url`); restoring the fix flips them green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — or N/A (inline comment explains the cron-path branch)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — or N/A (no new keys)
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

> Audited siblings: confirmed every \`_resolve_auto\` user goes through the same \`resolve_provider_client(resolved_provider, main_model, explicit_base_url=..., explicit_api_key=..., api_mode=...)\` call, so no other code path needs the cron-path widening. Vision-routing sibling \`resolve_vision_provider_client\` already calls \`_resolve_auto\` indirectly (it inherits the fix for free), and Step 2's \`_try_custom_endpoint\` already uses \`_resolve_custom_runtime()\` directly so no Step-2 change is needed. No widening needed.