### PR TITLE
fix(honcho): include manager-scoped honcho.json settings in gateway cache signature

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15106,11 +15106,10 @@ class GatewayRunner:
         except Exception:
             out["tools.registry_generation"] = None
 
-        # Honcho identity-mapping keys live in honcho.json, not user_config.
-        # HonchoSessionManager freezes the resolved peer_name / ai_peer /
-        # pin / aliases / prefix at construction; without busting here,
-        # mid-flight honcho.json edits go unread until the next unrelated
-        # cache eviction.
+        # Honcho config lives in honcho.json, not user_config.
+        # HonchoSessionManager freezes this resolved subset at construction;
+        # without busting here, mid-flight honcho.json edits go unread until
+        # the next unrelated cache eviction.
         try:
             from plugins.memory.honcho.client import HonchoClientConfig
 
@@ -15121,12 +15120,34 @@ class GatewayRunner:
             out["honcho.runtime_peer_prefix"] = hcfg.runtime_peer_prefix or ""
             aliases = hcfg.user_peer_aliases or {}
             out["honcho.user_peer_aliases"] = sorted(aliases.items()) if isinstance(aliases, dict) else []
+            out["honcho.context_tokens"] = hcfg.context_tokens
+            out["honcho.write_frequency"] = hcfg.write_frequency
+            out["honcho.dialectic_reasoning_level"] = hcfg.dialectic_reasoning_level
+            out["honcho.dialectic_dynamic"] = bool(hcfg.dialectic_dynamic)
+            out["honcho.dialectic_max_chars"] = hcfg.dialectic_max_chars
+            out["honcho.user_observe_me"] = bool(hcfg.user_observe_me)
+            out["honcho.user_observe_others"] = bool(hcfg.user_observe_others)
+            out["honcho.ai_observe_me"] = bool(hcfg.ai_observe_me)
+            out["honcho.ai_observe_others"] = bool(hcfg.ai_observe_others)
+            out["honcho.message_max_chars"] = hcfg.message_max_chars
+            out["honcho.dialectic_max_input_chars"] = hcfg.dialectic_max_input_chars
         except Exception:
             out["honcho.peer_name"] = None
             out["honcho.ai_peer"] = None
             out["honcho.pin_peer_name"] = None
             out["honcho.runtime_peer_prefix"] = None
             out["honcho.user_peer_aliases"] = None
+            out["honcho.context_tokens"] = None
+            out["honcho.write_frequency"] = None
+            out["honcho.dialectic_reasoning_level"] = None
+            out["honcho.dialectic_dynamic"] = None
+            out["honcho.dialectic_max_chars"] = None
+            out["honcho.user_observe_me"] = None
+            out["honcho.user_observe_others"] = None
+            out["honcho.ai_observe_me"] = None
+            out["honcho.ai_observe_others"] = None
+            out["honcho.message_max_chars"] = None
+            out["honcho.dialectic_max_input_chars"] = None
 
         return out
 

--- a/tests/honcho_plugin/test_pin_peer_name.py
+++ b/tests/honcho_plugin/test_pin_peer_name.py
@@ -817,6 +817,87 @@ class TestPinTransition:
 
         assert sig_before["honcho.ai_peer"] != sig_after["honcho.ai_peer"]
 
+    @pytest.mark.parametrize(
+        ("before_cfg", "after_cfg", "changed_keys"),
+        [
+            (
+                {"apiKey": "k", "peerName": "Igor", "contextTokens": 512},
+                {"apiKey": "k", "peerName": "Igor", "contextTokens": 1024},
+                ("honcho.context_tokens",),
+            ),
+            (
+                {"apiKey": "k", "peerName": "Igor", "writeFrequency": "async"},
+                {"apiKey": "k", "peerName": "Igor", "writeFrequency": "turn"},
+                ("honcho.write_frequency",),
+            ),
+            (
+                {"apiKey": "k", "peerName": "Igor", "dialecticReasoningLevel": "low"},
+                {"apiKey": "k", "peerName": "Igor", "dialecticReasoningLevel": "high"},
+                ("honcho.dialectic_reasoning_level",),
+            ),
+            (
+                {"apiKey": "k", "peerName": "Igor", "dialecticDynamic": True},
+                {"apiKey": "k", "peerName": "Igor", "dialecticDynamic": False},
+                ("honcho.dialectic_dynamic",),
+            ),
+            (
+                {"apiKey": "k", "peerName": "Igor", "dialecticMaxChars": 600},
+                {"apiKey": "k", "peerName": "Igor", "dialecticMaxChars": 1200},
+                ("honcho.dialectic_max_chars",),
+            ),
+            (
+                {"apiKey": "k", "peerName": "Igor", "observationMode": "directional"},
+                {"apiKey": "k", "peerName": "Igor", "observationMode": "unified"},
+                ("honcho.user_observe_others", "honcho.ai_observe_me"),
+            ),
+            (
+                {"apiKey": "k", "peerName": "Igor", "messageMaxChars": 25000},
+                {"apiKey": "k", "peerName": "Igor", "messageMaxChars": 4000},
+                ("honcho.message_max_chars",),
+            ),
+            (
+                {"apiKey": "k", "peerName": "Igor", "dialecticMaxInputChars": 10000},
+                {"apiKey": "k", "peerName": "Igor", "dialecticMaxInputChars": 800},
+                ("honcho.dialectic_max_input_chars",),
+            ),
+        ],
+    )
+    def test_cache_busting_signature_reflects_manager_scoped_settings(
+        self,
+        tmp_path,
+        monkeypatch,
+        before_cfg,
+        after_cfg,
+        changed_keys,
+    ):
+        """Gateway cache must bust when manager-scoped Honcho settings change."""
+        from gateway.run import GatewayRunner
+
+        cfg_path = tmp_path / "honcho.json"
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg_path.write_text(json.dumps(before_cfg))
+        cache_before = GatewayRunner._extract_cache_busting_config({})
+
+        cfg_path.write_text(json.dumps(after_cfg))
+        cache_after = GatewayRunner._extract_cache_busting_config({})
+
+        for key in changed_keys:
+            assert cache_before[key] != cache_after[key]
+
+        runtime = {
+            "api_key": "gateway-key",
+            "base_url": "https://example.test/v1",
+            "provider": "openrouter",
+        }
+        sig_before = GatewayRunner._agent_config_signature(
+            "claude-sonnet-4", runtime, ["hermes-telegram"], "", cache_keys=cache_before
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "claude-sonnet-4", runtime, ["hermes-telegram"], "", cache_keys=cache_after
+        )
+        assert sig_before != sig_after
+
 
 class TestProfilePeerUniqueness:
     """Each Hermes profile can pin to its own unique peerName.


### PR DESCRIPTION
## Summary

The gateway cache signature only fingerprints Honcho peer-mapping fields today, but `HonchoSessionManager` freezes a wider config subset at init. As a result, some `honcho.json` edits are ignored until an unrelated cache eviction or restart rebuilds the cached agent.

This patch extends the Honcho cache-busting subset to include the manager-scoped settings that are baked into `HonchoSessionManager` construction, and adds regression coverage for those settings.

## Problem

`HonchoSessionManager` snapshots settings like:

- `contextTokens`
- `writeFrequency`
- `dialecticReasoningLevel`
- `dialecticDynamic`
- `dialecticMaxChars`
- observation-derived booleans
- `messageMaxChars`
- `dialecticMaxInputChars`

But the gateway cache signature only covered peer routing / identity fields. That meant editing those manager-scoped settings in `honcho.json` would not take effect on the next gateway message if the cached agent was reused.

## Fix

Extend `GatewayRunner._extract_cache_busting_config()` to fingerprint the manager-scoped Honcho settings that are frozen by `HonchoSessionManager` at init.

Add regression coverage verifying that changing each of these settings changes both:

1. the extracted Honcho cache-busting subset
2. the final agent config signature

## Tests

Ran:

- `tests/honcho_plugin/test_pin_peer_name.py`
- `tests/gateway/test_agent_cache.py`

## Precedent

This follows the same cache-busting pattern established in:

- [6feb2afd5 fix(honcho): plug pinPeerName transition gaps](https://github.com/NousResearch/hermes-agent/commit/6feb2afd50cb7495cf614d4949412d457e46ce59)
- [1a8e67076 fix(honcho): cover pinUserPeer + aiPeer edge cases in setup, clone, and gateway cache](https://github.com/NousResearch/hermes-agent/commit/1a8e67076a0bef27262a11bbbaecf755f638aa19)