### PR TITLE
docs: align the image backend catalog

### DIFF
--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -64,7 +64,8 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
-| `image_gen/xai` | image backend | xAI `grok-2-image` backend |
+| `image_gen/xai` | image backend | xAI `grok-imagine-image` backend |
+| `image_gen/krea` | image backend | Krea `Krea 2` (Medium + Medium Turbo + Large) image generation backend |
 | `hermes-achievements` | dashboard tab | Steam-style collectible badges generated from your real Hermes session history |
 | `kanban/dashboard` | dashboard tab | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/built-in-plugins.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/built-in-plugins.md
@@ -61,7 +61,8 @@ hermes plugins disable disk-cleanup
 | `google_meet` | 独立插件 | 加入 Meet 通话、实时字幕转录、可选实时双工音频 |
 | `image_gen/openai` | 图像后端 | OpenAI `gpt-image-2` 图像生成后端（FAL 的替代方案） |
 | `image_gen/openai-codex` | 图像后端 | 通过 Codex OAuth 使用 OpenAI 图像生成 |
-| `image_gen/xai` | 图像后端 | xAI `grok-2-image` 后端 |
+| `image_gen/xai` | 图像后端 | xAI `grok-imagine-image` 后端 |
+| `image_gen/krea` | 图像后端 | Krea `Krea 2`（Medium + Medium Turbo + Large）图像生成后端 |
 | `hermes-achievements` | 仪表盘标签页 | Steam 风格的可收集徽章，根据你真实的 Hermes 会话历史生成 |
 | `kanban/dashboard` | 仪表盘标签页 | 多智能体调度器的看板（Kanban）UI——任务、评论、扇出、切换看板。参见 [Kanban 多智能体](./kanban.md)。 |
 


### PR DESCRIPTION
## Summary

- replace the stale xAI `grok-2-image` catalog entry with the shipped default, `grok-imagine-image`
- add the missing Krea backend to the English and zh-Hans plugin tables
- list all three current Krea 2 variants: Medium, Medium Turbo, and Large

## Validation

- verified the xAI `_MODELS` catalog and `DEFAULT_MODEL` in `plugins/image_gen/xai/__init__.py`
- verified all three Krea `_MODELS` entries and the matching `plugin.yaml` description
- confirmed no overlapping open Krea/xAI catalog PR or target-file relocation
- `git diff --check`

Docs-only change; no provider behavior is modified. This incorporates the requested Medium Turbo correction from the maintainer review.