### PR TITLE
fix: set HOME for profile gateway services

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -597,6 +597,7 @@ class S6ServiceManager:
             "#!/command/with-contenv sh",
             "# shellcheck shell=sh",
             "set -e",
+            'export HOME="${HERMES_HOME:-/opt/data}"',
             "cd /opt/data",
             ". /opt/hermes/.venv/bin/activate",
         ]

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -538,6 +538,10 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
     run_text = run_path.read_text()
     assert "hermes -p coder gateway run" in run_text
     assert "s6-setuidgid hermes" in run_text
+    assert 'export HOME="${HERMES_HOME:-/opt/data}"' in run_text
+    assert run_text.index('export HOME="${HERMES_HOME:-/opt/data}"') < run_text.index(
+        "exec s6-setuidgid hermes"
+    )
 
     log_run = svc_dir / "log" / "run"
     assert log_run.is_file()


### PR DESCRIPTION
## Summary
- Set HOME from HERMES_HOME in generated profile gateway s6 run scripts
- Keep profile gateway services from inheriting /root as HOME after s6-setuidgid drops to the hermes user
- Add test coverage for the generated run script

## Why
When a per-profile gateway runs under s6 in the Docker container, the generated service script drops privileges with `s6-setuidgid hermes` but can still inherit `HOME=/root`. Code paths that resolve state/cache paths through `Path.home()` or XDG defaults may then attempt to write under `/root`, causing permission errors for the hermes user. The container main wrapper already normalizes HOME; profile gateway service scripts should do the same.

## Test Plan
- `python -m pytest tests/hermes_cli/test_service_manager.py -q`
- `python -m ruff check hermes_cli/service_manager.py tests/hermes_cli/test_service_manager.py`
