### PR TITLE
feat(webhook): derive delivery_id from Alertmanager groupKey for dedup

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -483,14 +483,27 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
+        # Build a unique delivery ID. Header-based IDs win; Alertmanager has
+        # no such header so derive a stable hash from payload.groupKey to
+        # make retries hit the idempotency cache below. Route name is part
+        # of the hash input so two routes happening to receive the same
+        # groupKey value never collide in _seen_deliveries.
+        delivery_id = (
+            request.headers.get("X-GitHub-Delivery")
+            or request.headers.get("svix-id")
+            or request.headers.get("X-Request-ID")
         )
+        if not delivery_id and isinstance(payload, dict):
+            group_key = payload.get("groupKey")
+            if isinstance(group_key, str) and group_key.strip():
+                # 16 hex chars = 64 bits: collision-safe for any realistic
+                # alert-group cardinality at the 1h _idempotency_ttl horizon.
+                _hash_input = f"{route_name}:{group_key.strip()}".encode("utf-8")
+                delivery_id = "alertmanager:" + hashlib.sha256(
+                    _hash_input
+                ).hexdigest()[:16]
+        if not delivery_id:
+            delivery_id = str(int(time.time() * 1000))
 
         # ── Idempotency ─────────────────────────────────────────
         # Skip duplicate deliveries (webhook retries).

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -97,6 +97,43 @@ def check_webhook_requirements() -> bool:
     return AIOHTTP_AVAILABLE
 
 
+def _alertmanager_dedup_key(payload: Dict[str, Any]) -> str:
+    """Canonical string identifying an Alertmanager notification for dedup.
+
+    Hashing the full payload (rather than the ``groupKey`` alone) is what lets a
+    materially different notification for the same group — a membership change,
+    or the final ``resolved`` payload — bypass the idempotency cache instead of
+    being silently swallowed. But two aspects of the payload are volatile for an
+    *unchanged firing group* and must be normalized out, or ``repeat_interval``
+    re-sends would each look new and re-trigger the agent:
+
+    - ``alerts[*].endsAt`` is dropped for **firing** alerts. Prometheus refreshes
+      the end time of an active alert on every evaluation cycle, so it drifts
+      between notifications with no material change. It is kept for **resolved**
+      alerts, where it is the real resolution time and *should* bust the cache.
+    - the ``alerts`` list is ordered by ``fingerprint``, since array order is not
+      a meaningful part of the notification's identity.
+
+    Shallow copies keep the caller's ``payload`` (reused for rendering and
+    delivery) untouched.
+    """
+    normalized = dict(payload)
+    alerts = normalized.get("alerts")
+    if isinstance(alerts, list):
+        norm_alerts = []
+        for alert in alerts:
+            if isinstance(alert, dict):
+                alert = dict(alert)
+                if alert.get("status") == "firing":
+                    alert.pop("endsAt", None)
+            norm_alerts.append(alert)
+        norm_alerts.sort(
+            key=lambda a: a.get("fingerprint", "") if isinstance(a, dict) else ""
+        )
+        normalized["alerts"] = norm_alerts
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+
 class WebhookAdapter(BasePlatformAdapter):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
@@ -483,11 +520,13 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID. Header-based IDs win; Alertmanager has
-        # no such header so derive a stable hash from payload.groupKey to
-        # make retries hit the idempotency cache below. Route name is part
-        # of the hash input so two routes happening to receive the same
-        # groupKey value never collide in _seen_deliveries.
+        # Build a unique delivery ID. Header-based IDs win; Alertmanager has no
+        # such header, so for a payload that carries a groupKey we derive a
+        # stable hash of the (normalized) notification content — see
+        # _alertmanager_dedup_key for why it hashes the whole payload rather
+        # than the groupKey alone. The route name is folded in so two routes
+        # receiving the same upstream groupKey never collide in
+        # _seen_deliveries.
         delivery_id = (
             request.headers.get("X-GitHub-Delivery")
             or request.headers.get("svix-id")
@@ -496,11 +535,12 @@ class WebhookAdapter(BasePlatformAdapter):
         if not delivery_id and isinstance(payload, dict):
             group_key = payload.get("groupKey")
             if isinstance(group_key, str) and group_key.strip():
+                canonical = _alertmanager_dedup_key(payload)
+                hash_input = f"{route_name}:{canonical}".encode("utf-8")
                 # 16 hex chars = 64 bits: collision-safe for any realistic
                 # alert-group cardinality at the 1h _idempotency_ttl horizon.
-                _hash_input = f"{route_name}:{group_key.strip()}".encode("utf-8")
                 delivery_id = "alertmanager:" + hashlib.sha256(
-                    _hash_input
+                    hash_input
                 ).hexdigest()[:16]
         if not delivery_id:
             delivery_id = str(int(time.time() * 1000))

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -337,3 +337,226 @@ class TestGitHubCommentDelivery:
         # Delivery info is retained after send() so interim status messages
         # don't strand the final response (TTL-based cleanup happens on POST).
         assert chat_id in adapter._delivery_info
+
+
+# ===================================================================
+# Test 5: Alertmanager groupKey-based delivery_id dedup
+# ===================================================================
+
+ALERTMANAGER_PAYLOAD = {
+    "receiver": "hermes",
+    "status": "firing",
+    "alerts": [
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "HighRequestLatency",
+                "service": "api",
+                "severity": "warning",
+            },
+            "annotations": {"summary": "API latency spiked"},
+            "startsAt": "2026-01-01T00:00:00Z",
+            "endsAt": "0001-01-01T00:00:00Z",
+            "generatorURL": "",
+            "fingerprint": "abc123",
+        }
+    ],
+    "groupLabels": {"alertname": "HighRequestLatency"},
+    "commonLabels": {
+        "alertname": "HighRequestLatency",
+        "service": "api",
+        "severity": "warning",
+    },
+    "commonAnnotations": {"summary": "API latency spiked"},
+    "externalURL": "",
+    "version": "4",
+    # The key field this test exercises: stable per-group identifier.
+    "groupKey": '{}/{}:{alertname="HighRequestLatency"}',
+    "truncatedAlerts": 0,
+}
+
+
+import re
+
+
+class TestAlertmanagerGroupKeyDedup:
+
+    @pytest.mark.asyncio
+    async def test_groupkey_derived_delivery_id_dedups_retries(self):
+        """When the payload has a `groupKey` field, repeated POSTs of the
+        same alert group must collapse to a single delivery_id via
+        sha256(route + groupKey) so the idempotency loop catches the
+        second call as a duplicate. Without this Alertmanager retries
+        (which omit X-GitHub-Delivery / svix-id / X-Request-ID) re-trigger
+        the agent every time."""
+        routes = {
+            "alertmanager": {
+                "prompt": "Alert: {commonLabels.alertname}",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        body = json.dumps(ALERTMANAGER_PAYLOAD).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/alertmanager",
+                data=body,
+                headers={"Content-Type": "application/json"},
+            )
+            assert first.status == 202
+            data1 = await first.json()
+            assert data1["status"] == "accepted"
+            assert re.fullmatch(
+                r"alertmanager:[0-9a-f]{16}", data1["delivery_id"]
+            ), f"unexpected delivery_id: {data1['delivery_id']}"
+
+            # Same payload, same groupKey -> must dedup.
+            second = await cli.post(
+                "/webhooks/alertmanager",
+                data=body,
+                headers={"Content-Type": "application/json"},
+            )
+            assert second.status == 200
+            data2 = await second.json()
+            assert data2["status"] == "duplicate"
+            assert data2["delivery_id"] == data1["delivery_id"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_delivery_header_wins_over_groupkey(self):
+        """Senders that DO supply X-GitHub-Delivery / svix-id /
+        X-Request-ID continue to win - the payload-based derivation is a
+        fallback, not an override. Two POSTs with the same groupKey but
+        different X-Request-IDs are NOT deduped."""
+        routes = {
+            "alertmanager": {
+                "prompt": "Alert: {commonLabels.alertname}",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        body = json.dumps(ALERTMANAGER_PAYLOAD).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/alertmanager",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Request-ID": "explicit-id-001",
+                },
+            )
+            assert first.status == 202
+            data1 = await first.json()
+            assert data1["delivery_id"] == "explicit-id-001"
+
+            second = await cli.post(
+                "/webhooks/alertmanager",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Request-ID": "explicit-id-002",
+                },
+            )
+            assert second.status == 202
+            data2 = await second.json()
+            assert data2["delivery_id"] == "explicit-id-002"
+
+    @pytest.mark.asyncio
+    async def test_different_routes_get_distinct_delivery_ids(self):
+        """Same groupKey on two different routes must produce different
+        delivery_ids so a duplicate on route A never silently masks a
+        legitimate delivery on route B."""
+        routes = {
+            "alertmanager-a": {
+                "prompt": "A: {commonLabels.alertname}",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            },
+            "alertmanager-b": {
+                "prompt": "B: {commonLabels.alertname}",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            },
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        body = json.dumps(ALERTMANAGER_PAYLOAD).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            a = await cli.post(
+                "/webhooks/alertmanager-a",
+                data=body,
+                headers={"Content-Type": "application/json"},
+            )
+            b = await cli.post(
+                "/webhooks/alertmanager-b",
+                data=body,
+                headers={"Content-Type": "application/json"},
+            )
+            assert a.status == 202
+            assert b.status == 202
+            id_a = (await a.json())["delivery_id"]
+            id_b = (await b.json())["delivery_id"]
+            assert id_a != id_b
+            assert id_a.startswith("alertmanager:")
+            assert id_b.startswith("alertmanager:")
+
+    @pytest.mark.parametrize(
+        "group_key",
+        [
+            pytest.param(None, id="missing"),
+            pytest.param("", id="empty-string"),
+            pytest.param("   ", id="whitespace-only"),
+            pytest.param("\t\n", id="tab-newline"),
+            pytest.param(123, id="integer"),
+            pytest.param(["foo"], id="list"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_invalid_groupkey_falls_through_to_timestamp(self, group_key):
+        """Non-string or effectively-empty groupKey must fall through to
+        the timestamp fallback (a fresh unique ID per request), never to
+        a stable hash. Otherwise an absent groupKey would silently dedup
+        every retry of every alert across the deployment."""
+        routes = {
+            "alertmanager": {
+                "prompt": "Alert: x",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        payload = dict(ALERTMANAGER_PAYLOAD)
+        if group_key is None:
+            payload.pop("groupKey", None)
+        else:
+            payload["groupKey"] = group_key
+
+        app = _create_app(adapter)
+        body = json.dumps(payload).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/alertmanager",
+                data=body,
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 202
+            delivery_id = (await resp.json())["delivery_id"]
+            # Timestamp fallback is digits-only; the hash path starts with
+            # "alertmanager:". Either way it must NOT be the hash path.
+            assert not delivery_id.startswith("alertmanager:")
+            assert delivery_id.isdigit()

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -383,12 +383,13 @@ class TestAlertmanagerGroupKeyDedup:
 
     @pytest.mark.asyncio
     async def test_groupkey_derived_delivery_id_dedups_retries(self):
-        """When the payload has a `groupKey` field, repeated POSTs of the
-        same alert group must collapse to a single delivery_id via
-        sha256(route + groupKey) so the idempotency loop catches the
-        second call as a duplicate. Without this Alertmanager retries
-        (which omit X-GitHub-Delivery / svix-id / X-Request-ID) re-trigger
-        the agent every time."""
+        """When the payload has a `groupKey` field, an immediate identical
+        re-POST must collapse to a single delivery_id (derived from the route
+        name and the normalized payload) so the idempotency loop catches the
+        second call as a duplicate. Without this, Alertmanager deliveries
+        (which omit X-GitHub-Delivery / svix-id / X-Request-ID) re-trigger the
+        agent every time. The near-identical-but-drifting repeat_interval case
+        is covered by test_repeat_interval_endsat_drift_still_dedups."""
         routes = {
             "alertmanager": {
                 "prompt": "Alert: {commonLabels.alertname}",
@@ -560,3 +561,151 @@ class TestAlertmanagerGroupKeyDedup:
             # "alertmanager:". Either way it must NOT be the hash path.
             assert not delivery_id.startswith("alertmanager:")
             assert delivery_id.isdigit()
+
+    @pytest.mark.asyncio
+    async def test_status_transition_same_groupkey_not_deduped(self):
+        """A later notification that shares the groupKey but carries a real
+        state change (here: the `resolved` notification) must NOT be swallowed
+        as a duplicate. Alertmanager reuses one groupKey for a group's whole
+        lifecycle, so a firing->resolved transition still has to reach the
+        agent. Regression guard against keying idempotency on groupKey alone.
+        Covers the status-change axis only; the endsAt-drift axis is covered by
+        test_repeat_interval_endsat_drift_still_dedups."""
+        routes = {
+            "alertmanager": {
+                "prompt": "Alert: {commonLabels.alertname}",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        firing = json.dumps(ALERTMANAGER_PAYLOAD).encode()
+
+        # Same groupKey, but the group has now resolved: status flips and the
+        # alert gets an endsAt. Deep-copy via a JSON round-trip so the nested
+        # alert dict is not shared with ALERTMANAGER_PAYLOAD.
+        resolved_payload = json.loads(json.dumps(ALERTMANAGER_PAYLOAD))
+        resolved_payload["status"] = "resolved"
+        resolved_payload["alerts"][0]["status"] = "resolved"
+        resolved_payload["alerts"][0]["endsAt"] = "2026-01-01T00:05:00Z"
+        resolved = json.dumps(resolved_payload).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/alertmanager",
+                data=firing,
+                headers={"Content-Type": "application/json"},
+            )
+            assert first.status == 202
+            id_firing = (await first.json())["delivery_id"]
+
+            second = await cli.post(
+                "/webhooks/alertmanager",
+                data=resolved,
+                headers={"Content-Type": "application/json"},
+            )
+            # Must be processed, not deduped: different content -> different id.
+            assert second.status == 202
+            data2 = await second.json()
+            assert data2["status"] == "accepted"
+            assert data2["delivery_id"] != id_firing
+            assert data2["delivery_id"].startswith("alertmanager:")
+
+    @pytest.mark.asyncio
+    async def test_repeat_interval_endsat_drift_still_dedups(self):
+        """A repeat_interval re-send of an UNCHANGED firing group must still
+        dedup even though its body is not byte-identical: Prometheus refreshes
+        `alerts[].endsAt` on every evaluation cycle for an active alert, so the
+        end time drifts between notifications without any material change.
+        endsAt is normalized out for firing alerts, so the two still collapse to
+        one delivery. Without that normalization this is exactly the
+        're-trigger the agent every notification interval' bug the derivation
+        exists to prevent."""
+        routes = {
+            "alertmanager": {
+                "prompt": "Alert: {commonLabels.alertname}",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        first_body = json.dumps(ALERTMANAGER_PAYLOAD).encode()
+
+        # Same firing group, later evaluation cycle: only endsAt moved forward.
+        drifted = json.loads(json.dumps(ALERTMANAGER_PAYLOAD))
+        drifted["alerts"][0]["endsAt"] = "2026-01-01T00:10:00Z"
+        drifted_body = json.dumps(drifted).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/alertmanager",
+                data=first_body,
+                headers={"Content-Type": "application/json"},
+            )
+            assert first.status == 202
+            id1 = (await first.json())["delivery_id"]
+
+            second = await cli.post(
+                "/webhooks/alertmanager",
+                data=drifted_body,
+                headers={"Content-Type": "application/json"},
+            )
+            assert second.status == 200
+            data2 = await second.json()
+            assert data2["status"] == "duplicate"
+            assert data2["delivery_id"] == id1
+
+    @pytest.mark.asyncio
+    async def test_alert_array_order_does_not_affect_dedup(self):
+        """Two notifications with the same alert *set* in a different array
+        order are the same delivery: alerts are ordered by fingerprint before
+        hashing, so upstream ordering differences never cause a spurious
+        non-dedup."""
+        routes = {
+            "alertmanager": {
+                "prompt": "Alert: {commonLabels.alertname}",
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+
+        two_alerts = json.loads(json.dumps(ALERTMANAGER_PAYLOAD))
+        first_alert = two_alerts["alerts"][0]
+        second_alert = json.loads(json.dumps(first_alert))
+        second_alert["fingerprint"] = "def456"
+        second_alert["labels"]["service"] = "worker"
+        two_alerts["alerts"] = [first_alert, second_alert]
+        body_ab = json.dumps(two_alerts).encode()
+
+        reordered = json.loads(json.dumps(two_alerts))
+        reordered["alerts"] = [second_alert, first_alert]
+        body_ba = json.dumps(reordered).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/alertmanager",
+                data=body_ab,
+                headers={"Content-Type": "application/json"},
+            )
+            assert first.status == 202
+            id1 = (await first.json())["delivery_id"]
+
+            second = await cli.post(
+                "/webhooks/alertmanager",
+                data=body_ba,
+                headers={"Content-Type": "application/json"},
+            )
+            assert second.status == 200
+            data2 = await second.json()
+            assert data2["status"] == "duplicate"
+            assert data2["delivery_id"] == id1

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -310,7 +310,7 @@ hermes webhook subscribe antenna-matches \
 | Status | Meaning |
 |--------|---------|
 | `200 OK` | Delivered successfully. Body: `{"status": "delivered", "route": "...", "target": "...", "delivery_id": "..."}` |
-| `200 OK` (status=duplicate) | Duplicate `X-GitHub-Delivery` ID within the idempotency TTL (1 hour). Not re-delivered. |
+| `200 OK` (status=duplicate) | Duplicate delivery ID within the idempotency TTL (1 hour). Not re-delivered. |
 | `401 Unauthorized` | HMAC signature invalid or missing. |
 | `400 Bad Request` | Malformed JSON body. |
 | `404 Not Found` | Unknown route name. |
@@ -323,7 +323,7 @@ hermes webhook subscribe antenna-matches \
 - `deliver_only: true` requires `deliver` to be a real target. `deliver: log` (or omitting `deliver`) is rejected at startup — the adapter refuses to start if it finds a misconfigured route.
 - The `skills` field is ignored in direct delivery mode (no agent runs, so there's nothing to inject skills into).
 - Template rendering uses the same `{dot.notation}` syntax as agent mode, including the `{__raw__}` token.
-- Idempotency uses the same `X-GitHub-Delivery` / `X-Request-ID` header — retries with the same ID return `status=duplicate` and do NOT re-deliver.
+- Idempotency uses the delivery ID (the `X-GitHub-Delivery` / `svix-id` / `X-Request-ID` header, an Alertmanager payload-derived hash, or a timestamp fallback) — retries with the same ID return `status=duplicate` and do NOT re-deliver. See [Idempotency](#idempotency) for how the ID is resolved.
 
 ---
 
@@ -412,7 +412,11 @@ Requests exceeding the limit receive a `429 Too Many Requests` response.
 
 ### Idempotency
 
-Delivery IDs (from `X-GitHub-Delivery`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
+Delivery IDs are cached for **1 hour**; duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs. The delivery ID is resolved in this order:
+
+1. The `X-GitHub-Delivery`, `svix-id`, or `X-Request-ID` header, when present.
+2. For header-less Alertmanager notifications (a payload carrying a non-empty `groupKey`), a hash of the route name and the normalized JSON payload, formatted as `alertmanager:<sha256[:16]>`. Two volatile-but-immaterial details are normalized out first so that `repeat_interval` re-notifications of an **unchanged firing group** still collapse to a single delivery: the rolling `endsAt` of firing alerts (Prometheus refreshes it every evaluation cycle) is dropped, and the `alerts` array is ordered by fingerprint. A *materially different* notification for the same alert group (an alert joining or leaving the group, or the final `resolved` payload — where `endsAt` is kept because it is the real resolution time) hashes differently and is still delivered, so state changes are never masked.
+3. A millisecond timestamp fallback (unique per request) when neither applies.
 
 ### Body size limits
 


### PR DESCRIPTION
## What does this PR do?

Make the webhook adapter idempotent against Alertmanager retries by deriving a stable `delivery_id` from the notification payload when no standard delivery header is present. Today the timestamp fallback gives each retry a fresh ID, so the existing dedup loop never sees Alertmanager re-notifications as duplicates and the agent re-runs the same alert every notification interval.

## Related Issues

Not strictly a `Fixes #` for any of these, but adjacent / partially-overlapping with:

- #20201 [Feature]: Add route-level webhook debounce/coalescing — same problem space; this PR is the narrower idempotency-for-Alertmanager slice of it.
- #7448 Webhook idempotency is keyed only by delivery ID, so the second route is skipped in valid multi-route fan-out. This PR independently route-prefixes the **derived** ID so the new code path does NOT contribute to that bug; the underlying `Dict[str, float]` keyed only by `delivery_id` for header-stamped IDs is left for a follow-up.
- #16108 [Feature]: Gateway event idempotency, cancellation, and stale-response suppression — same theme at a higher level.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/webhook.py`: when none of `X-GitHub-Delivery` / `svix-id` / `X-Request-ID` is set and the JSON payload carries a non-empty `groupKey` string, derive `delivery_id = "alertmanager:" + sha256(route_name + ":" + normalized_payload)[:16]`. The identity hashes the **whole payload** (via `_alertmanager_dedup_key`), not `groupKey` alone, so a materially different notification for the same group — a membership change, or the final `resolved` payload — is delivered instead of being swallowed for the idempotency TTL. Two volatile-but-immaterial details are normalized first so `repeat_interval` re-sends of an **unchanged firing group** still dedup:
  - `alerts[*].endsAt` is dropped for **firing** alerts (Prometheus refreshes an active alert's end time every evaluation cycle, so it drifts between notifications). It is **kept** for **resolved** alerts, where it is the real resolution time and should bust the cache.
  - the `alerts` array is ordered by `fingerprint`, since array order is not part of the notification's identity.
  - the route name is folded into the hash so two routes sharing an upstream `groupKey` never collide in `_seen_deliveries`. Whitespace-only / non-string `groupKey` falls through to the timestamp fallback.
- `tests/gateway/test_webhook_integration.py`: `TestAlertmanagerGroupKeyDedup` class:
  - `test_groupkey_derived_delivery_id_dedups_retries` — identical re-POST → `status: duplicate`.
  - `test_repeat_interval_endsat_drift_still_dedups` — same firing group with only `endsAt` moved forward (an evaluation-cycle refresh) → still `duplicate`. Guards the core repeat_interval case.
  - `test_status_transition_same_groupkey_not_deduped` — firing then `resolved` on the same groupKey → second is delivered, not deduped.
  - `test_alert_array_order_does_not_affect_dedup` — same alert set in different array order → one delivery.
  - `test_explicit_delivery_header_wins_over_groupkey` — a delivery header still wins (the payload path is fallback-only).
  - `test_different_routes_get_distinct_delivery_ids` — same groupKey on two routes → distinct IDs.
  - `test_invalid_groupkey_falls_through_to_timestamp` (parametrized) — `None`, `""`, `"   "`, `"\t\n"`, int, list all fall through to the timestamp fallback.
- `website/docs/user-guide/messaging/webhooks.md`: document the delivery-ID resolution order and the firing-`endsAt` / alert-ordering normalization.

## Why this approach

- **Opt-in via field presence.** The branch only triggers with no delivery header AND a non-empty `groupKey` string. Header-stamped senders are unaffected; senders without either still get the timestamp fallback.
- **Hash the normalized payload, not `groupKey` alone.** `groupKey` is stable across a group's entire firing→resolved lifecycle, so keying on it would suppress real state changes (notably the `resolved` notification) for the TTL. Hashing the content distinguishes a true retry/repeat from a changed notification; normalizing the firing `endsAt` drift keeps the repeat_interval dedup this PR exists to provide.
- **Re-uses the existing `_idempotency_ttl` (1h).** No new config knobs, no new cache, no new dependencies (`hashlib`/`json` already imported).

## Test

```
pytest tests/gateway/test_webhook_integration.py::TestAlertmanagerGroupKeyDedup -v
```

## Compatibility

- No new dependencies, no config schema change.
- No public API change beyond the documented `delivery_id` value, which is treated as opaque by clients.
