### PR TITLE
fix(gateway): stream-only typing indicator for Telegram

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -298,6 +298,17 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # Typing-indicator policy:
+    #   - "always": refresh typing... continuously for the whole turn (legacy
+    #     behavior; default for non-Telegram platforms)
+    #   - "stream_only": only refresh typing while assistant text is actively
+    #     streaming/about to be sent; NOT during long tool calls or model
+    #     thinking. Default for Telegram (5s expiry window makes the
+    #     continuous indicator feel broken when a tool call takes 30s+).
+    #   - "off": never send a typing indicator
+    # ``None`` means "use platform default" (resolved at runtime).
+    typing_indicator: Optional[str] = None
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
 
@@ -308,6 +319,8 @@ class PlatformConfig:
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
         }
+        if self.typing_indicator is not None:
+            result["typing_indicator"] = self.typing_indicator
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -330,6 +343,15 @@ class PlatformConfig:
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
 
+        # typing_indicator follows the same top-level-or-extra pattern
+        _ti = data.get("typing_indicator")
+        if _ti is None:
+            _ti = data.get("extra", {}).get("typing_indicator")
+        if _ti is not None:
+            _ti = str(_ti).strip().lower()
+            if _ti not in ("always", "stream_only", "off"):
+                _ti = None
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
@@ -337,6 +359,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            typing_indicator=_ti,
             extra=data.get("extra", {}),
         )
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1573,6 +1573,11 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Chats where the agent is currently streaming/about-to-send assistant
+        # text. Only consulted when the platform's ``typing_indicator`` policy
+        # is ``stream_only``: send_typing fires when chat_id is in this set,
+        # and is suppressed during tool calls / model thinking.
+        self._typing_streaming: set = set()
 
     @property
     def message_len_fn(self) -> Callable[[str], int]:
@@ -2520,42 +2525,69 @@ class BasePlatformAdapter(ABC):
 
         return paths, cleaned
 
+    def typing_indicator_mode(self) -> str:
+        """Resolve the typing-indicator policy for this platform.
+
+        Returns one of ``"always"``, ``"stream_only"``, ``"off"``.  Reads from
+        the platform's config (``typing_indicator`` field); falls back to
+        ``stream_only`` for Telegram and ``always`` for every other platform
+        to preserve backwards compatibility.
+        """
+        cfg = getattr(self, "config", None)
+        explicit = getattr(cfg, "typing_indicator", None) if cfg is not None else None
+        if explicit in ("always", "stream_only", "off"):
+            return explicit
+        # Platform-specific defaults
+        if self.platform == Platform.TELEGRAM:
+            return "stream_only"
+        return "always"
+
     async def _keep_typing(
         self,
         chat_id: str,
-        interval: float = 2.0,
+        interval: float = 4.0,
         metadata=None,
         stop_event: asyncio.Event | None = None,
+        mode: str | None = None,
     ) -> None:
         """
         Continuously send typing indicator until cancelled.
-        
-        Telegram/Discord typing status expires after ~5 seconds, so we refresh every 2
-        to recover quickly after progress messages interrupt it.
-        
+
+        Telegram/Discord typing status expires after ~5 seconds, so we refresh
+        every 4s — keeps the bubble alive without spending an extra HTTP call
+        per second.
+
         Skips send_typing when the chat is in ``_typing_paused`` (e.g. while
         the agent is waiting for dangerous-command approval).  This is critical
         for Slack's Assistant API where ``assistant_threads_setStatus`` disables
         the compose box — pausing lets the user type ``/approve`` or ``/deny``.
 
+        When ``mode == "stream_only"``, send_typing only fires while the chat
+        is in ``_typing_streaming`` (set just before / during assistant text
+        emission). This avoids showing "typing..." for the entire turn when
+        the agent is grinding through long tool calls or model thinking.
+
         Each ``send_typing`` call is bounded by a ~1.5s timeout so a slow
-        network round-trip can't stall the refresh cadence.  Telegram- and
-        Discord-side typing expire after ~5s; if any individual send_typing
-        takes longer than the refresh interval, the bubble would die and
-        stay dead until that call returns.  Abandoning the slow call lets
-        the next tick fire a fresh send_typing on schedule — as long as
-        one of them succeeds within the 5s platform-side window, the bubble
-        stays visible across provider stalls / upstream API timeouts.
+        network round-trip can't stall the refresh cadence.
         """
         # Bound each send_typing round-trip so the refresh cadence isn't
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        if mode is None:
+            try:
+                mode = self.typing_indicator_mode()
+            except Exception:
+                mode = "always"
         try:
             while True:
                 if stop_event is not None and stop_event.is_set():
                     return
-                if chat_id not in self._typing_paused:
+                _should_fire = (
+                    chat_id not in self._typing_paused
+                    and (mode != "stream_only" or chat_id in self._typing_streaming)
+                )
+                if _should_fire:
                     try:
                         await asyncio.wait_for(
                             self.send_typing(chat_id, metadata=metadata),
@@ -2601,6 +2633,7 @@ class BasePlatformAdapter(ABC):
                 except Exception:
                     pass
             self._typing_paused.discard(chat_id)
+            self._typing_streaming.discard(chat_id)
 
     def pause_typing_for_chat(self, chat_id: str) -> None:
         """Pause typing indicator for a chat (e.g. during approval waits).
@@ -2613,6 +2646,19 @@ class BasePlatformAdapter(ABC):
     def resume_typing_for_chat(self, chat_id: str) -> None:
         """Resume typing indicator for a chat after approval resolves."""
         self._typing_paused.discard(chat_id)
+
+    def start_streaming_typing(self, chat_id: str) -> None:
+        """Mark a chat as actively streaming assistant text.
+
+        Only consulted when ``typing_indicator_mode() == "stream_only"``: the
+        ``_keep_typing`` loop fires send_typing while the chat_id is in this
+        set, and otherwise stays silent. Safe to call repeatedly.
+        """
+        self._typing_streaming.add(chat_id)
+
+    def stop_streaming_typing(self, chat_id: str) -> None:
+        """Clear the streaming marker for a chat (text emission finished)."""
+        self._typing_streaming.discard(chat_id)
 
     async def interrupt_session_activity(self, session_key: str, chat_id: str) -> None:
         """Signal the active session loop to stop and clear typing immediately."""
@@ -3509,23 +3555,44 @@ class BasePlatformAdapter(ABC):
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
         
-        # Start continuous typing indicator (refreshes every 2 seconds)
+        # Start continuous typing indicator (refreshes every 4 seconds).
+        # Respect the per-platform ``typing_indicator`` policy:
+        #   - "off": don't spawn the task at all
+        #   - "stream_only": spawn but only fire send_typing while
+        #     ``_typing_streaming`` is set (managed by the streaming pipeline)
+        #   - "always": legacy behavior — refresh for the whole turn
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-        _keep_typing_kwargs = {"metadata": _thread_metadata}
         try:
-            _keep_typing_sig = inspect.signature(self._keep_typing)
-        except (TypeError, ValueError):
-            _keep_typing_sig = None
-        if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
-            _keep_typing_kwargs["stop_event"] = interrupt_event
-        typing_task = asyncio.create_task(
-            self._keep_typing(
-                event.source.chat_id,
-                **_keep_typing_kwargs,
+            _typing_mode = self.typing_indicator_mode()
+        except Exception:
+            _typing_mode = "always"
+        typing_task: Optional[asyncio.Task] = None
+        if _typing_mode != "off":
+            _keep_typing_kwargs: Dict[str, Any] = {
+                "metadata": _thread_metadata,
+                "mode": _typing_mode,
+            }
+            try:
+                _keep_typing_sig = inspect.signature(self._keep_typing)
+            except (TypeError, ValueError):
+                _keep_typing_sig = None
+            if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
+                _keep_typing_kwargs["stop_event"] = interrupt_event
+            # Some adapter subclasses override _keep_typing with a narrower
+            # signature (no ``mode``); drop the kwarg in that case to avoid
+            # TypeError at spawn time.
+            if _keep_typing_sig is not None and "mode" not in _keep_typing_sig.parameters:
+                _keep_typing_kwargs.pop("mode", None)
+            typing_task = asyncio.create_task(
+                self._keep_typing(
+                    event.source.chat_id,
+                    **_keep_typing_kwargs,
+                )
             )
-        )
 
         async def _stop_typing_task() -> None:
+            if typing_task is None:
+                return
             typing_task.cancel()
             try:
                 await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)
@@ -3652,6 +3719,11 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
+                    # Mark this chat as actively streaming/sending assistant
+                    # text so the stream_only typing indicator wakes up just
+                    # before the user sees output (and stays quiet during
+                    # tool calls / model thinking).
+                    self.start_streaming_typing(event.source.chat_id)
                     _reply_anchor = _reply_anchor_for_event(event)
                     # Mark final response messages for notification delivery.
                     # Platform adapters that support per-message notification

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -308,6 +308,13 @@ class SlackAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.SLACK)
         self._app: Optional[Any] = None
         self._handler: Optional[Any] = None
+        # Multi-socket support: parallel lists, one entry per Slack app.
+        # self._app and self._handler remain set to the primary (index 0) for
+        # backward compatibility with code that references them directly.
+        self._apps: List[Any] = []
+        self._handlers: List[Any] = []
+        self._socket_tasks: List[asyncio.Task] = []
+        self._extra_app_tokens: List[str] = []
         self._bot_user_id: Optional[str] = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
         self._socket_mode_task: Optional[asyncio.Task] = None
@@ -315,6 +322,11 @@ class SlackAdapter(BasePlatformAdapter):
         self._team_clients: Dict[str, Any] = {}   # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}          # team_id → bot_user_id
         self._channel_team: Dict[str, str] = {}                # channel_id → team_id
+        # Multi-app-in-same-team support: when multiple Slack apps share a Slack
+        # workspace (same team_id), team_id alone can't pick the right client.
+        # Track which bot user actually received each event/channel.
+        self._bot_user_clients: Dict[str, Any] = {}    # bot_user_id → WebClient
+        self._channel_bot_user: Dict[str, str] = {}    # channel_id → bot_user_id
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events.
         self._dedup = MessageDeduplicator()
@@ -503,6 +515,101 @@ class SlackAdapter(BasePlatformAdapter):
         # Non-fatal — the user saw the initial ack already.
         return SendResult(success=True, message_id=None)
 
+    def _register_app_handlers(self, app: Any, bot_user_id: Optional[str] = None) -> None:
+        """Register the standard set of event/command/action handlers on an AsyncApp.
+
+        Factored out so that each Slack app (one per Socket Mode connection in
+        multi-workspace setups) gets the same wiring. When ``bot_user_id`` is
+        provided, it's stamped onto every inbound event as
+        ``_hermes_recipient_bot_user_id`` so downstream code can route the
+        outbound send through the correct workspace WebClient (critical when
+        multiple Slack apps share the same Slack team_id).
+        """
+        def _stamp(event: dict) -> None:
+            if bot_user_id and isinstance(event, dict):
+                event["_hermes_recipient_bot_user_id"] = bot_user_id
+
+        # Generic message event
+        @app.event("message")
+        async def handle_message_event(event, say):
+            _stamp(event)
+            await self._handle_slack_message(event)
+
+        # Handle app_mention explicitly. In some Slack app configurations,
+        # channel mentions arrive only as app_mention events rather than the
+        # generic message event. Forward them into the normal message
+        # pipeline so @mentions reliably produce replies.
+        # NOTE: when Slack fires BOTH message and app_mention for the same
+        # @mention, they share the same event ts — the dedup in
+        # _handle_slack_message (MessageDeduplicator) suppresses the second.
+        @app.event("app_mention")
+        async def handle_app_mention(event, say):
+            _stamp(event)
+            await self._handle_slack_message(event)
+
+        # File lifecycle events can arrive around snippet uploads even when
+        # the actual user message is what we care about. Ack them so Slack
+        # doesn't log noisy 404 "unhandled request" warnings.
+        @app.event("file_shared")
+        async def handle_file_shared(event, say):
+            pass
+
+        @app.event("file_created")
+        async def handle_file_created(event, say):
+            pass
+
+        @app.event("file_change")
+        async def handle_file_change(event, say):
+            pass
+
+        @app.event("assistant_thread_started")
+        async def handle_assistant_thread_started(event, say):
+            _stamp(event)
+            await self._handle_assistant_thread_lifecycle_event(event)
+
+        @app.event("assistant_thread_context_changed")
+        async def handle_assistant_thread_context_changed(event, say):
+            _stamp(event)
+            await self._handle_assistant_thread_lifecycle_event(event)
+
+        # Slash command handler(s)
+        from hermes_cli.commands import slack_native_slashes
+        import re as _re
+
+        _slash_names = [name for name, _d, _h in slack_native_slashes()]
+        if _slash_names:
+            _slash_pattern = _re.compile(
+                r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
+            )
+        else:  # pragma: no cover - registry always non-empty
+            _slash_pattern = _re.compile(r"^/hermes$")
+
+        @app.command(_slash_pattern)
+        async def handle_hermes_command(ack, command):
+            slash = (command.get("command") or "").lstrip("/")
+            await ack(
+                response_type="ephemeral",
+                text=f"Running `/{slash}`…",
+            )
+            await self._handle_slash_command(command)
+
+        # Block Kit action handlers for approval buttons
+        for _action_id in (
+            "hermes_approve_once",
+            "hermes_approve_session",
+            "hermes_approve_always",
+            "hermes_deny",
+        ):
+            app.action(_action_id)(self._handle_approval_action)
+
+        # Block Kit action handlers for slash-confirm buttons
+        for _action_id in (
+            "hermes_confirm_once",
+            "hermes_confirm_always",
+            "hermes_confirm_cancel",
+        ):
+            app.action(_action_id)(self._handle_slash_confirm_action)
+
     async def connect(self) -> bool:
         """Connect to Slack via Socket Mode."""
         if not SLACK_AVAILABLE:
@@ -549,27 +656,42 @@ class SlackAdapter(BasePlatformAdapter):
                 return False
             lock_acquired = True
 
-            # Close any previous handler before creating a new one so that
+            # Close any previous handlers before creating new ones so that
             # calling connect() a second time (e.g. during a gateway restart or
-            # in-process reconnect attempt) does not leave a zombie Socket Mode
-            # connection alive.  Both the old and new connections would otherwise
+            # in-process reconnect attempt) does not leave zombie Socket Mode
+            # connections alive.  Both the old and new connections would otherwise
             # receive every Slack event and dispatch it twice, producing double
             # responses — the same bug that affected DiscordAdapter (#18187).
-            if self._handler is not None:
+            for prev in list(self._handlers) or ([self._handler] if self._handler else []):
+                if prev is None:
+                    continue
                 try:
-                    await self._handler.close_async()
+                    await prev.close_async()
                 except Exception:
                     logger.debug("[%s] Failed to close previous Slack handler", self.name)
-                finally:
-                    self._handler = None
-                    self._app = None
+            self._handlers = []
+            self._apps = []
+            self._socket_tasks = []
+            self._handler = None
+            self._app = None
 
-            # First token is the primary — used for AsyncApp / Socket Mode
-            primary_token = bot_tokens[0]
-            self._app = AsyncApp(token=primary_token)
-            _apply_slack_proxy(self._app.client, proxy_url)
+            # Parse SLACK_APP_TOKEN as comma-separated, matching SLACK_BOT_TOKEN.
+            # Each Slack app has its own (bot_token, app_token) pair — you can NOT
+            # reuse one app_token across multiple Slack apps. So inbound events
+            # require one Socket Mode connection per app_token.
+            app_tokens = [t.strip() for t in app_token.split(",") if t.strip()]
+            if len(app_tokens) != len(bot_tokens):
+                logger.warning(
+                    "[Slack] Token count mismatch: %d bot token(s), %d app token(s). "
+                    "Will pair index-wise; extra/missing tokens are ignored. "
+                    "Inbound events only work for paired apps.",
+                    len(bot_tokens), len(app_tokens),
+                )
 
-            # Register each bot token and map team_id → client
+            # Register each bot token: build team_id → WebClient map for sends.
+            # Bot user IDs are returned by auth.test and used to disambiguate
+            # multi-app-in-same-team setups.
+            bot_user_id_by_token: Dict[str, str] = {}
             for token in bot_tokens:
                 client = AsyncWebClient(token=token)
                 _apply_slack_proxy(client, proxy_url)
@@ -581,6 +703,9 @@ class SlackAdapter(BasePlatformAdapter):
 
                 self._team_clients[team_id] = client
                 self._team_bot_user_ids[team_id] = bot_user_id
+                if bot_user_id:
+                    self._bot_user_clients[bot_user_id] = client
+                    bot_user_id_by_token[token] = bot_user_id
 
                 # First token sets the primary bot_user_id (backward compat)
                 if self._bot_user_id is None:
@@ -591,105 +716,35 @@ class SlackAdapter(BasePlatformAdapter):
                     bot_name, team_name, team_id,
                 )
 
-            # Register message event handler
-            @self._app.event("message")
-            async def handle_message_event(event, say):
-                await self._handle_slack_message(event)
-
-            # Handle app_mention explicitly. In some Slack app configurations,
-            # channel mentions arrive only as app_mention events rather than the
-            # generic message event. Forward them into the normal message
-            # pipeline so @mentions reliably produce replies.
-            # NOTE: when Slack fires BOTH message and app_mention for the same
-            # @mention, they share the same event ts — the dedup in
-            # _handle_slack_message (MessageDeduplicator) suppresses the second.
-            @self._app.event("app_mention")
-            async def handle_app_mention(event, say):
-                await self._handle_slack_message(event)
-
-            # File lifecycle events can arrive around snippet uploads even when
-            # the actual user message is what we care about. Ack them so Slack
-            # doesn't log noisy 404 "unhandled request" warnings.
-            @self._app.event("file_shared")
-            async def handle_file_shared(event, say):
-                pass
-
-            @self._app.event("file_created")
-            async def handle_file_created(event, say):
-                pass
-
-            @self._app.event("file_change")
-            async def handle_file_change(event, say):
-                pass
-
-            @self._app.event("assistant_thread_started")
-            async def handle_assistant_thread_started(event, say):
-                await self._handle_assistant_thread_lifecycle_event(event)
-
-            @self._app.event("assistant_thread_context_changed")
-            async def handle_assistant_thread_context_changed(event, say):
-                await self._handle_assistant_thread_lifecycle_event(event)
-
-            # Register slash command handler(s)
-            #
-            # Every gateway command from COMMAND_REGISTRY is a native Slack
-            # slash, matching Discord and Telegram's model (e.g. /btw, /stop,
-            # /model work directly without /hermes prefix). A single regex
-            # matcher dispatches all of them to one handler so we don't need
-            # N identical @app.command() decorators.
-            #
-            # The slash commands must ALSO be declared in the Slack app
-            # manifest (see `hermes slack manifest`). In Socket Mode, Slack
-            # routes the command event through the socket regardless of the
-            # manifest's request URL, but it will not deliver an event for
-            # a slash command the manifest doesn't declare.
-            from hermes_cli.commands import slack_native_slashes
-            import re as _re
-
-            _slash_names = [name for name, _d, _h in slack_native_slashes()]
-            if _slash_names:
-                _slash_pattern = _re.compile(
-                    r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
+            # Build one AsyncApp + Socket Mode handler per (bot_token, app_token) pair.
+            # First pair is the primary (self._app / self._handler) for backward compat.
+            paired = list(zip(bot_tokens, app_tokens))
+            for idx, (b_token, a_token) in enumerate(paired):
+                app = AsyncApp(token=b_token)
+                _apply_slack_proxy(app.client, proxy_url)
+                self._register_app_handlers(
+                    app, bot_user_id=bot_user_id_by_token.get(b_token),
                 )
-            else:  # pragma: no cover - registry always non-empty
-                _slash_pattern = _re.compile(r"^/hermes$")
 
-            @self._app.command(_slash_pattern)
-            async def handle_hermes_command(ack, command):
-                slash = (command.get("command") or "").lstrip("/")
-                await ack(
-                    response_type="ephemeral",
-                    text=f"Running `/{slash}`…",
-                )
-                await self._handle_slash_command(command)
+                handler = AsyncSocketModeHandler(app, a_token, proxy=proxy_url)
+                _apply_slack_proxy(handler.client, proxy_url)
+                task = asyncio.create_task(handler.start_async())
 
-            # Register Block Kit action handlers for approval buttons
-            for _action_id in (
-                "hermes_approve_once",
-                "hermes_approve_session",
-                "hermes_approve_always",
-                "hermes_deny",
-            ):
-                self._app.action(_action_id)(self._handle_approval_action)
+                self._apps.append(app)
+                self._handlers.append(handler)
+                self._socket_tasks.append(task)
 
-            # Register Block Kit action handlers for slash-confirm buttons
-            # (generic three-option prompts; see tools/slash_confirm.py).
-            for _action_id in (
-                "hermes_confirm_once",
-                "hermes_confirm_always",
-                "hermes_confirm_cancel",
-            ):
-                self._app.action(_action_id)(self._handle_slash_confirm_action)
-
-            # Start Socket Mode handler in background
-            self._handler = AsyncSocketModeHandler(self._app, app_token, proxy=proxy_url)
-            _apply_slack_proxy(self._handler.client, proxy_url)
-            self._socket_mode_task = asyncio.create_task(self._handler.start_async())
+                if idx == 0:
+                    self._app = app
+                    self._handler = handler
+                    self._socket_mode_task = task
+                else:
+                    self._extra_app_tokens.append(a_token)
 
             self._running = True
             logger.info(
-                "[Slack] Socket Mode connected (%d workspace(s))",
-                len(self._team_clients),
+                "[Slack] Socket Mode connected (%d socket(s), %d workspace(s))",
+                len(self._handlers), len(self._team_clients),
             )
             return True
 
@@ -736,12 +791,24 @@ class SlackAdapter(BasePlatformAdapter):
         return None
 
     async def disconnect(self) -> None:
-        """Disconnect from Slack."""
-        if self._handler:
+        """Disconnect from Slack — close every Socket Mode handler."""
+        handlers_to_close = list(self._handlers) if self._handlers else (
+            [self._handler] if self._handler else []
+        )
+        for handler in handlers_to_close:
+            if handler is None:
+                continue
             try:
-                await self._handler.close_async()
+                await handler.close_async()
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.warning("[Slack] Error while closing Socket Mode handler: %s", e, exc_info=True)
+        self._handlers = []
+        self._apps = []
+        self._socket_tasks = []
+        self._extra_app_tokens = []
+        self._handler = None
+        self._app = None
+        self._socket_mode_task = None
         self._running = False
 
         self._release_platform_lock()
@@ -749,7 +816,16 @@ class SlackAdapter(BasePlatformAdapter):
         logger.info("[Slack] Disconnected")
 
     def _get_client(self, chat_id: str) -> Any:
-        """Return the workspace-specific WebClient for a channel."""
+        """Return the workspace-specific WebClient for a channel.
+
+        Resolution order:
+        1. Bot-user-specific client (handles multi-app-in-same-team setups).
+        2. Team-specific client (handles single-app-per-team multi-workspace).
+        3. Primary app client as fallback.
+        """
+        bot_user_id = self._channel_bot_user.get(chat_id)
+        if bot_user_id and bot_user_id in self._bot_user_clients:
+            return self._bot_user_clients[bot_user_id]
         team_id = self._channel_team.get(chat_id)
         if team_id and team_id in self._team_clients:
             return self._team_clients[team_id]
@@ -1766,9 +1842,16 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _handle_slack_message(self, event: dict) -> None:
         """Handle an incoming Slack message event."""
-        # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
+        # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777).
+        # In multi-app setups where several Slack apps are members of the same
+        # channel, Slack legitimately delivers the SAME event_ts to each app's
+        # socket — once per app. We must dedup per-recipient, not globally,
+        # otherwise the first arrival wins and the actually-mentioned app's
+        # copy gets silently dropped.
         event_ts = event.get("ts", "")
-        if event_ts and self._dedup.is_duplicate(event_ts):
+        recipient = event.get("_hermes_recipient_bot_user_id", "")
+        dedup_key = f"{recipient}:{event_ts}" if recipient else event_ts
+        if event_ts and self._dedup.is_duplicate(dedup_key):
             return
 
         # Bot message filtering (SLACK_ALLOW_BOTS / config allow_bots):
@@ -1929,6 +2012,13 @@ class SlackAdapter(BasePlatformAdapter):
         if team_id and channel_id:
             self._channel_team[channel_id] = team_id
 
+        # Track which Slack app (bot user) actually received this event.
+        # Stamping is deferred to AFTER the mention/route check below, so that
+        # in multi-app-in-same-channel setups only the app that's actually
+        # responding claims the channel's WebClient — otherwise a non-mentioned
+        # app clobbers the mapping moments before the correct one would set it.
+        recipient_bot_user_id = event.get("_hermes_recipient_bot_user_id", "")
+
         # Determine if this is a DM or channel message
         channel_type = event.get("channel_type", "")
         if not channel_type and channel_id.startswith("D"):
@@ -1956,7 +2046,15 @@ class SlackAdapter(BasePlatformAdapter):
         #   2. The message is a reply in a thread the bot started/participated in, OR
         #   3. The message is in a thread where the bot was previously @mentioned, OR
         #   4. There's an existing session for this thread (survives restarts)
-        bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        # Pick the bot_user_id of the Slack app that actually received this
+        # event. Critical when multiple Slack apps share the same team_id —
+        # using the team_id alone returns whichever bot was registered last
+        # in self._team_bot_user_ids, which can flag a real @mention as
+        # "not mentioned" and silently drop the event.
+        bot_uid = (
+            event.get("_hermes_recipient_bot_user_id")
+            or self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        )
         routing_text = original_text or ""
         is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
         event_thread_ts = event.get("thread_ts")
@@ -1993,6 +2091,13 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 if not reply_to_bot_thread and not in_mentioned_thread and not has_session:
                     return
+
+        # Routing gate passed — this app IS responding. Now claim the channel
+        # for this bot user so the outbound send picks the correct WebClient.
+        # (Deferred from earlier to avoid non-mentioned apps clobbering the
+        # mapping when multiple apps are members of the same channel.)
+        if recipient_bot_user_id and channel_id:
+            self._channel_bot_user[channel_id] = recipient_bot_user_id
 
         if is_mentioned:
             # Strip the bot mention from the text

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -886,17 +886,19 @@ class SlackAdapter(BasePlatformAdapter):
                 await self.stop_typing(chat_id)
 
             # Track the sent message ts so we can auto-respond to thread
-            # replies without requiring @mention.
+            # replies without requiring @mention. Keyed by (bot_uid, ts) so
+            # multiple Slack apps sharing the same channel don't cross-trigger.
             sent_ts = last_result.get("ts") if last_result else None
             if sent_ts:
-                self._bot_message_ts.add(sent_ts)
+                _send_bot_uid = self._channel_bot_user.get(chat_id) or self._bot_user_id or ""
+                self._bot_message_ts.add((_send_bot_uid, sent_ts))
                 # Also register the thread root so replies-to-my-replies work
                 if thread_ts:
-                    self._bot_message_ts.add(thread_ts)
+                    self._bot_message_ts.add((_send_bot_uid, thread_ts))
                 if len(self._bot_message_ts) > self._BOT_TS_MAX:
                     excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
-                    for old_ts in list(self._bot_message_ts)[:excess]:
-                        self._bot_message_ts.discard(old_ts)
+                    for old_entry in list(self._bot_message_ts)[:excess]:
+                        self._bot_message_ts.discard(old_entry)
 
             return SendResult(
                 success=True,
@@ -1223,11 +1225,12 @@ class SlackAdapter(BasePlatformAdapter):
         """Treat successful file uploads as bot participation in a thread."""
         if not thread_ts:
             return
-        self._bot_message_ts.add(thread_ts)
+        _send_bot_uid = self._channel_bot_user.get(chat_id) or self._bot_user_id or ""
+        self._bot_message_ts.add((_send_bot_uid, thread_ts))
         if len(self._bot_message_ts) > self._BOT_TS_MAX:
             excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
-            for old_ts in list(self._bot_message_ts)[:excess]:
-                self._bot_message_ts.discard(old_ts)
+            for old_entry in list(self._bot_message_ts)[:excess]:
+                self._bot_message_ts.discard(old_entry)
 
     def _is_retryable_upload_error(self, exc: Exception) -> bool:
         """Best-effort detection for transient Slack upload failures."""
@@ -2075,11 +2078,11 @@ class SlackAdapter(BasePlatformAdapter):
                 return  # Strict mode: ignore until @-mentioned again
             elif not is_mentioned:
                 reply_to_bot_thread = (
-                    is_thread_reply and event_thread_ts in self._bot_message_ts
+                    is_thread_reply and (bot_uid, event_thread_ts) in self._bot_message_ts
                 )
                 in_mentioned_thread = (
                     event_thread_ts is not None
-                    and event_thread_ts in self._mentioned_threads
+                    and (bot_uid, event_thread_ts) in self._mentioned_threads
                 )
                 has_session = (
                     is_thread_reply
@@ -2107,7 +2110,7 @@ class SlackAdapter(BasePlatformAdapter):
             # re-mentioned every turn, so remembering the thread would
             # defeat the feature (and re-enable agent-to-agent ack loops).
             if event_thread_ts and not self._slack_strict_mention():
-                self._mentioned_threads.add(event_thread_ts)
+                self._mentioned_threads.add((bot_uid, event_thread_ts))
                 if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
                     to_remove = list(self._mentioned_threads)[:self._MENTIONED_THREADS_MAX // 2]
                     for t in to_remove:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -395,6 +395,17 @@ class GatewayStreamConsumer:
 
     async def run(self) -> None:
         """Async task that drains the queue and edits the platform message."""
+        # Tell the platform's typing-indicator task that assistant text is
+        # actively flowing — under the ``stream_only`` policy this is the
+        # signal to start refreshing typing... while we stream. No-op for
+        # ``always`` and ``off`` modes. Safe to call on adapters that don't
+        # expose the method (e.g. test MagicMocks).
+        _start_streaming = getattr(self.adapter, "start_streaming_typing", None)
+        if callable(_start_streaming):
+            try:
+                _start_streaming(self.chat_id)
+            except Exception:
+                pass
         # Platform message length limit — leave room for cursor + formatting.
         # Use the adapter's length function (e.g. utf16_len for Telegram) so
         # overflow detection matches what the platform actually enforces.

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -79,6 +79,7 @@ class TestKeepTypingTimeoutPerTick:
                 chat_id="123",
                 interval=1.0,
                 stop_event=stop_event,
+                mode="always",
             )
         )
         await asyncio.sleep(3.0)
@@ -123,6 +124,7 @@ class TestKeepTypingTimeoutPerTick:
                 chat_id="456",
                 interval=0.5,
                 stop_event=stop_event,
+                mode="always",
             )
         )
         await asyncio.sleep(1.2)  # ~3 ticks
@@ -157,6 +159,7 @@ class TestKeepTypingTimeoutPerTick:
                 chat_id="789",
                 interval=0.3,
                 stop_event=stop_event,
+                mode="always",
             )
         )
         await asyncio.sleep(1.0)

--- a/tests/gateway/test_typing_indicator_modes.py
+++ b/tests/gateway/test_typing_indicator_modes.py
@@ -1,0 +1,197 @@
+"""Tests for the per-platform ``typing_indicator`` policy.
+
+Three modes are supported on ``PlatformConfig.typing_indicator``:
+
+  - ``always``     — legacy: refresh typing... continuously for the whole turn.
+                     Default for every platform EXCEPT Telegram.
+  - ``stream_only`` — only refresh typing... while assistant text is actively
+                      streaming/about to be sent (gated by
+                      ``_typing_streaming``). NEW default for Telegram.
+  - ``off``        — never send a typing indicator.
+
+These tests pin all three behaviors at the ``_keep_typing`` level plus the
+default-resolution logic on ``typing_indicator_mode()``.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    Platform,
+    PlatformConfig,
+    SendResult,
+)
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self, platform: Platform = Platform.TELEGRAM, typing_indicator=None):
+        super().__init__(
+            PlatformConfig(enabled=True, token="test", typing_indicator=typing_indicator),
+            platform,
+        )
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+class TestTypingIndicatorModeResolution:
+    def test_telegram_default_is_stream_only(self):
+        adapter = _StubAdapter(platform=Platform.TELEGRAM)
+        assert adapter.typing_indicator_mode() == "stream_only"
+
+    def test_discord_default_is_always(self):
+        adapter = _StubAdapter(platform=Platform.DISCORD)
+        assert adapter.typing_indicator_mode() == "always"
+
+    def test_explicit_off_wins_over_default(self):
+        adapter = _StubAdapter(platform=Platform.TELEGRAM, typing_indicator="off")
+        assert adapter.typing_indicator_mode() == "off"
+
+    def test_explicit_always_wins_over_telegram_default(self):
+        adapter = _StubAdapter(platform=Platform.TELEGRAM, typing_indicator="always")
+        assert adapter.typing_indicator_mode() == "always"
+
+    def test_unknown_value_falls_through_to_default(self):
+        # Invalid values are sanitized to None at config-load time, but
+        # if one sneaks through ``typing_indicator_mode`` must still
+        # return a valid mode (the platform default).
+        adapter = _StubAdapter(platform=Platform.TELEGRAM, typing_indicator="garbage")
+        assert adapter.typing_indicator_mode() == "stream_only"
+
+
+class TestKeepTypingHonorsMode:
+    @pytest.mark.asyncio
+    async def test_always_mode_fires_send_typing(self, monkeypatch):
+        adapter = _StubAdapter(platform=Platform.DISCORD)
+        calls = []
+
+        async def recording(chat_id, metadata=None):
+            calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", recording)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(chat_id="c1", interval=0.3, stop_event=stop, mode="always")
+        )
+        await asyncio.sleep(1.0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert len(calls) >= 2, f"always mode should keep firing send_typing; got {calls}"
+
+    @pytest.mark.asyncio
+    async def test_stream_only_skips_when_not_streaming(self, monkeypatch):
+        adapter = _StubAdapter(platform=Platform.TELEGRAM)
+        calls = []
+
+        async def recording(chat_id, metadata=None):
+            calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", recording)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(chat_id="c1", interval=0.3, stop_event=stop, mode="stream_only")
+        )
+        await asyncio.sleep(1.0)  # ~3 ticks elapsed; no streaming flag set
+        stop.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert calls == [], (
+            f"stream_only must not call send_typing while _typing_streaming "
+            f"is empty; got {calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_only_fires_when_streaming_flag_set(self, monkeypatch):
+        adapter = _StubAdapter(platform=Platform.TELEGRAM)
+        calls = []
+
+        async def recording(chat_id, metadata=None):
+            calls.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", recording)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+        adapter.start_streaming_typing("c1")
+
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(chat_id="c1", interval=0.3, stop_event=stop, mode="stream_only")
+        )
+        await asyncio.sleep(1.0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert len(calls) >= 2, (
+            f"stream_only should fire send_typing once start_streaming_typing "
+            f"was called; got {calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_only_starts_quiet_then_wakes_up(self, monkeypatch):
+        """Verify the live transition: no ticks while idle, ticks once the
+        streaming flag flips on."""
+        adapter = _StubAdapter(platform=Platform.TELEGRAM)
+        calls = []
+
+        async def recording(chat_id, metadata=None):
+            calls.append((chat_id, asyncio.get_event_loop().time()))
+
+        monkeypatch.setattr(adapter, "send_typing", recording)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(chat_id="c1", interval=0.25, stop_event=stop, mode="stream_only")
+        )
+        # Phase 1: no streaming -> no calls
+        await asyncio.sleep(0.7)
+        assert calls == [], f"expected silence in phase 1, got {calls}"
+        # Phase 2: turn streaming on
+        adapter.start_streaming_typing("c1")
+        await asyncio.sleep(0.8)
+        stop.set()
+        await asyncio.wait_for(task, timeout=1.0)
+        assert len(calls) >= 1, (
+            f"expected send_typing after start_streaming_typing, got {calls}"
+        )
+
+
+class TestStreamingHelpers:
+    def test_start_and_stop_streaming_typing(self):
+        adapter = _StubAdapter()
+        adapter.start_streaming_typing("abc")
+        assert "abc" in adapter._typing_streaming
+        adapter.stop_streaming_typing("abc")
+        assert "abc" not in adapter._typing_streaming
+
+    def test_stop_streaming_typing_is_idempotent(self):
+        adapter = _StubAdapter()
+        # Should not raise when the chat was never marked streaming.
+        adapter.stop_streaming_typing("never-streamed")
+
+
+class TestKeepTypingDefaultInterval:
+    def test_default_interval_is_four_seconds(self):
+        """Refresh interval was bumped from 2.0s → 4.0s. Telegram's typing
+        bubble expires at ~5s, so 4s keeps it alive with one HTTP call per
+        tick instead of two."""
+        import inspect
+
+        sig = inspect.signature(BasePlatformAdapter._keep_typing)
+        assert sig.parameters["interval"].default == 4.0


### PR DESCRIPTION
## Problem

Telegram shows `typing...` continuously for the entire turn — including 30s+ tool calls and model thinking. With long-running tools (web search, browser, terminal builds), the indicator runs for minutes and makes the bot look stuck.

Telegram's `sendChatAction` is designed as a short-lived signal ("user is composing"). Best practice (ChatGPT, Poe, Cursor-bot) is to fire it only while text is actually being emitted.

## Fix

New per-platform `typing_indicator` config under `gateway.platforms.<name>`:

- `always` — legacy continuous refresh (default for non-Telegram platforms)
- `stream_only` — only refresh while assistant text is actively streaming / about to be sent (**new default for Telegram**)
- `off` — never send typing

Refresh interval bumped 2.0s → 4.0s (Telegram window is ~5s; 2s was 2× the necessary API calls).

## Default change

**Telegram default flips `always` → `stream_only`.** Users who want the old behavior can opt back in:

```yaml
gateway:
  platforms:
    telegram:
      typing_indicator: always
```

Other platforms unchanged.

## Wiring

- `base._process_message_background` — resolves mode; `off` skips spawning the task entirely, `stream_only` spawns it in idle state.
- `base` final-send path + `GatewayStreamConsumer.run()` — call `start_streaming_typing(chat_id)` when text is imminent.
- Existing `_typing_paused` machinery preserved (approval waits still suppress typing).

## Tests

- `tests/gateway/test_typing_indicator_modes.py` (new, 12 tests) — all three modes, default resolution per platform, live idle→streaming transition, helper idempotency, 4.0s interval pin.
- Updated 3 existing `test_keep_typing_timeout` tests to pass `mode='always'` explicitly (Telegram stub now defaults to `stream_only`).
- Local run: **117 tests pass** across `test_typing_indicator_modes`, `test_keep_typing_timeout`, `test_stream_consumer`, `test_stream_consumer_draft`. Zero failures.

## Limitations

- Adapters that override `_keep_typing` with a narrower signature fall back to pre-change behavior — the new `mode` kwarg is dropped defensively. Affects Discord/Slack overrides; Telegram (the target) uses the base implementation.
- `stream_only` wakes typing at two points: (a) `GatewayStreamConsumer.run()` start, (b) right before non-streamed final `send_message`. If a turn does no streaming and no final text (rare), no typing shows — arguably correct.
