### PR TITLE
approval: add docker restart/stop/kill to DANGEROUS_PATTERNS

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -367,6 +367,13 @@ DANGEROUS_PATTERNS = [
     # terminates all running agents mid-work.
     (r'\bhermes\s+gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    # Docker container lifecycle — any user with docker.sock mounted (a common
+    # Docker Compose pattern) gives the agent the ability to restart/stop/kill
+    # containers without approval.  These are agent-initiated lifecycle operations
+    # that should always require user consent, just like `hermes gateway restart`
+    # already does for the gateway process.
+    (r'\bdocker\s+compose\s+(restart|stop|kill|down)\b', "docker compose restart/stop/kill/down (container lifecycle)"),
+    (r'\bdocker\s+(restart|stop|kill)\b', "docker restart/stop/kill (container lifecycle)"),
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),


### PR DESCRIPTION
When docker.sock is mounted (standard Docker Compose setup), the agent can run docker restart/stop/kill without approval. hermes gateway restart was already protected, but Docker equivalents were missing. This caused a self-termination loop. Fix: added docker restart/stop/kill and docker compose restart/stop/kill/down to DANGEROUS_PATTERNS. +7 lines in tools/approval.py.