### PR TITLE
fix(vision): honor explicit gemini provider in resolve_vision_provider_client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3834,6 +3834,8 @@ def _resolve_strict_vision_backend(
         return resolve_provider_client("openai-codex", model, is_vision=True)
     if provider == "anthropic":
         return _try_anthropic()
+    if provider == "gemini":
+        return resolve_provider_client("gemini", model, is_vision=True)
     if provider == "custom":
         return _try_custom_endpoint()
     return None, None

--- a/tests/agent/test_gemini_vision_provider.py
+++ b/tests/agent/test_gemini_vision_provider.py
@@ -1,0 +1,127 @@
+"""Tests for explicit gemini vision provider resolution.
+
+Regression tests for #33389: when auxiliary.vision.provider is explicitly
+set to gemini, the vision routing should honor it instead of falling through
+to the generic _get_cached_client path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestGeminiVisionExplicitProvider:
+    """Explicit ``auxiliary.vision.provider: gemini`` must route correctly."""
+
+    def test_explicit_gemini_vision_returns_client(self, monkeypatch):
+        """_resolve_strict_vision_backend('gemini') must return a client,
+        not (None, None)."""
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        fake_client = MagicMock(name="gemini_client")
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            lambda provider, model=None, **kw: (fake_client, "gemini-3.5-flash")
+            if provider == "gemini"
+            else (None, None),
+        )
+
+        client, default_model = _resolve_strict_vision_backend("gemini")
+        assert client is fake_client
+        assert default_model == "gemini-3.5-flash"
+
+    def test_explicit_gemini_vision_passes_is_vision(self, monkeypatch):
+        """_resolve_strict_vision_backend('gemini') must pass is_vision=True
+        to resolve_provider_client so the client is flagged correctly."""
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        rpc_calls = []
+        fake_client = MagicMock(name="gemini_client")
+
+        def fake_rpc(provider, model=None, **kwargs):
+            rpc_calls.append((provider, kwargs))
+            return (fake_client, "gemini-3.5-flash") if provider == "gemini" else (None, None)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            fake_rpc,
+        )
+
+        _resolve_strict_vision_backend("gemini")
+        assert len(rpc_calls) == 1
+        assert rpc_calls[0][0] == "gemini"
+        assert rpc_calls[0][1].get("is_vision") is True
+
+    def test_explicit_gemini_vision_with_model_override(self, monkeypatch):
+        """When caller passes a model, it should flow through."""
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        fake_client = MagicMock(name="gemini_client")
+        captured = {}
+
+        def fake_rpc(provider, model=None, **kwargs):
+            captured["model"] = model
+            return (fake_client, model or "gemini-3.5-flash") if provider == "gemini" else (None, None)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            fake_rpc,
+        )
+
+        client, model = _resolve_strict_vision_backend("gemini", model="gemini-2.5-pro")
+        assert client is fake_client
+        assert captured["model"] == "gemini-2.5-pro"
+
+    def test_explicit_gemini_vision_no_credentials(self, monkeypatch):
+        """When Gemini has no API key, _resolve_strict_vision_backend
+        should return (None, None) gracefully."""
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            lambda provider, model=None, **kw: (None, None),
+        )
+
+        client, model = _resolve_strict_vision_backend("gemini")
+        assert client is None
+        assert model is None
+
+    def test_resolve_vision_provider_client_explicit_gemini(self, monkeypatch):
+        """End-to-end: resolve_vision_provider_client(provider='gemini')
+        should return a gemini client, not fall through to generic path."""
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        fake_client = MagicMock(name="gemini_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *a, **kw: ("gemini", "gemini-3.5-flash", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            lambda *args, **kwargs: (fake_client, "gemini-3.5-flash")
+            if args and args[0] == "gemini"
+            else (None, None),
+        )
+
+        provider, client, model = resolve_vision_provider_client(provider="gemini")
+        assert provider == "gemini"
+        assert client is fake_client
+        assert model == "gemini-3.5-flash"
+
+    def test_gemini_aliases_normalize_to_gemini(self, monkeypatch):
+        """Provider aliases like 'google' and 'google-gemini' should
+        normalize to 'gemini' and still work."""
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        fake_client = MagicMock(name="gemini_client")
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            lambda provider, model=None, **kw: (fake_client, "gemini-3.5-flash")
+            if provider == "gemini"
+            else (None, None),
+        )
+
+        for alias in ("google", "google-gemini", "google-ai-studio"):
+            client, model = _resolve_strict_vision_backend(alias)
+            assert client is fake_client, f"alias {alias!r} failed"


### PR DESCRIPTION
## What does this PR do?

When `auxiliary.vision.provider` is explicitly set to `gemini` in config.yaml, the vision routing in `resolve_vision_provider_client()` now honors it instead of falling through to the generic `_get_cached_client()` path.

Previously, gemini was not listed in `_resolve_strict_vision_backend()`, so explicit gemini config would either silently fall back to the main provider (which may be text-only like DeepSeek) or produce a client that could not handle the native Gemini endpoint correctly.

## Related Issue

Fixes #33389

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — added `gemini` branch to `_resolve_strict_vision_backend()` (2 lines). Delegates to the existing `resolve_provider_client("gemini", ...)` which already handles both the native Gemini endpoint (`GeminiNativeClient` with `x-goog-api-key` auth) and the OpenAI-compatible endpoint.
- `tests/agent/test_gemini_vision_provider.py` — 6 unit tests covering explicit gemini vision resolution, `is_vision=True` passthrough, model override, no-credentials graceful fallback, end-to-end `resolve_vision_provider_client()`, and alias normalization (`google`, `google-gemini`, `google-ai-studio`).

## How to Test

1. Set `GEMINI_API_KEY` in `.env`
2. Set `auxiliary.vision.provider: gemini` and `auxiliary.vision.model: gemini-3.5-flash` in `config.yaml`
3. Run: `python -m pytest tests/agent/test_gemini_vision_provider.py tests/agent/test_auxiliary_client.py -v -k "vision"`
4. Confirm all 18 tests pass (6 new, 12 existing vision tests)
5. Send an image via a vision-capable tool — verify it routes to Gemini instead of falling back to main provider

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I have run `pytest tests/ -q` and all tests pass (218 tested, 0 regressions)
- [x] I have added tests for my changes
- [x] I have tested on my platform: Linux (Ubuntu 24.04)

### Documentation & Housekeeping

- [x] I have updated relevant documentation — N/A (no user-facing config changes)
- [x] I have updated `cli-config.yaml.example` — N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I have considered cross-platform impact — N/A (stdlib-only changes)
- [x] I have updated tool descriptions/schemas — N/A