### PR TITLE
fix(gateway): repair Telegram topic compression routes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2296,6 +2296,190 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _compression_tip_for_session(self, session_id: str) -> str:
+        """Return the live compression continuation for a session id."""
+        if not session_id:
+            return session_id
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return session_id
+        try:
+            tip = session_db.get_compression_tip(session_id)
+        except Exception:
+            logger.debug("Failed to resolve compression tip", exc_info=True)
+            return session_id
+        return str(tip or session_id)
+
+    def _session_descends_from(
+        self,
+        session_id: str,
+        ancestor_session_id: str,
+    ) -> bool:
+        """Return True when session_id is in ancestor_session_id's child chain."""
+        if not session_id or not ancestor_session_id or session_id == ancestor_session_id:
+            return False
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return False
+        current = str(session_id)
+        ancestor = str(ancestor_session_id)
+        for _ in range(100):
+            try:
+                row = session_db.get_session(current)
+            except Exception:
+                logger.debug("Failed to inspect session parent chain", exc_info=True)
+                return False
+            if not row:
+                return False
+            parent = str(row.get("parent_session_id") or "")
+            if not parent:
+                return False
+            if parent == ancestor:
+                return True
+            current = parent
+        return False
+
+    def _rebind_telegram_topic_binding_to_session(
+        self,
+        source: SessionSource,
+        binding: Dict[str, Any],
+        *,
+        session_key: str,
+        session_id: str,
+    ) -> bool:
+        """Rewrite one Telegram topic binding to a new session id."""
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None or not binding or not session_id:
+            return False
+        chat_id = str(binding.get("chat_id") or source.chat_id or "")
+        thread_id = str(binding.get("thread_id") or source.thread_id or "")
+        if not chat_id or not thread_id:
+            return False
+        try:
+            session_db.bind_telegram_topic(
+                chat_id=chat_id,
+                thread_id=thread_id,
+                user_id=str(binding.get("user_id") or source.user_id or ""),
+                session_key=str(binding.get("session_key") or session_key or ""),
+                session_id=str(session_id),
+                managed_mode=str(binding.get("managed_mode") or "auto"),
+            )
+            return True
+        except Exception:
+            logger.debug("Failed to rewrite Telegram topic binding", exc_info=True)
+            return False
+
+    def _evict_cached_agent_on_session_mismatch(
+        self,
+        session_key: str,
+        canonical_session_id: str,
+    ) -> None:
+        """Evict cached agents that disagree with the canonical route session."""
+        if not session_key or not canonical_session_id:
+            return
+        cache = getattr(self, "_agent_cache", None)
+        lock = getattr(self, "_agent_cache_lock", None)
+        if cache is None or lock is None:
+            return
+        with lock:
+            cached = cache.get(session_key)
+            agent = cached[0] if isinstance(cached, tuple) and cached else cached
+            cached_session_id = (
+                getattr(agent, "session_id", None) if agent is not None else None
+            )
+            if (
+                isinstance(cached_session_id, str)
+                and cached_session_id
+                and cached_session_id != canonical_session_id
+            ):
+                logger.warning(
+                    "Evicting cached agent for %s after session mismatch: agent=%s canonical=%s",
+                    session_key,
+                    cached_session_id,
+                    canonical_session_id,
+                )
+                cache.pop(session_key, None)
+
+    def _repair_telegram_topic_compression_routes(self) -> int:
+        """Repair stale Telegram topic bindings left on compression ancestors."""
+        if self._session_db is None or getattr(self, "session_store", None) is None:
+            return 0
+        repaired = 0
+        try:
+            self.session_store._ensure_loaded()
+        except Exception:
+            logger.debug("Failed to load session store for Telegram topic repair", exc_info=True)
+            return 0
+
+        entries = list(getattr(self.session_store, "_entries", {}).items())
+        for session_key, entry in entries:
+            parsed = _parse_session_key(session_key)
+            if not parsed:
+                continue
+            if parsed.get("platform") != Platform.TELEGRAM.value:
+                continue
+            if parsed.get("chat_type") != "dm" or not parsed.get("thread_id"):
+                continue
+
+            try:
+                binding = self._session_db.get_telegram_topic_binding(
+                    chat_id=str(parsed["chat_id"]),
+                    thread_id=str(parsed["thread_id"]),
+                )
+            except Exception:
+                logger.debug("Failed to read Telegram topic binding during repair", exc_info=True)
+                continue
+            if not binding:
+                continue
+
+            bound_session_id = str(binding.get("session_id") or "")
+            route_session_id = str(getattr(entry, "session_id", "") or "")
+            if not bound_session_id or not route_session_id:
+                continue
+
+            target_session_id = self._compression_tip_for_session(bound_session_id)
+            if (
+                target_session_id == bound_session_id
+                and route_session_id != bound_session_id
+                and self._session_descends_from(route_session_id, bound_session_id)
+            ):
+                target_session_id = route_session_id
+            elif (
+                target_session_id != route_session_id
+                and self._session_descends_from(route_session_id, target_session_id)
+            ):
+                target_session_id = route_session_id
+
+            if target_session_id == bound_session_id:
+                continue
+
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(parsed["chat_id"]),
+                chat_type="dm",
+                thread_id=str(parsed["thread_id"]),
+                user_id=str(binding.get("user_id") or ""),
+            )
+            if self._rebind_telegram_topic_binding_to_session(
+                source,
+                binding,
+                session_key=session_key,
+                session_id=target_session_id,
+            ):
+                repaired += 1
+                logger.info(
+                    "Repaired Telegram topic compression binding for %s: %s -> %s",
+                    session_key,
+                    bound_session_id,
+                    target_session_id,
+                )
+                self._evict_cached_agent_on_session_mismatch(
+                    session_key,
+                    target_session_id,
+                )
+
+        return repaired
+
     def _recover_telegram_topic_thread_id(
         self,
         source: SessionSource,
@@ -4120,6 +4304,16 @@ class GatewayRunner:
                 logger.warning("Auto-suspended %d stuck-loop session(s)", stuck)
         except Exception as e:
             logger.debug("Stuck-loop detection failed: %s", e)
+
+        try:
+            repaired_topic_routes = self._repair_telegram_topic_compression_routes()
+            if repaired_topic_routes:
+                logger.info(
+                    "Repaired %d Telegram topic compression route binding(s)",
+                    repaired_topic_routes,
+                )
+        except Exception as e:
+            logger.debug("Telegram topic compression route repair failed: %s", e)
 
         connected_count = 0
         enabled_platform_count = 0
@@ -8177,7 +8371,57 @@ class GatewayRunner:
                 binding = None
             if binding:
                 bound_session_id = str(binding.get("session_id") or "")
-                if bound_session_id and bound_session_id != session_entry.session_id:
+                compression_tip = self._compression_tip_for_session(bound_session_id)
+                route_session_id = session_entry.session_id
+                if (
+                    compression_tip == bound_session_id
+                    and bound_session_id
+                    and route_session_id
+                    and route_session_id != bound_session_id
+                    and self._session_descends_from(route_session_id, bound_session_id)
+                ):
+                    compression_tip = route_session_id
+                followed_compression_tip = False
+                if compression_tip and compression_tip != bound_session_id:
+                    followed_compression_tip = True
+                    if self._rebind_telegram_topic_binding_to_session(
+                        source,
+                        binding,
+                        session_key=session_key,
+                        session_id=compression_tip,
+                    ):
+                        logger.info(
+                            "Telegram topic binding followed compression: %s -> %s",
+                            bound_session_id,
+                            compression_tip,
+                        )
+                    if compression_tip != route_session_id:
+                        try:
+                            advanced_entry = self.session_store.advance_session_after_compression(
+                                session_key,
+                                route_session_id,
+                                compression_tip,
+                            )
+                            if advanced_entry is not None:
+                                session_entry = advanced_entry
+                        except Exception:
+                            logger.debug(
+                                "Failed to advance Telegram topic route after compression",
+                                exc_info=True,
+                            )
+                            session_entry.session_id = compression_tip
+                        if getattr(session_entry, "session_id", None) != compression_tip:
+                            session_entry.session_id = compression_tip
+                    bound_session_id = compression_tip
+                    self._evict_cached_agent_on_session_mismatch(
+                        session_key,
+                        session_entry.session_id,
+                    )
+                if (
+                    bound_session_id
+                    and bound_session_id != session_entry.session_id
+                    and not followed_compression_tip
+                ):
                     # Route the override through SessionStore so the session_key
                     # → session_id mapping is persisted to disk and the previous
                     # lane session is ended cleanly. Mutating session_entry in
@@ -16665,16 +16909,31 @@ class GatewayRunner:
                 with _cache_lock:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
-                        agent = cached[0]
-                        # Refresh LRU order so the cap enforcement evicts
-                        # truly-oldest entries, not the one we just used.
-                        if hasattr(_cache, "move_to_end"):
-                            try:
-                                _cache.move_to_end(session_key)
-                            except KeyError:
-                                pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
-                        logger.debug("Reusing cached agent for session %s", session_key)
+                        cached_agent = cached[0]
+                        cached_session_id = getattr(cached_agent, "session_id", None)
+                        if (
+                            isinstance(cached_session_id, str)
+                            and cached_session_id
+                            and cached_session_id != session_id
+                        ):
+                            logger.warning(
+                                "Evicting cached agent for %s before turn: agent=%s canonical=%s",
+                                session_key,
+                                cached_session_id,
+                                session_id,
+                            )
+                            _cache.pop(session_key, None)
+                        else:
+                            agent = cached_agent
+                            # Refresh LRU order so the cap enforcement evicts
+                            # truly-oldest entries, not the one we just used.
+                            if hasattr(_cache, "move_to_end"):
+                                try:
+                                    _cache.move_to_end(session_key)
+                                except KeyError:
+                                    pass
+                            self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                            logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
                 # Config changed or first message — create fresh agent
@@ -17228,10 +17487,53 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
+                try:
+                    self.session_store.advance_session_after_compression(
+                        session_key,
+                        session_id,
+                        agent.session_id,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to advance session route after compression",
+                        exc_info=True,
+                    )
+                    entry = self.session_store._entries.get(session_key)
+                    if entry:
+                        entry.session_id = agent.session_id
+                        self.session_store._save()
+
+                if (
+                    getattr(source, "platform", None) == Platform.TELEGRAM
+                    and getattr(source, "chat_type", None) == "dm"
+                    and self._session_db is not None
+                ):
+                    try:
+                        binding = None
+                        if source.thread_id:
+                            binding = self._session_db.get_telegram_topic_binding(
+                                chat_id=str(source.chat_id),
+                                thread_id=str(source.thread_id),
+                            )
+                        if binding is None and hasattr(
+                            self._session_db,
+                            "get_telegram_topic_binding_by_session",
+                        ):
+                            binding = self._session_db.get_telegram_topic_binding_by_session(
+                                session_id=session_id,
+                            )
+                        if binding and str(binding.get("session_id") or "") == session_id:
+                            self._rebind_telegram_topic_binding_to_session(
+                                source,
+                                binding,
+                                session_key=session_key,
+                                session_id=agent.session_id,
+                            )
+                    except Exception:
+                        logger.debug(
+                            "Failed to advance Telegram topic binding after compression",
+                            exc_info=True,
+                        )
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -970,6 +970,48 @@ class SessionStore:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
 
+    def advance_session_after_compression(
+        self,
+        session_key: str,
+        old_session_id: str,
+        new_session_id: str,
+    ) -> Optional[SessionEntry]:
+        """Advance a gateway route after context compression.
+
+        This is narrower than switch_session(). Compression already ended
+        old_session_id with end_reason='compression' and created new_session_id
+        as the continuation, so following that lineage must not re-end the
+        parent as a manual session switch or reopen the child.
+        """
+        if not session_key or not new_session_id:
+            return None
+
+        with self._lock:
+            self._ensure_loaded_locked()
+
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+
+            if entry.session_id == new_session_id:
+                return entry
+
+            if old_session_id and entry.session_id != old_session_id:
+                logger.warning(
+                    "Compression route advance skipped for %s: route points at %s, expected %s -> %s",
+                    session_key,
+                    entry.session_id,
+                    old_session_id,
+                    new_session_id,
+                )
+                return entry
+
+            entry.session_id = new_session_id
+            entry.updated_at = _now()
+            entry.last_prompt_tokens = 0
+            self._save()
+            return entry
+
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -399,6 +399,40 @@ class TestAgentCacheLifecycle:
             assert "session-A" not in runner._agent_cache
             assert "session-B" in runner._agent_cache
 
+    def test_evicts_cached_agent_on_session_mismatch(self):
+        """Cached agents must agree with the canonical route session."""
+        runner = _make_runner()
+        stale_agent = MagicMock()
+        stale_agent.session_id = "compressed-child"
+
+        with runner._agent_cache_lock:
+            runner._agent_cache["session-key"] = (stale_agent, "sig")
+
+        runner._evict_cached_agent_on_session_mismatch(
+            "session-key",
+            "route-parent",
+        )
+
+        with runner._agent_cache_lock:
+            assert "session-key" not in runner._agent_cache
+
+    def test_keeps_cached_agent_on_session_match(self):
+        """Matching cached agents remain reusable."""
+        runner = _make_runner()
+        cached_agent = MagicMock()
+        cached_agent.session_id = "route-session"
+
+        with runner._agent_cache_lock:
+            runner._agent_cache["session-key"] = (cached_agent, "sig")
+
+        runner._evict_cached_agent_on_session_mismatch(
+            "session-key",
+            "route-session",
+        )
+
+        with runner._agent_cache_lock:
+            assert runner._agent_cache["session-key"][0] is cached_agent
+
     def test_reasoning_config_updates_in_place(self):
         """Reasoning config can be set on a cached agent without eviction."""
         from run_agent import AIAgent

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -4,6 +4,8 @@ Topic mode makes the root Telegram DM a system lobby while user-created
 Telegram topics act as independent Hermes session lanes.
 """
 
+import threading
+from collections import OrderedDict
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -101,6 +103,19 @@ def _make_runner(session_db=None):
     runner.session_store.update_session = MagicMock()
     runner.session_store.reset_session = MagicMock(return_value=None)
 
+    def _advance_after_compression(session_key, old_session_id, new_session_id):
+        entry = runner.session_store._entries.get(session_key)
+        if entry is None:
+            return None
+        if not old_session_id or entry.session_id == old_session_id:
+            entry.session_id = new_session_id
+            entry.last_prompt_tokens = 0
+        return entry
+
+    runner.session_store.advance_session_after_compression = MagicMock(
+        side_effect=_advance_after_compression,
+    )
+
     # Default switch_session impl: returns a SessionEntry carrying the target
     # session_id. Mirrors SessionStore.switch_session semantics for tests that
     # exercise Telegram topic binding rebinds without a real store.
@@ -154,6 +169,8 @@ def _make_runner(session_db=None):
     runner._clear_session_boundary_security_state = MagicMock()
     runner._set_session_reasoning_override = MagicMock()
     runner._format_session_info = MagicMock(return_value="")
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = threading.RLock()
     return runner
 
 
@@ -264,6 +281,272 @@ async def test_managed_topic_binding_reuses_restored_session_over_static_lane_se
 
     assert result == "restored response"
     assert captured["session_id"] == "restored-session"
+
+
+@pytest.mark.asyncio
+async def test_topic_binding_follows_compression_tip_without_switch_session(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    chat_id = topic_source.chat_id
+    thread_id = topic_source.thread_id
+    user_id = topic_source.user_id
+    parent_session_id = "topic-parent-session"
+    compressed_session_id = "topic-compressed-session"
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id=chat_id, user_id=user_id)
+    session_db.create_session(
+        session_id=parent_session_id,
+        source="telegram",
+        user_id=user_id,
+    )
+    session_db.end_session(parent_session_id, "compression")
+    session_db.create_session(
+        session_id=compressed_session_id,
+        source="telegram",
+        user_id=user_id,
+        parent_session_id=parent_session_id,
+    )
+    session_db.bind_telegram_topic(
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=user_id,
+        session_key=topic_key,
+        session_id=parent_session_id,
+        managed_mode="restored",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    route_entry = SessionEntry(
+        session_key=topic_key,
+        session_id=parent_session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+    )
+    runner.session_store._entries = {topic_key: route_entry}
+    runner.session_store.get_or_create_session.side_effect = (
+        lambda source, force_new=False: route_entry
+    )
+
+    captured = {}
+    parent_history = [
+        {"role": "user", "content": f"parent message {i}"}
+        for i in range(20)
+    ]
+    compressed_history = [{"role": "user", "content": "compressed summary"}]
+
+    def _load_transcript(session_id):
+        captured["loaded_session_id"] = session_id
+        return (
+            compressed_history
+            if session_id == compressed_session_id
+            else parent_history
+        )
+
+    async def fake_run_agent(*args, **kwargs):
+        captured["run_session_id"] = kwargs.get("session_id")
+        captured["history"] = list(kwargs.get("history") or [])
+        history = list(kwargs.get("history") or [])
+        return {
+            "success": True,
+            "final_response": "compressed response",
+            "session_id": kwargs.get("session_id"),
+            "history_offset": len(history),
+            "messages": history
+            + [
+                {"role": "user", "content": "continue"},
+                {"role": "assistant", "content": "compressed response"},
+            ],
+        }
+
+    runner.session_store.load_transcript.side_effect = _load_transcript
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+    runner._agent_cache[topic_key] = (
+        SimpleNamespace(session_id=parent_session_id),
+        "signature",
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("continue", thread_id="17585"))
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id=chat_id,
+        thread_id=thread_id,
+    )
+    assert result == "compressed response"
+    assert binding is not None
+    assert binding["session_id"] == compressed_session_id
+    assert binding["managed_mode"] == "restored"
+    assert captured["loaded_session_id"] == compressed_session_id
+    assert captured["run_session_id"] == compressed_session_id
+    assert captured["history"] == compressed_history
+    assert topic_key not in runner._agent_cache
+    runner.session_store.switch_session.assert_not_called()
+    assert session_db.get_session(parent_session_id)["end_reason"] == "compression"
+
+
+@pytest.mark.asyncio
+async def test_topic_binding_follows_current_descendant_when_parent_end_reason_was_lost(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    parent_session_id = "topic-parent-session"
+    current_session_id = "topic-current-child"
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(
+        chat_id=topic_source.chat_id,
+        user_id=topic_source.user_id,
+    )
+    session_db.create_session(
+        session_id=parent_session_id,
+        source="telegram",
+        user_id=topic_source.user_id,
+    )
+    # The live bug can corrupt old compression parents to a non-compression
+    # end_reason, so get_compression_tip(parent) returns parent. The gateway
+    # route still points at a descendant and must win over the stale binding.
+    session_db.create_session(
+        session_id=current_session_id,
+        source="telegram",
+        user_id=topic_source.user_id,
+        parent_session_id=parent_session_id,
+    )
+    session_db.bind_telegram_topic(
+        chat_id=topic_source.chat_id,
+        thread_id=topic_source.thread_id,
+        user_id=topic_source.user_id,
+        session_key=topic_key,
+        session_id=parent_session_id,
+        managed_mode="restored",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    route_entry = SessionEntry(
+        session_key=topic_key,
+        session_id=current_session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+    )
+    runner.session_store._entries = {topic_key: route_entry}
+    runner.session_store.get_or_create_session.side_effect = (
+        lambda source, force_new=False: route_entry
+    )
+
+    captured = {}
+    current_history = [{"role": "user", "content": "compressed summary"}]
+
+    def _load_transcript(session_id):
+        captured["loaded_session_id"] = session_id
+        return current_history if session_id == current_session_id else []
+
+    async def fake_run_agent(*args, **kwargs):
+        captured["run_session_id"] = kwargs.get("session_id")
+        captured["history"] = list(kwargs.get("history") or [])
+        return {
+            "success": True,
+            "final_response": "current response",
+            "session_id": kwargs.get("session_id"),
+            "history_offset": len(kwargs.get("history") or []),
+            "messages": list(kwargs.get("history") or []),
+        }
+
+    runner.session_store.load_transcript.side_effect = _load_transcript
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("continue", thread_id="17585"))
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id=topic_source.chat_id,
+        thread_id=topic_source.thread_id,
+    )
+    assert result == "current response"
+    assert binding is not None
+    assert binding["session_id"] == current_session_id
+    assert captured["loaded_session_id"] == current_session_id
+    assert captured["run_session_id"] == current_session_id
+    assert captured["history"] == current_history
+    runner.session_store.switch_session.assert_not_called()
+
+
+def test_startup_repair_rebinds_stale_topic_binding_to_route_descendant(tmp_path):
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    parent_session_id = "topic-parent-session"
+    current_session_id = "topic-current-child"
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(
+        chat_id=topic_source.chat_id,
+        user_id=topic_source.user_id,
+    )
+    session_db.create_session(
+        session_id=parent_session_id,
+        source="telegram",
+        user_id=topic_source.user_id,
+    )
+    session_db.create_session(
+        session_id=current_session_id,
+        source="telegram",
+        user_id=topic_source.user_id,
+        parent_session_id=parent_session_id,
+    )
+    session_db.bind_telegram_topic(
+        chat_id=topic_source.chat_id,
+        thread_id=topic_source.thread_id,
+        user_id=topic_source.user_id,
+        session_key=topic_key,
+        session_id=parent_session_id,
+        managed_mode="restored",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    route_entry = SessionEntry(
+        session_key=topic_key,
+        session_id=current_session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+    )
+    runner.session_store._entries = {topic_key: route_entry}
+    runner._agent_cache[topic_key] = (
+        SimpleNamespace(session_id=parent_session_id),
+        "signature",
+    )
+
+    repaired = runner._repair_telegram_topic_compression_routes()
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id=topic_source.chat_id,
+        thread_id=topic_source.thread_id,
+    )
+    assert repaired == 1
+    assert binding is not None
+    assert binding["session_id"] == current_session_id
+    assert binding["managed_mode"] == "restored"
+    assert topic_key not in runner._agent_cache
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- canonicalize Telegram topic bindings through compression tips/current descendants before transcript load
- rebind stale topic lanes to the live compression continuation and evict cached agents whose session id no longer matches the route
- advance compression routes without using switch_session(), preserving compression end_reason

Closes #33414

## Related
- Earlier issue: #25921
- Earlier PR on the same topic: #26204
- Related competing fix: #26088

## Tests
- `python -m pytest tests/gateway/test_telegram_topic_mode.py tests/gateway/test_agent_cache.py -q`
  - 103 passed