### PR TITLE
fix: /restart uses via_service=True on launchd (macOS)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9824,7 +9824,8 @@ class GatewayRunner:
         # exits when the gateway dies, taking the detached helper with it).
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        _under_launchd = bool(os.environ.get("XPC_SERVICE_NAME"))  # launchd sets this on macOS
+        if _under_service or _in_container or _under_launchd:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)


### PR DESCRIPTION
## Problem

On macOS, Hermes Gateway runs under launchd. When a user sends `/restart`, the gateway checks for `INVOCATION_ID` (systemd) or container files to decide whether to use service-aware restart (exit code 75) vs detached restart (exit code 0).

launchd does not set `INVOCATION_ID` and macOS is not a container, so `/restart` fell through to the detached path — `SystemExit(0)` — which launchd does not restart from.

## Fix

Detect launchd via `XPC_SERVICE_NAME`, which launchd injects into all managed jobs. When present, use `via_service=True` so the gateway exits with code 75 and launchd's `KeepAlive → SuccessfulExit: false` policy restarts it immediately.

```python
_under_launchd = bool(os.environ.get("XPC_SERVICE_NAME"))  # launchd sets this on macOS
if _under_service or _in_container or _under_launchd:
    self.request_restart(detached=False, via_service=True)
```

## Verification

Manual test confirmed: `/restart` now triggers launchd auto-restart on macOS.