### PR TITLE
feat: add Hermes eval framework

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -1,0 +1,87 @@
+name: Evals Nightly Regression
+
+on:
+  schedule:
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: evals-nightly
+  cancel-in-progress: false
+
+jobs:
+  evals-nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      HERMES_EVAL_MODEL: ${{ vars.HERMES_EVAL_MODEL }}
+      HERMES_EVAL_PROVIDER: ${{ vars.HERMES_EVAL_PROVIDER }}
+      HERMES_EVAL_JUDGE_MODEL: ${{ vars.HERMES_EVAL_JUDGE_MODEL }}
+      HERMES_EVAL_JUDGE_PROVIDER: ${{ vars.HERMES_EVAL_JUDGE_PROVIDER }}
+      HERMES_EVAL_BASELINE_PATH: ${{ vars.HERMES_EVAL_BASELINE_PATH }}
+      HERMES_EVAL_BASELINE_DIR: evals/results/baselines
+      HERMES_EVAL_OUTPUT_DIR: evals/results/nightly/${{ github.run_id }}
+      HERMES_EVAL_FAIL_UNDER: ${{ vars.HERMES_EVAL_FAIL_UNDER }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Validate nightly eval configuration
+        run: |
+          set -euo pipefail
+          missing=()
+
+          [[ -n "${HERMES_EVAL_MODEL:-}" ]] || missing+=("repo variable HERMES_EVAL_MODEL")
+          if [[ -z "${HERMES_EVAL_PROVIDER:-}" ]]; then
+            echo "HERMES_EVAL_PROVIDER not set; runner default provider resolution will be used."
+          fi
+          if [[ -z "${HERMES_EVAL_FAIL_UNDER:-}" ]]; then
+            export HERMES_EVAL_FAIL_UNDER=0.85
+          fi
+          if [[ -z "${OPENROUTER_API_KEY:-}${OPENAI_API_KEY:-}${NOUS_API_KEY:-}${ANTHROPIC_API_KEY:-}${GOOGLE_API_KEY:-}" ]]; then
+            missing+=("at least one provider API secret (OPENROUTER_API_KEY / OPENAI_API_KEY / NOUS_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY)")
+          fi
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing nightly eval configuration:\n' >&2
+            printf '  - %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+
+      - name: Run nightly eval regression suite
+        run: |
+          source .venv/bin/activate
+          bash scripts/run_eval_nightly.sh
+
+      - name: Upload nightly eval artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: evals-nightly-${{ github.run_id }}
+          path: |
+            evals/results/nightly/${{ github.run_id }}
+            evals/results/baselines
+          if-no-files-found: warn

--- a/.github/workflows/evals-smoke.yml
+++ b/.github/workflows/evals-smoke.yml
@@ -1,0 +1,71 @@
+name: Evals Smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'evals/**'
+      - 'scripts/run_eval_smoke.sh'
+      - 'scripts/run_evals.py'
+      - 'tests/evals/**'
+      - '.github/workflows/evals-smoke.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'evals/**'
+      - 'scripts/run_eval_smoke.sh'
+      - 'scripts/run_evals.py'
+      - 'tests/evals/**'
+      - '.github/workflows/evals-smoke.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: evals-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evals-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HERMES_EVAL_FIXTURE_RESULTS: evals/fixtures/smoke_ci.yaml
+      HERMES_EVAL_OUTPUT_DIR: evals/results/ci-smoke/${{ github.run_id }}
+      HERMES_EVAL_FAIL_UNDER: '1.0'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Run eval unit tests
+        run: |
+          source .venv/bin/activate
+          scripts/run_tests.sh tests/evals/test_run_evals_script.py tests/evals/test_loader.py tests/evals/test_checks.py tests/evals/test_reporting.py
+
+      - name: Run offline eval smoke suite
+        run: |
+          source .venv/bin/activate
+          bash scripts/run_eval_smoke.sh
+
+      - name: Upload eval smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: evals-smoke-${{ github.run_id }}
+          path: evals/results/ci-smoke/${{ github.run_id }}
+          if-no-files-found: warn

--- a/docs/evals-operations.md
+++ b/docs/evals-operations.md
@@ -1,0 +1,95 @@
+# Hermes eval operations
+
+This is the executable path for CI and scheduled eval runs introduced by the Hermes eval MVP.
+
+For the end-to-end human/operator workflow — case creation, suite runs, baseline comparison, and failcase promotion — see `docs/evals/README.md`.
+
+## CI smoke gate
+
+GitHub workflow: `.github/workflows/evals-smoke.yml`
+
+What always runs:
+- `scripts/run_tests.sh tests/evals/`
+- `python scripts/run_evals.py --help`
+- `python scripts/mine_eval_cases.py --help`
+
+What runs only when live eval credentials are configured in GitHub Actions:
+- `bash scripts/run_eval_smoke.sh`
+
+Required GitHub Actions configuration for live smoke runs:
+- secret: `OPENROUTER_API_KEY`
+- variable: `HERMES_EVAL_MODEL`
+- optional variables:
+  - `HERMES_EVAL_PROVIDER` (defaults to `openrouter`)
+  - `HERMES_EVAL_JUDGE_MODEL`
+  - `HERMES_EVAL_JUDGE_PROVIDER`
+
+Smoke gate corpus (fixed MVP set):
+- `routing.local-repo-inspection`
+- `routing.web-search-straightforward`
+- `review.pr-code-quality`
+- `briefing.change-summary-no-speculation`
+
+Why this split exists:
+- the repo can always validate loader/check/judge/report plumbing in hermetic CI,
+- live model evals require provider credentials and should fail visibly only in environments that intentionally enable them.
+
+## Scheduled regression runs
+
+GitHub workflow: `.github/workflows/evals-nightly.yml`
+
+Schedules:
+- nightly regression: `30 1 * * *`
+- weekly comparison window: `0 7 * * 1`
+
+Runner entrypoint:
+- `bash scripts/run_eval_nightly.sh`
+
+Default behavior:
+- runs the full current eval corpus
+- writes artifacts under `evals/results/nightly/`
+- saves fresh baselines under `evals/results/baselines/`
+- enforces `HERMES_EVAL_FAIL_UNDER` (default `0.85`)
+
+Optional manual dispatch inputs:
+- `baseline_path`
+- `fail_under`
+
+## Local commands
+
+Run eval unit tests:
+
+```bash
+scripts/run_tests.sh tests/evals/
+```
+
+Smoke the CLI entrypoints:
+
+```bash
+python scripts/run_evals.py --help
+python scripts/mine_eval_cases.py --help
+```
+
+Run the fixed smoke gate locally:
+
+```bash
+HERMES_EVAL_MODEL=<model> \
+HERMES_EVAL_PROVIDER=<provider> \
+OPENROUTER_API_KEY=[REDACTED] \
+./scripts/run_eval_smoke.sh
+```
+
+Run the nightly wrapper locally:
+
+```bash
+HERMES_EVAL_MODEL=<model> \
+HERMES_EVAL_PROVIDER=<provider> \
+OPENROUTER_API_KEY=[REDACTED] \
+./scripts/run_eval_nightly.sh
+```
+
+## MVP truthfulness notes
+
+- The always-on CI gate is currently unit/integration coverage for the eval framework itself plus CLI smoke, not an always-live model run. That is deliberate because public CI cannot assume paid model credentials.
+- The live smoke and nightly workflows become real execution gates only after the GitHub secret/variables above are configured.
+- The fixed smoke set is the current stand-in for “critical case regression” until the corpus grows explicit critical labels and baseline policies.

--- a/docs/evals/README.md
+++ b/docs/evals/README.md
@@ -1,0 +1,251 @@
+# Hermes eval operator workflow
+
+This guide is the day-to-day operator path for the Hermes eval MVP. It covers the flywheel from creating a curated case, running a suite, comparing against a baseline, and promoting a mined failcase into the versioned dataset.
+
+For CI and scheduled execution details, see `docs/evals-operations.md`.
+
+## What is in git vs. generated
+
+Versioned, reviewable inputs:
+
+- `evals/cases/<suite>/<case>.yaml` — curated eval cases.
+- `evals/rubrics/*.yaml` — rubric dimensions for judge-scored suites.
+- `evals/fixtures/*.yaml` — offline fixture results for CI-safe smoke tests.
+- `scripts/run_evals.py` — local/CI eval runner.
+- `scripts/mine_eval_cases.py` — session/trajectory mining helper.
+
+Generated outputs:
+
+- `evals/results/**` — run outputs, reports, comparisons, and baselines. This is ignored by default except for `.gitignore` and deliberately committed fixtures.
+- `evals/cases/drafts/**` — recommended temporary location for mined draft cases before human review. Do not treat drafts as accepted coverage until promoted into a suite directory.
+
+## Workflow 1 — Create a curated eval case
+
+1. Choose the suite and task type.
+
+   Current suite directories:
+
+   - `evals/cases/routing/`
+   - `evals/cases/review/`
+   - `evals/cases/briefing/`
+   - `evals/cases/multimodal/`
+
+2. Add a YAML file with a stable `case_id`.
+
+   Naming convention:
+
+   - file: `evals/cases/<suite>/<short-name>.yaml`
+   - case id: `<suite>.<short-name>`
+   - use lowercase kebab-case after the suite prefix
+
+3. Include at least one deterministic assertion.
+
+   Minimum useful fields:
+
+   ```yaml
+   case_id: review.decision-memo
+   suite: review
+   task_type: review
+   title: Decision memo usefulness
+   prompt: >
+     Review the provided decision memo and identify the decision, evidence,
+     missing proof, and recommended next move.
+   context: >
+     Output should separate facts from interpretation and avoid generic advice.
+   tags: [review, decision-quality]
+   enabled_toolsets: []
+   assertions:
+     - kind: non_empty_output
+       params: {}
+     - kind: required_regex
+       params: {pattern: '(?i)(decision|evidence|next move)'}
+   judge_dimensions:
+     - name: decision_usefulness
+       description: Does the output make the decision easier and safer to make?
+       pass_threshold: 4
+   ```
+
+4. Validate the new case through the loader/tests.
+
+   ```bash
+   scripts/run_tests.sh tests/evals/test_loader.py tests/evals/test_checks.py
+   ```
+
+   Then either run the new case with a real model-backed route, or add a fixture entry when the case should become part of the CI-safe smoke set. Fixture-backed runs only work for cases explicitly listed in `evals/fixtures/smoke_ci.yaml`.
+
+   ```bash
+   # Existing fixture-backed smoke example.
+   python scripts/run_evals.py \
+     --case routing.web-search-straightforward \
+     --fixture-results evals/fixtures/smoke_ci.yaml \
+     --output evals/results/manual-smoke
+
+   # New case example; requires a real model/provider route.
+   python scripts/run_evals.py \
+     --case review.decision-memo \
+     --provider openai-codex \
+     --model gpt-5.4 \
+     --output evals/results/manual/review-decision-memo
+   ```
+
+## Workflow 2 — Run a suite
+
+Use `scripts/run_evals.py` for both local runs and automation.
+
+Common local commands:
+
+```bash
+# Run all cases in a suite with the configured/default Hermes route.
+python scripts/run_evals.py --suite review --output evals/results/manual/review
+
+# Run one case.
+python scripts/run_evals.py --case routing.web-search-straightforward --output evals/results/manual/routing-web
+
+# Run with explicit model/provider.
+python scripts/run_evals.py --suite review --provider openai-codex --model gpt-5.4 --output evals/results/manual/review-gpt54
+
+# Run with judge scoring.
+python scripts/run_evals.py --suite review --provider openai-codex --model gpt-5.4 --judge-provider openai-codex --judge-model gpt-5.5 --output evals/results/manual/review-judged
+
+# Enforce a pass-rate gate.
+python scripts/run_evals.py --suite routing --fail-under 0.85 --output evals/results/manual/routing-gate
+```
+
+Each run writes:
+
+- `results.json` — machine-readable `EvalRunResult` records.
+- `report.md` — human-readable pass/fail and score summary, unless `--json` is used.
+- `comparison.json` — only when `--baseline` is supplied.
+
+Operator checks after every run:
+
+1. Open `report.md` first for the human summary.
+2. Inspect any failed case in `results.json` for assertion failures and tool calls.
+3. Treat judge output as advisory unless deterministic gates and source evidence support it.
+4. Do not promote a routing/model change on aggregate score alone; check regressions by case.
+
+## Workflow 3 — Save and compare a baseline
+
+A baseline is a snapshot of a known-good run used to judge a candidate run.
+
+1. Save a baseline from the reference route.
+
+   ```bash
+   python scripts/run_evals.py \
+     --suite review \
+     --provider openai-codex \
+     --model gpt-5.4 \
+     --output evals/results/baseline-build/review-gpt54 \
+     --save-baseline evals/results/baselines
+   ```
+
+2. Locate the written baseline JSON under `evals/results/baselines/`.
+
+3. Run the candidate route against that baseline.
+
+   ```bash
+   python scripts/run_evals.py \
+     --suite review \
+     --provider openai-codex \
+     --model gpt-5.5 \
+     --baseline evals/results/baselines/<baseline-file>.json \
+     --fail-under 0.85 \
+     --output evals/results/compare/review-gpt55
+   ```
+
+4. Read `evals/results/compare/review-gpt55/comparison.json` and the stderr recommendation.
+
+Decision rule:
+
+- `ship` — no material case regressions and pass-rate gate met.
+- `ship_with_scope_limit` — improvement exists but guardrails/regressions require narrower rollout.
+- `no_ship` — pass-rate gate failed, critical cases regressed, or cases disappeared from the candidate run.
+
+A comparison is decision-ready only if it names specific cases, not just the aggregate pass rate.
+
+## Workflow 4 — Promote a production failcase into the dataset
+
+Use mining to propose candidates, then human-review before promotion. Mining output is a draft, not an accepted eval.
+
+1. Mine candidates from the session database, trajectories, or cron outputs.
+
+   ```bash
+   # Recent tool-using sessions from state.db.
+   python scripts/mine_eval_cases.py \
+     --source state-db \
+     --days-back 7 \
+     --min-tool-calls 1 \
+     --limit 20 \
+     --output evals/cases/drafts/session-mining
+
+   # Failed trajectories.
+   python scripts/mine_eval_cases.py \
+     --source trajectories \
+     --failed-only \
+     --limit 20 \
+     --output evals/cases/drafts/failed-trajectories
+
+   # Cron outputs, useful for briefing failures.
+   python scripts/mine_eval_cases.py \
+     --source cron-outputs \
+     --limit 20 \
+     --output evals/cases/drafts/cron-briefings
+   ```
+
+2. Read the generated `MINED_REPORT.md`.
+
+   Prioritize candidates where at least one of these is true:
+
+   - a real user corrected the output,
+   - the run failed or produced empty/unsupported output,
+   - the tool route was surprising or expensive,
+   - the task type is strategically important: routing, review, CI briefing, multimodal.
+
+3. Convert the draft into a curated case.
+
+   Required cleanup before promotion:
+
+   - remove raw private or incidental context that is not needed for the eval,
+   - rewrite the title/prompt so the case is stable and repeatable,
+   - replace `needs-review` draft tags with intentional suite tags,
+   - add deterministic assertions that catch the original failure,
+   - add judge dimensions only when deterministic checks cannot capture quality,
+   - move the file from `evals/cases/drafts/...` into the appropriate suite directory.
+
+4. Run the promoted case.
+
+   ```bash
+   python scripts/run_evals.py --case <suite.case-id> --output evals/results/manual/promoted-case
+   scripts/run_tests.sh tests/evals/test_loader.py tests/evals/test_checks.py
+   ```
+
+5. Commit only the curated case/rubric/test changes, not the generated result directory.
+
+Promotion acceptance checklist:
+
+- The case reproduces a real or plausible failure mode.
+- The expected behavior is encoded in assertions or rubric dimensions.
+- The case is not overfit to one exact phrasing unless exact phrasing is the product requirement.
+- The case can run without live credentials unless explicitly classified as a live-only eval.
+- The case has no secrets, tokens, raw PII, or unnecessary session transcript material.
+
+## Rollout posture
+
+Default posture for the MVP:
+
+- Keep CI smoke hermetic by default: eval framework tests, script help checks, and fixture-backed smoke.
+- Use live model-backed smoke only when provider secrets and `HERMES_EVAL_*` variables are intentionally configured.
+- Use nightly/weekly runs for broader regression signal rather than blocking every PR on paid model calls.
+- Use GPT-5.5/reviewer judging only for bounded approval-board checks, calibration, and high-stakes analysis/review cases; do not run the whole eval pipeline on the premium route by default.
+- Treat the first corpus as calibration data. It is useful enough to catch regressions, not yet large enough to prove broad model superiority.
+
+## Quick operator checklist
+
+Before declaring an eval change ready:
+
+- New or changed cases load successfully.
+- Deterministic eval tests pass.
+- `python scripts/run_evals.py --help` and `python scripts/mine_eval_cases.py --help` still work.
+- A relevant suite/case was run and produced `results.json` plus `report.md`.
+- If changing model/routing posture, compare against a saved baseline and inspect per-case regressions.
+- If promoting a failcase, confirm it moved from draft to a curated suite and no generated result artifacts are being committed.

--- a/docs/plans/2026-05-26-hermes-evals-design.md
+++ b/docs/plans/2026-05-26-hermes-evals-design.md
@@ -1,0 +1,1065 @@
+# Hermes Application Evals Design & Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a Hermes-native eval system for agent workflows that measures quality, tool correctness, cost, latency, and regression risk across analyses, reviews, research, CI briefings, and multimodal orchestration.
+
+**Architecture:** Start with a Hermes-native eval layer that reuses existing session traces, tool-call data, trajectory saving, and insights/cost plumbing already present in the repo. Implement deterministic checks first, add rubric-based judge scoring second, and wire the system into local scripts, CI, and scheduled regression runs before considering any hosted eval platform.
+
+**Tech Stack:** Python, SQLite (`state.db` / `kanban.db` patterns), Hermes session store (`hermes_state.py`), Hermes runtime (`run_agent.py`), insights engine (`agent/insights.py`), local JSON/YAML datasets, pytest, cron, optional OpenAI/OpenRouter judge model.
+
+---
+
+## 1. Problem Statement
+
+Hermes currently has strong runtime capabilities but weak systematic quality control for application-level agent behavior. The repo already contains useful primitives:
+
+- `hermes_state.py` stores sessions, messages, tool calls, reasoning fields, token counts, and cost fields.
+- `agent/insights.py` already aggregates model, token, tool-call, and cost usage.
+- `run_agent.py` supports trajectory saving.
+- kanban, cron, and gateway flows already provide durable execution surfaces.
+
+What is missing is a first-class eval layer that can answer questions like:
+
+- Did a routing or prompt change improve or regress end-to-end task quality?
+- Is GPT-5.5 worth its cost uplift for analysis/review workloads?
+- Did the agent choose the correct tools and use them efficiently?
+- Are CI briefings, reviews, or multimodal analyses decision-ready?
+- Did quality improve enough to justify latency or cost increases?
+
+This design solves that gap without introducing a premature external platform dependency.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- Hermes-native offline eval runner for curated test cases
+- Deterministic assertions for tool use, format, required content, language, and groundedness proxies
+- Judge-model scoring for nuanced outputs like analyses and reviews
+- Structured datasets and result artifacts on disk
+- Cost/latency/quality comparisons across models and prompts
+- Reuse of session traces and optional trajectory exports
+- CI/cron integration for regression testing
+- Kanban-based implementation rollout
+
+### Out of scope for MVP
+
+- Full hosted observability UI (LangSmith/Braintrust class)
+- Automatic prompt optimization
+- Real-time live traffic shadowing
+- Complex OpenTelemetry instrumentation
+- Training/fine-tuning loops
+- Full human annotation product/UI
+
+---
+
+## 3. Design Principles
+
+1. **Hermes-native first.** Reuse existing storage and runtime surfaces before adding SaaS.
+2. **Deterministic before judge.** Cheap, robust assertions form the base layer.
+3. **Task-specific, not generic.** Evaluate analyses, reviews, briefings, and multimodal workflows differently.
+4. **Cost-aware quality.** Every run must carry quality, latency, and cost together.
+5. **Production-fed.** Failing real traces should become new eval cases.
+6. **Provider-agnostic.** The eval framework must compare Hermes behaviors across different model routes.
+7. **Decision-ready outputs.** Scores must explain what regressed and whether the change should ship.
+
+---
+
+## 4. Target Use Cases
+
+### 4.1 Core Hermes / routing evals
+
+Examples:
+- Should a task stay on GPT-5.4 or escalate to GPT-5.5?
+- Did a fallback route produce worse tool choice?
+- Did a browser-vs-web_extract policy change improve reliability?
+
+Primary metrics:
+- task completion
+- tool correctness
+- tool efficiency
+- latency
+- token usage
+- estimated/actual cost
+- failure rate
+
+### 4.2 Analysis / review evals
+
+Examples:
+- company analysis
+- PR/code review
+- research synthesis
+- strategic recommendation memo
+
+Primary metrics:
+- factuality
+- groundedness
+- completeness
+- novelty / non-genericness
+- actionability
+- decision usefulness
+- prioritization quality
+
+### 4.3 CI / briefing evals
+
+Examples:
+- homepage competitor briefing
+- daily summary artifact
+- multimodal commercial readout
+
+Primary metrics:
+- correct campaign detection
+- change detection accuracy
+- concise output compliance
+- commercial relevance
+- source linkage
+- hallucination rate
+
+### 4.4 Multimodal / tool orchestration evals
+
+Examples:
+- browser-driven screenshot analysis
+- image+web synthesis
+- extract → analyze → summarize workflows
+
+Primary metrics:
+- correct tool choice
+- correct modality coverage
+- end-to-end answer usefulness
+- trace completeness
+- latency and failure rate under tool orchestration
+
+---
+
+## 5. Proposed System Architecture
+
+## 5.1 High-level components
+
+### A. Eval case store
+Versioned case files stored in-repo.
+
+Proposed path:
+- `evals/cases/*.yaml`
+- `evals/cases/<suite>/<case>.yaml`
+
+Each case defines:
+- task type
+- prompt/user input
+- optional context
+- expected tools
+- assertions
+- rubric
+- tags
+- optional gold answer / notes
+
+### B. Eval runner
+A Python runner that:
+- loads one or more cases
+- runs Hermes in a reproducible way
+- captures final output, messages, tool calls, timing, and cost
+- executes deterministic checks
+- optionally invokes a judge model
+- writes structured results
+
+Proposed path:
+- `evals/runner.py`
+- `scripts/run_evals.py`
+
+### C. Deterministic check engine
+A library of machine-checkable assertions.
+
+Proposed path:
+- `evals/checks.py`
+
+Examples:
+- required substring / regex present
+- max length / bullet count
+- exact tool used / forbidden tool absent
+- language check
+- schema validity
+- source URL presence
+- no empty output
+
+### D. Judge scoring layer
+Rubric-based scoring for nuanced outputs.
+
+Proposed path:
+- `evals/judges.py`
+- `evals/rubrics/*.yaml`
+
+Judge outputs should be structured JSON with:
+- dimension scores
+- short justification
+- pass/fail recommendation
+
+### E. Report writer
+Outputs human-readable and machine-readable artifacts.
+
+Proposed path:
+- `evals/reporting.py`
+- output dir under `.hermes/artifacts/evals/` or `evals/results/`
+
+Artifacts:
+- JSON raw results
+- Markdown summary
+- optional HTML summary later
+
+### F. Trace / production mining utilities
+Turn existing Hermes traces/sessions into candidate eval cases.
+
+Proposed path:
+- `evals/mining.py`
+- `scripts/mine_eval_cases.py`
+
+Source surfaces:
+- `state.db`
+- saved trajectories
+- cron outputs
+- manually curated failcases
+
+---
+
+## 5.2 Hermes integration points
+
+The implementation should explicitly reuse these existing files/surfaces:
+
+- `run_agent.py`
+  - existing trajectory support
+  - direct reusable runtime entrypoint for eval execution
+- `agent/trajectory.py`
+  - leverage current trajectory format instead of inventing another one
+- `hermes_state.py`
+  - session/message/tool-call schema already stores useful eval evidence
+- `agent/insights.py`
+  - reuse cost/token aggregation logic
+- `batch_runner.py`
+  - inspect for reusable patterns around batch execution and result capture
+- `cron/scheduler.py`
+  - scheduled regression runs later
+- `gateway/run.py`
+  - optional notification/report delivery later
+- `tests/stress/test_benchmarks.py`
+  - existing regression mindset, but extend from performance into quality
+
+---
+
+## 6. Data Model
+
+## 6.1 EvalCase schema
+
+Proposed file: `evals/schemas.py`
+
+```python
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+TaskType = Literal[
+    "analysis",
+    "review",
+    "briefing",
+    "browser",
+    "multimodal",
+    "routing",
+    "tooling",
+]
+
+@dataclass
+class DeterministicAssertion:
+    kind: str
+    params: dict[str, Any] = field(default_factory=dict)
+    weight: float = 1.0
+    required: bool = True
+
+@dataclass
+class JudgeDimension:
+    name: str
+    description: str
+    scale_min: int = 1
+    scale_max: int = 5
+    pass_threshold: float | None = None
+
+@dataclass
+class EvalCase:
+    case_id: str
+    suite: str
+    task_type: TaskType
+    title: str
+    prompt: str
+    context: str | None = None
+    tags: list[str] = field(default_factory=list)
+    enabled_toolsets: list[str] = field(default_factory=list)
+    expected_tools: list[str] = field(default_factory=list)
+    forbidden_tools: list[str] = field(default_factory=list)
+    assertions: list[DeterministicAssertion] = field(default_factory=list)
+    judge_dimensions: list[JudgeDimension] = field(default_factory=list)
+    gold_answer: str | None = None
+    notes: str | None = None
+```
+
+### Example case YAML
+
+```yaml
+case_id: briefing.hp.homepage.visible-campaigns
+suite: ci-briefings
+task_type: briefing
+title: Detect visible homepage campaigns and summarize changes
+prompt: >
+  Review the provided homepage capture and summarize the visible campaigns,
+  banners, and promotional hooks in at most 10 lines.
+context: >
+  Output must be concise, observation-led, and avoid invented commercial claims.
+tags: [igo, homepage, daily, concise]
+enabled_toolsets: [browser, vision]
+expected_tools: [browser_navigate, browser_vision]
+forbidden_tools: [terminal]
+assertions:
+  - kind: max_lines
+    params: {max_lines: 10}
+  - kind: required_regex
+    params: {pattern: '(banner|campaign|promotion|discount)'}
+  - kind: no_placeholder_language
+    params: {}
+judge_dimensions:
+  - name: factuality
+    description: Are claims grounded in visible evidence?
+    pass_threshold: 4
+  - name: commercial_relevance
+    description: Does the summary isolate commercially relevant signals?
+    pass_threshold: 4
+  - name: non_genericness
+    description: Is the summary specific instead of boilerplate?
+    pass_threshold: 4
+```
+
+---
+
+## 6.2 EvalRunResult schema
+
+```python
+@dataclass
+class AssertionResult:
+    kind: str
+    passed: bool
+    score: float
+    details: dict[str, Any] = field(default_factory=dict)
+
+@dataclass
+class JudgeResult:
+    dimension: str
+    score: float
+    passed: bool
+    rationale: str
+
+@dataclass
+class EvalRunResult:
+    run_id: str
+    case_id: str
+    suite: str
+    provider: str | None
+    model: str | None
+    judge_provider: str | None
+    judge_model: str | None
+    started_at: str
+    ended_at: str
+    elapsed_ms: int
+    completed: bool
+    failed: bool
+    error: str | None
+    final_response: str
+    tool_calls: list[dict[str, Any]]
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None
+    cache_write_tokens: int | None
+    estimated_cost_usd: float | None
+    actual_cost_usd: float | None
+    assertions: list[AssertionResult]
+    judge_results: list[JudgeResult]
+    aggregate_scores: dict[str, float]
+    labels: dict[str, Any] = field(default_factory=dict)
+```
+
+---
+
+## 7. Scoring Model
+
+## 7.1 Deterministic score
+
+Compute a weighted ratio over assertions.
+
+Example:
+- required tool used = 2.0
+- output within max length = 1.0
+- source link present = 1.5
+
+`deterministic_score = passed_weight / total_weight`
+
+If a `required=True` assertion fails, the case may still continue to judge scoring, but the overall case cannot become an unconditional pass.
+
+## 7.2 Judge score
+
+Per-dimension 1–5 scoring, normalized to 0–1.
+
+Example normalized score:
+`(score - min) / (max - min)`
+
+Judge must emit strict JSON to reduce parsing fragility.
+
+## 7.3 Aggregate score
+
+Recommended MVP aggregation:
+- deterministic: 50%
+- judge: 40%
+- efficiency modifier: 10%
+
+Where efficiency modifier rewards acceptable cost/latency bands rather than raw cheapness.
+
+### Important rule
+A run cannot pass overall if any critical gate fails, for example:
+- missing required tool
+- empty final output
+- explicit hallucination marker / unsupported claim gate
+- case-level minimum factuality threshold
+
+---
+
+## 8. Deterministic Assertion Library
+
+Proposed file: `evals/checks.py`
+
+MVP assertions:
+- `non_empty_output`
+- `max_chars`
+- `max_lines`
+- `contains_substring`
+- `required_regex`
+- `forbidden_regex`
+- `tool_used`
+- `tool_not_used`
+- `allowed_toolset_only`
+- `contains_url`
+- `json_schema_valid`
+- `language_is`
+- `no_placeholder_language`
+- `response_not_generic`
+- `minimum_bullet_count`
+
+Later assertions:
+- exact extraction match
+- fuzzy extraction match
+- source-grounding check against supplied snippets
+- tool-order correctness
+- multimodal evidence mention
+
+---
+
+## 9. Judge Layer Design
+
+## 9.1 Judge prompt shape
+
+The judge should score against:
+- original task
+- optional context/rules
+- final output
+- optional tool summary
+- optional source snippets
+- rubric dimensions
+
+The judge prompt must explicitly separate:
+- facts visible in the source material
+- claims made by the agent
+- unsupported extrapolations
+
+## 9.2 Judge output contract
+
+Return strict JSON like:
+
+```json
+{
+  "scores": [
+    {"dimension": "factuality", "score": 4, "passed": true, "rationale": "Most claims grounded in source."},
+    {"dimension": "actionability", "score": 5, "passed": true, "rationale": "Output ends with specific recommendation."}
+  ],
+  "overall_pass": true,
+  "summary": "Strong result with one overgeneralized claim."
+}
+```
+
+## 9.3 Judge model policy
+
+Recommended:
+- deterministic checks always run
+- cheaper judge allowed for low-stakes suites
+- stronger judge for analysis/review suites
+- frontier judge only for calibration, approval-board quality review, or spot checks
+
+This matches the broader Hermes routing strategy rather than putting the whole eval pipeline on the most expensive model.
+
+---
+
+## 10. Execution Flow
+
+## 10.1 Offline curated eval flow
+
+1. Load selected cases.
+2. For each case, start a fresh Hermes eval run.
+3. Capture final response, trace metadata, tool calls, elapsed time, and cost.
+4. Run deterministic assertions.
+5. If case requires judge scoring, call judge model.
+6. Compute aggregate score and pass/fail.
+7. Write JSON + markdown report.
+8. Optionally compare against a baseline snapshot.
+
+## 10.2 Trace-mined eval flow
+
+1. Query `state.db` or saved trajectories for target sessions.
+2. Filter failures, regressions, surprising tool traces, or user-corrected outputs.
+3. Convert selected sessions into draft eval cases.
+4. Human review the draft cases.
+5. Promote approved cases into versioned `evals/cases/`.
+
+## 10.3 Regression gate flow
+
+1. Run suite against baseline config/model.
+2. Run suite against candidate config/model.
+3. Compare:
+   - aggregate quality
+   - case pass rate
+   - tool correctness
+   - median latency
+   - median cost
+4. Emit ship / no-ship recommendation.
+
+---
+
+## 11. CLI / Script Surface
+
+### MVP: script-first, not CLI-first
+
+Do **not** start by adding a fully polished `hermes evals` CLI subcommand. That is a second-step convenience layer.
+
+### Required MVP entrypoints
+
+Create:
+- `scripts/run_evals.py`
+- `scripts/mine_eval_cases.py`
+
+### `scripts/run_evals.py` contract
+
+Example usages:
+
+```bash
+python scripts/run_evals.py --suite ci-briefings
+python scripts/run_evals.py --suite analysis --model gpt-5.4
+python scripts/run_evals.py --suite review --model gpt-5.5 --judge-model gpt-5.5
+python scripts/run_evals.py --case routing.browser-vs-webextract --output evals/results/manual/
+```
+
+Arguments:
+- `--suite`
+- `--case`
+- `--model`
+- `--provider`
+- `--judge-model`
+- `--judge-provider`
+- `--max-cases`
+- `--output`
+- `--baseline`
+- `--fail-under`
+- `--json`
+
+### Phase 2 CLI integration
+
+Once the core is proven, add:
+- `hermes evals run`
+- `hermes evals compare`
+- `hermes evals mine`
+
+Likely files later:
+- `hermes_cli/main.py`
+- `hermes_cli/commands.py`
+- possibly dedicated `hermes_cli/evals.py`
+
+---
+
+## 12. Storage Layout
+
+Proposed repo structure:
+
+```text
+hermes-agent/
+  evals/
+    __init__.py
+    schemas.py
+    loader.py
+    runner.py
+    checks.py
+    judges.py
+    reporting.py
+    mining.py
+    baselines.py
+    cases/
+      analysis/
+      review/
+      briefing/
+      routing/
+      multimodal/
+    rubrics/
+      analysis.yaml
+      review.yaml
+      briefing.yaml
+      multimodal.yaml
+    results/
+      .gitignore
+  scripts/
+    run_evals.py
+    mine_eval_cases.py
+  tests/
+    evals/
+      test_loader.py
+      test_checks.py
+      test_judges.py
+      test_runner.py
+      test_mining.py
+```
+
+### Artifact policy
+
+- Keep cases and rubrics in git.
+- Keep run results out of git by default via `evals/results/.gitignore`.
+- For decision-grade comparisons, allow explicit export to `docs/` or `.hermes/artifacts/`.
+
+---
+
+## 13. Baseline & Comparison Strategy
+
+Proposed file: `evals/baselines.py`
+
+A baseline snapshot should include:
+- suite name
+- git sha
+- Hermes config fingerprint
+- run date
+- model/provider route
+- aggregate pass rate
+- per-case scores
+- median cost/latency
+
+Comparison report should answer:
+- Which cases regressed?
+- Which dimensions improved?
+- Did quality increase enough to justify extra cost?
+- Is the candidate safe to ship?
+
+Decision output example:
+
+```json
+{
+  "recommendation": "ship_with_scope_limit",
+  "summary": "Quality improved materially on review tasks but not on briefings.",
+  "improvements": ["review factuality +0.6", "tool correctness +8%"],
+  "regressions": ["briefing concision -0.3", "median latency +41%"],
+  "guardrails": ["route only analysis/review suites to GPT-5.5"]
+}
+```
+
+---
+
+## 14. CI / Cron Integration
+
+## 14.1 CI
+
+Add a lightweight job for deterministic and smoke evals.
+
+Proposed future files:
+- `.github/workflows/evals-smoke.yml`
+- optional `.github/workflows/evals-nightly.yml`
+
+### CI gates for MVP
+
+On pull request or important config/runtime changes:
+- loader/check unit tests must pass
+- smoke suite must pass
+- no critical case regression allowed
+
+## 14.2 Cron
+
+Use scheduled jobs for:
+- nightly regression run
+- weekly model comparison run
+- production failcase mining digest
+
+Likely later command pattern:
+- cron invokes `scripts/run_evals.py`
+- optionally posts markdown summary back to Telegram
+
+---
+
+## 15. Initial Golden Set
+
+Seed the system with **25–40 cases**, not 200.
+
+### Recommended first suites
+
+#### Suite A — routing/core (5–8 cases)
+- browser vs web_extract routing
+- safe fallback behavior
+- correct tool use under dynamic page conditions
+- escalation-to-reviewer gate behavior
+
+#### Suite B — analyses/reviews (8–10 cases)
+- strategic analysis summary
+- code review finding quality
+- decision memo usefulness
+- hallucination-sensitive synthesis
+
+#### Suite C — CI/briefings (8–10 cases)
+- homepage campaign detection
+- change summary concision
+- seasonal/commercial signal extraction
+- exactness vs speculation
+
+#### Suite D — multimodal/tool orchestration (5–8 cases)
+- screenshot analysis
+- image + text synthesis
+- browser screenshot + summarization
+- failure handling and fallback
+
+### Curation rule
+
+At least one-third of cases should come from real Hermes outputs or user-corrected failures, not purely synthetic prompts.
+
+---
+
+## 16. Testing Strategy
+
+## Unit tests
+
+Create:
+- `tests/evals/test_loader.py`
+- `tests/evals/test_checks.py`
+- `tests/evals/test_judges.py`
+- `tests/evals/test_reporting.py`
+
+Cover:
+- case parsing
+- invalid schema rejection
+- assertion behavior
+- judge result parsing
+- aggregate scoring logic
+
+## Integration tests
+
+Create:
+- `tests/evals/test_runner.py`
+- `tests/evals/test_mining.py`
+
+Cover:
+- single case end-to-end execution against a mocked/minimal runtime
+- result artifact generation
+- trace/session mining from fixture data
+
+### Important constraint
+
+Do not make the unit suite depend on live model calls. Judge responses and run outputs should be mockable or fixture-driven.
+
+---
+
+## 17. Rollout Plan
+
+## Phase 0 — design and scaffolding
+- finalize schemas
+- create directory structure
+- add loader/check/report skeletons
+
+## Phase 1 — deterministic MVP
+- implement case loader
+- implement deterministic checks
+- implement runner with final output + tool trace capture
+- add markdown/json reporting
+- seed first 8–12 cases
+
+## Phase 2 — judge scoring
+- implement rubric files
+- implement structured judge scoring
+- add aggregate scoring
+- calibrate first judge suite on analysis/review cases
+
+## Phase 3 — baseline comparisons
+- add baseline snapshotting
+- add compare reports
+- define pass/fail regression policy
+
+## Phase 4 — production-fed eval flywheel
+- mine failcases from `state.db` / trajectories
+- human review promotion flow
+- nightly/weekly scheduled runs
+
+## Phase 5 — optional CLI + hosted integration
+- add `hermes evals` CLI
+- consider Braintrust/LangSmith/OpenAI Evals only if the Hermes-native layer proves insufficient
+
+---
+
+## 18. Risks & Mitigations
+
+### Risk: judge-model overconfidence
+Mitigation:
+- deterministic gates first
+- rubric-based scoring only
+- periodic human calibration
+- use stronger judge only where needed
+
+### Risk: eval harness becomes too abstract
+Mitigation:
+- ship script-first MVP
+- force every case to map to a real Hermes task type
+- keep first suites small and high-signal
+
+### Risk: cost blowout
+Mitigation:
+- cheap deterministic layer by default
+- judge only on selected suites
+- explicit cost metrics in every result
+- separate calibration runs from routine runs
+
+### Risk: fragile integration with runtime internals
+Mitigation:
+- reuse existing session/trajectory formats
+- prefer wrappers and adapters over invasive runtime changes in phase 1
+- add tests around integration seams
+
+### Risk: synthetic test bias
+Mitigation:
+- mine production traces and user-corrected failures into the dataset
+
+---
+
+## 19. Concrete File Plan
+
+### Create
+- `evals/__init__.py`
+- `evals/schemas.py`
+- `evals/loader.py`
+- `evals/checks.py`
+- `evals/judges.py`
+- `evals/runner.py`
+- `evals/reporting.py`
+- `evals/mining.py`
+- `evals/baselines.py`
+- `evals/cases/analysis/`
+- `evals/cases/review/`
+- `evals/cases/briefing/`
+- `evals/cases/routing/`
+- `evals/cases/multimodal/`
+- `evals/rubrics/analysis.yaml`
+- `evals/rubrics/review.yaml`
+- `evals/rubrics/briefing.yaml`
+- `evals/rubrics/multimodal.yaml`
+- `evals/results/.gitignore`
+- `scripts/run_evals.py`
+- `scripts/mine_eval_cases.py`
+- `tests/evals/test_loader.py`
+- `tests/evals/test_checks.py`
+- `tests/evals/test_judges.py`
+- `tests/evals/test_runner.py`
+- `tests/evals/test_mining.py`
+
+### Read / reuse / likely modify
+- `run_agent.py`
+- `agent/trajectory.py`
+- `agent/insights.py`
+- `hermes_state.py`
+- `batch_runner.py`
+- later: `hermes_cli/main.py`, `hermes_cli/commands.py`
+
+---
+
+## 20. Implementation Tasks (for execution)
+
+### Task 1: Scaffold eval package and schemas
+
+**Objective:** Create the package structure and strict case/result schemas.
+
+**Files:**
+- Create: `evals/__init__.py`
+- Create: `evals/schemas.py`
+- Create: `tests/evals/test_loader.py`
+
+**Done when:**
+- case schema can parse valid YAML
+- invalid cases fail with clear errors
+- test suite passes locally
+
+### Task 2: Implement deterministic check engine
+
+**Objective:** Build the first assertion library and scoring helper.
+
+**Files:**
+- Create: `evals/checks.py`
+- Create: `tests/evals/test_checks.py`
+
+**Done when:**
+- core assertions listed in section 8 are implemented
+- weighted scoring works
+- required-failure semantics are tested
+
+### Task 3: Build case loader and result writer
+
+**Objective:** Load suites from disk and emit structured JSON/markdown results.
+
+**Files:**
+- Create: `evals/loader.py`
+- Create: `evals/reporting.py`
+- Create: `evals/results/.gitignore`
+
+**Done when:**
+- loader resolves suites/cases deterministically
+- report writer emits stable machine-readable output
+- markdown report is human-usable
+
+### Task 4: Build Hermes-native eval runner
+
+**Objective:** Execute a case through Hermes, capture output, tool calls, timing, and cost.
+
+**Files:**
+- Create: `evals/runner.py`
+- Create: `tests/evals/test_runner.py`
+- Read/reuse: `run_agent.py`, `agent/trajectory.py`, `hermes_state.py`, `agent/insights.py`
+
+**Done when:**
+- one case runs end-to-end
+- final output and tool summary are captured
+- run result includes timing and cost fields
+
+### Task 5: Seed first golden cases
+
+**Objective:** Add the first 8–12 high-signal eval cases across routing, review, briefing, and multimodal work.
+
+**Files:**
+- Create under: `evals/cases/...`
+- Create rubrics under: `evals/rubrics/...`
+
+**Done when:**
+- each suite has at least two cases
+- each case has assertions
+- at least some cases require judge scoring
+
+### Task 6: Implement judge scoring layer
+
+**Objective:** Add rubric-driven judge evaluation with strict JSON parsing.
+
+**Files:**
+- Create: `evals/judges.py`
+- Create: `tests/evals/test_judges.py`
+- Create: `evals/rubrics/*.yaml`
+
+**Done when:**
+- judge prompt is structured
+- judge output parser is robust
+- aggregate scoring combines deterministic and judge scores
+
+### Task 7: Add runnable scripts and baseline compare flow
+
+**Objective:** Make eval execution operational from scripts.
+
+**Files:**
+- Create: `scripts/run_evals.py`
+- Create: `evals/baselines.py`
+
+**Done when:**
+- suite runs from CLI script
+- baseline snapshot saves cleanly
+- comparison report calls out regressions and ship recommendation
+
+### Task 8: Add trace mining utilities
+
+**Objective:** Turn production/session traces into candidate eval cases.
+
+**Files:**
+- Create: `evals/mining.py`
+- Create: `scripts/mine_eval_cases.py`
+- Create: `tests/evals/test_mining.py`
+
+**Done when:**
+- mining can read fixture or real `state.db`-derived examples
+- draft cases can be exported for human review
+
+### Task 9: Wire smoke suite into CI / scheduled execution
+
+**Objective:** Make evals part of the actual release/regression loop.
+
+**Files:**
+- Create/modify: CI workflow file(s)
+- Optionally create cron wrapper script
+
+**Done when:**
+- smoke suite runs automatically
+- failure status is visible
+- nightly scheduled run path is defined
+
+### Task 10: Document operator workflow
+
+**Objective:** Make the eval flywheel usable by future operators.
+
+**Files:**
+- Update docs as needed
+- optionally add `docs/evals/README.md`
+
+**Done when:**
+- there is a clear workflow for: create case → run suite → compare baseline → promote failcase into dataset
+
+---
+
+## 21. Recommended Kanban Graph
+
+Use these task lanes:
+
+1. **Foundation**
+   - schemas
+   - loader
+   - checks
+2. **Runtime integration**
+   - runner
+   - reporting
+3. **Content calibration**
+   - golden cases
+   - rubrics
+   - judge layer
+4. **Operationalization**
+   - scripts
+   - baselines
+   - CI/cron
+   - mining
+5. **Documentation & rollout**
+   - operator docs
+   - adoption guide
+
+### Dependency shape
+
+- Task 1 → Tasks 2, 3
+- Tasks 2 + 3 → Task 4
+- Task 4 → Tasks 5, 7
+- Task 5 → Task 6
+- Tasks 6 + 7 → Task 9
+- Task 4 → Task 8
+- Tasks 8 + 9 → Task 10
+
+This allows useful parallelism without forcing speculative downstream work too early.
+
+---
+
+## 22. Recommendation
+
+Proceed with the Hermes-native MVP rather than jumping straight to an external eval platform.
+
+**Why:**
+- the repo already contains enough trace, tool-call, and cost data to support a serious first eval system
+- the immediate bottleneck is discipline and structure, not UI
+- this approach preserves provider/model neutrality
+- it creates a concrete basis for later deciding whether hosted observability is actually necessary
+
+**Success criterion for MVP:**
+Within one iteration, Hermes should be able to run a 10+ case suite and produce a decision-ready regression report showing quality, tool correctness, latency, and cost differences across at least two model routes.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,56 @@
+from .judges import EvalJudgeError, aggregate_eval_scores, build_judge_prompt, evaluate_judge_output
+from .loader import group_cases_by_suite, load_eval_cases, load_eval_suite, resolve_case_files
+from .mining import (
+    MinedCandidate,
+    MiningResult,
+    candidate_to_draft_case,
+    export_candidates_report,
+    export_draft_cases,
+    mine_from_cron_outputs,
+    mine_from_session_db,
+    mine_from_trajectories,
+)
+from .reporting import render_markdown_report, results_to_json_bytes, write_markdown_report, write_results_json
+from .schemas import (
+    AssertionResult,
+    DeterministicAssertion,
+    EvalCase,
+    EvalRunResult,
+    EvalSchemaError,
+    JudgeDimension,
+    JudgeResult,
+    load_eval_case_file,
+    load_eval_case_yaml,
+)
+
+__all__ = [
+    "EvalJudgeError",
+    "AssertionResult",
+    "DeterministicAssertion",
+    "EvalCase",
+    "EvalRunResult",
+    "EvalSchemaError",
+    "JudgeDimension",
+    "JudgeResult",
+    "MinedCandidate",
+    "MiningResult",
+    "aggregate_eval_scores",
+    "build_judge_prompt",
+    "candidate_to_draft_case",
+    "evaluate_judge_output",
+    "export_candidates_report",
+    "export_draft_cases",
+    "group_cases_by_suite",
+    "load_eval_case_file",
+    "load_eval_case_yaml",
+    "load_eval_cases",
+    "load_eval_suite",
+    "mine_from_cron_outputs",
+    "mine_from_session_db",
+    "mine_from_trajectories",
+    "render_markdown_report",
+    "resolve_case_files",
+    "results_to_json_bytes",
+    "write_markdown_report",
+    "write_results_json",
+]

--- a/evals/baselines.py
+++ b/evals/baselines.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from statistics import median
+from typing import Any, Iterable, Sequence
+
+from .schemas import EvalRunResult
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class CaseScore:
+    """Per-case score snapshot for comparison."""
+
+    case_id: str
+    suite: str
+    score: float
+    deterministic: float
+    passed: bool
+    failed: bool
+    elapsed_ms: int
+    estimated_cost_usd: float | None
+    actual_cost_usd: float | None
+
+    @classmethod
+    def from_run(cls, result: EvalRunResult) -> CaseScore:
+        return cls(
+            case_id=result.case_id,
+            suite=result.suite,
+            score=result.aggregate_scores.get("overall", 0.0),
+            deterministic=result.aggregate_scores.get("deterministic", 0.0),
+            passed=not result.failed and not any(
+                not a.passed for a in result.assertions
+            ),
+            failed=result.failed,
+            elapsed_ms=result.elapsed_ms,
+            estimated_cost_usd=result.estimated_cost_usd,
+            actual_cost_usd=result.actual_cost_usd,
+        )
+
+
+@dataclass(slots=True)
+class BaselineSnapshot:
+    """A durable baseline snapshot representing one eval run."""
+
+    suite: str
+    git_sha: str
+    config_fingerprint: str
+    run_date: str
+    model: str | None
+    provider: str | None
+    total_cases: int
+    passed_cases: int
+    pass_rate: float
+    median_latency_ms: float
+    median_cost_usd: float | None
+    per_case: list[CaseScore]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_results(
+        cls,
+        results: Iterable[EvalRunResult],
+        *,
+        suite: str | None = None,
+        git_sha: str | None = None,
+        config_fingerprint: str = "",
+    ) -> BaselineSnapshot:
+        ordered = list(results)
+        if not ordered:
+            raise ValueError("cannot create baseline from empty results")
+
+        resolved_suite = suite or ordered[0].suite
+        resolved_git_sha = git_sha or _detect_git_sha()
+
+        scores = [CaseScore.from_run(r) for r in ordered]
+        passed = sum(1 for s in scores if s.passed)
+        total = len(scores)
+        latencies = [s.elapsed_ms for s in scores]
+        costs = [
+            c
+            for s in scores
+            if (c := s.actual_cost_usd or s.estimated_cost_usd) is not None
+        ]
+
+        return cls(
+            suite=resolved_suite,
+            git_sha=resolved_git_sha,
+            config_fingerprint=config_fingerprint,
+            run_date=ordered[0].started_at,
+            model=ordered[0].model,
+            provider=ordered[0].provider,
+            total_cases=total,
+            passed_cases=passed,
+            pass_rate=passed / total if total else 0.0,
+            median_latency_ms=median(latencies) if latencies else 0.0,
+            median_cost_usd=median(costs) if costs else None,
+            per_case=scores,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class CaseComparison:
+    """Diff of one case between baseline and candidate."""
+
+    case_id: str
+    suite: str
+    baseline_score: float
+    candidate_score: float
+    delta: float  # positive = improvement, negative = regression
+    regression: bool
+    improvement: bool
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ComparisonReport:
+    """Full comparison between a baseline and a candidate run."""
+
+    recommendation: str  # "ship" | "ship_with_scope_limit" | "no_ship"
+    summary: str
+    pass_rate_baseline: float
+    pass_rate_candidate: float
+    pass_rate_delta: float
+    median_latency_baseline: float
+    median_latency_candidate: float
+    median_cost_baseline: float | None
+    median_cost_candidate: float | None
+    improvements: list[str]
+    regressions: list[str]
+    case_comparisons: list[CaseComparison]
+    guardrails: list[str]
+
+
+_DEFAULT_REGRESSION_THRESHOLD = 0.05  # score points
+
+
+def compare_baselines(
+    baseline: BaselineSnapshot,
+    candidate: BaselineSnapshot,
+    *,
+    regression_threshold: float = _DEFAULT_REGRESSION_THRESHOLD,
+    fail_under: float = 0.0,
+) -> ComparisonReport:
+    """Compare a baseline snapshot to a candidate run snapshot.
+
+    Parameters
+    ----------
+    baseline : BaselineSnapshot
+        The reference run.
+    candidate : BaselineSnapshot
+        The candidate run to evaluate.
+    regression_threshold : float
+        Minimum score drop (0-1) to classify as a regression.
+    fail_under : float
+        If candidate pass rate is below this, force no_ship.
+
+    Returns
+    -------
+    ComparisonReport
+        Structured comparison with ship recommendation.
+    """
+    baseline_map = {s.case_id: s for s in baseline.per_case}
+    candidate_map = {s.case_id: s for s in candidate.per_case}
+    all_case_ids = sorted(set(baseline_map) | set(candidate_map))
+
+    comparisons: list[CaseComparison] = []
+    regressions: list[str] = []
+    improvements: list[str] = []
+    guardrails: list[str] = []
+
+    for case_id in all_case_ids:
+        base_score_s, cand_score_s = 0.0, 0.0
+        base_case = baseline_map.get(case_id)
+        cand_case = candidate_map.get(case_id)
+        present_in_both = base_case is not None and cand_case is not None
+
+        if base_case is not None:
+            base_score_s = base_case.score
+        if cand_case is not None:
+            cand_score_s = cand_case.score
+
+        delta_s = cand_score_s - base_score_s
+        is_regression = delta_s < -regression_threshold
+        is_improvement = delta_s > regression_threshold
+
+        details: dict[str, Any] = {}
+        resolved_suite = ""
+        if present_in_both:
+            details = {
+                "baseline_deterministic": base_case.deterministic,
+                "candidate_deterministic": cand_case.deterministic,
+                "baseline_elapsed_ms": base_case.elapsed_ms,
+                "candidate_elapsed_ms": cand_case.elapsed_ms,
+                "baseline_failed": base_case.failed,
+                "candidate_failed": cand_case.failed,
+            }
+            resolved_suite = base_case.suite
+        elif base_case is not None:
+            details = {"note": "new case (not in baseline)"}
+            is_improvement = False  # can't claim improvement on unknown prior
+            resolved_suite = base_case.suite
+        else:
+            details = {"note": "missing from candidate run"}
+            is_regression = True  # case disappeared = regression
+            if cand_case is not None:
+                resolved_suite = cand_case.suite
+
+        if is_regression:
+            prefix = f"[{resolved_suite}] " if resolved_suite else ""
+            regressions.append(f"{prefix}{case_id} — {delta_s:+.3f}")
+        if is_improvement:
+            prefix = f"[{resolved_suite}] " if resolved_suite else ""
+            improvements.append(f"{prefix}{case_id} — {delta_s:+.3f}")
+
+        comparisons.append(
+            CaseComparison(
+                case_id=case_id,
+                suite=resolved_suite,
+                baseline_score=base_score_s,
+                candidate_score=cand_score_s,
+                delta=delta_s,
+                regression=is_regression,
+                improvement=is_improvement,
+                details=details,
+            )
+        )
+
+    # Aggregate stats
+    pass_rate_baseline_val = baseline.passed_cases / baseline.total_cases
+    pass_rate_cand_val = candidate.passed_cases / candidate.total_cases
+    pass_rate_delta_val = pass_rate_cand_val - pass_rate_baseline_val
+
+    latency_delta = candidate.median_latency_ms - baseline.median_latency_ms
+    cost_str = ""
+    if candidate.median_cost_usd is not None and baseline.median_cost_usd is not None:
+        cost_ratio = (
+            candidate.median_cost_usd / baseline.median_cost_usd
+            if baseline.median_cost_usd > 0
+            else float("inf")
+        )
+        cost_str = (
+            f"cost {cost_ratio:.2f}x (${candidate.median_cost_usd:.6f} vs ${baseline.median_cost_usd:.6f})"
+        )
+    elif candidate.median_cost_usd is not None:
+        cost_str = f"cost ${candidate.median_cost_usd:.6f} (no baseline cost data)"
+
+    # Decide recommendation
+    recommendation = "ship"
+
+    if len(regressions) >= 1:
+        # Check if any regression is from a case that was passing before
+        critical_regressions = [
+            c
+            for c in comparisons
+            if c.delta < -regression_threshold * 2  # double the threshold = critical
+            and c.baseline_score >= 0.8
+        ]
+        if critical_regressions:
+            recommendation = "no_ship"
+            guardrails.append(
+                f"Critical regression(s) in previously passing cases: {', '.join(c.case_id for c in critical_regressions)}"
+            )
+        elif len(regressions) >= 3:
+            recommendation = "no_ship"
+            guardrails.append(f"{len(regressions)} cases regressed — rollup exceeds tolerance")
+        elif len(regressions) >= 1:
+            recommendation = "ship_with_scope_limit"
+            guardrails.append(f"Review regressed cases: {', '.join(r for r in regressions[:5])}")
+    if fail_under > 0 and pass_rate_cand_val < fail_under:
+        recommendation = "no_ship"
+        guardrails.append(f"Candidate pass rate {pass_rate_cand_val:.1%} below --fail-under {fail_under:.1%}")
+
+    candidate_pass_rate_str = f"{candidate.passed_cases}/{candidate.total_cases}"
+    baseline_pass_rate_str = f"{baseline.passed_cases}/{baseline.total_cases}"
+
+    summary_parts: list[str] = []
+
+    if recommendation == "ship":
+        if improvements:
+            summary_parts.insert(
+                0,
+                f"Recommendation: ship — quality maintained or improved with {candidate_pass_rate_str} pass rate (was {baseline_pass_rate_str}).",
+            )
+        else:
+            summary_parts.insert(
+                0,
+                f"Recommendation: ship — no material change ({candidate_pass_rate_str} pass rate, was {baseline_pass_rate_str}).",
+            )
+        if cost_str:
+            if latency_delta > 1000:
+                guardrails.append(f"Latency increased by {latency_delta:.0f}ms — monitor user-facing impact")
+            summary_parts.append(cost_str)
+        improvements_prefix = ""
+        if improvements:
+            improvements_prefix = f"Quality improved across {len(improvements)} case(s). "
+        summary_parts.append(f"{improvements_prefix}All cases stable or better.")
+
+    elif recommendation == "ship_with_scope_limit":
+        summary_parts.insert(
+            0,
+            f"Recommendation: ship with scope limits — {len(regressions)} case(s) regressed ({candidate_pass_rate_str} vs {baseline_pass_rate_str}).",
+        )
+        if cost_str:
+            summary_parts.append(cost_str)
+        if improvements:
+            summary_parts.append(f"{len(improvements)} case(s) improved.")
+
+    else:  # no_ship
+        summary_parts.insert(
+            0,
+            f"Recommendation: no_ship — {len(regressions)} case(s) regressed, "
+            f"Pass rate {candidate_pass_rate_str} (was {baseline_pass_rate_str}).",
+        )
+        if any("Critical regression" in guardrail for guardrail in guardrails):
+            summary_parts.append("Critical regressions found in previously passing cases.")
+        elif any("below --fail-under" in guardrail for guardrail in guardrails):
+            summary_parts.append(f"Candidate pass rate fell below the required {fail_under:.1%} gate.")
+
+    if recommendation != "no_ship":
+        guardrails = [g for g in guardrails if "Critical regression" not in g]
+
+    return ComparisonReport(
+        recommendation=recommendation,
+        summary="\n\n".join(summary_parts),
+        pass_rate_baseline=pass_rate_baseline_val,
+        pass_rate_candidate=pass_rate_cand_val,
+        pass_rate_delta=pass_rate_delta_val,
+        median_latency_baseline=baseline.median_latency_ms,
+        median_latency_candidate=candidate.median_latency_ms,
+        median_cost_baseline=baseline.median_cost_usd,
+        median_cost_candidate=candidate.median_cost_usd,
+        improvements=improvements,
+        regressions=regressions,
+        case_comparisons=comparisons,
+        guardrails=guardrails,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def save_baseline(snapshot: BaselineSnapshot, path: str | Path) -> Path:
+    """Write a baseline snapshot to disk as JSON."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = snapshot.to_dict()
+    output_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    logger.info("baseline snapshot saved to %s", output_path)
+    return output_path
+
+
+def load_baseline(path: str | Path) -> BaselineSnapshot:
+    """Read a baseline snapshot from a JSON file."""
+    raw = Path(path).read_text(encoding="utf-8")
+    data = json.loads(raw)
+    per_case = [CaseScore(**cs) for cs in data.pop("per_case", [])]
+    return BaselineSnapshot(**data, per_case=per_case)
+
+
+def snapshot_dir_from_results(
+    results: Sequence[EvalRunResult], output_dir: str | Path
+) -> Path:
+    """Write per-suite baseline snapshots into *output_dir*.
+
+    Returns the directory path.
+    """
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+
+    # Group by suite
+    suites: dict[str, list[EvalRunResult]] = {}
+    for r in results:
+        suites.setdefault(r.suite, []).append(r)
+
+    for suite_name, suite_results in suites.items():
+        snapshot = BaselineSnapshot.from_results(suite_results, suite=suite_name)
+        path = root / f"baseline.{suite_name}.json"
+        save_baseline(snapshot, path)
+
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_git_sha() -> str:
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        logger.warning("could not detect git sha")
+    return "unknown"

--- a/evals/cases/briefing/change-summary-no-speculation.yaml
+++ b/evals/cases/briefing/change-summary-no-speculation.yaml
@@ -1,0 +1,48 @@
+case_id: briefing.change-summary-no-speculation
+suite: briefing
+task_type: briefing
+title: Change summary highlights what changed without overclaiming why
+prompt: >
+  Yesterday's homepage had a generic "Shop Now" hero and no promo ribbon.
+  Today's homepage shows "Back to School - Buy 2 Get 1 Free" plus a new top-bar
+  message "Free Returns this week". Summarize the change in at most 6 lines.
+context: >
+  Focus on change detection. State what changed, the visible commercial angle,
+  and any seasonal cue. Do not speculate about internal strategy, inventory, or
+  performance.
+tags: [briefing, change-detection, concise, no-speculation]
+enabled_toolsets: []
+expected_tools: []
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: max_lines
+    params: {max_lines: 6}
+    weight: 2.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "(changed|new|now|previously|back to school|free returns)", ignore_case: true}
+    weight: 2.0
+    required: true
+  - kind: forbidden_regex
+    params: {pattern: "(because|due to weak demand|inventory issue|underperform)", ignore_case: true}
+    weight: 1.5
+    required: true
+judge_dimensions:
+  - name: delta_clarity
+    description: Does the briefing clearly distinguish the old state from the new homepage state?
+    pass_threshold: 4
+  - name: commercial_relevance
+    description: Does the summary extract the visible promotional and seasonal significance without bloating the output?
+    pass_threshold: 4
+  - name: speculation_control
+    description: Does the output avoid unsupported reasons for the change?
+    pass_threshold: 4
+notes: >
+  Seed briefing case for homepage change summaries where exactness matters more
+  than elaborate interpretation.

--- a/evals/cases/briefing/homepage-visible-campaigns.yaml
+++ b/evals/cases/briefing/homepage-visible-campaigns.yaml
@@ -1,0 +1,52 @@
+case_id: briefing.homepage-visible-campaigns
+suite: briefing
+task_type: briefing
+title: Homepage campaign briefing stays concise and observation-led
+prompt: >
+  You are given a homepage capture showing a large hero banner reading
+  "Summer Sale - 20% Off", a secondary tile for "Free Shipping over €50",
+  and a small ribbon saying "New eco collection". Write a concise daily
+  commercial briefing in at most 8 lines covering the visible campaigns,
+  promotional hooks, and seasonal focus.
+context: >
+  Keep the briefing factual and concise. Mention only what is visible, separate
+  observation from interpretation, and avoid invented business explanations.
+tags: [briefing, homepage, campaign-detection, concise]
+enabled_toolsets: [vision]
+expected_tools: []
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: max_lines
+    params: {max_lines: 8}
+    weight: 2.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "(Summer Sale|20% Off|Free Shipping|eco)", ignore_case: true}
+    weight: 2.0
+    required: true
+  - kind: forbidden_regex
+    params: {pattern: "(likely|probably|suggests they need|must be)", ignore_case: true}
+    weight: 1.5
+    required: true
+judge_dimensions:
+  - name: visible_signal_coverage
+    description: Does the briefing capture the main visible promotional signals without missing obvious elements?
+    pass_threshold: 4
+  - name: concision
+    description: Is the output compact, scannable, and free of unnecessary filler?
+    pass_threshold: 4
+  - name: observation_vs_inference
+    description: Does the output avoid turning visible homepage elements into unsupported commercial conclusions?
+    pass_threshold: 4
+gold_answer: >
+  Visible summer-sale hero with 20% discount, a free-shipping threshold promo,
+  and a sustainability-themed eco collection ribbon; seasonal focus is summer.
+notes: >
+  Seed briefing case based on concise homepage campaign detection with explicit
+  anti-speculation constraints.

--- a/evals/cases/multimodal/browser-screenshot-fallback.yaml
+++ b/evals/cases/multimodal/browser-screenshot-fallback.yaml
@@ -1,0 +1,49 @@
+case_id: multimodal.browser-screenshot-fallback
+suite: multimodal
+task_type: browser
+title: Browser-first screenshot task uses page navigation and visual inspection
+prompt: >
+  Visit a visually rich homepage, inspect the hero area, and summarize the main
+  promotional message, CTA, and any trust or delivery signals shown above the
+  fold. If the text extraction is incomplete, rely on screenshot/vision rather
+  than pretending certainty.
+context: >
+  This is a browser + vision workflow, not a pure text extraction task. The
+  output should explicitly describe visible elements and avoid fake certainty
+  when page text alone would be insufficient.
+tags: [multimodal, browser, screenshot, fallback]
+enabled_toolsets: [browser, vision]
+expected_tools: [browser_navigate, browser_vision]
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: tool_used
+    params: {tool: browser_navigate}
+    weight: 2.0
+    required: true
+  - kind: tool_used
+    params: {tool: browser_vision}
+    weight: 2.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "(hero|CTA|promotion|banner|delivery|trust)", ignore_case: true}
+    weight: 1.0
+    required: false
+judge_dimensions:
+  - name: modality_choice
+    description: Does the agent correctly use browser plus visual inspection instead of relying on brittle text-only extraction?
+    pass_threshold: 4
+  - name: visible_element_reporting
+    description: Does the answer report the key visible elements a human would expect from an above-the-fold readout?
+    pass_threshold: 4
+  - name: uncertainty_honesty
+    description: When information is ambiguous, does the answer acknowledge uncertainty instead of inventing details?
+    pass_threshold: 4
+notes: >
+  Seed browser/multimodal orchestration case covering the intended fallback from
+  text extraction to screenshot-based understanding.

--- a/evals/cases/multimodal/screenshot-commercial-readout.yaml
+++ b/evals/cases/multimodal/screenshot-commercial-readout.yaml
@@ -1,0 +1,50 @@
+case_id: multimodal.screenshot-commercial-readout
+suite: multimodal
+task_type: multimodal
+title: Screenshot analysis extracts visible commercial signals from image-like context
+prompt: >
+  You are analyzing a screenshot that visibly contains: a hero image of running
+  shoes, headline "Spring Run Week", a bright badge saying "30% Off", and a CTA
+  button labeled "Shop Men". Summarize the visible commercial message and call
+  out any audience or seasonal signal in at most 8 lines.
+context: >
+  Treat this as a multimodal readout. The answer should sound like a factual
+  screenshot analysis, not a creative rewrite. Keep it observation-led.
+tags: [multimodal, screenshot, commercial-readout, concise]
+enabled_toolsets: [vision]
+expected_tools: []
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: max_lines
+    params: {max_lines: 8}
+    weight: 1.5
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "(Spring Run Week|30% Off|Shop Men|running shoes)", ignore_case: true}
+    weight: 2.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "(season|spring|audience|men)", ignore_case: true}
+    weight: 1.0
+    required: false
+judge_dimensions:
+  - name: image_grounding
+    description: Does the answer stay tied to visible elements rather than inventing context not present in the screenshot?
+    pass_threshold: 4
+  - name: synthesis_quality
+    description: Does the answer combine headline, visual theme, offer, and CTA into a coherent commercial readout?
+    pass_threshold: 4
+  - name: commercial_signal_extraction
+    description: Does the analysis identify the key promotional, audience, and seasonal signals a human operator would care about?
+    pass_threshold: 4
+gold_answer: >
+  Spring-themed running-shoe campaign with a 30% discount and a men's shopping
+  CTA, signaling a seasonal running promotion aimed at male shoppers.
+notes: >
+  Seed multimodal case for screenshot-style commercial signal extraction.

--- a/evals/cases/review/briefing-factuality-review.yaml
+++ b/evals/cases/review/briefing-factuality-review.yaml
@@ -1,0 +1,54 @@
+case_id: review.briefing-factuality-review
+suite: review
+task_type: review
+title: Review a draft competitor briefing for unsupported claims and missing evidence
+prompt: >
+  Review this draft briefing and identify unsupported claims, overreach, and
+  places where the writer confuses observation with inference:
+
+  "The homepage hero says 'Summer Deals'. This clearly proves the company is
+  missing revenue targets and is pivoting toward low-margin clearance sales.
+  The green banner also means they are prioritizing sustainability over profit.
+  Customers will almost certainly respond positively because the CTA is bold."
+
+  Provide a structured review with specific findings and concrete rewrite guidance.
+context: >
+  Focus on factual grounding and analytical discipline. Flag claims that go beyond
+  what is visible in the text, explain why they are weak, and suggest tighter
+  observation-led rewrites.
+tags: [review, factuality, briefing, critique]
+enabled_toolsets: []
+expected_tools: []
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "(unsupported|speculat|inference|evidence|visible|observ)", ignore_case: true}
+    weight: 2.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "(rewrite|replace|rephrase|instead)", ignore_case: true}
+    weight: 1.0
+    required: false
+  - kind: forbidden_regex
+    params: {pattern: "(looks great|seems fine|no major issues)", ignore_case: true}
+    weight: 1.5
+    required: true
+judge_dimensions:
+  - name: evidence_discipline
+    description: Does the review clearly separate visible facts from speculation and unsupported inference?
+    pass_threshold: 4
+  - name: finding_specificity
+    description: Are the review findings tied to concrete phrases or claims in the draft rather than generic critique?
+    pass_threshold: 4
+  - name: rewrite_actionability
+    description: Does the review provide concrete rewrite guidance that would improve the draft immediately?
+    pass_threshold: 4
+notes: >
+  Review seed aimed at catching analytical overreach in briefing-style outputs.
+  It complements the existing code-review and strategic-analysis cases.

--- a/evals/cases/review/decision-memo.yaml
+++ b/evals/cases/review/decision-memo.yaml
@@ -1,0 +1,61 @@
+case_id: review.decision-memo
+suite: review
+task_type: analysis
+title: Strategic decision memo weighs tradeoffs and makes a specific recommendation
+prompt: >
+  Draft a decision memo on whether our team should adopt Hermes Agent as
+  our internal automation platform vs continuing with our current ad-hoc
+  script approach. We are a 5-person team doing research, data analysis,
+  and report generation.
+
+  Consider:
+  - Learning curve vs productivity gain
+  - Cost (API usage, infrastructure)
+  - Reliability and maintenance burden
+  - Integration with existing tools
+  - Team autonomy vs dependency
+
+  End with a clear recommendation.
+context: >
+  Structure the memo as: context, options considered, tradeoff analysis
+  (pros/cons per option), recommendation with rationale. Be specific
+  about conditions or thresholds that would change the recommendation.
+  No placeholder language.
+tags: [analysis, decision-memo, tradeoffs, structured]
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: (recommend|recommendation|conclusion|decision), ignore_case: true}
+    weight: 1.5
+    required: true
+  - kind: required_regex
+    params: {pattern: (tradeoff|pro|con|advantage|disadvantage|option|alternative), ignore_case: true}
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: (learning curve|cost|reliability|maintenance), ignore_case: true}
+    weight: 1.0
+    required: false
+  - kind: forbidden_regex
+    params: {pattern: \b(todo|tbd|fixme)\b, ignore_case: true}
+    weight: 1.5
+    required: true
+judge_dimensions:
+  - name: tradeoff_balance
+    description: Are pros and cons presented honestly for all options rather than just advocating one side?
+    pass_threshold: 4
+  - name: specificity
+    description: Are arguments concrete (team size, specific tools, cost ranges) rather than abstract?
+    pass_threshold: 4
+  - name: conditional_thinking
+    description: Does the memo identify conditions under which the recommendation would change?
+    pass_threshold: 3
+notes: >
+  Tests the agent's ability to produce a balanced decision memo with
+  genuine tradeoff analysis. Good stress test for critical thinking
+  vs generic fill-in-the-blanks output.

--- a/evals/cases/review/pr-code-quality.yaml
+++ b/evals/cases/review/pr-code-quality.yaml
@@ -1,0 +1,70 @@
+case_id: review.pr-code-quality
+suite: review
+task_type: review
+title: PR code review identifies specific findings with actionable recommendations
+prompt: >
+  Review this code for issues:
+
+  ```python
+  def get_user(user_id, db):
+      query = "SELECT * FROM users WHERE id = " + user_id
+      result = db.execute(query)
+      if result:
+          return {"id": result[0], "name": result[1], "email": result[2]}
+      return None
+
+  def update_email(user_id, new_email):
+      db = get_db()
+      db.execute(f"UPDATE users SET email = '{new_email}' WHERE id = {user_id}")
+      db.commit()
+      return True
+
+  def delete_user(user_id):
+      db = get_db()
+      db.execute(f"DELETE FROM users WHERE id = {user_id}")
+  ```
+
+  Identify all issues with code quality, security, error handling, and best
+  practices. For each finding, explain why it matters and suggest a fix.
+context: >
+  Produce a structured code review with specific findings (at least 3),
+  severity levels, and actionable recommendations. Be specific — not
+  "improve security" but "line 3: SQL injection via string concatenation".
+tags: [review, code-quality, security, structured]
+enabled_toolsets: [terminal]
+expected_tools: []
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: (SQL injection|SQLi|string concatenation|parameterized), ignore_case: true}
+    weight: 2.0
+    required: true
+  - kind: forbidden_regex
+    params: {pattern: "I'm unable|I cannot review", ignore_case: true}
+    weight: 1.5
+    required: true
+  - kind: required_regex
+    params: {pattern: (finding|issue|vulnerability|problem|recommend|fix), ignore_case: true}
+    weight: 1.5
+    required: false
+judge_dimensions:
+  - name: finding_specificity
+    description: Are findings specific (file, line, exact issue) rather than vague?
+    pass_threshold: 4
+  - name: actionability
+    description: Does each finding include a concrete fix or remediation?
+    pass_threshold: 4
+  - name: prioritization
+    description: Are findings ordered or flagged by severity/impact?
+    pass_threshold: 3
+notes: >
+  Classic code review eval with SQL injection as the anchor issue. The
+  deterministic assertions catch the basic requirement (SQL injection
+  must be mentioned). Judge dimensions evaluate the quality dimensions
+  that can't be hard-coded.

--- a/evals/cases/review/strategic-analysis.yaml
+++ b/evals/cases/review/strategic-analysis.yaml
@@ -1,0 +1,60 @@
+case_id: review.strategic-analysis
+suite: review
+task_type: analysis
+title: Strategic investment analysis with structured reasoning and evidence
+prompt: >
+  Analyze NVIDIA (NVDA) as an investment for the next 12 months. Cover:
+  - Competitive position in AI chips and data center revenue
+  - Key risks (geopolitical, demand cyclicality, competition)
+  - Current valuation vs historical and peer multiples
+  - Catalysts on the horizon (product cycles, new markets)
+  - Decision recommendation with rationale
+
+  Keep the analysis decision-ready, evidence-driven, and structured.
+context: >
+  Write a formal analysis memo. Every claim must be grounded in data or
+  explicitly labeled as speculation. Structure with clear sections.
+  End with a specific recommendation (buy/hold/sell) with conviction level.
+tags: [analysis, investment, structured, evidence-driven]
+enabled_toolsets: [web]
+expected_tools: [web_search]
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: (NVIDIA|NVDA), ignore_case: true}
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: (recommendation|buy|hold|sell|conviction), ignore_case: true}
+    weight: 1.5
+    required: true
+  - kind: required_regex
+    params: {pattern: (risk|catalyst|competitive|valuation), ignore_case: true}
+    weight: 1.0
+    required: false
+  - kind: forbidden_regex
+    params:
+      pattern: \b(?:I'm not a financial advisor|you should consult|I cannot provide)\b
+      ignore_case: true
+    weight: 2.0
+    required: true
+judge_dimensions:
+  - name: factual_grounding
+    description: Are claims supported by data, references, or specific evidence rather than generic assertions?
+    pass_threshold: 4
+  - name: reasoning_depth
+    description: Does the analysis connect causes to effects (e.g. new product -> revenue impact -> margins)?
+    pass_threshold: 4
+  - name: decision_usefulness
+    description: Does the analysis end with a clear, specific, actionable recommendation?
+    pass_threshold: 4
+notes: >
+  Tests that the agent produces substantive analysis without deflecting
+  on financial advice grounds. Judge scoring evaluates the quality of
+  reasoning that deterministic checks alone cannot capture.

--- a/evals/cases/routing/browser-vs-webextract.yaml
+++ b/evals/cases/routing/browser-vs-webextract.yaml
@@ -1,0 +1,43 @@
+case_id: routing.browser-vs-webextract
+suite: routing
+task_type: routing
+title: Agent chooses browser_navigate + browser_vision over web_extract for visual page analysis
+prompt: >
+  Go to https://example.com and tell me what the main heading and any hero
+  banner images look like on the page — describe their visual appearance,
+  colors, and layout.
+context: >
+  You must use the browser tools to navigate the page and take a screenshot.
+  web_extract would miss the visual layout. Describe what you actually see
+  in the screenshot.
+tags: [routing, tool-choice, browser, vision]
+enabled_toolsets: [browser, vision]
+expected_tools: [browser_navigate, browser_vision]
+forbidden_tools: [web_extract]
+assertions:
+  - kind: tool_used
+    params: {tool: browser_navigate}
+    weight: 2.0
+    required: true
+  - kind: tool_used
+    params: {tool: browser_vision}
+    weight: 2.0
+    required: true
+  - kind: tool_not_used
+    params: {tool: web_extract}
+    weight: 1.0
+    required: true
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: (heading|banner|hero|layout|color|look|appear), ignore_case: true}
+    weight: 1.5
+    required: false
+notes: >
+  This case verifies the agent correctly routes a visual page analysis task
+  to browser tools rather than text-only extraction. The browser_navigate +
+  browser_vision tool sequence is the expected correct flow.

--- a/evals/cases/routing/escalation-to-reviewer.yaml
+++ b/evals/cases/routing/escalation-to-reviewer.yaml
@@ -1,0 +1,43 @@
+case_id: routing.escalation-to-reviewer
+suite: routing
+task_type: routing
+title: Agent recognizes when escalation to a more powerful model/reviewer is appropriate
+prompt: >
+  I need a comprehensive security audit of our authentication system. This
+  requires deep analysis of auth patterns, token handling, session management,
+  and OWASP compliance. Please produce a thorough security review with specific
+  code-level recommendations.
+context: >
+  This task requires a high-confidence security analysis. If you have a
+  reviewer/escalation capability, clearly note which aspects warrant escalation
+  or deeper review. Your output must include specific findings, not generic
+  security advice.
+tags: [routing, escalation, review, security]
+enabled_toolsets: [delegation, terminal]
+expected_tools: [delegate_task]
+forbidden_tools: []
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: required_regex
+    params: {pattern: (security|auth|token|OWASP|vulnerabilit|recommend), ignore_case: true}
+    weight: 1.5
+    required: true
+  - kind: required_regex
+    params: {pattern: (specific|finding|recommendation|issue), ignore_case: true}
+    weight: 1.0
+    required: false
+  - kind: forbidden_regex
+    params:
+      pattern: \b(?:I'm\s+(?:just\s+)?(?:an\s+)?(?:AI|assistant)|I cannot|I'm\s+not\s+able)\b
+      ignore_case: true
+    weight: 2.0
+    required: true
+notes: >
+  Tests that the agent handles requests appropriately when a task warrants
+  escalation — either through delegation to a more capable subagent or by
+  providing substantive analysis instead of deflecting with safety refusals.

--- a/evals/cases/routing/local-repo-inspection.yaml
+++ b/evals/cases/routing/local-repo-inspection.yaml
@@ -1,0 +1,37 @@
+case_id: routing.local-repo-inspection
+suite: routing
+task_type: routing
+title: Agent chooses file-inspection tools for local repo questions instead of web/browser tools
+prompt: >
+  In the current repository, identify where eval case YAML files live and whether
+  any rubric YAML files exist. Answer with the relevant paths and a one-sentence
+  recommendation on how to keep the eval corpus maintainable.
+context: >
+  This is a local repository inspection task. Prefer file-search and file-read
+  tools over web or browser tools. The answer should be concise and path-specific.
+tags: [routing, file-tools, local-repo, evals]
+enabled_toolsets: [file]
+expected_tools: [search_files, read_file]
+forbidden_tools: [web_search, browser_navigate, web_extract]
+assertions:
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: true
+  - kind: tool_used
+    params: {tool: search_files}
+    weight: 2.0
+    required: true
+  - kind: required_regex
+    params: {pattern: "evals/(cases|rubrics)", ignore_case: true}
+    weight: 1.5
+    required: true
+  - kind: tool_not_used
+    params: {tool: browser_navigate}
+    weight: 1.0
+    required: false
+notes: >
+  Routing seed for local-repo questions. The main thing being tested is whether
+  Hermes reaches for file tools instead of web/browser tooling.

--- a/evals/cases/routing/web-search-straightforward.yaml
+++ b/evals/cases/routing/web-search-straightforward.yaml
@@ -1,0 +1,36 @@
+case_id: routing.web-search-straightforward
+suite: routing
+task_type: routing
+title: Agent prefers web_search for straightforward factual queries instead of heavyweight browser
+prompt: >
+  What is the capital of France and what is its approximate population?
+context: >
+  This is a simple factual question that can be answered from web search
+  results. Do not launch a full browser session for this.
+assertions:
+  - kind: tool_used
+    params: {tool: web_search}
+    weight: 2.0
+    required: true
+  - kind: tool_not_used
+    params: {tool: browser_navigate}
+    weight: 1.5
+    required: true
+  - kind: non_empty_output
+    weight: 1.0
+    required: true
+  - kind: contains_substring
+    params: {substring: Paris, ignore_case: true}
+    weight: 1.5
+    required: true
+  - kind: no_placeholder_language
+    weight: 1.0
+    required: false
+tags: [routing, efficiency, tool-choice, web-search]
+enabled_toolsets: [web, terminal]
+expected_tools: [web_search]
+forbidden_tools: [browser_navigate]
+notes: >
+  Simple routing case: lightweight tool (web_search) should be preferred over
+  heavyweight browser for factoid queries. Also checks the agent correctly
+  extracts and returns the answer.

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Iterable, Mapping
+
+from .schemas import AssertionResult, DeterministicAssertion
+
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_PLACEHOLDER_PATTERNS = (
+    re.compile(r"\blorem ipsum\b", re.IGNORECASE),
+    re.compile(r"\b(?:todo|tbd|fixme|placeholder)\b", re.IGNORECASE),
+    re.compile(r"\b(?:your|the)\s+(?:answer|content|response|text|details|summary)\s+here\b", re.IGNORECASE),
+    re.compile(r"\b(?:insert|add|provide|include|write)\s+(?:your|the)\s+(?:answer|content|response|text|details|summary)\b", re.IGNORECASE),
+    re.compile(r"\[\s*(?:insert|add|provide|write)[^\]]*\]", re.IGNORECASE),
+    re.compile(r"<[^>\n]{1,120}>"),
+)
+
+
+class EvalCheckError(ValueError):
+    """Raised when an assertion is unknown or misconfigured."""
+
+
+@dataclass(slots=True)
+class DeterministicScore:
+    score: float
+    passed: bool
+    total_weight: float
+    earned_weight: float
+    required_failures: list[str]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "passed": self.passed,
+            "total_weight": self.total_weight,
+            "earned_weight": self.earned_weight,
+            "required_failures": list(self.required_failures),
+        }
+
+
+_CHECKS = {
+    "non_empty_output",
+    "max_chars",
+    "max_lines",
+    "contains_substring",
+    "required_regex",
+    "forbidden_regex",
+    "tool_used",
+    "tool_not_used",
+    "contains_url",
+    "no_placeholder_language",
+}
+
+
+def evaluate_assertion(
+    assertion: DeterministicAssertion,
+    *,
+    final_response: str,
+    tool_calls: Iterable[Mapping[str, Any]] | None = None,
+) -> AssertionResult:
+    response = final_response or ""
+    tools = _normalize_tool_names(tool_calls or [])
+
+    if assertion.kind not in _CHECKS:
+        allowed = ", ".join(sorted(_CHECKS))
+        raise EvalCheckError(f"Unknown assertion kind {assertion.kind!r}; expected one of [{allowed}]")
+
+    passed, details = _evaluate_kind(assertion.kind, assertion.params, response, tools)
+    details = {
+        **details,
+        "weight": assertion.weight,
+        "required": assertion.required,
+    }
+    return AssertionResult(
+        kind=assertion.kind,
+        passed=passed,
+        score=1.0 if passed else 0.0,
+        details=details,
+    )
+
+
+
+def evaluate_assertions(
+    assertions: Iterable[DeterministicAssertion],
+    *,
+    final_response: str,
+    tool_calls: Iterable[Mapping[str, Any]] | None = None,
+) -> list[AssertionResult]:
+    return [
+        evaluate_assertion(assertion, final_response=final_response, tool_calls=tool_calls)
+        for assertion in assertions
+    ]
+
+
+
+def aggregate_assertion_scores(
+    assertions: Iterable[DeterministicAssertion],
+    results: Iterable[AssertionResult],
+) -> DeterministicScore:
+    assertion_list = list(assertions)
+    result_list = list(results)
+    if len(assertion_list) != len(result_list):
+        raise EvalCheckError(
+            f"Assertion/result length mismatch: {len(assertion_list)} assertions vs {len(result_list)} results"
+        )
+
+    total_weight = 0.0
+    earned_weight = 0.0
+    required_failures: list[str] = []
+
+    for assertion, result in zip(assertion_list, result_list, strict=True):
+        weight = _validate_weight(assertion)
+        total_weight += weight
+        normalized_score = _normalize_result_score(result.score, result.kind)
+        earned_weight += normalized_score * weight
+        if assertion.required and not result.passed:
+            required_failures.append(assertion.kind)
+
+    score = 1.0 if total_weight == 0 else earned_weight / total_weight
+    return DeterministicScore(
+        score=score,
+        passed=not required_failures,
+        total_weight=total_weight,
+        earned_weight=earned_weight,
+        required_failures=required_failures,
+    )
+
+
+
+def _evaluate_kind(
+    kind: str,
+    params: Mapping[str, Any],
+    response: str,
+    tool_names: set[str],
+) -> tuple[bool, dict[str, Any]]:
+    if kind == "non_empty_output":
+        trimmed = response.strip()
+        return bool(trimmed), {"chars": len(response), "trimmed_chars": len(trimmed)}
+
+    if kind == "max_chars":
+        max_chars = _require_int(params, "max_chars", kind)
+        observed = len(response)
+        return observed <= max_chars, {"max_chars": max_chars, "observed_chars": observed}
+
+    if kind == "max_lines":
+        max_lines = _require_int(params, "max_lines", kind)
+        observed = len(response.splitlines()) if response else 0
+        return observed <= max_lines, {"max_lines": max_lines, "observed_lines": observed}
+
+    if kind == "contains_substring":
+        expected = _require_string(params, "substring", kind)
+        ignore_case = _optional_bool(params.get("ignore_case"), default=False, path=f"{kind}.ignore_case")
+        haystack = response.casefold() if ignore_case else response
+        needle = expected.casefold() if ignore_case else expected
+        return needle in haystack, {"substring": expected, "ignore_case": ignore_case}
+
+    if kind == "required_regex":
+        pattern = _require_string(params, "pattern", kind)
+        flags = re.IGNORECASE if _optional_bool(params.get("ignore_case"), default=False, path=f"{kind}.ignore_case") else 0
+        matched = re.search(pattern, response, flags=flags) is not None
+        return matched, {"pattern": pattern, "ignore_case": bool(flags & re.IGNORECASE)}
+
+    if kind == "forbidden_regex":
+        pattern = _require_string(params, "pattern", kind)
+        flags = re.IGNORECASE if _optional_bool(params.get("ignore_case"), default=False, path=f"{kind}.ignore_case") else 0
+        matched = re.search(pattern, response, flags=flags) is not None
+        return not matched, {"pattern": pattern, "ignore_case": bool(flags & re.IGNORECASE)}
+
+    if kind == "tool_used":
+        tool_name = _require_string(params, "tool", kind)
+        return tool_name in tool_names, {"tool": tool_name, "used_tools": sorted(tool_names)}
+
+    if kind == "tool_not_used":
+        tool_name = _require_string(params, "tool", kind)
+        return tool_name not in tool_names, {"tool": tool_name, "used_tools": sorted(tool_names)}
+
+    if kind == "contains_url":
+        url = _first_url(response)
+        return url is not None, {"matched_url": url}
+
+    if kind == "no_placeholder_language":
+        matched_pattern = _first_placeholder_match(response)
+        return matched_pattern is None, {"matched_placeholder": matched_pattern}
+
+    raise EvalCheckError(f"Unhandled assertion kind {kind!r}")
+
+
+
+def _normalize_tool_names(tool_calls: Iterable[Mapping[str, Any]]) -> set[str]:
+    names: set[str] = set()
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, Mapping):
+            continue
+        raw_name = tool_call.get("tool_name") or tool_call.get("name") or tool_call.get("tool")
+        if isinstance(raw_name, str) and raw_name.strip():
+            names.add(raw_name.strip())
+    return names
+
+
+
+def _first_url(response: str) -> str | None:
+    match = _URL_RE.search(response)
+    return match.group(0) if match else None
+
+
+
+def _first_placeholder_match(response: str) -> str | None:
+    for pattern in _PLACEHOLDER_PATTERNS:
+        match = pattern.search(response)
+        if match:
+            return match.group(0)
+    return None
+
+
+
+def _validate_weight(assertion: DeterministicAssertion) -> float:
+    weight = assertion.weight
+    if weight < 0:
+        raise EvalCheckError(f"Assertion {assertion.kind!r} has negative weight {weight}")
+    return float(weight)
+
+
+
+def _normalize_result_score(score: float, kind: str) -> float:
+    normalized = float(score)
+    if normalized < 0 or normalized > 1:
+        raise EvalCheckError(f"Assertion result {kind!r} has score outside [0, 1]: {normalized}")
+    return normalized
+
+
+
+def _require_string(params: Mapping[str, Any], key: str, kind: str) -> str:
+    value = params.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise EvalCheckError(f"Assertion {kind!r} requires non-empty string param {key!r}")
+    return value
+
+
+
+def _require_int(params: Mapping[str, Any], key: str, kind: str) -> int:
+    value = params.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise EvalCheckError(f"Assertion {kind!r} requires integer param {key!r}")
+    return value
+
+
+
+def _optional_bool(value: Any, *, default: bool, path: str) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    raise EvalCheckError(f"{path} must be a boolean when provided")

--- a/evals/fixtures/smoke_ci.yaml
+++ b/evals/fixtures/smoke_ci.yaml
@@ -1,0 +1,37 @@
+defaults:
+  provider: fixture
+  model: fixture-smoke
+  elapsed_ms: 25
+  input_tokens: 120
+  output_tokens: 60
+  estimated_cost_usd: 0.0
+  actual_cost_usd: 0.0
+
+cases:
+  routing.local-repo-inspection:
+    tool_calls:
+      - search_files
+      - read_file
+    final_response: |
+      Eval case YAML files live under evals/cases/, and I found no rubric YAML files under evals/rubrics.
+      Keep the corpus maintainable by grouping small, path-specific cases by suite and avoiding duplicated assertions.
+
+  routing.web-search-straightforward:
+    tool_calls:
+      - web_search
+    final_response: |
+      Paris is the capital of France.
+      Its population is approximately 2.1 million people in the city proper.
+
+  review.pr-code-quality:
+    final_response: |
+      Finding 1 (critical): SQL injection via string concatenation in get_user; build a parameterized query instead of concatenating user_id.
+      Finding 2 (critical): update_email interpolates new_email and user_id directly into SQL; use bound parameters and validate input.
+      Finding 3 (high): delete_user executes a destructive query without commit/error handling; wrap it in transaction handling and return failures explicitly.
+      Recommendation: prioritize the SQLi fixes first, then add proper transaction handling and tests for invalid inputs.
+
+  briefing.change-summary-no-speculation:
+    final_response: |
+      The homepage changed from a generic "Shop Now" hero to a Back to School buy-2-get-1-free promotion.
+      New top-bar messaging now highlights Free Returns this week.
+      The visible commercial angle is a stronger promotional offer plus a seasonal back-to-school cue.

--- a/evals/judges.py
+++ b/evals/judges.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+from statistics import mean
+from typing import Any, Mapping, Sequence
+
+from .schemas import EvalCase, JudgeResult
+
+
+class EvalJudgeError(ValueError):
+    """Raised when judge prompts or outputs are invalid."""
+
+
+def build_judge_prompt(case: EvalCase, *, final_response: str) -> str:
+    """Build a strict-JSON grading prompt for rubric-based eval scoring."""
+    if not case.judge_dimensions:
+        raise EvalJudgeError("case has no judge_dimensions")
+
+    dimension_lines = []
+    for dimension in case.judge_dimensions:
+        threshold = (
+            f", pass_threshold={dimension.pass_threshold}"
+            if dimension.pass_threshold is not None
+            else ""
+        )
+        dimension_lines.append(
+            "- {name}: {description} (scale {scale_min}-{scale_max}{threshold})".format(
+                name=dimension.name,
+                description=dimension.description,
+                scale_min=dimension.scale_min,
+                scale_max=dimension.scale_max,
+                threshold=threshold,
+            )
+        )
+
+    return "\n".join(
+        [
+            "You are grading a Hermes eval response.",
+            "Score each rubric dimension independently and return strict JSON only.",
+            "",
+            f"Case ID: {case.case_id}",
+            f"Suite: {case.suite}",
+            f"Task type: {case.task_type}",
+            f"Title: {case.title}",
+            "",
+            "Rubric dimensions:",
+            *dimension_lines,
+            "",
+            "Return JSON with this exact shape:",
+            '{"scores": [{"dimension": "<name>", "score": <number>, "passed": <true|false>, "rationale": "<brief rationale>"}], "overall_pass": <true|false>, "summary": "<brief summary>"}',
+            "",
+            "Rules:",
+            "- Use every dimension exactly once.",
+            "- score must stay within the declared scale for that dimension.",
+            "- passed must reflect whether the score meets the dimension pass_threshold.",
+            "- overall_pass must be a boolean pass/fail recommendation for the full output.",
+            "- summary must be concise and evidence-based.",
+            "- Do not add markdown fences or extra prose.",
+            "",
+            "Context:",
+            case.context or "",
+            "",
+            "Prompt:",
+            case.prompt,
+            "",
+            "Model response to grade:",
+            final_response,
+        ]
+    ).strip()
+
+
+def evaluate_judge_output(
+    case: EvalCase,
+    judge_output: str | Mapping[str, Any],
+) -> list[JudgeResult]:
+    """Parse strict-JSON judge output into normalized JudgeResult values."""
+    if not case.judge_dimensions:
+        return []
+
+    payload = _load_payload(judge_output)
+    rows = payload.get("scores")
+    if not isinstance(rows, list):
+        raise EvalJudgeError("judge output must contain a list field 'scores'")
+
+    overall_pass = payload.get("overall_pass")
+    if not isinstance(overall_pass, bool):
+        raise EvalJudgeError("judge output field 'overall_pass' must be a boolean")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        raise EvalJudgeError("judge output field 'summary' must be a non-empty string")
+
+    by_name = {dimension.name: dimension for dimension in case.judge_dimensions}
+    results: list[JudgeResult] = []
+    seen: set[str] = set()
+
+    for idx, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise EvalJudgeError(f"judge output scores[{idx}] must be an object")
+
+        name = row.get("dimension")
+        if not isinstance(name, str) or not name:
+            raise EvalJudgeError(f"judge output scores[{idx}].dimension must be a non-empty string")
+        if name not in by_name:
+            raise EvalJudgeError(f"unknown judge dimension {name!r}")
+        if name in seen:
+            raise EvalJudgeError(f"duplicate judge dimension {name!r}")
+        seen.add(name)
+
+        dimension = by_name[name]
+        raw_score = _coerce_float(row.get("score"), f"scores[{idx}].score")
+        if raw_score < dimension.scale_min or raw_score > dimension.scale_max:
+            raise EvalJudgeError(
+                f"judge score for {name!r} out of range: {raw_score} not in [{dimension.scale_min}, {dimension.scale_max}]"
+            )
+
+        provided_passed = row.get("passed")
+        if not isinstance(provided_passed, bool):
+            raise EvalJudgeError(f"judge output scores[{idx}].passed must be a boolean")
+
+        rationale = row.get("rationale")
+        if not isinstance(rationale, str) or not rationale.strip():
+            raise EvalJudgeError(f"judge output scores[{idx}].rationale must be a non-empty string")
+
+        normalized = normalize_judge_score(
+            raw_score,
+            scale_min=dimension.scale_min,
+            scale_max=dimension.scale_max,
+        )
+        threshold = dimension.pass_threshold if dimension.pass_threshold is not None else dimension.scale_min
+        threshold_normalized = normalize_judge_score(
+            threshold,
+            scale_min=dimension.scale_min,
+            scale_max=dimension.scale_max,
+        )
+        computed_passed = normalized >= threshold_normalized
+        if provided_passed != computed_passed:
+            raise EvalJudgeError(
+                f"judge output scores[{idx}].passed disagrees with threshold-derived pass for {name!r}"
+            )
+
+        results.append(
+            JudgeResult(
+                dimension=name,
+                score=normalized,
+                passed=computed_passed,
+                rationale=rationale.strip(),
+            )
+        )
+
+    missing = [dimension.name for dimension in case.judge_dimensions if dimension.name not in seen]
+    if missing:
+        raise EvalJudgeError(f"judge output missing dimension(s): {', '.join(missing)}")
+
+    computed_overall_pass = all(result.passed for result in results)
+    if overall_pass != computed_overall_pass:
+        raise EvalJudgeError("judge output field 'overall_pass' disagrees with dimension pass results")
+
+    return results
+
+
+def normalize_judge_score(score: float, *, scale_min: float, scale_max: float) -> float:
+    """Normalize a raw rubric score into the 0..1 range."""
+    if scale_max <= scale_min:
+        raise EvalJudgeError(
+            f"invalid judge scale: scale_max ({scale_max}) must be greater than scale_min ({scale_min})"
+        )
+    if score < scale_min or score > scale_max:
+        raise EvalJudgeError(f"judge score {score} is outside [{scale_min}, {scale_max}]")
+    return (score - scale_min) / (scale_max - scale_min)
+
+
+def aggregate_eval_scores(
+    *,
+    deterministic_score: float,
+    judge_results: Sequence[JudgeResult] | None = None,
+    efficiency_score: float | None = None,
+) -> dict[str, float]:
+    """Combine deterministic and rubric scores using the eval-plan MVP weights."""
+    det = _clamp_01(deterministic_score, name="deterministic_score")
+    judge_rows = list(judge_results or [])
+
+    if not judge_rows:
+        return {
+            "deterministic": det,
+            "overall": det,
+        }
+
+    judge_score = mean(row.score for row in judge_rows)
+    judge_score = _clamp_01(judge_score, name="judge_score")
+    eff = 1.0 if efficiency_score is None else _clamp_01(efficiency_score, name="efficiency_score")
+
+    overall = (0.5 * det) + (0.4 * judge_score) + (0.1 * eff)
+    return {
+        "deterministic": det,
+        "judge": judge_score,
+        "efficiency": eff,
+        "overall": round(overall, 6),
+    }
+
+
+def _load_payload(judge_output: str | Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(judge_output, Mapping):
+        payload = judge_output
+    else:
+        if not isinstance(judge_output, str) or not judge_output.strip():
+            raise EvalJudgeError("judge output must be a non-empty JSON string or mapping")
+        try:
+            payload = json.loads(judge_output)
+        except json.JSONDecodeError as exc:
+            raise EvalJudgeError(f"judge output is not valid JSON: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise EvalJudgeError("judge output JSON root must be an object")
+    return payload
+
+
+def _coerce_float(value: Any, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise EvalJudgeError(f"{path} must be a number")
+    return float(value)
+
+
+def _clamp_01(value: float, *, name: str) -> float:
+    if value < 0.0 or value > 1.0:
+        raise EvalJudgeError(f"{name} must be between 0 and 1 inclusive; got {value}")
+    return float(value)

--- a/evals/loader.py
+++ b/evals/loader.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .schemas import EvalCase, EvalSchemaError, load_eval_case_file
+
+DEFAULT_CASES_DIR = Path("evals/cases")
+
+
+def resolve_case_files(
+    root: str | Path = DEFAULT_CASES_DIR,
+    *,
+    suites: Sequence[str] | None = None,
+) -> list[Path]:
+    base_dir = Path(root)
+    if not base_dir.exists():
+        raise EvalSchemaError(f"case root does not exist: {base_dir}")
+    if not base_dir.is_dir():
+        raise EvalSchemaError(f"case root must be a directory: {base_dir}")
+
+    suite_filter = {suite for suite in (suites or [])}
+    case_files: list[Path] = []
+    for path in base_dir.rglob("*.yaml"):
+        if not path.is_file():
+            continue
+        if suite_filter:
+            relative = path.relative_to(base_dir)
+            inferred_suite = relative.parts[0] if len(relative.parts) > 1 else None
+            if inferred_suite not in suite_filter:
+                continue
+        case_files.append(path)
+
+    return sorted(case_files, key=lambda path: path.relative_to(base_dir).as_posix())
+
+
+def load_eval_cases(
+    root: str | Path = DEFAULT_CASES_DIR,
+    *,
+    suites: Sequence[str] | None = None,
+    case_ids: Sequence[str] | None = None,
+) -> list[EvalCase]:
+    requested_case_ids = list(case_ids or [])
+    requested_case_id_set = set(requested_case_ids)
+    cases: list[EvalCase] = []
+
+    for path in resolve_case_files(root, suites=suites):
+        case = load_eval_case_file(path)
+        if requested_case_id_set and case.case_id not in requested_case_id_set:
+            continue
+        cases.append(case)
+
+    cases.sort(key=_case_sort_key)
+
+    if requested_case_ids:
+        found_case_ids = {case.case_id for case in cases}
+        missing = sorted(requested_case_id_set - found_case_ids)
+        if missing:
+            raise EvalSchemaError(f"missing case_id(s): {', '.join(missing)}")
+
+    return cases
+
+
+def load_eval_suite(root: str | Path = DEFAULT_CASES_DIR, suite: str = "") -> list[EvalCase]:
+    if not suite:
+        raise EvalSchemaError("suite is required")
+    return load_eval_cases(root, suites=[suite])
+
+
+def group_cases_by_suite(cases: Iterable[EvalCase]) -> dict[str, list[EvalCase]]:
+    grouped: dict[str, list[EvalCase]] = {}
+    for case in sorted(cases, key=_case_sort_key):
+        grouped.setdefault(case.suite, []).append(case)
+    return grouped
+
+
+def _case_sort_key(case: EvalCase) -> tuple[str, str, str]:
+    return (case.suite, case.case_id, case.title)

--- a/evals/mining.py
+++ b/evals/mining.py
@@ -1,0 +1,773 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import re
+import sqlite3
+import uuid
+from dataclasses import dataclass, field, fields, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+import yaml
+
+from .schemas import EvalSchemaError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+MiningSource = Literal["state-db", "trajectories", "cron-outputs"]
+
+
+@dataclass
+class MinedCandidate:
+    """A single session or trace that is a candidate for promotion to an eval case."""
+
+    candidate_id: str
+    source: MiningSource
+    session_id: str
+    prompt: str
+    final_response: str
+    tool_names: list[str]
+    tool_call_count: int
+    failed: bool
+    mined_at: str
+    model: str | None = None
+    provider: str | None = None
+    title: str | None = None
+    context: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    estimated_cost_usd: float | None = None
+    elapsed_ms: int | None = None
+    reason: str | None = None
+    tags: list[str] = field(default_factory=lambda: ["mined", "needs-review"])
+
+    @classmethod
+    def from_session_row(
+        cls,
+        session: dict[str, Any],
+        first_user_msg: str,
+        last_assistant_msg: str,
+        tool_names: list[str],
+        *,
+        reason: str | None = None,
+    ) -> "MinedCandidate":
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        short_id = session.get("id", "unknown")[:12]
+        fields_ = {
+            "candidate_id": f"mined.state.{short_id}",
+            "source": "state-db",
+            "session_id": session.get("id", ""),
+            "model": session.get("model"),
+            "provider": session.get("billing_provider"),
+            "title": session.get("title"),
+            "prompt": first_user_msg,
+            "context": session.get("system_prompt"),
+            "final_response": last_assistant_msg,
+            "tool_names": tool_names,
+            "tool_call_count": session.get("tool_call_count", 0),
+            "input_tokens": session.get("input_tokens"),
+            "output_tokens": session.get("output_tokens"),
+            "estimated_cost_usd": session.get("estimated_cost_usd"),
+            "elapsed_ms": _compute_elapsed_ms(session),
+            "failed": session.get("end_reason") in ("error", "interrupted") or not last_assistant_msg,
+            "reason": reason,
+            "tags": ["mined", "state-db", "needs-review"],
+            "mined_at": now_iso,
+        }
+        return cls(**fields_)  # type: ignore[arg-type]
+
+    @classmethod
+    def from_trajectory_entry(
+        cls,
+        entry: dict[str, Any],
+        *,
+        reason: str | None = None,
+    ) -> "MinedCandidate":
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        conversations = entry.get("conversations", [])
+        first_user = _first_user_message(conversations)
+        last_assistant = _last_assistant_message(conversations)
+        tool_names = _unique_tool_names_from_conversations(conversations)
+        tool_call_count = len(
+            [m for m in conversations if m.get("role") == "assistant" and m.get("tool_calls")]
+        )
+        session_id = entry.get("session_id", entry.get("timestamp", "unknown"))
+        short_id = session_id[:12]
+
+        return cls(
+            candidate_id=f"mined.traj.{short_id}",
+            source="trajectories",
+            session_id=str(session_id),
+            model=entry.get("model"),
+            provider=None,
+            title=None,
+            prompt=first_user,
+            context=None,
+            final_response=last_assistant,
+            tool_names=tool_names,
+            tool_call_count=tool_call_count,
+            input_tokens=None,
+            output_tokens=None,
+            estimated_cost_usd=None,
+            failed=not entry.get("completed", True),
+            reason=reason,
+            tags=["mined", "trajectory", "needs-review"],
+            mined_at=now_iso,
+        )
+
+
+@dataclass
+class MiningResult:
+    """Summary of a single mining run over one source."""
+
+    source_name: MiningSource
+    candidates: list[MinedCandidate]
+    total_sessions_scanned: int
+    total_candidates: int
+
+
+# ---------------------------------------------------------------------------
+# Session DB mining
+# ---------------------------------------------------------------------------
+
+def mine_from_session_db(
+    db_path: str | Path,
+    *,
+    source: str | None = None,
+    model: str | None = None,
+    failed_only: bool = False,
+    min_tool_calls: int = 0,
+    min_tokens: int = 0,
+    days_back: int | None = None,
+    limit: int = 50,
+    cursor_factory: Any = None,
+) -> MiningResult:
+    """Mine candidate eval cases from a Hermes SessionDB (state.db).
+
+    Parameters
+    ----------
+    db_path :
+        Path to the SQLite database.
+    source :
+        Optional session source filter (e.g. ``\"cli\"``, ``\"telegram\"``).
+    model :
+        Optional model name filter (LIKE match).
+    failed_only :
+        Only include sessions with ``end_reason`` in (error, interrupted).
+    min_tool_calls :
+        Minimum ``tool_call_count`` (helps keep low-noise sessions out).
+    min_tokens :
+        Minimum total tokens across input + output.
+    days_back :
+        Only sessions started within this many days.
+    limit :
+        Maximum candidates to return.
+    cursor_factory :
+        For testing — pass a pre-opened sqlite3 Cursor to avoid opening
+        a real file.  The cursor's ``connection`` is used as-is.
+    """
+    candidates: list[MinedCandidate] = []
+
+    if cursor_factory is not None:
+        conn = cursor_factory.connection
+    else:
+        db_path = Path(db_path)
+        if not db_path.exists():
+            logger.warning("Session DB not found at %s", db_path)
+            return MiningResult(
+                source_name="state-db",
+                candidates=[],
+                total_sessions_scanned=0,
+                total_candidates=0,
+            )
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+
+    try:
+        where_clauses: list[str] = []
+        params: list[Any] = []
+
+        if source:
+            where_clauses.append("s.source = ?")
+            params.append(source)
+        if model:
+            where_clauses.append("s.model LIKE ?")
+            params.append(f"%{model}%")
+        if failed_only:
+            where_clauses.append("s.end_reason IN ('error', 'interrupted')")
+        if min_tool_calls > 0:
+            where_clauses.append("s.tool_call_count >= ?")
+            params.append(min_tool_calls)
+        if days_back is not None and days_back > 0:
+            cutoff = datetime.now(timezone.utc).timestamp() - (days_back * 86400)
+            where_clauses.append("s.started_at >= ?")
+            params.append(cutoff)
+
+        where_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
+
+        # Fetch sessions ordered by recency
+        rows = conn.execute(
+            f"SELECT s.* FROM sessions s WHERE {where_sql} ORDER BY s.started_at DESC LIMIT ?",
+            [*params, limit],
+        ).fetchall()
+
+        total = len(rows)
+
+        for row in rows:
+            session = dict(row)
+            sid = session.get("id", "")
+            if not sid:
+                continue
+
+            # Fetch messages for this session
+            msgs = conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                (sid,),
+            ).fetchall()
+            msg_dicts = [dict(m) for m in msgs]
+
+            first_user = _first_user_message(msg_dicts)
+            last_assistant = _last_assistant_message(msg_dicts)
+
+            # Bail if there's no real user input to build a prompt from
+            if not first_user and not last_assistant:
+                continue
+
+            tool_names = _unique_tool_names_from_messages(msg_dicts)
+            total_tokens = (session.get("input_tokens") or 0) + (session.get("output_tokens") or 0)
+
+            if min_tokens > 0 and total_tokens < min_tokens:
+                continue
+
+            # Heuristic reason
+            reason = _infer_mining_reason(
+                session,
+                tool_names=tool_names,
+                has_prompt=bool(first_user),
+                has_response=bool(last_assistant),
+            )
+
+            candidate = MinedCandidate.from_session_row(
+                session,
+                first_user,
+                last_assistant,
+                tool_names,
+                reason=reason,
+            )
+            candidates.append(candidate)
+
+    finally:
+        if cursor_factory is None:
+            conn.close()
+
+    return MiningResult(
+        source_name="state-db",
+        candidates=candidates,
+        total_sessions_scanned=total,
+        total_candidates=len(candidates),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trajectory file mining
+# ---------------------------------------------------------------------------
+
+def mine_from_trajectories(
+    trajectories_path: str | Path,
+    *,
+    failed_only: bool = False,
+    limit: int = 50,
+) -> MiningResult:
+    """Mine candidate eval cases from trajectory JSONL files.
+
+    The trajectory format used by ``agent/trajectory.py``: one JSON object
+    per line with keys ``conversations``, ``model``, ``completed``,
+    ``timestamp``.
+    """
+    traj_path = Path(trajectories_path)
+    if not traj_path.exists():
+        logger.warning("Trajectory file not found at %s", traj_path)
+        return MiningResult(source_name="trajectories", candidates=[], total_sessions_scanned=0, total_candidates=0)
+
+    candidates: list[MinedCandidate] = []
+    total_scanned = 0
+
+    with traj_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping unparseable trajectory line in %s", traj_path)
+                continue
+
+            total_scanned += 1
+            completed = entry.get("completed", True)
+
+            if failed_only and completed:
+                continue
+
+            reason = "failed trajectory" if not completed else "trajectory sample"
+            candidate = MinedCandidate.from_trajectory_entry(entry, reason=reason)
+            candidates.append(candidate)
+
+            if len(candidates) >= limit:
+                break
+
+    return MiningResult(
+        source_name="trajectories",
+        candidates=candidates,
+        total_sessions_scanned=total_scanned,
+        total_candidates=len(candidates),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cron output mining
+# ---------------------------------------------------------------------------
+
+def mine_from_cron_outputs(
+    cron_dir: str | Path,
+    *,
+    limit: int = 20,
+    pattern: str = "*.md",
+) -> MiningResult:
+    """Mine candidate eval cases from cron output directories.
+
+    Scans ``cron_dir/<job_id>/`` for the most recent ``.md`` output files
+    and extracts the first user message (typically the cron prompt) and the
+    last content block from each.
+    """
+    cron_path = Path(cron_dir)
+    if not cron_path.is_dir():
+        logger.warning("Cron output directory not found at %s", cron_path)
+        return MiningResult(source_name="cron-outputs", candidates=[], total_sessions_scanned=0, total_candidates=0)
+
+    candidates: list[MinedCandidate] = []
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    job_dirs = sorted(
+        [d for d in cron_path.iterdir() if d.is_dir()],
+        key=lambda d: d.name,
+    )
+
+    for job_dir in job_dirs:
+        if len(candidates) >= limit:
+            break
+
+        # Find the most recent output file
+        out_files = sorted(job_dir.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+        if not out_files:
+            continue
+
+        latest = out_files[0]
+        try:
+            text = latest.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        # Extract the first significant content (skip skill preamble)
+        # Heuristic: the cron prompt is typically at the very beginning or
+        # just after the skill preamble.
+        lines = text.splitlines()
+        prompt = _extract_cron_prompt(lines)
+        final_response = _extract_cron_final_response(lines)
+
+        if not prompt and not final_response:
+            continue
+
+        job_id = job_dir.name
+        candidate = MinedCandidate(
+            candidate_id=f"mined.cron.{job_id}",
+            source="cron-outputs",
+            session_id=f"cron/{job_id}",
+            model=None,
+            provider=None,
+            title=f"cron job {job_id}",
+            prompt=prompt,
+            context=None,
+            final_response=final_response,
+            tool_names=[],
+            tool_call_count=0,
+            input_tokens=None,
+            output_tokens=None,
+            estimated_cost_usd=None,
+            failed=False,
+            reason="cron output sample",
+            tags=["mined", "cron", "needs-review"],
+            mined_at=now_iso,
+        )
+        candidates.append(candidate)
+
+    return MiningResult(
+        source_name="cron-outputs",
+        candidates=candidates,
+        total_sessions_scanned=len(job_dirs),
+        total_candidates=len(candidates),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Conversion to draft eval case YAML
+# ---------------------------------------------------------------------------
+
+def candidate_to_draft_case(
+    candidate: MinedCandidate,
+    *,
+    default_suite: str = "mined",
+    default_task_type: str = "analysis",
+) -> dict[str, Any]:
+    """Convert a ``MinedCandidate`` into a YAML-serializable draft eval case dict.
+
+    The returned dict is suitable for writing directly to a ``.yaml`` file
+    for human review and later promotion to ``evals/cases/<suite>/``.
+    """
+    # Heuristic task type based on tool usage
+    task_type = _heuristic_task_type(candidate.tool_names, candidate.prompt)
+
+    # Build a human-readable title from the prompt first line
+    title = candidate.title or _prompt_to_title(candidate.prompt)
+
+    # Generate deterministic assertions from the observed tools
+    assertions: list[dict[str, Any]] = []
+
+    if candidate.tool_names:
+        for tool_name in sorted(set(candidate.tool_names)):
+            assertions.append(
+                {
+                    "kind": "tool_used",
+                    "params": {"tool": tool_name},
+                    "weight": 1.0,
+                    "required": False,
+                }
+            )
+
+    # Basic quality gates
+    assertions.append(
+        {"kind": "non_empty_output", "weight": 2.0, "required": True}
+    )
+
+    # Build tags
+    tags = list(candidate.tags) if candidate.tags else []
+    if candidate.failed:
+        tags.append("regression")
+    if "browser" in str(candidate.tool_names):
+        tags.append("browser")
+    if "web_search" in str(candidate.tool_names) or "web_extract" in str(candidate.tool_names):
+        tags.append("web")
+    tags = list(dict.fromkeys(tags))  # deduplicate preserving order
+
+    reason = candidate.reason or ""
+    notes = f"Mined from {candidate.source} session {candidate.session_id[:16]}"
+    if reason:
+        notes += f". Reason: {reason}"
+
+    return {
+        "case_id": candidate.candidate_id,
+        "suite": default_suite,
+        "task_type": task_type,
+        "title": title,
+        "prompt": candidate.prompt,
+        "context": candidate.context or None,
+        "tags": tags,
+        "enabled_toolsets": _heuristic_toolsets(candidate.tool_names),
+        "expected_tools": sorted(set(candidate.tool_names)),
+        "forbidden_tools": [],
+        "assertions": assertions,
+        "judge_dimensions": [],
+        "gold_answer": None,
+        "notes": notes,
+    }
+
+
+def export_draft_cases(
+    candidates: list[MinedCandidate],
+    *,
+    output_dir: str | Path,
+    default_suite: str = "mined",
+    prefix: str = "draft_",
+) -> list[Path]:
+    """Write each candidate as a standalone YAML draft case file.
+
+    Returns the list of written file paths.
+    """
+    out_root = Path(output_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    for candidate in candidates:
+        draft = candidate_to_draft_case(candidate, default_suite=default_suite)
+        safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", draft["case_id"])
+        filename = f"{prefix}{safe_id}.yaml"
+        file_path = out_root / filename
+
+        yaml_bytes = yaml.safe_dump(
+            draft,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=120,
+        ).encode("utf-8")
+
+        file_path.write_bytes(yaml_bytes)
+        written.append(file_path)
+
+    return written
+
+
+def export_candidates_report(
+    candidates: list[MinedCandidate],
+    output_path: str | Path,
+) -> Path:
+    """Write a summary markdown report listing all mined candidates."""
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        "# Mined eval case candidates",
+        "",
+        f"**Generated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
+        f"**Total candidates:** {len(candidates)}",
+        "",
+        "## Candidates",
+        "",
+        "| # | Candidate ID | Session | Model | Tools | Failed | Reason |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+
+    for idx, c in enumerate(candidates, start=1):
+        tool_str = ", ".join(c.tool_names[:5])
+        if len(c.tool_names) > 5:
+            tool_str += " ..."
+        session_short = c.session_id[:16] if c.session_id else "-"
+        lines.append(
+            f"| {idx} | {c.candidate_id} | {session_short} | {c.model or '-'} "
+            f"| {tool_str or '-'} | {'❌' if c.failed else '✅'} | {c.reason or '-'} |"
+        )
+
+    lines.append("")
+    out.write_text("\n".join(lines), encoding="utf-8")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_user_message(messages: list[dict[str, Any]]) -> str:
+    """Return the content of the first user message (not tool results)."""
+    for msg in messages:
+        role = msg.get("role", "")
+        if role == "user":
+            content = msg.get("content", "") or ""
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+    return ""
+
+
+def _last_assistant_message(messages: list[dict[str, Any]]) -> str:
+    """Return the content of the last assistant message that has no tool_calls."""
+    last_text = ""
+    for msg in messages:
+        role = msg.get("role", "")
+        if role == "assistant":
+            content = msg.get("content", "") or ""
+            tc = msg.get("tool_calls")
+            # Prefer final text-only responses (no tool calls)
+            if isinstance(content, str) and content.strip() and not tc:
+                last_text = content.strip()
+            # Fallback: capture even empty text as long as it's final
+            elif isinstance(content, str) and not tc:
+                last_text = content.strip()
+    return last_text
+
+
+def _unique_tool_names_from_messages(messages: list[dict[str, Any]]) -> list[str]:
+    """Extract unique tool names from assistant tool_calls in messages."""
+    seen: set[str] = set()
+    names: list[str] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        raw_tc = msg.get("tool_calls")
+        if not raw_tc or not isinstance(raw_tc, (list, str)):
+            continue
+        if isinstance(raw_tc, str):
+            try:
+                raw_tc = json.loads(raw_tc)
+            except (json.JSONDecodeError, TypeError):
+                continue
+        for tc in raw_tc:
+            if isinstance(tc, dict):
+                func = tc.get("function", {})
+                name = func.get("name", "") if isinstance(func, dict) else ""
+                if not name:
+                    name = tc.get("name", "")
+                if name and name not in seen:
+                    seen.add(name)
+                    names.append(name)
+    return names
+
+
+def _unique_tool_names_from_conversations(conversations: list[dict[str, Any]]) -> list[str]:
+    """Extract unique tool names from ShareGPT-format conversations."""
+    seen: set[str] = set()
+    names: list[str] = []
+    for msg in conversations:
+        if msg.get("role") != "assistant":
+            continue
+        raw_tc = msg.get("tool_calls")
+        if not raw_tc or not isinstance(raw_tc, list):
+            continue
+        for tc in raw_tc:
+            if isinstance(tc, dict):
+                func = tc.get("function", {})
+                name = func.get("name", "") if isinstance(func, dict) else ""
+                if not name:
+                    name = tc.get("name", "")
+                if name and name not in seen:
+                    seen.add(name)
+                    names.append(name)
+    return names
+
+
+def _compute_elapsed_ms(session: dict[str, Any]) -> int | None:
+    started = session.get("started_at")
+    ended = session.get("ended_at")
+    if started is not None and ended is not None:
+        return int((ended - started) * 1000)
+    return None
+
+
+def _infer_mining_reason(
+    session: dict[str, Any],
+    *,
+    tool_names: list[str],
+    has_prompt: bool,
+    has_response: bool,
+) -> str | None:
+    """Heuristic: why this session is worth mining."""
+    end_reason = session.get("end_reason")
+
+    if end_reason in ("error", "interrupted"):
+        return f"session ended with {end_reason}"
+    if end_reason == "branched":
+        return "session was manually branched — likely interesting"
+    if not has_response:
+        return "no assistant response — possibly incomplete"
+    if not has_prompt:
+        return None  # no user input to build a prompt from
+    if tool_names:
+        return f"used {len(tool_names)} tool(s): {', '.join(tool_names[:3])}"
+    return "completed session with direct response"
+
+
+def _heuristic_task_type(tool_names: list[str], prompt: str) -> str:
+    """Guess the task type from tool usage and prompt text."""
+    prompt_lower = prompt.lower()
+
+    if "browser" in str(tool_names) or "vision" in str(tool_names):
+        if "browser_navigate" in tool_names or "browser_vision" in tool_names:
+            return "browser"
+        return "multimodal"
+    if any(t in tool_names for t in ("web_search", "web_extract")):
+        if "review" in prompt_lower or "analyse" in prompt_lower or "analyze" in prompt_lower or "audit" in prompt_lower:
+            return "review"
+        if (
+            "brief" in prompt_lower
+            or "summary" in prompt_lower
+            or "summarize" in prompt_lower
+            or "summarise" in prompt_lower
+            or "report" in prompt_lower
+        ):
+            return "briefing"
+        return "analysis"
+    if "terminal" in tool_names or "execute_code" in tool_names:
+        return "tooling"
+    if "routing" in prompt_lower or "model" in prompt_lower or "provider" in prompt_lower:
+        return "routing"
+    return "analysis"
+
+
+def _heuristic_toolsets(tool_names: list[str]) -> list[str]:
+    """Infer required toolsets from tool names."""
+    toolsets: list[str] = []
+    if any(t in tool_names for t in ("web_search", "web_extract")):
+        toolsets.append("web")
+    if any(t in tool_names for t in ("browser_navigate", "browser_vision", "browser_click")):
+        toolsets.append("browser")
+    if any(t in tool_names for t in ("terminal",)):
+        toolsets.append("terminal")
+    if any(t in tool_names for t in ("execute_code",)):
+        toolsets.append("code_execution")
+    if any(t in tool_names for t in ("vision_analyze",)):
+        toolsets.append("vision")
+    if any(t in tool_names for t in ("delegate_task",)):
+        toolsets.append("delegation")
+    return toolsets
+
+
+def _prompt_to_title(prompt: str) -> str:
+    """Derive a short title from the first line or sentence of the prompt."""
+    first_line = prompt.split("\n")[0].strip()
+    # Take first ~80 chars
+    if len(first_line) > 80:
+        first_line = first_line[:77] + "..."
+    return first_line or "Mined session"
+
+
+def _extract_cron_prompt(lines: list[str]) -> str:
+    """Extract the cron prompt from output lines.
+
+    The first non-empty line that looks like a user instruction.
+    """
+    # Skip first few lines if they look like markdown headers or skill preambles
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("---"):
+            continue
+        if len(stripped) > 20:
+            return stripped[:200]
+    return ""
+
+
+def _extract_cron_final_response(lines: list[str]) -> str:
+    """Extract the final content block from a cron output file.
+
+    Looks for the last substantial text block (not a preamble line).
+    """
+    # Find the last significant paragraph (non-empty, non-header, meaningful length)
+    content_blocks: list[str] = []
+    current: list[str] = []
+
+    for line in reversed(lines):
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and not stripped.startswith("---"):
+            current.append(stripped)
+        elif current:
+            content_blocks.append(" ".join(reversed(current)))
+            current = []
+            if len(content_blocks) >= 3:
+                break
+
+    if current:
+        content_blocks.append(" ".join(reversed(current)))
+
+    # The last content block (reversed order) is the final section
+    if content_blocks:
+        result = content_blocks[0]
+        if len(result) > 500:
+            result = result[:497] + "..."
+        return result
+    return ""

--- a/evals/reporting.py
+++ b/evals/reporting.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from statistics import mean
+from typing import Any, Iterable
+
+from .schemas import EvalRunResult
+
+DEFAULT_RESULTS_DIR = Path("evals/results")
+
+
+def results_to_json_bytes(results: Iterable[EvalRunResult]) -> bytes:
+    ordered_results = _ordered_results(results)
+    payload = {
+        "summary": _build_summary(ordered_results),
+        "results": [_result_to_dict(result) for result in ordered_results],
+    }
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def write_results_json(results: Iterable[EvalRunResult], path: str | Path) -> Path:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(results_to_json_bytes(results))
+    return output_path
+
+
+def render_markdown_report(results: Iterable[EvalRunResult]) -> str:
+    ordered_results = _ordered_results(results)
+    summary = _build_summary(ordered_results)
+    lines = [
+        "# Hermes eval report",
+        "",
+        "## Summary",
+        f"- Total runs: {summary['total']}",
+        f"- Passed: {summary['passed']}",
+        f"- Failed: {summary['failed']}",
+        f"- Completed: {summary['completed']}",
+        f"- Suites: {summary['suites']}",
+    ]
+
+    if ordered_results:
+        lines.extend(
+            [
+                f"- Mean overall score: {_mean_score(ordered_results, 'overall'):.3f}",
+                f"- Mean deterministic score: {_mean_score(ordered_results, 'deterministic'):.3f}",
+                "",
+                "## Runs",
+                "| Suite | Case ID | Status | Overall | Deterministic | Elapsed ms |",
+                "| --- | --- | --- | ---: | ---: | ---: |",
+            ]
+        )
+        for result in ordered_results:
+            lines.append(
+                "| {suite} | {case_id} | {status} | {overall:.3f} | {deterministic:.3f} | {elapsed_ms} |".format(
+                    suite=result.suite,
+                    case_id=result.case_id,
+                    status="✅" if _is_pass(result) else "❌",
+                    overall=result.aggregate_scores.get("overall", 0.0),
+                    deterministic=result.aggregate_scores.get("deterministic", 0.0),
+                    elapsed_ms=result.elapsed_ms,
+                )
+            )
+
+        failed_results = [result for result in ordered_results if not _is_pass(result)]
+        if failed_results:
+            lines.extend(["", "## Failed runs"])
+            for result in failed_results:
+                reason = result.error or _failure_reason(result)
+                lines.append(f"- `{result.case_id}` ({result.suite}) — {reason}")
+
+    return "\n".join(lines) + "\n"
+
+
+def write_markdown_report(results: Iterable[EvalRunResult], path: str | Path) -> Path:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_markdown_report(results), encoding="utf-8")
+    return output_path
+
+
+def _ordered_results(results: Iterable[EvalRunResult]) -> list[EvalRunResult]:
+    return sorted(results, key=lambda result: (result.suite, result.case_id, result.run_id))
+
+
+def _build_summary(results: list[EvalRunResult]) -> dict[str, int]:
+    return {
+        "total": len(results),
+        "completed": sum(1 for result in results if result.completed),
+        "failed": sum(1 for result in results if result.failed),
+        "passed": sum(1 for result in results if _is_pass(result)),
+        "suites": len({result.suite for result in results}),
+    }
+
+
+def _result_to_dict(result: EvalRunResult) -> dict[str, Any]:
+    return asdict(result)
+
+
+def _is_pass(result: EvalRunResult) -> bool:
+    if result.failed or not result.completed:
+        return False
+    if any(not assertion.passed for assertion in result.assertions):
+        return False
+    if any(not judge_result.passed for judge_result in result.judge_results):
+        return False
+    return True
+
+
+def _failure_reason(result: EvalRunResult) -> str:
+    failed_assertions = [assertion.kind for assertion in result.assertions if not assertion.passed]
+    if failed_assertions:
+        return f"failed assertions: {', '.join(failed_assertions)}"
+    failed_dimensions = [judge.dimension for judge in result.judge_results if not judge.passed]
+    if failed_dimensions:
+        return f"failed judge dimensions: {', '.join(failed_dimensions)}"
+    if not result.completed:
+        return "run did not complete"
+    return "run marked unsuccessful"
+
+
+def _mean_score(results: list[EvalRunResult], name: str) -> float:
+    values = [result.aggregate_scores[name] for result in results if name in result.aggregate_scores]
+    if not values:
+        return 0.0
+    return mean(values)

--- a/evals/results/.gitignore
+++ b/evals/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/evals/rubrics/briefing.yaml
+++ b/evals/rubrics/briefing.yaml
@@ -1,0 +1,27 @@
+version: 1
+rubric_id: briefing.seed
+suite: briefing
+purpose: Shared seed rubric for concise observation-led briefing cases.
+status: informational-until-loader-support
+notes: >
+  The executable source of truth remains inline judge_dimensions on each case.
+  This rubric file captures the intended common dimensions for briefing work.
+dimensions:
+  - name: visible_signal_coverage
+    description: Does the briefing capture the key visible campaigns, offers, and seasonal cues without missing obvious items?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: concision
+    description: Is the output compact, scannable, and faithful to the requested length constraint?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: observation_vs_inference
+    description: Does the output distinguish visible evidence from speculation about motives or performance?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+applies_to_cases:
+  - briefing.homepage-visible-campaigns
+  - briefing.change-summary-no-speculation

--- a/evals/rubrics/multimodal.yaml
+++ b/evals/rubrics/multimodal.yaml
@@ -1,0 +1,27 @@
+version: 1
+rubric_id: multimodal.seed
+suite: multimodal
+purpose: Shared seed rubric for screenshot and browser-plus-vision eval cases.
+status: informational-until-loader-support
+notes: >
+  These rubrics are committed now for design continuity, but the current runner
+  still relies on inline judge_dimensions embedded in each case.
+dimensions:
+  - name: modality_choice
+    description: Does the agent choose the right modality mix (browser, screenshot, vision, text) for the task?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: image_grounding
+    description: Are claims grounded in visible elements from the image or screenshot rather than invented context?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: synthesis_quality
+    description: Does the answer integrate visible elements into a coherent, decision-useful summary?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+applies_to_cases:
+  - multimodal.screenshot-commercial-readout
+  - multimodal.browser-screenshot-fallback

--- a/evals/rubrics/review.yaml
+++ b/evals/rubrics/review.yaml
@@ -1,0 +1,30 @@
+version: 1
+rubric_id: review.seed
+suite: review
+purpose: Shared seed rubric for review and analysis-quality cases.
+status: informational-until-loader-support
+notes: >
+  External rubric loading is not wired into evals/loader.py yet. These rubric
+  files document the intended shared judge dimensions while cases continue to
+  embed inline judge_dimensions for executable coverage.
+dimensions:
+  - name: factual_grounding
+    description: Are findings or claims tied to concrete evidence rather than generic assertions?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: finding_specificity
+    description: Are findings specific enough that a reviewer could act on them immediately?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: actionability
+    description: Does the response provide concrete next steps, fixes, or rewrites instead of vague advice?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+applies_to_cases:
+  - review.pr-code-quality
+  - review.strategic-analysis
+  - review.decision-memo
+  - review.briefing-factuality-review

--- a/evals/rubrics/routing.yaml
+++ b/evals/rubrics/routing.yaml
@@ -1,0 +1,30 @@
+version: 1
+rubric_id: routing.seed
+suite: routing
+purpose: Shared seed rubric for routing/tool-choice eval cases.
+status: informational-until-loader-support
+notes: >
+  Current eval implementation scores quality via inline judge_dimensions on each
+  case. This file is a seed rubric catalog to preserve continuity with the eval
+  design plan until external rubric loading is implemented.
+dimensions:
+  - name: tool_choice_correctness
+    description: Does the agent choose the right primary tool path for the task instead of an obviously mismatched tool?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: scope_discipline
+    description: Does the agent stay within the user's actual request rather than broadening unnecessarily?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+  - name: uncertainty_handling
+    description: When routing is ambiguous, does the agent explain uncertainty honestly without stalling on avoidable clarification?
+    scale_min: 1
+    scale_max: 5
+    pass_threshold: 4
+applies_to_cases:
+  - routing.browser-vs-webextract
+  - routing.web-search-straightforward
+  - routing.escalation-to-reviewer
+  - routing.local-repo-inspection

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from .checks import aggregate_assertion_scores, evaluate_assertions
+from .judges import aggregate_eval_scores, build_judge_prompt, evaluate_judge_output
+from .schemas import EvalCase, EvalRunResult, JudgeResult
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_eval_case(
+    case: EvalCase,
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    save_trajectories: bool = False,
+    max_turns: int = 90,
+    judge_model: str | None = None,
+    judge_provider: str | None = None,
+    judge_base_url: str | None = None,
+    judge_api_key: str | None = None,
+    injected_agent: Any = None,
+    injected_judge: Any = None,
+) -> EvalRunResult:
+    """Run a single eval case through Hermes and return a structured result."""
+    if injected_agent is not None:
+        agent = injected_agent
+    else:
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model=model,
+            provider=provider,
+            base_url=base_url,
+            api_key=api_key,
+            max_iterations=max_turns,
+            enabled_toolsets=case.enabled_toolsets or None,
+            save_trajectories=save_trajectories,
+        )
+
+    run_id = _generate_run_id()
+    started_at = datetime.now(timezone.utc)
+    ended_at = started_at
+    error: str | None = None
+    failed = False
+    final_response = ""
+    completed = False
+
+    try:
+        result = agent.run_conversation(
+            case.prompt,
+            system_message=case.context,
+        )
+    except Exception as exc:
+        failed = True
+        error = f"{type(exc).__name__}: {exc}"
+    else:
+        final_response = result.get("final_response", "") or ""
+        completed = result.get("completed", False)
+        if not completed:
+            failed = True
+    finally:
+        ended_at = datetime.now(timezone.utc)
+
+    elapsed_ms = int((ended_at - started_at).total_seconds() * 1000)
+
+    metrics = _extract_session_metrics(agent)
+    assertion_results = evaluate_assertions(
+        case.assertions,
+        final_response=final_response,
+        tool_calls=metrics["tool_calls"],
+    )
+    det_score = aggregate_assertion_scores(case.assertions, assertion_results)
+
+    judge_results = _run_judge_if_configured(
+        case,
+        final_response=final_response,
+        judge_model=judge_model,
+        judge_provider=judge_provider,
+        judge_base_url=judge_base_url,
+        judge_api_key=judge_api_key,
+        injected_judge=injected_judge,
+    )
+    aggregate_scores = aggregate_eval_scores(
+        deterministic_score=det_score.score,
+        judge_results=judge_results,
+    )
+
+    agent_model = getattr(agent, "model", None)
+    agent_provider = getattr(agent, "provider", None)
+
+    return EvalRunResult(
+        run_id=run_id,
+        case_id=case.case_id,
+        suite=case.suite,
+        provider=agent_provider,
+        model=agent_model,
+        judge_provider=judge_provider if judge_results else None,
+        judge_model=judge_model if judge_results else None,
+        started_at=_iso_now(started_at),
+        ended_at=_iso_now(ended_at),
+        elapsed_ms=elapsed_ms,
+        completed=completed,
+        failed=failed,
+        error=error,
+        final_response=final_response,
+        tool_calls=metrics["tool_calls"],
+        input_tokens=metrics["input_tokens"],
+        output_tokens=metrics["output_tokens"],
+        cache_read_tokens=metrics["cache_read_tokens"],
+        cache_write_tokens=metrics["cache_write_tokens"],
+        estimated_cost_usd=metrics["estimated_cost_usd"],
+        actual_cost_usd=metrics["actual_cost_usd"],
+        assertions=assertion_results,
+        judge_results=judge_results,
+        aggregate_scores=aggregate_scores,
+        labels={},
+    )
+
+
+def run_eval_suite(
+    cases: list[EvalCase],
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    save_trajectories: bool = False,
+    max_turns: int = 90,
+    judge_model: str | None = None,
+    judge_provider: str | None = None,
+    judge_base_url: str | None = None,
+    judge_api_key: str | None = None,
+    injected_judge: Any = None,
+) -> list[EvalRunResult]:
+    """Run multiple eval cases sequentially."""
+    return [
+        run_eval_case(
+            case,
+            model=model,
+            provider=provider,
+            base_url=base_url,
+            api_key=api_key,
+            save_trajectories=save_trajectories,
+            max_turns=max_turns,
+            judge_model=judge_model,
+            judge_provider=judge_provider,
+            judge_base_url=judge_base_url,
+            judge_api_key=judge_api_key,
+            injected_judge=injected_judge,
+        )
+        for case in cases
+    ]
+
+
+def build_result_from_components(
+    case: EvalCase,
+    *,
+    final_response: str,
+    completed: bool,
+    failed: bool = False,
+    error: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cache_read_tokens: int | None = None,
+    cache_write_tokens: int | None = None,
+    estimated_cost_usd: float | None = None,
+    actual_cost_usd: float | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+    judge_results: list[JudgeResult] | None = None,
+    judge_model: str | None = None,
+    judge_provider: str | None = None,
+    efficiency_score: float | None = None,
+    elapsed_ms: int = 0,
+) -> EvalRunResult:
+    """Construct an ``EvalRunResult`` from pre-extracted components."""
+    tool_calls = tool_calls or []
+
+    assertion_results = evaluate_assertions(
+        case.assertions,
+        final_response=final_response,
+        tool_calls=tool_calls,
+    )
+    det_score = aggregate_assertion_scores(case.assertions, assertion_results)
+    judge_results = judge_results or []
+    aggregate_scores = aggregate_eval_scores(
+        deterministic_score=det_score.score,
+        judge_results=judge_results,
+        efficiency_score=efficiency_score,
+    )
+
+    now = _iso_now(datetime.now(timezone.utc))
+    return EvalRunResult(
+        run_id=_generate_run_id(),
+        case_id=case.case_id,
+        suite=case.suite,
+        provider=provider,
+        model=model,
+        judge_provider=judge_provider if judge_results else None,
+        judge_model=judge_model if judge_results else None,
+        started_at=now,
+        ended_at=now,
+        elapsed_ms=elapsed_ms,
+        completed=completed,
+        failed=failed,
+        error=error,
+        final_response=final_response,
+        tool_calls=tool_calls,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        estimated_cost_usd=estimated_cost_usd,
+        actual_cost_usd=actual_cost_usd,
+        assertions=assertion_results,
+        judge_results=judge_results,
+        aggregate_scores=aggregate_scores,
+        labels={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_run_id() -> str:
+    short = uuid.uuid4().hex[:12]
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    return f"run_{ts}_{short}"
+
+
+def _iso_now(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _extract_session_metrics(agent: Any) -> dict[str, Any]:
+    """Pull token counts, cost, and tool-call names from the agent's session DB."""
+    result: dict[str, Any] = {
+        "tool_calls": [],
+        "input_tokens": None,
+        "output_tokens": None,
+        "cache_read_tokens": None,
+        "cache_write_tokens": None,
+        "estimated_cost_usd": None,
+        "actual_cost_usd": None,
+    }
+
+    try:
+        session_db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", None)
+        if session_db is None or session_id is None:
+            return result
+
+        session = session_db.get_session(session_id)
+        if session:
+            result["input_tokens"] = session.get("input_tokens")
+            result["output_tokens"] = session.get("output_tokens")
+            result["cache_read_tokens"] = session.get("cache_read_tokens")
+            result["cache_write_tokens"] = session.get("cache_write_tokens")
+            result["estimated_cost_usd"] = session.get("estimated_cost_usd")
+            result["actual_cost_usd"] = session.get("actual_cost_usd")
+
+        messages = session_db.get_messages(session_id)
+        seen: set[str] = set()
+        tool_calls_list: list[dict[str, Any]] = []
+        for msg in messages:
+            raw_tc = msg.get("tool_calls")
+            if not raw_tc or not isinstance(raw_tc, list):
+                continue
+            for tc in raw_tc:
+                func = tc.get("function", {})
+                name = func.get("name", "") if isinstance(func, dict) else ""
+                if not name:
+                    name = tc.get("name", "")
+                if name and name not in seen:
+                    seen.add(name)
+                    tool_calls_list.append({"name": name})
+        result["tool_calls"] = tool_calls_list
+
+    except Exception as exc:
+        logger.warning("Failed to extract session metrics: %s", exc)
+
+    return result
+
+
+def _run_judge_if_configured(
+    case: EvalCase,
+    *,
+    final_response: str,
+    judge_model: str | None,
+    judge_provider: str | None,
+    judge_base_url: str | None,
+    judge_api_key: str | None,
+    injected_judge: Any = None,
+) -> list[JudgeResult]:
+    if not case.judge_dimensions or not final_response.strip():
+        return []
+    if injected_judge is None and not judge_model:
+        return []
+
+    prompt = build_judge_prompt(case, final_response=final_response)
+
+    if injected_judge is not None:
+        if callable(injected_judge):
+            raw_output = injected_judge(case=case, final_response=final_response, prompt=prompt)
+        else:
+            judge_response = injected_judge.run_conversation(prompt)
+            raw_output = (
+                judge_response.get("final_response", "")
+                if isinstance(judge_response, dict)
+                else judge_response
+            )
+    else:
+        from run_agent import AIAgent
+
+        judge_agent_kwargs: dict[str, Any] = {
+            "max_iterations": 8,
+            "enabled_toolsets": [],
+            "save_trajectories": False,
+        }
+        if judge_model is not None:
+            judge_agent_kwargs["model"] = judge_model
+        if judge_provider is not None:
+            judge_agent_kwargs["provider"] = judge_provider
+        if judge_base_url is not None:
+            judge_agent_kwargs["base_url"] = judge_base_url
+        if judge_api_key is not None:
+            judge_agent_kwargs["api_key"] = judge_api_key
+
+        judge_agent = AIAgent(**judge_agent_kwargs)
+        judge_response = judge_agent.run_conversation(prompt)
+        raw_output = (
+            judge_response.get("final_response", "")
+            if isinstance(judge_response, dict)
+            else judge_response
+        )
+
+    if isinstance(raw_output, dict):
+        judge_payload: str | dict[str, Any] = raw_output
+    elif isinstance(raw_output, str):
+        judge_payload = raw_output
+    else:
+        raise TypeError(f"unsupported judge output type: {type(raw_output).__name__}")
+
+    return evaluate_judge_output(case, judge_payload)

--- a/evals/schemas.py
+++ b/evals/schemas.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Mapping, TypeVar, cast
+
+import yaml
+
+TaskType = Literal[
+    "analysis",
+    "review",
+    "briefing",
+    "browser",
+    "multimodal",
+    "routing",
+    "tooling",
+]
+
+_ALLOWED_TASK_TYPES = set(TaskType.__args__)
+_T = TypeVar("_T")
+
+
+class EvalSchemaError(ValueError):
+    """Raised when an eval case or result payload violates the schema."""
+
+
+@dataclass(slots=True)
+class DeterministicAssertion:
+    kind: str
+    params: dict[str, Any] = field(default_factory=dict)
+    weight: float = 1.0
+    required: bool = True
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], *, path: str = "assertions[]") -> "DeterministicAssertion":
+        payload = _expect_mapping(data, path)
+        _reject_unknown_keys(payload, {"kind", "params", "weight", "required"}, path)
+        return cls(
+            kind=_require_string(payload, "kind", path),
+            params=_optional_mapping(payload.get("params"), f"{path}.params"),
+            weight=_optional_float(payload.get("weight"), f"{path}.weight", default=1.0),
+            required=_optional_bool(payload.get("required"), f"{path}.required", default=True),
+        )
+
+
+@dataclass(slots=True)
+class JudgeDimension:
+    name: str
+    description: str
+    scale_min: int = 1
+    scale_max: int = 5
+    pass_threshold: float | None = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], *, path: str = "judge_dimensions[]") -> "JudgeDimension":
+        payload = _expect_mapping(data, path)
+        _reject_unknown_keys(payload, {"name", "description", "scale_min", "scale_max", "pass_threshold"}, path)
+        return cls(
+            name=_require_string(payload, "name", path),
+            description=_require_string(payload, "description", path),
+            scale_min=_optional_int(payload.get("scale_min"), f"{path}.scale_min", default=1),
+            scale_max=_optional_int(payload.get("scale_max"), f"{path}.scale_max", default=5),
+            pass_threshold=_nullable_float(payload.get("pass_threshold"), f"{path}.pass_threshold"),
+        )
+
+
+@dataclass(slots=True)
+class EvalCase:
+    case_id: str
+    suite: str
+    task_type: TaskType
+    title: str
+    prompt: str
+    context: str | None = None
+    tags: list[str] = field(default_factory=list)
+    enabled_toolsets: list[str] = field(default_factory=list)
+    expected_tools: list[str] = field(default_factory=list)
+    forbidden_tools: list[str] = field(default_factory=list)
+    assertions: list[DeterministicAssertion] = field(default_factory=list)
+    judge_dimensions: list[JudgeDimension] = field(default_factory=list)
+    gold_answer: str | None = None
+    notes: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], *, path: str = "case") -> "EvalCase":
+        payload = _expect_mapping(data, path)
+        _reject_unknown_keys(
+            payload,
+            {
+                "case_id",
+                "suite",
+                "task_type",
+                "title",
+                "prompt",
+                "context",
+                "tags",
+                "enabled_toolsets",
+                "expected_tools",
+                "forbidden_tools",
+                "assertions",
+                "judge_dimensions",
+                "gold_answer",
+                "notes",
+            },
+            path,
+        )
+        task_type = _require_string(payload, "task_type", path)
+        if task_type not in _ALLOWED_TASK_TYPES:
+            allowed = ", ".join(sorted(_ALLOWED_TASK_TYPES))
+            raise EvalSchemaError(f"{path}.task_type must be one of [{allowed}], got {task_type!r}")
+        return cls(
+            case_id=_require_string(payload, "case_id", path),
+            suite=_require_string(payload, "suite", path),
+            task_type=cast(TaskType, task_type),
+            title=_require_string(payload, "title", path),
+            prompt=_require_string(payload, "prompt", path),
+            context=_nullable_string(payload.get("context"), f"{path}.context"),
+            tags=_list_of_strings(payload.get("tags"), f"{path}.tags"),
+            enabled_toolsets=_list_of_strings(payload.get("enabled_toolsets"), f"{path}.enabled_toolsets"),
+            expected_tools=_list_of_strings(payload.get("expected_tools"), f"{path}.expected_tools"),
+            forbidden_tools=_list_of_strings(payload.get("forbidden_tools"), f"{path}.forbidden_tools"),
+            assertions=_list_of_objects(payload.get("assertions"), DeterministicAssertion.from_dict, f"{path}.assertions"),
+            judge_dimensions=_list_of_objects(payload.get("judge_dimensions"), JudgeDimension.from_dict, f"{path}.judge_dimensions"),
+            gold_answer=_nullable_string(payload.get("gold_answer"), f"{path}.gold_answer"),
+            notes=_nullable_string(payload.get("notes"), f"{path}.notes"),
+        )
+
+
+@dataclass(slots=True)
+class AssertionResult:
+    kind: str
+    passed: bool
+    score: float
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], *, path: str = "assertions[]") -> "AssertionResult":
+        payload = _expect_mapping(data, path)
+        _reject_unknown_keys(payload, {"kind", "passed", "score", "details"}, path)
+        return cls(
+            kind=_require_string(payload, "kind", path),
+            passed=_require_bool(payload, "passed", path),
+            score=_require_float(payload, "score", path),
+            details=_optional_mapping(payload.get("details"), f"{path}.details"),
+        )
+
+
+@dataclass(slots=True)
+class JudgeResult:
+    dimension: str
+    score: float
+    passed: bool
+    rationale: str
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], *, path: str = "judge_results[]") -> "JudgeResult":
+        payload = _expect_mapping(data, path)
+        _reject_unknown_keys(payload, {"dimension", "score", "passed", "rationale"}, path)
+        return cls(
+            dimension=_require_string(payload, "dimension", path),
+            score=_require_float(payload, "score", path),
+            passed=_require_bool(payload, "passed", path),
+            rationale=_require_string(payload, "rationale", path),
+        )
+
+
+@dataclass(slots=True)
+class EvalRunResult:
+    run_id: str
+    case_id: str
+    suite: str
+    provider: str | None
+    model: str | None
+    judge_provider: str | None
+    judge_model: str | None
+    started_at: str
+    ended_at: str
+    elapsed_ms: int
+    completed: bool
+    failed: bool
+    error: str | None
+    final_response: str
+    tool_calls: list[dict[str, Any]]
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None
+    cache_write_tokens: int | None
+    estimated_cost_usd: float | None
+    actual_cost_usd: float | None
+    assertions: list[AssertionResult]
+    judge_results: list[JudgeResult]
+    aggregate_scores: dict[str, float]
+    labels: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any], *, path: str = "result") -> "EvalRunResult":
+        payload = _expect_mapping(data, path)
+        _reject_unknown_keys(
+            payload,
+            {
+                "run_id",
+                "case_id",
+                "suite",
+                "provider",
+                "model",
+                "judge_provider",
+                "judge_model",
+                "started_at",
+                "ended_at",
+                "elapsed_ms",
+                "completed",
+                "failed",
+                "error",
+                "final_response",
+                "tool_calls",
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "cache_write_tokens",
+                "estimated_cost_usd",
+                "actual_cost_usd",
+                "assertions",
+                "judge_results",
+                "aggregate_scores",
+                "labels",
+            },
+            path,
+        )
+        return cls(
+            run_id=_require_string(payload, "run_id", path),
+            case_id=_require_string(payload, "case_id", path),
+            suite=_require_string(payload, "suite", path),
+            provider=_nullable_string(payload.get("provider"), f"{path}.provider"),
+            model=_nullable_string(payload.get("model"), f"{path}.model"),
+            judge_provider=_nullable_string(payload.get("judge_provider"), f"{path}.judge_provider"),
+            judge_model=_nullable_string(payload.get("judge_model"), f"{path}.judge_model"),
+            started_at=_require_string(payload, "started_at", path),
+            ended_at=_require_string(payload, "ended_at", path),
+            elapsed_ms=_require_int(payload, "elapsed_ms", path),
+            completed=_require_bool(payload, "completed", path),
+            failed=_require_bool(payload, "failed", path),
+            error=_nullable_string(payload.get("error"), f"{path}.error"),
+            final_response=_require_string(payload, "final_response", path),
+            tool_calls=_list_of_mappings(payload.get("tool_calls"), f"{path}.tool_calls"),
+            input_tokens=_nullable_int(payload.get("input_tokens"), f"{path}.input_tokens"),
+            output_tokens=_nullable_int(payload.get("output_tokens"), f"{path}.output_tokens"),
+            cache_read_tokens=_nullable_int(payload.get("cache_read_tokens"), f"{path}.cache_read_tokens"),
+            cache_write_tokens=_nullable_int(payload.get("cache_write_tokens"), f"{path}.cache_write_tokens"),
+            estimated_cost_usd=_nullable_float(payload.get("estimated_cost_usd"), f"{path}.estimated_cost_usd"),
+            actual_cost_usd=_nullable_float(payload.get("actual_cost_usd"), f"{path}.actual_cost_usd"),
+            assertions=_list_of_objects(payload.get("assertions"), AssertionResult.from_dict, f"{path}.assertions"),
+            judge_results=_list_of_objects(payload.get("judge_results"), JudgeResult.from_dict, f"{path}.judge_results"),
+            aggregate_scores=_dict_of_floats(payload.get("aggregate_scores"), f"{path}.aggregate_scores"),
+            labels=_optional_mapping(payload.get("labels"), f"{path}.labels"),
+        )
+
+
+def load_eval_case_yaml(raw_yaml: str) -> EvalCase:
+    try:
+        data = yaml.safe_load(raw_yaml)
+    except yaml.YAMLError as exc:
+        raise EvalSchemaError(f"case YAML could not be parsed: {exc}") from exc
+    return EvalCase.from_dict(_expect_mapping(data, "case"))
+
+
+def load_eval_case_file(path: str | Path) -> EvalCase:
+    case_path = Path(path)
+    try:
+        raw_yaml = case_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise EvalSchemaError(f"could not read case file {case_path}: {exc}") from exc
+    return load_eval_case_yaml(raw_yaml)
+
+
+def _reject_unknown_keys(data: Mapping[str, Any], allowed: set[str], path: str) -> None:
+    extras = sorted(set(data) - allowed)
+    if extras:
+        extra_list = ", ".join(extras)
+        raise EvalSchemaError(f"{path} contains unknown field(s): {extra_list}")
+
+
+def _expect_mapping(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise EvalSchemaError(f"{path} must be a mapping, got {type(value).__name__}")
+    return dict(value)
+
+
+def _require_string(data: Mapping[str, Any], key: str, path: str) -> str:
+    if key not in data:
+        raise EvalSchemaError(f"{path}.{key} is required")
+    return _coerce_string(data[key], f"{path}.{key}")
+
+
+def _nullable_string(value: Any, path: str) -> str | None:
+    if value is None:
+        return None
+    return _coerce_string(value, path)
+
+
+def _coerce_string(value: Any, path: str) -> str:
+    if not isinstance(value, str):
+        raise EvalSchemaError(f"{path} must be a string, got {type(value).__name__}")
+    return value
+
+
+def _require_bool(data: Mapping[str, Any], key: str, path: str) -> bool:
+    if key not in data:
+        raise EvalSchemaError(f"{path}.{key} is required")
+    return _coerce_bool(data[key], f"{path}.{key}")
+
+
+def _optional_bool(value: Any, path: str, *, default: bool) -> bool:
+    if value is None:
+        return default
+    return _coerce_bool(value, path)
+
+
+def _coerce_bool(value: Any, path: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise EvalSchemaError(f"{path} must be a boolean, got {type(value).__name__}")
+
+
+def _require_int(data: Mapping[str, Any], key: str, path: str) -> int:
+    if key not in data:
+        raise EvalSchemaError(f"{path}.{key} is required")
+    return _coerce_int(data[key], f"{path}.{key}")
+
+
+def _optional_int(value: Any, path: str, *, default: int) -> int:
+    if value is None:
+        return default
+    return _coerce_int(value, path)
+
+
+def _nullable_int(value: Any, path: str) -> int | None:
+    if value is None:
+        return None
+    return _coerce_int(value, path)
+
+
+def _coerce_int(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise EvalSchemaError(f"{path} must be an integer, got {type(value).__name__}")
+    return value
+
+
+def _require_float(data: Mapping[str, Any], key: str, path: str) -> float:
+    if key not in data:
+        raise EvalSchemaError(f"{path}.{key} is required")
+    return _coerce_float(data[key], f"{path}.{key}")
+
+
+def _optional_float(value: Any, path: str, *, default: float) -> float:
+    if value is None:
+        return default
+    return _coerce_float(value, path)
+
+
+def _nullable_float(value: Any, path: str) -> float | None:
+    if value is None:
+        return None
+    return _coerce_float(value, path)
+
+
+def _coerce_float(value: Any, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise EvalSchemaError(f"{path} must be a number, got {type(value).__name__}")
+    return float(value)
+
+
+def _optional_mapping(value: Any, path: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return _expect_mapping(value, path)
+
+
+def _list_of_strings(value: Any, path: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise EvalSchemaError(f"{path} must be a list, got {type(value).__name__}")
+    result: list[str] = []
+    for index, item in enumerate(value):
+        result.append(_coerce_string(item, f"{path}[{index}]") )
+    return result
+
+
+def _list_of_objects(value: Any, loader: Any, path: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise EvalSchemaError(f"{path} must be a list, got {type(value).__name__}")
+    result: list[Any] = []
+    for index, item in enumerate(value):
+        result.append(loader(item, path=f"{path}[{index}]") )
+    return result
+
+
+def _list_of_mappings(value: Any, path: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise EvalSchemaError(f"{path} must be a list, got {type(value).__name__}")
+    result: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        result.append(_expect_mapping(item, f"{path}[{index}]"))
+    return result
+
+
+def _dict_of_floats(value: Any, path: str) -> dict[str, float]:
+    mapping = _optional_mapping(value, path)
+    result: dict[str, float] = {}
+    for key, item in mapping.items():
+        if not isinstance(key, str):
+            raise EvalSchemaError(f"{path} keys must be strings, got {type(key).__name__}")
+        result[key] = _coerce_float(item, f"{path}.{key}")
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "evals", "evals.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/mine_eval_cases.py
+++ b/scripts/mine_eval_cases.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Mine candidate eval cases from Hermes session/trajectory data.
+
+Usage
+-----
+
+    # Mine from state.db (default)
+    python scripts/mine_eval_cases.py --source state-db --limit 20
+
+    # Mine failed trajectories
+    python scripts/mine_eval_cases.py --source trajectories --failed-only
+
+    # Export draft YAML cases
+    python scripts/mine_eval_cases.py --source state-db --limit 10 --output evals/cases/drafts/
+
+    # Full spec
+    python scripts/mine_eval_cases.py \\
+        --source state-db \\
+        --source-filter cli \\
+        --model gpt-5.4 \\
+        --min-tool-calls 1 \\
+        --min-tokens 100 \\
+        --days-back 7 \\
+        --limit 20 \\
+        --output evals/cases/drafts/
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Ensure the repo root is on sys.path so ``evals`` is importable
+_repo_root = Path(__file__).resolve().parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from evals.mining import (
+    candidate_to_draft_case,
+    export_candidates_report,
+    export_draft_cases,
+    mine_from_cron_outputs,
+    mine_from_session_db,
+    mine_from_trajectories,
+)
+
+from hermes_constants import get_hermes_home  # noqa: E402
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Mine candidate eval cases from Hermes traces and sessions.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    parser.add_argument(
+        "--source",
+        choices=["state-db", "trajectories", "cron-outputs"],
+        default="state-db",
+        help="Data source to mine from (default: state-db)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of candidates to return (default: 50)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output directory for draft YAML case files. "
+        "If set, writes individual YAML draft cases and a summary report. "
+        "If omitted, prints a summary to stdout.",
+    )
+    parser.add_argument(
+        "--failed-only",
+        action="store_true",
+        help="Only include sessions/trajectories that failed or ended with errors",
+    )
+
+    # state-db specific filters
+    parser.add_argument(
+        "--source-filter",
+        type=str,
+        default=None,
+        help="Session source filter (e.g. 'cli', 'telegram')",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Model name filter (LIKE match)",
+    )
+    parser.add_argument(
+        "--min-tool-calls",
+        type=int,
+        default=0,
+        help="Minimum tool_call_count for sessions (default: 0 = no filter)",
+    )
+    parser.add_argument(
+        "--min-tokens",
+        type=int,
+        default=0,
+        help="Minimum total tokens (input+output) for sessions (default: 0)",
+    )
+    parser.add_argument(
+        "--days-back",
+        type=int,
+        default=None,
+        help="Only include sessions started within this many days (default: all)",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=str,
+        default=None,
+        help="Explicit path to state.db (default: ~/.hermes/state.db)",
+    )
+    parser.add_argument(
+        "--trajectories-path",
+        type=str,
+        default=None,
+        help="Path to trajectory JSONL file (default: auto-detect from HERMES_HOME)",
+    )
+    parser.add_argument(
+        "--cron-dir",
+        type=str,
+        default=None,
+        help="Path to cron output directory (default: ~/.hermes/cron/output/)",
+    )
+    parser.add_argument(
+        "--report",
+        type=str,
+        default=None,
+        help="Optional path for a markdown summary report (default: same as --output)",
+    )
+
+    return parser
+
+
+def _resolve_default_paths() -> dict[str, Path]:
+    hermes_home = get_hermes_home()
+    return {
+        "db_path": hermes_home / "state.db",
+        "trajectories_path": hermes_home / "trajectories",
+        "cron_dir": hermes_home / "cron" / "output",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    defaults = _resolve_default_paths()
+
+    # --- Run the appropriate miner ---
+    if args.source == "state-db":
+        db_path = args.db_path or str(defaults["db_path"])
+        if not Path(db_path).exists():
+            print(f"ERROR: session DB not found at {db_path}", file=sys.stderr)
+            return 1
+        result = mine_from_session_db(
+            db_path,
+            source=args.source_filter,
+            model=args.model,
+            failed_only=args.failed_only,
+            min_tool_calls=args.min_tool_calls,
+            min_tokens=args.min_tokens,
+            days_back=args.days_back,
+            limit=args.limit,
+        )
+    elif args.source == "trajectories":
+        traj_path = args.trajectories_path or str(defaults["trajectories_path"])
+        result = mine_from_trajectories(
+            traj_path,
+            failed_only=args.failed_only,
+            limit=args.limit,
+        )
+    elif args.source == "cron-outputs":
+        cron_dir = args.cron_dir or str(defaults["cron_dir"])
+        result = mine_from_cron_outputs(
+            cron_dir,
+            limit=args.limit,
+        )
+    else:
+        print(f"ERROR: unknown source {args.source!r}", file=sys.stderr)
+        return 1
+
+    # --- Output ---
+    if args.output:
+        out_dir = Path(args.output)
+        files = export_draft_cases(
+            result.candidates,
+            output_dir=out_dir,
+        )
+
+        report_path = args.report or str(out_dir / "MINED_REPORT.md")
+        export_candidates_report(result.candidates, report_path)
+
+        print(f"Mined {len(result.candidates)} candidates from {args.source}")
+        print(f"  Draft YAML cases: {len(files)} files in {out_dir}")
+        print(f"  Summary report:   {report_path}")
+        print(f"  Sessions scanned: {result.total_sessions_scanned}")
+    else:
+        # Print summary to stdout
+        print(f"Source: {args.source}")
+        print(f"Sessions scanned: {result.total_sessions_scanned}")
+        print(f"Candidates mined: {result.total_candidates}")
+        print()
+
+        if not result.candidates:
+            print("No candidates found matching the given filters.")
+            return 0
+
+        print(f"{'#':>3}  {'Candidate ID':<36} {'Model':<22} {'Tools':<24} {'Failed':<7} {'Reason'}")
+        print("---  " + "-" * 35 + "  " + "-" * 21 + "  " + "-" * 23 + "  " + "-" * 6 + "  " + "------")
+        for idx, c in enumerate(result.candidates, start=1):
+            tool_str = ", ".join(c.tool_names[:3])
+            if len(c.tool_names) > 3:
+                tool_str += "..."
+            print(
+                f"{idx:>3}  {c.candidate_id:<36} {(c.model or '-'):<22} {tool_str:<24} "
+                f"{'❌' if c.failed else '✅':<7} {c.reason or '-'}"
+            )
+
+        print()
+        print(f"Run with --output <dir> to export draft YAML case files.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_eval_nightly.sh
+++ b/scripts/run_eval_nightly.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Nightly/weekly scheduled regression wrapper.
+# The caller supplies model/provider env plus optional baseline location.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTPUT_DIR="${HERMES_EVAL_OUTPUT_DIR:-evals/results/nightly/${STAMP}}"
+BASELINE_DIR="${HERMES_EVAL_BASELINE_DIR:-evals/results/baselines}"
+FAIL_UNDER="${HERMES_EVAL_FAIL_UNDER:-0.85}"
+
+CMD=(
+  python scripts/run_evals.py
+  --fail-under "$FAIL_UNDER"
+  --output "$OUTPUT_DIR"
+  --save-baseline "$BASELINE_DIR"
+)
+
+if [[ -n "${HERMES_EVAL_MODEL:-}" ]]; then
+  CMD+=(--model "$HERMES_EVAL_MODEL")
+fi
+if [[ -n "${HERMES_EVAL_PROVIDER:-}" ]]; then
+  CMD+=(--provider "$HERMES_EVAL_PROVIDER")
+fi
+if [[ -n "${HERMES_EVAL_JUDGE_MODEL:-}" ]]; then
+  CMD+=(--judge-model "$HERMES_EVAL_JUDGE_MODEL")
+fi
+if [[ -n "${HERMES_EVAL_JUDGE_PROVIDER:-}" ]]; then
+  CMD+=(--judge-provider "$HERMES_EVAL_JUDGE_PROVIDER")
+fi
+if [[ -n "${HERMES_EVAL_BASELINE_PATH:-}" ]]; then
+  CMD+=(--baseline "$HERMES_EVAL_BASELINE_PATH")
+fi
+
+mkdir -p "$BASELINE_DIR"
+"${CMD[@]}"

--- a/scripts/run_eval_smoke.sh
+++ b/scripts/run_eval_smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight, PR-friendly smoke run over a fixed gate set.
+# Expected env overrides:
+#   HERMES_EVAL_MODEL / HERMES_EVAL_PROVIDER
+#   HERMES_EVAL_JUDGE_MODEL / HERMES_EVAL_JUDGE_PROVIDER
+#   HERMES_EVAL_OUTPUT_DIR
+#   HERMES_EVAL_FAIL_UNDER
+#   HERMES_EVAL_FIXTURE_RESULTS   (optional offline YAML/JSON payload for CI-safe smoke)
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+OUTPUT_DIR="${HERMES_EVAL_OUTPUT_DIR:-evals/results/smoke}"
+FAIL_UNDER="${HERMES_EVAL_FAIL_UNDER:-1.0}"
+
+CMD=(
+  python scripts/run_evals.py
+  --case routing.local-repo-inspection
+  --case routing.web-search-straightforward
+  --case review.pr-code-quality
+  --case briefing.change-summary-no-speculation
+  --fail-under "$FAIL_UNDER"
+  --output "$OUTPUT_DIR"
+)
+
+if [[ -n "${HERMES_EVAL_MODEL:-}" ]]; then
+  CMD+=(--model "$HERMES_EVAL_MODEL")
+fi
+if [[ -n "${HERMES_EVAL_PROVIDER:-}" ]]; then
+  CMD+=(--provider "$HERMES_EVAL_PROVIDER")
+fi
+if [[ -n "${HERMES_EVAL_JUDGE_MODEL:-}" ]]; then
+  CMD+=(--judge-model "$HERMES_EVAL_JUDGE_MODEL")
+fi
+if [[ -n "${HERMES_EVAL_JUDGE_PROVIDER:-}" ]]; then
+  CMD+=(--judge-provider "$HERMES_EVAL_JUDGE_PROVIDER")
+fi
+if [[ -n "${HERMES_EVAL_FIXTURE_RESULTS:-}" ]]; then
+  CMD+=(--fixture-results "$HERMES_EVAL_FIXTURE_RESULTS")
+fi
+
+"${CMD[@]}"

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Hermes eval runner — CLI entrypoint for suite/case execution.
+
+Usage examples::
+
+    # Run a full suite
+    python scripts/run_evals.py --suite ci-briefings
+
+    # Run with a specific model
+    python scripts/run_evals.py --suite analysis --model gpt-5.4
+
+    # Run a specific case
+    python scripts/run_evals.py --case routing.browser-vs-webextract --output evals/results/manual/
+
+    # Run with judge model
+    python scripts/run_evals.py --suite review --model gpt-5.5 --judge-model gpt-5.5
+
+    # Run with baseline comparison
+    python scripts/run_evals.py --suite ci-briefings --baseline evals/results/baseline.ci-briefings.json
+
+    # Save baseline after running
+    python scripts/run_evals.py --suite ci-briefings --save-baseline evals/results/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+TYPE_CHECKING = False
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s | %(name)s | %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("run_evals")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Hermes eval suites/cases.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # Target selection
+    target = parser.add_argument_group("target selection")
+    target.add_argument(
+        "--suite",
+        action="append",
+        default=[],
+        dest="suites",
+        help="Suite filter (repeatable, e.g. --suite ci-briefings --suite analysis). "
+        "When omitted, all suites are included.",
+    )
+    target.add_argument(
+        "--case",
+        action="append",
+        default=[],
+        dest="case_ids",
+        help="Specific case IDs (repeatable). When set, only these cases run.",
+    )
+    target.add_argument(
+        "--max-cases",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Limit number of cases run (default: no limit).",
+    )
+
+    # Model / provider
+    model = parser.add_argument_group("model configuration")
+    model.add_argument(
+        "--model",
+        default=None,
+        help="Model name override (e.g. gpt-5.4, claude-sonnet-4).",
+    )
+    model.add_argument(
+        "--provider",
+        default=None,
+        help="Provider override (e.g. openai-codex, anthropic, openrouter).",
+    )
+    model.add_argument(
+        "--judge-model",
+        default=None,
+        help="Judge model for rubric-based scoring (requires evals/judges.py).",
+    )
+    model.add_argument(
+        "--judge-provider",
+        default=None,
+        help="Provider for the judge model.",
+    )
+
+    # Output
+    output = parser.add_argument_group("output")
+    output.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        metavar="DIR",
+        help="Output directory for results. Default: evals/results/<suite>/<timestamp>/",
+    )
+    output.add_argument(
+        "--json",
+        dest="json_only",
+        action="store_true",
+        default=False,
+        help="Only output JSON (no markdown report).",
+    )
+
+    # Baseline
+    baseline = parser.add_argument_group("baseline comparison")
+    baseline.add_argument(
+        "--baseline",
+        default=None,
+        metavar="PATH",
+        help="Path to baseline snapshot JSON for comparison.",
+    )
+    baseline.add_argument(
+        "--save-baseline",
+        default=None,
+        metavar="DIR",
+        help="Directory to save baseline snapshot(s) after running.",
+    )
+
+    # Pass/fail gate
+    gate = parser.add_argument_group("pass/fail gate")
+    gate.add_argument(
+        "--fail-under",
+        type=float,
+        default=0.0,
+        metavar="SCORE",
+        help="Minimum aggregate pass rate (0-1) required to pass. "
+        "Exits with code 1 when the pass rate is below this threshold.",
+    )
+    gate.add_argument(
+        "--fixture-results",
+        default=None,
+        metavar="PATH",
+        help="Offline fixture payload (YAML or JSON) used to build canned eval results "
+        "for CI-safe smoke runs without calling a live model.",
+    )
+
+    # Cases root
+    parser.add_argument(
+        "--cases-root",
+        default="evals/cases",
+        metavar="DIR",
+        help="Root directory for case YAML files (default: evals/cases).",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    # ---- Load cases --------------------------------------------------------
+    from evals.loader import load_eval_cases
+
+    logger.info(
+        "Loading cases from %s (suites=%s, case_ids=%s)",
+        args.cases_root,
+        args.suites or "all",
+        args.case_ids or "all",
+    )
+
+    try:
+        cases = load_eval_cases(
+            args.cases_root,
+            suites=args.suites or None,
+            case_ids=args.case_ids or None,
+        )
+    except Exception as exc:
+        logger.error("Failed to load cases: %s", exc)
+        return 1
+
+    if not cases:
+        logger.warning("No cases matched the given filters.")
+        return 0
+
+    if args.max_cases > 0 and len(cases) > args.max_cases:
+        logger.info("Limiting to %d/%d cases", args.max_cases, len(cases))
+        cases = cases[: args.max_cases]
+
+    logger.info("Loaded %d case(s)", len(cases))
+    for case in cases:
+        logger.info("  [%s] %s — %s", case.suite, case.case_id, case.title)
+
+    # ---- Run cases ---------------------------------------------------------
+    if args.fixture_results:
+        logger.info("Building %d canned fixture result(s) from %s", len(cases), args.fixture_results)
+        try:
+            results = _build_fixture_results(
+                cases,
+                fixture_path=args.fixture_results,
+                model=args.model,
+                provider=args.provider,
+                judge_model=args.judge_model,
+                judge_provider=args.judge_provider,
+            )
+        except Exception as exc:
+            logger.error("Failed to build fixture results: %s", exc)
+            return 1
+    else:
+        from evals.runner import run_eval_suite
+
+        logger.info(
+            "Running %d case(s) (model=%s, provider=%s)", len(cases), args.model, args.provider
+        )
+
+        results = run_eval_suite(
+            cases,
+            model=args.model,
+            provider=args.provider,
+            judge_model=args.judge_model,
+            judge_provider=args.judge_provider,
+        )
+
+    # ---- Reporting helpers -------------------------------------------------
+    from evals.reporting import _is_pass, write_markdown_report, write_results_json
+
+    passed = sum(1 for r in results if _is_pass(r))
+    failed = len(results) - passed
+    logger.info("Results: %d passed, %d failed (of %d)", passed, failed, len(results))
+
+    # ---- Write output ------------------------------------------------------
+
+    output_dir = args.output
+    if not output_dir:
+        # Default: evals/results/<first_suite>/<timestamp>/
+        from datetime import datetime, timezone
+
+        first_suite = args.suites[0] if args.suites else "all"
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        output_dir = str(Path("evals/results") / first_suite / timestamp)
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # JSON
+    json_path = output_path / "results.json"
+    write_results_json(results, json_path)
+    logger.info("Wrote JSON results to %s", json_path)
+
+    # Markdown (unless --json-only)
+    if not args.json_only:
+        md_path = output_path / "report.md"
+        write_markdown_report(results, md_path)
+        logger.info("Wrote markdown report to %s", md_path)
+
+    # ---- Baseline snapshot -------------------------------------------------
+    from evals.baselines import BaselineSnapshot, ComparisonReport, compare_baselines, snapshot_dir_from_results
+
+    if args.save_baseline:
+        snapshot_dir_from_results(results, args.save_baseline)
+        logger.info("Baseline snapshot(s) saved to %s", args.save_baseline)
+
+    # ---- Baseline comparison -----------------------------------------------
+    comparison: ComparisonReport | None = None
+    if args.baseline:
+        try:
+            from evals.baselines import load_baseline
+
+            baseline = load_baseline(args.baseline)
+            candidate = BaselineSnapshot.from_results(results, suite=baseline.suite)
+            comparison = compare_baselines(
+                baseline, candidate, fail_under=args.fail_under
+            )
+
+            # Write comparison report to the same output dir
+            report_path = output_path / "comparison.json"
+            report_path.write_text(
+                json.dumps(_comparison_to_dict(comparison), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            logger.info("Comparison report written to %s", report_path)
+
+            # Print decision to stderr
+            _print_comparison(comparison)
+
+        except Exception as exc:
+            logger.error("Baseline comparison failed: %s", exc)
+            comparison = None
+
+    # ---- Fail-under gate ---------------------------------------------------
+    if args.fail_under > 0.0:
+        pass_rate = passed / len(results) if results else 0.0
+        if pass_rate < args.fail_under:
+            logger.error(
+                "FAIL: pass rate %.1f%% is below --fail-under %.1f%%",
+                pass_rate * 100,
+                args.fail_under * 100,
+            )
+            return 1
+        logger.info(
+            "PASS: pass rate %.1f%% meets --fail-under %.1f%%",
+            pass_rate * 100,
+            args.fail_under * 100,
+        )
+
+    return 0
+
+
+def _print_comparison(comparison: ComparisonReport) -> None:
+    """Print the comparison report to stderr in a human-readable format."""
+    print(file=sys.stderr)
+    print("=" * 60, file=sys.stderr)
+    print("BASELINE COMPARISON", file=sys.stderr)
+    print("=" * 60, file=sys.stderr)
+    print(f"Recommendation: {comparison.recommendation}", file=sys.stderr)
+    print(file=sys.stderr)
+    print(comparison.summary, file=sys.stderr)
+    print(file=sys.stderr)
+
+    if comparison.guardrails:
+        print("Guardrails:", file=sys.stderr)
+        for g in comparison.guardrails:
+            print(f"  ⚠  {g}", file=sys.stderr)
+        print(file=sys.stderr)
+
+    if comparison.regressions:
+        print(f"Regressions ({len(comparison.regressions)}):", file=sys.stderr)
+        for r in comparison.regressions:
+            print(f"  ↓ {r}", file=sys.stderr)
+        print(file=sys.stderr)
+
+    if comparison.improvements:
+        print(f"Improvements ({len(comparison.improvements)}):", file=sys.stderr)
+        for imp in comparison.improvements:
+            print(f"  ↑ {imp}", file=sys.stderr)
+        print(file=sys.stderr)
+
+    print(
+        f"Pass rate: {comparison.pass_rate_candidate:.1%} (was {comparison.pass_rate_baseline:.1%})",
+        file=sys.stderr,
+    )
+    print(
+        f"Median latency: {comparison.median_latency_candidate:.0f}ms "
+        f"(was {comparison.median_latency_baseline:.0f}ms)",
+        file=sys.stderr,
+    )
+    if comparison.median_cost_candidate is not None:
+        print(
+            f"Median cost: ${comparison.median_cost_candidate:.6f} "
+            f"(was ${comparison.median_cost_baseline:.6f})",
+            file=sys.stderr,
+        )
+    print("=" * 60, file=sys.stderr)
+
+
+def _comparison_to_dict(comparison: ComparisonReport) -> dict[str, Any]:
+    """Serialise a ComparisonReport for JSON output."""
+    return {
+        "recommendation": comparison.recommendation,
+        "summary": comparison.summary,
+        "pass_rate_baseline": comparison.pass_rate_baseline,
+        "pass_rate_candidate": comparison.pass_rate_candidate,
+        "pass_rate_delta": comparison.pass_rate_delta,
+        "median_latency_baseline_ms": comparison.median_latency_baseline,
+        "median_latency_candidate_ms": comparison.median_latency_candidate,
+        "median_cost_baseline_usd": comparison.median_cost_baseline,
+        "median_cost_candidate_usd": comparison.median_cost_candidate,
+        "improvements": comparison.improvements,
+        "regressions": comparison.regressions,
+        "guardrails": comparison.guardrails,
+        "case_comparisons": [
+            {
+                "case_id": cc.case_id,
+                "suite": cc.suite,
+                "baseline_score": cc.baseline_score,
+                "candidate_score": cc.candidate_score,
+                "delta": cc.delta,
+                "regression": cc.regression,
+                "improvement": cc.improvement,
+                "details": cc.details,
+            }
+            for cc in comparison.case_comparisons
+        ],
+    }
+
+
+def _build_fixture_results(
+    cases: list[Any],
+    *,
+    fixture_path: str,
+    model: str | None,
+    provider: str | None,
+    judge_model: str | None,
+    judge_provider: str | None,
+) -> list[Any]:
+    from evals.runner import build_result_from_components
+
+    fixture_payload = _load_fixture_payload(fixture_path)
+    defaults = fixture_payload.get("defaults", {})
+    if not isinstance(defaults, dict):
+        raise ValueError("fixture payload 'defaults' must be a mapping when present")
+
+    cases_payload = fixture_payload.get("cases")
+    if not isinstance(cases_payload, dict):
+        raise ValueError("fixture payload must contain a top-level 'cases' mapping")
+
+    results = []
+    for case in cases:
+        case_fixture = cases_payload.get(case.case_id)
+        if not isinstance(case_fixture, dict):
+            raise ValueError(f"fixture payload missing case entry for {case.case_id}")
+
+        merged = dict(defaults)
+        merged.update(case_fixture)
+        tool_calls = _normalize_tool_calls(merged.get("tool_calls"))
+        results.append(
+            build_result_from_components(
+                case,
+                final_response=str(merged.get("final_response", "")),
+                completed=bool(merged.get("completed", True)),
+                failed=bool(merged.get("failed", False)),
+                error=_optional_string(merged.get("error")),
+                tool_calls=tool_calls,
+                input_tokens=_optional_int(merged.get("input_tokens")),
+                output_tokens=_optional_int(merged.get("output_tokens")),
+                cache_read_tokens=_optional_int(merged.get("cache_read_tokens")),
+                cache_write_tokens=_optional_int(merged.get("cache_write_tokens")),
+                estimated_cost_usd=_optional_float(merged.get("estimated_cost_usd")),
+                actual_cost_usd=_optional_float(merged.get("actual_cost_usd")),
+                model=model or _optional_string(merged.get("model")) or "fixture-smoke",
+                provider=provider or _optional_string(merged.get("provider")) or "fixture",
+                judge_model=judge_model or _optional_string(merged.get("judge_model")),
+                judge_provider=judge_provider or _optional_string(merged.get("judge_provider")),
+                elapsed_ms=_optional_int(merged.get("elapsed_ms")) or 0,
+            )
+        )
+    return results
+
+
+def _load_fixture_payload(path: str) -> dict[str, Any]:
+    raw = Path(path).read_text(encoding="utf-8")
+    if path.endswith(".json"):
+        payload = json.loads(raw)
+    else:
+        payload = yaml.safe_load(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("fixture payload root must be a mapping")
+    return payload
+
+
+def _normalize_tool_calls(raw_tool_calls: Any) -> list[dict[str, Any]]:
+    if raw_tool_calls is None:
+        return []
+    if not isinstance(raw_tool_calls, list):
+        raise ValueError("fixture tool_calls must be a list")
+
+    normalized: list[dict[str, Any]] = []
+    for item in raw_tool_calls:
+        if isinstance(item, str):
+            normalized.append({"name": item})
+        elif isinstance(item, dict):
+            normalized.append(dict(item))
+        else:
+            raise ValueError("fixture tool_calls entries must be strings or mappings")
+    return normalized
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/evals/test_checks.py
+++ b/tests/evals/test_checks.py
@@ -1,0 +1,167 @@
+import pytest
+
+from evals.checks import DeterministicScore, EvalCheckError, aggregate_assertion_scores, evaluate_assertion, evaluate_assertions
+from evals.schemas import AssertionResult, DeterministicAssertion
+
+
+def _assertion(kind: str, *, params: dict | None = None, weight: float = 1.0, required: bool = True) -> DeterministicAssertion:
+    return DeterministicAssertion(kind=kind, params=params or {}, weight=weight, required=required)
+
+
+class TestDeterministicChecks:
+    def test_non_empty_output_rejects_blank_response(self):
+        result = evaluate_assertion(_assertion("non_empty_output"), final_response="   \n", tool_calls=[])
+
+        assert result.passed is False
+        assert result.score == 0.0
+        assert result.details["trimmed_chars"] == 0
+
+    def test_max_chars_and_max_lines_use_observed_response_shape(self):
+        response = "line one\nline two"
+
+        chars = evaluate_assertion(_assertion("max_chars", params={"max_chars": len(response)}), final_response=response, tool_calls=[])
+        lines = evaluate_assertion(_assertion("max_lines", params={"max_lines": 2}), final_response=response, tool_calls=[])
+        lines_fail = evaluate_assertion(_assertion("max_lines", params={"max_lines": 1}), final_response=response, tool_calls=[])
+
+        assert chars.passed is True
+        assert chars.details["observed_chars"] == len(response)
+        assert lines.passed is True
+        assert lines.details["observed_lines"] == 2
+        assert lines_fail.passed is False
+
+    def test_required_and_forbidden_regex_checks(self):
+        response = "Visible hero banner with 20% discount."
+
+        required = evaluate_assertion(
+            _assertion("required_regex", params={"pattern": r"\bdiscount\b"}),
+            final_response=response,
+            tool_calls=[],
+        )
+        forbidden = evaluate_assertion(
+            _assertion("forbidden_regex", params={"pattern": r"\bfree money\b", "ignore_case": True}),
+            final_response=response,
+            tool_calls=[],
+        )
+
+        assert required.passed is True
+        assert forbidden.passed is True
+
+    def test_tool_used_and_tool_not_used_accept_multiple_trace_key_shapes(self):
+        tool_calls = [
+            {"name": "browser_navigate"},
+            {"tool_name": "browser_vision"},
+            {"tool": "web_extract"},
+        ]
+
+        used = evaluate_assertion(_assertion("tool_used", params={"tool": "browser_vision"}), final_response="ok", tool_calls=tool_calls)
+        not_used = evaluate_assertion(_assertion("tool_not_used", params={"tool": "terminal"}), final_response="ok", tool_calls=tool_calls)
+        used_fail = evaluate_assertion(_assertion("tool_used", params={"tool": "terminal"}), final_response="ok", tool_calls=tool_calls)
+
+        assert used.passed is True
+        assert sorted(used.details["used_tools"]) == ["browser_navigate", "browser_vision", "web_extract"]
+        assert not_used.passed is True
+        assert used_fail.passed is False
+
+    def test_contains_url_detects_http_and_https(self):
+        result = evaluate_assertion(
+            _assertion("contains_url"),
+            final_response="Source: https://example.com/report and http://backup.example.com.",
+            tool_calls=[],
+        )
+
+        assert result.passed is True
+        assert result.details["matched_url"] == "https://example.com/report"
+
+    @pytest.mark.parametrize(
+        ("response", "expected_match"),
+        [
+            ("Lorem ipsum placeholder copy", "Lorem ipsum"),
+            ("TODO: replace this section", "TODO"),
+            ("[insert screenshot summary]", "[insert screenshot summary]"),
+            ("Use <company name> in the recommendation", "<company name>"),
+            ("Write your answer here before sending", "your answer here"),
+        ],
+    )
+    def test_no_placeholder_language_flags_common_placeholder_patterns(self, response: str, expected_match: str):
+        result = evaluate_assertion(_assertion("no_placeholder_language"), final_response=response, tool_calls=[])
+
+        assert result.passed is False
+        assert result.details["matched_placeholder"] == expected_match
+
+    def test_evaluate_assertions_runs_batch(self):
+        assertions = [
+            _assertion("non_empty_output"),
+            _assertion("required_regex", params={"pattern": r"hero"}),
+        ]
+
+        results = evaluate_assertions(assertions, final_response="Visible hero banner", tool_calls=[])
+
+        assert [result.kind for result in results] == ["non_empty_output", "required_regex"]
+        assert all(result.passed for result in results)
+
+    def test_unknown_assertion_kind_raises_clear_error(self):
+        with pytest.raises(EvalCheckError, match=r"Unknown assertion kind"):
+            evaluate_assertion(_assertion("language_is"), final_response="hello", tool_calls=[])
+
+
+class TestDeterministicScoring:
+    def test_weighted_scoring_uses_fractional_scores(self):
+        assertions = [
+            _assertion("non_empty_output", weight=1.0),
+            _assertion("contains_url", weight=3.0, required=False),
+        ]
+        results = [
+            AssertionResult(kind="non_empty_output", passed=True, score=1.0, details={}),
+            AssertionResult(kind="contains_url", passed=False, score=0.0, details={}),
+        ]
+
+        score = aggregate_assertion_scores(assertions, results)
+
+        assert isinstance(score, DeterministicScore)
+        assert score.score == pytest.approx(0.25)
+        assert score.earned_weight == pytest.approx(1.0)
+        assert score.total_weight == pytest.approx(4.0)
+        assert score.passed is True
+        assert score.required_failures == []
+
+    def test_required_failure_blocks_pass_even_when_optional_weight_score_is_high(self):
+        assertions = [
+            _assertion("required_regex", params={"pattern": r"required"}, weight=1.0, required=True),
+            _assertion("contains_url", weight=5.0, required=False),
+        ]
+        results = [
+            AssertionResult(kind="required_regex", passed=False, score=0.0, details={}),
+            AssertionResult(kind="contains_url", passed=True, score=1.0, details={}),
+        ]
+
+        score = aggregate_assertion_scores(assertions, results)
+
+        assert score.score == pytest.approx(5.0 / 6.0)
+        assert score.passed is False
+        assert score.required_failures == ["required_regex"]
+
+    def test_zero_assertions_returns_full_score(self):
+        score = aggregate_assertion_scores([], [])
+
+        assert score.score == 1.0
+        assert score.passed is True
+        assert score.total_weight == 0.0
+        assert score.earned_weight == 0.0
+
+    def test_aggregate_scoring_rejects_mismatched_lengths(self):
+        with pytest.raises(EvalCheckError, match=r"length mismatch"):
+            aggregate_assertion_scores([_assertion("non_empty_output")], [])
+
+    def test_aggregate_scoring_rejects_invalid_score_range(self):
+        with pytest.raises(EvalCheckError, match=r"outside \[0, 1\]"):
+            aggregate_assertion_scores(
+                [_assertion("non_empty_output")],
+                [AssertionResult(kind="non_empty_output", passed=True, score=1.5, details={})],
+            )
+
+    def test_aggregate_scoring_rejects_negative_weight(self):
+        with pytest.raises(EvalCheckError, match=r"negative weight"):
+            aggregate_assertion_scores(
+                [_assertion("non_empty_output", weight=-1.0)],
+                [AssertionResult(kind="non_empty_output", passed=True, score=1.0, details={})],
+            )

--- a/tests/evals/test_judges.py
+++ b/tests/evals/test_judges.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import pytest
+
+from evals.judges import EvalJudgeError, aggregate_eval_scores, build_judge_prompt, evaluate_judge_output
+from evals.schemas import EvalCase, JudgeDimension, JudgeResult
+
+
+def _make_case(*, prompt: str = "Summarize the page", judge_dimensions: list[JudgeDimension]) -> EvalCase:
+    return EvalCase(
+        case_id="routing.case",
+        suite="routing",
+        task_type="routing",
+        title="Routing case",
+        prompt=prompt,
+        context="Ground findings in the provided evidence.",
+        tags=[],
+        enabled_toolsets=[],
+        expected_tools=[],
+        forbidden_tools=[],
+        assertions=[],
+        judge_dimensions=judge_dimensions,
+        gold_answer=None,
+        notes=None,
+    )
+
+
+def test_build_judge_prompt_mentions_strict_json_contract_and_response():
+    case = _make_case(
+        judge_dimensions=[
+            JudgeDimension(
+                name="factuality",
+                description="Grounded in evidence",
+                pass_threshold=4,
+            )
+        ]
+    )
+
+    prompt = build_judge_prompt(case, final_response="A concise summary")
+
+    assert "strict JSON" in prompt
+    assert '"scores"' in prompt
+    assert '"overall_pass"' in prompt
+    assert '"summary"' in prompt
+    assert "factuality" in prompt
+    assert "A concise summary" in prompt
+
+
+def test_evaluate_judge_output_parses_strict_json_normalizes_and_applies_thresholds():
+    case = _make_case(
+        judge_dimensions=[
+            JudgeDimension(
+                name="factuality",
+                description="Grounded in evidence",
+                pass_threshold=4,
+            ),
+            JudgeDimension(
+                name="specificity",
+                description="Specific instead of generic",
+                pass_threshold=3,
+            ),
+        ]
+    )
+
+    results = evaluate_judge_output(
+        case,
+        """
+        {
+          "scores": [
+            {"dimension": "factuality", "score": 5, "passed": true, "rationale": "Well grounded."},
+            {"dimension": "specificity", "score": 2, "passed": false, "rationale": "Too generic."}
+          ],
+          "overall_pass": false,
+          "summary": "Grounded but too generic overall."
+        }
+        """,
+    )
+
+    assert [result.dimension for result in results] == ["factuality", "specificity"]
+    assert results[0].score == pytest.approx(1.0)
+    assert results[0].passed is True
+    assert results[1].score == pytest.approx(0.25)
+    assert results[1].passed is False
+
+
+def test_evaluate_judge_output_rejects_non_json_framing():
+    case = _make_case(
+        judge_dimensions=[
+            JudgeDimension(
+                name="factuality",
+                description="Grounded in evidence",
+                pass_threshold=4,
+            )
+        ]
+    )
+
+    raw_output = 'Here is the JSON: {"scores": [], "overall_pass": true, "summary": "ok"}'
+
+    with pytest.raises(EvalJudgeError, match="valid JSON"):
+        evaluate_judge_output(case, raw_output)
+
+
+def test_evaluate_judge_output_requires_exact_dimension_set():
+    case = _make_case(
+        judge_dimensions=[
+            JudgeDimension(
+                name="factuality",
+                description="Grounded in evidence",
+                pass_threshold=4,
+            ),
+            JudgeDimension(
+                name="actionability",
+                description="Ends with a concrete recommendation",
+                pass_threshold=4,
+            ),
+        ]
+    )
+
+    raw_output = """
+    {
+      "scores": [
+        {"dimension": "factuality", "score": 4, "passed": true, "rationale": "Grounded."}
+      ],
+      "overall_pass": true,
+      "summary": "Missing one dimension."
+    }
+    """
+
+    with pytest.raises(EvalJudgeError, match="actionability"):
+        evaluate_judge_output(case, raw_output)
+
+
+def test_aggregate_eval_scores_uses_plan_weights_when_judges_present():
+    judge_results = [
+        JudgeResult(dimension="factuality", score=1.0, passed=True, rationale="ok"),
+        JudgeResult(dimension="specificity", score=0.5, passed=True, rationale="ok"),
+    ]
+
+    scores = aggregate_eval_scores(
+        deterministic_score=0.8,
+        judge_results=judge_results,
+        efficiency_score=0.9,
+    )
+
+    assert scores == {
+        "deterministic": 0.8,
+        "judge": 0.75,
+        "efficiency": 0.9,
+        "overall": 0.79,
+    }

--- a/tests/evals/test_loader.py
+++ b/tests/evals/test_loader.py
@@ -1,0 +1,276 @@
+import textwrap
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import yaml
+
+from evals.loader import load_eval_cases, resolve_case_files
+from evals.schemas import EvalCase, EvalRunResult, EvalSchemaError, load_eval_case_file
+
+
+class TestEvalCaseLoading:
+    def test_load_eval_case_file_parses_valid_yaml(self, tmp_path):
+        case_file = tmp_path / "case.yaml"
+        case_file.write_text(
+            textwrap.dedent(
+                """
+                case_id: briefing.hp.homepage.visible-campaigns
+                suite: ci-briefings
+                task_type: briefing
+                title: Detect visible homepage campaigns and summarize changes
+                prompt: >
+                  Review the provided homepage capture and summarize the visible campaigns,
+                  banners, and promotional hooks in at most 10 lines.
+                context: >
+                  Output must be concise, observation-led, and avoid invented commercial claims.
+                tags: [igo, homepage, daily, concise]
+                enabled_toolsets: [browser, vision]
+                expected_tools: [browser_navigate, browser_vision]
+                forbidden_tools: [terminal]
+                assertions:
+                  - kind: max_lines
+                    params:
+                      max_lines: 10
+                  - kind: required_regex
+                    params:
+                      pattern: "(banner|campaign|promotion|discount)"
+                    weight: 2
+                    required: false
+                judge_dimensions:
+                  - name: factuality
+                    description: Are claims grounded in visible evidence?
+                    pass_threshold: 4
+                gold_answer: Visible hero banner plus seasonal promotion summary.
+                notes: Seed case for the briefing suite.
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        case = load_eval_case_file(case_file)
+
+        assert isinstance(case, EvalCase)
+        assert case.case_id == "briefing.hp.homepage.visible-campaigns"
+        assert case.task_type == "briefing"
+        assert case.enabled_toolsets == ["browser", "vision"]
+        assert case.assertions[0].kind == "max_lines"
+        assert case.assertions[0].params == {"max_lines": 10}
+        assert case.assertions[1].weight == 2.0
+        assert case.assertions[1].required is False
+        assert case.judge_dimensions[0].name == "factuality"
+        assert case.judge_dimensions[0].pass_threshold == 4.0
+
+    def test_load_eval_case_file_rejects_unknown_top_level_fields(self, tmp_path):
+        case_file = tmp_path / "case.yaml"
+        case_file.write_text(
+            textwrap.dedent(
+                """
+                case_id: invalid.extra-field
+                suite: ci-briefings
+                task_type: briefing
+                title: Invalid case
+                prompt: Hello
+                unexpected_field: nope
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(EvalSchemaError, match=r"unexpected_field"):
+            load_eval_case_file(case_file)
+
+    def test_load_eval_case_file_rejects_invalid_task_type(self, tmp_path):
+        case_file = tmp_path / "case.yaml"
+        case_file.write_text(
+            textwrap.dedent(
+                """
+                case_id: invalid.task-type
+                suite: ci-briefings
+                task_type: summary
+                title: Invalid task type
+                prompt: Hello
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(EvalSchemaError, match=r"task_type"):
+            load_eval_case_file(case_file)
+
+
+class TestSuiteResolution:
+    def test_resolve_case_files_orders_root_and_nested_cases_deterministically(self, tmp_path):
+        (tmp_path / "z-last.yaml").write_text(
+            "case_id: z-last\nsuite: alpha\ntask_type: briefing\ntitle: Z\nprompt: hi\n",
+            encoding="utf-8",
+        )
+        suite_dir = tmp_path / "alpha"
+        suite_dir.mkdir()
+        (suite_dir / "b-second.yaml").write_text(
+            "case_id: b-second\nsuite: alpha\ntask_type: briefing\ntitle: B\nprompt: hi\n",
+            encoding="utf-8",
+        )
+        (suite_dir / "a-first.yaml").write_text(
+            "case_id: a-first\nsuite: alpha\ntask_type: briefing\ntitle: A\nprompt: hi\n",
+            encoding="utf-8",
+        )
+
+        paths = resolve_case_files(tmp_path)
+
+        assert [path.relative_to(tmp_path).as_posix() for path in paths] == [
+            "alpha/a-first.yaml",
+            "alpha/b-second.yaml",
+            "z-last.yaml",
+        ]
+
+    def test_load_eval_cases_filters_by_suite_and_case_id(self, tmp_path):
+        alpha_dir = tmp_path / "alpha"
+        alpha_dir.mkdir()
+        beta_dir = tmp_path / "beta"
+        beta_dir.mkdir()
+        (alpha_dir / "first.yaml").write_text(
+            "case_id: alpha.first\nsuite: alpha\ntask_type: briefing\ntitle: First\nprompt: hi\n",
+            encoding="utf-8",
+        )
+        (beta_dir / "second.yaml").write_text(
+            "case_id: beta.second\nsuite: beta\ntask_type: briefing\ntitle: Second\nprompt: hi\n",
+            encoding="utf-8",
+        )
+
+        cases = load_eval_cases(tmp_path, suites=["beta"], case_ids=["beta.second"])
+
+        assert [case.case_id for case in cases] == ["beta.second"]
+
+    def test_load_eval_cases_rejects_unknown_case_ids(self, tmp_path):
+        (tmp_path / "case.yaml").write_text(
+            "case_id: alpha.first\nsuite: alpha\ntask_type: briefing\ntitle: First\nprompt: hi\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(EvalSchemaError, match=r"missing case_id\(s\): beta.second"):
+            load_eval_cases(tmp_path, case_ids=["beta.second"])
+
+    def test_repo_seed_cases_load_and_cover_requested_suites(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        cases_dir = repo_root / "evals" / "cases"
+
+        cases = load_eval_cases(cases_dir)
+
+        counts = Counter(case.suite for case in cases)
+
+        required_suites = {"routing", "review", "briefing", "multimodal"}
+
+        assert len(cases) >= 8
+        assert required_suites.issubset(counts)
+        assert all(counts[suite] >= 1 for suite in required_suites)
+        assert all(case.assertions for case in cases)
+        assert any(case.judge_dimensions for case in cases if case.suite in {"review", "briefing", "multimodal"})
+
+    def test_seed_rubric_files_exist_and_have_dimensions(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        rubrics_dir = repo_root / "evals" / "rubrics"
+        expected = ["routing.yaml", "review.yaml", "briefing.yaml", "multimodal.yaml"]
+
+        for name in expected:
+            path = rubrics_dir / name
+            assert path.exists(), f"missing rubric file: {name}"
+
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+            assert data["version"] == 1
+            assert data["suite"] == path.stem
+            assert data["status"] == "informational-until-loader-support"
+            assert isinstance(data["dimensions"], list)
+            assert data["dimensions"]
+            assert all(dimension.get("name") for dimension in data["dimensions"])
+            assert all(dimension.get("description") for dimension in data["dimensions"])
+
+
+class TestEvalRunResultSchema:
+    def test_eval_run_result_from_dict_parses_nested_results(self):
+        result = EvalRunResult.from_dict(
+            {
+                "run_id": "run-123",
+                "case_id": "briefing.hp.homepage.visible-campaigns",
+                "suite": "ci-briefings",
+                "provider": "openai",
+                "model": "gpt-5.4",
+                "judge_provider": None,
+                "judge_model": None,
+                "started_at": "2026-05-26T12:00:00Z",
+                "ended_at": "2026-05-26T12:00:01Z",
+                "elapsed_ms": 1000,
+                "completed": True,
+                "failed": False,
+                "error": None,
+                "final_response": "Visible campaign summary.",
+                "tool_calls": [{"name": "browser_navigate"}],
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "estimated_cost_usd": 0.01,
+                "actual_cost_usd": 0.02,
+                "assertions": [
+                    {
+                        "kind": "max_lines",
+                        "passed": True,
+                        "score": 1,
+                        "details": {"max_lines": 10},
+                    }
+                ],
+                "judge_results": [
+                    {
+                        "dimension": "factuality",
+                        "score": 4,
+                        "passed": True,
+                        "rationale": "Grounded in the capture.",
+                    }
+                ],
+                "aggregate_scores": {"deterministic": 1.0, "overall": 0.9},
+                "labels": {"channel": "ci"},
+            }
+        )
+
+        assert isinstance(result, EvalRunResult)
+        assert result.elapsed_ms == 1000
+        assert result.assertions[0].score == 1.0
+        assert result.judge_results[0].dimension == "factuality"
+        assert result.aggregate_scores["overall"] == 0.9
+
+    def test_eval_run_result_from_dict_rejects_unknown_fields(self):
+        with pytest.raises(EvalSchemaError, match=r"mystery"):
+            EvalRunResult.from_dict(
+                {
+                    "run_id": "run-123",
+                    "case_id": "briefing.hp.homepage.visible-campaigns",
+                    "suite": "ci-briefings",
+                    "provider": None,
+                    "model": None,
+                    "judge_provider": None,
+                    "judge_model": None,
+                    "started_at": "2026-05-26T12:00:00Z",
+                    "ended_at": "2026-05-26T12:00:01Z",
+                    "elapsed_ms": 1000,
+                    "completed": True,
+                    "failed": False,
+                    "error": None,
+                    "final_response": "Visible campaign summary.",
+                    "tool_calls": [],
+                    "input_tokens": None,
+                    "output_tokens": None,
+                    "cache_read_tokens": None,
+                    "cache_write_tokens": None,
+                    "estimated_cost_usd": None,
+                    "actual_cost_usd": None,
+                    "assertions": [],
+                    "judge_results": [],
+                    "aggregate_scores": {},
+                    "labels": {},
+                    "mystery": True,
+                }
+            )

--- a/tests/evals/test_mining.py
+++ b/tests/evals/test_mining.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from evals.mining import (
+    MinedCandidate,
+    export_candidates_report,
+    export_draft_cases,
+    mine_from_session_db,
+)
+from evals.schemas import load_eval_case_file
+from scripts import mine_eval_cases
+
+
+def _make_state_db(path: Path) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            model TEXT,
+            system_prompt TEXT,
+            started_at REAL,
+            ended_at REAL,
+            end_reason TEXT,
+            tool_call_count INTEGER,
+            input_tokens INTEGER,
+            output_tokens INTEGER,
+            billing_provider TEXT,
+            estimated_cost_usd REAL,
+            title TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            tool_calls TEXT
+        )
+        """
+    )
+
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id, source, model, system_prompt, started_at, ended_at, end_reason,
+            tool_call_count, input_tokens, output_tokens, billing_provider,
+            estimated_cost_usd, title
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "sess_1234567890abcdef",
+            "cli",
+            "gpt-5.4",
+            "system context",
+            1000.0,
+            1002.5,
+            "completed",
+            2,
+            150,
+            60,
+            "openai-codex",
+            0.12,
+            "Useful mining session",
+        ),
+    )
+
+    conn.executemany(
+        "INSERT INTO messages (id, session_id, role, content, tool_calls) VALUES (?, ?, ?, ?, ?)",
+        [
+            (1, "sess_1234567890abcdef", "user", "Research the topic and summarize it.", None),
+            (
+                2,
+                "sess_1234567890abcdef",
+                "assistant",
+                "",
+                json.dumps(
+                    [
+                        {"function": {"name": "web_search"}},
+                        {"function": {"name": "web_extract"}},
+                    ]
+                ),
+            ),
+            (3, "sess_1234567890abcdef", "tool", "search results", None),
+            (4, "sess_1234567890abcdef", "assistant", "Final grounded answer.", None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_mine_from_session_db_extracts_candidate_fields(tmp_path):
+    db_path = _make_state_db(tmp_path / "state.db")
+
+    result = mine_from_session_db(db_path, source="cli", min_tool_calls=1, min_tokens=100, limit=10)
+
+    assert result.source_name == "state-db"
+    assert result.total_sessions_scanned == 1
+    assert result.total_candidates == 1
+
+    candidate = result.candidates[0]
+    assert candidate.candidate_id == "mined.state.sess_1234567"
+    assert candidate.session_id == "sess_1234567890abcdef"
+    assert candidate.prompt == "Research the topic and summarize it."
+    assert candidate.final_response == "Final grounded answer."
+    assert candidate.tool_names == ["web_search", "web_extract"]
+    assert candidate.tool_call_count == 2
+    assert candidate.failed is False
+    assert candidate.provider == "openai-codex"
+    assert candidate.elapsed_ms == 2500
+    assert candidate.reason == "used 2 tool(s): web_search, web_extract"
+
+
+def test_export_draft_cases_writes_schema_valid_yaml(tmp_path):
+    candidate = MinedCandidate(
+        candidate_id="mined.state.demo_case",
+        source="state-db",
+        session_id="sess_demo",
+        prompt="Research the product launch and summarize findings.",
+        final_response="Summary ready.",
+        tool_names=["web_search", "web_extract"],
+        tool_call_count=2,
+        failed=False,
+        mined_at="2026-05-26T12:00:00Z",
+        model="gpt-5.4",
+        provider="openai-codex",
+        title=None,
+        context="system context",
+        reason="used 2 tool(s): web_search, web_extract",
+    )
+
+    written = export_draft_cases([candidate], output_dir=tmp_path)
+
+    assert len(written) == 1
+    case = load_eval_case_file(written[0])
+    assert case.case_id == "mined.state.demo_case"
+    assert case.suite == "mined"
+    assert case.task_type == "briefing"
+    assert case.enabled_toolsets == ["web"]
+    assert case.expected_tools == ["web_extract", "web_search"]
+    assert case.context == "system context"
+    assert any(assertion.kind == "non_empty_output" for assertion in case.assertions)
+
+
+
+def test_export_candidates_report_contains_candidate_row(tmp_path):
+    candidate = MinedCandidate(
+        candidate_id="mined.state.demo_case",
+        source="state-db",
+        session_id="sess_demo_123456789",
+        prompt="Prompt",
+        final_response="Answer",
+        tool_names=["terminal"],
+        tool_call_count=1,
+        failed=True,
+        mined_at="2026-05-26T12:00:00Z",
+        model="gpt-5.4",
+        provider="openai-codex",
+        reason="session ended with error",
+    )
+
+    report_path = export_candidates_report([candidate], tmp_path / "MINED_REPORT.md")
+
+    text = report_path.read_text(encoding="utf-8")
+    assert "# Mined eval case candidates" in text
+    assert "mined.state.demo_case" in text
+    assert "session ended with error" in text
+    assert "❌" in text
+
+
+
+def test_mine_eval_cases_main_exports_files_and_returns_zero(tmp_path):
+    db_path = _make_state_db(tmp_path / "state.db")
+    out_dir = tmp_path / "drafts"
+
+    exit_code = mine_eval_cases.main(
+        [
+            "--source",
+            "state-db",
+            "--db-path",
+            str(db_path),
+            "--source-filter",
+            "cli",
+            "--min-tool-calls",
+            "1",
+            "--min-tokens",
+            "100",
+            "--limit",
+            "5",
+            "--output",
+            str(out_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    draft_files = sorted(out_dir.glob("draft_*.yaml"))
+    assert len(draft_files) == 1
+    assert (out_dir / "MINED_REPORT.md").exists()

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -1,0 +1,118 @@
+import json
+
+from evals.reporting import render_markdown_report, results_to_json_bytes, write_markdown_report, write_results_json
+from evals.schemas import AssertionResult, EvalRunResult, JudgeResult
+
+
+def _make_result(
+    *,
+    run_id: str,
+    suite: str,
+    case_id: str,
+    completed: bool = True,
+    failed: bool = False,
+    error: str | None = None,
+    overall: float = 1.0,
+    deterministic: float = 1.0,
+) -> EvalRunResult:
+    return EvalRunResult(
+        run_id=run_id,
+        case_id=case_id,
+        suite=suite,
+        provider="openai",
+        model="gpt-5.4",
+        judge_provider=None,
+        judge_model=None,
+        started_at="2026-05-26T12:00:00Z",
+        ended_at="2026-05-26T12:00:01Z",
+        elapsed_ms=1000,
+        completed=completed,
+        failed=failed,
+        error=error,
+        final_response="Decision-ready answer.",
+        tool_calls=[{"name": "browser_navigate"}],
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        estimated_cost_usd=0.01,
+        actual_cost_usd=0.02,
+        assertions=[
+            AssertionResult(kind="max_lines", passed=not failed, score=deterministic, details={"max_lines": 10})
+        ],
+        judge_results=[
+            JudgeResult(
+                dimension="factuality",
+                score=4.0 if not failed else 2.0,
+                passed=not failed,
+                rationale="Grounded in evidence." if not failed else "Missing evidence.",
+            )
+        ],
+        aggregate_scores={"deterministic": deterministic, "overall": overall},
+        labels={"channel": "ci"},
+    )
+
+
+class TestResultsJson:
+    def test_results_to_json_bytes_is_stable_and_sorted(self):
+        later = _make_result(run_id="run-2", suite="zeta", case_id="zeta.case")
+        earlier = _make_result(run_id="run-1", suite="alpha", case_id="alpha.case")
+
+        payload = results_to_json_bytes([later, earlier]).decode("utf-8")
+        parsed = json.loads(payload)
+
+        assert [item["case_id"] for item in parsed["results"]] == ["alpha.case", "zeta.case"]
+        assert parsed["summary"] == {
+            "total": 2,
+            "completed": 2,
+            "failed": 0,
+            "passed": 2,
+            "suites": 2,
+        }
+        assert payload.endswith("\n")
+        assert payload == results_to_json_bytes([later, earlier]).decode("utf-8")
+
+    def test_write_results_json_writes_parent_directories(self, tmp_path):
+        output_path = tmp_path / "nested" / "results.json"
+        result = _make_result(run_id="run-1", suite="alpha", case_id="alpha.case")
+
+        written = write_results_json([result], output_path)
+
+        assert written == output_path
+        assert output_path.exists()
+        assert json.loads(output_path.read_text(encoding="utf-8"))["results"][0]["case_id"] == "alpha.case"
+
+
+class TestMarkdownReporting:
+    def test_render_markdown_report_summarizes_failures_and_scores(self):
+        passing = _make_result(run_id="run-1", suite="alpha", case_id="alpha.case", overall=0.95)
+        failing = _make_result(
+            run_id="run-2",
+            suite="beta",
+            case_id="beta.case",
+            failed=True,
+            error="tool timeout",
+            overall=0.25,
+            deterministic=0.0,
+        )
+
+        report = render_markdown_report([failing, passing])
+
+        assert report.startswith("# Hermes eval report\n")
+        assert "- Total runs: 2" in report
+        assert "- Passed: 1" in report
+        assert "- Failed: 1" in report
+        assert "## Failed runs" in report
+        assert "beta.case" in report
+        assert "tool timeout" in report
+        assert "| alpha | alpha.case | ✅ | 0.950 | 1.000 | 1000 |" in report
+        assert "| beta | beta.case | ❌ | 0.250 | 0.000 | 1000 |" in report
+
+    def test_write_markdown_report_writes_parent_directories(self, tmp_path):
+        output_path = tmp_path / "nested" / "summary.md"
+        result = _make_result(run_id="run-1", suite="alpha", case_id="alpha.case")
+
+        written = write_markdown_report([result], output_path)
+
+        assert written == output_path
+        assert output_path.read_text(encoding="utf-8").startswith("# Hermes eval report\n")

--- a/tests/evals/test_run_evals_script.py
+++ b/tests/evals/test_run_evals_script.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from evals.baselines import BaselineSnapshot, CaseScore, compare_baselines
+from evals.schemas import AssertionResult, EvalRunResult
+from scripts import run_evals
+
+
+def _make_case(*, suite: str = "alpha", case_id: str = "alpha.case", title: str = "Alpha case"):
+    class Case:
+        def __init__(self):
+            self.suite = suite
+            self.case_id = case_id
+            self.title = title
+
+    return Case()
+
+
+def _make_result(
+    *,
+    suite: str = "alpha",
+    case_id: str = "alpha.case",
+    completed: bool = True,
+    failed: bool = False,
+    assertion_passed: bool = True,
+) -> EvalRunResult:
+    return EvalRunResult(
+        run_id="run_20260526_abcdef",
+        case_id=case_id,
+        suite=suite,
+        provider="openai-codex",
+        model="gpt-5.4",
+        judge_provider=None,
+        judge_model=None,
+        started_at="2026-05-26T12:00:00Z",
+        ended_at="2026-05-26T12:00:01Z",
+        elapsed_ms=1000,
+        completed=completed,
+        failed=failed,
+        error=None,
+        final_response="answer",
+        tool_calls=[],
+        input_tokens=10,
+        output_tokens=5,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        estimated_cost_usd=0.001,
+        actual_cost_usd=0.001,
+        assertions=[
+            AssertionResult(
+                kind="contains_substring",
+                passed=assertion_passed,
+                score=1.0 if assertion_passed else 0.0,
+                details={},
+            )
+        ],
+        judge_results=[],
+        aggregate_scores={
+            "deterministic": 1.0 if assertion_passed else 0.0,
+            "overall": 1.0 if assertion_passed else 0.0,
+        },
+        labels={},
+    )
+
+
+def test_main_fail_under_counts_assertion_failures_as_not_passed(tmp_path, monkeypatch):
+    monkeypatch.setattr("evals.loader.load_eval_cases", lambda *args, **kwargs: [_make_case()])
+    monkeypatch.setattr(
+        "evals.runner.run_eval_suite",
+        lambda *args, **kwargs: [_make_result(assertion_passed=False)],
+    )
+    monkeypatch.setattr("evals.reporting.write_results_json", lambda results, path: Path(path))
+    monkeypatch.setattr("evals.reporting.write_markdown_report", lambda results, path: Path(path))
+
+    exit_code = run_evals.main(
+        ["--suite", "alpha", "--fail-under", "1.0", "--output", str(tmp_path)]
+    )
+
+    assert exit_code == 1
+
+
+def test_compare_baselines_fail_under_updates_recommendation_and_summary_together():
+    baseline = BaselineSnapshot(
+        suite="briefing",
+        git_sha="abc123",
+        config_fingerprint="cfg-1",
+        run_date="2026-05-26T12:00:00Z",
+        model="gpt-5.4",
+        provider="openai-codex",
+        total_cases=1,
+        passed_cases=1,
+        pass_rate=1.0,
+        median_latency_ms=500,
+        median_cost_usd=0.001,
+        per_case=[
+            CaseScore(
+                case_id="briefing.stable",
+                suite="briefing",
+                score=0.9,
+                deterministic=1.0,
+                passed=True,
+                failed=False,
+                elapsed_ms=500,
+                estimated_cost_usd=0.001,
+                actual_cost_usd=0.001,
+            )
+        ],
+    )
+    candidate = BaselineSnapshot(
+        suite="briefing",
+        git_sha="def456",
+        config_fingerprint="cfg-2",
+        run_date="2026-05-26T13:00:00Z",
+        model="gpt-5.4",
+        provider="openai-codex",
+        total_cases=1,
+        passed_cases=0,
+        pass_rate=0.0,
+        median_latency_ms=480,
+        median_cost_usd=0.001,
+        per_case=[
+            CaseScore(
+                case_id="briefing.stable",
+                suite="briefing",
+                score=0.9,
+                deterministic=1.0,
+                passed=False,
+                failed=False,
+                elapsed_ms=480,
+                estimated_cost_usd=0.001,
+                actual_cost_usd=0.001,
+            )
+        ],
+    )
+
+    comparison = compare_baselines(baseline, candidate, fail_under=0.5)
+
+    assert comparison.recommendation == "no_ship"
+    assert comparison.summary.startswith("Recommendation: no_ship")
+    assert any("below --fail-under 50.0%" in guardrail for guardrail in comparison.guardrails)
+
+
+def test_main_passes_judge_flags_to_run_eval_suite(tmp_path, monkeypatch):
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr("evals.loader.load_eval_cases", lambda *args, **kwargs: [_make_case()])
+
+    def fake_run_eval_suite(*args, **kwargs):
+        seen.update(kwargs)
+        return [_make_result()]
+
+    monkeypatch.setattr("evals.runner.run_eval_suite", fake_run_eval_suite)
+    monkeypatch.setattr("evals.reporting.write_results_json", lambda results, path: Path(path))
+    monkeypatch.setattr("evals.reporting.write_markdown_report", lambda results, path: Path(path))
+
+    exit_code = run_evals.main(
+        [
+            "--suite",
+            "alpha",
+            "--judge-model",
+            "gpt-5.4",
+            "--judge-provider",
+            "openrouter",
+            "--output",
+            str(tmp_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert seen["judge_model"] == "gpt-5.4"
+    assert seen["judge_provider"] == "openrouter"
+
+
+def test_main_uses_fixture_results_for_offline_smoke(tmp_path):
+    cases_root = tmp_path / "cases"
+    cases_root.mkdir()
+    (cases_root / "alpha.yaml").write_text(
+        """
+case_id: alpha.case
+suite: alpha
+task_type: routing
+title: Alpha case
+prompt: Say Alpha.
+assertions:
+  - kind: non_empty_output
+    required: true
+  - kind: contains_substring
+    params: {substring: Alpha, ignore_case: true}
+    required: true
+  - kind: tool_used
+    params: {tool: search_files}
+    required: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    fixture_path = tmp_path / "fixture.yaml"
+    fixture_path.write_text(
+        """
+defaults:
+  provider: fixture-ci
+  model: fixture-smoke
+cases:
+  alpha.case:
+    final_response: Alpha answer from fixture mode.
+    tool_calls:
+      - search_files
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    exit_code = run_evals.main(
+        [
+            "--case",
+            "alpha.case",
+            "--cases-root",
+            str(cases_root),
+            "--fixture-results",
+            str(fixture_path),
+            "--fail-under",
+            "1.0",
+            "--output",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads((output_dir / "results.json").read_text(encoding="utf-8"))
+    assert payload["summary"]["total"] == 1
+    result = payload["results"][0]
+    assert result["provider"] == "fixture-ci"
+    assert result["model"] == "fixture-smoke"
+    assert result["tool_calls"] == [{"name": "search_files"}]
+    assert result["final_response"] == "Alpha answer from fixture mode."
+
+
+def test_main_fixture_results_require_all_requested_cases(tmp_path):
+    cases_root = tmp_path / "cases"
+    cases_root.mkdir()
+    (cases_root / "alpha.yaml").write_text(
+        """
+case_id: alpha.case
+suite: alpha
+task_type: routing
+title: Alpha case
+prompt: Say Alpha.
+assertions:
+  - kind: non_empty_output
+    required: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    fixture_path = tmp_path / "fixture.yaml"
+    fixture_path.write_text(
+        "cases: {}\n",
+        encoding="utf-8",
+    )
+
+    exit_code = run_evals.main(
+        [
+            "--case",
+            "alpha.case",
+            "--cases-root",
+            str(cases_root),
+            "--fixture-results",
+            str(fixture_path),
+            "--output",
+            str(tmp_path / "out"),
+        ]
+    )
+
+    assert exit_code == 1

--- a/tests/evals/test_runner.py
+++ b/tests/evals/test_runner.py
@@ -1,0 +1,570 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from evals.runner import (
+    _extract_session_metrics,
+    build_result_from_components,
+    run_eval_case,
+    run_eval_suite,
+)
+from evals.schemas import (
+    DeterministicAssertion,
+    EvalCase,
+    EvalRunResult,
+    JudgeDimension,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_case(
+    case_id: str = "test.simple",
+    suite: str = "test",
+    task_type: str = "analysis",
+    title: str = "Simple test",
+    prompt: str = "What is 2+2?",
+    context: str | None = None,
+    enabled_toolsets: list[str] | None = None,
+    judge_dimensions: list[JudgeDimension] | None = None,
+) -> EvalCase:
+    return EvalCase(
+        case_id=case_id,
+        suite=suite,
+        task_type=task_type,  # type: ignore[arg-type]
+        title=title,
+        prompt=prompt,
+        context=context,
+        enabled_toolsets=enabled_toolsets or [],
+        expected_tools=[],
+        forbidden_tools=[],
+        assertions=[],
+        judge_dimensions=judge_dimensions or [],
+    )
+
+
+def _mock_agent(
+    *,
+    run_result: dict | None = None,
+    session: dict | None = None,
+    messages: list[dict] | None = None,
+    model: str = "gpt-5.4",
+    provider: str = "openai-codex",
+    run_raises: Exception | None = None,
+) -> MagicMock:
+    agent = MagicMock()
+    agent.model = model
+    agent.provider = provider
+
+    if run_raises:
+        agent.run_conversation.side_effect = run_raises
+    else:
+        agent.run_conversation.return_value = run_result or {
+            "final_response": "4",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "4"},
+            ],
+        }
+
+    if session is not None or messages is not None:
+        db = MagicMock()
+        db.get_session.return_value = session or _default_session()
+        db.get_messages.return_value = messages or _default_messages()
+        agent._session_db = db
+        agent.session_id = "sess_eval_test"
+    else:
+        agent._session_db = None
+        agent.session_id = None
+
+    return agent
+
+
+def _default_session() -> dict:
+    return {
+        "input_tokens": 50,
+        "output_tokens": 10,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "estimated_cost_usd": 0.001,
+        "actual_cost_usd": 0.002,
+    }
+
+
+def _default_messages() -> list[dict]:
+    return [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "4"},
+    ]
+
+
+def _tool_messages() -> list[dict]:
+    return [
+        {"role": "user", "content": "Search for X"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "content": "Results", "tool_name": "web_search"},
+        {
+            "role": "assistant",
+            "content": "Here are the results",
+            "tool_calls": [
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "web_extract", "arguments": "{}"},
+                },
+            ],
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# run_eval_case — integration with mocked agent
+# ---------------------------------------------------------------------------
+
+
+class TestRunEvalCase:
+    def test_successful_run_populates_all_fields(self):
+        """A successful agent run yields a complete EvalRunResult."""
+        case = _make_case()
+        agent = _mock_agent()
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert isinstance(result, EvalRunResult)
+        assert result.case_id == "test.simple"
+        assert result.suite == "test"
+        assert result.final_response == "4"
+        assert result.completed is True
+        assert result.failed is False
+        assert result.error is None
+        assert ":Z" in result.started_at or "T" in result.started_at
+        assert ":Z" in result.ended_at or "T" in result.ended_at
+        assert result.elapsed_ms >= 0
+        assert result.run_id.startswith("run_")
+        assert result.model == "gpt-5.4"
+        assert result.provider == "openai-codex"
+
+    def test_captures_session_metrics(self):
+        """Token/cost fields are populated from the agent's session DB."""
+        case = _make_case()
+        agent = _mock_agent(
+            session=_default_session(),
+            messages=_default_messages(),
+        )
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert result.input_tokens == 50
+        assert result.output_tokens == 10
+        assert result.cache_read_tokens == 0
+        assert result.cache_write_tokens == 0
+        assert result.estimated_cost_usd == 0.001
+        assert result.actual_cost_usd == 0.002
+        assert result.tool_calls == []
+
+    def test_captures_tool_calls_from_messages(self):
+        """Tool calls in assistant messages appear in the result."""
+        case = _make_case()
+        agent = _mock_agent(
+            session=_default_session(),
+            messages=_tool_messages(),
+        )
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert len(result.tool_calls) == 2
+        names = {tc["name"] for tc in result.tool_calls}
+        assert names == {"web_search", "web_extract"}
+
+    def test_records_agent_failure(self):
+        """When run_conversation raises, the result records the error."""
+        case = _make_case()
+        agent = _mock_agent(run_raises=RuntimeError("API timeout"))
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert result.failed is True
+        assert result.completed is False
+        assert result.error is not None
+        assert "RuntimeError" in result.error
+        assert "API timeout" in result.error
+        assert result.final_response == ""
+
+    def test_records_incomplete_run_as_failed(self):
+        """When completed=False, the run is failed but not an exception."""
+        case = _make_case()
+        agent = _mock_agent(
+            run_result={
+                "final_response": "partial answer",
+                "completed": False,
+            },
+        )
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert result.completed is False
+        assert result.failed is True
+        assert result.error is None
+        assert result.final_response == "partial answer"
+
+    def test_handles_missing_session_db_gracefully(self):
+        """All metrics are None/empty when the agent has no session DB."""
+        case = _make_case()
+        agent = _mock_agent()
+        agent._session_db = None
+        agent.session_id = None
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert result.input_tokens is None
+        assert result.output_tokens is None
+        assert result.estimated_cost_usd is None
+        assert result.actual_cost_usd is None
+        assert result.tool_calls == []
+
+    def test_runs_optional_judge_and_combines_scores(self):
+        case = _make_case(
+            prompt="Review the summary",
+            judge_dimensions=[
+                JudgeDimension(
+                    name="factuality",
+                    description="Grounded in evidence",
+                    pass_threshold=4,
+                ),
+                JudgeDimension(
+                    name="specificity",
+                    description="Specific instead of generic",
+                    pass_threshold=4,
+                ),
+            ],
+        )
+        agent = _mock_agent(
+            run_result={
+                "final_response": "Strong answer with specifics.",
+                "completed": True,
+            }
+        )
+
+        def fake_judge(**_: object) -> str:
+            return """
+            {
+              "scores": [
+                {"dimension": "factuality", "score": 5, "passed": true, "rationale": "Grounded."},
+                {"dimension": "specificity", "score": 4, "passed": true, "rationale": "Concrete."}
+              ],
+              "overall_pass": true,
+              "summary": "Strong and specific review."
+            }
+            """
+
+        result = run_eval_case(
+            case,
+            injected_agent=agent,
+            judge_model="gpt-5.4-mini",
+            judge_provider="openrouter",
+            injected_judge=fake_judge,
+        )
+
+        assert len(result.judge_results) == 2
+        assert result.judge_model == "gpt-5.4-mini"
+        assert result.judge_provider == "openrouter"
+        assert result.aggregate_scores["judge"] == 0.875
+        assert result.aggregate_scores["efficiency"] == 1.0
+        assert result.aggregate_scores["overall"] == 0.95
+
+    def test_assertions_evaluated_on_final_response(self):
+        """Deterministic assertions run against the final response."""
+        case = EvalCase(
+            case_id="test.assertions",
+            suite="test",
+            task_type="analysis",  # type: ignore[arg-type]
+            title="Assertions test",
+            prompt="Say 'hello world'",
+            context=None,
+            enabled_toolsets=[],
+            expected_tools=[],
+            forbidden_tools=[],
+            assertions=[
+                DeterministicAssertion(kind="non_empty_output"),
+                DeterministicAssertion(
+                    kind="contains_substring",
+                    params={"substring": "hello"},
+                ),
+                DeterministicAssertion(
+                    kind="forbidden_regex",
+                    params={"pattern": "goodbye"},
+                ),
+            ],
+            judge_dimensions=[],
+        )
+        agent = _mock_agent(
+            run_result={
+                "final_response": "hello world",
+                "completed": True,
+            },
+            session=_default_session(),
+            messages=_default_messages(),
+        )
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert len(result.assertions) == 3
+        for ar in result.assertions:
+            assert ar.passed is True
+        assert result.aggregate_scores["deterministic"] == 1.0
+        assert result.aggregate_scores["overall"] == 1.0
+
+    def test_assertion_failures_reflected_in_score(self):
+        """Failing assertions lower the deterministic score."""
+        case = EvalCase(
+            case_id="test.fail-assert",
+            suite="test",
+            task_type="analysis",  # type: ignore[arg-type]
+            title="Fail assertions",
+            prompt="Say 'goodbye'",
+            context=None,
+            enabled_toolsets=[],
+            expected_tools=[],
+            forbidden_tools=[],
+            assertions=[
+                DeterministicAssertion(
+                    kind="contains_substring",
+                    params={"substring": "hello"},
+                    weight=1.0,
+                ),
+                DeterministicAssertion(
+                    kind="max_lines",
+                    params={"max_lines": 1},
+                    weight=2.0,
+                    required=True,
+                ),
+            ],
+            judge_dimensions=[],
+        )
+        agent = _mock_agent(
+            run_result={
+                "final_response": "goodbye\nfriend\nhow are you",
+                "completed": True,
+            },
+        )
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert result.assertions[0].passed is False
+        assert result.assertions[1].passed is False
+        # Score = 0 earned / 3 total = 0.0
+        assert result.aggregate_scores["deterministic"] == 0.0
+
+    def test_evaluates_tool_assertions(self):
+        """Tool assertions (tool_used, tool_not_used) work via session data."""
+        case = EvalCase(
+            case_id="test.tool-assert",
+            suite="test",
+            task_type="tooling",  # type: ignore[arg-type]
+            title="Tool assertion test",
+            prompt="Search for Hermes Agent",
+            enabled_toolsets=["web"],
+            expected_tools=[],
+            forbidden_tools=[],
+            assertions=[
+                DeterministicAssertion(
+                    kind="tool_used",
+                    params={"tool": "web_search"},
+                ),
+                DeterministicAssertion(
+                    kind="tool_not_used",
+                    params={"tool": "terminal"},
+                ),
+            ],
+            judge_dimensions=[],
+        )
+        agent = _mock_agent(
+            run_result={
+                "final_response": "Here are the results.",
+                "completed": True,
+            },
+            session=_default_session(),
+            messages=_tool_messages(),
+        )
+
+        result = run_eval_case(case, injected_agent=agent)
+
+        assert result.assertions[0].passed is True  # web_search was used
+        assert result.assertions[1].passed is True  # terminal was not used
+        assert result.aggregate_scores["deterministic"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# run_eval_suite
+# ---------------------------------------------------------------------------
+
+
+class TestRunEvalSuite:
+    def test_runs_multiple_cases_returns_ordered_results(self):
+        cases = [
+            _make_case(case_id="suite.first", prompt="First"),
+            _make_case(case_id="suite.second", prompt="Second"),
+        ]
+        agents = [_mock_agent(), _mock_agent()]
+        injected = iter(agents)
+
+        # Monkey-patch run_eval_case to inject our agents
+        def _patched(case, **kw):
+            return run_eval_case(case, injected_agent=next(injected), **kw)
+
+        import evals.runner as runner_mod
+
+        original = runner_mod.run_eval_case
+        runner_mod.run_eval_case = _patched
+        try:
+            results = run_eval_suite(cases, model="gpt-5.4")
+        finally:
+            runner_mod.run_eval_case = original
+
+        assert len(results) == 2
+        assert results[0].case_id == "suite.first"
+        assert results[1].case_id == "suite.second"
+
+
+# ---------------------------------------------------------------------------
+# build_result_from_components — direct unit test
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResultFromComponents:
+    def test_builds_result_directly(self):
+        case = _make_case()
+        result = build_result_from_components(
+            case,
+            final_response="direct answer",
+            completed=True,
+            tool_calls=[{"name": "web_search"}],
+            input_tokens=100,
+            output_tokens=50,
+            estimated_cost_usd=0.01,
+        )
+
+        assert result.final_response == "direct answer"
+        assert result.completed is True
+        assert result.failed is False
+        assert result.tool_calls == [{"name": "web_search"}]
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+        assert result.estimated_cost_usd == 0.01
+
+    def test_builds_failed_result(self):
+        case = _make_case()
+        result = build_result_from_components(
+            case,
+            final_response="",
+            completed=False,
+            failed=True,
+            error="ValueError: bad input",
+        )
+
+        assert result.completed is False
+        assert result.failed is True
+        assert result.error == "ValueError: bad input"
+        assert result.final_response == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_session_metrics — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSessionMetrics:
+    def test_no_session_db_returns_defaults(self):
+        agent = MagicMock()
+        agent._session_db = None
+        agent.session_id = None
+
+        m = _extract_session_metrics(agent)
+        assert m["tool_calls"] == []
+        assert m["input_tokens"] is None
+
+    def test_exception_during_extraction_is_handled(self):
+        db = MagicMock()
+        db.get_session.side_effect = RuntimeError("corrupt DB")
+        agent = MagicMock()
+        agent._session_db = db
+        agent.session_id = "sess_bad"
+
+        m = _extract_session_metrics(agent)
+        # Should return defaults without propagating the exception
+        assert m["tool_calls"] == []
+        assert m["input_tokens"] is None
+
+    def test_deduplicates_tool_call_names(self):
+        """Same tool name used multiple times only appears once."""
+        db = MagicMock()
+        db.get_session.return_value = _default_session()
+        db.get_messages.return_value = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    },
+                ],
+            },
+        ]
+        agent = MagicMock()
+        agent._session_db = db
+        agent.session_id = "sess_dedup"
+
+        m = _extract_session_metrics(agent)
+        assert len(m["tool_calls"]) == 1
+        assert m["tool_calls"][0]["name"] == "web_search"
+
+    def test_handles_legacy_tool_call_format(self):
+        """Some agents store tool_calls as list of {name, args} not {function: {name}}."""
+        db = MagicMock()
+        db.get_session.return_value = _default_session()
+        db.get_messages.return_value = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"name": "web_search", "arguments": "{}"},
+                ],
+            },
+        ]
+        agent = MagicMock()
+        agent._session_db = db
+        agent.session_id = "sess_legacy"
+
+        m = _extract_session_metrics(agent)
+        assert len(m["tool_calls"]) == 1
+        assert m["tool_calls"][0]["name"] == "web_search"


### PR DESCRIPTION
## Summary
- add a Hermes-native eval framework with schemas, loader, runner, checks, judges, reporting, baselines, and trace mining
- seed initial routing, review, briefing, and multimodal eval cases plus rubrics and smoke fixtures
- wire smoke/nightly workflows, operator docs, and packaging so the eval tooling works outside editable installs

## Test Plan
- `scripts/run_tests.sh tests/evals/ tests/run_agent/test_run_agent_codex_responses.py`
- `python scripts/run_evals.py --case routing.local-repo-inspection --case routing.web-search-straightforward --case review.pr-code-quality --case briefing.change-summary-no-speculation --fixture-results evals/fixtures/smoke_ci.yaml -o evals/results/precommit-smoke`
