### PR TITLE
feat: add header_timeout_seconds provider config for response header timeout control

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -48,7 +48,7 @@ from agent.tool_guardrails import (
     ToolGuardrailDecision,
 )
 from hermes_cli.config import cfg_get
-from hermes_cli.timeouts import get_provider_request_timeout
+from hermes_cli.timeouts import get_provider_request_timeout, get_provider_header_timeout
 from hermes_constants import get_hermes_home
 from utils import base_url_host_matches, is_truthy_value
 
@@ -787,7 +787,8 @@ def init_agent(
     # every client construction path below (Anthropic native, OpenAI-wire,
     # router-based implicit auth) can apply it consistently.  Bedrock
     # Claude uses its own timeout path and is not covered here.
-    _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
+    from hermes_cli.timeouts import build_provider_timeout
+    _provider_timeout = build_provider_timeout(agent.provider, agent.model)
 
     if agent.api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
@@ -851,7 +852,7 @@ def init_agent(
             # the third-party identity-injection bug.
             from agent.anthropic_adapter import _is_oauth_token as _is_oat
             agent._is_anthropic_oauth = _is_oat(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
-            agent._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+            agent._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout, header_timeout=get_provider_header_timeout(agent.provider, agent.model))
             # No OpenAI client needed for Anthropic mode
             agent.client = None
             agent._client_kwargs = {}

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -31,7 +31,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.timeouts import get_provider_request_timeout
+from hermes_cli.timeouts import get_provider_request_timeout, get_provider_header_timeout
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -1097,6 +1097,7 @@ def try_recover_primary_transport(
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
+                header_timeout=get_provider_header_timeout(agent.provider, agent.model),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -1269,6 +1270,7 @@ def restore_primary_runtime(agent) -> bool:
             agent._anthropic_client = build_anthropic_client(
                 rt["anthropic_api_key"], rt["anthropic_base_url"],
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
+                header_timeout=get_provider_header_timeout(agent.provider, agent.model),
             )
             agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
             agent.client = None
@@ -2047,6 +2049,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent._anthropic_client = build_anthropic_client(
                 effective_key, agent._anthropic_base_url,
                 timeout=get_provider_request_timeout(agent.provider, agent.model),
+                header_timeout=get_provider_header_timeout(agent.provider, agent.model),
             )
             agent._is_anthropic_oauth = _is_oauth_token(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
             agent.client = None
@@ -2076,7 +2079,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 )
             except Exception:
                 logger.debug("custom-provider TLS resolution skipped on switch_model", exc_info=True)
-            _sm_timeout = get_provider_request_timeout(agent.provider, agent.model)
+            from hermes_cli.timeouts import build_provider_timeout
+            _sm_timeout = build_provider_timeout(agent.provider, agent.model)
             if _sm_timeout is not None:
                 agent._client_kwargs["timeout"] = _sm_timeout
             # Reapply provider-specific headers (e.g. OpenRouter HTTP-Referer,

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -637,6 +637,7 @@ def _build_anthropic_client_with_bearer_hook(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
+    header_timeout: float = None,
 ):
     """Anthropic-on-Foundry Entra ID variant of :func:`build_anthropic_client`.
 
@@ -667,7 +668,11 @@ def _build_anthropic_client_with_bearer_hook(
     from agent.azure_identity_adapter import build_bearer_http_client
 
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
-    timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0)
+    _header = float(header_timeout) if (isinstance(header_timeout, (int, float)) and header_timeout > 0) else None
+    if _header is not None:
+        timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0, read=_header)
+    else:
+        timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0)
 
     # Strip any trailing /v1 — the Anthropic SDK appends /v1/messages.
     normalized_base_url = _normalize_base_url_text(base_url)
@@ -713,6 +718,7 @@ def build_anthropic_client(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
+    header_timeout: float = None,
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -754,6 +760,7 @@ def build_anthropic_client(
         return _build_anthropic_client_with_bearer_hook(
             api_key, base_url, timeout,
             drop_context_1m_beta=drop_context_1m_beta,
+            header_timeout=header_timeout,
         )
 
     normalize_proxy_env_vars()
@@ -765,8 +772,13 @@ def build_anthropic_client(
         import re as _re
         normalized_base_url = _re.sub(r"/v1/?$", "", normalized_base_url.rstrip("/"))
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
+    _header = float(header_timeout) if (isinstance(header_timeout, (int, float)) and header_timeout > 0) else None
+    if _header is not None:
+        _timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0, read=_header)
+    else:
+        _timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0)
     kwargs = {
-        "timeout": Timeout(timeout=float(_read_timeout), connect=10.0),
+        "timeout": _timeout_obj,
         # Delegate all rate-limit / 5xx retry to hermes's outer conversation
         # loop, which honors Retry-After. The SDK default (max_retries=2) uses
         # its own 1-2s backoff that ignores Retry-After and double-retries

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4926,7 +4926,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
-        "request_timeout_seconds", "stale_timeout_seconds",
+        "request_timeout_seconds", "stale_timeout_seconds", "header_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
     }

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -40,6 +40,35 @@ def get_provider_request_timeout(
     return _coerce_timeout(provider_config.get("request_timeout_seconds"))
 
 
+def get_provider_header_timeout(
+    provider_id: str, model: str | None = None
+) -> float | None:
+    """Return a configured provider header timeout in seconds, if any."""
+    if not provider_id:
+        return None
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return None
+
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    )
+    if not isinstance(provider_config, dict):
+        return None
+
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        timeout = _coerce_timeout(model_config.get("header_timeout_seconds"))
+        if timeout is not None:
+            return timeout
+
+    return _coerce_timeout(provider_config.get("header_timeout_seconds"))
+
+
 def get_provider_stale_timeout(
     provider_id: str, model: str | None = None
 ) -> float | None:
@@ -80,3 +109,19 @@ def _get_model_config(
     if isinstance(model_config, dict):
         return model_config
     return None
+
+
+def build_provider_timeout(provider_id: str, model: str | None = None):
+    """Build an httpx.Timeout (or float) for the given provider/model.
+    Returns httpx.Timeout if header_timeout_seconds is configured, float if only
+    request_timeout_seconds, or None if neither."""
+    req_timeout = get_provider_request_timeout(provider_id, model)
+    hdr_timeout = get_provider_header_timeout(provider_id, model)
+    if hdr_timeout is None:
+        return req_timeout
+    try:
+        from httpx import Timeout
+    except ImportError:
+        return req_timeout
+    overall = req_timeout if (req_timeout is not None and req_timeout > 0) else 1800.0
+    return Timeout(timeout=overall, connect=10.0, read=float(hdr_timeout))

--- a/run_agent.py
+++ b/run_agent.py
@@ -120,6 +120,7 @@ from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
     get_provider_stale_timeout,
+    get_provider_header_timeout,
 )
 
 _hermes_home = get_hermes_home()
@@ -4489,6 +4490,7 @@ class AIAgent:
                 new_token,
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                header_timeout=get_provider_header_timeout(self.provider, self.model),
             )
         except Exception as exc:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
@@ -4611,6 +4613,7 @@ class AIAgent:
             self._anthropic_client = build_anthropic_client(
                 runtime_key, runtime_base,
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                header_timeout=get_provider_header_timeout(self.provider, self.model),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
@@ -4680,6 +4683,7 @@ class AIAgent:
                 self._anthropic_api_key,
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
+                header_timeout=get_provider_header_timeout(self.provider, self.model),
                 drop_context_1m_beta=_drop_1m,
             )
 

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -268,6 +268,88 @@ def test_resolved_api_call_stale_timeout_priority(monkeypatch, tmp_path):
     assert agent2._resolved_api_call_stale_timeout_base() == (90.0, True)
 
 
+from hermes_cli.timeouts import get_provider_header_timeout, build_provider_timeout
+
+
+def test_provider_header_timeout(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          ollama-local:
+            header_timeout_seconds: 600
+    """)
+    assert get_provider_header_timeout("ollama-local") == 600.0
+
+
+def test_model_header_timeout_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          openrouter:
+            header_timeout_seconds: 30
+            models:
+              openai/gpt-4o-mini:
+                header_timeout_seconds: 10
+    """)
+    assert get_provider_header_timeout("openrouter", "openai/gpt-4o-mini") == 10.0
+
+
+def test_header_timeout_missing_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          openai:
+            request_timeout_seconds: 300
+    """)
+    assert get_provider_header_timeout("openai", "gpt-4o") is None
+    assert get_provider_header_timeout("missing-provider") is None
+
+
+def test_invalid_header_timeout_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          ollama:
+            header_timeout_seconds: "slow"
+    """)
+    assert get_provider_header_timeout("ollama") is None
+
+
+def test_build_provider_timeout_with_header(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          ollama:
+            request_timeout_seconds: 1800
+            header_timeout_seconds: 600
+    """)
+    result = build_provider_timeout("ollama")
+    import httpx
+    assert isinstance(result, httpx.Timeout)
+    assert result.read == 600.0
+    assert result.connect == 10.0
+
+
+def test_build_provider_timeout_without_header(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          openai:
+            request_timeout_seconds: 300
+    """)
+    result = build_provider_timeout("openai")
+    assert result == 300.0
+
+
+def test_build_provider_timeout_returns_none_when_unset(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          openai: {}
+    """)
+    assert build_provider_timeout("openai") is None
+
+
 def test_default_non_stream_stale_timeout_auto_disables_for_local_endpoints(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / ".env").write_text("", encoding="utf-8")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7186,7 +7186,7 @@ class TestAnthropicCredentialRefresh:
 
         old_client.close.assert_called_once()
         rebuild.assert_called_once_with(
-            "sk-ant-oat01-fresh-token", "https://api.anthropic.com", timeout=None,
+            "sk-ant...oken", "https://api.anthropic.com", timeout=None, header_timeout=None,
         )
         assert agent._anthropic_client is new_client
         assert agent._anthropic_api_key == "sk-ant-oat01-fresh-token"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7186,7 +7186,7 @@ class TestAnthropicCredentialRefresh:
 
         old_client.close.assert_called_once()
         rebuild.assert_called_once_with(
-            "sk-ant...oken", "https://api.anthropic.com", timeout=None, header_timeout=None,
+            "sk-ant-oat01-fresh-token", "https://api.anthropic.com", timeout=None, header_timeout=None,
         )
         assert agent._anthropic_client is new_client
         assert agent._anthropic_api_key == "sk-ant-oat01-fresh-token"


### PR DESCRIPTION
## What does this PR do?

Adds per-provider `header_timeout_seconds` config to control how long Hermes waits for response headers (time-to-first-byte), separate from the overall `request_timeout_seconds`.

Solves the "fail fast on dead endpoints but wait 10 minutes for my local Llama to warm up" problem that `request_timeout_seconds` alone can't express. Mirrors the `request_timeout_seconds` / `stale_timeout_seconds` pattern already in the codebase.

## Related Issue

No issue — feature addition inspired by OpenCode's `headerTimeout` (v1.15.11).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/timeouts.py` — Added `get_provider_header_timeout()` and `build_provider_timeout()` (returns `httpx.Timeout` with separate `read` timeout when header timeout set, flat float otherwise)
- `hermes_cli/config.py` — Added `header_timeout_seconds` to provider config `_KNOWN_KEYS` validation set
- `agent/agent_init.py` — OpenAI client creation uses `build_provider_timeout()`
- `agent/agent_runtime_helpers.py` — switch_model OpenAI path uses `build_provider_timeout()`; all Anthropic `build_anthropic_client()` call sites pass `header_timeout=`
- `agent/anthropic_adapter.py` — `build_anthropic_client()` accepts `header_timeout` param, sets `httpx.Timeout(read=...)` when provided
- `run_agent.py` — Anthropic client call sites pass `header_timeout=`
- `tests/hermes_cli/test_timeouts.py` — 7 new tests covering provider-level, model-level override, missing/invalid values, and `build_provider_timeout()` with/without header timeout

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_timeouts.py -v -o "addopts="` — all 19 tests pass (12 existing + 7 new)
2. Configure a provider with `header_timeout_seconds` in `config.yaml`:
   ```yaml
   providers:
     ollama-local:
       request_timeout_seconds: 1800
       header_timeout_seconds: 600
   ```
3. Verify no behavior change when `header_timeout_seconds` is omitted

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_timeouts.py -q -o "addopts="` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.17.0-1011-oracle)

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (config key follows existing `request_timeout_seconds` pattern, no example file update needed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (Python httpx, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
tests/hermes_cli/test_timeouts.py::test_provider_header_timeout PASSED
tests/hermes_cli/test_timeouts.py::test_model_header_timeout_override_wins PASSED
tests/hermes_cli/test_timeouts.py::test_header_timeout_missing_returns_none PASSED
tests/hermes_cli/test_timeouts.py::test_invalid_header_timeout_returns_none PASSED
tests/hermes_cli/test_timeouts.py::test_build_provider_timeout_with_header PASSED
tests/hermes_cli/test_timeouts.py::test_build_provider_timeout_without_header PASSED
tests/hermes_cli/test_timeouts.py::test_build_provider_timeout_returns_none_when_unset PASSED
19 passed, 1 warning in 3.53s
```