### PR TITLE
fix(memory): warn on oversized raw markdown imports

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
+import logging
 import pytest
 from pathlib import Path
 
@@ -392,6 +393,45 @@ class TestMemoryStorePersistence:
         store = MemoryStore()
         store.load_from_disk()
         assert len(store.memory_entries) == 2
+
+    def test_load_warns_for_raw_markdown_over_limit(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        raw_markdown = (
+            "## Schedule\n"
+            "- Daily: website check\n\n"
+            "## Projects\n"
+            + ("FOAF network contact dossier. " * 30)
+        )
+        (tmp_path / "MEMORY.md").write_text(raw_markdown, encoding="utf-8")
+
+        store = MemoryStore(memory_char_limit=200)
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store.load_from_disk()
+
+        assert len(store.memory_entries) == 1
+        assert any(
+            "MEMORY.md contains one" in record.message
+            and "no '\\n§\\n' delimiters" in record.message
+            for record in caplog.records
+        )
+
+    def test_load_does_not_warn_for_normal_single_entry(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        (tmp_path / "MEMORY.md").write_text(
+            "User prefers concise answers.",
+            encoding="utf-8",
+        )
+
+        store = MemoryStore(memory_char_limit=200)
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store.load_from_disk()
+
+        assert store.memory_entries == ["User prefers concise answers."]
+        assert not caplog.records
 
 
 class TestMemoryStoreSnapshot:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -156,6 +156,17 @@ class MemoryStore:
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
         self.user_entries = list(dict.fromkeys(self.user_entries))
 
+        self._warn_if_single_oversized_entry(
+            mem_dir / "MEMORY.md",
+            "memory",
+            self.memory_entries,
+        )
+        self._warn_if_single_oversized_entry(
+            mem_dir / "USER.md",
+            "user",
+            self.user_entries,
+        )
+
         # Sanitize entries for the system-prompt snapshot only.  Live state
         # (memory_entries / user_entries) keeps the raw text so the user
         # can see + remove poisoned entries via the memory tool.
@@ -296,6 +307,36 @@ class MemoryStore:
         if target == "user":
             return self.user_char_limit
         return self.memory_char_limit
+
+    def _warn_if_single_oversized_entry(
+        self,
+        path: Path,
+        target: str,
+        entries: List[str],
+    ) -> None:
+        """Warn when a raw markdown dump parses as one oversized entry.
+
+        A legitimate one-entry memory file also has no delimiter, so only warn
+        when that single parsed entry exceeds the target's whole-store budget.
+        """
+        if len(entries) != 1 or ENTRY_DELIMITER in entries[0]:
+            return
+
+        entry_len = len(entries[0])
+        limit = self._char_limit(target)
+        if entry_len <= limit:
+            return
+
+        logger.warning(
+            "%s contains one %s-character entry with no %r delimiters; "
+            "raw markdown imports can parse as a single oversized entry and "
+            "may be omitted from useful memory context. Split it into "
+            "smaller entries separated by %r.",
+            path.name,
+            f"{entry_len:,}",
+            ENTRY_DELIMITER,
+            ENTRY_DELIMITER.strip(),
+        )
 
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""


### PR DESCRIPTION
Fixes #32965.

## Summary
- Warn during memory load when `MEMORY.md` or `USER.md` parses as one delimiterless entry larger than that target's char budget.
- Keep normal single-entry memory files quiet to avoid noisy false positives.
- Add regression coverage for oversized raw markdown imports and normal one-entry files.

This is intentionally narrower than raw-markdown parsing: it preserves the current storage format and only makes the silent-failure case diagnosable.

## Validation
- `python -m compileall tools/memory_tool.py tests/tools/test_memory_tool.py`
- `uv run --extra dev python -m pytest tests/tools/test_memory_tool.py -q`