### PR TITLE
feat: add Telegram session health nudge

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -351,6 +351,82 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
     return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
 
 
+_SESSION_HEALTH_NUDGE_MIN_MESSAGES = 24
+_SESSION_HEALTH_NUDGE_MESSAGE_THRESHOLD = 120
+_SESSION_HEALTH_NUDGE_CONTEXT_PCT = 0.60
+_SESSION_HEALTH_NUDGE_AGE_HOURS = 12.0
+
+
+def _format_session_health_age_hours(age_seconds: float) -> str:
+    """Return a compact age label for session-health nudges."""
+    hours = max(1, round(max(0.0, age_seconds) / 3600.0))
+    return f"{hours}h"
+
+
+def _build_session_health_nudge(
+    *,
+    platform: Any,
+    session_entry: Any,
+    history: list[dict[str, Any]] | None,
+    approx_tokens: int,
+    context_length: Optional[int],
+    now: Optional[datetime] = None,
+) -> Optional[tuple[str, str]]:
+    """Return a one-shot Telegram session-health notice when a chat gets heavy.
+
+    This is intentionally a soft nudge, not an auto-reset. It fires well before
+    hard hygiene compression so the user can summarize/externalize and start a
+    fresh thread before the session turns into a broad workspace.
+    """
+    if _gateway_platform_value(platform) != "telegram":
+        return None
+    if session_entry is None or getattr(session_entry, "session_health_nudged", False):
+        return None
+
+    history = list(history or [])
+    msg_count = len(history)
+    if msg_count < _SESSION_HEALTH_NUDGE_MIN_MESSAGES:
+        return None
+
+    created_at = getattr(session_entry, "created_at", None)
+    if now is None:
+        now = datetime.now()
+    age_seconds = 0.0
+    if isinstance(created_at, datetime):
+        try:
+            age_seconds = max(0.0, (now - created_at).total_seconds())
+        except Exception:
+            age_seconds = 0.0
+
+    context_pct = 0.0
+    if context_length and context_length > 0 and approx_tokens > 0:
+        context_pct = approx_tokens / context_length
+
+    reasons: list[tuple[str, str]] = []
+    if context_pct >= _SESSION_HEALTH_NUDGE_CONTEXT_PCT:
+        pct_label = max(1, round(context_pct * 100))
+        reasons.append(("context", f"context is already ~{pct_label}% full"))
+    if msg_count >= _SESSION_HEALTH_NUDGE_MESSAGE_THRESHOLD:
+        reasons.append(("messages", f"thread already has {msg_count} messages"))
+    if age_seconds >= (_SESSION_HEALTH_NUDGE_AGE_HOURS * 3600.0):
+        reasons.append(("age", f"session has been open for {_format_session_health_age_hours(age_seconds)}"))
+    if not reasons:
+        return None
+
+    reason_key = reasons[0][0]
+    reason_text = ", ".join(text for _, text in reasons)
+    notice = (
+        "⚠️ Session-health nudge: this Telegram session is getting heavy "
+        f"({reason_text}).\n\n"
+        "If the topic is drifting, better flow is:\n"
+        "• summarize the current state\n"
+        "• externalize durable notes to memory/skills/KB\n"
+        "• start a fresh thread with /new\n\n"
+        "If you want to keep this thread, /compress is the safer next step than letting context keep ballooning."
+    )
+    return notice, reason_key
+
+
 # Only auto-continue interrupted gateway turns while the interruption is fresh.
 # Stale tool-tail/resume markers can otherwise revive an unrelated old task
 # after a gateway restart when the user's next message starts new work.
@@ -8619,6 +8695,37 @@ class GatewayRunner:
                         logger.warning(
                             "Session hygiene auto-compress failed: %s", e
                         )
+
+        _session_health_context_length = None
+        try:
+            _session_health_context_length = locals().get("_hyg_context_length")
+        except Exception:
+            _session_health_context_length = None
+        _session_health_tokens = max(
+            0,
+            int(getattr(session_entry, "last_prompt_tokens", 0) or 0),
+        )
+        if _session_health_tokens <= 0 and history:
+            try:
+                _session_health_tokens = max(
+                    0,
+                    sum(len(str(m.get("content") or "")) for m in history) // 4,
+                )
+            except Exception:
+                _session_health_tokens = 0
+        _session_health_notice = _build_session_health_nudge(
+            platform=source.platform,
+            session_entry=session_entry,
+            history=history,
+            approx_tokens=_session_health_tokens,
+            context_length=_session_health_context_length,
+        )
+        if _session_health_notice:
+            _notice_text, _notice_reason = _session_health_notice
+            await self._deliver_platform_notice(source, _notice_text)
+            session_entry.session_health_nudged = True
+            session_entry.session_health_nudge_reason = _notice_reason
+            self.session_store._save()
 
         # First-message onboarding -- only on the very first interaction ever
         if not history and not self.session_store.has_any_sessions():

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -452,6 +452,12 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # One-shot Telegram session-health nudge state. Used to avoid repeating
+    # the same "this thread is getting heavy" guidance on every turn once a
+    # session crosses the soft threshold.
+    session_health_nudged: bool = False
+    session_health_nudge_reason: Optional[str] = None
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -506,6 +512,8 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "session_health_nudged": self.session_health_nudged,
+            "session_health_nudge_reason": self.session_health_nudge_reason,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -562,6 +570,8 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            session_health_nudged=data.get("session_health_nudged", False),
+            session_health_nudge_reason=data.get("session_health_nudge_reason"),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),

--- a/tests/gateway/test_session_health_nudge.py
+++ b/tests/gateway/test_session_health_nudge.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta
+from typing import Any, cast
+
+from gateway.config import Platform
+from gateway.run import _build_session_health_nudge
+from gateway.session import SessionEntry
+
+
+def _make_entry(**overrides: Any) -> SessionEntry:
+    now = datetime.now()
+    data: dict[str, Any] = {
+        "session_key": "telegram:dm:u1:c1",
+        "session_id": "sess-1",
+        "created_at": now - timedelta(hours=13),
+        "updated_at": now,
+        "platform": Platform.TELEGRAM,
+        "chat_type": "dm",
+    }
+    data.update(overrides)
+    return cast(SessionEntry, SessionEntry(**data))
+
+
+def test_session_health_nudge_triggers_for_old_heavy_telegram_session():
+    entry = _make_entry()
+    history = [{"role": "user", "content": f"message {i}"} for i in range(130)]
+
+    result = _build_session_health_nudge(
+        platform=Platform.TELEGRAM,
+        session_entry=entry,
+        history=history,
+        approx_tokens=70000,
+        context_length=100000,
+        now=datetime.now(),
+    )
+
+    assert result is not None
+    notice, reason = result
+    assert reason == "context"
+    assert "thread already has 130 messages" in notice
+    assert "session has been open for" in notice
+    assert "/new" in notice
+    assert "/compress" in notice
+
+
+def test_session_health_nudge_skips_non_telegram_and_already_nudged():
+    history = [{"role": "user", "content": f"message {i}"} for i in range(130)]
+
+    non_telegram = _build_session_health_nudge(
+        platform=Platform.DISCORD,
+        session_entry=_make_entry(platform=Platform.DISCORD),
+        history=history,
+        approx_tokens=70000,
+        context_length=100000,
+        now=datetime.now(),
+    )
+    assert non_telegram is None
+
+    already_nudged = _build_session_health_nudge(
+        platform=Platform.TELEGRAM,
+        session_entry=_make_entry(session_health_nudged=True),
+        history=history,
+        approx_tokens=70000,
+        context_length=100000,
+        now=datetime.now(),
+    )
+    assert already_nudged is None
+
+
+def test_session_entry_round_trips_health_nudge_fields():
+    entry = _make_entry(
+        session_health_nudged=True,
+        session_health_nudge_reason="messages",
+    )
+
+    restored = SessionEntry.from_dict(entry.to_dict())
+
+    assert restored.session_health_nudged is True
+    assert restored.session_health_nudge_reason == "messages"


### PR DESCRIPTION
## Summary
- add a one-shot Telegram session health nudge when a conversation gets stale, bloated, or compression-heavy
- persist nudge state on session entries to avoid repeat prompts
- cover the nudge behavior with focused gateway tests

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_session_health_nudge.py`
