### PR TITLE
fix(update): check upstream even when origin/main has no new commits (salvages #4873)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8928,6 +8928,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         if commit_count == 0:
             _invalidate_update_cache()
+
+            # Even if origin is up to date, the fork may be behind upstream
+            if is_fork and branch == "main":
+                _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+
             # Restore stash and switch back to original branch if we moved
             if auto_stash_ref is not None:
                 _restore_stashed_changes(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -106,6 +106,33 @@ class TestCmdUpdateBranchFallback:
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_on_fork_checks_upstream_when_origin_up_to_date(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """Regression for issue #26172: forks whose local HEAD already matches
+        origin/main must still consult upstream/main before printing
+        "Already up to date!" — otherwise a fork that's caught up to its own
+        origin but behind NousResearch/hermes-agent silently misses updates.
+        """
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock:
+            cmd_update(mock_args)
+
+        sync_mock.assert_called_once_with(["git"], PROJECT_ROOT)
+        captured = capsys.readouterr()
+        assert "Already up to date!" in captured.out
+
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_update_refreshes_repo_and_tui_node_dependencies(


### PR DESCRIPTION
Salvages #4873 with a regression test on top. Fixes #26172.

## What this fixes

`hermes update` on a fork silently bails with "Already up to date!" when local `HEAD` already matches `origin/main`, even if `upstream/main` has new commits. The existing `_sync_with_upstream_if_needed()` call only runs on the post-pull happy path (line 9079), so the `commit_count == 0` early-return at line 8929 never consults upstream — the fork is blind to NousResearch/hermes-agent updates whenever its origin happens to be caught up.

#19696 fixed the analogous bug on the `--check` probe path. This is the apply-path counterpart.

## Changes

1. **`hermes_cli/main.py`** — @francip's fix, cherry-picked verbatim: 5 lines adding a `_sync_with_upstream_if_needed()` call inside the `commit_count == 0` branch, gated on the same `is_fork and branch == "main"` condition used on the post-pull path.
2. **`tests/hermes_cli/test_cmd_update.py`** — Regression test (my follow-up) asserting that when `is_fork=True` and `commit_count == 0`, `_sync_with_upstream_if_needed(["git"], PROJECT_ROOT)` is called exactly once before "Already up to date!" prints. Locks the fix in so it can't silently regress out of the early-return branch.

`_sync_with_upstream_if_needed()` is already robust to all the relevant edge cases (missing remote → prompts user, origin ahead of upstream → preserves fork changes, upstream == origin → no-op print, upstream ahead → FF-only pull), so dropping it into the early-return path is safe by construction.

## Credit

- **#4873** — @francip identified the bug and authored the fix (Apr 3, 2026). His commit is preserved with original authorship.
- **#26172** — issue filed citing #4873 as the proposed fix.

Two other open PRs solve the same bug; both should be closed in favor of this one:
- **#26249** (@LeonSGP43) — same one-line fix + a regression test in the same shape as the one here. Functionally equivalent.
- **#29524** (@WompaJango) — different approach (hoists the upstream sync before fetch/pull and drops the post-pull call). Wrong direction — the current control flow (fetch origin → check delta → sync upstream conditionally) is intentional; sync-before-fetch wastes a roundtrip on every update and removes the upstream check from the post-pull path.

@ddiall already closed #21892 as a duplicate of #4873.

## How to test

```bash
bash scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py
# 21 passed
```

Manual repro:
1. Fork hermes-agent, clone your fork.
2. Add `upstream` remote pointing at NousResearch/hermes-agent.
3. Let your fork's `origin/main` fall behind `upstream/main`.
4. Locally: `git pull origin main` so local HEAD == `origin/main`.
5. `hermes update` — before this PR: "Already up to date!" with no upstream check. After this PR: fetches `upstream`, FF-pulls the missing commits, then continues with the normal post-update steps.

Closes #4873.
Closes #26172.
