### PR TITLE
fix(cli): skip OSC 11 background probe for VSCode/Cursor terminals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1504,6 +1504,10 @@ _LIGHT_MODE_CACHE: bool | None = None
 _TRUE_RE = re.compile(r"^(1|true|on|yes|y)$")
 _FALSE_RE = re.compile(r"^(0|false|off|no|n)$")
 _LIGHT_DEFAULT_TERM_PROGRAMS = frozenset()  # Apple_Terminal doesn't reliably indicate; require explicit
+# Terminals whose OSC 11 response handling is unreliable — the reply
+# leaks into the visible CLI stream instead of being consumed silently.
+# Skip the probe for these and fall through to the dark default.
+_SKIP_OSC11_TERM_PROGRAMS = frozenset({"vscode", "cursor"})
 
 
 def _luminance_from_hex(hex_str: str) -> float | None:
@@ -1627,8 +1631,10 @@ def _detect_light_mode() -> bool:
                 if 0 <= bg < 16:
                     _LIGHT_MODE_CACHE = result
                     return result
-        # 5. OSC 11 query (best-effort, only when stdin/stdout are TTY)
-        bg_color = _query_osc11_background()
+        # 5. OSC 11 query (best-effort, skip for terminals that leak the reply)
+        tp_osc = (os.environ.get("TERM_PROGRAM") or "").strip()
+        if tp_osc not in _SKIP_OSC11_TERM_PROGRAMS:
+            bg_color = _query_osc11_background()
         if bg_color:
             lum = _luminance_from_hex(bg_color)
             if lum is not None:

--- a/tests/cli/test_cli_light_mode.py
+++ b/tests/cli/test_cli_light_mode.py
@@ -76,6 +76,25 @@ class TestLightModeDetection:
         assert cli_mod._detect_light_mode() is True
 
 
+
+    def test_osc11_skipped_for_vscode(self, cli_mod, monkeypatch):
+        """OSC 11 probe must be skipped for VSCode/Cursor terminals to
+        prevent the reply from leaking into the CLI stream (#33203)."""
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.delenv("COLORFGBG", raising=False)
+        monkeypatch.setenv("TERM_PROGRAM", "vscode")
+
+        called = []
+        monkeypatch.setattr(cli_mod, "_query_osc11_background", lambda: (called.append(1) or None))
+
+        # Should fall through to dark default without calling the probe
+        assert cli_mod._detect_light_mode() is False
+        assert called == [], "OSC 11 probe should be skipped for vscode terminals"
+
+
 class TestLightModeRemap:
     def test_remap_no_op_in_dark_mode(self, cli_mod, monkeypatch):
         monkeypatch.setenv("HERMES_LIGHT", "0")


### PR DESCRIPTION
## What does this PR do?

Skip the OSC 11 background-color probe when `TERM_PROGRAM` is `vscode` or `cursor`, preventing the terminal reply from leaking into the visible CLI stream.
## Related Issue

Fixes #33203

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- Analyzed: `cli.py:_detect_light_mode()` (callers: module import, resize handler) and `cli.py:_query_osc11_background()`
- Blast radius: LOW — single detection function, no cross-module dependencies
- Related patterns: `_LIGHT_DEFAULT_TERM_PROGRAMS` (existing TERM_PROGRAM allow-list pattern)