### PR TITLE
feat(display): add display.show_quota_pct to surface quota % in the agent UI

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -999,6 +999,14 @@ display:
   #   false: Hide reasoning (default)
   show_reasoning: false
 
+  # Surface a compact quota-usage percentage line in /usage (peak rate-limit
+  # bucket, else account-usage percent). Degrades silently when the provider
+  # emits no rate-limit headers and no account-usage signal is available.
+  # Overridable per-platform via display.platforms.<platform>.show_quota_pct.
+  #   true:  Show "Quota used: N%"
+  #   false: Hide (default)
+  show_quota_pct: false
+
   # Stream tokens to the terminal as they arrive instead of waiting for the
   # full response. The response box opens on first token and text appears
   # line-by-line. Tool calls are still captured silently.

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,10 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "show_reasoning": False,
+    # When true, surface a compact quota-usage percentage line in the agent
+    # UI (e.g. /usage). Off by default. Degrades silently when the provider
+    # emits no rate-limit headers and no account-usage signal is available.
+    "show_quota_pct": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
     # Gateway-only assistant/status chatter controls. These default on for
@@ -224,6 +228,7 @@ def _normalise(setting: str, value: Any) -> Any:
         "interim_assistant_messages",
         "long_running_notifications",
         "busy_ack_detail",
+        "show_quota_pct",
     }:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1394,6 +1394,40 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _peak_quota_pct(rl_state, account_snapshot) -> "float | None":
+    """Return the most-constrained quota usage percentage, or None.
+
+    Reads existing precomputed signals only (display-layer feature — no
+    tracking changes):
+      * peak ``RateLimitBucket.usage_pct`` across rate-limit buckets, when the
+        provider emitted rate-limit headers (``rl_state.has_data``);
+      * else the max ``AccountUsageWindow.used_percent`` from the account-usage
+        snapshot, when available.
+
+    Returns None when there is no quota signal at all (e.g. a provider that
+    emits no rate-limit headers and exposes no account usage) so callers can
+    degrade gracefully without rendering a misleading 0%.
+    """
+    pct: float | None = None
+    if rl_state is not None and getattr(rl_state, "has_data", False):
+        for bucket in (
+            getattr(rl_state, "requests_min", None),
+            getattr(rl_state, "requests_hour", None),
+            getattr(rl_state, "tokens_min", None),
+            getattr(rl_state, "tokens_hour", None),
+        ):
+            if bucket is not None and getattr(bucket, "limit", 0) > 0:
+                bp = bucket.usage_pct
+                pct = bp if pct is None else max(pct, bp)
+    if pct is None and account_snapshot is not None:
+        windows = getattr(account_snapshot, "windows", None) or []
+        for window in windows:
+            up = getattr(window, "used_percent", None)
+            if up is not None:
+                pct = float(up) if pct is None else max(pct, float(up))
+    return pct
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -13120,6 +13154,7 @@ class GatewayRunner:
         # Fetch account usage off the event loop so slow provider APIs don't
         # block the gateway. Failures are non-fatal -- account_lines stays [].
         account_lines: list[str] = []
+        account_snapshot = None
         if provider:
             try:
                 account_snapshot = await asyncio.to_thread(
@@ -13142,6 +13177,20 @@ class GatewayRunner:
                 from agent.rate_limit_tracker import format_rate_limit_compact
                 lines.append(t("gateway.usage.rate_limits", state=format_rate_limit_compact(rl_state)))
                 lines.append("")
+
+            # Quota usage percentage (display.show_quota_pct) — opt-in compact
+            # surface of the most-constrained quota. Off by default; silently
+            # omitted when no quota signal exists (graceful degrade). Wrapped so
+            # a display-config quirk can never break the /usage response.
+            try:
+                from gateway.display_config import resolve_display_setting as _rds
+                if _rds(_load_gateway_config(), _platform_config_key(source.platform), "show_quota_pct", False):
+                    _qpct = _peak_quota_pct(rl_state, account_snapshot)
+                    if _qpct is not None:
+                        lines.append(t("gateway.usage.quota_pct", pct=f"{_qpct:.0f}"))
+                        lines.append("")
+            except Exception:
+                pass
 
             # Session token usage — detailed breakdown matching CLI
             input_tokens = getattr(agent, "session_input_tokens", 0) or 0

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -316,6 +316,7 @@ gateway:
 
   usage:
     rate_limits:              "⏱️ **Rate Limits:** {state}"
+    quota_pct:                "📈 **Quota used:** {pct}%"
     header_session:           "📊 **Session Token Usage**"
     label_model:              "Model: `{model}`"
     label_input_tokens:       "Input tokens: {count}"

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -251,3 +251,73 @@ class TestUsageAccountSection:
         assert calls["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
         assert "📊 **Session Info**" in result
         assert "📈 **Account limits**" in result
+
+
+class _Bucket:
+    """Minimal RateLimitBucket stand-in (limit + usage_pct)."""
+
+    def __init__(self, limit, remaining):
+        self.limit = limit
+        self.remaining = remaining
+
+    @property
+    def used(self):
+        return max(0, self.limit - self.remaining)
+
+    @property
+    def usage_pct(self):
+        return (self.used / self.limit) * 100.0 if self.limit > 0 else 0.0
+
+
+class _RL:
+    def __init__(self, has_data, rmin, rhour, tmin, thour):
+        self.has_data = has_data
+        self.requests_min = rmin
+        self.requests_hour = rhour
+        self.tokens_min = tmin
+        self.tokens_hour = thour
+
+
+class _Window:
+    def __init__(self, used_percent):
+        self.used_percent = used_percent
+
+
+class _Snapshot:
+    def __init__(self, windows):
+        self.windows = windows
+
+
+class TestPeakQuotaPct:
+    """display.show_quota_pct data source: agent.gateway.run._peak_quota_pct."""
+
+    def test_peak_across_rate_limit_buckets(self):
+        from gateway.run import _peak_quota_pct
+        rl = _RL(
+            True,
+            _Bucket(100, 10),    # 90%
+            _Bucket(1000, 900),  # 10%
+            _Bucket(0, 0),       # no data — skipped
+            _Bucket(50, 49),     # 2%
+        )
+        assert _peak_quota_pct(rl, None) == 90.0
+
+    def test_rate_limit_takes_precedence_over_account(self):
+        from gateway.run import _peak_quota_pct
+        rl = _RL(True, _Bucket(100, 10), _Bucket(0, 0), _Bucket(0, 0), _Bucket(0, 0))
+        snap = _Snapshot([_Window(42.0)])
+        assert _peak_quota_pct(rl, snap) == 90.0
+
+    def test_account_usage_fallback_when_no_rate_limit_headers(self):
+        from gateway.run import _peak_quota_pct
+        rl = _RL(False, _Bucket(0, 0), _Bucket(0, 0), _Bucket(0, 0), _Bucket(0, 0))
+        snap = _Snapshot([_Window(None), _Window(42.0), _Window(17.0)])
+        assert _peak_quota_pct(rl, snap) == 42.0
+
+    def test_none_when_no_signal_at_all(self):
+        """Graceful degrade: no rate-limit headers and no account snapshot."""
+        from gateway.run import _peak_quota_pct
+        rl = _RL(False, _Bucket(0, 0), _Bucket(0, 0), _Bucket(0, 0), _Bucket(0, 0))
+        assert _peak_quota_pct(rl, None) is None
+        assert _peak_quota_pct(None, None) is None
+        assert _peak_quota_pct(rl, _Snapshot([_Window(None)])) is None


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in display flag, `display.show_quota_pct`, that surfaces a compact
"Quota used: N%" line in the agent UI (`/usage`). The quota/usage tracking already
exists — this is a display-layer-only addition that reads existing precomputed
signals. Off by default, so no behavior change unless explicitly enabled.

## Related Issue

<!-- link/create the tracking issue, or delete this line -->
Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/display_config.py`: add `show_quota_pct` (default `false`) to
  `_GLOBAL_DEFAULTS`, mirroring `show_reasoning`; add it to the boolean
  normaliser. Resolves via the existing `resolve_display_setting()` chain, so it
  is overridable per-platform (`display.platforms.<platform>.show_quota_pct`).
- `gateway/run.py`: new `_peak_quota_pct()` helper that reads existing data only
  — peak `RateLimitBucket.usage_pct`, else max `AccountUsageWindow.used_percent`;
  gated quota line in `_handle_usage_command`, wrapped so a display-config quirk
  can never break `/usage`.
- `locales/en.yaml`: `usage.quota_pct` string (other locales fall back to en via
  `t()`).
- `cli-config.yaml.example`: documented `display.show_quota_pct`.
- `tests/gateway/test_usage_command.py`: `TestPeakQuotaPct` covering peak,
  rate-limit-over-account precedence, account-usage fallback, and the None
  graceful-degrade path.

Graceful degradation: when the provider emits no rate-limit headers and no
account-usage snapshot is available, `_peak_quota_pct` returns `None` and the
line is omitted (no misleading 0%).

## How to Test

1. In `config.yaml`, set:
   ```yaml
   display:
     show_quota_pct: true
   ```
2. Run a turn, then `/usage` — a "Quota used: N%" line appears when quota data is
   available.
3. With a provider that emits no rate-limit headers, confirm `/usage` still
   renders normally with no quota line.
4. `pytest tests/gateway/test_usage_command.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (single commit)
- [x] I've run the relevant suite: `pytest tests/gateway/test_usage_command.py -q`
      (12 passed) and `tests/.../test_account_usage.py` (passed)
- [x] I've added tests for my changes (`TestPeakQuotaPct`)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] Updated `cli-config.yaml.example` for the new `display.show_quota_pct` key
- [x] Docstrings added (`_peak_quota_pct`)
- [x] Cross-platform: pure Python, no platform-specific calls
