### PR TITLE
fix(weixin): wrap aiohttp requests in asyncio.create_task

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -376,14 +376,16 @@ async def _api_post(
     token: Optional[str],
     timeout_ms: int,
 ) -> Dict[str, Any]:
-    body = _json_dumps({**payload, "base_info": _base_info()})
-    url = f"{base_url.rstrip('/')}/{endpoint}"
-    timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
-    async with session.post(url, data=body, headers=_headers(token, body), timeout=timeout) as response:
-        raw = await response.text()
-        if not response.ok:
-            raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+    async def _inner():
+        body = _json_dumps({**payload, "base_info": _base_info()})
+        url = f"{base_url.rstrip('/')}/{endpoint}"
+        timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
+        async with session.post(url, data=body, headers=_headers(token, body), timeout=timeout) as response:
+            raw = await response.text()
+            if not response.ok:
+                raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
+            return json.loads(raw)
+    return await asyncio.create_task(_inner())
 
 
 async def _api_get(
@@ -393,17 +395,19 @@ async def _api_get(
     endpoint: str,
     timeout_ms: int,
 ) -> Dict[str, Any]:
-    url = f"{base_url.rstrip('/')}/{endpoint}"
-    headers = {
-        "iLink-App-Id": ILINK_APP_ID,
-        "iLink-App-ClientVersion": str(ILINK_APP_CLIENT_VERSION),
-    }
-    timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
-    async with session.get(url, headers=headers, timeout=timeout) as response:
-        raw = await response.text()
-        if not response.ok:
-            raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+    async def _inner():
+        url = f"{base_url.rstrip('/')}/{endpoint}"
+        headers = {
+            "iLink-App-Id": ILINK_APP_ID,
+            "iLink-App-ClientVersion": str(ILINK_APP_CLIENT_VERSION),
+        }
+        timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
+        async with session.get(url, headers=headers, timeout=timeout) as response:
+            raw = await response.text()
+            if not response.ok:
+                raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
+            return json.loads(raw)
+    return await asyncio.create_task(_inner())
 
 
 async def _get_updates(


### PR DESCRIPTION
### What does this PR do?

When running the Weixin platform gateway, sending messages can occasionally fail with:
`RuntimeError: Timeout context manager should be used inside a task`

This happens because the `aiohttp.ClientSession` requests (`session.post` and `session.get`) use `asyncio.timeout` internally, but they were being awaited directly in the call stack outside of a proper `asyncio.Task` context. This PR wraps the inner HTTP calls within `asyncio.create_task()` so that the timeout context manager is safely scoped within a task, preventing the crash.

### Why is it needed?
This bug prevents messages from being reliably delivered via Weixin, especially if there's a slight network delay triggering the timeout evaluation path. We noticed this in production where cron-delivered Weixin messages would repeatedly fail to send due to this exception.

### How was it fixed?
Wrapped the core HTTP logic inside `_api_post` and `_api_get` inside an `_inner()` async function, and returned `await asyncio.create_task(_inner())`.