### PR TITLE
Clean up model picker rows and cron auth fallback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1573,7 +1573,13 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if entry.get("api_key"):
                         fb_kwargs["explicit_api_key"] = entry["api_key"]
                     runtime = resolve_runtime_provider(**fb_kwargs)
-                    logger.info("Job '%s': fallback resolved to %s", job_id, runtime.get("provider"))
+                    model = str(entry.get("model") or model).strip() or model
+                    logger.info(
+                        "Job '%s': fallback resolved to %s/%s",
+                        job_id,
+                        runtime.get("provider"),
+                        model,
+                    )
                     break
                 except Exception as fb_exc:
                     logger.debug("Job '%s': fallback %s failed: %s", job_id, entry.get("provider"), fb_exc)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -54,10 +54,10 @@ def _is_loopback_url(url: str) -> bool:
 def _is_local_user_provider(ep_name: str, display_name: str, api_url: str) -> bool:
     """Return True for user-configured local model endpoints.
 
-    Trey's config runs several local OpenAI-compatible servers on different
-    loopback ports (local-mlx, local-heretic, local-hauhaucs, local-mlx-vlm).
-    The picker should show those as one provider row, "Local", while runtime
-    resolution still routes the selected model to its underlying port.
+    Configs often run several local OpenAI-compatible servers on different
+    loopback ports. The picker should show those as one provider row, "Local",
+    while runtime resolution still routes the selected model to its underlying
+    port.
     """
     key = str(ep_name or "").strip().lower()
     label = str(display_name or "").strip().lower()
@@ -1767,6 +1767,11 @@ def list_authenticated_providers(
             #   live discovery so bare-endpoint custom providers (local
             #   llama.cpp / Ollama servers) still appear populated.
             should_probe = bool(api_url) and (bool(api_key) or not grp["models"])
+            if _is_loopback_url(api_url) and grp["models"]:
+                # Local/Ollama endpoints can have a live catalog that differs
+                # from the explicit subset the user configured. Preserve the
+                # configured subset for deterministic picker rows and tests.
+                should_probe = False
             if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -46,6 +46,24 @@ from agent.models_dev import (
 logger = logging.getLogger(__name__)
 
 
+def _is_loopback_url(url: str) -> bool:
+    normalized = str(url or "").strip().lower()
+    return any(host in normalized for host in ("127.0.0.1", "localhost", "[::1]", "0.0.0.0"))
+
+
+def _is_local_user_provider(ep_name: str, display_name: str, api_url: str) -> bool:
+    """Return True for user-configured local model endpoints.
+
+    Trey's config runs several local OpenAI-compatible servers on different
+    loopback ports (local-mlx, local-heretic, local-hauhaucs, local-mlx-vlm).
+    The picker should show those as one provider row, "Local", while runtime
+    resolution still routes the selected model to its underlying port.
+    """
+    key = str(ep_name or "").strip().lower()
+    label = str(display_name or "").strip().lower()
+    return key.startswith("local-") or label.startswith("local") or _is_loopback_url(api_url)
+
+
 # ---------------------------------------------------------------------------
 # Non-agentic model warning
 # ---------------------------------------------------------------------------
@@ -1323,23 +1341,14 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Credential pool check failed for %s: %s", hermes_slug, exc)
-        # Fallback: check external credential files directly.
-        # The credential pool gates anthropic behind
-        # is_provider_explicitly_configured() to prevent auxiliary tasks
-        # from silently consuming Claude Code tokens (PR #4210).
-        # But the /model picker is discovery-oriented — we WANT to show
-        # providers the user can switch to, even if they aren't currently
-        # configured.
+        # Fallback: check external Anthropic credentials by resolving a usable
+        # token, not merely by detecting a stale Claude Code credential file.
+        # Expired/unrefreshable OAuth records should not make /model show
+        # Anthropic as authenticated when runtime will immediately fail.
         if not has_creds and hermes_slug == "anthropic":
             try:
-                from agent.anthropic_adapter import (
-                    read_claude_code_credentials,
-                    read_hermes_oauth_credentials,
-                )
-                hermes_creds = read_hermes_oauth_credentials()
-                cc_creds = read_claude_code_credentials()
-                if (hermes_creds and hermes_creds.get("accessToken")) or \
-                   (cc_creds and cc_creds.get("accessToken")):
+                from agent.anthropic_adapter import resolve_anthropic_token
+                if resolve_anthropic_token():
                     has_creds = True
             except Exception as exc:
                 logger.debug("Anthropic external creds check failed: %s", exc)
@@ -1466,6 +1475,14 @@ def list_authenticated_providers(
     # produces two picker rows: one bare-slug ("openrouter") from section 3
     # and one "custom:openrouter" from section 4, both labelled identically.
     _section3_emitted_pairs: set = set()
+    _local_group: dict = {
+        "slug": "local",
+        "name": "Local",
+        "models": [],
+        "routes": {},
+        "api_urls": [],
+        "is_current": str(current_provider or "").strip().lower() == "local",
+    }
     if user_providers and isinstance(user_providers, dict):
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
@@ -1526,7 +1543,7 @@ def list_authenticated_providers(
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
-            if api_url and api_key and discover:
+            if api_url and api_key and discover and not _is_local_user_provider(ep_name, display_name, api_url):
                 try:
                     from hermes_cli.models import fetch_api_models
                     live_models = fetch_api_models(api_key, api_url)
@@ -1534,6 +1551,32 @@ def list_authenticated_providers(
                         models_list = live_models
                 except Exception:
                     pass
+
+            if _is_local_user_provider(ep_name, display_name, api_url):
+                for model_id in models_list:
+                    if not model_id:
+                        continue
+                    if model_id not in _local_group["models"]:
+                        _local_group["models"].append(model_id)
+                    _local_group["routes"].setdefault(model_id, ep_name)
+                if api_url and api_url not in _local_group["api_urls"]:
+                    _local_group["api_urls"].append(api_url)
+                current_base_norm = str(current_base_url or "").strip().rstrip("/").lower()
+                if (
+                    ep_name == current_provider
+                    or custom_provider_slug(display_name) == current_provider
+                    or (current_base_norm and current_base_norm == str(api_url).strip().rstrip("/").lower())
+                ):
+                    _local_group["is_current"] = True
+                seen_slugs.add(ep_name.lower())
+                seen_slugs.add(custom_provider_slug(display_name).lower())
+                _pair = (
+                    str(display_name).strip().lower(),
+                    str(api_url).strip().rstrip("/").lower(),
+                )
+                if _pair[0] and _pair[1]:
+                    _section3_emitted_pairs.add(_pair)
+                continue
 
             results.append({
                 "slug": ep_name,
@@ -1553,6 +1596,20 @@ def list_authenticated_providers(
             )
             if _pair[0] and _pair[1]:
                 _section3_emitted_pairs.add(_pair)
+
+    if _local_group["models"]:
+        results.append({
+            "slug": "local",
+            "name": "Local",
+            "is_current": bool(_local_group["is_current"]),
+            "is_user_defined": True,
+            "models": _local_group["models"][:max_models],
+            "total_models": len(_local_group["models"]),
+            "source": "user-config",
+            "api_url": ",".join(_local_group["api_urls"]),
+            "local_routes": dict(_local_group["routes"]),
+        })
+        seen_slugs.add("local")
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named
@@ -1587,6 +1644,9 @@ def list_authenticated_providers(
                 or ""
             ).strip().rstrip("/")
             if not raw_name or not api_url:
+                continue
+            provider_key = str(entry.get("provider_key", "") or "").strip().lower()
+            if provider_key and provider_key in seen_slugs:
                 continue
             api_key = (entry.get("api_key") or "").strip()
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -58,12 +58,10 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("x-ai/grok-4.3",                          ""),
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     ("deepseek/deepseek-v4-pro",               ""),
+    ("inclusionai/ring-2.6-1t",                ""),
     # Free tier
-    ("openrouter/elephant-alpha",              "free"),
     ("openrouter/owl-alpha",                   "free"),
-    ("tencent/hy3-preview:free",               "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
-    ("inclusionai/ring-2.6-1t:free",           "free"),
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
@@ -213,14 +211,16 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "gemini": [
         "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
         "gemini-3-flash-preview",
-        "gemini-3.1-flash-lite-preview",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
     ],
     "google-gemini-cli": [
         "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
         "gemini-3-flash-preview",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
     ],
     "zai": [
         "glm-5.1",
@@ -1953,8 +1953,6 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "nvidia",
     "huggingface",
     "zai",
-    "gemini",
-    "google",
 })
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -474,6 +474,101 @@ def _try_resolve_from_custom_pool(
         return None
 
 
+def _configured_models_for_entry(entry: Dict[str, Any]) -> list[str]:
+    models: list[str] = []
+    default_model = entry.get("default_model", "") or entry.get("model", "")
+    if default_model:
+        models.append(str(default_model))
+    cfg_models = entry.get("models", [])
+    if isinstance(cfg_models, dict):
+        for model_id in cfg_models:
+            if model_id and str(model_id) not in models:
+                models.append(str(model_id))
+    elif isinstance(cfg_models, list):
+        for model_id in cfg_models:
+            if model_id and str(model_id) not in models:
+                models.append(str(model_id))
+    return models
+
+
+def _is_local_user_provider(ep_name: str, entry: Dict[str, Any]) -> bool:
+    display_name = str(entry.get("name", "") or ep_name or "").strip().lower()
+    provider_key = str(ep_name or "").strip().lower()
+    base_url = str(
+        entry.get("base_url", "")
+        or entry.get("api", "")
+        or entry.get("url", "")
+        or ""
+    ).strip().lower()
+    return (
+        provider_key.startswith("local-")
+        or display_name.startswith("local")
+        or any(host in base_url for host in ("127.0.0.1", "localhost", "[::1]", "0.0.0.0"))
+    )
+
+
+def _resolve_local_aggregate_runtime(target_model: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Resolve the synthetic `local` provider to the configured local endpoint.
+
+    The /model picker aggregates several user-configured local-* providers into
+    one row named Local. At runtime, the selected model still needs to route to
+    the loopback port configured for that model.
+    """
+    config = load_config()
+    providers = config.get("providers")
+    if not isinstance(providers, dict):
+        return None
+
+    requested_model = str(target_model or "").strip()
+    fallback: Optional[tuple[str, Dict[str, Any], list[str]]] = None
+    for ep_name, entry in providers.items():
+        if not isinstance(entry, dict) or not _is_local_user_provider(ep_name, entry):
+            continue
+        models = _configured_models_for_entry(entry)
+        if fallback is None:
+            fallback = (str(ep_name), entry, models)
+        if requested_model and requested_model not in models:
+            continue
+        base_url = str(
+            entry.get("base_url", "")
+            or entry.get("api", "")
+            or entry.get("url", "")
+            or ""
+        ).strip().rstrip("/")
+        if not base_url:
+            continue
+        api_key = str(entry.get("api_key", "") or "").strip() or "no-key-required"
+        api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport")) or _detect_api_mode_for_url(base_url) or "chat_completions"
+        result = {
+            "provider": "custom",
+            "api_mode": api_mode,
+            "base_url": base_url,
+            "api_key": api_key,
+            "source": f"local:{ep_name}",
+            "requested_provider": "local",
+        }
+        if requested_model:
+            result["model"] = requested_model
+        elif models:
+            result["model"] = models[0]
+        return result
+
+    if fallback is not None and not requested_model:
+        ep_name, entry, models = fallback
+        base_url = str(entry.get("base_url", "") or entry.get("api", "") or entry.get("url", "") or "").strip().rstrip("/")
+        if base_url:
+            return {
+                "provider": "custom",
+                "api_mode": _parse_api_mode(entry.get("api_mode") or entry.get("transport")) or _detect_api_mode_for_url(base_url) or "chat_completions",
+                "base_url": base_url,
+                "api_key": str(entry.get("api_key", "") or "").strip() or "no-key-required",
+                "source": f"local:{ep_name}",
+                "requested_provider": "local",
+                "model": models[0] if models else "",
+            }
+    return None
+
+
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm or requested_norm == "custom":
@@ -628,6 +723,7 @@ def _resolve_named_custom_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     # Bare `provider="custom"` with an explicit base_url (e.g. propagated
     # from a `model_aliases:` direct-alias resolution) — build a runtime
@@ -638,6 +734,10 @@ def _resolve_named_custom_runtime(
     # `provider: ollama` with a LAN/WireGuard `base_url` doesn't silently
     # fall through to OpenRouter.
     requested_norm = (requested_provider or "").strip().lower()
+    local_runtime = _resolve_local_aggregate_runtime(target_model) if requested_norm in {"local", "custom:local"} else None
+    if local_runtime:
+        return local_runtime
+
     if requested_norm and requested_norm != "custom":
         try:
             from hermes_cli.auth import resolve_provider as _resolve_provider
@@ -1255,6 +1355,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -868,6 +868,61 @@ class TestDeliverResultErrorReturns:
 
 
 class TestRunJobSessionPersistence:
+    def test_run_job_auth_fallback_uses_fallback_model(self, tmp_path):
+        """Auth fallback must switch both provider and model for cron jobs."""
+        from hermes_cli.auth import AuthError
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  default: gpt-5.5\n"
+            "  provider: openai-codex\n"
+            "fallback_providers:\n"
+            "  - provider: zai\n"
+            "    model: glm-5.1\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "fallback-job",
+            "name": "fallback",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=[
+                     AuthError(
+                         "Codex auth is missing access_token.",
+                         provider="openai-codex",
+                         relogin_required=True,
+                     ),
+                     {
+                         "api_key": "test-key",
+                         "base_url": "https://example.invalid/v1",
+                         "provider": "zai",
+                         "api_mode": "chat_completions",
+                     },
+                 ],
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["provider"] == "zai"
+        assert kwargs["model"] == "glm-5.1"
+
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
         job = {
             "id": "test-job",


### PR DESCRIPTION
## Summary
- Clean up `/model` provider picker rows: aggregate local loopback providers into a single Local row, suppress duplicate custom rows, and require a resolvable Anthropic token before marking Anthropic authenticated.
- Refresh curated model lists by removing dead OpenRouter/Gemini entries and adding verified replacements.
- Fix cron auth fallback so fallback provider selection also switches to the fallback model.

## Verification
- `hermes config check`
- `python -m py_compile hermes_cli/model_switch.py hermes_cli/models.py hermes_cli/runtime_provider.py`
- `git diff --check -- hermes_cli/model_switch.py hermes_cli/models.py hermes_cli/runtime_provider.py`
- `git diff --check -- cron/scheduler.py tests/cron/test_scheduler.py`
- `python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py`
- `pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_auth_fallback_uses_fallback_model -q`

## Runtime smoke checks
Representative `/model` provider runtime checks passed locally for Anthropic, OpenAI Codex, Google, Z.AI, Kimi For Coding, Local, OpenRouter, GitHub Copilot, xAI, and xAI Grok OAuth.
