### PR TITLE
fix: handle Codex API response.completed omitting output field

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -841,13 +841,13 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     """Normalize a Responses API object to an assistant_message-like object."""
     output = getattr(response, "output", None)
     if not isinstance(output, list) or not output:
-        # The Codex backend can return empty output when the answer was
-        # delivered entirely via stream events. Check output_text as a
-        # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
+        # The Codex backend can return empty/missing output when the answer
+        # was delivered entirely via stream events. Check output_text and
+        # text as last-resort fallbacks before raising.
+        out_text = getattr(response, "output_text", None) or getattr(response, "text", None)
         if isinstance(out_text, str) and out_text.strip():
             logger.debug(
-                "Codex response has empty output but output_text is present (%d chars); "
+                "Codex response has empty output but plain text is present (%d chars); "
                 "synthesizing output item.", len(out_text.strip()),
             )
             output = [SimpleNamespace(

--- a/run_agent.py
+++ b/run_agent.py
@@ -6998,12 +6998,46 @@ class AIAgent:
                                 sum(len(p) for p in self._codex_streamed_text_parts),
                                 self._client_log_context(),
                             )
-                    final_response = stream.get_final_response()
+                    try:
+                        final_response = stream.get_final_response()
+                    except TypeError:
+                        # SDK parse_response() crashed because the Codex API
+                        # response.completed event no longer includes `output`.
+                        # Recover from collected stream events or text deltas.
+                        if collected_output_items:
+                            final_response = SimpleNamespace(
+                                output=list(collected_output_items),
+                                status="completed",
+                            )
+                            logger.debug(
+                                "Codex stream: SDK parse_response() failed; "
+                                "synthesized from %d collected output items",
+                                len(collected_output_items),
+                            )
+                            return final_response
+                        if self._codex_streamed_text_parts and not has_tool_calls:
+                            assembled = "".join(self._codex_streamed_text_parts)
+                            final_response = SimpleNamespace(
+                                output=[SimpleNamespace(
+                                    type="message",
+                                    role="assistant",
+                                    status="completed",
+                                    content=[SimpleNamespace(type="output_text", text=assembled)],
+                                )],
+                                status="completed",
+                            )
+                            logger.debug(
+                                "Codex stream: SDK parse_response() failed; "
+                                "synthesized from %d text deltas (%d chars)",
+                                len(self._codex_streamed_text_parts), len(assembled),
+                            )
+                            return final_response
+                        raise
                     # PATCH: ChatGPT Codex backend streams valid output items
-                    # but get_final_response() can return an empty output list.
+                    # but get_final_response() can return a None or empty output list.
                     # Backfill from collected items or synthesize from deltas.
                     _out = getattr(final_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    if not isinstance(_out, list) or not _out:
                         if collected_output_items:
                             final_response.output = list(collected_output_items)
                             logger.debug(
@@ -7103,9 +7137,9 @@ class AIAgent:
                 if terminal_response is None and isinstance(event, dict):
                     terminal_response = event.get("response")
                 if terminal_response is not None:
-                    # Backfill empty output from collected stream events
+                    # Backfill missing/empty output from collected stream events
                     _out = getattr(terminal_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    if not isinstance(_out, list) or not _out:
                         if collected_output_items:
                             terminal_response.output = list(collected_output_items)
                             logger.debug(


### PR DESCRIPTION
## Summary

The Codex API (`chatgpt.com/backend-api/codex/responses`) recently changed its `response.completed` SSE event to no longer include the `output` field. The OpenAI Python SDK's `parse_response()` iterates `for output in response.output` without a None guard, causing `TypeError: 'NoneType' object is not iterable` inside the stream processing.

This PR makes Hermes resilient to this upstream SDK bug by recovering from collected stream events.

## Changes

- **`codex_responses_adapter.py`**: fall back to `response.text` when `output_text` is also missing (the API puts text in `text` field on `response.completed`)
- **`run_agent.py:_run_codex_stream`**: catch `TypeError` from SDK's `get_final_response()` and recover from already-collected stream events or text deltas
- **`run_agent.py`**: fix backfill guard to trigger on `None` output (`isinstance+and` → `not isinstance+or`)

## Test plan

- [x] Unit tests: `_normalize_codex_response` correctly handles `output=None` with `response.text` fallback
- [x] Unit tests: `_normalize_codex_response` raises `RuntimeError` when all fallbacks are empty
- [x] Live test: Codex stream via WeChat gateway recovers and returns valid response after SDK crash

## Related

- Closes #33449
- Upstream: openai/openai-python `_parsing/_responses.py:61` `parse_response()` should guard against `response.output=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)