### PR TITLE
fix(cron): execute job once after missed-grace fast-forward instead of skipping

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1082,7 +1082,10 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             rj["next_run_at"] = new_next
                             needs_save = True
                             break
-                    continue  # Skip this run
+                    # Don't skip execution — the job didn't miss because the
+                    # gateway was down, it missed because it was still running.
+                    # Fast-forward prevents burst-catchup, but the job should
+                    # still run once now. See #33315.
 
             due.append(job)
 


### PR DESCRIPTION
## Summary

Fixes #33315 — recurring cron jobs perpetually deferred after long execution.

When a cron job's execution time exceeds interval + grace_period, the scheduler correctly fast-forwards next_run_at to prevent burst-catchup, but then skips execution entirely (continue). This causes a job that takes 15min on a 5min schedule to effectively never run again.

## Fix

Removed the continue on line 1085 of cron/jobs.py so the job falls through to due.append(job) after the fast-forward. Burst-catchup prevention is preserved but the job still runs once now.

## Before vs After

BEFORE: job runs 15min → missed by > grace → fast-forward → SKIP → runs ~21min later (broken)
AFTER:  job runs 15min → missed by > grace → fast-forward → RUN once now → next run on schedule

Closes #33315