### PR TITLE
feat(observability): log per-turn request budgets

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -668,6 +668,9 @@ def init_agent(
     agent._last_activity_desc: str = "initializing"
     agent._current_tool: str | None = None
     agent._api_call_count: int = 0
+    agent._request_budget = None
+    agent._request_budget_reason: str | None = None
+    agent._last_request_budget: Optional[Dict[str, Any]] = None
     # Opt-out flag for the between-turns MCP tool refresh (build_turn_context).
     # Set on internal forks (e.g. background_review) that must keep ``tools[]``
     # byte-identical to a parent for provider cache parity.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+from functools import wraps
 import json
 import logging
 import os
@@ -58,6 +59,7 @@ from agent.model_metadata import (
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
+from agent.request_budget import RequestBudget
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
@@ -520,7 +522,7 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     return sp
 
 
-def run_conversation(
+def _run_conversation_impl(
     agent,
     user_message: str,
     system_message: str = None,
@@ -595,6 +597,8 @@ def run_conversation(
     messages = _ctx.messages
     conversation_history = _ctx.conversation_history
     active_system_prompt = _ctx.active_system_prompt
+    if agent._request_budget is not None:
+        agent._request_budget.record_skill_index(active_system_prompt)
     effective_task_id = _ctx.effective_task_id
     turn_id = _ctx.turn_id
     current_turn_user_idx = _ctx.current_turn_user_idx
@@ -1155,6 +1159,8 @@ def run_conversation(
 
             try:
                 agent._reset_stream_delivery_tracking()
+                if agent._request_budget is not None:
+                    agent._request_budget.record_tool_schema(agent.tools or [])
                 # api_messages is built once, before this retry loop, while the
                 # primary provider is active.  A mid-conversation fallback can
                 # switch to a require-side provider (DeepSeek / Kimi / MiMo) that
@@ -1324,11 +1330,25 @@ def run_conversation(
                             allow_stream=False,
                             is_github_responses=agent._is_copilot_url(),
                         )
-                    if _use_streaming:
-                        return agent._interruptible_streaming_api_call(
-                            next_api_kwargs, on_first_delta=_stop_spinner
-                        )
-                    return agent._interruptible_api_call(next_api_kwargs)
+                    request_budget = agent._request_budget
+                    if request_budget is not None:
+                        request_budget.mark_model_request_start()
+
+                    def _mark_first_model_byte():
+                        if request_budget is not None:
+                            request_budget.mark_model_first_byte()
+                        _stop_spinner()
+
+                    try:
+                        if _use_streaming:
+                            return agent._interruptible_streaming_api_call(
+                                next_api_kwargs,
+                                on_first_delta=_mark_first_model_byte,
+                            )
+                        return agent._interruptible_api_call(next_api_kwargs)
+                    finally:
+                        if request_budget is not None:
+                            request_budget.mark_model_request_end()
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 
@@ -5349,6 +5369,88 @@ def run_conversation(
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
     )
+
+
+def _request_budget_reason(agent, result: Any) -> str:
+    detailed_reason = getattr(agent, "_request_budget_reason", None)
+    if detailed_reason:
+        return str(detailed_reason)
+    if isinstance(result, dict):
+        if result.get("interrupted"):
+            return "interrupted"
+        if result.get("failed"):
+            return "failed"
+        if result.get("completed"):
+            return "completed"
+        if result.get("error"):
+            return "error"
+    return "returned"
+
+
+@wraps(_run_conversation_impl)
+def run_conversation(
+    agent,
+    user_message: str,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[str] = None,
+    persist_user_timestamp: Optional[float] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run one turn and finalize request diagnostics for every return path."""
+    budget = RequestBudget(
+        session_id=getattr(agent, "session_id", "") or "",
+        turn_id=str(getattr(agent, "_user_turn_count", 0) + 1),
+        model=getattr(agent, "model", "") or "",
+        provider=getattr(agent, "provider", "") or "",
+        platform=getattr(agent, "platform", "") or "cli",
+    )
+    agent._request_budget = budget
+    agent._request_budget_reason = None
+    result = None
+    raised = None
+    try:
+        result = _run_conversation_impl(
+            agent,
+            user_message,
+            system_message,
+            conversation_history,
+            task_id,
+            stream_callback,
+            persist_user_message,
+            persist_user_timestamp=persist_user_timestamp,
+            moa_config=moa_config,
+        )
+        return result
+    except BaseException as exc:
+        raised = exc
+        raise
+    finally:
+        reason = (
+            f"exception:{type(raised).__name__}"
+            if raised is not None
+            else _request_budget_reason(agent, result)
+        )
+        api_calls = (
+            int(result.get("api_calls", budget.model_call_count))
+            if isinstance(result, dict)
+            else budget.model_call_count
+        )
+        try:
+            payload = budget.log_agent_turn(
+                logger=logger,
+                reason=reason,
+                api_calls=api_calls,
+            )
+        except Exception:
+            logger.debug("request budget finalization failed", exc_info=True)
+            payload = budget.snapshot(reason=reason, api_calls=api_calls)
+        if isinstance(result, dict):
+            result["request_budget"] = payload
+        agent._last_request_budget = payload
+        agent._request_budget = None
 
 
 

--- a/agent/request_budget.py
+++ b/agent/request_budget.py
@@ -1,0 +1,220 @@
+"""Coarse per-turn request budget diagnostics.
+
+The metrics intentionally contain timing and payload-size buckets only. Request
+contents, tool arguments, prompts, and model responses never enter the log.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+import json
+import logging
+import time
+from typing import Any
+
+
+def _ceil_tokens_from_bytes(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return (byte_count + 3) // 4
+
+
+def _json_bytes(value: Any) -> int:
+    try:
+        rendered = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+    except Exception:
+        rendered = str(value)
+    return len(rendered.encode("utf-8"))
+
+
+def estimate_tool_schema_tokens(tools: Any) -> tuple[int, int, int]:
+    """Return ``(schema_count, estimated_tokens, byte_count)``."""
+    if not isinstance(tools, list) or not tools:
+        return 0, 0, 0
+    byte_count = _json_bytes(tools)
+    return len(tools), _ceil_tokens_from_bytes(byte_count), byte_count
+
+
+def estimate_skill_index_tokens(prompt: str | None) -> int:
+    """Estimate the rendered skills-index weight inside a system prompt."""
+    if not prompt:
+        return 0
+    marker = "## Skills (mandatory)"
+    start = prompt.find(marker)
+    if start < 0:
+        return 0
+    tail = prompt[start:]
+    end_marker = "Only proceed without loading a skill"
+    end = tail.find(end_marker)
+    if end >= 0:
+        tail = tail[: end + len(end_marker)]
+    return _ceil_tokens_from_bytes(len(tail.encode("utf-8")))
+
+
+@dataclass
+class RequestBudget:
+    session_id: str
+    turn_id: str
+    model: str
+    provider: str
+    platform: str
+    started_at: float = field(default_factory=time.perf_counter)
+    tool_schema_count: int = 0
+    tool_schema_tokens: int = 0
+    tool_schema_bytes: int = 0
+    skill_index_tokens: int = 0
+    skill_index_build_ms: int = 0
+    model_ttfb_ms: int | None = None
+    model_ttfb_source: str | None = None
+    model_ttfb_max_ms: int | None = None
+    model_request_ms: int = 0
+    model_call_count: int = 0
+    tool_execution_ms: int = 0
+    tool_call_count: int = 0
+    tool_names: list[str] = field(default_factory=list)
+
+    _active_model_start: float | None = field(default=None, init=False, repr=False)
+    _active_first_byte_at: float | None = field(default=None, init=False, repr=False)
+
+    def record_tool_schema(self, tools: Any) -> None:
+        count, tokens, byte_count = estimate_tool_schema_tokens(tools)
+        self.tool_schema_count = count
+        self.tool_schema_tokens = tokens
+        self.tool_schema_bytes = byte_count
+
+    def record_skill_index(
+        self,
+        prompt: str | None,
+        *,
+        build_ms: float | int | None = None,
+    ) -> None:
+        self.skill_index_tokens = estimate_skill_index_tokens(prompt)
+        if build_ms is not None:
+            self.skill_index_build_ms += max(0, int(round(float(build_ms))))
+
+    def mark_model_request_start(self) -> None:
+        self.model_call_count += 1
+        self._active_model_start = time.perf_counter()
+        self._active_first_byte_at = None
+
+    def mark_model_first_byte(self, *, source: str = "stream_delta") -> None:
+        if self._active_model_start is None or self._active_first_byte_at is not None:
+            return
+        self._active_first_byte_at = time.perf_counter()
+        ttfb_ms = max(
+            0,
+            int(round((self._active_first_byte_at - self._active_model_start) * 1000)),
+        )
+        if self.model_ttfb_ms is None:
+            self.model_ttfb_ms = ttfb_ms
+            self.model_ttfb_source = source
+        if self.model_ttfb_max_ms is None or ttfb_ms > self.model_ttfb_max_ms:
+            self.model_ttfb_max_ms = ttfb_ms
+
+    def mark_model_request_end(self) -> None:
+        if self._active_model_start is None:
+            return
+        if self._active_first_byte_at is None:
+            self.mark_model_first_byte(source="response_complete")
+        elapsed_ms = max(
+            0,
+            int(round((time.perf_counter() - self._active_model_start) * 1000)),
+        )
+        self.model_request_ms += elapsed_ms
+        self._active_model_start = None
+        self._active_first_byte_at = None
+
+    def add_tool_execution(
+        self,
+        tool_names: Iterable[str],
+        duration_s: float,
+    ) -> None:
+        names = [str(name) for name in tool_names if name]
+        self.tool_execution_ms += max(0, int(round(duration_s * 1000)))
+        self.tool_call_count += len(names)
+        self.tool_names.extend(names)
+
+    def snapshot(self, *, reason: str, api_calls: int) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "turn_id": self.turn_id,
+            "model": self.model,
+            "provider": self.provider,
+            "platform": self.platform,
+            "reason": reason,
+            "api_calls": api_calls,
+            "total_ms": max(
+                0, int(round((time.perf_counter() - self.started_at) * 1000))
+            ),
+            "model_ttfb_ms": self.model_ttfb_ms,
+            "model_ttfb_source": self.model_ttfb_source,
+            "model_ttfb_max_ms": self.model_ttfb_max_ms,
+            "model_request_ms": self.model_request_ms,
+            "model_call_count": self.model_call_count,
+            "tool_schema_count": self.tool_schema_count,
+            "tool_schema_tokens": self.tool_schema_tokens,
+            "tool_schema_bytes": self.tool_schema_bytes,
+            "skill_index_tokens": self.skill_index_tokens,
+            "skill_index_build_ms": self.skill_index_build_ms,
+            "tool_execution_ms": self.tool_execution_ms,
+            "tool_call_count": self.tool_call_count,
+            "tool_names": list(dict.fromkeys(self.tool_names)),
+        }
+
+    def log_agent_turn(
+        self,
+        *,
+        logger: logging.Logger,
+        reason: str,
+        api_calls: int,
+    ) -> dict[str, Any]:
+        payload = self.snapshot(reason=reason, api_calls=api_calls)
+        logger.info(
+            "request_budget.v1 %s",
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+        return payload
+
+
+def log_gateway_delivery_budget(
+    *,
+    logger: logging.Logger,
+    platform: str,
+    chat_id: str | None,
+    session_key: str | None,
+    gateway_delivery_ms: float,
+    response_chars: int,
+    delivery_succeeded: bool,
+    delivery_kind: str,
+) -> dict[str, Any]:
+    payload = {
+        "platform": platform,
+        "chat_id": chat_id or "",
+        "session_key": session_key or "",
+        "delivery_kind": delivery_kind,
+        "gateway_delivery_ms": max(0, int(round(gateway_delivery_ms))),
+        "response_chars": max(0, int(response_chars)),
+        "delivery_succeeded": bool(delivery_succeeded),
+    }
+    logger.info(
+        "request_budget.gateway_delivery.v1 %s",
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+    return payload

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -311,11 +312,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             )
         except Exception:
             _compact_cats = frozenset()
+        _skill_index_start = time.perf_counter()
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
         )
+        request_budget = getattr(agent, "_request_budget", None)
+        if request_budget is not None:
+            request_budget.record_skill_index(
+                skills_prompt,
+                build_ms=(time.perf_counter() - _skill_index_start) * 1000,
+            )
     else:
         skills_prompt = ""
     if skills_prompt:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -534,4 +534,5 @@ def finalize_turn(
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)
 
+    agent._request_budget_reason = str(_turn_exit_reason)
     return result

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -42,6 +42,43 @@ def _platform_name(platform) -> str:
     return str(value or "").lower()
 
 
+async def _timed_gateway_delivery(
+    *,
+    sender,
+    platform,
+    chat_id: str | None,
+    session_key: str | None,
+    delivery_kind: str,
+    response_chars: int = 0,
+):
+    """Run one final delivery and emit a bounded diagnostic for its outcome."""
+    started_at = time.perf_counter()
+    try:
+        result = await sender()
+    except Exception:
+        delivery_succeeded = False
+        raise
+    else:
+        delivery_succeeded = bool(getattr(result, "success", True))
+        return result
+    finally:
+        try:
+            from agent.request_budget import log_gateway_delivery_budget
+
+            log_gateway_delivery_budget(
+                logger=logger,
+                platform=_platform_name(platform),
+                chat_id=chat_id,
+                session_key=session_key,
+                gateway_delivery_ms=(time.perf_counter() - started_at) * 1000,
+                response_chars=response_chars,
+                delivery_succeeded=delivery_succeeded,
+                delivery_kind=delivery_kind,
+            )
+        except Exception:
+            logger.debug("request budget delivery log failed", exc_info=True)
+
+
 def _float_env(name: str, default: float) -> float:
     raw = os.environ.get(name, "").strip()
     if not raw:
@@ -5007,11 +5044,18 @@ class BasePlatformAdapter(ABC):
                             and text_content[:1024] == text_content
                         ):
                             telegram_tts_caption = text_content
-                        tts_result = await self.play_tts(
+                        tts_result = await _timed_gateway_delivery(
+                            sender=lambda: self.play_tts(
+                                chat_id=event.source.chat_id,
+                                audio_path=_tts_path,
+                                caption=telegram_tts_caption,
+                                metadata=_final_thread_metadata,
+                            ),
+                            platform=self.platform,
                             chat_id=event.source.chat_id,
-                            audio_path=_tts_path,
-                            caption=telegram_tts_caption,
-                            metadata=_final_thread_metadata,
+                            session_key=session_key,
+                            delivery_kind="tts",
+                            response_chars=len(telegram_tts_caption or ""),
                         )
                         _tts_caption_delivered = bool(
                             telegram_tts_caption and getattr(tts_result, "success", False)
@@ -5026,11 +5070,18 @@ class BasePlatformAdapter(ABC):
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     _reply_anchor = _reply_anchor_for_event(event)
-                    result = await self._send_with_retry(
+                    result = await _timed_gateway_delivery(
+                        sender=lambda: self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=text_content,
+                            reply_to=_reply_anchor,
+                            metadata=_final_thread_metadata,
+                        ),
+                        platform=self.platform,
                         chat_id=event.source.chat_id,
-                        content=text_content,
-                        reply_to=_reply_anchor,
-                        metadata=_final_thread_metadata,
+                        session_key=session_key,
+                        delivery_kind="text",
+                        response_chars=len(text_content),
                     )
                     _record_delivery(result)
 
@@ -5056,11 +5107,17 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
-                        await self.send_multiple_images(
+                        await _timed_gateway_delivery(
+                            sender=lambda: self.send_multiple_images(
+                                chat_id=event.source.chat_id,
+                                images=images,
+                                metadata=_final_thread_metadata,
+                                human_delay=human_delay,
+                            ),
+                            platform=self.platform,
                             chat_id=event.source.chat_id,
-                            images=images,
-                            metadata=_final_thread_metadata,
-                            human_delay=human_delay,
+                            session_key=session_key,
+                            delivery_kind="image",
                         )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
@@ -5098,11 +5155,17 @@ class BasePlatformAdapter(ABC):
                 if _image_paths:
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
+                        await _timed_gateway_delivery(
+                            sender=lambda: self.send_multiple_images(
+                                chat_id=event.source.chat_id,
+                                images=_batch,
+                                metadata=_final_thread_metadata,
+                                human_delay=human_delay,
+                            ),
+                            platform=self.platform,
                             chat_id=event.source.chat_id,
-                            images=_batch,
-                            metadata=_final_thread_metadata,
-                            human_delay=human_delay,
+                            session_key=session_key,
+                            delivery_kind="image",
                         )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
@@ -5113,23 +5176,34 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(media_path).suffix.lower()
                         if should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
-                            media_result = await self.send_voice(
+                            delivery_kind = "voice"
+                            sender = lambda: self.send_voice(
                                 chat_id=event.source.chat_id,
                                 audio_path=media_path,
                                 metadata=_final_thread_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
-                            media_result = await self.send_video(
+                            delivery_kind = "video"
+                            sender = lambda: self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            media_result = await self.send_document(
+                            delivery_kind = "document"
+                            sender = lambda: self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=media_path,
                                 metadata=_final_thread_metadata,
                             )
+
+                        media_result = await _timed_gateway_delivery(
+                            sender=sender,
+                            platform=self.platform,
+                            chat_id=event.source.chat_id,
+                            session_key=session_key,
+                            delivery_kind=delivery_kind,
+                        )
 
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
@@ -5143,17 +5217,26 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            delivery_kind = "video"
+                            sender = lambda: self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            await self.send_document(
+                            delivery_kind = "document"
+                            sender = lambda: self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
+                        await _timed_gateway_delivery(
+                            sender=sender,
+                            platform=self.platform,
+                            chat_id=event.source.chat_id,
+                            session_key=session_key,
+                            delivery_kind=delivery_kind,
+                        )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5681,6 +5681,7 @@ class AIAgent:
 
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
+        tool_batch_start = time.perf_counter()
         try:
             if not _should_parallelize_tool_batch(tool_calls):
                 return self._execute_tool_calls_sequential(
@@ -5691,6 +5692,16 @@ class AIAgent:
                 assistant_message, messages, effective_task_id, api_call_count
             )
         finally:
+            request_budget = getattr(self, "_request_budget", None)
+            if request_budget is not None:
+                tool_names = [
+                    getattr(getattr(tool_call, "function", None), "name", "")
+                    for tool_call in (tool_calls or [])
+                ]
+                request_budget.add_tool_execution(
+                    tool_names,
+                    time.perf_counter() - tool_batch_start,
+                )
             self._executing_tools = False
 
     def _dispatch_delegate_task(self, function_args: dict) -> str:

--- a/tests/agent/test_request_budget.py
+++ b/tests/agent/test_request_budget.py
@@ -1,0 +1,78 @@
+import json
+import logging
+
+from agent.request_budget import RequestBudget, estimate_tool_schema_tokens
+
+
+def test_tool_schema_token_estimate_counts_serialized_schema():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search the web.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    count, tokens, byte_count = estimate_tool_schema_tokens(tools)
+
+    assert count == 1
+    assert tokens > 0
+    assert byte_count > 0
+
+
+def test_request_budget_keeps_multi_tool_batch_names_machine_readable():
+    budget = RequestBudget(
+        session_id="session-1",
+        turn_id="turn-1",
+        model="gpt-5.5",
+        provider="openai-codex",
+        platform="slack",
+    )
+
+    budget.add_tool_execution(["read_file", "web_search"], 0.123)
+    payload = budget.snapshot(reason="tool_response", api_calls=1)
+
+    assert payload["tool_call_count"] == 2
+    assert payload["tool_names"] == ["read_file", "web_search"]
+    assert payload["tool_execution_ms"] == 123
+
+
+def test_request_budget_logs_core_turn_phases(caplog):
+    budget = RequestBudget(
+        session_id="session-1",
+        turn_id="turn-1",
+        model="gpt-5.5",
+        provider="openai-codex",
+        platform="slack",
+    )
+    budget.record_tool_schema(
+        [{"type": "function", "function": {"name": "read_file"}}]
+    )
+    budget.record_skill_index(
+        prompt="## Skills (mandatory)\n<available_skills>\n- x\n</available_skills>"
+    )
+    budget.mark_model_request_start()
+    budget.mark_model_first_byte()
+    budget.mark_model_request_end()
+    budget.add_tool_execution(["read_file"], 0.123)
+
+    with caplog.at_level(logging.INFO):
+        payload = budget.log_agent_turn(
+            logger=logging.getLogger("tests.request_budget"),
+            reason="text_response",
+            api_calls=1,
+        )
+
+    assert payload["model_ttfb_ms"] is not None
+    assert payload["tool_schema_tokens"] > 0
+    assert payload["skill_index_tokens"] > 0
+    assert payload["tool_execution_ms"] == 123
+    assert "request_budget.v1" in caplog.text
+    logged = caplog.records[-1].getMessage().split("request_budget.v1 ", 1)[1]
+    assert json.loads(logged)["session_id"] == "session-1"

--- a/tests/gateway/test_request_budget_delivery.py
+++ b/tests/gateway/test_request_budget_delivery.py
@@ -1,0 +1,176 @@
+import asyncio
+import json
+import logging
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class DeliveryTimingAdapter(BasePlatformAdapter):
+    def __init__(self, platform=Platform.SLACK):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), platform)
+        self.sent = []
+        self.delivered_kinds = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        await asyncio.sleep(0)
+        self.sent.append({"chat_id": chat_id, "content": content})
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def send_multiple_images(self, **kwargs):
+        self.delivered_kinds.append("image")
+
+    async def send_voice(self, **kwargs):
+        self.delivered_kinds.append("voice")
+        return SendResult(success=True, message_id="voice-1")
+
+    async def play_tts(self, **kwargs):
+        self.delivered_kinds.append("tts")
+        return SendResult(success=True, message_id="tts-1")
+
+    async def send_video(self, **kwargs):
+        self.delivered_kinds.append("video")
+        return SendResult(success=True, message_id="video-1")
+
+    async def send_document(self, **kwargs):
+        self.delivered_kinds.append("document")
+        return SendResult(success=True, message_id="document-1")
+
+
+async def _hold_typing(_chat_id, interval=2.0, metadata=None, stop_event=None):
+    if stop_event is not None:
+        await stop_event.wait()
+    else:
+        await asyncio.Event().wait()
+
+
+def _event(platform=Platform.SLACK, *, message_type=MessageType.TEXT):
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=platform,
+            chat_id="C123",
+            chat_type="group",
+            user_id="U123",
+        ),
+        message_id="m1",
+        message_type=message_type,
+    )
+
+
+def _delivery_payloads(caplog):
+    return [
+        json.loads(record.getMessage().split("request_budget.gateway_delivery.v1 ", 1)[1])
+        for record in caplog.records
+        if "request_budget.gateway_delivery.v1 " in record.getMessage()
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_delivery_budget_logs_text_send(caplog):
+    adapter = DeliveryTimingAdapter()
+    adapter._keep_typing = _hold_typing
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="ack"))
+    event = _event()
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    payloads = _delivery_payloads(caplog)
+    assert [payload["delivery_kind"] for payload in payloads] == ["text"]
+    assert payloads[0]["response_chars"] == 3
+    assert payloads[0]["delivery_succeeded"] is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_delivery_budget_logs_remote_image_only_response(caplog):
+    adapter = DeliveryTimingAdapter()
+    adapter._keep_typing = _hold_typing
+    adapter.set_message_handler(
+        lambda _event: asyncio.sleep(
+            0, result="![chart](https://example.com/chart.png)"
+        )
+    )
+    event = _event()
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert adapter.delivered_kinds == ["image"]
+    assert [payload["delivery_kind"] for payload in _delivery_payloads(caplog)] == [
+        "image"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("suffix", "expected_kind"),
+    [(".wav", "voice"), (".mp4", "video"), (".pdf", "document")],
+)
+@pytest.mark.asyncio
+async def test_gateway_delivery_budget_logs_local_media_only_response(
+    suffix, expected_kind, tmp_path, caplog
+):
+    media_path = tmp_path / f"artifact{suffix}"
+    media_path.write_bytes(b"fixture")
+    adapter = DeliveryTimingAdapter()
+    adapter._keep_typing = _hold_typing
+    adapter.set_message_handler(
+        lambda _event: asyncio.sleep(0, result=f"MEDIA:{media_path}")
+    )
+    event = _event()
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert adapter.delivered_kinds == [expected_kind]
+    assert [payload["delivery_kind"] for payload in _delivery_payloads(caplog)] == [
+        expected_kind
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_delivery_budget_logs_auto_tts(caplog, monkeypatch, tmp_path):
+    import tools.tts_tool as tts_tool
+
+    audio_path = tmp_path / "tts.wav"
+    audio_path.write_bytes(b"fixture")
+    monkeypatch.setattr(tts_tool, "check_tts_requirements", lambda: True)
+    monkeypatch.setattr(
+        tts_tool,
+        "text_to_speech_tool",
+        lambda **kwargs: json.dumps({"file_path": str(audio_path)}),
+    )
+
+    adapter = DeliveryTimingAdapter(Platform.TELEGRAM)
+    adapter._keep_typing = _hold_typing
+    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="spoken"))
+    event = _event(Platform.TELEGRAM, message_type=MessageType.VOICE)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert adapter.delivered_kinds == ["tts"]
+    assert [payload["delivery_kind"] for payload in _delivery_payloads(caplog)] == [
+        "tts"
+    ]

--- a/tests/run_agent/test_request_budget_diagnostics.py
+++ b/tests/run_agent/test_request_budget_diagnostics.py
@@ -1,0 +1,165 @@
+import json
+import logging
+import sys
+import types
+from types import SimpleNamespace
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from agent import conversation_loop
+from agent.request_budget import RequestBudget
+import run_agent
+
+
+def _patch_agent_bootstrap(monkeypatch):
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+
+def _message_response(text: str):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    role="assistant",
+                    content=text,
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=2, total_tokens=12),
+        model="gpt-5.5",
+    )
+
+
+def test_run_conversation_emits_request_budget_payload(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+    _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setattr(
+        run_agent,
+        "OpenAI",
+        lambda **kwargs: SimpleNamespace(
+            close=lambda: None,
+            is_closed=lambda: False,
+        ),
+    )
+
+    agent = run_agent.AIAgent(
+        model="gpt-5.5",
+        provider="openai",
+        api_mode="chat_completions",
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+        quiet_mode=True,
+        max_iterations=2,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="slack",
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._save_session_log = lambda messages: None
+    agent._disable_streaming = True
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: _message_response("OK"),
+    )
+
+    with caplog.at_level(logging.INFO):
+        result = agent.run_conversation("hello")
+
+    assert result["final_response"] == "OK"
+    payload = result["request_budget"]
+    assert payload["tool_schema_tokens"] > 0
+    assert payload["model_ttfb_ms"] is not None
+    assert payload["tool_execution_ms"] == 0
+    assert payload["reason"].startswith("text_response")
+
+    records = [
+        record.getMessage().split("request_budget.v1 ", 1)[1]
+        for record in caplog.records
+        if "request_budget.v1 " in record.getMessage()
+    ]
+    assert len(records) == 1
+    logged = json.loads(records[0])
+    assert logged["session_id"] == agent.session_id
+    assert logged["tool_schema_tokens"] == payload["tool_schema_tokens"]
+
+
+def test_direct_terminal_return_still_finalizes_request_budget(monkeypatch, caplog):
+    agent = SimpleNamespace(
+        session_id="session-early",
+        _user_turn_count=4,
+        model="gpt-5.5",
+        provider="openai-codex",
+        platform="slack",
+    )
+
+    monkeypatch.setattr(
+        conversation_loop,
+        "_run_conversation_impl",
+        lambda *args, **kwargs: {
+            "final_response": "provider unavailable",
+            "api_calls": 0,
+            "completed": False,
+            "failed": True,
+        },
+    )
+
+    with caplog.at_level(logging.INFO):
+        result = conversation_loop.run_conversation(agent, "hello")
+
+    assert result["request_budget"]["reason"] == "failed"
+    assert result["request_budget"]["api_calls"] == 0
+    assert sum("request_budget.v1 " in r.getMessage() for r in caplog.records) == 1
+    assert agent._request_budget is None
+
+
+def test_tool_batch_records_each_name_separately(monkeypatch):
+    agent = object.__new__(run_agent.AIAgent)
+    agent._request_budget = RequestBudget(
+        session_id="session-tools",
+        turn_id="1",
+        model="gpt-5.5",
+        provider="openai-codex",
+        platform="slack",
+    )
+    agent._execute_tool_calls_sequential = lambda *args: None
+    monkeypatch.setattr(
+        run_agent,
+        "_should_parallelize_tool_batch",
+        lambda tool_calls: False,
+    )
+    assistant_message = SimpleNamespace(
+        tool_calls=[
+            SimpleNamespace(function=SimpleNamespace(name="read_file")),
+            SimpleNamespace(function=SimpleNamespace(name="web_search")),
+        ]
+    )
+
+    agent._execute_tool_calls(assistant_message, [], "task-1")
+
+    payload = agent._request_budget.snapshot(reason="tool_response", api_calls=1)
+    assert payload["tool_call_count"] == 2
+    assert payload["tool_names"] == ["read_file", "web_search"]


### PR DESCRIPTION
## Summary
- Add structured per-turn `request_budget.v1` logs for model TTFB, model request duration, tool schema size, skill index size, and tool execution time.
- Add `request_budget.gateway_delivery.v1` timing around final platform sends.
- Include the request budget payload in every returned agent turn result for tests and future tooling.

Part of #33002.

## Related Issues
This is a small diagnostic slice that supports several existing context/token-efficiency discussions:

- #33002 — direct match: asks for context budget diagnostics and lazy/hierarchical context loading for large profiles. This PR implements the first observable budget buckets without attempting lazy loading yet.
- #6839 — lazy tool schema loading: `tool_schema_count`, `tool_schema_tokens`, and `tool_schema_bytes` provide a baseline for deciding when lazy schema loading is worth the extra round trip.
- #20880 — tool-heavy agents paying high input-token overhead from uncached/replayed tool schemas: the new tool-schema budget fields make that overhead visible per turn.
- #10617 — `/context` and `/usage` prompt-composition visibility: `request_budget.v1` is a machine-readable log surface that can feed those future user-facing commands.
- #16105 — gateway context budget compiler and stable profile snapshots: the gateway delivery timing and per-turn budget payload are a lightweight trace that complements deeper gateway request-budget work.
- #33213 — skill menu/category filtering to reduce per-turn context overhead: `skill_index_tokens` and `skill_index_build_ms` make skill-index cost visible before changing skill loading policy.

This PR intentionally does **not** close those issues; it provides observability that can guide the larger fixes.

## Why This Matters
Hermes latency can come from several different places that look identical to users:

- the model is slow to produce its first token
- the request is carrying a large tool schema surface
- the skills index or system prompt is large
- one or more tools are slow
- the gateway takes extra time to deliver the final message

Without per-turn diagnostics, performance work has to guess which bucket is responsible. This PR makes those buckets visible in normal logs so future optimization work can target the actual hot path instead of changing routing, compression, or tool loading blindly.

## What This Adds
Agent turn logs now emit a structured line:

```text
request_budget.v1 {...}
```

The payload includes:

- `model_ttfb_ms`: time to first model byte/delta for the first observed model response
- `model_ttfb_max_ms`: slowest observed first byte across model calls in the turn
- `model_request_ms`: total model request time across model calls
- `model_call_count`: number of model calls in the turn
- `tool_schema_count`, `tool_schema_tokens`, `tool_schema_bytes`: size of the loaded tool schema surface
- `skill_index_tokens`, `skill_index_build_ms`: rendered skills-index size and build timing
- `tool_execution_ms`, `tool_call_count`, `tool_names`: aggregate tool execution cost
- `api_calls`, `total_ms`, `reason`, `model`, `provider`, `platform`, `session_id`, `turn_id`

Gateway final-send logs now emit:

```text
request_budget.gateway_delivery.v1 {...}
```

The payload includes:

- `platform`
- `chat_id`
- `session_key`
- `gateway_delivery_ms`
- `response_chars`
- `delivery_succeeded`
- `delivery_kind`

## How To Use It
Run Hermes normally, then inspect the session logs:

```bash
hermes logs --session <session_id>
```

or search the agent log directly:

```bash
grep 'request_budget.v1' ~/.hermes/logs/agent.log
grep 'request_budget.gateway_delivery.v1' ~/.hermes/logs/agent.log
```

For tests and future tooling, every returned `run_conversation()` result also includes:

```python
result["request_budget"]
```

That makes it possible to assert diagnostic fields without parsing log files.

## Demo
Example agent-turn log:

```text
request_budget.v1 {"api_calls":1,"model":"gpt-5.5","provider":"openai-codex","platform":"slack","reason":"text_response","model_ttfb_ms":4204,"model_ttfb_max_ms":4204,"model_request_ms":4849,"model_call_count":1,"tool_schema_count":56,"tool_schema_tokens":18064,"skill_index_tokens":2310,"skill_index_build_ms":8,"tool_execution_ms":0,"tool_call_count":0,"tool_names":[],"total_ms":5120,"session_id":"...","turn_id":"1"}
```

Example gateway-delivery log:

```text
request_budget.gateway_delivery.v1 {"platform":"slack","chat_id":"C123","session_key":"agent:main:slack:C123","gateway_delivery_ms":137,"response_chars":1240,"delivery_succeeded":true,"delivery_kind":"text"}
```

These two lines answer different questions:

- Is the model slow? Look at `model_ttfb_ms` and `model_request_ms`.
- Is the request too heavy before the model starts? Look at `tool_schema_tokens` and `skill_index_tokens`.
- Are tools the bottleneck? Look at `tool_execution_ms` and `tool_names`.
- Is the message done but slow to reach the user? Look at `gateway_delivery_ms`.

## Value
This gives maintainers and users a low-noise way to compare slow turns across providers, platforms, profiles, and toolsets. It should help prioritize follow-up work such as lazy tool loading, lazy skill routing, profile slimming, gateway delivery tuning, or provider-specific fixes using data from real turns.

The change is diagnostic-only:

- no model routing changes
- no tool loading changes
- no skill loading changes
- no compression policy changes
- no gateway behavior changes beyond logging final-send timing

## Implementation Notes
- `agent/request_budget.py` owns estimation, timing, snapshot, and structured logging helpers.
- `agent/conversation_loop.py` records model/request/schema/skill diagnostics and uses a single outer finalizer so direct terminal returns also log and expose the payload.
- `run_agent.py` records aggregate tool-batch timing while preserving each tool name as a separate machine-readable element.
- `gateway/platforms/base.py` records final delivery timing for text, TTS, image, voice, video, and document sends.
- Tests cover the pure estimator/logger, normal and direct-return turns, multi-tool batches, and text plus media-only gateway delivery.

## Validation
- `scripts/run_tests.sh tests/agent/test_request_budget.py tests/run_agent/test_request_budget_diagnostics.py tests/gateway/test_request_budget_delivery.py -- -o addopts=''`

Result: 12 targeted tests passed. The affected wider suite also passed 618 tests (630 total, 0 failures).

## Duplicate Check
- Searched existing PRs/issues for `request_budget.v1`, `tool_schema_tokens`, `model_ttfb_ms`, and `request budget diagnostics`; no exact duplicate found.
