### PR TITLE
fix(delegation): use configured provider instead of hardcoded 'custom'

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -890,6 +890,28 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
+    def test_direct_endpoint_auto_provider_stays_custom(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "qwen2.5-coder",
+            "provider": "auto",
+            "base_url": "https://proxy.example/v1",
+            "api_key": "proxy-key",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "custom")
+
+    def test_direct_endpoint_preserves_explicit_named_provider(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-pro",
+            "provider": "opencode-go",
+            "base_url": "https://proxy.example/v1",
+            "api_key": "proxy-key",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "opencode-go")
+
     def test_direct_endpoint_auto_detects_anthropic_messages_suffix(self):
         # Issue #10213: Azure AI Foundry exposes Anthropic-compatible models at
         # a /anthropic URL suffix. Subagents must pick anthropic_messages

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2387,7 +2387,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         from hermes_cli.runtime_provider import _detect_api_mode_for_url
 
         base_lower = configured_base_url.lower()
-        provider = configured_provider
+        provider = configured_provider or "custom"
+        if provider in {"auto", "openrouter"}:
+            provider = "custom"
         api_mode = _detect_api_mode_for_url(configured_base_url) or "chat_completions"
         if (
             base_url_hostname(configured_base_url) == "chatgpt.com"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2387,7 +2387,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         from hermes_cli.runtime_provider import _detect_api_mode_for_url
 
         base_lower = configured_base_url.lower()
-        provider = "custom"
+        provider = configured_provider
         api_mode = _detect_api_mode_for_url(configured_base_url) or "chat_completions"
         if (
             base_url_hostname(configured_base_url) == "chatgpt.com"
@@ -2397,9 +2397,6 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             api_mode = "codex_responses"
         elif base_url_hostname(configured_base_url) == "api.anthropic.com":
             provider = "anthropic"
-            api_mode = "anthropic_messages"
-        elif "api.kimi.com/coding" in base_lower:
-            provider = "custom"
             api_mode = "anthropic_messages"
 
         # Explicit delegation.api_mode in config always wins. Lets users force


### PR DESCRIPTION
## Problem

In `_resolve_delegation_credentials()` (tools/delegate_tool.py), when `delegation.base_url` is configured, the function hardcodes `provider = "custom"` instead of using the `delegation.provider` value from config.

This causes subagents to fail with 401/404 errors when the config specifies a named provider (e.g., `opencode-go`), because the credential resolver uses the wrong provider lookup path.

## Symptoms

- `delegate_task` without explicit model override fails with 401 or 404
- Result shows fallback model (e.g., `kimi-k2.6`) instead of delegation model (e.g., `deepseek-v4-pro`)
- Direct API calls work fine with the same credentials

## Root Cause

Line 2390 in `_resolve_delegation_credentials()`:

```python
provider = "custom"  # ← Hardcoded, ignores delegation.provider
```

## Fix

- Use `configured_provider` from config instead of hardcoding `"custom"`
- Removed the duplicated `api.kimi.com/coding` branch because the shared `_detect_api_mode_for_url()` detector already maps that endpoint to `anthropic_messages`
- The existing `configured_api_mode` fallback (line 2407) already handles cases where URL heuristic can't detect the correct api_mode

## Testing

Before fix: `delegate_task` → 401 error, model=kimi-k2.6 (fallback)
After fix: `delegate_task` → success, model=deepseek-v4-pro (from delegation config)