### PR TITLE
fix(api-server): name both API_SERVER_KEY env and platforms.api_server.key in 403 messages

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -905,12 +905,15 @@ class APIServerAdapter(BasePlatformAdapter):
         if not self._api_key:
             logger.warning(
                 "X-Hermes-Session-Key rejected: no API key configured. "
-                "Set API_SERVER_KEY to enable long-term memory scoping."
+                "Set API_SERVER_KEY (env) or platforms.api_server.key "
+                "(config.yaml) to enable long-term memory scoping."
             )
             return None, web.json_response(
                 _openai_error(
                     "X-Hermes-Session-Key requires API key authentication. "
-                    "Configure API_SERVER_KEY to enable this feature."
+                    "Configure API_SERVER_KEY (env) or "
+                    "platforms.api_server.key (config.yaml) to enable this "
+                    "feature."
                 ),
                 status=403,
             )
@@ -1745,13 +1748,16 @@ class APIServerAdapter(BasePlatformAdapter):
             if not self._api_key:
                 logger.warning(
                     "Session continuation via X-Hermes-Session-Id rejected: "
-                    "no API key configured.  Set API_SERVER_KEY to enable "
+                    "no API key configured.  Set API_SERVER_KEY (env) or "
+                    "platforms.api_server.key (config.yaml) to enable "
                     "session continuity."
                 )
                 return web.json_response(
                     _openai_error(
                         "Session continuation requires API key authentication. "
-                        "Configure API_SERVER_KEY to enable this feature."
+                        "Configure API_SERVER_KEY (env) or "
+                        "platforms.api_server.key (config.yaml) to enable this "
+                        "feature."
                     ),
                     status=403,
                 )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3293,6 +3293,27 @@ class TestSessionIdHeader:
             assert call_kwargs["user_message"] == "new question"
 
     @pytest.mark.asyncio
+    async def test_session_continuation_403_message_points_at_config(self, adapter):
+        """Session continuation without API_SERVER_KEY returns 403 with an
+        error message that names *both* the env var and the
+        ``platforms.api_server.key`` config path, so a user who configured
+        the auth key in one place isn't sent hunting for the other
+        (#33207).
+        """
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Id": "anything"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert resp.status == 403
+            payload = await resp.json()
+            msg = payload.get("error", {}).get("message", "")
+            assert "API_SERVER_KEY" in msg
+            assert "platforms.api_server.key" in msg
+
+    @pytest.mark.asyncio
     async def test_db_failure_falls_back_to_empty_history(self, auth_adapter):
         """If SessionDB raises, history falls back to empty and request still succeeds."""
         mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
@@ -3406,6 +3427,13 @@ class TestSessionKeyHeader:
                 json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
             )
             assert resp.status == 403
+            # Error message must point users at both the env var AND the
+            # config path so users who configured only one don't get stuck
+            # hunting for the other (#33207).
+            payload = await resp.json()
+            msg = payload.get("error", {}).get("message", "")
+            assert "API_SERVER_KEY" in msg
+            assert "platforms.api_server.key" in msg
 
     @pytest.mark.asyncio
     async def test_session_key_rejects_control_chars(self, auth_adapter):


### PR DESCRIPTION
## What does this PR do?

When the API server has no auth key configured, the 403 returned by the session-continuation (`X-Hermes-Session-Id`) and long-term memory (`X-Hermes-Session-Key`) headers tells users only to "Configure `API_SERVER_KEY` to enable this feature." Users who set the key through `config.yaml` (via `hermes config set platforms.api_server.key …` or hand-editing) then go hunting for a separate env var instead of being pointed back at the config path they already used.

This PR mirrors the wording the no-key startup warning at `gateway/platforms/api_server.py:4146` already uses (`API_SERVER_KEY / platforms.api_server.key`) across both 403 error envelopes and their accompanying log warnings, so users see both configuration paths at the moment they hit the gate.

The underlying auth check is unchanged: `APIServerAdapter.__init__` already reads `extra.get("key", os.getenv("API_SERVER_KEY", ""))`, so a `platforms.api_server.extra.key` value in `config.yaml` already works end-to-end. This PR only updates the user-facing error/log strings.

## Related Issue

Fixes #33207 (message-clarity sub-bug only — see "Related / Positioning" below).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py` — update the two 403 error envelopes (\`X-Hermes-Session-Id\` continuation, \`X-Hermes-Session-Key\` memory scope) and their two accompanying ``logger.warning`` lines to name both \`API_SERVER_KEY\` (env) and \`platforms.api_server.key\` (config.yaml).
- \`tests/gateway/test_api_server.py\` — add two assertions on the 403 response bodies (one in \`TestSessionIdHeader\`, one extending \`TestSessionKeyHeader::test_session_key_rejected_without_api_key\`) that lock in both substrings so future edits can't silently drop the config-path reference.

## How to Test

1. Run the focused tests:
   \`\`\`
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \\
     tests/gateway/test_api_server.py::TestSessionIdHeader::test_session_continuation_403_message_points_at_config \\
     tests/gateway/test_api_server.py::TestSessionKeyHeader::test_session_key_rejected_without_api_key -v
   \`\`\`
2. Spot-check 403 wording against current main: \`grep -n "Configure API_SERVER_KEY" gateway/platforms/api_server.py\` returns nothing on this branch; \`grep -n "platforms.api_server.key" gateway/platforms/api_server.py\` now matches the two 403 sites plus the existing no-key startup warning at line 4146.
3. Full \`tests/gateway/test_api_server.py\` passes locally (157 tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see "Related / Positioning"
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — N/A; this PR only edits user-facing error strings, no doc surface affected.
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A; no new config keys.
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; pure string change.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Related / Positioning

Issue #33207 asks for two things:

1. **Auth fall-through** — \`platforms.api_server.key\` written at the bare-string top level (the shape \`hermes config set …\` produces) should be honored by \`APIServerAdapter\`. This is the broader \`PlatformConfig.from_dict\` "silent drop of top-level platform keys" bug also covered by issue #20501 / #10206. There are two open PRs already in flight on this:
    - #20506 (Beandon13) — \`PlatformConfig.from_dict\` merges all unknown top-level keys into \`extra\`.
    - #20528 (Kailigithub) — narrower variant covering \`port\` / \`host\` / \`key\` / \`cors_origins\` for \`api_server\` specifically.

    Both touch \`gateway/config.py\` and were flagged as duplicates of each other by @alt-glitch on 2026-05-06. **This PR intentionally does NOT touch \`gateway/config.py\`** to avoid stacking a third duplicate on top — once either of those lands, the bare-string \`platforms.api_server.key\` path will work end-to-end.

2. **Message clarity** — the 403 error currently names only the env var, even on configs that set the key via \`platforms.api_server.key\`. That's the piece this PR fixes. Orthogonal to #20506 / #20528; not touched by either of them.

> Audited siblings: the no-key startup warning at \`gateway/platforms/api_server.py:4146\` already names both \`API_SERVER_KEY\` and \`platforms.api_server.key\`. The bind-guard refusal messages at lines 4111 and 4124 are about network-binding policy rather than "where do I configure the key" UX, so I intentionally left them out of this PR's scope. Happy to widen if preferred.