### PR TITLE
fix(browser): detect agent-browser Chrome cache

### DIFF
--- a/tests/tools/test_browser_chromium_check.py
+++ b/tests/tools/test_browser_chromium_check.py
@@ -39,6 +39,11 @@ class TestChromiumSearchRoots:
         home = os.path.expanduser("~")
         assert any(r == os.path.join(home, ".cache", "ms-playwright") for r in roots)
 
+    def test_includes_agent_browser_chrome_cache(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path))
+        roots = bt._chromium_search_roots()
+        assert str(tmp_path / ".agent-browser" / "browsers") in roots
+
 
 class TestChromiumInstalled:
     def test_true_when_plain_chromium_on_path(self, monkeypatch):
@@ -60,6 +65,37 @@ class TestChromiumInstalled:
         monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path))
         (tmp_path / "chromium_headless_shell-1208").mkdir()
         assert bt._chromium_installed() is True
+
+    def test_true_when_agent_browser_chrome_for_testing_present(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+        monkeypatch.setattr(bt.shutil, "which", lambda _: None)
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path))
+        chrome_exe = (
+            tmp_path
+            / ".agent-browser"
+            / "browsers"
+            / "chrome-149.0.7827.22"
+            / "Google Chrome for Testing.app"
+            / "Contents"
+            / "MacOS"
+            / "Google Chrome for Testing"
+        )
+        chrome_exe.parent.mkdir(parents=True)
+        chrome_exe.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        assert bt._chromium_installed() is True
+
+    def test_false_when_agent_browser_chrome_dir_has_no_executable(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+        monkeypatch.setattr(bt.shutil, "which", lambda _: None)
+        monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path))
+        (tmp_path / ".agent-browser" / "browsers" / "chrome-149.0.7827.22").mkdir(
+            parents=True
+        )
+
+        assert bt._chromium_installed() is False
 
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3502,7 +3502,8 @@ def _chromium_search_roots() -> List[str]:
        ``/opt/hermes/.playwright``).
     2. ``~/.cache/ms-playwright`` — Playwright's default on Linux/macOS.
     3. ``~/Library/Caches/ms-playwright`` — Playwright's default on macOS.
-    4. ``%USERPROFILE%\\AppData\\Local\\ms-playwright`` — Playwright's default
+    4. ``~/.agent-browser/browsers`` — agent-browser's Chrome for Testing cache.
+    5. ``%USERPROFILE%\\AppData\\Local\\ms-playwright`` — Playwright's default
        on Windows.
     """
     roots: List[str] = []
@@ -3513,12 +3514,40 @@ def _chromium_search_roots() -> List[str]:
     roots.append(os.path.join(home, ".cache", "ms-playwright"))
     if sys.platform == "darwin":
         roots.append(os.path.join(home, "Library", "Caches", "ms-playwright"))
+    roots.append(os.path.join(home, ".agent-browser", "browsers"))
     if sys.platform == "win32":
         local = os.environ.get("LOCALAPPDATA") or os.path.join(
             home, "AppData", "Local"
         )
         roots.append(os.path.join(local, "ms-playwright"))
     return roots
+
+
+def _agent_browser_chrome_executable(browser_dir: str) -> Optional[str]:
+    """Return the Chrome for Testing executable inside an agent-browser cache dir.
+
+    ``agent-browser install`` downloads Chrome into ``~/.agent-browser/browsers``
+    with entries named ``chrome-<version>``. The executable layout differs by
+    platform, so probe known Chrome for Testing shapes instead of treating any
+    ``chrome-*`` directory as usable.
+    """
+    candidates = [
+        os.path.join(
+            browser_dir,
+            "Google Chrome for Testing.app",
+            "Contents",
+            "MacOS",
+            "Google Chrome for Testing",
+        ),
+        os.path.join(browser_dir, "chrome-linux64", "chrome"),
+        os.path.join(browser_dir, "chrome-win64", "chrome.exe"),
+        os.path.join(browser_dir, "chrome.exe"),
+        os.path.join(browser_dir, "chrome"),
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+    return None
 
 
 def _chromium_installed() -> bool:
@@ -3530,8 +3559,9 @@ def _chromium_installed() -> bool:
        agent-browser at a pre-installed Chrome/Chromium.
     2. System Chrome/Chromium in PATH (``google-chrome``, ``chromium``,
        ``chromium-browser``, ``chrome``).
-    3. Playwright's browser cache (current logic) — directories containing
-       ``chromium-*`` or ``chromium_headless_shell-*``.
+    3. Browser caches — Playwright directories containing ``chromium-*`` or
+       ``chromium_headless_shell-*``, plus agent-browser's Chrome for Testing
+       cache under ``~/.agent-browser/browsers/chrome-*``.
 
     agent-browser (0.26+) downloads Playwright's chromium / headless-shell
     builds into ``PLAYWRIGHT_BROWSERS_PATH`` and won't start without at least
@@ -3562,7 +3592,8 @@ def _chromium_installed() -> bool:
         _cached_chromium_installed = True
         return True
 
-    # 3. Playwright browser cache (legacy — chromium-* / chromium_headless_shell-* dirs)
+    # 3. Browser caches. Playwright uses chromium-* / chromium_headless_shell-*.
+    # agent-browser uses chrome-* entries containing a Chrome for Testing binary.
     for root in _chromium_search_roots():
         if not root or not os.path.isdir(root):
             continue
@@ -3575,6 +3606,11 @@ def _chromium_installed() -> bool:
         for entry in entries:
             if entry.startswith("chromium-") or entry.startswith(
                 "chromium_headless_shell-"
+            ):
+                _cached_chromium_installed = True
+                return True
+            if entry.startswith("chrome-") and _agent_browser_chrome_executable(
+                os.path.join(root, entry)
             ):
                 _cached_chromium_installed = True
                 return True


### PR DESCRIPTION
Fix browser requirement detection for agent-browser Chrome cache.

Hermes currently hides browser_* tools when agent-browser has installed Chrome for Testing into its own cache at ~/.agent-browser/browsers, because _chromium_installed() only checks AGENT_BROWSER_EXECUTABLE_PATH, system Chrome names, and Playwright cache directories.

This patch:
- adds ~/.agent-browser/browsers to Chromium search roots
- recognizes agent-browser chrome-* cache entries only when a real Chrome for Testing executable exists
- adds regression tests for the cache root and executable validation

Local verification:
- python -m pytest tests/tools/test_browser_chromium_check.py -q
- hermes doctor now reports Playwright Chromium/browser engine OK on a machine where agent-browser doctor already passes via ~/.agent-browser/browsers
