### PR TITLE
fix(terminal): guard os.getcwd() against deleted CWD in _get_env_config

### DIFF
--- a/tests/tools/test_terminal_cleanup_cwd.py
+++ b/tests/tools/test_terminal_cleanup_cwd.py
@@ -1,0 +1,38 @@
+"""Regression test for #33367: _get_env_config should not raise when CWD is deleted."""
+
+import os
+from unittest.mock import patch
+
+
+def test_get_env_config_handles_deleted_cwd(monkeypatch):
+    """When os.getcwd() raises FileNotFoundError (e.g. tmpfs cleanup on Arch
+    Linux), _get_env_config should fall back to the home directory instead of
+    propagating the error.  See #33367."""
+    from tools import terminal_tool as tt
+
+    def _raise_fnf(*a, **kw):
+        raise FileNotFoundError("No such file or directory")
+
+    monkeypatch.setattr(os, "getcwd", _raise_fnf)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    config = tt._get_env_config()
+
+    assert config["env_type"] == "local"
+    assert config["cwd"] == os.path.expanduser("~")
+
+
+def test_get_env_config_handles_oserror_on_cwd(monkeypatch):
+    """os.getcwd() can also raise OSError (errno 10: no current directory)."""
+    from tools import terminal_tool as tt
+
+    def _raise_os(*a, **kw):
+        raise OSError(10, "No current process")
+
+    monkeypatch.setattr(os, "getcwd", _raise_os)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    config = tt._get_env_config()
+
+    assert config["env_type"] == "local"
+    assert config["cwd"] == os.path.expanduser("~")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -953,7 +953,13 @@ def _get_env_config() -> Dict[str, Any]:
     # remote home, and everything else starts in the backend's default
     # root-like cwd.
     if env_type == "local":
-        default_cwd = os.getcwd()
+        try:
+            default_cwd = os.getcwd()
+        except (FileNotFoundError, OSError):
+            # CWD may have been deleted (e.g. tmpfs cleanup on Arch Linux).
+            # Fall back to the home directory so the cleanup thread does not
+            # spam errors.log every 60 seconds.  See #33367.
+            default_cwd = os.path.expanduser("~")
     elif env_type == "ssh":
         default_cwd = "~"
     else:


### PR DESCRIPTION
## What does this PR do?

`_get_env_config()` calls `os.getcwd()` unconditionally for the `local` backend. When the process's current working directory has been deleted (common on Arch Linux where `/tmp` is tmpfs and stale namespaces are reaped aggressively), this raises `FileNotFoundError`.

The cleanup thread calls `_get_env_config()` every 60 seconds. Although the exception is caught by the thread's `except Exception` handler, it logs a full traceback to `errors.log` on every tick — creating a recurring, noisy warning that never resolves.

## Related Issue

Fixes #33367

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: Guard `os.getcwd()` against deleted CWD
- `tests/tools/test_terminal_cleanup_cwd.py`: Regression tests for `FileNotFoundError` and `OSError`

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `Function:tools/terminal_tool.py:_get_env_config` (callers: 10+ including terminal_tool, file_tools, code_execution_tool, cleanup_thread_worker, prompt_builder)
- Blast radius: LOW — single line change with safe fallback; all callers benefit from the guard
- Related patterns: `os.getcwd()` is also called at line 978 (docker CWD passthrough) but only when `env_type == "docker"`, which is not the affected code path