### PR TITLE
fix(gateway): suppress home channel notice for email platform

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8663,7 +8663,7 @@ class GatewayRunner:
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK and source.platform != Platform.EMAIL:
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
             if not os.getenv(env_key):


### PR DESCRIPTION
## Summary

The "No home channel" notice (`📬 No home channel is set for Email...`) is sent on the first message of every new session when no home channel is configured. For email, this notice is delivered **via email itself** — which is contradictory and pointless, since email is not a viable home channel (cron results and cross-platform messages should go to Telegram/Discord, not back to the email inbox).

This notice fires after every gateway restart or session reset (daily/idle), creating a recurring nuisance for email platform users.

## Fix

Skip the home channel notice for the email platform, same as `LOCAL` and `WEBHOOK` are already skipped.

```python
# Before:
if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:

# After:
if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK and source.platform != Platform.EMAIL:
```

## Rationale

Email is fundamentally unsuitable as a home channel because:
1. The notice about missing home channel is sent **via email** — circular and unhelpful
2. Cron job results and cross-platform messages are delivered to Telegram/Discord, not email
3. Users who receive email notifications (e.g., from a mail-checker cron job) don't want gateway bootstrap noise in their inbox
