### PR TITLE
fix(tools): invalidate tool caches on dotenv reload

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -156,6 +156,22 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     _sanitize_loaded_credentials()
 
 
+def _invalidate_tool_availability_caches() -> None:
+    """Clear tool availability caches after environment reloads.
+
+    Avoid importing ``model_tools`` solely to clear an empty cache: importing it
+    performs tool discovery. If the modules are loaded, their caches may be
+    stale; if they are not loaded, there is nothing to invalidate.
+    """
+    for module_name, function_name in (
+        ("tools.registry", "invalidate_check_fn_cache"),
+        ("model_tools", "_clear_tool_defs_cache"),
+    ):
+        clear_cache = getattr(sys.modules.get(module_name), function_name, None)
+        if callable(clear_cache):
+            clear_cache()
+
+
 def _sanitize_env_file_if_needed(path: Path) -> None:
     """Pre-sanitize a .env file before python-dotenv reads it.
 
@@ -243,6 +259,7 @@ def load_hermes_dotenv(
         loaded.append(project_env_path)
 
     _apply_external_secret_sources(home_path)
+    _invalidate_tool_availability_caches()
 
     return loaded
 

--- a/tests/gateway/test_runtime_env_reload_config_authority.py
+++ b/tests/gateway/test_runtime_env_reload_config_authority.py
@@ -51,3 +51,38 @@ def test_reload_runtime_env_keeps_env_max_iterations_when_config_omits_key(
     gateway_run._reload_runtime_env_preserving_config_authority()
 
     assert os.environ["HERMES_MAX_ITERATIONS"] == "123"
+
+
+def test_reload_runtime_env_invalidates_tool_availability_caches(
+    tmp_path: Path, monkeypatch
+) -> None:
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    env_file = hermes_home / ".env"
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.delenv("HASS_TOKEN", raising=False)
+
+    from model_tools import _clear_tool_defs_cache, get_tool_definitions
+    from tools.registry import invalidate_check_fn_cache
+
+    _clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+    try:
+        unavailable = get_tool_definitions(
+            enabled_toolsets=["homeassistant"], quiet_mode=True
+        )
+        unavailable_names = {tool["function"]["name"] for tool in unavailable}
+        assert "ha_list_entities" not in unavailable_names
+
+        env_file.write_text("HASS_TOKEN=fresh-token\n", encoding="utf-8")
+        gateway_run._reload_runtime_env_preserving_config_authority()
+
+        available = get_tool_definitions(
+            enabled_toolsets=["homeassistant"], quiet_mode=True
+        )
+        available_names = {tool["function"]["name"] for tool in available}
+        assert "ha_list_entities" in available_names
+    finally:
+        _clear_tool_defs_cache()
+        invalidate_check_fn_cache()

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -103,3 +103,36 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_dotenv_reload_invalidates_tool_availability_caches(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+
+    monkeypatch.delenv("HASS_TOKEN", raising=False)
+
+    from model_tools import _clear_tool_defs_cache, get_tool_definitions
+    from tools.registry import invalidate_check_fn_cache
+
+    _clear_tool_defs_cache()
+    invalidate_check_fn_cache()
+    try:
+        unavailable = get_tool_definitions(
+            enabled_toolsets=["homeassistant"], quiet_mode=True
+        )
+        unavailable_names = {tool["function"]["name"] for tool in unavailable}
+        assert "ha_list_entities" not in unavailable_names
+
+        env_file.write_text("HASS_TOKEN=fresh-token\n", encoding="utf-8")
+        loaded = load_hermes_dotenv(hermes_home=home)
+
+        assert loaded == [env_file]
+        available = get_tool_definitions(
+            enabled_toolsets=["homeassistant"], quiet_mode=True
+        )
+        available_names = {tool["function"]["name"] for tool in available}
+        assert "ha_list_entities" in available_names
+    finally:
+        _clear_tool_defs_cache()
+        invalidate_check_fn_cache()


### PR DESCRIPTION
Fixes #30565 — tool availability caches (`_check_fn_cache`, `_tool_defs_cache`) are not invalidated after `.env` reloads, so env-gated toolsets (e.g. Discord) can remain silently unavailable after their required variables are added to `~/.hermes/.env`.

Root-cause trace posted at https://github.com/NousResearch/hermes-agent/issues/30565#issuecomment-4557380468.

## Changes

- `hermes_cli/env_loader.py`: call `invalidate_check_fn_cache()` and `_clear_tool_defs_cache()` after dotenv and external secret reloads; uses `sys.modules.get()` to avoid importing `model_tools` solely for cache clearing when it has not been loaded.
- `tests/hermes_cli/test_env_loader.py`: regression test verifying a previously-unavailable env-gated toolset (`homeassistant` / `HASS_TOKEN`) becomes available after `load_hermes_dotenv()`.
- `tests/gateway/test_runtime_env_reload_config_authority.py`: same regression coverage through the gateway runtime `_reload_runtime_env_preserving_config_authority()` path.

## Validation

| | Before | After |
|---|---|---|
| Env-gated tool added to `.env` at runtime | Stale `False` persists in `_check_fn_cache` (30s) and indefinitely in `_tool_defs_cache` | Caches cleared; next `get_tool_definitions()` picks up new env state |
| `load_hermes_dotenv()` + gateway reload tests | — | 10/10 pass |