### PR TITLE
fix(feishu): handle SimpleNamespace action_value in webhook card actions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2515,6 +2515,10 @@ class FeishuAdapter(BasePlatformAdapter):
         event = getattr(data, "event", None)
         action = getattr(event, "action", None)
         action_value = getattr(action, "value", {}) or {}
+        # _namespace_from_mapping converts dicts to SimpleNamespace in webhook
+        # mode; normalise back to dict so .get() routing works.
+        if isinstance(action_value, SimpleNamespace):
+            action_value = vars(action_value)
         hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
         update_prompt_action = (
             action_value.get("hermes_update_prompt_action")
@@ -2799,6 +2803,14 @@ class FeishuAdapter(BasePlatformAdapter):
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
+        # Normalise SimpleNamespace back to dict for JSON serialisation.
+        if isinstance(action_value, SimpleNamespace):
+            action_value = vars(action_value)
+        elif isinstance(action_value, str):
+            try:
+                action_value = json.loads(action_value)
+            except (json.JSONDecodeError, ValueError):
+                action_value = {}
 
         synthetic_text = f"/card {action_tag}"
         if action_value:
@@ -3331,7 +3343,32 @@ class FeishuAdapter(BasePlatformAdapter):
         elif event_type in {"im.message.reaction.created_v1", "im.message.reaction.deleted_v1"}:
             self._on_reaction_event(event_type, data)
         elif event_type == "card.action.trigger":
-            self._on_card_action_trigger(data)
+            card_response = self._on_card_action_trigger(data)
+            if card_response is not None and P2CardActionTriggerResponse is not None and isinstance(card_response, P2CardActionTriggerResponse):
+                resp_body: dict = {"code": 0, "msg": "ok"}
+                cb_card = getattr(card_response, "card", None)
+                if cb_card is not None:
+                    card_dict: dict = {}
+                    card_type = getattr(cb_card, "type", None)
+                    if card_type is not None:
+                        card_dict["type"] = card_type
+                    card_data = getattr(cb_card, "data", None)
+                    if card_data is not None:
+                        card_dict["data"] = card_data
+                    if card_dict:
+                        resp_body["card"] = card_dict
+                toast = getattr(card_response, "toast", None)
+                if toast is not None:
+                    toast_dict: dict = {}
+                    toast_type = getattr(toast, "type", None)
+                    if toast_type is not None:
+                        toast_dict["type"] = toast_type
+                    toast_content = getattr(toast, "content", None)
+                    if toast_content is not None:
+                        toast_dict["content"] = toast_content
+                    if toast_dict:
+                        resp_body["toast"] = toast_dict
+                return web.json_response(resp_body)
         elif event_type == "drive.notice.comment_add_v1":
             self._on_drive_comment_event(data)
         else:

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -800,3 +800,119 @@ class TestResolveUpdatePrompt:
         await adapter._resolve_update_prompt(99, "n", "Nobody")
 
         assert not (tmp_path / ".hermes" / ".update_response").exists()
+
+# ===========================================================================
+# Regression: webhook SimpleNamespace handling (issue #33354)
+# ===========================================================================
+
+def _make_webhook_card_action_data(
+    action_value: dict,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+    token: str = "tok_abc",
+) -> SimpleNamespace:
+    """Simulate _namespace_from_mapping converting dicts to SimpleNamespace.
+
+    In webhook mode, the entire payload is recursively converted via
+    ``_namespace_from_mapping``, so action.value arrives as a SimpleNamespace
+    rather than a dict.
+    """
+    def _to_ns(obj):
+        if isinstance(obj, dict):
+            return SimpleNamespace(**{k: _to_ns(v) for k, v in obj.items()})
+        if isinstance(obj, list):
+            return [_to_ns(item) for item in obj]
+        return obj
+
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id),
+            action=SimpleNamespace(
+                tag="button",
+                value=_to_ns(action_value),
+            ),
+        ),
+    )
+
+
+class TestWebhookSimpleNamespaceHandling:
+    """Verify that card actions arriving as SimpleNamespace (webhook mode) are
+    correctly routed — the original bug was that isinstance(action_value, dict)
+    returned False for SimpleNamespace, silently dropping all card actions."""
+
+    def test_approval_action_routed_when_value_is_simplenamespace(self, _patch_callback_card_types):
+        """_on_card_action_trigger must detect hermes_action even when
+        action_value is a SimpleNamespace (webhook mode)."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._approval_state[1] = {
+            "session_key": "sess-1",
+            "message_id": "msg-1",
+            "chat_id": "oc_12345",
+        }
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+        data = _make_webhook_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 1},
+            open_id="ou_bob",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        card = response.card.data
+        assert "Approved once" in card["header"]["title"]["content"]
+
+    def test_update_prompt_action_routed_when_value_is_simplenamespace(self, _patch_callback_card_types):
+        """_on_card_action_trigger must detect hermes_update_prompt_action even
+        when action_value is a SimpleNamespace."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._is_interactive_operator_authorized = MagicMock(return_value=True)
+        adapter._update_prompt_state[1] = {
+            "session_key": "sess-up",
+            "message_id": "msg-up",
+            "chat_id": "oc_12345",
+        }
+        adapter._sender_name_cache["ou_user1"] = ("Alice", 9999999999)
+        data = _make_webhook_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 1},
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+
+    @pytest.mark.asyncio
+    async def test_card_action_event_serialises_simplenamespace_value(self):
+        """_handle_card_action_event must serialise SimpleNamespace action_value
+        to JSON, not silently produce empty text."""
+        adapter = _make_adapter()
+        data = _make_webhook_card_action_data(
+            {"custom_action": "something_else"},
+            token="tok_ns",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_called_once()
+        event = mock_handle.call_args[0][0]
+        # The serialised value should contain the action data, not be empty
+        assert "custom_action" in event.text
+        assert "something_else" in event.text


### PR DESCRIPTION
## What does this PR do?

In webhook mode, `FeishuAdapter._handle_webhook_request` converts the entire JSON payload to nested `SimpleNamespace` objects via `_namespace_from_mapping`. However, `_on_card_action_trigger` only checks `isinstance(action_value, dict)` to route approval and update-prompt actions. Since `SimpleNamespace` is not a `dict`, all card button clicks silently fall through to the generic text-event branch, producing useless synthetic messages like `[Card Action] button`.

Two additional bugs compound the problem:
1. `_handle_card_action_event` also fails to serialise `SimpleNamespace` values (produces empty JSON)
2. The webhook path discards the `P2CardActionTriggerResponse` return value, so Feishu never receives the card update/toast

## Related Issue

Fixes #33354

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- **Analyzed**: `gateway/platforms/feishu.py` — `_on_card_action_trigger`, `_handle_card_action_event`, `_handle_webhook_request`
- **Blast radius**: LOW — changes are scoped to the webhook code path; WebSocket mode is unaffected
- **Related patterns**: `_namespace_from_mapping` (L3236) is the root cause — recursive dict→SimpleNamespace conversion

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are focused and minimal (2 files, +154/-1)
- [x] PR body includes Code Intelligence section
- [x] Regression tests added and passing
- [x] Fixes the reported issue without breaking existing functionality