### PR TITLE
fix(test): bootstrap required dev test packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "agent-client-protocol==0.9.0", "ty==0.0.21", "ruff==0.15.10"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.3"]

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -38,12 +38,14 @@ Exit code: 0 if every file's pytest exited 0; 1 otherwise.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 import threading
 import time
+import tomllib
 from concurrent.futures import ThreadPoolExecutor, Future
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -81,6 +83,130 @@ _DEFAULT_FILE_TIMEOUT_SECONDS = 600.0  # 10 minutes
 # wall-clock seconds. Used by ``--slice`` to distribute files across
 # CI jobs by estimated total time, so no one job gets all the slow files.
 _DURATIONS_FILE = "test_durations.json"
+
+# These packages are required by the default test suite. Without the pytest
+# plugins, pytest fails before collection with "unrecognized arguments" for
+# options such as --timeout; without acp, default ACP tests fail at import/use
+# time. The shell wrapper may pick a local .venv that exists but was not
+# installed with the dev extra, so the runner bootstraps the exact dev-extra
+# pins before its first pytest subprocess.
+_REQUIRED_TEST_PACKAGES = {
+    "pytest_timeout": "pytest-timeout",
+    "pytest_asyncio": "pytest-asyncio",
+    "acp": "agent-client-protocol",
+}
+
+
+def _normalize_package_name(name: str) -> str:
+    return name.replace("_", "-").lower()
+
+
+def _requirement_package_name(requirement: str) -> str:
+    """Return the package portion of a requirement string.
+
+    Good enough for the pinned dev-extra requirements in pyproject.toml, while
+    avoiding an extra dependency on packaging just to bootstrap the test env.
+    """
+    head = requirement.split(";", 1)[0].strip()
+    for marker in ("[", "==", ">=", "<=", "~=", "!=", ">", "<"):
+        if marker in head:
+            head = head.split(marker, 1)[0]
+            break
+    return _normalize_package_name(head.strip())
+
+
+def _dev_extra_specs(repo_root: Path) -> dict[str, str]:
+    pyproject = repo_root / "pyproject.toml"
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+    dev_requirements = (
+        data.get("project", {})
+        .get("optional-dependencies", {})
+        .get("dev", [])
+    )
+    return {
+        _requirement_package_name(requirement): requirement
+        for requirement in dev_requirements
+        if isinstance(requirement, str)
+    }
+
+
+def _ensure_required_test_packages(repo_root: Path) -> bool:
+    """Install missing test packages from the exact pinned dev extra.
+
+    Returns True when all required packages are importable. On install failure,
+    prints a clear setup error and returns False so the runner exits before
+    producing a wall of duplicate pytest usage/import failures.
+    """
+    missing = [
+        (module_name, package_name)
+        for module_name, package_name in _REQUIRED_TEST_PACKAGES.items()
+        if importlib.util.find_spec(module_name) is None
+    ]
+    if not missing:
+        return True
+
+    if os.environ.get("HERMES_TEST_NO_BOOTSTRAP"):
+        missing_names = ", ".join(package for _module, package in missing)
+        print(
+            "error: missing required test package(s): "
+            f"{missing_names}. Install the dev extra with `python -m pip install -e '.[dev]'`.",
+            file=sys.stderr,
+        )
+        return False
+
+    dev_specs = _dev_extra_specs(repo_root)
+    install_specs: List[str] = []
+    missing_specs: List[str] = []
+    for _module_name, package_name in missing:
+        spec = dev_specs.get(_normalize_package_name(package_name))
+        if spec:
+            install_specs.append(spec)
+        else:
+            missing_specs.append(package_name)
+
+    if missing_specs:
+        print(
+            "error: pyproject.toml [project.optional-dependencies].dev does not "
+            f"pin required test package(s): {', '.join(missing_specs)}",
+            file=sys.stderr,
+        )
+        return False
+
+    print(
+        "▶ bootstrapping missing test package(s): " + ", ".join(install_specs),
+        flush=True,
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", *install_specs],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        print(
+            "error: failed to install required test package(s). "
+            "Run `python -m pip install -e '.[dev]'` and retry.",
+            file=sys.stderr,
+        )
+        return False
+
+    importlib.invalidate_caches()
+    still_missing = [
+        package_name
+        for module_name, package_name in missing
+        if importlib.util.find_spec(module_name) is None
+    ]
+    if still_missing:
+        print(
+            "error: test package bootstrap completed but these package(s) are "
+            f"still not importable: {', '.join(still_missing)}",
+            file=sys.stderr,
+        )
+        return False
+
+    return True
 
 
 def _count_tests(
@@ -680,6 +806,9 @@ def main() -> int:
             sys.exit(2)
 
     repo_root = Path(__file__).resolve().parent.parent
+
+    if not _ensure_required_test_packages(repo_root):
+        return 2
 
     # Resolve discovery roots: positional path args override --paths if any
     # were supplied, otherwise --paths (which itself defaults to 'tests').

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -112,6 +112,14 @@ def test_feishu_extra_includes_qrcode_for_qr_login():
     assert any(dep.startswith("qrcode") for dep in feishu_extra)
 
 
+def test_dev_extra_includes_acp_for_default_acp_tests():
+    """ACP tests are part of the default suite, so [dev] must install ACP."""
+    optional_dependencies = _load_optional_dependencies()
+
+    dev_extra = optional_dependencies["dev"]
+    assert any(dep.startswith("agent-client-protocol==") for dep in dev_extra)
+
+
 def test_dashboard_plugin_manifests_and_assets_are_packaged():
     """Bundled dashboard plugins need their manifests and built assets in
     wheel installs so /api/dashboard/plugins can discover them outside a

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import textwrap
 import time
+import types
 from pathlib import Path
 
 import pytest
@@ -36,6 +37,19 @@ import pytest
 # so concurrent invocations of the suite don't clobber each other.
 _HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
 _HANDOFF_DIR.mkdir(exist_ok=True)
+
+
+def _load_runner_module():
+    import importlib.util
+
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    spec = importlib.util.spec_from_file_location("run_tests_parallel_test_module", runner)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def _handoff_path_for(nonce: str) -> Path:
@@ -61,6 +75,55 @@ def _pid_alive(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def test_bootstrap_installs_missing_test_package_from_dev_extra(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The runner repairs a partial dev venv before pytest sees addopts/imports."""
+    runner = _load_runner_module()
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent("""
+        [project.optional-dependencies]
+        dev = ["pytest==9.0.2", "pytest-timeout==2.4.0", "pytest-asyncio==1.3.0"]
+    """))
+
+    timeout_checks = 0
+
+    def fake_find_spec(name: str):
+        nonlocal timeout_checks
+        if name == "pytest_timeout":
+            timeout_checks += 1
+            return None if timeout_checks == 1 else object()
+        if name == "pytest_asyncio":
+            return object()
+        return object()
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, cwd):
+        calls.append(list(cmd))
+        assert cwd == tmp_path
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(runner.importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    assert runner._ensure_required_test_packages(tmp_path) is True
+    assert calls == [[sys.executable, "-m", "pip", "install", "pytest-timeout==2.4.0"]]
+
+
+def test_bootstrap_can_fail_fast_when_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("HERMES_TEST_NO_BOOTSTRAP", "1")
+    monkeypatch.setattr(runner.importlib.util, "find_spec", lambda _name: None)
+
+    assert runner._ensure_required_test_packages(tmp_path) is False
+    assert "missing required test package(s)" in capsys.readouterr().err
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only probe")


### PR DESCRIPTION
## Summary
- bootstrap missing required test packages from exact [dev] pins before per-file pytest runs
- include agent-client-protocol in the dev extra because ACP tests are part of the default suite
- add regressions for bootstrap behavior and dev metadata

## Test plan
- ./scripts/run_tests.sh tests/acp tests/test_run_tests_parallel.py tests/test_project_metadata.py -j 4
- ./.venv/bin/python -m py_compile scripts/run_tests_parallel.py tests/test_run_tests_parallel.py tests/test_project_metadata.py
- git diff --check

## Notes
A broader ./scripts/run_tests.sh -j 12 run got past the original bootstrap failure and reached ~56% before the 10-minute local cap. It exposed unrelated failures in existing suites (Anthropic adapter mocks, WSL/systemd service tests on macOS, WeCom callback XML import path, custom provider list grouping/catalog fallback).