### PR TITLE
fix(codex): fail fast on zero-event TTFB stalls

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -35,7 +35,7 @@ from urllib.parse import urlparse, parse_qs, urlunparse
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
-from agent.error_classifier import classify_api_error, FailoverReason
+from agent.error_classifier import CodexNoFirstByteTimeout, classify_api_error, FailoverReason
 from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
     _sanitize_surrogates,
@@ -162,7 +162,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
-    result = {"response": None, "error": None}
+    result: Dict[str, Any] = {"response": None, "error": None}
     request_client_holder = {"client": None, "owner_tid": None}
     request_client_lock = threading.Lock()
 
@@ -425,14 +425,24 @@ def interruptible_api_call(agent, api_kwargs: dict):
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
                 if _silent_hint:
-                    result["error"] = TimeoutError(
+                    result["error"] = CodexNoFirstByteTimeout(
                         f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s). {_silent_hint}"
+                        f"(TTFB threshold: {int(_ttfb_timeout)}s). {_silent_hint}",
+                        provider=getattr(agent, "provider", None),
+                        model=api_kwargs.get("model") or getattr(agent, "model", None),
+                        base_url=str(getattr(agent, "base_url", "") or "") or None,
+                        api_mode=getattr(agent, "api_mode", None),
+                        elapsed_seconds=_elapsed,
                     )
                 else:
-                    result["error"] = TimeoutError(
+                    result["error"] = CodexNoFirstByteTimeout(
                         f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s)"
+                        f"(TTFB threshold: {int(_ttfb_timeout)}s)",
+                        provider=getattr(agent, "provider", None),
+                        model=api_kwargs.get("model") or getattr(agent, "model", None),
+                        base_url=str(getattr(agent, "base_url", "") or "") or None,
+                        api_mode=getattr(agent, "api_mode", None),
+                        elapsed_seconds=_elapsed,
                     )
             break
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -74,6 +74,109 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
+_CODEX_ZERO_EVENT_BREAKERS: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+_CODEX_ZERO_EVENT_WINDOW_SECONDS = 10 * 60.0
+_CODEX_ZERO_EVENT_COOLDOWN_SECONDS = 20 * 60.0
+
+
+def _is_codex_zero_event_failfast_target(agent: Any) -> bool:
+    """Known-bad route: openai-codex gpt-5.5 via Responses API."""
+    provider = (getattr(agent, "provider", "") or "").strip().lower()
+    model = (getattr(agent, "model", "") or "").strip().lower()
+    api_mode = (getattr(agent, "api_mode", "") or "").strip().lower()
+    return (
+        provider == "openai-codex"
+        and api_mode == "codex_responses"
+        and model.startswith("gpt-5.5")
+    )
+
+
+def _codex_zero_event_breaker_key(agent: Any) -> Optional[tuple[str, str, str, str]]:
+    if not _is_codex_zero_event_failfast_target(agent):
+        return None
+    provider = (getattr(agent, "provider", "") or "").strip().lower()
+    base_url = str(getattr(agent, "base_url", "") or "").rstrip("/").lower()
+    model = (getattr(agent, "model", "") or "").strip().lower()
+    api_mode = (getattr(agent, "api_mode", "") or "").strip().lower()
+    return (provider, base_url, model, api_mode)
+
+
+def _codex_zero_event_breaker_threshold(agent: Any) -> int:
+    # Child/subagent sessions carry a parent_session_id; keep them stricter.
+    return 1 if getattr(agent, "_parent_session_id", None) else 2
+
+
+def _prune_codex_zero_event_breaker(now: float) -> None:
+    for key, state in list(_CODEX_ZERO_EVENT_BREAKERS.items()):
+        failures = [ts for ts in state.get("failures", []) if now - ts <= _CODEX_ZERO_EVENT_WINDOW_SECONDS]
+        open_until = float(state.get("open_until", 0.0) or 0.0)
+        if failures or open_until > now:
+            state["failures"] = failures
+            _CODEX_ZERO_EVENT_BREAKERS[key] = state
+        else:
+            _CODEX_ZERO_EVENT_BREAKERS.pop(key, None)
+
+
+def _record_codex_zero_event_failure(agent: Any) -> Optional[float]:
+    key = _codex_zero_event_breaker_key(agent)
+    if key is None:
+        return None
+    now = time.monotonic()
+    _prune_codex_zero_event_breaker(now)
+    state = _CODEX_ZERO_EVENT_BREAKERS.setdefault(key, {"failures": [], "open_until": 0.0})
+    failures = [ts for ts in state.get("failures", []) if now - ts <= _CODEX_ZERO_EVENT_WINDOW_SECONDS]
+    failures.append(now)
+    state["failures"] = failures
+    threshold = _codex_zero_event_breaker_threshold(agent)
+    if len(failures) >= threshold:
+        state["open_until"] = max(float(state.get("open_until", 0.0) or 0.0), now + _CODEX_ZERO_EVENT_COOLDOWN_SECONDS)
+    _CODEX_ZERO_EVENT_BREAKERS[key] = state
+    return float(state.get("open_until", 0.0) or 0.0)
+
+
+def _codex_zero_event_breaker_remaining(agent: Any) -> float:
+    key = _codex_zero_event_breaker_key(agent)
+    if key is None:
+        return 0.0
+    now = time.monotonic()
+    _prune_codex_zero_event_breaker(now)
+    state = _CODEX_ZERO_EVENT_BREAKERS.get(key)
+    if not state:
+        return 0.0
+    open_until = float(state.get("open_until", 0.0) or 0.0)
+    if open_until <= now:
+        return 0.0
+    return open_until - now
+
+
+def _clear_codex_zero_event_breaker(agent: Any) -> None:
+    key = _codex_zero_event_breaker_key(agent)
+    if key is None:
+        return
+    _CODEX_ZERO_EVENT_BREAKERS.pop(key, None)
+
+
+def _format_duration_seconds(seconds: float) -> str:
+    seconds = max(0.0, float(seconds))
+    if seconds < 90:
+        return f"{int(round(seconds))}s"
+    minutes = int(round(seconds / 60.0))
+    return f"{minutes}m"
+
+
+def _maybe_failfast_codex_zero_event_breaker(agent: Any) -> bool:
+    remaining = _codex_zero_event_breaker_remaining(agent)
+    if remaining <= 0:
+        return False
+    if agent._fallback_index >= len(agent._fallback_chain):
+        return False
+    agent._emit_status(
+        "⚠️ Codex gpt-5.5 zero-event circuit breaker open — "
+        f"skipping unhealthy route for {_format_duration_seconds(remaining)} and switching to fallback..."
+    )
+    return agent._try_activate_fallback(reason=FailoverReason.codex_zero_event_ttfb)
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -1080,6 +1183,12 @@ def run_conversation(
                 except Exception:
                     pass  # Never let rate guard break the agent loop
 
+            if _maybe_failfast_codex_zero_event_breaker(agent):
+                retry_count = 0
+                compression_attempts = 0
+                primary_recovery_attempted = False
+                continue
+
             try:
                 agent._reset_stream_delivery_tracking()
                 api_kwargs = agent._build_api_kwargs(api_messages)
@@ -1175,7 +1284,10 @@ def run_conversation(
                     )
                 else:
                     response = agent._interruptible_api_call(api_kwargs)
-                
+
+                if _is_codex_zero_event_failfast_target(agent):
+                    _clear_codex_zero_event_breaker(agent)
+
                 api_duration = time.time() - api_start_time
                 
                 # Stop thinking spinner silently -- the response box or tool
@@ -2544,6 +2656,33 @@ def run_conversation(
                             compression_attempts = 0
                             primary_recovery_attempted = False
                             continue
+
+                if classified.reason == FailoverReason.codex_zero_event_ttfb:
+                    _breaker_open_until = _record_codex_zero_event_failure(agent)
+                    if _is_codex_zero_event_failfast_target(agent):
+                        logger.warning(
+                            "Codex zero-event TTFB detected; failing over immediately. %s",
+                            agent._client_log_context(),
+                        )
+                        if agent._fallback_index < len(agent._fallback_chain):
+                            _cooldown_hint = ""
+                            if _breaker_open_until and _breaker_open_until > time.monotonic():
+                                _cooldown_hint = (
+                                    f" Circuit breaker armed for "
+                                    f"{_format_duration_seconds(_breaker_open_until - time.monotonic())}."
+                                )
+                            agent._emit_status(
+                                "⚠️ Codex gpt-5.5 produced no first byte — "
+                                f"upstream zero-event stall detected, switching to fallback.{_cooldown_hint}"
+                            )
+                            if agent._try_activate_fallback(reason=classified.reason):
+                                retry_count = 0
+                                compression_attempts = 0
+                                primary_recovery_attempted = False
+                                continue
+                        # No fallback configured: don't burn two more 45s stalls.
+                        retry_count = max_retries
+                        primary_recovery_attempted = True
 
                 # ── Nous Portal: record rate limit & skip retries ─────
                 # When Nous returns a 429 that is a genuine account-

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -19,6 +19,33 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 
+class CodexNoFirstByteTimeout(TimeoutError):
+    """Codex Responses accepted the connection but produced zero stream events.
+
+    Distinct from a generic transport timeout: the backend reached the stream
+    endpoint, but no SSE event arrived before Hermes' TTFB watchdog cut the
+    request. This known openai-codex/gpt-5.5 failure mode should generally
+    fail over faster than ordinary read/connect timeouts.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        api_mode: str | None = None,
+        elapsed_seconds: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.model = model
+        self.base_url = base_url
+        self.api_mode = api_mode
+        self.elapsed_seconds = elapsed_seconds
+
+
 # ── Error taxonomy ──────────────────────────────────────────────────────
 
 class FailoverReason(enum.Enum):
@@ -38,6 +65,7 @@ class FailoverReason(enum.Enum):
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
+    codex_zero_event_ttfb = "codex_zero_event_ttfb"  # Codex stream accepted the connection but emitted no first byte/event before watchdog cutoff
 
     # Context / payload
     context_overflow = "context_overflow"  # Context too large — compress, not failover
@@ -482,6 +510,13 @@ def classify_api_error(
         }
         defaults.update(overrides)
         return ClassifiedError(**defaults)
+
+    if isinstance(error, CodexNoFirstByteTimeout):
+        return _result(
+            FailoverReason.codex_zero_event_ttfb,
+            retryable=False,
+            should_fallback=True,
+        )
 
     # ── 1. Provider-specific patterns (highest priority) ────────────
 

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -62,6 +62,7 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
     cutoff, well before the 60s wall-clock stale timeout, with a retryable
     TimeoutError and a ``codex_ttfb_kill`` close reason."""
     from agent import chat_completion_helpers as h
+    from agent.error_classifier import CodexNoFirstByteTimeout
 
     agent = _make_codex_agent(tmp_path, monkeypatch)
     monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "1")
@@ -94,6 +95,7 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
         with pytest.raises(TimeoutError) as excinfo:
             h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
         elapsed = time.time() - t0
+        assert isinstance(excinfo.value, CodexNoFirstByteTimeout)
         assert "TTFB" in str(excinfo.value)
         assert "codex_ttfb_kill" in closes
         # ~1s cutoff + 2s join grace; must be far under the 60s stale timeout.

--- a/tests/agent/test_codex_zero_event_breaker.py
+++ b/tests/agent/test_codex_zero_event_breaker.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from agent.conversation_loop import (
+    _CODEX_ZERO_EVENT_BREAKERS,
+    _clear_codex_zero_event_breaker,
+    _codex_zero_event_breaker_remaining,
+    _codex_zero_event_breaker_threshold,
+    _is_codex_zero_event_failfast_target,
+    _record_codex_zero_event_failure,
+)
+
+
+def _make_agent(*, parent_session_id=None):
+    return SimpleNamespace(
+        provider="openai-codex",
+        model="gpt-5.5",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_mode="codex_responses",
+        _parent_session_id=parent_session_id,
+    )
+
+
+def setup_function():
+    _CODEX_ZERO_EVENT_BREAKERS.clear()
+
+
+def test_breaker_only_targets_openai_codex_gpt_5_5():
+    good = _make_agent()
+    bad = SimpleNamespace(
+        provider="openai-codex",
+        model="gpt-5.4",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_mode="codex_responses",
+        _parent_session_id=None,
+    )
+    assert _is_codex_zero_event_failfast_target(good) is True
+    assert _is_codex_zero_event_failfast_target(bad) is False
+
+
+def test_breaker_opens_after_two_failures_for_normal_session():
+    agent = _make_agent()
+    assert _codex_zero_event_breaker_threshold(agent) == 2
+    assert _codex_zero_event_breaker_remaining(agent) == 0
+    _record_codex_zero_event_failure(agent)
+    assert _codex_zero_event_breaker_remaining(agent) == 0
+    _record_codex_zero_event_failure(agent)
+    assert _codex_zero_event_breaker_remaining(agent) > 0
+
+
+def test_breaker_is_stricter_for_child_sessions():
+    agent = _make_agent(parent_session_id="parent-123")
+    assert _codex_zero_event_breaker_threshold(agent) == 1
+    _record_codex_zero_event_failure(agent)
+    assert _codex_zero_event_breaker_remaining(agent) > 0
+    _clear_codex_zero_event_breaker(agent)
+    assert _codex_zero_event_breaker_remaining(agent) == 0

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -3,6 +3,7 @@
 import pytest
 from agent.error_classifier import (
     ClassifiedError,
+    CodexNoFirstByteTimeout,
     FailoverReason,
     classify_api_error,
     _extract_status_code,
@@ -54,6 +55,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "overloaded", "server_error", "timeout",
+            "codex_zero_event_ttfb",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
@@ -214,6 +216,20 @@ class TestClassify402:
 
 class TestClassifyApiError:
     """End-to-end classification tests."""
+
+    def test_codex_no_first_byte_timeout_classified_for_fast_fallback(self):
+        err = CodexNoFirstByteTimeout(
+            "Codex stream produced no bytes within 45s (TTFB threshold: 45s)",
+            provider="openai-codex",
+            model="gpt-5.5",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+            elapsed_seconds=45,
+        )
+        result = classify_api_error(err, provider="openai-codex", model="gpt-5.5")
+        assert result.reason == FailoverReason.codex_zero_event_ttfb
+        assert result.retryable is False
+        assert result.should_fallback is True
 
     # ── Auth errors ──
 


### PR DESCRIPTION
This change does not claim to fix upstream Codex gpt-5.5 zero-event stalls.

    What it does:
    - detects the distinct failure mode where the Codex Responses path accepts the request but emits zero SSE events before Hermes’ TTFB watchdog fires
    - classifies that path separately from ordinary timeouts
    - fails over immediately for the known unhealthy route
    - adds a small route-level circuit breaker so Hermes does not repeatedly burn TTFB windows on the same failing path
    - improves delegated/subagent reliability by applying a stricter fail-fast policy there

    In short:
    this is a scoped client-side reliability fix for an upstream failure mode that Hermes cannot directly repair.

    Local verification:
    - relevant tests passed: 293 passed
