### PR TITLE
docs(messaging): clarify email typing support

### DIFF
--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -39,6 +39,8 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 
 **Voice** = TTS audio replies and/or voice message transcription. **Images** = send/receive images. **Files** = send/receive file attachments. **Threads** = threaded conversations. **Reactions** = emoji reactions on messages. **Typing** = typing indicator while processing. **Streaming** = progressive message updates via editing.
 
+For Email, typing indicators are unsupported by IMAP/SMTP itself; the Email adapter's `send_typing()` hook is intentionally a no-op for that protocol.
+
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION
Adds a short note under the messaging platform table that Email cannot show typing status because IMAP/SMTP does not have that concept.

Closes #33303

Checked with `git diff --check`.