### PR TITLE
fix(mattermost): honor metadata thread_id in send_multiple_images for Thread routing

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -596,6 +596,17 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 }
+                # Thread support: propagate thread_id from metadata
+                # (set by the Gateway runner's _thread_meta) so batch
+                # images appear in the correct Thread.
+                if (
+                    metadata
+                    and metadata.get("thread_id")
+                    and self._reply_mode == "thread"
+                ):
+                    payload["root_id"] = await self._resolve_root_id(
+                        metadata["thread_id"]
+                    )
                 logger.info(
                     "Mattermost: sending %d image(s) as single post (chunk %d/%d)",
                     len(file_ids), chunk_idx + 1, len(chunks),


### PR DESCRIPTION
## Problem

`send_multiple_images()` in the bundled Mattermost adapter receives a `metadata` dict (populated by the Gateway runner's `_thread_metadata_for_source` with `thread_id`) but ignores it entirely. Batch image uploads always land in the main channel instead of the current Thread.

## Reproduction

1. In a Mattermost Thread, ask Hermes to generate multiple images
2. Images appear in the channel main stream, not in the Thread 💀

## Root Cause

The adapter builds the post payload at line 594-598 with `channel_id`, `message`, and `file_ids` — but never inspects `metadata` for `thread_id`. Other send methods like `send()` and `_send_local_file()` properly resolve `reply_to` into `root_id`.

## Fix

Add metadata-aware Thread routing before the API call:

```python
if (
    metadata
    and metadata.get("thread_id")
    and self._reply_mode == "thread"
):
    payload["root_id"] = await self._resolve_root_id(
        metadata["thread_id"]
    )
```

This follows the same pattern used by `send()` (line 290-294) and `_send_url_as_file()` (line 473-474).

## Related

- Plugin fix tracking the same issue: [colin-chang/hermes-plugin-mattermost-enhancer](https://github.com/colin-chang/hermes-plugin-mattermost-enhancer)
- The companion plugin's `send_multiple_images` override includes this fix plus additional media method overrides for `send_image`/`send_video`/`send_document`/`send_voice` which have a similar metadata-dropping pattern — this PR starts with the clearest case.