### PR TITLE
fix(langfuse): support local Host header routing

### DIFF
--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -39,6 +39,7 @@ HERMES_LANGFUSE_ENV=production       # environment tag
 HERMES_LANGFUSE_RELEASE=v1.0.0       # release tag
 HERMES_LANGFUSE_SAMPLE_RATE=0.5      # sample 50% of traces
 HERMES_LANGFUSE_MAX_CHARS=12000      # max chars per field (default: 12000)
+HERMES_LANGFUSE_HOST_HEADER=langfuse.example.com  # optional local vhost routing
 HERMES_LANGFUSE_DEBUG=true           # verbose plugin logging
 ```
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -19,6 +19,7 @@ Optional env vars:
   HERMES_LANGFUSE_SAMPLE_RATE - sampling rate 0.0–1.0 (default: 1.0)
   HERMES_LANGFUSE_MAX_CHARS   - max chars per field (default: 12000)
   HERMES_LANGFUSE_DEBUG       - set to "true" for verbose logging
+  HERMES_LANGFUSE_HOST_HEADER - optional Host header for local reverse proxies
 """
 from __future__ import annotations
 
@@ -58,6 +59,7 @@ _LANGFUSE_CLIENT = None
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
+_HOST_HEADER_RE = re.compile(r"^[A-Za-z0-9.-]+(?::\d{1,5})?$")
 
 # Langfuse-issued keys always carry these prefixes (cloud or self-hosted —
 # the prefix is baked into the server-side issuance flow, not a UI hint).
@@ -137,6 +139,29 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
     )
 
 
+def _additional_headers() -> Optional[Dict[str, str]]:
+    """Build optional SDK headers from env, defensively.
+
+    Jay's self-hosted Langfuse can sit behind a local edge-nginx vhost while
+    the public hostname is protected by Cloudflare Access. In that topology the
+    SDK should post to the local listener (for example ``http://127.0.0.1:8080``)
+    while still sending ``Host: langfuse.example.com`` so nginx routes to the
+    Langfuse container. Keep this intentionally narrow: only a syntactically safe
+    Host header is supported, which avoids turning env config into a generic
+    credential/header exfiltration channel.
+    """
+    host_header = _env("HERMES_LANGFUSE_HOST_HEADER") or _env("LANGFUSE_HOST_HEADER")
+    if not host_header:
+        return None
+    if not _HOST_HEADER_RE.match(host_header):
+        logger.warning(
+            "Invalid HERMES_LANGFUSE_HOST_HEADER=%r; ignoring Langfuse Host header override.",
+            _redact_key_preview(host_header),
+        )
+        return None
+    return {"Host": host_header}
+
+
 def _get_langfuse() -> Optional[Langfuse]:
     """Return a cached Langfuse client, or ``None`` if unavailable.
 
@@ -199,6 +224,9 @@ def _get_langfuse() -> Optional[Langfuse]:
         "secret_key": secret_key,
         "base_url": base_url,
     }
+    additional_headers = _additional_headers()
+    if additional_headers:
+        kwargs["additional_headers"] = additional_headers
     if environment:
         kwargs["environment"] = environment
     if release:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -433,16 +433,49 @@ class TestPlaceholderKeyDetection:
         wanted."""
         self._clear_env(monkeypatch)
         monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
-        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-...-xyz")
         plugin = self._fresh_plugin(monkeypatch)
         with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
             client = plugin._get_langfuse()
         assert isinstance(client, _FakeLangfuse)
         assert client.kwargs["public_key"] == "pk-lf-real-public-xyz"
-        assert client.kwargs["secret_key"] == "sk-lf-real-secret-xyz"
+        assert client.kwargs["secret_key"] == "sk-lf-...-xyz"
         assert "placeholders" not in caplog.text.lower(), (
             f"Valid Langfuse keys tripped the placeholder guard: {caplog.text!r}"
         )
+
+    def test_host_header_override_is_passed_to_sdk(self, monkeypatch):
+        """Self-hosted installs behind local vhost proxies need a Host header.
+
+        This lets Hermes post to a local listener that bypasses Cloudflare Access
+        while nginx still routes the request to the Langfuse container.
+        """
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-...-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_BASE_URL", "http://127.0.0.1:8080")
+        monkeypatch.setenv("HERMES_LANGFUSE_HOST_HEADER", "langfuse.example.com")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert client.kwargs["base_url"] == "http://127.0.0.1:8080"
+        assert client.kwargs["additional_headers"] == {"Host": "langfuse.example.com"}
+
+    def test_invalid_host_header_override_is_ignored(self, monkeypatch, caplog):
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-...-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_HOST_HEADER", "bad.example\r\nX-Injected: yes")
+        plugin = self._fresh_plugin(monkeypatch)
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            client = plugin._get_langfuse()
+
+        assert isinstance(client, _FakeLangfuse)
+        assert "additional_headers" not in client.kwargs
+        assert "Invalid HERMES_LANGFUSE_HOST_HEADER" in caplog.text
 
 
 class TestRequestMessageCoercion:


### PR DESCRIPTION
## Summary
- Add `HERMES_LANGFUSE_HOST_HEADER` / `LANGFUSE_HOST_HEADER` support for self-hosted Langfuse instances reached via a local reverse proxy
- Pass a validated `Host` header through Langfuse SDK `additional_headers`
- Document the option and add regression tests for valid and invalid header values

## Test plan
- `PYTHONPATH=/tmp/hermes-langfuse-worktree-20260527194626 /Users/jaybychoi/.hermes/hermes-agent/.venv/bin/python -m pytest tests/plugins/test_langfuse_plugin.py -q -o 'addopts='`
