### PR TITLE
chore: add JohnC1009 to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1334,6 +1334,7 @@ AUTHOR_MAP = {
     "krislidimo@gmail.com": "krislidimo",  # PR #29775 (tighten Telegram table row-group spacing; drop redundant first bullet)
     "timothy.b.dixon@gmail.com": "Codename-11",  # PR #29302 (API server session controls — sessions/chat/fork/stream)
     "jpschwartz2@uwalumni.com": "Schwartz10",  # PR #29302 sub-PR (multimodal media in session chat API)
+    "JohnC1009@users.noreply.github.com": "JohnC1009",  # PR #32020 salvage (auth: global auth.json fallback in _load_provider_state)
 }
 
 


### PR DESCRIPTION
## Summary

Adds `JohnC1009@users.noreply.github.com → JohnC1009` to `AUTHOR_MAP` in `scripts/release.py`.

Pre-requisite for the PR #32020 salvage (auth: fall back to global `auth.json` in `_load_provider_state`). The `contributor_audit.py` strict mode fails on any commit author email on `main` that isn't in `AUTHOR_MAP`, so this needs to land before the salvage PR.

## Test plan

- One line added; no other changes.
- Merge this first, then the #32020 salvage.
