### PR TITLE
fix(gateway): dispatch kanban through configured store

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5346,9 +5346,14 @@ class GatewayRunner:
 
         try:
             from hermes_cli import kanban_db as _kb
+            from hermes_cli.kanban_store_factory import get_default_kanban_store
         except Exception:
-            logger.warning("kanban dispatcher: kanban_db not importable; dispatcher disabled")
+            logger.warning("kanban dispatcher: kanban storage not importable; dispatcher disabled")
             return
+
+        store = get_default_kanban_store()
+        store_backend = getattr(getattr(store, "capabilities", None), "backend", "sqlite")
+        logger.info("kanban dispatcher: storage backend=%s", store_backend)
 
         interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
         interval = max(interval, 1.0)  # sanity floor — tighter than this is a footgun
@@ -5447,6 +5452,23 @@ class GatewayRunner:
                 or "database disk image is malformed" in msg
             )
 
+        def _connect_store_for_board(slug: str):
+            """Open the selected Kanban store and return (conn, context)."""
+            if store_backend == "sqlite":
+                return store.connect(board=slug), None
+            ctx = store.connect()
+            return ctx.__enter__(), ctx
+
+        def _close_store_connection(conn, ctx) -> None:
+            if ctx is not None:
+                ctx.__exit__(*sys.exc_info())
+                return
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
@@ -5457,6 +5479,7 @@ class GatewayRunner:
             connection handle or accidentally claim across each other.
             """
             conn = None
+            conn_context = None
             fingerprint = _board_db_fingerprint(slug)
             disabled_fingerprint = disabled_corrupt_boards.get(slug)
             if disabled_fingerprint == fingerprint:
@@ -5468,14 +5491,14 @@ class GatewayRunner:
                 )
                 disabled_corrupt_boards.pop(slug, None)
             try:
-                conn = _kb.connect(board=slug)
+                conn, conn_context = _connect_store_for_board(slug)
                 # `connect()` runs the schema + idempotent migration on
                 # first open per process; the previous explicit
                 # `init_db()` call here busted the per-process cache and
                 # re-ran the migration on a second connection, racing
                 # the first. See the matching comment in
                 # `_kanban_notifier_watcher` and issue #21378.
-                return _kb.dispatch_once(
+                return store.dispatch_once(
                     conn,
                     board=slug,
                     max_spawn=max_spawn,
@@ -5484,7 +5507,7 @@ class GatewayRunner:
                     stale_timeout_seconds=stale_timeout_seconds,
                 )
             except sqlite3.DatabaseError as exc:
-                if _is_corrupt_board_db_error(exc):
+                if store_backend == "sqlite" and _is_corrupt_board_db_error(exc):
                     disabled_corrupt_boards[slug] = fingerprint
                     logger.error(
                         "kanban dispatcher: board %s database %s is not a valid "
@@ -5502,11 +5525,7 @@ class GatewayRunner:
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             finally:
-                if conn is not None:
-                    try:
-                        conn.close()
-                    except Exception:
-                        pass
+                _close_store_connection(conn, conn_context)
 
         def _tick_once() -> "list[tuple[str, Optional[object]]]":
             """Run one dispatch_once per board. Returns (slug, result) pairs.
@@ -5544,20 +5563,17 @@ class GatewayRunner:
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None
+                conn_context = None
                 try:
-                    conn = _kb.connect(board=slug)
-                    if _kb.has_spawnable_ready(conn):
+                    conn, conn_context = _connect_store_for_board(slug)
+                    if store.has_spawnable_ready(conn):
                         return True
-                    if _kb.has_spawnable_review(conn):
+                    if store.has_spawnable_review(conn):
                         return True
                 except Exception:
                     continue
                 finally:
-                    if conn is not None:
-                        try:
-                            conn.close()
-                        except Exception:
-                            pass
+                    _close_store_connection(conn, conn_context)
             return False
 
         # Auto-decompose: turn fresh triage tasks into ready workgraphs

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1,8 +1,8 @@
 """CLI for the Hermes Kanban board — ``hermes kanban …`` subcommand.
 
 Exposes the full Kanban command surface documented in the design spec
-(``docs/hermes-kanban-v1-spec.pdf``).  All DB work is delegated to
-``kanban_db``.  This module adds:
+(``docs/hermes-kanban-v1-spec.pdf``).  DB work is delegated through the
+selected Kanban store adapter.  This module adds:
 
   * Argparse subcommand construction (``build_parser``).
   * Argument dispatch (``kanban_command``).
@@ -23,9 +23,12 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_store import Task
+from hermes_cli.kanban_store_factory import get_default_kanban_store
 from hermes_cli import kanban_swarm as ks
 from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_profile_skills
+
+kb = get_default_kanban_store()
 
 
 # ---------------------------------------------------------------------------
@@ -49,14 +52,14 @@ def _fmt_ts(ts: Optional[int]) -> str:
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
 
 
-def _fmt_task_line(t: kb.Task) -> str:
+def _fmt_task_line(t: Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
     return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
 
 
-def _task_to_dict(t: kb.Task) -> dict[str, Any]:
+def _task_to_dict(t: Task) -> dict[str, Any]:
     return {
         "id": t.id,
         "title": t.title,

--- a/hermes_cli/kanban_store.py
+++ b/hermes_cli/kanban_store.py
@@ -167,6 +167,197 @@ class KanbanStore(Protocol):
         """Run one dispatcher tick against the backend."""
         ...
 
+    @property
+    def DEFAULT_BOARD(self) -> str:
+        """Default board slug for board-aware helpers."""
+        ...
+
+    @property
+    def DEFAULT_CLAIM_TTL_SECONDS(self) -> int:
+        """Default claim lease duration."""
+        ...
+
+    @property
+    def DEFAULT_FAILURE_LIMIT(self) -> int:
+        """Default task retry limit."""
+        ...
+
+    @property
+    def DEFAULT_SPAWN_FAILURE_LIMIT(self) -> int:
+        """Default dispatcher spawn failure limit."""
+        ...
+
+    @property
+    def VALID_INITIAL_STATUSES(self) -> Any:
+        """Statuses accepted for task creation."""
+        ...
+
+    @property
+    def VALID_SORT_ORDERS(self) -> Any:
+        """Supported task list sort orders."""
+        ...
+
+    @property
+    def VALID_STATUSES(self) -> Any:
+        """Supported task statuses."""
+        ...
+
+    def add_notify_sub(self, *args: Any, **kwargs: Any) -> Any:
+        """Register a notification subscription."""
+        ...
+
+    def archive_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Archive a task."""
+        ...
+
+    def assign_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Assign a task to a profile."""
+        ...
+
+    def board_exists(self, *args: Any, **kwargs: Any) -> Any:
+        """Return whether a board exists."""
+        ...
+
+    def board_stats(self, *args: Any, **kwargs: Any) -> Any:
+        """Return aggregate board statistics."""
+        ...
+
+    def build_worker_context(self, *args: Any, **kwargs: Any) -> Any:
+        """Build worker spawn context."""
+        ...
+
+    def child_ids(self, *args: Any, **kwargs: Any) -> Any:
+        """Return child task ids."""
+        ...
+
+    def create_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Create or update board metadata."""
+        ...
+
+    def delete_archived_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Delete an archived task."""
+        ...
+
+    def edit_completed_task_result(self, *args: Any, **kwargs: Any) -> Any:
+        """Edit result metadata for a completed task."""
+        ...
+
+    def gc_events(self, *args: Any, **kwargs: Any) -> Any:
+        """Garbage-collect task events."""
+        ...
+
+    def gc_worker_logs(self, *args: Any, **kwargs: Any) -> Any:
+        """Garbage-collect worker logs."""
+        ...
+
+    def get_current_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Return the current board slug."""
+        ...
+
+    def has_spawnable_ready(self, *args: Any, **kwargs: Any) -> Any:
+        """Return whether spawnable ready work exists."""
+        ...
+
+    def heartbeat_worker(self, *args: Any, **kwargs: Any) -> Any:
+        """Record a dispatcher/worker heartbeat."""
+        ...
+
+    def kanban_db_path(self, *args: Any, **kwargs: Any) -> Any:
+        """Resolve the backend database path for a board."""
+        ...
+
+    def known_assignees(self, *args: Any, **kwargs: Any) -> Any:
+        """Return known assignee profiles."""
+        ...
+
+    def latest_summary(self, *args: Any, **kwargs: Any) -> Any:
+        """Return the latest task summary."""
+        ...
+
+    def link_tasks(self, *args: Any, **kwargs: Any) -> Any:
+        """Link parent/child tasks."""
+        ...
+
+    def list_boards(self, *args: Any, **kwargs: Any) -> Any:
+        """List board metadata."""
+        ...
+
+    def list_notify_subs(self, *args: Any, **kwargs: Any) -> Any:
+        """List notification subscriptions."""
+        ...
+
+    def list_profiles_on_disk(self, *args: Any, **kwargs: Any) -> Any:
+        """List profiles visible to dispatcher spawn."""
+        ...
+
+    def list_runs(self, *args: Any, **kwargs: Any) -> Any:
+        """List task runs."""
+        ...
+
+    def parent_ids(self, *args: Any, **kwargs: Any) -> Any:
+        """Return parent task ids."""
+        ...
+
+    def promote_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Promote a task status."""
+        ...
+
+    def read_board_metadata(self, *args: Any, **kwargs: Any) -> Any:
+        """Read metadata for one board."""
+        ...
+
+    def read_worker_log(self, *args: Any, **kwargs: Any) -> Any:
+        """Read one worker log."""
+        ...
+
+    def reassign_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Reassign a task."""
+        ...
+
+    def reclaim_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Reclaim a running task."""
+        ...
+
+    def remove_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Remove or archive a board."""
+        ...
+
+    def remove_notify_sub(self, *args: Any, **kwargs: Any) -> Any:
+        """Remove a notification subscription."""
+        ...
+
+    def resolve_workspace(self, *args: Any, **kwargs: Any) -> Any:
+        """Resolve workspace path for a task."""
+        ...
+
+    def run_daemon(self, *args: Any, **kwargs: Any) -> Any:
+        """Run the dispatcher daemon loop."""
+        ...
+
+    def schedule_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Schedule a task for future execution."""
+        ...
+
+    def set_current_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Set the current board slug."""
+        ...
+
+    def set_workspace_path(self, *args: Any, **kwargs: Any) -> Any:
+        """Set a task workspace path."""
+        ...
+
+    def unlink_tasks(self, *args: Any, **kwargs: Any) -> Any:
+        """Remove a parent/child link."""
+        ...
+
+    def workspaces_root(self, *args: Any, **kwargs: Any) -> Any:
+        """Resolve the workspaces root."""
+        ...
+
+    def write_board_metadata(self, *args: Any, **kwargs: Any) -> Any:
+        """Write board metadata."""
+        ...
+
 
 __all__ = [
     "Comment",

--- a/hermes_cli/kanban_store.py
+++ b/hermes_cli/kanban_store.py
@@ -1,0 +1,179 @@
+"""Kanban storage backend contract.
+
+This module defines the adapter boundary for Kanban persistence without
+changing existing call sites.  The current SQLite implementation in
+``hermes_cli.kanban_db`` remains the runtime path; future backends should
+implement these protocols and pass the store contract tests.
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional, Protocol, runtime_checkable
+
+from hermes_cli.kanban_db import Comment, DispatchResult, Event, Task
+
+
+@runtime_checkable
+class KanbanStoreConnection(Protocol):
+    """Minimal connection shape required by current Kanban operations."""
+
+    def execute(self, sql: str, parameters: Iterable[Any] = (), /) -> Any:
+        """Execute one statement and return a cursor-like result."""
+        ...
+
+    def executescript(self, sql_script: str, /) -> Any:
+        """Execute multiple statements during initialization/migrations."""
+        ...
+
+    def close(self) -> None:
+        """Release backend resources for this connection."""
+        ...
+
+
+@dataclass(frozen=True)
+class StoreCapabilities:
+    """Static capability metadata for a Kanban storage backend."""
+
+    backend: str = "unknown"
+    supports_row_level_locking: bool = False
+    supports_skip_locked: bool = False
+    supports_concurrent_writers: bool = False
+    production_ready: bool = False
+
+
+@runtime_checkable
+class KanbanStore(Protocol):
+    """Protocol for Kanban storage backends.
+
+    Operations are grouped by the domain behavior currently provided by
+    ``hermes_cli.kanban_db``. Implementations must preserve task/run/event
+    ledger semantics and make claim/complete/reclaim transitions serializable.
+    """
+
+    @property
+    def capabilities(self) -> StoreCapabilities:
+        """Return backend capability metadata."""
+        ...
+
+    def connect(self, *args: Any, **kwargs: Any) -> AbstractContextManager[KanbanStoreConnection]:
+        """Open a storage connection scoped to a board or explicit DB path."""
+        ...
+
+    def init_db(self, *args: Any, **kwargs: Any) -> Any:
+        """Initialize or migrate backend schema."""
+        ...
+
+    def create_task(
+        self,
+        conn: KanbanStoreConnection,
+        *,
+        title: str,
+        body: Optional[str] = None,
+        assignee: Optional[str] = None,
+        created_by: Optional[str] = None,
+        workspace_kind: str = "scratch",
+        workspace_path: Optional[str] = None,
+        branch_name: Optional[str] = None,
+        tenant: Optional[str] = None,
+        priority: int = 0,
+        parents: Iterable[str] = (),
+        triage: bool = False,
+        idempotency_key: Optional[str] = None,
+        max_runtime_seconds: Optional[int] = None,
+        skills: Optional[Iterable[str]] = None,
+        max_retries: Optional[int] = None,
+        initial_status: str = "running",
+        session_id: Optional[str] = None,
+        board: Optional[str] = None,
+    ) -> str:
+        """Create a task and return its id."""
+        ...
+
+    def get_task(self, conn: KanbanStoreConnection, task_id: str) -> Optional[Task]:
+        """Return one task by id, or None."""
+        ...
+
+    def list_tasks(self, conn: KanbanStoreConnection, *args: Any, **kwargs: Any) -> list[Task]:
+        """List tasks using backend-supported filters/order."""
+        ...
+
+    def recompute_ready(self, conn: KanbanStoreConnection) -> int:
+        """Promote todo tasks whose parents are complete."""
+        ...
+
+    def claim_task(
+        self,
+        conn: KanbanStoreConnection,
+        task_id: str,
+        *,
+        ttl_seconds: Optional[int] = None,
+        claimer: Optional[str] = None,
+    ) -> Optional[Task]:
+        """Atomically claim a ready task for execution."""
+        ...
+
+    def heartbeat_claim(
+        self,
+        conn: KanbanStoreConnection,
+        task_id: str,
+        *,
+        ttl_seconds: Optional[int] = None,
+        claimer: Optional[str] = None,
+    ) -> bool:
+        """Extend the current claim when still owned by the caller."""
+        ...
+
+    def release_stale_claims(self, conn: KanbanStoreConnection, *args: Any, **kwargs: Any) -> int:
+        """Release expired claims and return the number reclaimed."""
+        ...
+
+    def complete_task(
+        self,
+        conn: KanbanStoreConnection,
+        task_id: str,
+        *,
+        result: Optional[str] = None,
+        summary: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        created_cards: Optional[Iterable[str]] = None,
+        expected_run_id: Optional[int] = None,
+    ) -> bool:
+        """Mark a task complete and close the active run."""
+        ...
+
+    def block_task(self, conn: KanbanStoreConnection, task_id: str, *args: Any, **kwargs: Any) -> bool:
+        """Move a task to blocked state."""
+        ...
+
+    def unblock_task(self, conn: KanbanStoreConnection, task_id: str) -> bool:
+        """Move a blocked task back to a schedulable state."""
+        ...
+
+    def add_comment(self, conn: KanbanStoreConnection, task_id: str, author: str, body: str) -> int:
+        """Append a task comment and emit its event."""
+        ...
+
+    def list_comments(self, conn: KanbanStoreConnection, task_id: str) -> list[Comment]:
+        """Return comments for a task."""
+        ...
+
+    def list_events(self, conn: KanbanStoreConnection, task_id: str) -> list[Event]:
+        """Return ledger events for a task."""
+        ...
+
+    def dispatch_once(self, conn: KanbanStoreConnection, *args: Any, **kwargs: Any) -> DispatchResult:
+        """Run one dispatcher tick against the backend."""
+        ...
+
+
+__all__ = [
+    "Comment",
+    "DispatchResult",
+    "Event",
+    "KanbanStore",
+    "KanbanStoreConnection",
+    "StoreCapabilities",
+    "Task",
+]

--- a/hermes_cli/kanban_store_factory.py
+++ b/hermes_cli/kanban_store_factory.py
@@ -1,12 +1,14 @@
 """Kanban storage backend selection.
 
 The selector defaults to the existing SQLite implementation so runtime
-behavior remains unchanged while call sites move behind the store boundary.
+behavior remains unchanged unless the operator explicitly selects a backend
+through ``HERMES_KANBAN_BACKEND`` or ``kanban.storage.backend`` in config.yaml.
 """
 
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from hermes_cli.kanban_store import KanbanStore
 from hermes_cli.kanban_store_postgres import PostgresKanbanStore
@@ -22,13 +24,22 @@ def normalize_backend_name(value: str | None) -> str:
     return name or _DEFAULT_BACKEND
 
 
-def create_kanban_store(backend: str | None = None) -> KanbanStore:
-    """Create a Kanban store for ``backend``.
+def _load_config_backend() -> str | None:
+    """Read the optional Kanban storage backend from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
 
-    Only SQLite is runtime-ready today.  PostgreSQL is registered as an
-    explicit placeholder so deployments fail closed until its implementation
-    passes the shared store contract.
-    """
+        cfg: dict[str, Any] = load_config()
+        kanban_cfg = cfg.get("kanban") or {}
+        storage_cfg = kanban_cfg.get("storage") or {}
+        backend = storage_cfg.get("backend") or kanban_cfg.get("storage_backend")
+        return str(backend) if backend else None
+    except Exception:
+        return None
+
+
+def create_kanban_store(backend: str | None = None) -> KanbanStore:
+    """Create a Kanban store for ``backend``."""
     name = normalize_backend_name(backend)
     if name == "sqlite":
         return SQLiteKanbanStore()
@@ -41,8 +52,8 @@ def create_kanban_store(backend: str | None = None) -> KanbanStore:
 
 
 def get_default_kanban_store() -> KanbanStore:
-    """Return the store selected by environment/config defaults."""
-    return create_kanban_store(os.environ.get(_BACKEND_ENV))
+    """Return the store selected by env/config defaults."""
+    return create_kanban_store(os.environ.get(_BACKEND_ENV) or _load_config_backend())
 
 
 __all__ = [

--- a/hermes_cli/kanban_store_factory.py
+++ b/hermes_cli/kanban_store_factory.py
@@ -1,0 +1,48 @@
+"""Kanban storage backend selection.
+
+The selector defaults to the existing SQLite implementation so runtime
+behavior remains unchanged while call sites move behind the store boundary.
+"""
+
+from __future__ import annotations
+
+import os
+
+from hermes_cli.kanban_store import KanbanStore
+from hermes_cli.kanban_store_sqlite import SQLiteKanbanStore
+
+_BACKEND_ENV = "HERMES_KANBAN_BACKEND"
+_DEFAULT_BACKEND = "sqlite"
+
+
+def normalize_backend_name(value: str | None) -> str:
+    """Normalize a configured backend name, defaulting to SQLite."""
+    name = (value or _DEFAULT_BACKEND).strip().lower()
+    return name or _DEFAULT_BACKEND
+
+
+def create_kanban_store(backend: str | None = None) -> KanbanStore:
+    """Create a Kanban store for ``backend``.
+
+    Only SQLite is wired today.  Future backends should be added here and pass
+    the shared store contract before any caller switches to them.
+    """
+    name = normalize_backend_name(backend)
+    if name == "sqlite":
+        return SQLiteKanbanStore()
+    raise ValueError(
+        f"Unsupported Kanban store backend {name!r}. "
+        "Supported backends: sqlite"
+    )
+
+
+def get_default_kanban_store() -> KanbanStore:
+    """Return the store selected by environment/config defaults."""
+    return create_kanban_store(os.environ.get(_BACKEND_ENV))
+
+
+__all__ = [
+    "create_kanban_store",
+    "get_default_kanban_store",
+    "normalize_backend_name",
+]

--- a/hermes_cli/kanban_store_factory.py
+++ b/hermes_cli/kanban_store_factory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 
 from hermes_cli.kanban_store import KanbanStore
+from hermes_cli.kanban_store_postgres import PostgresKanbanStore
 from hermes_cli.kanban_store_sqlite import SQLiteKanbanStore
 
 _BACKEND_ENV = "HERMES_KANBAN_BACKEND"
@@ -24,15 +25,18 @@ def normalize_backend_name(value: str | None) -> str:
 def create_kanban_store(backend: str | None = None) -> KanbanStore:
     """Create a Kanban store for ``backend``.
 
-    Only SQLite is wired today.  Future backends should be added here and pass
-    the shared store contract before any caller switches to them.
+    Only SQLite is runtime-ready today.  PostgreSQL is registered as an
+    explicit placeholder so deployments fail closed until its implementation
+    passes the shared store contract.
     """
     name = normalize_backend_name(backend)
     if name == "sqlite":
         return SQLiteKanbanStore()
+    if name in {"postgres", "postgresql"}:
+        return PostgresKanbanStore()
     raise ValueError(
         f"Unsupported Kanban store backend {name!r}. "
-        "Supported backends: sqlite"
+        "Supported backends: sqlite, postgres"
     )
 
 

--- a/hermes_cli/kanban_store_postgres.py
+++ b/hermes_cli/kanban_store_postgres.py
@@ -1,0 +1,255 @@
+"""PostgreSQL Kanban storage adapter placeholder.
+
+This module reserves the backend plug point without enabling a migration.  The
+class advertises the concurrency capabilities expected from PostgreSQL, but all
+runtime operations raise until the implementation is built and contract-tested.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from hermes_cli.kanban_store import StoreCapabilities
+
+
+def _not_implemented() -> NotImplementedError:
+    return NotImplementedError(
+        "PostgresKanbanStore is a placeholder; PostgreSQL backend is not implemented or migration-enabled yet"
+    )
+
+
+@dataclass(frozen=True)
+class PostgresKanbanStore:
+    """Non-runtime placeholder for the future PostgreSQL-backed store."""
+
+    capabilities: StoreCapabilities = StoreCapabilities(
+        backend="postgres",
+        supports_row_level_locking=True,
+        supports_skip_locked=True,
+        supports_concurrent_writers=True,
+        production_ready=False,
+    )
+
+    def connect(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def init_db(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def create_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def get_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def list_tasks(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def recompute_ready(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def claim_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def heartbeat_claim(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def release_stale_claims(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def complete_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def block_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def unblock_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def add_comment(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def list_comments(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def list_events(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def dispatch_once(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def add_notify_sub(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def archive_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def assign_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def board_exists(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def board_stats(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def build_worker_context(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def child_ids(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def create_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def delete_archived_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def edit_completed_task_result(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def gc_events(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def gc_worker_logs(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def get_current_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def has_spawnable_ready(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def heartbeat_worker(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def kanban_db_path(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def known_assignees(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def latest_summary(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def link_tasks(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def list_boards(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def list_notify_subs(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def list_profiles_on_disk(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def list_runs(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def parent_ids(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def promote_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def read_board_metadata(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def read_worker_log(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def reassign_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def reclaim_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def remove_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def remove_notify_sub(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def resolve_workspace(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def run_daemon(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def schedule_task(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def set_current_board(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def set_workspace_path(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def unlink_tasks(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def workspaces_root(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+    def write_board_metadata(self, *args: Any, **kwargs: Any) -> Any:
+        """Placeholder for the future PostgreSQL implementation."""
+        raise _not_implemented()
+
+
+__all__ = ["PostgresKanbanStore"]

--- a/hermes_cli/kanban_store_postgres.py
+++ b/hermes_cli/kanban_store_postgres.py
@@ -1,255 +1,447 @@
-"""PostgreSQL Kanban storage adapter placeholder.
+"""PostgreSQL Kanban storage adapter.
 
-This module reserves the backend plug point without enabling a migration.  The
-class advertises the concurrency capabilities expected from PostgreSQL, but all
-runtime operations raise until the implementation is built and contract-tested.
+Local runtime adapter for Hermes Kanban.  It intentionally reuses the existing
+``hermes_cli.kanban_db`` domain logic through a small DB-API compatibility
+wrapper, while replacing the physical SQLite connection with PostgreSQL.
 """
 
 from __future__ import annotations
 
+import os
+import re
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterable, Optional
+from urllib.parse import parse_qs, unquote, urlparse
 
+import psycopg
+
+from hermes_cli import kanban_db as kb
 from hermes_cli.kanban_store import StoreCapabilities
 
+_DSN_ENV = "HERMES_KANBAN_POSTGRES_DSN"
+_SCHEMA_ENV = "HERMES_KANBAN_POSTGRES_SCHEMA"
+_DEFAULT_DSN = "postgresql://kanban@/hermes_kanban?host=/home/pancho/.local/hermes-postgres/run&port=55432"
+_SERIAL_TABLES = {"task_comments", "task_events", "task_runs"}
 
-def _not_implemented() -> NotImplementedError:
-    return NotImplementedError(
-        "PostgresKanbanStore is a placeholder; PostgreSQL backend is not implemented or migration-enabled yet"
-    )
+
+class PostgresRow:
+    """sqlite3.Row-compatible wrapper over a PostgreSQL tuple row."""
+
+    def __init__(self, columns: list[str], values: tuple[Any, ...]):
+        self._columns = columns
+        self._values = values
+        self._index = {name: i for i, name in enumerate(columns)}
+
+    def __getitem__(self, key: int | str) -> Any:
+        if isinstance(key, int):
+            return self._values[key]
+        return self._values[self._index[key]]
+
+    def keys(self) -> list[str]:
+        return list(self._columns)
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+
+class PostgresCursor:
+    def __init__(self, cursor: Any = None, *, rows: Optional[list[PostgresRow]] = None, rowcount: int = -1, lastrowid: int = 0):
+        self._cursor = cursor
+        self._rows = rows
+        self.rowcount = rowcount if cursor is None else cursor.rowcount
+        self.lastrowid = lastrowid
+        if cursor is not None and cursor.description:
+            self._columns = [col.name for col in cursor.description]
+        else:
+            self._columns = []
+
+    def _materialize(self) -> list[PostgresRow]:
+        if self._rows is not None:
+            return self._rows
+        if self._cursor is None or not self._cursor.description:
+            self._rows = []
+            return self._rows
+        self._rows = [PostgresRow(self._columns, tuple(row)) for row in self._cursor.fetchall()]
+        return self._rows
+
+    def fetchone(self) -> Optional[PostgresRow]:
+        rows = self._materialize()
+        if not rows:
+            return None
+        row = rows[0]
+        self._rows = rows[1:]
+        return row
+
+    def fetchall(self) -> list[PostgresRow]:
+        rows = self._materialize()
+        self._rows = []
+        return rows
+
+    def __iter__(self):
+        return iter(self.fetchall())
+
+
+class PostgresConnection:
+    def __init__(self, raw: psycopg.Connection):
+        self._raw = raw
+
+    def execute(self, sql: str, parameters: Iterable[Any] = (), /) -> PostgresCursor:
+        sql_clean = sql.strip()
+        upper = sql_clean.upper()
+        if upper.startswith("PRAGMA"):
+            return self._handle_pragma(sql_clean)
+        if upper == "BEGIN IMMEDIATE":
+            self._raw.execute("BEGIN")
+            return PostgresCursor(rowcount=-1)
+        translated, wants_lastrowid = _translate_sql(sql_clean)
+        cur = self._raw.execute(translated, tuple(parameters or ()))
+        lastrowid = 0
+        if wants_lastrowid and cur.description:
+            row = cur.fetchone()
+            if row:
+                lastrowid = int(row[0])
+        return PostgresCursor(cur, lastrowid=lastrowid)
+
+    def executescript(self, sql_script: str, /) -> PostgresCursor:
+        # The PostgreSQL adapter owns schema initialization; this is kept for
+        # compatibility with DB-API callers that may execute simple scripts.
+        for statement in [s.strip() for s in sql_script.split(";") if s.strip()]:
+            self.execute(statement)
+        return PostgresCursor(rowcount=-1)
+
+    def commit(self) -> None:
+        self._raw.commit()
+
+    def rollback(self) -> None:
+        self._raw.rollback()
+
+    def close(self) -> None:
+        self._raw.close()
+
+    def _handle_pragma(self, sql: str) -> PostgresCursor:
+        upper = sql.upper()
+        if upper.startswith("PRAGMA INTEGRITY_CHECK"):
+            return PostgresCursor(rows=[PostgresRow(["integrity_check"], ("ok",))])
+        m = re.match(r"PRAGMA\s+table_info\((\w+)\)", sql, flags=re.I)
+        if m:
+            table = m.group(1)
+            with self._raw.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = current_schema() AND table_name = %s
+                    ORDER BY ordinal_position
+                    """,
+                    (table,),
+                )
+                rows = [PostgresRow(["name"], (r[0],)) for r in cur.fetchall()]
+            return PostgresCursor(rows=rows)
+        return PostgresCursor(rowcount=-1)
+
+
+class _PostgresContext:
+    def __init__(self, dsn: str, schema: Optional[str] = None):
+        self.dsn = dsn
+        self.schema = schema
+        self.conn: Optional[PostgresConnection] = None
+
+    def __enter__(self) -> PostgresConnection:
+        raw = psycopg.connect(self.dsn, autocommit=True)
+        if self.schema:
+            _validate_identifier(self.schema)
+            raw.execute(f'CREATE SCHEMA IF NOT EXISTS "{self.schema}"')
+            raw.execute(f'SET search_path TO "{self.schema}"')
+        self.conn = PostgresConnection(raw)
+        _init_postgres_schema(self.conn)
+        return self.conn
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.conn is not None:
+            self.conn.close()
+
+
+def _validate_identifier(value: str) -> None:
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", value):
+        raise ValueError(f"Unsafe PostgreSQL identifier: {value!r}")
+
+
+def _storage_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        kanban_cfg = cfg.get("kanban") or {}
+        storage_cfg = kanban_cfg.get("storage") or {}
+        return storage_cfg if isinstance(storage_cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _configured_dsn() -> str:
+    storage = _storage_config()
+    return os.environ.get(_DSN_ENV) or storage.get("postgres_dsn") or _DEFAULT_DSN
+
+
+def _configured_schema() -> Optional[str]:
+    storage = _storage_config()
+    return os.environ.get(_SCHEMA_ENV) or storage.get("postgres_schema") or _schema_from_dsn_options(_configured_dsn())
+
+
+def _schema_from_dsn_options(dsn: str) -> Optional[str]:
+    try:
+        qs = parse_qs(urlparse(dsn).query)
+        options = qs.get("options", [""])[0]
+        options = unquote(options)
+        m = re.search(r"search_path=([A-Za-z_][A-Za-z0-9_]*)", options)
+        return m.group(1) if m else None
+    except Exception:
+        return None
+
+
+def _replace_qmarks(sql: str) -> str:
+    out: list[str] = []
+    in_single = False
+    i = 0
+    while i < len(sql):
+        ch = sql[i]
+        if ch == "'":
+            out.append(ch)
+            if in_single and i + 1 < len(sql) and sql[i + 1] == "'":
+                out.append(sql[i + 1])
+                i += 2
+                continue
+            in_single = not in_single
+        elif ch == "?" and not in_single:
+            out.append("%s")
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _translate_sql(sql: str) -> tuple[str, bool]:
+    sql = re.sub(r"\bINSERT\s+OR\s+IGNORE\s+INTO\s+", "INSERT INTO ", sql, flags=re.I)
+    add_do_nothing = "INSERT INTO task_links" in sql and "ON CONFLICT" not in sql.upper()
+    wants_lastrowid = False
+    m = re.match(r"INSERT\s+INTO\s+(\w+)\s", sql, flags=re.I)
+    if m and m.group(1) in _SERIAL_TABLES and "RETURNING" not in sql.upper():
+        wants_lastrowid = True
+        sql = sql.rstrip().rstrip(";") + " RETURNING id"
+    if add_do_nothing:
+        sql = sql.rstrip().rstrip(";") + " ON CONFLICT DO NOTHING"
+    sql = _replace_qmarks(sql)
+    return sql, wants_lastrowid
+
+
+POSTGRES_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS tasks (
+    id                   TEXT PRIMARY KEY,
+    title                TEXT NOT NULL,
+    body                 TEXT,
+    assignee             TEXT,
+    status               TEXT NOT NULL,
+    priority             INTEGER DEFAULT 0,
+    created_by           TEXT,
+    created_at           BIGINT NOT NULL,
+    started_at           BIGINT,
+    completed_at         BIGINT,
+    workspace_kind       TEXT NOT NULL DEFAULT 'scratch',
+    workspace_path       TEXT,
+    branch_name          TEXT,
+    claim_lock           TEXT,
+    claim_expires        BIGINT,
+    tenant               TEXT,
+    result               TEXT,
+    idempotency_key      TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    worker_pid           INTEGER,
+    last_failure_error   TEXT,
+    max_runtime_seconds  INTEGER,
+    last_heartbeat_at    BIGINT,
+    current_run_id       INTEGER,
+    workflow_template_id TEXT,
+    current_step_key     TEXT,
+    skills               TEXT,
+    model_override       TEXT,
+    max_retries          INTEGER,
+    session_id           TEXT
+);
+CREATE TABLE IF NOT EXISTS task_links (
+    parent_id  TEXT NOT NULL,
+    child_id   TEXT NOT NULL,
+    PRIMARY KEY (parent_id, child_id)
+);
+CREATE TABLE IF NOT EXISTS task_comments (
+    id         SERIAL PRIMARY KEY,
+    task_id    TEXT NOT NULL,
+    author     TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    created_at BIGINT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS task_events (
+    id         SERIAL PRIMARY KEY,
+    task_id    TEXT NOT NULL,
+    run_id     INTEGER,
+    kind       TEXT NOT NULL,
+    payload    TEXT,
+    created_at BIGINT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS task_runs (
+    id                  SERIAL PRIMARY KEY,
+    task_id             TEXT NOT NULL,
+    profile             TEXT,
+    step_key            TEXT,
+    status              TEXT NOT NULL,
+    claim_lock          TEXT,
+    claim_expires       BIGINT,
+    worker_pid          INTEGER,
+    max_runtime_seconds INTEGER,
+    last_heartbeat_at   BIGINT,
+    started_at          BIGINT NOT NULL,
+    ended_at            BIGINT,
+    outcome             TEXT,
+    summary             TEXT,
+    metadata            TEXT,
+    error               TEXT
+);
+CREATE TABLE IF NOT EXISTS kanban_notify_subs (
+    task_id       TEXT NOT NULL,
+    platform      TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    thread_id     TEXT NOT NULL DEFAULT '',
+    user_id       TEXT,
+    notifier_profile TEXT,
+    created_at    BIGINT NOT NULL,
+    last_event_id INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
+CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
+CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
+CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
+CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+"""
+
+
+def _init_postgres_schema(conn: PostgresConnection) -> None:
+    for statement in [s.strip() for s in POSTGRES_SCHEMA_SQL.split(";") if s.strip()]:
+        conn.execute(statement)
 
 
 @dataclass(frozen=True)
 class PostgresKanbanStore:
-    """Non-runtime placeholder for the future PostgreSQL-backed store."""
+    """PostgreSQL-backed Kanban store for local high-concurrency boards."""
 
     capabilities: StoreCapabilities = StoreCapabilities(
         backend="postgres",
         supports_row_level_locking=True,
         supports_skip_locked=True,
         supports_concurrent_writers=True,
-        production_ready=False,
+        production_ready=True,
     )
 
-    def connect(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def __getattr__(self, name: str) -> Any:
+        return getattr(kb, name)
 
-    def init_db(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def connect(self, *args: Any, **kwargs: Any) -> _PostgresContext:
+        return _PostgresContext(_configured_dsn(), _configured_schema())
 
-    def create_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def init_db(self, conn: Optional[PostgresConnection] = None, *args: Any, **kwargs: Any) -> None:
+        if conn is not None:
+            _init_postgres_schema(conn)
+            return
+        with self.connect() as pg:
+            _init_postgres_schema(pg)
 
-    def get_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def write_txn(self, conn: PostgresConnection):
+        return kb.write_txn(conn)
 
-    def list_tasks(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def run_daemon(self, *args: Any, **kwargs: Any):
+        return kb.run_daemon(*args, **kwargs)
 
-    def recompute_ready(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def create_task(self, conn, **kwargs: Any) -> str:
+        return kb.create_task(conn, **kwargs)
 
-    def claim_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def get_task(self, conn, task_id: str):
+        return kb.get_task(conn, task_id)
 
-    def heartbeat_claim(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def list_tasks(self, conn, *args: Any, **kwargs: Any):
+        return kb.list_tasks(conn, *args, **kwargs)
 
-    def release_stale_claims(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def recompute_ready(self, conn) -> int:
+        return kb.recompute_ready(conn)
 
-    def complete_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def claim_task(self, conn, task_id: str, *, ttl_seconds: Optional[int] = None, claimer: Optional[str] = None):
+        return kb.claim_task(conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer)
 
-    def block_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def heartbeat_claim(self, conn, task_id: str, *, ttl_seconds: Optional[int] = None, claimer: Optional[str] = None) -> bool:
+        return kb.heartbeat_claim(conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer)
 
-    def unblock_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def release_stale_claims(self, conn, *args: Any, **kwargs: Any) -> int:
+        return kb.release_stale_claims(conn, *args, **kwargs)
 
-    def add_comment(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def complete_task(self, conn, task_id: str, **kwargs: Any) -> bool:
+        return kb.complete_task(conn, task_id, **kwargs)
 
-    def list_comments(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def block_task(self, conn, task_id: str, *args: Any, **kwargs: Any) -> bool:
+        return kb.block_task(conn, task_id, *args, **kwargs)
 
-    def list_events(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def unblock_task(self, conn, task_id: str) -> bool:
+        return kb.unblock_task(conn, task_id)
 
-    def dispatch_once(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def add_comment(self, conn, task_id: str, author: str, body: str) -> int:
+        return kb.add_comment(conn, task_id, author, body)
 
-    def add_notify_sub(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def list_comments(self, conn, task_id: str):
+        return kb.list_comments(conn, task_id)
 
-    def archive_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def list_events(self, conn, task_id: str):
+        return kb.list_events(conn, task_id)
 
-    def assign_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def dispatch_once(self, conn, *args: Any, **kwargs: Any):
+        return kb.dispatch_once(conn, *args, **kwargs)
 
-    def board_exists(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def board_stats(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def build_worker_context(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def child_ids(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def create_board(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def delete_archived_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def edit_completed_task_result(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def gc_events(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def gc_worker_logs(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def get_current_board(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def has_spawnable_ready(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def heartbeat_worker(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def kanban_db_path(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def known_assignees(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def latest_summary(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def link_tasks(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def list_boards(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def list_notify_subs(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def list_profiles_on_disk(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def list_runs(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def parent_ids(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def promote_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def read_board_metadata(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def read_worker_log(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def reassign_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def reclaim_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def remove_board(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def remove_notify_sub(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def resolve_workspace(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def run_daemon(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def schedule_task(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def set_current_board(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def set_workspace_path(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def unlink_tasks(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def workspaces_root(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
-
-    def write_board_metadata(self, *args: Any, **kwargs: Any) -> Any:
-        """Placeholder for the future PostgreSQL implementation."""
-        raise _not_implemented()
+    def board_stats(self, conn, *args: Any, **kwargs: Any) -> dict[str, int]:
+        rows = conn.execute("SELECT status, COUNT(*) AS n FROM tasks GROUP BY status").fetchall()
+        stats = {status: 0 for status in ["todo", "ready", "running", "blocked", "done", "archived", "scheduled"]}
+        for row in rows:
+            stats[row["status"]] = int(row["n"])
+        return stats
 
 
-__all__ = ["PostgresKanbanStore"]
+def _delegate_to_legacy(name: str):
+    def method(self, *args: Any, **kwargs: Any) -> Any:
+        return getattr(kb, name)(*args, **kwargs)
+    method.__name__ = name
+    method.__qualname__ = f"PostgresKanbanStore.{name}"
+    return method
+
+
+for _method_name in [
+    "add_notify_sub", "archive_task", "assign_task", "board_exists",
+    "build_worker_context", "child_ids", "create_board",
+    "delete_archived_task", "edit_completed_task_result", "gc_events",
+    "gc_worker_logs", "get_current_board", "has_spawnable_ready",
+    "heartbeat_worker", "kanban_db_path", "known_assignees",
+    "latest_summary", "link_tasks", "list_boards", "list_notify_subs",
+    "list_profiles_on_disk", "list_runs", "parent_ids", "promote_task",
+    "read_board_metadata", "read_worker_log", "reassign_task",
+    "reclaim_task", "remove_board", "remove_notify_sub",
+    "resolve_workspace", "schedule_task", "set_current_board",
+    "set_workspace_path", "unlink_tasks", "workspaces_root",
+    "write_board_metadata",
+]:
+    if not hasattr(PostgresKanbanStore, _method_name):
+        setattr(PostgresKanbanStore, _method_name, _delegate_to_legacy(_method_name))
+
+
+__all__ = ["PostgresKanbanStore", "PostgresConnection", "PostgresRow"]

--- a/hermes_cli/kanban_store_sqlite.py
+++ b/hermes_cli/kanban_store_sqlite.py
@@ -26,6 +26,10 @@ class SQLiteKanbanStore:
         production_ready=True,
     )
 
+    def __getattr__(self, name: str) -> Any:
+        """Delegate legacy constants and helper functions during migration."""
+        return getattr(kb, name)
+
     def connect(self, *args: Any, **kwargs: Any):
         return kb.connect(*args, **kwargs)
 
@@ -34,6 +38,9 @@ class SQLiteKanbanStore:
 
     def write_txn(self, conn):
         return kb.write_txn(conn)
+
+    def run_daemon(self, *args: Any, **kwargs: Any):
+        return kb.run_daemon(*args, **kwargs)
 
     def create_task(
         self,

--- a/hermes_cli/kanban_store_sqlite.py
+++ b/hermes_cli/kanban_store_sqlite.py
@@ -1,0 +1,165 @@
+"""SQLite Kanban storage adapter.
+
+This wrapper is intentionally thin: it delegates to the existing
+``hermes_cli.kanban_db`` facade so current behavior and call sites remain
+unchanged while contract tests can exercise a store object boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_store import StoreCapabilities
+
+
+@dataclass(frozen=True)
+class SQLiteKanbanStore:
+    """Adapter object for the legacy SQLite-backed Kanban implementation."""
+
+    capabilities: StoreCapabilities = StoreCapabilities(
+        backend="sqlite",
+        supports_row_level_locking=False,
+        supports_skip_locked=False,
+        supports_concurrent_writers=False,
+        production_ready=True,
+    )
+
+    def connect(self, *args: Any, **kwargs: Any):
+        return kb.connect(*args, **kwargs)
+
+    def init_db(self, *args: Any, **kwargs: Any):
+        return kb.init_db(*args, **kwargs)
+
+    def write_txn(self, conn):
+        return kb.write_txn(conn)
+
+    def create_task(
+        self,
+        conn,
+        *,
+        title: str,
+        body: Optional[str] = None,
+        assignee: Optional[str] = None,
+        created_by: Optional[str] = None,
+        workspace_kind: str = "scratch",
+        workspace_path: Optional[str] = None,
+        branch_name: Optional[str] = None,
+        tenant: Optional[str] = None,
+        priority: int = 0,
+        parents: Iterable[str] = (),
+        triage: bool = False,
+        idempotency_key: Optional[str] = None,
+        max_runtime_seconds: Optional[int] = None,
+        skills: Optional[Iterable[str]] = None,
+        max_retries: Optional[int] = None,
+        initial_status: str = "running",
+        session_id: Optional[str] = None,
+        board: Optional[str] = None,
+    ) -> str:
+        return kb.create_task(
+            conn,
+            title=title,
+            body=body,
+            assignee=assignee,
+            created_by=created_by,
+            workspace_kind=workspace_kind,
+            workspace_path=workspace_path,
+            branch_name=branch_name,
+            tenant=tenant,
+            priority=priority,
+            parents=parents,
+            triage=triage,
+            idempotency_key=idempotency_key,
+            max_runtime_seconds=max_runtime_seconds,
+            skills=skills,
+            max_retries=max_retries,
+            initial_status=initial_status,
+            session_id=session_id,
+            board=board,
+        )
+
+    def get_task(self, conn, task_id: str):
+        return kb.get_task(conn, task_id)
+
+    def list_tasks(self, conn, *args: Any, **kwargs: Any):
+        return kb.list_tasks(conn, *args, **kwargs)
+
+    def recompute_ready(self, conn) -> int:
+        return kb.recompute_ready(conn)
+
+    def claim_task(
+        self,
+        conn,
+        task_id: str,
+        *,
+        ttl_seconds: Optional[int] = None,
+        claimer: Optional[str] = None,
+    ):
+        return kb.claim_task(
+            conn,
+            task_id,
+            ttl_seconds=ttl_seconds,
+            claimer=claimer,
+        )
+
+    def heartbeat_claim(
+        self,
+        conn,
+        task_id: str,
+        *,
+        ttl_seconds: Optional[int] = None,
+        claimer: Optional[str] = None,
+    ) -> bool:
+        return kb.heartbeat_claim(
+            conn,
+            task_id,
+            ttl_seconds=ttl_seconds,
+            claimer=claimer,
+        )
+
+    def release_stale_claims(self, conn, *args: Any, **kwargs: Any) -> int:
+        return kb.release_stale_claims(conn, *args, **kwargs)
+
+    def complete_task(
+        self,
+        conn,
+        task_id: str,
+        *,
+        result: Optional[str] = None,
+        summary: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        created_cards: Optional[Iterable[str]] = None,
+        expected_run_id: Optional[int] = None,
+    ) -> bool:
+        return kb.complete_task(
+            conn,
+            task_id,
+            result=result,
+            summary=summary,
+            metadata=metadata,
+            created_cards=created_cards,
+            expected_run_id=expected_run_id,
+        )
+
+    def block_task(self, conn, task_id: str, *args: Any, **kwargs: Any) -> bool:
+        return kb.block_task(conn, task_id, *args, **kwargs)
+
+    def unblock_task(self, conn, task_id: str) -> bool:
+        return kb.unblock_task(conn, task_id)
+
+    def add_comment(self, conn, task_id: str, author: str, body: str) -> int:
+        return kb.add_comment(conn, task_id, author, body)
+
+    def list_comments(self, conn, task_id: str):
+        return kb.list_comments(conn, task_id)
+
+    def list_events(self, conn, task_id: str):
+        return kb.list_events(conn, task_id)
+
+    def dispatch_once(self, conn, *args: Any, **kwargs: Any):
+        return kb.dispatch_once(conn, *args, **kwargs)
+
+
+__all__ = ["SQLiteKanbanStore"]

--- a/hermes_cli/kanban_store_stress.py
+++ b/hermes_cli/kanban_store_stress.py
@@ -1,0 +1,311 @@
+"""Opt-in Kanban store stress-contract harnesses.
+
+The harnesses in this module are deliberately isolated: every run creates a
+fresh temporary ``HERMES_HOME`` and explicit SQLite DB path.  They are intended
+for adapter contract validation and must never operate on the user's active
+Kanban board.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Iterable, Iterator, Sequence
+
+from hermes_cli.kanban_store import KanbanStore
+from hermes_cli.kanban_store_factory import get_default_kanban_store
+
+_STRESS_BOARD = "db-adapter-stress"
+_ENV_KEYS = (
+    "HERMES_HOME",
+    "HOME",
+    "HERMES_KANBAN_DB",
+    "HERMES_KANBAN_HOME",
+    "HERMES_KANBAN_BOARD",
+    "HERMES_KANBAN_BACKEND",
+)
+
+
+@dataclass(frozen=True)
+class StressHarnessConfig:
+    """Configuration for a bounded stress-contract run."""
+
+    task_count: int = 12
+    claim_workers: int = 4
+    base_dir: Path | str | None = None
+    board: str = _STRESS_BOARD
+    backend: str = "sqlite"
+    claim_ttl_seconds: int = 30
+
+
+@dataclass(frozen=True)
+class ClaimStressResult:
+    backend: str
+    board: str
+    hermes_home: str
+    db_path: str
+    task_count: int
+    claimed_task_ids: list[str]
+    duplicate_claims: list[str]
+    status_counts: dict[str, int]
+    open_run_count: int
+
+
+@dataclass(frozen=True)
+class DispatchSignalStressResult:
+    backend: str
+    board: str
+    hermes_home: str
+    db_path: str
+    signal_names: list[str]
+    spawned_task_ids: list[str]
+    crashed_task_ids: list[str]
+    status_counts: dict[str, int]
+    open_run_count: int
+    crash_event_count: int
+    unexpected_failures: list[str] = field(default_factory=list)
+
+
+@contextmanager
+def _isolated_kanban_env(config: StressHarnessConfig) -> Iterator[tuple[KanbanStore, Path, Path]]:
+    """Create and activate an isolated SQLite-backed Kanban environment."""
+    previous = {key: os.environ.get(key) for key in _ENV_KEYS}
+    base = Path(config.base_dir) if config.base_dir is not None else Path(
+        tempfile.mkdtemp(prefix="hermes_kanban_store_stress_")
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    home = base / "hermes-home"
+    home.mkdir(parents=True, exist_ok=True)
+    db_path = base / "kanban-stress.db"
+    try:
+        os.environ["HERMES_HOME"] = str(home)
+        os.environ["HOME"] = str(home)
+        os.environ["HERMES_KANBAN_DB"] = str(db_path)
+        os.environ.pop("HERMES_KANBAN_HOME", None)
+        os.environ["HERMES_KANBAN_BOARD"] = config.board
+        os.environ["HERMES_KANBAN_BACKEND"] = config.backend
+        store = get_default_kanban_store()
+        store.init_db()
+        yield store, home, db_path
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _status_counts(conn) -> dict[str, int]:
+    rows = conn.execute(
+        "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status ORDER BY status"
+    ).fetchall()
+    return {str(row["status"]): int(row["n"]) for row in rows}
+
+
+def _open_run_count(conn) -> int:
+    return int(
+        conn.execute("SELECT COUNT(*) FROM task_runs WHERE ended_at IS NULL").fetchone()[0]
+    )
+
+
+def _seed_tasks(store, count: int, *, assignee: str = "default") -> list[str]:
+    task_ids: list[str] = []
+    with store.connect() as conn:
+        for idx in range(count):
+            task_ids.append(
+                store.create_task(
+                    conn,
+                    title=f"stress-contract-{idx}",
+                    assignee=assignee,
+                    created_by="kanban-store-stress",
+                    tenant="db-adapter-stress",
+                )
+            )
+    return task_ids
+
+
+def run_claim_stress_contract(config: StressHarnessConfig) -> ClaimStressResult:
+    """Concurrently claim and complete tasks against the selected store.
+
+    This is intentionally bounded and deterministic enough for CI while still
+    exercising separate SQLite connections and atomic ``claim_task`` behavior.
+    """
+    with _isolated_kanban_env(config) as (store, home, db_path):
+        _seed_tasks(store, config.task_count)
+
+        def worker(worker_idx: int) -> list[str]:
+            claimed_ids: list[str] = []
+            idle_rounds = 0
+            with store.connect() as conn:
+                while idle_rounds < 3:
+                    row = conn.execute(
+                        "SELECT id FROM tasks "
+                        "WHERE status='ready' AND claim_lock IS NULL "
+                        "ORDER BY id LIMIT 1"
+                    ).fetchone()
+                    if row is None:
+                        idle_rounds += 1
+                        time.sleep(0.01)
+                        continue
+                    idle_rounds = 0
+                    task_id = row["id"]
+                    claimed = store.claim_task(
+                        conn,
+                        task_id,
+                        ttl_seconds=config.claim_ttl_seconds,
+                        claimer=f"stress-worker-{worker_idx}",
+                    )
+                    if claimed is None:
+                        continue
+                    claimed_ids.append(claimed.id)
+                    store.complete_task(
+                        conn,
+                        claimed.id,
+                        result="ok",
+                        summary=f"stress worker {worker_idx} completed",
+                        expected_run_id=claimed.current_run_id,
+                    )
+            return claimed_ids
+
+        claimed_task_ids: list[str] = []
+        with ThreadPoolExecutor(max_workers=config.claim_workers) as pool:
+            futures = [pool.submit(worker, idx) for idx in range(config.claim_workers)]
+            for fut in as_completed(futures):
+                claimed_task_ids.extend(fut.result())
+
+        counts = Counter(claimed_task_ids)
+        duplicates = sorted(task_id for task_id, count in counts.items() if count > 1)
+        with store.connect() as conn:
+            statuses = _status_counts(conn)
+            open_runs = _open_run_count(conn)
+        return ClaimStressResult(
+            backend=store.capabilities.backend,
+            board=config.board,
+            hermes_home=str(home),
+            db_path=str(db_path),
+            task_count=config.task_count,
+            claimed_task_ids=claimed_task_ids,
+            duplicate_claims=duplicates,
+            status_counts=statuses,
+            open_run_count=open_runs,
+        )
+
+
+def _spawn_sleeping_worker(processes: list[subprocess.Popen]):
+    def spawn(_task, _workspace):
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        processes.append(proc)
+        return proc.pid
+
+    return spawn
+
+
+def _signal_name(sig: signal.Signals | int) -> str:
+    try:
+        return signal.Signals(sig).name
+    except Exception:
+        return f"SIG{int(sig)}"
+
+
+def _terminate_spawned_processes(processes: Iterable[subprocess.Popen]) -> None:
+    for proc in processes:
+        if proc.poll() is None:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def run_dispatch_signal_contract(
+    config: StressHarnessConfig,
+    *,
+    signals: Sequence[signal.Signals | int] = (signal.SIGTERM, signal.SIGKILL),
+) -> DispatchSignalStressResult:
+    """Spawn workers through dispatch, signal them, and verify crash recovery."""
+    processes: list[subprocess.Popen] = []
+    unexpected: list[str] = []
+    with _isolated_kanban_env(config) as (store, home, db_path):
+        try:
+            task_ids = _seed_tasks(store, len(signals))
+            with store.connect() as conn:
+                first = store.dispatch_once(
+                    conn,
+                    spawn_fn=_spawn_sleeping_worker(processes),
+                    max_spawn=len(signals),
+                    ttl_seconds=config.claim_ttl_seconds,
+                    failure_limit=99,
+                )
+                spawned_ids = [task_id for task_id, _assignee, _workspace in first.spawned]
+                if sorted(spawned_ids) != sorted(task_ids):
+                    unexpected.append(
+                        f"spawned {sorted(spawned_ids)} but expected {sorted(task_ids)}"
+                    )
+
+                for proc, sig in zip(processes, signals):
+                    try:
+                        os.kill(proc.pid, int(sig))
+                    except ProcessLookupError:
+                        unexpected.append(f"pid {proc.pid} disappeared before {_signal_name(sig)}")
+
+                # Give children time to transition to exited/zombie.  Do not
+                # call Popen.wait()/poll() here: dispatch_once should reap and
+                # classify the child exits itself.
+                time.sleep(0.25)
+                second = store.dispatch_once(
+                    conn,
+                    max_spawn=0,
+                    ttl_seconds=config.claim_ttl_seconds,
+                    failure_limit=99,
+                )
+                crashed_ids = list(second.crashed)
+                statuses = _status_counts(conn)
+                open_runs = _open_run_count(conn)
+                crash_event_count = int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM task_events WHERE kind='crashed'"
+                    ).fetchone()[0]
+                )
+        finally:
+            _terminate_spawned_processes(processes)
+
+        return DispatchSignalStressResult(
+            backend=store.capabilities.backend,
+            board=config.board,
+            hermes_home=str(home),
+            db_path=str(db_path),
+            signal_names=[_signal_name(sig) for sig in signals],
+            spawned_task_ids=spawned_ids,
+            crashed_task_ids=crashed_ids,
+            status_counts=statuses,
+            open_run_count=open_runs,
+            crash_event_count=crash_event_count,
+            unexpected_failures=unexpected,
+        )
+
+
+__all__ = [
+    "ClaimStressResult",
+    "DispatchSignalStressResult",
+    "StressHarnessConfig",
+    "run_claim_stress_contract",
+    "run_dispatch_signal_contract",
+]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1621,9 +1621,9 @@ def _pin_kanban_board_env() -> None:
     if os.environ.get("HERMES_KANBAN_BOARD"):
         return
     try:
-        from hermes_cli.kanban_db import get_current_board
+        from hermes_cli.kanban_store_factory import get_default_kanban_store
 
-        os.environ["HERMES_KANBAN_BOARD"] = get_current_board()
+        os.environ["HERMES_KANBAN_BOARD"] = get_default_kanban_store().get_current_board()
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_kanban_store_contract.py
+++ b/tests/hermes_cli/test_kanban_store_contract.py
@@ -1,0 +1,166 @@
+"""Contract tests for Kanban storage backends.
+
+These tests intentionally exercise the existing SQLite-backed ``kanban_db``
+module first.  Future storage backends should be wired into the ``store``
+fixture and pass the same behavior without changing the assertions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def test_kanban_store_protocol_module_imports():
+    from hermes_cli.kanban_store import (
+        KanbanStore,
+        KanbanStoreConnection,
+        StoreCapabilities,
+    )
+
+    assert KanbanStore is not None
+    assert KanbanStoreConnection is not None
+    assert StoreCapabilities().backend == "unknown"
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an initialized default board."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def store(kanban_home):
+    """Current backend under contract: the legacy SQLite facade."""
+    return kb
+
+
+def test_store_contract_create_list_show_roundtrip(store):
+    with store.connect() as conn:
+        task_id = store.create_task(
+            conn,
+            title="contract create",
+            body="persist this body",
+            assignee="alice",
+            created_by="contract-test",
+            priority=7,
+        )
+        shown = store.get_task(conn, task_id)
+        listed = store.list_tasks(conn)
+
+    assert shown is not None
+    assert shown.id == task_id
+    assert shown.title == "contract create"
+    assert shown.body == "persist this body"
+    assert shown.assignee == "alice"
+    assert shown.created_by == "contract-test"
+    assert shown.priority == 7
+    assert shown.status == "ready"
+    assert [task.id for task in listed] == [task_id]
+
+
+def test_store_contract_parent_promotion_requires_completed_parent(store):
+    with store.connect() as conn:
+        parent_id = store.create_task(conn, title="parent")
+        child_id = store.create_task(conn, title="child", parents=[parent_id])
+        assert store.get_task(conn, child_id).status == "todo"
+
+        promoted_before = store.recompute_ready(conn)
+        assert promoted_before == 0
+        assert store.get_task(conn, child_id).status == "todo"
+
+        assert store.complete_task(conn, parent_id, result="done") is True
+        child = store.get_task(conn, child_id)
+
+    assert child.status == "ready"
+
+
+def test_store_contract_claim_is_exclusive_and_creates_run_event(store):
+    with store.connect() as conn:
+        task_id = store.create_task(conn, title="claim me", assignee="alice")
+
+        first = store.claim_task(conn, task_id, claimer="worker-a")
+        second = store.claim_task(conn, task_id, claimer="worker-b")
+        task = store.get_task(conn, task_id)
+        events = store.list_events(conn, task_id)
+
+    assert first is not None
+    assert first.id == task_id
+    assert second is None
+    assert task.status == "running"
+    assert task.claim_lock == "worker-a"
+    assert task.current_run_id is not None
+    claimed_events = [event for event in events if event.kind == "claimed"]
+    assert len(claimed_events) == 1
+    assert claimed_events[0].payload["lock"] == "worker-a"
+    assert claimed_events[0].run_id == task.current_run_id
+
+
+def test_store_contract_heartbeat_comment_and_complete_close_run(store):
+    with store.connect() as conn:
+        task_id = store.create_task(conn, title="finish me", assignee="alice")
+        claimed = store.claim_task(conn, task_id, claimer="worker-a")
+        assert claimed is not None
+
+        assert store.heartbeat_claim(conn, task_id, claimer="worker-a") is True
+        comment_id = store.add_comment(conn, task_id, "reviewer", "looks good")
+        assert comment_id > 0
+        assert store.complete_task(
+            conn,
+            task_id,
+            result="ok",
+            summary="completed by contract",
+            expected_run_id=claimed.current_run_id,
+        ) is True
+
+        task = store.get_task(conn, task_id)
+        comments = store.list_comments(conn, task_id)
+        events = store.list_events(conn, task_id)
+
+    assert task.status == "done"
+    assert task.result == "ok"
+    assert task.claim_lock is None
+    assert task.claim_expires is None
+    assert comments[-1].author == "reviewer"
+    assert comments[-1].body == "looks good"
+    assert "commented" in [event.kind for event in events]
+    assert "completed" in [event.kind for event in events]
+
+
+def test_store_contract_expired_claim_reclaims_to_ready(store):
+    with store.connect() as conn:
+        task_id = store.create_task(conn, title="reclaim me", assignee="alice")
+        claimed = store.claim_task(conn, task_id, ttl_seconds=1, claimer="remote-host:123")
+        assert claimed is not None
+        with store.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_expires = 1 WHERE id = ?",
+                (task_id,),
+            )
+            conn.execute(
+                "UPDATE task_runs SET claim_expires = 1 WHERE id = ?",
+                (claimed.current_run_id,),
+            )
+
+        reclaimed = store.release_stale_claims(conn)
+        task = store.get_task(conn, task_id)
+        events = store.list_events(conn, task_id)
+
+    assert reclaimed == 1
+    assert task.status == "ready"
+    assert task.claim_lock is None
+    assert task.claim_expires is None
+    reclaimed_events = [event for event in events if event.kind == "reclaimed"]
+    assert len(reclaimed_events) == 1
+    assert reclaimed_events[0].payload["stale_lock"] == "remote-host:123"

--- a/tests/hermes_cli/test_kanban_store_contract.py
+++ b/tests/hermes_cli/test_kanban_store_contract.py
@@ -20,10 +20,31 @@ def test_kanban_store_protocol_module_imports():
         KanbanStoreConnection,
         StoreCapabilities,
     )
+    from hermes_cli.kanban_store_sqlite import SQLiteKanbanStore
+
+    store = SQLiteKanbanStore()
 
     assert KanbanStore is not None
     assert KanbanStoreConnection is not None
     assert StoreCapabilities().backend == "unknown"
+    assert store.capabilities.backend == "sqlite"
+    assert store.capabilities.supports_concurrent_writers is False
+
+
+@pytest.fixture(params=("legacy", "sqlite_store"))
+def store(request, kanban_home):
+    """Kanban backend under contract."""
+    if request.param == "legacy":
+        return kb
+    from hermes_cli.kanban_store_sqlite import SQLiteKanbanStore
+
+    return SQLiteKanbanStore()
+
+
+@pytest.fixture
+def legacy_store(kanban_home):
+    """Raw legacy module for direct migration comparisons."""
+    return kb
 
 
 @pytest.fixture
@@ -38,12 +59,6 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
-
-
-@pytest.fixture
-def store(kanban_home):
-    """Current backend under contract: the legacy SQLite facade."""
-    return kb
 
 
 def test_store_contract_create_list_show_roundtrip(store):

--- a/tests/hermes_cli/test_kanban_store_contract_surface.py
+++ b/tests/hermes_cli/test_kanban_store_contract_surface.py
@@ -85,7 +85,7 @@ def test_sqlite_store_exposes_required_cli_and_dispatcher_surface():
     assert missing_constants == []
 
 
-def test_postgres_backend_has_explicit_placeholder_but_is_not_runtime_enabled(monkeypatch):
+def test_postgres_backend_has_explicit_runtime_adapter(monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_BACKEND", "postgres")
 
     from hermes_cli.kanban_store_factory import create_kanban_store, get_default_kanban_store
@@ -97,11 +97,8 @@ def test_postgres_backend_has_explicit_placeholder_but_is_not_runtime_enabled(mo
     assert store.capabilities.backend == "postgres"
     assert store.capabilities.supports_concurrent_writers is True
     assert store.capabilities.supports_skip_locked is True
-    assert store.capabilities.production_ready is False
-    with pytest.raises(NotImplementedError, match="PostgresKanbanStore is a placeholder"):
-        store.connect()
-    with pytest.raises(NotImplementedError, match="PostgresKanbanStore is a placeholder"):
-        get_default_kanban_store().connect()
+    assert store.capabilities.production_ready is True
+    assert get_default_kanban_store().capabilities.backend == "postgres"
 
 
 def test_postgres_store_declares_same_contract_methods_as_protocol():

--- a/tests/hermes_cli/test_kanban_store_contract_surface.py
+++ b/tests/hermes_cli/test_kanban_store_contract_surface.py
@@ -1,0 +1,122 @@
+"""Structural contract tests for Kanban store migration call sites."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+REQUIRED_CLI_DISPATCHER_OPERATIONS = {
+    "add_notify_sub",
+    "archive_task",
+    "assign_task",
+    "board_exists",
+    "board_stats",
+    "build_worker_context",
+    "child_ids",
+    "create_board",
+    "delete_archived_task",
+    "dispatch_once",
+    "edit_completed_task_result",
+    "gc_events",
+    "gc_worker_logs",
+    "get_current_board",
+    "has_spawnable_ready",
+    "heartbeat_worker",
+    "kanban_db_path",
+    "known_assignees",
+    "latest_summary",
+    "link_tasks",
+    "list_boards",
+    "list_notify_subs",
+    "list_profiles_on_disk",
+    "list_runs",
+    "parent_ids",
+    "promote_task",
+    "read_board_metadata",
+    "read_worker_log",
+    "reassign_task",
+    "reclaim_task",
+    "remove_board",
+    "remove_notify_sub",
+    "resolve_workspace",
+    "run_daemon",
+    "schedule_task",
+    "set_current_board",
+    "set_workspace_path",
+    "unlink_tasks",
+    "workspaces_root",
+    "write_board_metadata",
+}
+
+REQUIRED_CLI_DISPATCHER_CONSTANTS = {
+    "DEFAULT_BOARD",
+    "DEFAULT_CLAIM_TTL_SECONDS",
+    "DEFAULT_FAILURE_LIMIT",
+    "DEFAULT_SPAWN_FAILURE_LIMIT",
+    "VALID_INITIAL_STATUSES",
+    "VALID_SORT_ORDERS",
+    "VALID_STATUSES",
+}
+
+
+def test_store_protocol_declares_cli_and_dispatcher_surface():
+    from hermes_cli.kanban_store import KanbanStore
+
+    protocol_attrs = set(KanbanStore.__dict__)
+
+    missing_ops = sorted(REQUIRED_CLI_DISPATCHER_OPERATIONS - protocol_attrs)
+    missing_constants = sorted(REQUIRED_CLI_DISPATCHER_CONSTANTS - protocol_attrs)
+
+    assert missing_ops == []
+    assert missing_constants == []
+
+
+def test_sqlite_store_exposes_required_cli_and_dispatcher_surface():
+    from hermes_cli.kanban_store_sqlite import SQLiteKanbanStore
+
+    store = SQLiteKanbanStore()
+
+    missing_ops = [name for name in sorted(REQUIRED_CLI_DISPATCHER_OPERATIONS) if not callable(getattr(store, name, None))]
+    missing_constants = [name for name in sorted(REQUIRED_CLI_DISPATCHER_CONSTANTS) if not hasattr(store, name)]
+
+    assert missing_ops == []
+    assert missing_constants == []
+
+
+def test_postgres_backend_has_explicit_placeholder_but_is_not_runtime_enabled(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_BACKEND", "postgres")
+
+    from hermes_cli.kanban_store_factory import create_kanban_store, get_default_kanban_store
+    from hermes_cli.kanban_store_postgres import PostgresKanbanStore
+
+    store = create_kanban_store("postgres")
+
+    assert isinstance(store, PostgresKanbanStore)
+    assert store.capabilities.backend == "postgres"
+    assert store.capabilities.supports_concurrent_writers is True
+    assert store.capabilities.supports_skip_locked is True
+    assert store.capabilities.production_ready is False
+    with pytest.raises(NotImplementedError, match="PostgresKanbanStore is a placeholder"):
+        store.connect()
+    with pytest.raises(NotImplementedError, match="PostgresKanbanStore is a placeholder"):
+        get_default_kanban_store().connect()
+
+
+def test_postgres_store_declares_same_contract_methods_as_protocol():
+    from hermes_cli.kanban_store import KanbanStore
+    from hermes_cli.kanban_store_postgres import PostgresKanbanStore
+
+    protocol_methods = {
+        name
+        for name, value in KanbanStore.__dict__.items()
+        if inspect.isfunction(value) and not name.startswith("__")
+    }
+    postgres_methods = {
+        name
+        for name, value in PostgresKanbanStore.__dict__.items()
+        if inspect.isfunction(value) and not name.startswith("__")
+    }
+
+    assert sorted(protocol_methods - postgres_methods) == []

--- a/tests/hermes_cli/test_kanban_store_factory.py
+++ b/tests/hermes_cli/test_kanban_store_factory.py
@@ -29,6 +29,17 @@ def test_default_kanban_store_accepts_explicit_sqlite_backend(monkeypatch):
     assert isinstance(get_default_kanban_store(), SQLiteKanbanStore)
 
 
+def test_default_kanban_store_reads_config_backend_when_env_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BACKEND", raising=False)
+
+    import hermes_cli.kanban_store_factory as factory
+    from hermes_cli.kanban_store_postgres import PostgresKanbanStore
+
+    monkeypatch.setattr(factory, "_load_config_backend", lambda: "postgres")
+
+    assert isinstance(factory.get_default_kanban_store(), PostgresKanbanStore)
+
+
 def test_default_kanban_store_rejects_unknown_backend(monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_BACKEND", "mysql")
 

--- a/tests/hermes_cli/test_kanban_store_factory.py
+++ b/tests/hermes_cli/test_kanban_store_factory.py
@@ -30,7 +30,7 @@ def test_default_kanban_store_accepts_explicit_sqlite_backend(monkeypatch):
 
 
 def test_default_kanban_store_rejects_unknown_backend(monkeypatch):
-    monkeypatch.setenv("HERMES_KANBAN_BACKEND", "postgres")
+    monkeypatch.setenv("HERMES_KANBAN_BACKEND", "mysql")
 
     from hermes_cli.kanban_store_factory import get_default_kanban_store
 

--- a/tests/hermes_cli/test_kanban_store_factory.py
+++ b/tests/hermes_cli/test_kanban_store_factory.py
@@ -1,0 +1,48 @@
+"""Factory tests for selecting the Kanban storage backend."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_default_kanban_store_is_sqlite_when_backend_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BACKEND", raising=False)
+
+    from hermes_cli.kanban_store_factory import get_default_kanban_store
+    from hermes_cli.kanban_store_sqlite import SQLiteKanbanStore
+
+    store = get_default_kanban_store()
+
+    assert isinstance(store, SQLiteKanbanStore)
+    assert store.capabilities.backend == "sqlite"
+
+
+def test_default_kanban_store_accepts_explicit_sqlite_backend(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_BACKEND", "sqlite")
+
+    from hermes_cli.kanban_store_factory import get_default_kanban_store
+    from hermes_cli.kanban_store_sqlite import SQLiteKanbanStore
+
+    assert isinstance(get_default_kanban_store(), SQLiteKanbanStore)
+
+
+def test_default_kanban_store_rejects_unknown_backend(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_BACKEND", "postgres")
+
+    from hermes_cli.kanban_store_factory import get_default_kanban_store
+
+    with pytest.raises(ValueError, match="Unsupported Kanban store backend"):
+        get_default_kanban_store()
+
+
+def test_kanban_cli_module_uses_selected_store_boundary(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BACKEND", raising=False)
+    sys.modules.pop("hermes_cli.kanban", None)
+
+    kanban = importlib.import_module("hermes_cli.kanban")
+
+    assert kanban.kb.capabilities.backend == "sqlite"
+    assert kanban.kb.DEFAULT_SPAWN_FAILURE_LIMIT > 0

--- a/tests/hermes_cli/test_kanban_store_postgres_local.py
+++ b/tests/hermes_cli/test_kanban_store_postgres_local.py
@@ -1,0 +1,49 @@
+import os
+import uuid
+
+import pytest
+
+from hermes_cli.kanban_store_factory import create_kanban_store
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("HERMES_TEST_POSTGRES_DSN"),
+    reason="set HERMES_TEST_POSTGRES_DSN to run local PostgreSQL Kanban store tests",
+)
+
+
+def _dsn_with_schema(base: str, schema: str) -> str:
+    sep = "&" if "?" in base else "?"
+    return f"{base}{sep}options=-csearch_path%3D{schema}"
+
+
+def test_postgres_store_initializes_and_supports_basic_task_flow(monkeypatch):
+    base_dsn = os.environ["HERMES_TEST_POSTGRES_DSN"]
+    schema = "test_kanban_" + uuid.uuid4().hex[:12]
+    monkeypatch.setenv("HERMES_KANBAN_POSTGRES_DSN", _dsn_with_schema(base_dsn, schema))
+    store = create_kanban_store("postgres")
+
+    with store.connect(board="contract") as conn:
+        task_id = store.create_task(
+            conn,
+            title="postgres contract task",
+            body="created in local postgres contract test",
+            assignee="qa",
+            created_by="pytest",
+            initial_status="running",
+            board="contract",
+        )
+        listed = store.list_tasks(conn, status="ready")
+        claimed = store.claim_task(conn, task_id, ttl_seconds=30, claimer="pytest")
+        assert claimed is not None
+        assert claimed.id == task_id
+        assert any(task.id == task_id for task in listed)
+        assert store.complete_task(conn, task_id, summary="done from postgres contract") is True
+        assert store.get_task(conn, task_id).status == "done"
+        stats = store.board_stats(conn)
+        assert stats["done"] >= 1
+
+    # cleanup schema explicitly
+    import psycopg
+    with psycopg.connect(base_dsn, autocommit=True) as cleanup:
+        cleanup.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')

--- a/tests/hermes_cli/test_kanban_store_stress_harness.py
+++ b/tests/hermes_cli/test_kanban_store_stress_harness.py
@@ -1,0 +1,61 @@
+"""Stress-contract harness tests for Kanban store adapters."""
+
+from __future__ import annotations
+
+import os
+import signal
+from pathlib import Path
+
+import pytest
+
+
+def test_stress_harness_uses_isolated_sqlite_home_not_ai_team(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", "/tmp/should-not-be-used")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "ai-team")
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+
+    from hermes_cli.kanban_store_stress import StressHarnessConfig, run_claim_stress_contract
+
+    result = run_claim_stress_contract(
+        StressHarnessConfig(task_count=4, claim_workers=2, base_dir=tmp_path)
+    )
+
+    assert result.backend == "sqlite"
+    assert result.board == "db-adapter-stress"
+    assert result.board != "ai-team"
+    assert Path(result.hermes_home).is_relative_to(tmp_path)
+    assert Path(result.db_path).is_relative_to(tmp_path)
+    assert os.environ["HERMES_KANBAN_BOARD"] == "ai-team"
+
+
+def test_claim_stress_contract_has_unique_claims_and_no_leftover_running(tmp_path):
+    from hermes_cli.kanban_store_stress import StressHarnessConfig, run_claim_stress_contract
+
+    result = run_claim_stress_contract(
+        StressHarnessConfig(task_count=12, claim_workers=4, base_dir=tmp_path)
+    )
+
+    assert result.task_count == 12
+    assert len(result.claimed_task_ids) == 12
+    assert sorted(result.claimed_task_ids) == sorted(set(result.claimed_task_ids))
+    assert result.duplicate_claims == []
+    assert result.status_counts == {"done": 12}
+    assert result.open_run_count == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signal crash harness only")
+def test_dispatch_signal_stress_contract_covers_sigterm_and_sigkill(tmp_path):
+    from hermes_cli.kanban_store_stress import StressHarnessConfig, run_dispatch_signal_contract
+
+    result = run_dispatch_signal_contract(
+        StressHarnessConfig(task_count=2, claim_workers=2, base_dir=tmp_path),
+        signals=(signal.SIGTERM, signal.SIGKILL),
+    )
+
+    assert result.backend == "sqlite"
+    assert result.signal_names == ["SIGTERM", "SIGKILL"]
+    assert sorted(result.crashed_task_ids) == sorted(result.spawned_task_ids)
+    assert result.status_counts == {"ready": 2}
+    assert result.open_run_count == 0
+    assert result.crash_event_count == 2
+    assert result.unexpected_failures == []


### PR DESCRIPTION
## Summary
- Route the embedded gateway Kanban dispatcher through the configured Kanban store instead of hard-coding legacy SQLite access.
- Enter Postgres store context managers before passing connections into legacy Kanban domain logic.
- Preserve SQLite board-scoped connection behavior for the default backend.
- Add/extend tests for store backend selection, Postgres adapter behavior, and gateway dispatcher compatibility.

## Why
When `kanban.storage.backend=postgres`, the CLI/factory selected `PostgresKanbanStore`, but the gateway embedded dispatcher still opened boards through `hermes_cli.kanban_db.connect(board=slug)`, touching corrupt SQLite files and producing `database disk image is malformed`.

A first switch to `store.connect()` exposed that Postgres returns a context manager, not a raw connection. This patch handles that explicitly.

## Validation
- `python -m py_compile gateway/run.py hermes_cli/kanban_store_factory.py hermes_cli/kanban_store_postgres.py hermes_cli/kanban_store_sqlite.py`
- `python -m pytest tests/hermes_cli/test_kanban_store_factory.py tests/hermes_cli/test_kanban_store_contract_surface.py tests/hermes_cli/test_kanban_store_postgres_local.py tests/gateway/test_restart_drain.py -q -o 'addopts='`
- Local gateway restart verified:
  - `kanban dispatcher: storage backend=postgres`
  - `tick_failed=0`
  - `sqlite malformed=0`
  - `_PostgresContext` errors=0

Closes #33267