### PR TITLE
Add NotFair Google Ads MCP catalog entry

### DIFF
--- a/optional-mcps/notfair-google-ads/manifest.yaml
+++ b/optional-mcps/notfair-google-ads/manifest.yaml
@@ -1,0 +1,57 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: notfair-google-ads
+description: Analyze and manage Google Ads accounts through NotFair with OAuth, safety guardrails, and change tracking.
+source: https://notfair.co
+
+# NotFair hosts a remote MCP server with native OAuth. Hermes's MCP client
+# handles discovery, PKCE, token exchange, and refresh — nothing to install
+# locally.
+transport:
+  type: http
+  url: https://notfair.co/api/mcp/google_ads
+
+auth:
+  type: oauth
+  # No `provider:` — this is native MCP OAuth, not a third-party provider.
+  # The MCP client triggers the browser flow on first probe / first connect.
+
+# Tool selection at install time:
+# NotFair exposes both read-only analytics tools and Google Ads mutation tools
+# (campaign, ad, keyword, budget, experiment, asset, and conversion changes).
+# Keep the default surface analysis-first; users can opt into mutation tools
+# from the install/configure checklist if they want Hermes to make account
+# changes after explicit approval.
+tools:
+  default_enabled:
+    - listConnectedAccounts
+    - summarizeAccountSetup
+    - runScript
+    - searchGeoTargets
+    - getKeywordIdeas
+    - listActiveExperiments
+    - listKeywords
+    - getChanges
+    - reviewChangeImpact
+    - listChangeInterventions
+    - getChangeIntervention
+    - getGuardrails
+    - getResourceMetadata
+    - listQueryableResources
+    - listExperimentAsyncErrors
+    - getAssetLinks
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with NotFair.
+  After auth, restart your Hermes session so the NotFair Google Ads tools are loaded.
+
+  Start with read-only requests such as:
+    - Summarize my Google Ads account setup
+    - Audit my account for wasted spend
+    - Find search terms I should add as negatives
+
+  NotFair also exposes mutation tools for campaign, budget, bid, keyword,
+  asset, experiment, and conversion-action changes. Review enabled tools with:
+    hermes mcp configure notfair-google-ads


### PR DESCRIPTION
## Summary
Adds a Nous-approved MCP catalog manifest for NotFair Google Ads.

NotFair hosts a remote OAuth MCP server at `https://notfair.co/api/mcp/google_ads` that lets Hermes analyze and manage Google Ads accounts through NotFair's guardrailed MCP surface.

## Default tool selection
The manifest keeps the default install surface analysis-first/read-mostly:
- account discovery/setup summaries
- GAQL read-only analytics via `runScript`
- geo/keyword research helpers
- experiment/change-impact review
- keyword inventory and guardrail/resource metadata reads

Mutation tools remain available in the install/configure checklist, but are not enabled by default.

## Validation
- `python -m pytest tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_mcp_config.py` — 66 passed
- `python - <<'PY' ... list_catalog() ... PY` — verified the new manifest parses as http + oauth with 16 default-enabled tools
- Existing local Hermes config tested the NotFair MCP server: OAuth connected and discovered 92 tools
