### PR TITLE
fix(dashboard-auth): honor dashboard.public_url across login redirects, next landing, and SPA base path

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -80,11 +80,11 @@ def _unauth_response(request: Request, *, reason: str) -> Response:
     proxied login page rather than the bare ``/login`` (which the
     proxy doesn't route to the dashboard).
     """
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
+    from hermes_cli.dashboard_auth.prefix import effective_prefix_from_request
 
     path = request.url.path
     next_param = _safe_next_target(request)
-    prefix = prefix_from_request(request)
+    prefix = effective_prefix_from_request(request)
     login_url = (
         f"{prefix}/login?next={next_param}" if next_param
         else f"{prefix}/login"
@@ -116,10 +116,14 @@ def _safe_next_target(request: Request) -> str:
     """Build the URL-encoded ``next`` query value, or empty string.
 
     Only same-origin relative paths are accepted; absolute URLs or
-    ``//evil.com`` open-redirect attempts are silently dropped. The empty
-    string return means the caller produces a bare ``/login`` URL — fine,
-    user lands at the dashboard root after re-auth.
+    ``//evil.com`` open-redirect attempts are silently dropped. The encoded
+    value uses the dashboard's PUBLIC path shape (``/hermes/sessions`` when
+    mounted under a prefix) so post-login redirects return the browser to the
+    externally-visible route rather than the backend's internal stripped path.
+    The empty string return means the caller produces a bare ``/login`` URL.
     """
+    from hermes_cli.dashboard_auth.prefix import effective_prefix_from_request
+
     path = request.url.path
     # Reject anything that doesn't start with "/" or starts with "//"
     # (protocol-relative URL — would open-redirect to an attacker host).
@@ -131,9 +135,11 @@ def _safe_next_target(request: Request) -> str:
         for p in ("/login", "/auth/", "/api/auth/")
     ):
         return ""
+    prefix = effective_prefix_from_request(request)
+    public_path = f"{prefix}{path}" if prefix else path
     # Preserve query string if present (e.g. /sessions?page=2).
     query = request.url.query
-    target = f"{path}?{query}" if query else path
+    target = f"{public_path}?{query}" if query else public_path
     # urlencode the whole thing as a single value.
     from urllib.parse import quote
     return quote(target, safe="")
@@ -199,8 +205,8 @@ async def gated_auth_middleware(
         # prefix so the deletion's Path matches the set-Path (otherwise
         # the browser ignores it).
         from hermes_cli.dashboard_auth.cookies import clear_session_cookies
-        from hermes_cli.dashboard_auth.prefix import prefix_from_request
-        clear_session_cookies(response, prefix=prefix_from_request(request))
+        from hermes_cli.dashboard_auth.prefix import effective_prefix_from_request
+        clear_session_cookies(response, prefix=effective_prefix_from_request(request))
         return response
 
     request.state.session = session

--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -64,7 +64,9 @@ def prefix_from_request(request) -> str:
     """Convenience wrapper that reads the header off a Starlette/FastAPI
     Request and normalises it. Returns ``""`` when no prefix.
     """
-    return normalise_prefix(request.headers.get("x-forwarded-prefix"))
+    headers = getattr(request, "headers", None)
+    raw = headers.get("x-forwarded-prefix") if headers else ""
+    return normalise_prefix(raw)
 
 
 # ---------------------------------------------------------------------------
@@ -155,3 +157,42 @@ def resolve_public_url() -> str:
         return env_clean
     cfg_raw = _load_dashboard_section().get("public_url", "")
     return _normalise_public_url(str(cfg_raw))
+
+
+def resolve_public_path_prefix() -> str:
+    """Return the path prefix baked into ``dashboard.public_url``.
+
+    ``https://example.com/hermes`` -> ``"/hermes"``
+    ``https://example.com``        -> ``""``
+
+    The path component is normalized through the same prefix validator used
+    for ``X-Forwarded-Prefix`` so every public-facing URL builder agrees on
+    what a safe mount prefix looks like.
+    """
+    public_url = resolve_public_url()
+    if not public_url:
+        return ""
+    try:
+        parsed = urllib.parse.urlparse(public_url)
+    except ValueError:
+        return ""
+    path = parsed.path or ""
+    if not path or path == "/":
+        return ""
+    return normalise_prefix(path)
+
+
+def effective_prefix_from_request(request) -> str:
+    """Resolve the public path prefix for outward-facing URLs.
+
+    Precedence:
+      1. The path baked into ``dashboard.public_url`` when configured.
+      2. ``X-Forwarded-Prefix`` from the active request.
+
+    This keeps the callback URL, login redirects, cookie Path attributes, and
+    SPA bootstrap/asset rewriting on the same canonical public mount.
+    """
+    public_prefix = resolve_public_path_prefix()
+    if public_prefix:
+        return public_prefix
+    return prefix_from_request(request)

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -76,7 +76,7 @@ def _redirect_uri(request: Request) -> str:
     from urllib.parse import urlparse, urlunparse
 
     from hermes_cli.dashboard_auth.prefix import (
-        prefix_from_request,
+        effective_prefix_from_request,
         resolve_public_url,
     )
 
@@ -92,7 +92,7 @@ def _redirect_uri(request: Request) -> str:
     # Tier 2 + 3: reconstruct from the request URL, optionally with
     # X-Forwarded-Prefix layered on top of the path.
     base = str(request.url_for("auth_callback"))
-    prefix = prefix_from_request(request)
+    prefix = effective_prefix_from_request(request)
     if not prefix:
         return base
     parsed = urlparse(base)
@@ -114,8 +114,8 @@ def _prefix(request: Request) -> str:
     redirect builders (login_url construction). See
     ``hermes_cli.dashboard_auth.prefix`` for the normalisation rules.
     """
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
-    return prefix_from_request(request)
+    from hermes_cli.dashboard_auth.prefix import effective_prefix_from_request
+    return effective_prefix_from_request(request)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3843,8 +3843,9 @@ def mount_spa(application: FastAPI):
     def _serve_index(prefix: str = ""):
         """Return index.html with the session token + base-path injected.
 
-        ``prefix`` is the normalised ``X-Forwarded-Prefix`` (e.g. ``/hermes``)
-        or empty string when served at root.
+        ``prefix`` is the resolved public mount prefix (from
+        ``dashboard.public_url`` or ``X-Forwarded-Prefix``) or empty string
+        when served at root.
 
         When the OAuth auth gate is active (``app.state.auth_required``),
         the legacy ``_SESSION_TOKEN`` is NOT injected — the SPA reads
@@ -3901,7 +3902,9 @@ def mount_spa(application: FastAPI):
             WEB_DIST.resolve()
         ):
             return JSONResponse({"error": "not found"}, status_code=404)
-        prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
+        from hermes_cli.dashboard_auth.prefix import effective_prefix_from_request
+
+        prefix = effective_prefix_from_request(request)
         css = css_path.read_text()
         if prefix:
             for asset_dir in ("/fonts/", "/fonts-terminal/", "/ds-assets/", "/assets/"):
@@ -3914,7 +3917,9 @@ def mount_spa(application: FastAPI):
 
     @application.get("/{full_path:path}")
     async def serve_spa(full_path: str, request: Request):
-        prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
+        from hermes_cli.dashboard_auth.prefix import effective_prefix_from_request
+
+        prefix = effective_prefix_from_request(request)
         file_path = WEB_DIST / full_path
         # Prevent path traversal via url-encoded sequences (%2e%2e/)
         if (

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -36,6 +36,7 @@ import pytest
 # web_server.app.state.auth_required at module level.
 pytestmark = pytest.mark.xdist_group("dashboard_auth_app_state")
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
@@ -386,6 +387,109 @@ class TestPublicUrlOverride:
         patch_config("https://from-config.example")
         redirect_uri = self._redirect_uri(gated_app_direct)
         assert redirect_uri == "https://from-config.example/auth/callback"
+
+    def test_public_url_prefix_drives_login_redirects_and_next(
+        self, gated_app_direct, patch_config, monkeypatch
+    ):
+        """The public URL override must not stop at redirect_uri.
+
+        When the operator declares ``https://example.com/hermes``, every
+        outward-facing login URL must use that public mount and the
+        round-trip ``next=`` target must bring the browser back to the
+        same public path, not the backend's stripped ``/sessions`` path.
+        """
+        patch_config(None)
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL", "https://example.com/hermes",
+        )
+
+        r_html = gated_app_direct.get("/sessions", follow_redirects=False)
+        assert r_html.status_code == 302
+        assert r_html.headers["location"] == (
+            "/hermes/login?next=%2Fhermes%2Fsessions"
+        )
+
+        r_api = gated_app_direct.get("/api/sessions?page=2", follow_redirects=False)
+        assert r_api.status_code == 401
+        body = r_api.json()
+        assert body["login_url"].startswith("/hermes/login")
+        assert "%2Fhermes%2Fapi%2Fsessions%3Fpage%3D2" in body["login_url"]
+
+    def test_public_url_prefix_round_trips_callback_landing(
+        self, gated_app_direct, patch_config, monkeypatch
+    ):
+        """The post-login redirect must land on the public path prefix."""
+        patch_config(None)
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL", "https://example.com/hermes",
+        )
+
+        r1 = gated_app_direct.get(
+            "/auth/login?provider=stub&next=%2Fhermes%2Fsessions",
+            follow_redirects=False,
+        )
+        assert r1.status_code == 302
+        pkce_set = next(
+            c for c in r1.headers.get_list("set-cookie")
+            if "hermes_session_pkce" in c
+        )
+        pkce_kv = pkce_set.split(";", 1)[0]
+        state = r1.headers["location"].split("state=")[1]
+
+        r2 = gated_app_direct.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            headers={"cookie": pkce_kv},
+            follow_redirects=False,
+        )
+        assert r2.status_code == 302
+        assert r2.headers["location"] == "/hermes/sessions"
+
+    def test_public_url_prefix_redirects_logout_and_bootstraps_spa(
+        self, gated_app_direct, patch_config, monkeypatch, tmp_path
+    ):
+        """Logout and SPA bootstrap should use the same public mount."""
+        patch_config(None)
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL", "https://example.com/hermes",
+        )
+
+        r_logout = gated_app_direct.post("/auth/logout", follow_redirects=False)
+        assert r_logout.status_code == 302
+        assert r_logout.headers["location"] == "/hermes/login"
+
+        web_dist = tmp_path / "web_dist"
+        assets_dir = web_dist / "assets"
+        assets_dir.mkdir(parents=True)
+        (web_dist / "index.html").write_text(
+            (
+                "<html><head>"
+                '<link rel="stylesheet" href="/assets/app.css">'
+                "</head><body>"
+                '<script src="/assets/app.js"></script>'
+                "</body></html>"
+            ),
+            encoding="utf-8",
+        )
+        (assets_dir / "app.css").write_text("body{}", encoding="utf-8")
+        (assets_dir / "app.js").write_text("console.log('ok')", encoding="utf-8")
+
+        monkeypatch.setattr(web_server, "WEB_DIST", web_dist)
+        prev_required = getattr(web_server.app.state, "auth_required", None)
+        web_server.app.state.auth_required = False
+        try:
+            spa_app = FastAPI()
+            web_server.mount_spa(spa_app)
+            client = TestClient(
+                spa_app,
+                base_url="https://fly-app.fly.dev",
+            )
+            r_index = client.get("/")
+        finally:
+            web_server.app.state.auth_required = prev_required
+
+        assert r_index.status_code == 200
+        assert 'window.__HERMES_BASE_PATH__="/hermes"' in r_index.text
+        assert "/hermes/assets/" in r_index.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow up a890389b6 (feat(dashboard-auth): HERMES_DASHBOARD_PUBLIC_URL / dashboard.public_url override) 
by making `dashboard.public_url` authoritative for the dashboard's public path prefix across the rest of the auth and SPA flow, not just the OAuth callback URL.



## Problem

`a890389b6` taught `_redirect_uri()` to honor `dashboard.public_url`, but sibling outward-facing paths still derived their prefix from `X-Forwarded-Prefix` only.

That left a parity gap in deployments where:
- `dashboard.public_url` includes a path such as `/hermes`
- the proxy does not consistently provide `X-Forwarded-Prefix`

In that setup, the OAuth callback could be correct while login/logout redirects, `next=` round-trips, and SPA asset/base-path handling still emitted unprefixed paths.

## Fix

Introduce a shared public-prefix resolver with this precedence:
1. path component from `dashboard.public_url`
2. `X-Forwarded-Prefix` from the request

Use that resolver for:
- OAuth redirect URI construction
- unauthenticated login redirects and 401 `login_url`
- `next=` target generation
- logout redirect handling
- cookie clear path selection
- SPA bootstrap/base path injection
- CSS/asset URL rewriting

## Tests

Added regression coverage for:
- login redirects using the `dashboard.public_url` path prefix
- `next=` values round-tripping back to the public prefixed path
- callback landing redirecting to `/hermes/...`
- logout redirecting to the prefixed login path
- SPA bootstrap and asset rewriting using the same public prefix

Ran the dashboard auth regression suite:
- 12 files
- 167 tests passed
- 0 failed