### PR TITLE
feat(cli): add provider login slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8325,6 +8325,8 @@ class HermesCLI:
             self.show_toolsets()
         elif canonical == "config":
             self.show_config()
+        elif canonical == "login":
+            self._handle_login_command(cmd_original)
         elif canonical == "redraw":
             # Manual recovery for terminal buffer drift from multiplexer
             # tab switches, subshell ``clear``, SSH window restores, etc.
@@ -8780,6 +8782,18 @@ class HermesCLI:
                     _cprint(f"{_DIM}{_ACCENT}Type /help for available commands{_RST}")
         
         return True
+
+    def _handle_login_command(self, cmd: str):
+        """Handle /login — convenience wrapper around `hermes auth`."""
+        try:
+            from hermes_cli.login_slash import run_login_slash
+            run_login_slash(cmd)
+        except SystemExit as exc:
+            code = getattr(exc, "code", 0)
+            if code not in (0, None) and not isinstance(code, int):
+                _cprint(f"  {_escape(str(code))}")
+        except Exception as exc:
+            _cprint(f"  Login command failed: {_escape(str(exc))}")
     
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -33,7 +33,7 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "google-gemini-cli", "minimax-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "copilot", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "google-gemini-cli", "minimax-oauth"}
 
 
 def _get_custom_provider_names() -> list:
@@ -240,6 +240,32 @@ def auth_add_command(args) -> None:
             access_token=creds["access_token"],
             refresh_token=creds.get("refresh_token"),
             expires_at_ms=creds.get("expires_at_ms"),
+            base_url=_provider_base_url(provider),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider == "copilot":
+        from hermes_cli.copilot_auth import copilot_device_code_login
+
+        token = copilot_device_code_login(
+            timeout_seconds=getattr(args, "timeout", None) or 300,
+        )
+        if not token:
+            raise SystemExit("GitHub Copilot OAuth login did not return a token.")
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            token,
+            _oauth_default_label(provider, len(pool.entries()) + 1),
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:device_code",
+            access_token=token,
             base_url=_provider_base_url(provider),
         )
         pool.add_entry(entry)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -65,6 +65,14 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Session
     CommandDef("start", "Acknowledge platform start pings without a reply", "Session",
                gateway_only=True),
+    CommandDef(
+        "login",
+        "Login for provider-backed Hermes sessions",
+        "Configuration",
+        args_hint="[login|refresh|status|logout] [provider flags]",
+        cli_only=True,
+        subcommands=("login", "refresh", "status", "logout"),
+    ),
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",

--- a/hermes_cli/login_slash.py
+++ b/hermes_cli/login_slash.py
@@ -1,0 +1,195 @@
+"""Interactive CLI slash command wrapper for provider login.
+
+The canonical credential plumbing lives under ``hermes auth``.  This module
+keeps ``/login`` as a small, cache-safe CLI convenience layer so users can add,
+inspect, and remove provider credentials without leaving a Hermes session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+from types import SimpleNamespace
+
+from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.auth_commands import (
+    auth_add_command,
+    auth_list_command,
+    auth_remove_command,
+    auth_reset_command,
+)
+
+_PROVIDER_ALIASES = {
+    "claude": "anthropic",
+    "claude-code": "anthropic",
+    "anthropic": "anthropic",
+    "codex": "openai-codex",
+    "openai": "openai-codex",
+    "openai-codex": "openai-codex",
+    "github": "copilot",
+    "github-copilot": "copilot",
+    "github-models": "copilot",
+    "copilot": "copilot",
+    "grok": "xai-oauth",
+    "xai": "xai-oauth",
+    "xai-oauth": "xai-oauth",
+    "gemini": "google-gemini-cli",
+    "google": "google-gemini-cli",
+    "google-gemini-cli": "google-gemini-cli",
+    "qwen": "qwen-oauth",
+    "qwen-oauth": "qwen-oauth",
+    "nous": "nous",
+    "minimax": "minimax-oauth",
+    "minimax-oauth": "minimax-oauth",
+}
+
+_OAUTH_DEFAULT_PROVIDERS = {
+    "anthropic",
+    "copilot",
+    "google-gemini-cli",
+    "minimax-oauth",
+    "nous",
+    "openai-codex",
+    "qwen-oauth",
+    "xai-oauth",
+}
+
+
+def normalize_login_provider(raw: str) -> str:
+    """Normalize user-facing ``/login`` provider aliases."""
+    provider = (raw or "").strip().lower().replace("_", "-")
+    return _PROVIDER_ALIASES.get(provider, provider)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="/login",
+        description="Authenticate provider-backed Hermes sessions.",
+    )
+    parser.add_argument(
+        "action_or_provider",
+        nargs="?",
+        default="status",
+        help="provider alias, or one of: add, status, list, logout, remove, refresh",
+    )
+    parser.add_argument("provider", nargs="?", help="provider for subcommands")
+    parser.add_argument("target", nargs="?", help="credential index/id/label for logout/remove")
+    parser.add_argument("--type", dest="auth_type", choices=["oauth", "api-key", "api_key"])
+    parser.add_argument("--label", help="credential label/account name")
+    parser.add_argument("--api-key", help="API key value for --type api-key")
+    parser.add_argument("--no-browser", action="store_true", help="do not open browser automatically")
+    parser.add_argument("--manual-paste", action="store_true", help="paste OAuth callback URL/code manually when supported")
+    parser.add_argument("--timeout", type=float, default=None, help="login timeout in seconds")
+    parser.add_argument("--portal-url", help="Nous portal override")
+    parser.add_argument("--inference-url", help="provider inference URL override")
+    parser.add_argument("--client-id", help="OAuth client id override")
+    parser.add_argument("--scope", help="OAuth scope override")
+    parser.add_argument("--ca-bundle", help="CA bundle path")
+    parser.add_argument("--insecure", action="store_true", help="disable TLS verification for testing")
+    return parser
+
+
+def _known_provider(provider: str) -> bool:
+    return provider in PROVIDER_REGISTRY or provider == "openrouter" or provider.startswith("custom:")
+
+
+def _add_args(provider: str, ns: argparse.Namespace) -> SimpleNamespace:
+    auth_type = (ns.auth_type or "").strip().lower().replace("-", "_")
+    if auth_type == "api_key":
+        auth_type = "api_key"
+    elif auth_type == "oauth":
+        auth_type = "oauth"
+    elif provider in _OAUTH_DEFAULT_PROVIDERS:
+        auth_type = "oauth"
+    else:
+        auth_type = "api_key"
+
+    return SimpleNamespace(
+        provider=provider,
+        auth_type=auth_type,
+        label=ns.label,
+        api_key=ns.api_key,
+        portal_url=ns.portal_url,
+        inference_url=ns.inference_url,
+        client_id=ns.client_id,
+        scope=ns.scope,
+        no_browser=bool(ns.no_browser),
+        manual_paste=bool(ns.manual_paste),
+        timeout=ns.timeout,
+        insecure=bool(ns.insecure),
+        ca_bundle=ns.ca_bundle,
+        min_key_ttl_seconds=5 * 60,
+    )
+
+
+def run_login_slash(command: str) -> None:
+    """Execute a ``/login`` command body.
+
+    ``command`` may include or omit the leading slash command token.  Raises
+    ``SystemExit`` from argparse/auth helpers just like normal CLI subcommands.
+    """
+    text = (command or "").strip()
+    if text.startswith("/login"):
+        text = text[len("/login"):].strip()
+    argv = shlex.split(text) if text else []
+    ns = _build_parser().parse_args(argv)
+
+    first = (ns.action_or_provider or "status").strip().lower().replace("_", "-")
+    action_aliases = {
+        "ls": "status",
+        "list": "status",
+        "status": "status",
+        "add": "add",
+        "login": "add",
+        "remove": "remove",
+        "logout": "remove",
+        "rm": "remove",
+        "refresh": "refresh",
+        "reset": "refresh",
+    }
+
+    if first in action_aliases:
+        action = action_aliases[first]
+        provider = normalize_login_provider(ns.provider or "")
+    else:
+        action = "add"
+        provider = normalize_login_provider(first)
+
+    if action == "status":
+        provider = normalize_login_provider(ns.provider or "")
+        auth_list_command(SimpleNamespace(provider=provider or None))
+        if provider and _known_provider(provider):
+            # auth_list_command is intentionally quiet for empty pools; give an
+            # explicit line so `/login status anthropic` is legible.
+            from agent.credential_pool import load_pool
+
+            if not load_pool(provider).has_credentials():
+                print(f"{provider}: no pooled credentials")
+        return
+
+    if not provider:
+        raise SystemExit("Provider required. Examples: /login anthropic, /login codex, /login github")
+    if not _known_provider(provider):
+        raise SystemExit(f"Unknown provider: {provider}")
+
+    if action == "add":
+        auth_add_command(_add_args(provider, ns))
+        return
+
+    if action == "remove":
+        target = ns.target or ""
+        if not target:
+            raise SystemExit(
+                "Credential target required. Usage: /login logout <provider> <index|id|label>"
+            )
+        auth_remove_command(SimpleNamespace(provider=provider, target=target))
+        return
+
+    if action == "refresh":
+        # This resets local cooldown/error state. Runtime OAuth refresh still
+        # happens through the provider-specific credential resolver on next use.
+        auth_reset_command(SimpleNamespace(provider=provider))
+        print(f"{provider}: credential cooldowns reset; runtime token will refresh on next use if needed")
+        return
+
+    raise SystemExit(f"Unknown /login action: {action}")

--- a/tests/hermes_cli/test_auth_copilot_oauth_add.py
+++ b/tests/hermes_cli/test_auth_copilot_oauth_add.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.credential_pool import AUTH_TYPE_OAUTH, load_pool
+from hermes_cli.auth_commands import auth_add_command
+
+
+def test_auth_add_copilot_oauth_device_code_stores_pool_entry(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    for name in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+
+    with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value=None), patch(
+        "hermes_cli.copilot_auth.copilot_device_code_login",
+        return_value="gho_testtoken",
+    ) as login:
+        auth_add_command(
+            SimpleNamespace(
+                provider="copilot",
+                auth_type="oauth",
+                label="github-main",
+                timeout=1,
+            )
+        )
+
+    login.assert_called_once_with(timeout_seconds=1)
+    with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value=None):
+        entries = load_pool("copilot").entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.provider == "copilot"
+    assert entry.auth_type == AUTH_TYPE_OAUTH
+    assert entry.source == "manual:device_code"
+    assert entry.access_token == "gho_testtoken"
+    assert entry.label == "github-main"

--- a/tests/hermes_cli/test_login_slash.py
+++ b/tests/hermes_cli/test_login_slash.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.login_slash import normalize_login_provider, run_login_slash
+
+
+def test_login_provider_aliases_cover_common_oauth_names():
+    assert normalize_login_provider("anthropic") == "anthropic"
+    assert normalize_login_provider("claude") == "anthropic"
+    assert normalize_login_provider("codex") == "openai-codex"
+    assert normalize_login_provider("github") == "copilot"
+    assert normalize_login_provider("github-copilot") == "copilot"
+
+
+def test_login_anthropic_defaults_to_oauth():
+    with patch("hermes_cli.login_slash.auth_add_command") as add:
+        run_login_slash("/login anthropic --label main --no-browser")
+
+    args = add.call_args.args[0]
+    assert args.provider == "anthropic"
+    assert args.auth_type == "oauth"
+    assert args.label == "main"
+    assert args.no_browser is True
+
+
+@pytest.mark.parametrize(
+    ("command", "provider"),
+    [
+        ("/login codex", "openai-codex"),
+        ("/login github", "copilot"),
+        ("/login add github", "copilot"),
+    ],
+)
+def test_login_normalizes_codex_and_github_aliases(command, provider):
+    with patch("hermes_cli.login_slash.auth_add_command") as add:
+        run_login_slash(command)
+
+    args = add.call_args.args[0]
+    assert args.provider == provider
+    assert args.auth_type == "oauth"
+
+
+def test_login_status_lists_pool_for_optional_provider():
+    with patch("hermes_cli.login_slash.auth_list_command") as status, patch(
+        "agent.credential_pool.load_pool"
+    ) as load_pool:
+        load_pool.return_value.has_credentials.return_value = True
+        run_login_slash("/login status anthropic")
+
+    status.assert_called_once()
+    assert status.call_args.args[0].provider == "anthropic"
+
+
+def test_login_logout_requires_credential_target():
+    with pytest.raises(SystemExit) as exc:
+        run_login_slash("/login logout anthropic")
+
+    assert "Credential target required" in str(exc.value)
+
+
+def test_login_logout_removes_target():
+    with patch("hermes_cli.login_slash.auth_remove_command") as remove:
+        run_login_slash("/login logout github 1")
+
+    args = remove.call_args.args[0]
+    assert args.provider == "copilot"
+    assert args.target == "1"
+
+
+def test_login_refresh_resets_provider_status(capsys):
+    with patch("hermes_cli.login_slash.auth_reset_command") as reset:
+        run_login_slash("/login refresh codex")
+
+    args = reset.call_args.args[0]
+    assert args.provider == "openai-codex"
+    assert "runtime token will refresh" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Adds CLI `/login` as a convenience wrapper over existing `hermes auth` plumbing.
- Supports provider aliases for Anthropic/Claude, OpenAI Codex, GitHub/Copilot, Nous, xAI, Gemini, Qwen, and MiniMax.
- Adds `/login status`, `/login logout <provider> <target>`, and `/login refresh <provider>` routing.
- Adds GitHub/Copilot OAuth device-code support to `hermes auth add copilot --type oauth`.

## Integration notes
- Original local commit: `779ab4c52 feat(cli): add provider login slash command`.
- Cleanly rebased/cherry-picked onto current `origin/main` as `e0139531e`.
- One trivial conflict in `hermes_cli/commands.py` because upstream added `/start`; resolved by keeping both `/start` and `/login`.
- Old untracked prototype `hermes_cli/oauth_pkce.py` was intentionally not included.

## Test plan
Focused tests on a clean `origin/main` worktree:

- `tests/hermes_cli/test_login_slash.py`
- `tests/hermes_cli/test_auth_copilot_oauth_add.py`
- `tests/hermes_cli/test_auth_commands.py`
- `tests/hermes_cli/test_auth_codex_provider.py`
- `tests/hermes_cli/test_copilot_auth.py`
- `tests/hermes_cli/test_copilot_catalog_oauth_fallback.py`
- `tests/hermes_cli/test_web_oauth_dispatch.py`

Result: `120 passed / 0 failed`.

Patch proof from local audit:
- Patch: `/tmp/hermes-login-e0139531e-on-origin-main.patch`
- SHA256: `2c6553c1b69e8789c4e6f8ffecef8287d7a9f21c0ea2f2a9d0c7e8e24db6b116`
