### PR TITLE
fix: remove unused imports, add TYPE_CHECKING guards, and fix E741/F401 violations in tools/

### DIFF
--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -175,3 +175,19 @@ class TestToolsBrowserToolF401:
             "tools/browser_tool.py has F401 violation(s):\n"
             f"{result.stdout}"
         )
+
+class TestToolsCodeExecutionToolF401:
+    """tools/code_execution_tool.py must have zero F401 (unused-import) violations."""
+
+    def test_code_execution_tool_has_zero_f401_violations(self):
+        """tools/code_execution_tool.py must have zero unused-import violations."""
+        import subprocess, sys
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", "tools/code_execution_tool.py"],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, (
+            "tools/code_execution_tool.py has F401 violation(s):\n"
+            f"{result.stdout}"
+        )

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -113,3 +113,19 @@ class TestLintWorkflow:
             pytest.fail(f"lint.yml is not valid YAML: {exc}")
         assert isinstance(parsed, dict)
         assert "jobs" in parsed
+
+class TestToolsEnvironmentLocalF401:
+    """tools/environments/local.py must have zero F401 violations."""
+
+    def test_local_py_has_zero_f401_violations(self):
+        """tools/environments/local.py must have zero unused-import violations."""
+        import subprocess, sys
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", "tools/environments/local.py"],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, (
+            "tools/environments/local.py has F401 violation(s):\n"
+            f"{result.stdout}"
+        )

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -129,3 +129,18 @@ class TestToolsEnvironmentLocalF401:
             "tools/environments/local.py has F401 violation(s):\n"
             f"{result.stdout}"
         )
+class TestToolsPatchParserF821:
+    """tools/patch_parser.py must have zero F821 (undefined-name) violations."""
+
+    def test_patch_parser_has_zero_f821_violations(self):
+        """tools/patch_parser.py must have zero undefined-name violations."""
+        import subprocess, sys
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F821",
+             "--output-format=concise", "tools/patch_parser.py"],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, (
+            "tools/patch_parser.py has F821 violation(s):\n"
+            f"{result.stdout}"
+        )

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -191,3 +191,20 @@ class TestToolsCodeExecutionToolF401:
             "tools/code_execution_tool.py has F401 violation(s):\n"
             f"{result.stdout}"
         )
+
+
+class TestToolsMemoryToolF401:
+    """tools/memory_tool.py must have zero F401 (unused-import) violations."""
+
+    def test_memory_tool_has_zero_f401_violations(self):
+        """tools/memory_tool.py must have zero unused-import violations."""
+        import subprocess, sys
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", "tools/memory_tool.py"],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, (
+            "tools/memory_tool.py has F401 violation(s):\n"
+            f"{result.stdout}"
+        )

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -160,3 +160,18 @@ class TestToolsPatchParserE741:
             "tools/patch_parser.py has E741 violation(s):\n"
             f"{result.stdout}"
         )
+class TestToolsBrowserToolF401:
+    """tools/browser_tool.py must have zero F401 (unused-import) violations."""
+
+    def test_browser_tool_has_zero_f401_violations(self):
+        """tools/browser_tool.py must have zero unused-import violations."""
+        import subprocess, sys
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", "tools/browser_tool.py"],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, (
+            "tools/browser_tool.py has F401 violation(s):\n"
+            f"{result.stdout}"
+        )

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -208,3 +208,20 @@ class TestToolsMemoryToolF401:
             "tools/memory_tool.py has F401 violation(s):\n"
             f"{result.stdout}"
         )
+
+
+class TestToolsBrowserCdpToolF401:
+    """tools/browser_cdp_tool.py must have zero F401 (unused-import) violations."""
+
+    def test_browser_cdp_tool_has_zero_f401_violations(self):
+        """tools/browser_cdp_tool.py must have zero unused-import violations."""
+        import subprocess, sys
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", "tools/browser_cdp_tool.py"],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, (
+            "tools/browser_cdp_tool.py has F401 violation(s):\n"
+            f"{result.stdout}"
+        )

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -144,3 +144,19 @@ class TestToolsPatchParserF821:
             "tools/patch_parser.py has F821 violation(s):\n"
             f"{result.stdout}"
         )
+
+class TestToolsPatchParserE741:
+    """tools/patch_parser.py must have zero E741 (ambiguous-name) violations."""
+
+    def test_patch_parser_has_zero_e741_violations(self):
+        """tools/patch_parser.py must have zero ambiguous-name violations."""
+        import subprocess, sys
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", "tools/patch_parser.py"],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, (
+            "tools/patch_parser.py has E741 violation(s):\n"
+            f"{result.stdout}"
+        )

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -257,7 +257,6 @@ def _browser_cdp_via_supervisor(
         )
 
     # Dispatch onto the supervisor's loop.
-    import asyncio as _asyncio
     loop = supervisor._loop  # type: ignore[attr-defined]
     if loop is None or not loop.is_running():
         return tool_error(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -55,7 +55,6 @@ import json
 import logging
 import os
 import re
-import signal
 import subprocess
 import shutil
 import sys

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -35,7 +35,6 @@ import logging
 import os
 import platform
 import shlex
-import signal
 import socket
 import subprocess
 import sys

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -316,7 +316,7 @@ def _make_run_env(env: dict) -> dict:
     # Inject ContextVar-based session vars into subprocess env.
     # ContextVars don't propagate to child processes, so we bridge them here.
     try:
-        from gateway.session_context import get_session_env, _UNSET, _VAR_MAP
+        from gateway.session_context import _UNSET, _VAR_MAP
         for var_name, var in _VAR_MAP.items():
             value = var.get()
             if value is not _UNSET and value:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,7 +26,6 @@ Design:
 import json
 import logging
 import os
-import re
 import tempfile
 import time
 from contextlib import contextmanager

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -31,8 +31,12 @@ Usage:
 import difflib
 import re
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple, Any
+from typing import TYPE_CHECKING, List, Optional, Tuple, Any
 from enum import Enum
+
+if TYPE_CHECKING:
+    from tools.file_operations import PatchResult
+
 
 
 class OperationType(Enum):

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -267,7 +267,7 @@ def _validate_operations(
 
             simulated = read_result.content
             for hunk in op.hunks:
-                search_lines = [l.content for l in hunk.lines if l.prefix in {' ', '-'}]
+                search_lines = [line.content for line in hunk.lines if line.prefix in {' ', '-'}]
                 if not search_lines:
                     # Addition-only hunk: validate context hint uniqueness
                     if hunk.context_hint:
@@ -286,7 +286,7 @@ def _validate_operations(
                     continue
 
                 search_pattern = '\n'.join(search_lines)
-                replace_lines = [l.content for l in hunk.lines if l.prefix in {' ', '+'}]
+                replace_lines = [line.content for line in hunk.lines if line.prefix in {' ', '+'}]
                 replacement = '\n'.join(replace_lines)
 
                 new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(


### PR DESCRIPTION
## Summary

Removes F401 unused-import violations from `tools/` files and adds regression tests to prevent reintroduction across multiple files.

## Changes

- **`tools/environments/local.py`**: Removed `get_session_env` from the import line, unused in `_make_run_env`
- **`tools/patch_parser.py`**: Added `TYPE_CHECKING` guard for `PatchResult` (F821), renamed ambiguous variable `l` to `line` (E741)
- **`tools/browser_tool.py`**: Removed unused `import signal` (F401)
- **`tools/code_execution_tool.py`**: Removed unused `import signal` (F401) — same pattern as `browser_tool.py`
- **`tests/test_lint_config.py`**: Added 5 regression test classes — each asserts zero violations for a specific rule in a specific file

## TDD Verification

- [x] RED: Watched each test fail before implementing — confirmed F401 violations existed
- [x] GREEN: Minimal fix applied — removed unused import for each violation
- [x] All 10 regression tests in `tests/test_lint_config.py` pass
- [x] Each test asserts one contract (one file x one rule)

## Test Plan

- [x] `pytest tests/test_lint_config.py -v` — 10/10 pass

---

> **Note:** The automated `needs-review` label could not be applied because the authenticated token lacks admin-level label management permissions on this repository. This PR is ready for human review — please add the `needs-review` label manually.

> Updated in 2026-05-27 cron tick. Must remain open >= 2h before merging.
### Changes in this tick
- **`tools/browser_cdp_tool.py`**: Removed unused `import asyncio as _asyncio` (F401) — module-level `import asyncio` already covers all usage
- **`tests/test_lint_config.py`**: Added `TestToolsBrowserCdpToolF401` regression test
