### PR TITLE
fix(aux): fall back to config base_url/api_key for custom provider in cron/background tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1659,6 +1659,44 @@ def _read_main_provider() -> str:
     return ""
 
 
+def _read_main_base_url() -> str:
+    """Read the user's configured ``model.base_url`` from config.yaml.
+
+    Returns the stripped URL string or ``""`` if not configured.
+    Only meaningful when the provider is ``custom`` or ``custom:<name>``.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, dict):
+            base_url = str(model_cfg.get("base_url", "") or "").strip()
+            if base_url:
+                return base_url
+    except Exception:
+        pass
+    return ""
+
+
+def _read_main_api_key() -> str:
+    """Read the user's configured ``model.api_key`` from config.yaml.
+
+    Returns the stripped key string or ``""`` if not configured.
+    Only meaningful when the provider is ``custom`` or ``custom:<name>``.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, dict):
+            api_key = str(model_cfg.get("api_key", "") or "").strip()
+            if api_key:
+                return api_key
+    except Exception:
+        pass
+    return ""
+
+
 # Process-local override set by AIAgent at session/turn start. Single-threaded
 # per turn — no lock needed. Cleared by ``clear_runtime_main()``.
 _RUNTIME_MAIN_PROVIDER: str = ""
@@ -2955,6 +2993,16 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
             resolved_provider = "custom"
             explicit_base_url = runtime_base_url
             explicit_api_key = runtime_api_key or None
+        elif (main_provider == "custom" or main_provider.startswith("custom:")) and not runtime_base_url:
+            # No runtime override (cron / background tasks): fall back to
+            # model.base_url and model.api_key from config.yaml so that
+            # custom-provider users don't lose aux routing when no active
+            # CLI/gateway session is present.
+            resolved_provider = "custom"
+            cfg_base_url = _read_main_base_url()
+            if cfg_base_url:
+                explicit_base_url = cfg_base_url
+                explicit_api_key = _read_main_api_key() or None
         elif runtime_api_key:
             # Pin auxiliary to the same api_key as the active main chat session
             # so that a working key is reused instead of re-selecting from the pool

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1659,44 +1659,6 @@ def _read_main_provider() -> str:
     return ""
 
 
-def _read_main_base_url() -> str:
-    """Read the user's configured ``model.base_url`` from config.yaml.
-
-    Returns the stripped URL string or ``""`` if not configured.
-    Only meaningful when the provider is ``custom`` or ``custom:<name>``.
-    """
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        model_cfg = cfg.get("model", {})
-        if isinstance(model_cfg, dict):
-            base_url = str(model_cfg.get("base_url", "") or "").strip()
-            if base_url:
-                return base_url
-    except Exception:
-        pass
-    return ""
-
-
-def _read_main_api_key() -> str:
-    """Read the user's configured ``model.api_key`` from config.yaml.
-
-    Returns the stripped key string or ``""`` if not configured.
-    Only meaningful when the provider is ``custom`` or ``custom:<name>``.
-    """
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        model_cfg = cfg.get("model", {})
-        if isinstance(model_cfg, dict):
-            api_key = str(model_cfg.get("api_key", "") or "").strip()
-            if api_key:
-                return api_key
-    except Exception:
-        pass
-    return ""
-
-
 # Process-local override set by AIAgent at session/turn start. Single-threaded
 # per turn — no lock needed. Cleared by ``clear_runtime_main()``.
 _RUNTIME_MAIN_PROVIDER: str = ""
@@ -2989,20 +2951,26 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None
-        if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
+        explicit_api_mode = runtime_api_mode or None
+        if main_provider == "custom" or main_provider.startswith("custom:"):
             resolved_provider = "custom"
-            explicit_base_url = runtime_base_url
-            explicit_api_key = runtime_api_key or None
-        elif (main_provider == "custom" or main_provider.startswith("custom:")) and not runtime_base_url:
-            # No runtime override (cron / background tasks): fall back to
-            # model.base_url and model.api_key from config.yaml so that
-            # custom-provider users don't lose aux routing when no active
-            # CLI/gateway session is present.
-            resolved_provider = "custom"
-            cfg_base_url = _read_main_base_url()
-            if cfg_base_url:
-                explicit_base_url = cfg_base_url
-                explicit_api_key = _read_main_api_key() or None
+            if runtime_base_url:
+                # Active CLI/gateway session — use the live runtime override.
+                explicit_base_url = runtime_base_url
+                explicit_api_key = runtime_api_key or None
+            else:
+                # No runtime override (cron / background tasks): resolve the
+                # custom endpoint the same way the main CLI does. This covers
+                # config.yaml-saved endpoints, OPENAI_BASE_URL/OPENAI_API_KEY
+                # env setups, api_mode propagation for non-OpenAI gateways, and
+                # local-server / OpenRouter-fallback normalization — none of
+                # which a bare config.yaml read would handle.
+                custom_base, custom_key, custom_mode = _resolve_custom_runtime()
+                if custom_base:
+                    explicit_base_url = custom_base
+                    explicit_api_key = custom_key
+                    if custom_mode:
+                        explicit_api_mode = custom_mode
         elif runtime_api_key:
             # Pin auxiliary to the same api_key as the active main chat session
             # so that a working key is reused instead of re-selecting from the pool
@@ -3022,7 +2990,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
                 main_model,
                 explicit_base_url=explicit_base_url,
                 explicit_api_key=explicit_api_key,
-                api_mode=runtime_api_mode or None,
+                api_mode=explicit_api_mode,
             )
             if client is not None:
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -163,6 +163,116 @@ class TestResolveAutoMainFirst:
         assert mock_resolve.call_args.args[1] == "runtime-model"
 
 
+class TestResolveAutoCustomNoRuntime:
+    """Custom provider must keep aux routing when no live runtime override exists.
+
+    Regression for #33333: cron jobs and gateway background tasks have no
+    active CLI/gateway session, so ``runtime_base_url`` is empty. The custom
+    branch must resolve the endpoint via ``_resolve_custom_runtime()`` (the
+    same resolver the main CLI uses) instead of dropping to ``None`` and
+    falling through to the wrong provider.
+    """
+
+    def test_custom_no_runtime_resolves_via_resolve_custom_runtime(self):
+        """No runtime override → endpoint comes from _resolve_custom_runtime()."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="custom",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="local-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            return_value=("https://my-endpoint.example/v1", "sk-cfg-key", None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve:
+            mock_client = MagicMock()
+            mock_resolve.return_value = (mock_client, "local-model")
+
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto()
+
+        assert client is mock_client
+        assert model == "local-model"
+        mock_resolve.assert_called_once()
+        assert mock_resolve.call_args.args[0] == "custom"
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://my-endpoint.example/v1"
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] == "sk-cfg-key"
+
+    def test_custom_no_runtime_propagates_api_mode(self):
+        """api_mode from _resolve_custom_runtime() must reach resolve_provider_client."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="custom",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="codex-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            return_value=("https://gw.example/v1", "sk-key", "codex_responses"),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve:
+            mock_resolve.return_value = (MagicMock(), "codex-model")
+
+            from agent.auxiliary_client import _resolve_auto
+
+            _resolve_auto()
+
+        assert mock_resolve.call_args.kwargs["api_mode"] == "codex_responses"
+
+    def test_custom_with_runtime_override_skips_config_fallback(self):
+        """An active runtime base_url wins; _resolve_custom_runtime is not consulted."""
+        with patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+        ) as mock_custom_runtime, patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve:
+            mock_resolve.return_value = (MagicMock(), "runtime-model")
+
+            from agent.auxiliary_client import _resolve_auto
+
+            _resolve_auto(main_runtime={
+                "provider": "custom",
+                "model": "runtime-model",
+                "base_url": "https://live-session.example/v1",
+                "api_key": "sk-live",
+                "api_mode": "",
+            })
+
+        mock_custom_runtime.assert_not_called()
+        assert mock_resolve.call_args.args[0] == "custom"
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://live-session.example/v1"
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] == "sk-live"
+
+    def test_custom_no_runtime_no_config_does_not_fabricate_base_url(self, monkeypatch):
+        """No runtime and no resolvable custom endpoint → don't invent a base_url;
+        fall through to the aux chain instead."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        chain_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="custom",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="local-model",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            return_value=(None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(None, None),
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._try_openrouter",
+            return_value=(chain_client, "google/gemini-3-flash-preview"),
+        ):
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto()
+
+        # Step 1 still attempts custom, but with no fabricated base_url.
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] is None
+        # …and resolution falls through to the aux chain.
+        assert client is chain_client
+        assert model == "google/gemini-3-flash-preview"
+
+
 # ── Vision — resolve_vision_provider_client ─────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

When `model.provider` is `custom` and no active CLI/gateway session provides a runtime override (i.e. **cron jobs** and **gateway background tasks**), `_resolve_auto()` previously passed `explicit_base_url=None` to `resolve_provider_client()`, causing it to silently fail and fall through to the wrong provider or return `(None, None)`.

## Root Cause

In `_resolve_auto()` (agent/auxiliary_client.py), the guard on line 2954:

```python
if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
```

When `main_runtime=None` (no active session), `runtime_base_url` is empty string (falsy), so the condition fails. The custom provider's `base_url` and `api_key` from config.yaml are never passed through.

## Fix

1. Added `_read_main_base_url()` and `_read_main_api_key()` helper functions following the existing pattern of `_read_main_provider()` / `_read_main_model()`.
2. Added an `elif` branch in `_resolve_auto()` that activates when the provider is custom but `runtime_base_url` is empty, falling back to config values.

## Testing

- All 176 tests in `tests/agent/test_auxiliary_client.py` pass (1 pre-existing failure excluded)
- All vision, video, GMI provider auxiliary tests pass
- Import verification passes

Fixes #33333