### PR TITLE
fix(gateway): deduplicate auto-resume sessions per (platform, chat_id)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3832,6 +3832,26 @@ class GatewayRunner:
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
             return 0
 
+        # Deduplicate: keep only the most recent session per (platform, chat_id).
+        # When multiple threads in the same channel are auto-resumed
+        # simultaneously (e.g. after a gateway crash), responses from one
+        # thread can leak into another — the user sees a message about
+        # an unrelated topic appearing in their current thread.
+        _per_chat: dict = {}
+        for entry in candidates:
+            key = (entry.origin.platform, entry.origin.chat_id)
+            existing = _per_chat.get(key)
+            if (
+                existing is None
+                or (
+                    entry.updated_at
+                    and existing.updated_at
+                    and entry.updated_at > existing.updated_at
+                )
+            ):
+                _per_chat[key] = entry
+        candidates = list(_per_chat.values())
+
         now = datetime.now()
         scheduled = 0
         for entry in candidates:


### PR DESCRIPTION
## Problem

`_schedule_resume_pending_sessions()` auto-resumes ALL restart-interrupted sessions without considering that multiple sessions may target the same channel. When two threads in one Mattermost channel are auto-resumed simultaneously after a gateway restart, responses from one thread can leak into another — the user sees a message about an unrelated topic appearing in their current thread (串台 / cross-thread context leak).

## Reproduction

1. Have two active Thread conversations in the same Mattermost channel
2. Gateway crashes (SIGTERM, systemd restart, etc.)
3. On restart, both sessions are marked `resume_reason="restart_interrupted"`
4. Both are auto-resumed simultaneously
5. Response from Thread B appears in Thread A

## Evidence

Gateway log from a real incident:

```
01:52:23 Marked 1 in-flight session(s) as resumable from previous run
01:52:24 Scheduled auto-resume for 2 restart-interrupted session(s)  ← BOTH resumed
01:52:24 inbound message: msg=''  (phantom auto-resume event #1)
01:52:24 inbound message: msg=''  (phantom auto-resume event #2)
01:52:32 session 014825 triggers web search unrelated to its thread context
```

## Fix

Add a deduplication step after building the candidate list: group by `(platform, chat_id)`, keeping only the most recently updated session per channel. Older sessions remain `resume_pending` and recover naturally when the user sends a real message in their respective thread.

```python
_per_chat: dict = {}
for entry in candidates:
    key = (entry.origin.platform, entry.origin.chat_id)
    existing = _per_chat.get(key)
    if existing is None or (
        entry.updated_at and existing.updated_at
        and entry.updated_at > existing.updated_at
    ):
        _per_chat[key] = entry
candidates = list(_per_chat.values())
```

## Scope

- 1 file, +20 lines
- Pure additive — no existing behavior changed except the dedup
- Platform-agnostic — works for any platform (Telegram, Discord, Slack, etc.)