### PR TITLE
fix(codex): drop dead model slugs that HTTP 400 on ChatGPT Pro

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -29,21 +29,29 @@ DEFAULT_CODEX_MODELS: List[str] = [
     # curated fallback so Pro users still see Spark in `/model` when live
     # discovery is unavailable (offline first run, transient API failure).
     "gpt-5.3-codex-spark",
-    "gpt-5.2-codex",
-    "gpt-5.1-codex-max",
-    "gpt-5.1-codex-mini",
+    # NOTE: gpt-5.2-codex / gpt-5.1-codex-max / gpt-5.1-codex-mini were
+    # previously listed here but the chatgpt.com Codex backend returns
+    # HTTP 400 "The '<model>' model is not supported when using Codex with
+    # a ChatGPT account." for all three on every ChatGPT Pro account we've
+    # tested (verified live 2026-05-27). Keeping them in the fallback list
+    # leaked dead slugs into /model when live discovery was unavailable
+    # (transient API failure, first-run before refresh) and surfaced HTTP 400
+    # crashes on selection. The Codex CLI public catalog still references
+    # these slugs, which is why they survived previously — but those entries
+    # describe the public OpenAI API, not the OAuth-backed Codex backend
+    # Hermes uses. Removed here. If OpenAI re-enables them on Codex backend,
+    # live discovery will pick them up automatically via _fetch_models_from_api.
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
-    ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
-    ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
-    ("gpt-5.3-codex", ("gpt-5.2-codex",)),
+    ("gpt-5.4-mini", ("gpt-5.3-codex",)),
+    ("gpt-5.4", ("gpt-5.3-codex",)),
     # Surface Spark whenever any compatible Codex template is present so
     # accounts hitting the live endpoint with an older lineup still see
     # Spark in the picker. Backend gates real availability by ChatGPT Pro
     # entitlement; Hermes does not.
-    ("gpt-5.3-codex-spark", ("gpt-5.3-codex", "gpt-5.2-codex")),
+    ("gpt-5.3-codex-spark", ("gpt-5.3-codex",)),
 ]
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -60,16 +60,19 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",
-        lambda access_token: ["gpt-5.2-codex"],
+        lambda access_token: ["gpt-5.3-codex"],
     )
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
+    # When live discovery only returns gpt-5.3-codex, forward-compat synthesis
+    # should surface gpt-5.5, gpt-5.4, gpt-5.4-mini, and gpt-5.3-codex-spark
+    # (each is templated off gpt-5.3-codex).
     assert models == [
-        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+        "gpt-5.5",
         "gpt-5.4-mini",
         "gpt-5.4",
-        "gpt-5.3-codex",
         "gpt-5.3-codex-spark",
     ]
 


### PR DESCRIPTION
## Summary
Remove three dead Codex-CLI slugs from the `openai-codex` OAuth fallback list. The chatgpt.com Codex backend rejects them with HTTP 400 for every ChatGPT Pro account we tested live today.

Affected slugs:
- `gpt-5.2-codex`
- `gpt-5.1-codex-max`
- `gpt-5.1-codex-mini`

Backend response on every call:
```
HTTP 400 {'detail': "The '<slug>' model is not supported when using Codex with a ChatGPT account."}
```

Reproducible live against `https://chatgpt.com/backend-api/codex/models?client_version=1.0.0` — the live list returns 6 slugs (gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), none of which are the three removed here.

## Why this matters
Whenever `_fetch_models_from_api()` falls back to `DEFAULT_CODEX_MODELS` (transient network failure, first-run before cache, no token yet) the picker surfaced these dead slugs and HTTP 400'd on selection. The forward-compat synthesis table chained them downstream too.

## Changes
- `hermes_cli/codex_models.py`:
  - drop the 3 dead slugs from `DEFAULT_CODEX_MODELS`
  - drop them from `_FORWARD_COMPAT_TEMPLATE_MODELS` driver/synthetic positions
  - explanatory comment so they don't get re-added from the public Codex CLI catalog
- `tests/hermes_cli/test_codex_models.py`: pivot the forward-compat test driver from `gpt-5.2-codex` (now removed) to `gpt-5.3-codex` (which is templated by 4 entries — gpt-5.5, gpt-5.4-mini, gpt-5.4, gpt-5.3-codex-spark — so still exercises the synthesis path)

The Copilot, opencode-zen, openai (public API) and openai-api lists in `hermes_cli/models.py` still reference these slugs — those providers may accept them, scope is intentionally limited to `openai-codex` OAuth.

## Validation
- Live verified `chatgpt.com/backend-api/codex/models` returns 6 slugs, none matching the 3 removed
- Targeted suite: 285/285 pass across `test_codex_models.py`, `test_cli_provider_resolution.py`, `test_fast_command.py`, `test_model_metadata.py`, `test_model_validation.py`, `test_copilot_auth.py`, `test_image_generation_plugin_dispatch.py`
- E2E: `get_codex_model_ids()` with no API access now returns `['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.3-codex-spark']` — all 5 live-verified working against the OAuth backend earlier today
- Live test E (separate session): 5/5 working models pass identical prompts in 1.84-5.03s; same test confirmed the 3 removed slugs all crash with HTTP 400

## Forward path
If OpenAI re-enables these on the Codex backend, `_fetch_models_from_api()` will pick them up automatically — no code change needed. The defaults list is only consulted when live discovery is unavailable.
