### PR TITLE
fix(tool-result-storage): persist oversized MCP tool results via local filesystem fallback

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -1,5 +1,6 @@
 """Tests for tools/tool_result_storage.py -- 3-layer tool result persistence."""
 
+import os
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -254,7 +255,8 @@ class TestMaybePersistToolResult:
         # command string — see test_large_content_via_stdin for why).
         assert env.execute.call_args[1]["stdin_data"] == content
 
-    def test_above_threshold_no_env_truncates_inline(self):
+    def test_above_threshold_no_env_falls_back_to_local_write(self):
+        """With env=None (e.g. MCP tools), should write via local open()."""
         content = "x" * 60_000
         result = maybe_persist_tool_result(
             content=content,
@@ -263,8 +265,14 @@ class TestMaybePersistToolResult:
             env=None,
             threshold=30_000,
         )
-        assert PERSISTED_OUTPUT_TAG not in result
-        assert "Truncated" in result
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "60,000 characters" in result
+        assert "/tmp/hermes-results/tc_789.txt" in result
+        # Verify the file was actually written to disk
+        file_path = "/tmp/hermes-results/tc_789.txt"
+        assert os.path.exists(file_path)
+        assert os.path.getsize(file_path) == len(content)
+        os.remove(file_path)
         assert len(result) < len(content)
 
     def test_env_write_failure_falls_back_to_truncation(self):

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """Tool result persistence -- preserves large outputs instead of truncating.
 
 Defense against context-window overflow operates at three levels:
@@ -166,6 +168,25 @@ def maybe_persist_tool_result(
                 return _build_persisted_message(preview, has_more, len(content), remote_path)
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
+    else:
+        # Local filesystem fallback for tools without a terminal env
+        # (e.g. MCP tools dispatched without an active BaseEnvironment).
+        # Safe here because env=None means the local backend; remote
+        # backends always supply env.
+        try:
+            os.makedirs(storage_dir, exist_ok=True)
+            with open(remote_path, "w", encoding="utf-8") as f:
+                f.write(content)
+            logger.info(
+                "Persisted large tool result (local fallback): %s (%s, %d chars -> %s)",
+                tool_name, tool_use_id, len(content), remote_path,
+            )
+            return _build_persisted_message(preview, has_more, len(content), remote_path)
+        except Exception as exc:
+            logger.warning(
+                "Sandbox write failed (local fallback) for %s: %s",
+                tool_use_id, exc,
+            )
 
     logger.info(
         "Inline-truncating large tool result: %s (%d chars, no sandbox write)",


### PR DESCRIPTION
## What does this PR do?

MCP tools (serena, postgres, redis, github, fetch, context7, etc.) are dispatched **without an active BaseEnvironment** — `get_active_env()` returns `None` for their tool call IDs. The existing `maybe_persist_tool_result` only attempted sandbox writes via `env.execute()`, falling back to inline truncation when `env` was `None`. This left large MCP results (180K+ chars) inline in the conversation context, wasting context window.

This PR adds a **local filesystem fallback** (`os.makedirs` + `open()`) in the `else` branch for when `env is None`. This is safe because `env=None` corresponds to the local terminal backend; remote backends (Docker, SSH, Modal) always supply `env` for their tool calls.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_result_storage.py` — added `else` branch in `maybe_persist_tool_result` that writes via `os.makedirs` + `open()` when `env is None`, with the same preview/persisted-output format as the `env.execute()` path
- `tests/tools/test_tool_result_storage.py` — updated `test_above_threshold_no_env_truncates_inline` to assert persisted-output behavior + file-on-disk verification; added `import os`

## How to Test

1. Run the existing test suite: `cd hermes-agent && venv/bin/python -m pytest tests/tools/test_tool_result_storage.py -v`
2. Start a Hermes session and run an MCP query returning >100K chars (e.g. a large postgres query or broad serena search)
3. Verify log shows `Persisted large tool result (local fallback)`:
   ```
   tools.tool_result_storage: Persisted large tool result (local fallback): mcp_postgres_query (call_..., 937606 chars -> /tmp/hermes-results/call_....txt)
   ```
4. Verify `/tmp/hermes-results/` contains the persisted file with correct size

## Evidence

### Before the fix (same session, 180K serena result):
```
tools.tool_result_storage: Inline-truncating large tool result: mcp_serena_search_for_pattern (180081 chars, no sandbox write)
```
→ 180K chars inline in context.

### After the fix (fresh session, 937K postgres result):
```
tools.tool_result_storage: Persisted large tool result (local fallback): mcp_postgres_query (call_00_..., 937606 chars -> /tmp/hermes-results/call_00_....txt)
```
→ 937K chars → ~1.8K preview. File verified on disk at correct size (937,700 bytes).

### Test suite: 49/49 passed

```
============================== 49 passed in 0.33s ==============================
```

### Context savings per large MCP result:
- 180K result: 1789 chars in-context = **~99% savings**
- 937K result: ~1800 chars in-context = **~99.8% savings**
- Follow-up API calls stayed at ~40K-47K input tokens (vs ~977K without the fix)

## Screenshots / Logs

```
# Log evidence
2026-05-27 21:21:46,703 INFO tools.tool_result_storage:
  Persisted large tool result (local fallback):
  mcp_postgres_query (call_00_..., 937606 chars ->
  /tmp/hermes-results/call_00_....txt)

# Sandbox file on disk
$ ls -la /tmp/hermes-results/
-rw-rw-r-- 1 akash akash 937700 May 27 21:21 call_00_....txt

# Fresh-import unit test
PASS: fresh import with patched code
  120K chars -> 1784 char preview (99% savings)
  File written: 120000 bytes
  persisted-output tag: True
```