### PR TITLE
fix(tools): guard os.getcwd() in _get_env_config against missing CWD

### DIFF
--- a/tests/tools/test_get_env_config_cwd_fallback.py
+++ b/tests/tools/test_get_env_config_cwd_fallback.py
@@ -1,0 +1,98 @@
+"""Tests for _get_env_config handling of missing CWD (FileNotFoundError).
+
+Regression test for https://github.com/NousResearch/hermes-agent/issues/33367:
+On systems with aggressive tmpfs cleanup (e.g. Arch Linux), os.getcwd() can raise
+FileNotFoundError when the process's CWD has been removed. The cleanup thread calls
+_get_env_config() every 60 seconds, so this must not crash.
+"""
+
+import os
+import types
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def _tt_mod():
+    """Import the terminal_tool module once."""
+    import importlib
+    return importlib.import_module("tools.terminal_tool")
+
+
+class TestGetEnvConfigCwdFallback:
+    """_get_env_config must not raise when os.getcwd() fails."""
+
+    def test_local_env_getcwd_file_not_found(self, _tt_mod, monkeypatch):
+        """When env_type=local and os.getcwd() raises FileNotFoundError,
+        _get_env_config should fall back to the user's home directory."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        def _boom():
+            raise FileNotFoundError(2, "No such file or directory")
+
+        with patch("os.getcwd", side_effect=_boom):
+            config = _tt_mod._get_env_config()
+
+        assert config["env_type"] == "local"
+        # Should have fallen back to home directory, not crashed
+        assert config["cwd"] == os.path.expanduser("~")
+        assert os.path.isabs(config["cwd"])
+
+    def test_local_env_getcwd_os_error(self, _tt_mod, monkeypatch):
+        """When env_type=local and os.getcwd() raises OSError (e.g. ENOENT),
+        _get_env_config should fall back to the user's home directory."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        def _boom():
+            raise OSError(2, "No such file or directory")
+
+        with patch("os.getcwd", side_effect=_boom):
+            config = _tt_mod._get_env_config()
+
+        assert config["env_type"] == "local"
+        assert config["cwd"] == os.path.expanduser("~")
+
+    def test_local_env_getcwd_normal(self, _tt_mod, monkeypatch):
+        """Normal case: os.getcwd() succeeds, default_cwd should be the real CWD."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        config = _tt_mod._get_env_config()
+
+        assert config["env_type"] == "local"
+        # Should be the actual CWD, not the fallback
+        assert config["cwd"] == os.getcwd()
+
+    def test_local_env_terminal_cwd_overrides_fallback(self, _tt_mod, monkeypatch):
+        """When TERMINAL_CWD is set, it should be used even if os.getcwd() fails."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", "/some/explicit/path")
+
+        def _boom():
+            raise FileNotFoundError(2, "No such file or directory")
+
+        with patch("os.getcwd", side_effect=_boom):
+            config = _tt_mod._get_env_config()
+
+        # TERMINAL_CWD should still be the effective cwd
+        assert config["cwd"] == "/some/explicit/path"
+
+    def test_docker_mount_cwd_getcwd_file_not_found(self, _tt_mod, monkeypatch):
+        """When env_type=docker and mount_cwd is enabled, os.getcwd() failure
+        should not crash; should fall back gracefully."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        def _boom():
+            raise FileNotFoundError(2, "No such file or directory")
+
+        with patch("os.getcwd", side_effect=_boom):
+            config = _tt_mod._get_env_config()
+
+        assert config["env_type"] == "docker"
+        # Should not crash; docker_cwd_source should fall back to home
+        assert config["cwd"] in ("/workspace", os.path.expanduser("~"))

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -953,7 +953,12 @@ def _get_env_config() -> Dict[str, Any]:
     # remote home, and everything else starts in the backend's default
     # root-like cwd.
     if env_type == "local":
-        default_cwd = os.getcwd()
+        try:
+            default_cwd = os.getcwd()
+        except (FileNotFoundError, OSError):
+            # CWD may have been removed (e.g. tmpfs cleanup on Arch Linux).
+            # Fall back to the user's home directory.
+            default_cwd = os.path.expanduser("~")
     elif env_type == "ssh":
         default_cwd = "~"
     else:
@@ -969,7 +974,10 @@ def _get_env_config() -> Dict[str, Any]:
     host_cwd = None
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or os.getcwd()
+        try:
+            docker_cwd_source = os.getenv("TERMINAL_CWD") or os.getcwd()
+        except (FileNotFoundError, OSError):
+            docker_cwd_source = os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in host_prefixes)


### PR DESCRIPTION
## Summary

`_get_env_config()` in `tools/terminal_tool.py` calls `os.getcwd()` without protection. When the process's CWD is removed (e.g. by Arch Linux's aggressive tmpfs cleanup of `/tmp`), this raises `FileNotFoundError`. The background cleanup thread calls `_get_env_config()` every 60 seconds, producing a recurring warning in `errors.log` that never stops — and the cleanup itself never runs, so stale environments accumulate.

## Fix

Guard both `os.getcwd()` call sites in `_get_env_config()` with `try/except (FileNotFoundError, OSError)`, falling back to `os.path.expanduser("~")`:

1. **Line 956** (local default CWD): `os.getcwd()` → wrapped in try/except
2. **Line 972** (docker mount CWD source): `os.getcwd()` fallback → wrapped in try/except

## Regression test

New test file `tests/tools/test_get_env_config_cwd_fallback.py` with 5 test cases:
- `test_local_env_getcwd_file_not_found` — FileNotFoundError falls back to home
- `test_local_env_getcwd_os_error` — OSError falls back to home
- `test_local_env_getcwd_normal` — normal case still uses real CWD
- `test_local_env_terminal_cwd_overrides_fallback` — explicit TERMINAL_CWD still takes precedence
- `test_docker_mount_cwd_getcwd_file_not_found` — docker mount path doesn't crash

All 5 new tests pass. Existing `test_parse_env_var.py` (12 tests) also passes.

## Code Intelligence
- Analyzed: `tools/terminal_tool.py:_get_env_config` (callers: 4 — `_cleanup_thread_worker`, `create_terminal_environment`, `create_file_environment`, `create_web_environment`)
- Blast radius: LOW — only adds graceful fallback, no behavior change for normal operation
- Related patterns: `_cleanup_thread_worker` catches all exceptions at line 1242, but the FileNotFoundError clutters logs every 60s and prevents cleanup from running

Fixes #33367
