### PR TITLE
fix(cli): add /handoff platform completions to slash command autocomplete

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -545,7 +545,26 @@ class GatewayConfig:
         if config:
             return config.home_channel
         return None
-    
+
+    def get_handoff_platforms(self) -> List[tuple]:
+        """Return ``(platform, home_channel)`` pairs eligible for /handoff.
+
+        A platform is handoff-eligible when it is enabled and has a home
+        channel with a chat_id — the same gate ``/handoff`` enforces before
+        queuing a handoff (see ``cli.py::_handle_handoff_command``).  Shared by
+        the CLI completer so autocomplete can't drift from what the command
+        actually accepts.
+        """
+        eligible: List[tuple] = []
+        for platform, config in self.platforms.items():
+            if not config or not config.enabled:
+                continue
+            home = config.home_channel
+            if not home or not home.chat_id:
+                continue
+            eligible.append((platform, home))
+        return eligible
+
     def get_reset_policy(
         self, 
         platform: Optional[Platform] = None,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1598,6 +1598,29 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
+    @staticmethod
+    def _handoff_completions(sub_text: str, sub_lower: str):
+        """Yield completions for /handoff from configured gateway platforms."""
+        try:
+            from gateway.config import load_gateway_config
+            gw = load_gateway_config()
+            for platform, pcfg in gw.platforms.items():
+                if not pcfg or not pcfg.enabled:
+                    continue
+                home = pcfg.home_channel
+                if not home or not home.chat_id:
+                    continue
+                name = platform.value
+                if name.startswith(sub_lower) and name != sub_lower:
+                    yield Completion(
+                        name,
+                        start_position=-len(sub_text),
+                        display=name,
+                        display_meta=pcfg.name if hasattr(pcfg, 'name') and pcfg.name else "",
+                    )
+        except Exception:
+            pass
+
     def _model_completions(self, sub_text: str, sub_lower: str):
         """Yield completions for /model from config aliases + built-in aliases."""
         seen = set()
@@ -1675,6 +1698,9 @@ class SlashCommandCompleter(Completer):
                     return
                 if base_cmd == "/personality":
                     yield from self._personality_completions(sub_text, sub_lower)
+                    return
+                if base_cmd == "/handoff":
+                    yield from self._handoff_completions(sub_text, sub_lower)
                     return
 
             # Static subcommand completions

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1198,6 +1198,11 @@ class SlashCommandCompleter(Completer):
         self._file_cache: list[str] = []
         self._file_cache_time: float = 0.0
         self._file_cache_cwd: str = ""
+        # Cached gateway config for /handoff completions. load_gateway_config()
+        # re-reads config files, runs plugin discovery, and mutates os.environ,
+        # so we must not call it on every keystroke (complete_while_typing).
+        self._gateway_cfg = None
+        self._gateway_cfg_time: float = 0.0
 
     def _command_allowed(self, slash_command: str) -> bool:
         if self._command_filter is None:
@@ -1598,25 +1603,24 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
-    @staticmethod
-    def _handoff_completions(sub_text: str, sub_lower: str):
-        """Yield completions for /handoff from configured gateway platforms."""
+    def _handoff_completions(self, sub_text: str, sub_lower: str):
+        """Yield completions for /handoff from handoff-eligible gateway platforms."""
         try:
-            from gateway.config import load_gateway_config
-            gw = load_gateway_config()
-            for platform, pcfg in gw.platforms.items():
-                if not pcfg or not pcfg.enabled:
-                    continue
-                home = pcfg.home_channel
-                if not home or not home.chat_id:
-                    continue
+            now = time.monotonic()
+            gw = self._gateway_cfg
+            if gw is None or now - self._gateway_cfg_time >= 5.0:
+                from gateway.config import load_gateway_config
+                gw = load_gateway_config()
+                self._gateway_cfg = gw
+                self._gateway_cfg_time = now
+            for platform, home in gw.get_handoff_platforms():
                 name = platform.value
                 if name.startswith(sub_lower) and name != sub_lower:
                     yield Completion(
                         name,
                         start_position=-len(sub_text),
                         display=name,
-                        display_meta=pcfg.name if hasattr(pcfg, 'name') and pcfg.name else "",
+                        display_meta=home.name or "",
                     )
         except Exception:
             pass

--- a/tests/hermes_cli/test_handoff_completion.py
+++ b/tests/hermes_cli/test_handoff_completion.py
@@ -1,0 +1,74 @@
+"""Tests for /handoff slash-command autocomplete (#33070).
+
+Covers three things the completer must get right:
+  1. ``GatewayConfig.get_handoff_platforms()`` returns exactly the platforms
+     ``/handoff`` would accept (enabled AND a home channel with a chat_id) —
+     the shared eligibility rule the completer and the command both rely on.
+  2. The completion's ``display_meta`` surfaces the home channel name, not an
+     empty string (``PlatformConfig`` has no ``name``; the human-readable name
+     lives on ``HomeChannel``).
+  3. The completer caches the gateway config instead of re-loading it (and
+     re-running plugin discovery + file I/O) on every keystroke.
+"""
+
+from __future__ import annotations
+
+import gateway.config as gwconfig
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from hermes_cli.commands import SlashCommandCompleter
+from prompt_toolkit.document import Document
+
+
+def _gw(platforms):
+    return GatewayConfig(platforms=platforms)
+
+
+def test_get_handoff_platforms_filters_to_enabled_with_home():
+    home = HomeChannel(platform=Platform.TELEGRAM, chat_id="123", name="My Phone")
+    gw = _gw({
+        Platform.TELEGRAM: PlatformConfig(enabled=True, home_channel=home),
+        # enabled but no home channel → not eligible
+        Platform.DISCORD: PlatformConfig(enabled=True, home_channel=None),
+        # has a home channel but disabled → not eligible
+        Platform.SLACK: PlatformConfig(
+            enabled=False,
+            home_channel=HomeChannel(Platform.SLACK, "999", "Slack"),
+        ),
+        # enabled, home present but chat_id empty → not eligible
+        Platform.SIGNAL: PlatformConfig(
+            enabled=True,
+            home_channel=HomeChannel(Platform.SIGNAL, "", "Signal"),
+        ),
+    })
+
+    assert gw.get_handoff_platforms() == [(Platform.TELEGRAM, home)]
+
+
+def test_handoff_completion_display_meta_shows_home_name(monkeypatch):
+    home = HomeChannel(platform=Platform.TELEGRAM, chat_id="123", name="My Phone")
+    gw = _gw({Platform.TELEGRAM: PlatformConfig(enabled=True, home_channel=home)})
+    monkeypatch.setattr(gwconfig, "load_gateway_config", lambda: gw)
+
+    completer = SlashCommandCompleter()
+    comps = list(completer.get_completions(Document("/handoff te"), None))
+
+    metas = {c.text: c.display_meta_text for c in comps}
+    assert metas.get("telegram") == "My Phone"
+
+
+def test_handoff_completion_caches_gateway_config(monkeypatch):
+    calls = {"n": 0}
+    home = HomeChannel(platform=Platform.TELEGRAM, chat_id="123", name="My Phone")
+    gw = _gw({Platform.TELEGRAM: PlatformConfig(enabled=True, home_channel=home)})
+
+    def fake_load():
+        calls["n"] += 1
+        return gw
+
+    monkeypatch.setattr(gwconfig, "load_gateway_config", fake_load)
+
+    completer = SlashCommandCompleter()
+    list(completer.get_completions(Document("/handoff t"), None))
+    list(completer.get_completions(Document("/handoff te"), None))
+
+    assert calls["n"] == 1


### PR DESCRIPTION
## What does this PR do?

`/handoff <platform>` had no autocomplete — the completion menu was empty
because `SlashCommandCompleter` had no dynamic handler for it. This PR adds one
that lists the gateway platforms eligible for handoff (enabled, with a
configured home channel), following the existing `/model`, `/skin`,
`/personality` pattern.

It also folds in fixes from self-review of the initial commit:

- **Completion meta was always empty.** It read `pcfg.name`, but
  `PlatformConfig` has no `name` field, so the `hasattr` guard never fired. It
  now shows the home channel's name (`HomeChannel.name`) — the same value
  `/handoff` prints on success.
- **Config was reloaded on every keystroke.** `_handoff_completions` called
  `load_gateway_config()` per keystroke (`complete_while_typing`), which
  re-reads config files, runs plugin discovery, and mutates `os.environ`. It is
  now cached on the completer with a 5s TTL, mirroring the existing `@`-file
  cache.
- **Eligibility logic was duplicated.** Added
  `GatewayConfig.get_handoff_platforms()` as the single source of truth for
  handoff eligibility (enabled + `home_channel.chat_id`), so the completer
  cannot drift from `cli.py::_handle_handoff_command`.

## Related Issue

Fixes #33070

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/commands.py` — add `SlashCommandCompleter._handoff_completions()` and a `/handoff` dispatch branch; cache the gateway config on the completer (5s TTL); show `HomeChannel.name` as `display_meta`.
- `gateway/config.py` — add `GatewayConfig.get_handoff_platforms()`, the single source of truth for handoff eligibility.
- `tests/hermes_cli/test_handoff_completion.py` — new regression tests for the eligibility filter, the meta name, and the per-keystroke caching.

## How to Test

1. Configure a gateway platform with a home channel (e.g. Telegram, then `/sethome` in the destination chat).
2. In the CLI, type `/handoff ` and press Tab — eligible platforms appear, each with its home channel name shown as the meta hint.
3. `pytest tests/hermes_cli/test_handoff_completion.py -q` → 3 passed.

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): …`)
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.5)
- [ ] I've run `pytest tests/ -q` and all tests pass

> **Full-suite note.** I ran the full suite via `scripts/run_tests_parallel.py`.
> Every test relevant to this change passes (handoff / completer / gateway-config
> — 213 tests). The remaining failures are pre-existing and unrelated to this PR:
> missing optional deps (`acp` module) and macOS-specific env issues (the patch /
> file tools reject writes under `/private/var/folders/...`, macOS's `$TMPDIR`,
> as "sensitive system paths"). I confirmed the same files fail identically on the
> pre-change baseline (`13dc1cb45^`): `15 failed, 14 passed` across
> `test_patch_failure_tracking` + `test_cross_profile_guard` +
> `test_line_ending_preservation`.

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed.
