### PR TITLE
feat(gateway): add more file extensions to MEDIA delivery regex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|vcf|ics|json|yaml|yml|toml|md|html?|xml|svg)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16968,7 +16968,8 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|csv|apk|ipa|vcf|ics|json|yaml|yml|toml|'
+                            r'md|html?|xml|svg))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -17274,7 +17275,8 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'txt|csv|apk|ipa|vcf|ics|json|yaml|yml|toml|'
+                                r'md|html?|xml|svg))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):


### PR DESCRIPTION
## What does this PR do?

The gateway's `MEDIA:<path>` file delivery regex only recognized a hardcoded set of extensions (images, video, audio, pdf, zip, office docs). When the agent tried to send other file types like `.vcf` contacts, `.html`, `.md`, or `.json` via `MEDIA:<path>`, the tag was silently ignored — the file never reached the user on Telegram/Discord/etc.

I ran into this firsthand: I asked Hermes to send me a `.vcf` contacts file over Telegram and it just... didn't show up. The text arrived but the file was dropped silently. Turns out the extension wasn't in the allowlist.

This adds 11 new extensions to all 3 regex patterns that handle MEDIA tag extraction:
- **Contact/calendar:** `vcf`, `ics`
- **Data/config:** `json`, `yaml`, `yml`, `toml`
- **Document/web:** `md`, `html`/`htm`, `xml`, `svg`

All of these are file types that Telegram (and other messaging platforms) already handle natively as document attachments — we just weren't passing them through.

## Related Issue

N/A — hit this while using Hermes day-to-day.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `gateway/platforms/base.py` — extended `media_pattern` regex in `_extract_media_paths()`
- `gateway/run.py` — extended `_TOOL_MEDIA_RE` in 2 spots (history dedup scan + tool result media scan)

## How to Test

1. Create a test `.vcf`, `.html`, or `.json` file on the host
2. Have the agent respond with `MEDIA:/path/to/file.vcf` on Telegram
3. Verify the file arrives as a downloadable document attachment (previously: silently dropped)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `ruff check` and all checks pass
- [ ] I've added tests for my changes — see note below
- [x] I've tested on my platform: Ubuntu 24.04 via Telegram gateway

### Documentation & Housekeeping

- [x] N/A — no new config keys, no architecture changes, no doc changes needed

## Note on tests

The three regex patterns have identical structure and only differ in file extension coverage. I'm happy to add a unit test if the maintainers would find it useful — just wasn't sure if there's an existing test module for the MEDIA extraction logic I should extend vs. creating a new one.
