### PR TITLE
fix(cli): register session_search in aux-task registries (#33348)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2506,6 +2506,7 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("mcp", "MCP", "MCP tool reasoning"),
     ("title_generation", "Title generation", "session titles"),
     ("skills_hub", "Skills hub", "skills search/install"),
+    ("session_search", "Session search", "cross-session content retrieval"),
     ("triage_specifier", "Triage specifier", "kanban spec fleshing"),
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),
     ("profile_describer", "Profile describer", "auto profile descriptions"),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -977,6 +977,7 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
     "web_extract",
     "compression",
     "skills_hub",
+    "session_search",
     "approval",
     "mcp",
     "title_generation",


### PR DESCRIPTION
## Summary

`session_search` is a real auxiliary slot — it has config entries, a dedicated provider/model slot, and is dispatched via `agent/auxiliary_client.py`. But it was missing from two canonical registries:

- **`_AUX_TASKS`** in `hermes_cli/main.py` — powers the CLI aux config menu (`/aux`)
- **`_AUX_TASK_SLOTS`** in `hermes_cli/web_server.py` — drives the dashboard Models page REST API allowlist

Without these entries, `session_search` is invisible in the CLI aux menu and the web UI config panel, even though it works fine when configured manually.

## Changes

1. `hermes_cli/main.py`: Added `session_search` entry to `_AUX_TASKS` tuple
2. `hermes_cli/web_server.py`: Added `"session_search"` to `_AUX_TASK_SLOTS` tuple

## Verification

- `session_search` already has config entries in `DEFAULT_CONFIG["auxiliary"]` (with a note that it no longer uses an auxiliary LLM since PR #27590)
- The slot is already dispatched via `agent/auxiliary_client.py` — this PR just registers it in the UI-facing lists

Closes #33348