### PR TITLE
feat: add personal reminder brief helper

### DIFF
--- a/docs/plans/2026-05-28-personal-reminder-brief-helper.md
+++ b/docs/plans/2026-05-28-personal-reminder-brief-helper.md
@@ -1,0 +1,52 @@
+# Personal Reminder Brief Helper Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a small local-first script that turns a YAML/JSON reminder list into a Joe-style morning brief with due/soon/overdue grouping and exact `[SILENT]` support.
+
+**Architecture:** Keep the helper standalone under `scripts/` so it can be used by cron script hooks without adding new runtime services or private data access. Parse YAML/JSON reminders, classify them by date against an explicit `--today`, and render Traditional Chinese markdown.
+
+**Tech Stack:** Python standard library + PyYAML (already a core dependency), pytest via `scripts/run_tests.sh`.
+
+---
+
+### Task 1: Add tests for reminder parsing and due classification
+
+**Objective:** Define the desired behavior before implementation.
+
+**Files:**
+- Create: `tests/scripts/test_personal_reminder_brief.py`
+- Create: `scripts/personal_reminder_brief.py`
+
+**Steps:**
+1. Write tests that load the script via `importlib.util.spec_from_file_location` and register it in `sys.modules` before executing.
+2. Cover YAML/JSON parsing into reminders.
+3. Cover overdue, due today, and soon classification.
+4. Cover completed/future-only reminders returning exact `[SILENT]`.
+5. Run focused test and verify RED: `scripts/run_tests.sh tests/scripts/test_personal_reminder_brief.py -q` should fail because the script is missing.
+
+### Task 2: Implement minimal reminder brief helper
+
+**Objective:** Make the tests pass with a reversible standalone script.
+
+**Files:**
+- Create: `scripts/personal_reminder_brief.py`
+
+**Steps:**
+1. Add a `Reminder` dataclass with title, due date, optional cadence, area, action, source, completed flag, and notes.
+2. Add `load_reminders(path)`, `classify_reminders(reminders, today, soon_days)`, and `render_brief(...)` functions.
+3. Add a CLI with `--input`, `--today`, `--soon-days`, and `--silent-if-empty`.
+4. Run focused tests and smoke-check sample YAML output plus empty `[SILENT]` output.
+
+### Task 3: Verify and prepare PR
+
+**Objective:** Leave a clean, reviewable PR.
+
+**Files:**
+- Modify: generated files only from Tasks 1-2.
+
+**Steps:**
+1. Run `scripts/run_tests.sh tests/scripts/test_personal_reminder_brief.py -q`.
+2. Run `python scripts/personal_reminder_brief.py --help`.
+3. Commit with `feat: add personal reminder brief helper`.
+4. Push to Joe fork and open a PR against `NousResearch/hermes-agent:main`.

--- a/scripts/personal_reminder_brief.py
+++ b/scripts/personal_reminder_brief.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Render a local-first personal reminder morning brief.
+
+Input is a small YAML/JSON reminder list, for example:
+
+reminders:
+  - title: Clean fridge
+    due: 2026-05-28
+    cadence: monthly
+    area: home
+    action: Throw expired food and wipe shelves.
+    source: Joe Operating Manual
+
+The script intentionally only reads local files and prints markdown. It does
+not create reminders, send messages, or modify user data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Reminder:
+    """A single local reminder item."""
+
+    title: str
+    due: date
+    cadence: str = ""
+    area: str = ""
+    action: str = ""
+    source: str = ""
+    notes: tuple[str, ...] = field(default_factory=tuple)
+    completed: bool = False
+
+
+@dataclass(frozen=True)
+class ReminderGroups:
+    """Actionable reminders grouped by urgency."""
+
+    overdue: tuple[Reminder, ...]
+    today: tuple[Reminder, ...]
+    soon: tuple[Reminder, ...]
+
+    @property
+    def has_items(self) -> bool:
+        return bool(self.overdue or self.today or self.soon)
+
+    @property
+    def count(self) -> int:
+        return len(self.overdue) + len(self.today) + len(self.soon)
+
+
+class ReminderBriefError(ValueError):
+    """Raised when reminder input is invalid."""
+
+
+def _parse_date(value: Any) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise ReminderBriefError(f"Invalid due date {value!r}; expected YYYY-MM-DD") from exc
+    raise ReminderBriefError(f"Invalid due date {value!r}; expected YYYY-MM-DD")
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "done", "completed"}
+    return bool(value)
+
+
+def _as_notes(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,) if value.strip() else ()
+    if isinstance(value, Iterable):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    return (str(value).strip(),) if str(value).strip() else ()
+
+
+def _coerce_reminder(raw: Any) -> Reminder:
+    if not isinstance(raw, dict):
+        raise ReminderBriefError("Each reminder must be an object")
+    title = str(raw.get("title") or "").strip()
+    if not title:
+        raise ReminderBriefError("Reminder is missing required field: title")
+    if "due" not in raw:
+        raise ReminderBriefError(f"Reminder {title!r} is missing required field: due")
+    return Reminder(
+        title=title,
+        due=_parse_date(raw["due"]),
+        cadence=str(raw.get("cadence") or "").strip(),
+        area=str(raw.get("area") or "").strip(),
+        action=str(raw.get("action") or "").strip(),
+        source=str(raw.get("source") or "").strip(),
+        notes=_as_notes(raw.get("notes")),
+        completed=_as_bool(raw.get("completed", raw.get("done", False))),
+    )
+
+
+def load_reminders(path: str | Path) -> list[Reminder]:
+    """Load reminders from a YAML/JSON file.
+
+    Accepts either a top-level list or an object with a ``reminders`` list.
+    """
+
+    reminder_path = Path(path)
+    text = reminder_path.read_text(encoding="utf-8")
+    if reminder_path.suffix.lower() == ".json":
+        data = json.loads(text)
+    else:
+        data = yaml.safe_load(text) or {}
+
+    raw_reminders = data.get("reminders") if isinstance(data, dict) else data
+    if raw_reminders is None:
+        raw_reminders = []
+    if not isinstance(raw_reminders, list):
+        raise ReminderBriefError("Input must be a list or contain a reminders list")
+    return [_coerce_reminder(item) for item in raw_reminders]
+
+
+def classify_reminders(
+    reminders: Iterable[Reminder], *, today: date | None = None, soon_days: int = 7
+) -> ReminderGroups:
+    """Group incomplete reminders into overdue, today, and soon buckets."""
+
+    anchor = today or date.today()
+    overdue: list[Reminder] = []
+    due_today: list[Reminder] = []
+    soon: list[Reminder] = []
+    for reminder in reminders:
+        if reminder.completed:
+            continue
+        days_until_due = (reminder.due - anchor).days
+        if days_until_due < 0:
+            overdue.append(reminder)
+        elif days_until_due == 0:
+            due_today.append(reminder)
+        elif days_until_due <= soon_days:
+            soon.append(reminder)
+
+    key = lambda item: (item.due, item.title.lower())
+    return ReminderGroups(
+        overdue=tuple(sorted(overdue, key=key)),
+        today=tuple(sorted(due_today, key=key)),
+        soon=tuple(sorted(soon, key=key)),
+    )
+
+
+def _format_reminder(reminder: Reminder, anchor: date) -> str:
+    day_delta = (reminder.due - anchor).days
+    if day_delta < 0:
+        timing = f"逾期 {abs(day_delta)} 天"
+    elif day_delta == 0:
+        timing = "今天到期"
+    else:
+        timing = f"{day_delta} 天後到期"
+
+    meta = [f"due {reminder.due.isoformat()}", timing]
+    if reminder.cadence:
+        meta.append(f"cadence: {reminder.cadence}")
+    if reminder.area:
+        meta.append(f"area: {reminder.area}")
+    line = f"- **{reminder.title}** ({'; '.join(meta)})"
+    details: list[str] = []
+    if reminder.action:
+        details.append(f"  - Action for Joe: {reminder.action}")
+    if reminder.source:
+        details.append(f"  - Source: {reminder.source}")
+    for note in reminder.notes:
+        details.append(f"  - Note: {note}")
+    return "\n".join([line, *details])
+
+
+def render_brief(
+    groups: ReminderGroups, *, today: date | None = None, silent_if_empty: bool = False
+) -> str:
+    """Render grouped reminders as a Joe-style Traditional Chinese markdown brief."""
+
+    anchor = today or date.today()
+    if not groups.has_items:
+        if silent_if_empty:
+            return "[SILENT]"
+        return "## TL;DR\n- 今天沒有到期、逾期或近期提醒。"
+
+    lines = [
+        "## TL;DR",
+        f"- {anchor.isoformat()} 有 {groups.count} 個需要注意的個人提醒。",
+        "- 建議：先處理逾期與今天到期項目；近期項目只做排程，不要過度佔用今天注意力。",
+        "",
+        "## Fact / verified",
+        "- 來源是本機 YAML/JSON 檔；此腳本只讀取檔案並輸出 Markdown，不會建立提醒、不會發訊息。",
+    ]
+
+    buckets = [
+        ("逾期", groups.overdue),
+        ("今天到期", groups.today),
+        ("未來 7 天內", groups.soon),
+    ]
+    for heading, reminders in buckets:
+        if not reminders:
+            continue
+        lines.extend(["", f"### {heading}"])
+        lines.extend(_format_reminder(reminder, anchor) for reminder in reminders)
+
+    lines.extend(
+        [
+            "",
+            "## Action for Joe",
+            "- 如果提醒仍有效：手動執行或排進今天行程。",
+            "- 如果提醒已不重要：在來源檔標記 `completed: true`，下次輸出會自動安靜。",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render a personal reminder morning brief")
+    parser.add_argument("--input", required=True, help="YAML/JSON reminder file")
+    parser.add_argument("--today", help="Override today's date as YYYY-MM-DD")
+    parser.add_argument("--soon-days", type=int, default=7, help="Include reminders due within N days")
+    parser.add_argument(
+        "--silent-if-empty",
+        action="store_true",
+        help="Print exact [SILENT] when no actionable reminders exist",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    anchor = _parse_date(args.today) if args.today else date.today()
+    reminders = load_reminders(args.input)
+    groups = classify_reminders(reminders, today=anchor, soon_days=args.soon_days)
+    print(render_brief(groups, today=anchor, silent_if_empty=args.silent_if_empty))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_personal_reminder_brief.py
+++ b/tests/scripts/test_personal_reminder_brief.py
@@ -1,0 +1,136 @@
+"""Tests for scripts/personal_reminder_brief.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "personal_reminder_brief.py"
+    spec = importlib.util.spec_from_file_location("_personal_reminder_brief", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_reminders_accepts_yaml_and_normalizes_fields(tmp_path):
+    module = _load_module()
+    data_path = tmp_path / "reminders.yaml"
+    data_path.write_text(
+        """
+reminders:
+  - title: Clean fridge
+    due: 2026-05-28
+    cadence: monthly
+    area: home
+    action: Throw expired food and wipe shelves.
+    source: Joe Operating Manual
+  - title: Future item
+    due: 2026-07-01
+    done: true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    reminders = module.load_reminders(data_path)
+
+    assert [r.title for r in reminders] == ["Clean fridge", "Future item"]
+    assert reminders[0].due == date(2026, 5, 28)
+    assert reminders[0].cadence == "monthly"
+    assert reminders[0].area == "home"
+    assert reminders[0].action == "Throw expired food and wipe shelves."
+    assert reminders[0].source == "Joe Operating Manual"
+    assert reminders[1].completed is True
+
+
+def test_load_reminders_accepts_json_list(tmp_path):
+    module = _load_module()
+    data_path = tmp_path / "reminders.json"
+    data_path.write_text(
+        json.dumps([
+            {"title": "AC cleaning", "due": "2026-05-30", "cadence": "quarterly"}
+        ]),
+        encoding="utf-8",
+    )
+
+    reminders = module.load_reminders(data_path)
+
+    assert len(reminders) == 1
+    assert reminders[0].title == "AC cleaning"
+    assert reminders[0].due == date(2026, 5, 30)
+
+
+def test_classify_reminders_groups_overdue_today_and_soon():
+    module = _load_module()
+    reminders = [
+        module.Reminder(title="Overdue", due=date(2026, 5, 26)),
+        module.Reminder(title="Today", due=date(2026, 5, 28)),
+        module.Reminder(title="Soon", due=date(2026, 5, 31)),
+        module.Reminder(title="Later", due=date(2026, 6, 20)),
+        module.Reminder(title="Done", due=date(2026, 5, 27), completed=True),
+    ]
+
+    groups = module.classify_reminders(reminders, today=date(2026, 5, 28), soon_days=7)
+
+    assert [r.title for r in groups.overdue] == ["Overdue"]
+    assert [r.title for r in groups.today] == ["Today"]
+    assert [r.title for r in groups.soon] == ["Soon"]
+    assert groups.has_items is True
+
+
+def test_render_brief_outputs_joe_style_traditional_chinese_sections():
+    module = _load_module()
+    reminders = [
+        module.Reminder(
+            title="Clean fridge",
+            due=date(2026, 5, 28),
+            cadence="monthly",
+            area="home",
+            action="Throw expired food and wipe shelves.",
+            source="Joe Operating Manual",
+        )
+    ]
+    groups = module.classify_reminders(reminders, today=date(2026, 5, 28), soon_days=7)
+
+    brief = module.render_brief(groups, today=date(2026, 5, 28), silent_if_empty=True)
+
+    assert brief.startswith("## TL;DR")
+    assert "Fact / verified" in brief
+    assert "Action for Joe" in brief
+    assert "Clean fridge" in brief
+    assert "2026-05-28" in brief
+    assert "Joe Operating Manual" in brief
+
+
+def test_render_brief_can_return_exact_silent_for_no_actionable_items():
+    module = _load_module()
+    reminders = [module.Reminder(title="Later", due=date(2026, 7, 1))]
+    groups = module.classify_reminders(reminders, today=date(2026, 5, 28), soon_days=7)
+
+    assert module.render_brief(groups, today=date(2026, 5, 28), silent_if_empty=True) == "[SILENT]"
+
+
+def test_cli_prints_exact_silent_when_requested_and_empty(tmp_path, capsys):
+    module = _load_module()
+    data_path = tmp_path / "reminders.yaml"
+    data_path.write_text(
+        "reminders:\n  - title: Later\n    due: 2026-07-01\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main([
+        "--input",
+        str(data_path),
+        "--today",
+        "2026-05-28",
+        "--silent-if-empty",
+    ])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == "[SILENT]\n"


### PR DESCRIPTION
## Summary
- Add `scripts/personal_reminder_brief.py`, a local-first YAML/JSON reminder brief renderer for Joe-style morning cron outputs.
- Group incomplete reminders into overdue, due today, and soon buckets.
- Support exact `[SILENT]` output when there are no actionable reminders, so scheduled jobs can suppress noise.
- Add a spec plan and focused tests for parsing, classification, rendering, and CLI behavior.

## Why this helps
- Turns small personal/household reminders into a low-friction morning brief without sending messages, creating reminders, deploying services, or touching private platforms.
- Keeps the workflow reversible: edit a local YAML/JSON file, run the script, and optionally wire it into an existing cron script hook later.

## Test Plan
- [x] `python -m pytest tests/scripts/test_personal_reminder_brief.py -q -o 'addopts='`
- [x] `python -m ruff check scripts/personal_reminder_brief.py tests/scripts/test_personal_reminder_brief.py`
- [x] `python -m py_compile scripts/personal_reminder_brief.py tests/scripts/test_personal_reminder_brief.py`
- [x] `python scripts/personal_reminder_brief.py --input .hermes/tmp-reminders.yaml --today 2026-05-28 --silent-if-empty`
- [x] `python scripts/personal_reminder_brief.py --input .hermes/tmp-empty-reminders.yaml --today 2026-05-28 --silent-if-empty`
- [x] `python scripts/personal_reminder_brief.py --help`

## Note
- `scripts/run_tests.sh tests/scripts/test_personal_reminder_brief.py` currently fails in this local worktree before collection because the shared Hermes dev venv is missing `pytest-timeout` (`No module named pytest_timeout`) and has no `pip`; I used the documented direct-pytest fallback with `-o 'addopts='` for the focused smoke check.
