### PR TITLE
fix(model): normalize dict entries in provider model lists

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1142,6 +1142,17 @@ def list_authenticated_providers(
             )
         )
 
+    def _add_model_id(target: list, item) -> None:
+        """Append a model id from config entries that may be strings or dicts."""
+        if isinstance(item, str):
+            model_id = item.strip()
+        elif isinstance(item, dict):
+            model_id = str(item.get("name") or item.get("id") or item.get("model") or "").strip()
+        else:
+            model_id = ""
+        if model_id and model_id not in target:
+            target.append(model_id)
+
     def _has_aws_sdk_creds_for_listing(slug: str) -> bool:
         """Credential check for AWS SDK providers in non-runtime discovery."""
         slug_norm = str(slug or "").strip().lower()
@@ -1499,12 +1510,10 @@ def list_authenticated_providers(
             cfg_models = ep_cfg.get("models", [])
             if isinstance(cfg_models, dict):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    _add_model_id(models_list, m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    _add_model_id(models_list, m)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
@@ -1639,12 +1648,10 @@ def list_authenticated_providers(
             cfg_models = entry.get("models", {})
             if isinstance(cfg_models, dict):
                 for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
+                    _add_model_id(groups[group_key]["models"], m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
+                    _add_model_id(groups[group_key]["models"], m)
 
         _section4_emitted_slugs: set = set()
         for grp_key, grp in groups.items():

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -180,6 +180,90 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     assert user_prov["total_models"] == 2
 
 
+@pytest.mark.parametrize(
+    "model_entry, expected_model",
+    [
+        ({"name": "qwen3.7-max"}, "qwen3.7-max"),
+        ({"id": "qwen3.7-max"}, "qwen3.7-max"),
+        ({"model": "qwen3.7-max"}, "qwen3.7-max"),
+    ],
+)
+def test_list_authenticated_providers_normalizes_list_of_model_dicts(
+    monkeypatch, model_entry, expected_model
+):
+    """providers: entries may use YAML list items like ``- name: model``.
+
+    Regression: Telegram /model crashed because list_authenticated_providers
+    passed those dicts through to the picker instead of extracting strings.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "dashscope": {
+            "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            "models": [
+                model_entry,
+                {"name": "qwen3.6-flash"},
+            ],
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "dashscope"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["total_models"] == 2
+    assert user_prov["models"] == [expected_model, "qwen3.6-flash"]
+    assert all(isinstance(model, str) for model in user_prov["models"])
+
+
+def test_list_authenticated_providers_ignores_empty_dict_model_entries_and_dedupes(monkeypatch):
+    """Malformed dict model entries should not leak to the Telegram picker."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "xiaomi-token-plan": {
+            "base_url": "https://api.example.test/v1",
+            "model": "mimo-v2.5-pro",
+            "models": [
+                {"name": "mimo-v2.5-pro"},
+                {"id": "mimo-v2.5"},
+                {"model": "mimo-v2.5-flash"},
+                {"name": "mimo-v2.5-pro"},
+                {},
+                123,
+            ],
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="xiaomi-token-plan",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "xiaomi-token-plan"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["models"] == ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2.5-flash"]
+    assert user_prov["total_models"] == 3
+
+
 def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
     """Dict-format ``models:`` without a ``default_model`` must still expose
     every dict key, not collapse to an empty list."""


### PR DESCRIPTION
## Summary
- normalize provider model list entries that are YAML dicts (`name`, `id`, or `model`) before exposing them to the model picker
- skip malformed/empty entries and dedupe normalized model ids
- add regression coverage for Telegram `/model` crashes caused by non-string button text

## Test
- `python -m pytest tests/hermes_cli/test_user_providers_model_switch.py -q`
- `33 passed in 13.32s`

## Context
This fixes configs where provider `models:` is written as a list of objects, e.g. `- name: mimo-v2.5-pro`, which previously leaked dicts into the picker UI.

Related PRs found before opening:
- #32341 dashboard list-of-dict `models:` handling
- #32371 dashboard custom provider dict-format crash

This PR targets the shared `hermes_cli.model_switch.list_authenticated_providers()` path used by the gateway/model picker.