### PR TITLE
fix(mcp): validate mcp_servers entries on load; skip-with-warning instead of crashing

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -76,13 +76,39 @@ def _prompt(question: str, *, password: bool = False, default: str = "") -> str:
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
 def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
-    """Return the ``mcp_servers`` dict from config, or empty dict."""
+    """Return the ``mcp_servers`` dict from config, or empty dict.
+
+    Malformed entries (non-dict values, or entries missing both
+    ``command`` and ``url``) are filtered out with a warning so a single
+    bad row written by a third-party installer cannot break the
+    ``hermes mcp`` picker / list / test commands (issue #33119). The
+    rules mirror :func:`tools.mcp_tool._validate_mcp_entry`.
+    """
     if config is None:
         config = load_config()
     servers = config.get("mcp_servers")
     if not servers or not isinstance(servers, dict):
         return {}
-    return servers
+    validated: Dict[str, dict] = {}
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            logger.warning(
+                "Skipping malformed mcp_servers entry %r: entry value is "
+                "not a dict (got %s). Fix or remove this entry in "
+                "~/.hermes/config.yaml.",
+                name, type(cfg).__name__,
+            )
+            continue
+        if not cfg.get("command") and not cfg.get("url"):
+            logger.warning(
+                "Skipping malformed mcp_servers entry %r: declares "
+                "neither 'command' (stdio) nor 'url' (http). Fix or "
+                "remove this entry in ~/.hermes/config.yaml.",
+                name,
+            )
+            continue
+        validated[name] = cfg
+    return validated
 
 
 def _save_mcp_server(name: str, server_config: dict) -> bool:

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -636,3 +636,170 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+
+# ---------------------------------------------------------------------------
+# Issue #33119: validate mcp_servers entries on load (skip-with-warning).
+#
+# Third-party tools (e.g. `codegraph install -t hermes`) can write malformed
+# rows directly to ~/.hermes/config.yaml. Both `_get_mcp_servers` (CLI picker)
+# and `tools.mcp_tool._load_mcp_config` (runtime discovery) must:
+#   - drop entries whose value is not a dict
+#   - drop entries with neither `command` (stdio) nor `url` (http)
+#   - log a warning naming the bad entry + concrete reason
+#   - leave valid entries unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestMcpConfigValidation:
+    """Validate `mcp_servers` entries at load time — issue #33119."""
+
+    # ---- CLI side: hermes_cli.mcp_config._get_mcp_servers ----------------
+
+    def test_cli_skips_non_dict_entry(self, caplog):
+        from hermes_cli.mcp_config import _get_mcp_servers
+
+        config = {"mcp_servers": {"broken": "oops_string"}}
+        with caplog.at_level("WARNING", logger="hermes_cli.mcp_config"):
+            result = _get_mcp_servers(config)
+
+        assert result == {}
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "broken" in joined
+        assert "not a dict" in joined
+
+    def test_cli_skips_entry_missing_command_and_url(self, caplog):
+        from hermes_cli.mcp_config import _get_mcp_servers
+
+        config = {"mcp_servers": {"empty": {"args": ["--help"]}}}
+        with caplog.at_level("WARNING", logger="hermes_cli.mcp_config"):
+            result = _get_mcp_servers(config)
+
+        assert result == {}
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "empty" in joined
+        assert "command" in joined and "url" in joined
+
+    def test_cli_passes_valid_stdio_entry_through(self):
+        from hermes_cli.mcp_config import _get_mcp_servers
+
+        good = {"command": "codex", "args": ["mcp-server"]}
+        config = {"mcp_servers": {"codex": good}}
+        result = _get_mcp_servers(config)
+
+        assert result == {"codex": good}
+
+    def test_cli_passes_valid_http_entry_through(self):
+        from hermes_cli.mcp_config import _get_mcp_servers
+
+        good = {"url": "https://example.com/mcp"}
+        config = {"mcp_servers": {"remote": good}}
+        result = _get_mcp_servers(config)
+
+        assert result == {"remote": good}
+
+    def test_cli_mixed_config_keeps_good_drops_bad(self, caplog):
+        from hermes_cli.mcp_config import _get_mcp_servers
+
+        good = {"command": "codex", "args": ["mcp-server"]}
+        config = {
+            "mcp_servers": {
+                "codex": good,
+                "broken_str": "oops",
+                "broken_empty": {"args": []},
+                "broken_list": [1, 2, 3],
+                "broken_none": None,
+                "remote": {"url": "https://example.com/mcp"},
+            }
+        }
+        with caplog.at_level("WARNING", logger="hermes_cli.mcp_config"):
+            result = _get_mcp_servers(config)
+
+        assert set(result.keys()) == {"codex", "remote"}
+        assert result["codex"] == good
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        for bad in ("broken_str", "broken_empty", "broken_list", "broken_none"):
+            assert bad in joined, f"warning missing for {bad}: {joined!r}"
+
+    # ---- Runtime side: tools.mcp_tool._load_mcp_config -------------------
+
+    def test_runtime_skips_non_dict_entry(self, caplog, monkeypatch):
+        import tools.mcp_tool as mcp_mod
+        import hermes_cli.config as cfg_mod
+        monkeypatch.setattr(
+            cfg_mod, "load_config",
+            lambda: {"mcp_servers": {"broken": "oops_string"}},
+        )
+
+        with caplog.at_level("WARNING", logger="tools.mcp_tool"):
+            result = mcp_mod._load_mcp_config()
+
+        assert result == {}
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "broken" in joined
+        assert "not a dict" in joined
+
+    def test_runtime_skips_entry_missing_command_and_url(self, caplog, monkeypatch):
+        import tools.mcp_tool as mcp_mod
+        import hermes_cli.config as cfg_mod
+
+        monkeypatch.setattr(
+            cfg_mod, "load_config",
+            lambda: {"mcp_servers": {"empty": {"args": ["--foo"]}}},
+        )
+
+        with caplog.at_level("WARNING", logger="tools.mcp_tool"):
+            result = mcp_mod._load_mcp_config()
+
+        assert result == {}
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "empty" in joined
+        assert "command" in joined and "url" in joined
+
+    def test_runtime_mixed_config_keeps_good_drops_bad(self, caplog, monkeypatch):
+        import tools.mcp_tool as mcp_mod
+        import hermes_cli.config as cfg_mod
+
+        good = {"command": "codex", "args": ["mcp-server"]}
+        monkeypatch.setattr(
+            cfg_mod, "load_config",
+            lambda: {
+                "mcp_servers": {
+                    "codex": good,
+                    "broken_str": "oops",
+                    "broken_empty": {"timeout": 5},
+                    "remote": {"url": "https://example.com/mcp"},
+                }
+            },
+        )
+
+        with caplog.at_level("WARNING", logger="tools.mcp_tool"):
+            result = mcp_mod._load_mcp_config()
+
+        assert set(result.keys()) == {"codex", "remote"}
+        assert result["codex"] == good
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "broken_str" in joined
+        assert "broken_empty" in joined
+
+    def test_runtime_validate_entry_helper(self):
+        from tools.mcp_tool import _validate_mcp_entry
+
+        ok, reason = _validate_mcp_entry("good", {"command": "x"})
+        assert ok is True and reason == ""
+
+        ok, reason = _validate_mcp_entry("good", {"url": "https://x"})
+        assert ok is True and reason == ""
+
+        ok, reason = _validate_mcp_entry("bad_str", "oops")
+        assert ok is False and "not a dict" in reason
+
+        ok, reason = _validate_mcp_entry("bad_list", [1, 2])
+        assert ok is False and "not a dict" in reason
+
+        ok, reason = _validate_mcp_entry("bad_none", None)
+        assert ok is False and "not a dict" in reason
+
+        ok, reason = _validate_mcp_entry("bad_empty", {"timeout": 5})
+        assert ok is False and "command" in reason and "url" in reason
+

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -113,7 +113,7 @@ import time
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
+from typing import Any, Coroutine, Dict, List, Optional, Tuple, Set, Tuple
 from urllib.parse import urlparse
 
 from tools.registry import tool_error
@@ -4872,6 +4872,31 @@ def _filter_suspicious_mcp_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
     return safe_servers
 
 
+
+def _validate_mcp_entry(name: str, cfg: Any) -> Tuple[bool, str]:
+    """Validate a single ``mcp_servers`` entry.
+
+    Returns ``(is_valid, reason)``. ``reason`` is a short human-readable
+    string describing why an entry was rejected, suitable for logging.
+    Validation rules (deliberately minimal, to mirror the upstream
+    ``_connect_server`` contract):
+
+    1. The entry value must be a ``dict`` — strings, lists, ``None`` and
+       scalars are rejected.
+    2. The entry must declare at least one of ``command`` (stdio
+       transport) or ``url`` (HTTP transport).
+
+    Anything that passes these two gates is forwarded to
+    ``_connect_server`` unchanged, preserving the existing behaviour for
+    well-formed configs (closes #33119).
+    """
+    if not isinstance(cfg, dict):
+        return False, f"entry value is not a dict (got {type(cfg).__name__})"
+    if not cfg.get("command") and not cfg.get("url"):
+        return False, "entry declares neither 'command' (stdio) nor 'url' (http)"
+    return True, ""
+
+
 def _load_mcp_config() -> Dict[str, dict]:
     """Read ``mcp_servers`` from the Hermes config file.
 
@@ -4882,6 +4907,12 @@ def _load_mcp_config() -> Dict[str, dict]:
 
     ``${ENV_VAR}`` placeholders in string values are resolved from
     ``os.environ`` (which includes ``~/.hermes/.env`` loaded at startup).
+
+    Malformed entries (non-dict values, or entries missing both
+    ``command`` and ``url``) are skipped with a ``logger.warning(...)``
+    naming the offending entry and the concrete reason. This prevents a
+    single bad row written by a third-party installer from bricking
+    Hermes on startup (issue #33119).
     """
     try:
         from hermes_cli.config import load_config
@@ -4899,28 +4930,43 @@ def _load_mcp_config() -> Dict[str, dict]:
             load_hermes_dotenv()
         except Exception:
             pass
-        safe_servers: Dict[str, dict] = {}
+        validated: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
+            ok, reason = _validate_mcp_entry(name, cfg)
+            if not ok:
+                logger.warning(
+                    "Skipping malformed mcp_servers entry %r: %s. "
+                    "Fix or remove this entry in ~/.hermes/config.yaml.",
+                    name, reason,
+                )
+                continue
             interpolated = _interpolate_env_vars(cfg)
             if isinstance(interpolated, dict):
                 _warn_hidden_whitespace(name, interpolated)
-                safe_servers[name] = interpolated
+                validated[name] = interpolated
         try:
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
             discover_plugins()
             portable = get_plugin_manager().get_portable_mcp_servers()
             for name, cfg in _filter_suspicious_mcp_servers(portable).items():
-                if name in safe_servers:
+                ok, reason = _validate_mcp_entry(name, cfg)
+                if not ok:
+                    logger.warning(
+                        "Skipping malformed portable mcp_servers entry %r: %s.",
+                        name, reason,
+                    )
+                    continue
+                if name in validated:
                     logger.warning(
                         "Portable MCP server '%s' conflicts with native config; skipping",
                         name,
                     )
                     continue
-                safe_servers[name] = dict(cfg)
+                validated[name] = dict(cfg)
         except Exception:
             logger.debug("Failed to load portable MCP servers", exc_info=True)
-        return safe_servers
+        return validated
     except Exception as exc:
         logger.debug("Failed to load MCP config: %s", exc)
         return {}


### PR DESCRIPTION
Closes #33119

## Problem
Third-party tools (e.g. `codegraph install -t hermes`) write directly to `~/.hermes/config.yaml` without validation. A malformed `mcp_servers` entry currently propagates into the MCP discovery loop and crashes Hermes on startup, requiring manual YAML repair to recover.

The hermes-agent skill itself documents this as the #1 user pitfall, and the timing matters: the new MCP catalog is about to drive a significant uptick in MCP installs across the user base.

## Root cause
Two sites assume every value under `mcp_servers` is a well-formed dict with at least one of `command` or `url`:

- `tools/mcp_tool.py::_load_mcp_config()` — feeds `_discover_and_register_server()`, which does `config.get("connect_timeout", ...)` and crashes when the entry isn't a dict.
- `hermes_cli/mcp_config.py::_get_mcp_servers()` — feeds the `hermes mcp` picker, which also assumes dict-shaped entries.

A single bad row (string value, null, list, or missing both command and url) takes the whole agent down.

## Fix
Add per-entry validation at both load chokepoints. Each malformed entry is dropped from the returned mapping and a `logger.warning(...)` is emitted naming the entry and the concrete reason. Hermes continues to boot; valid MCP servers stay fully functional; the user sees exactly which config row is broken.

Validation rules (kept deliberately minimal to mirror the upstream `_connect_server` contract):
1. Value must be a `dict` — strings, lists, `None`, and scalars are rejected.
2. Value must declare at least one of `command` (stdio) or `url` (http) — entries with neither are rejected.

A small `_validate_mcp_entry(name, cfg) -> (ok, reason)` helper lives in `tools/mcp_tool.py` and centralizes the rules. `hermes_cli/mcp_config.py` applies the same rules inline (kept explicit rather than cross-importing, to avoid coupling the CLI surface to the runtime tool module beyond what already exists).

`_remove_mcp_server` is unchanged and still operates on the raw config — so users can run `hermes mcp remove <name>` to clean up the malformed entry the warning told them about.

## Tests
New `TestMcpConfigValidation` class in `tests/hermes_cli/test_mcp_catalog.py` covering both code paths:

CLI side (`_get_mcp_servers`):
- non-dict entry skipped + warned
- entry missing both `command` and `url` skipped + warned
- valid stdio entry passes through unchanged
- valid http entry passes through unchanged
- mixed config: 2 good entries kept, 4 malformed variants (string, list, None, missing-keys) dropped, warnings name each one

Runtime side (`tools.mcp_tool._load_mcp_config`):
- non-dict entry skipped + warned
- entry missing both `command` and `url` skipped + warned
- mixed config: good entries kept, bad entries dropped
- direct unit test of `_validate_mcp_entry` helper across all branches

## Verification
```
pytest tests/hermes_cli/test_mcp_catalog.py tests/tools/test_mcp_stability.py tests/hermes_cli/test_mcp_config.py
=> 91 passed in 13.20s
```

Includes the existing `test_mcp_config.py` suite which already exercises `_get_mcp_servers` — no regressions.

No public API changes. No config schema changes. Backwards compatible: well-formed configs behave identically to before, malformed configs now skip-with-warning instead of crashing.