### PR TITLE
fix(discord): add 15s timeout to authenticated attachment read

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -20,7 +20,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Any, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 logger = logging.getLogger(__name__)
 
@@ -4398,12 +4398,25 @@ class DiscordAdapter(BasePlatformAdapter):
         expose a callable ``read()`` or the read itself fails. Callers
         should treat ``None`` as a signal to fall back to the URL-based
         downloaders.
+
+        A 15-second timeout prevents indefinite hangs on slow or unreachable
+        CDNs (e.g. corporate proxies blocking ``cdn.discordapp.com``).  The
+        timeout is intentionally shorter than Discord's signed-URL expiry
+        window (~30-60 s) so the fallback URL path still has a valid link
+        when the authenticated read gives up.
         """
         reader = getattr(att, "read", None)
         if reader is None or not callable(reader):
             return None
         try:
-            return await reader()
+            return await asyncio.wait_for(cast(Any, reader)(), timeout=15.0)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[Discord] Authenticated attachment read timed out (15s) for %s; "
+                "falling back to URL download",
+                getattr(att, "filename", None) or getattr(att, "url", "<unknown>"),
+            )
+            return None
         except Exception as e:
             logger.warning(
                 "[Discord] Authenticated attachment read failed for %s: %s",

--- a/tests/plugins/test_discord_attachment_read_timeout.py
+++ b/tests/plugins/test_discord_attachment_read_timeout.py
@@ -1,0 +1,88 @@
+"""Tests for _read_attachment_bytes timeout behavior.
+
+Regression test for https://github.com/NousResearch/hermes-agent/issues/33400:
+When Discord's CDN is slow or unreachable, att.read() can hang indefinitely.
+The fix wraps the call in asyncio.wait_for with a 15-second timeout so the
+fallback URL download path runs while the signed CDN URL is still valid.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def adapter():
+    """Create a minimal DiscordAdapter instance for testing."""
+    import importlib
+    mod = importlib.import_module("plugins.platforms.discord.adapter")
+    # Use __new__ to bypass __init__ which requires complex setup
+    obj = mod.DiscordAdapter.__new__(mod.DiscordAdapter)
+    return obj
+
+
+class TestReadAttachmentBytesTimeout:
+    """_read_attachment_bytes must time out on slow CDN reads."""
+
+    @pytest.mark.asyncio
+    async def test_normal_read_succeeds(self, adapter):
+        """Normal case: att.read() returns bytes quickly."""
+        att = MagicMock()
+        expected = b"fake-audio-data"
+        att.read = AsyncMock(return_value=expected)
+        att.filename = "voice.ogg"
+
+        result = await adapter._read_attachment_bytes(att)
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_read_timeout_returns_none(self, adapter):
+        """When att.read() hangs past 15s, should return None (triggering fallback)."""
+        async def _slow_read():
+            await asyncio.sleep(999)  # Simulate indefinite hang
+            return b"never-reached"
+
+        att = MagicMock()
+        att.read = _slow_read
+        att.filename = "voice.ogg"
+
+        # Patch asyncio.wait_for to use a very short timeout for testing
+        original_wait_for = asyncio.wait_for
+
+        async def _fast_wait_for(coro, timeout=None):
+            return await original_wait_for(coro, timeout=0.05)  # 50ms for test speed
+
+        with patch("asyncio.wait_for", side_effect=_fast_wait_for):
+            result = await adapter._read_attachment_bytes(att)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_read_exception_returns_none(self, adapter):
+        """When att.read() raises an exception, should return None."""
+        att = MagicMock()
+        att.read = AsyncMock(side_effect=ConnectionError("CDN unreachable"))
+        att.filename = "voice.ogg"
+
+        result = await adapter._read_attachment_bytes(att)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_read_method_returns_none(self, adapter):
+        """When att has no read() method, should return None."""
+        att = MagicMock(spec=[])  # No read attribute
+        att.filename = "voice.ogg"
+
+        result = await adapter._read_attachment_bytes(att)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_read_not_callable_returns_none(self, adapter):
+        """When att.read exists but is not callable, should return None."""
+        att = MagicMock()
+        att.read = "not-a-function"
+        att.filename = "voice.ogg"
+
+        result = await adapter._read_attachment_bytes(att)
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

`_read_attachment_bytes` in `plugins/platforms/discord/adapter.py` calls `await reader()` (discord.py's `Attachment.read()` authenticated via the bot session) with no timeout. When Discord's CDN is slow or unreachable (corporate proxies, VPNs, network issues), this call hangs for 60-120s+ until the OS TCP timeout fires. By then the signed CDN URL has expired (~30-60s window), so the fallback URL download also fails — silently losing voice messages and file attachments.

## Related Issue

Fixes #33400

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `plugins/platforms/discord/adapter.py:_read_attachment_bytes` (callers: 3 — `_cache_discord_image`, `_cache_discord_audio`, `_cache_discord_voice`)
- Blast radius: LOW — only adds timeout guard, no behavior change for normal operation
- Related patterns: all 3 callers already handle `None` return by falling back to URL-based downloaders

Fixes #33400