### PR TITLE
fix(install): set world-readable uv python dirs for root FHS layout (salvages #22494)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -268,10 +268,18 @@ resolve_install_layout() {
         fi
         INSTALL_DIR="/usr/local/lib/hermes-agent"
         ROOT_FHS_LAYOUT=true
+        # Place uv-managed Python under /usr/local/share so the venv interpreter
+        # is world-readable.  Default uv paths land in /root/.local/share/uv,
+        # which non-root users can't traverse — leaving the shared
+        # /usr/local/bin/hermes wrapper unable to exec the bad-interpreter venv
+        # python.  See #21457.
+        export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-/usr/local/share/uv/python}"
+        export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-/usr/local/share/uv/bin}"
         log_info "Root install on Linux — using FHS layout"
         log_info "  Code:    $INSTALL_DIR"
         log_info "  Command: /usr/local/bin/hermes"
         log_info "  Data:    $HERMES_HOME (unchanged)"
+        log_info "  uv Python: $UV_PYTHON_INSTALL_DIR (world-readable)"
         return 0
     fi
 

--- a/tests/test_install_sh_root_fhs_uv_python_path.py
+++ b/tests/test_install_sh_root_fhs_uv_python_path.py
@@ -1,0 +1,35 @@
+"""Regression test for install.sh root-mode uv Python install path.
+
+When installing as root with the FHS layout (INSTALL_DIR=/usr/local/lib/...),
+``uv python install`` must place the managed Python under a world-readable
+location, otherwise the venv interpreter ends up at ``/root/.local/share/uv/...``
+and the shared ``/usr/local/bin/hermes`` wrapper fails for non-root users with
+"bad interpreter: Permission denied".  See #21457.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_root_fhs_layout_exports_world_readable_uv_python_dirs() -> None:
+    text = INSTALL_SH.read_text()
+
+    assert 'export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-/usr/local/share/uv/python}"' in text
+    assert 'export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-/usr/local/share/uv/bin}"' in text
+
+
+def test_root_fhs_uv_python_export_is_inside_root_branch() -> None:
+    """The export must live in the root-FHS branch of resolve_install_layout,
+    above its `return 0`, so non-root and Termux installs are unaffected."""
+    text = INSTALL_SH.read_text()
+
+    marker = 'ROOT_FHS_LAYOUT=true'
+    assert marker in text
+    after_marker = text.split(marker, 1)[1]
+    return_idx = after_marker.find('return 0')
+    export_idx = after_marker.find('UV_PYTHON_INSTALL_DIR')
+    assert export_idx != -1
+    assert export_idx < return_idx

--- a/tests/test_install_sh_root_fhs_uv_python_path.py
+++ b/tests/test_install_sh_root_fhs_uv_python_path.py
@@ -14,8 +14,26 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
+def _resolve_install_layout_body() -> str:
+    """Return just the body of resolve_install_layout(), bounded by its
+    opening signature and the next top-level ``}`` close brace.
+
+    Using the function body (not "first ``return 0`` after a marker") guards
+    the tests below against future refactors that hoist the export above
+    another conditional with its own early-return, or that insert an early-
+    return between the marker and the export — both of which would leave the
+    export unreachable while a less-strict assertion still passed.
+    """
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    head, _, rest = text.partition("resolve_install_layout() {\n")
+    assert rest, "Could not find resolve_install_layout() in scripts/install.sh"
+    body, _, _ = rest.partition("\n}\n")
+    assert body, "Could not find resolve_install_layout() closing brace"
+    return body
+
+
 def test_root_fhs_layout_exports_world_readable_uv_python_dirs() -> None:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     assert 'export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-/usr/local/share/uv/python}"' in text
     assert 'export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-/usr/local/share/uv/bin}"' in text
@@ -23,13 +41,19 @@ def test_root_fhs_layout_exports_world_readable_uv_python_dirs() -> None:
 
 def test_root_fhs_uv_python_export_is_inside_root_branch() -> None:
     """The export must live in the root-FHS branch of resolve_install_layout,
-    above its `return 0`, so non-root and Termux installs are unaffected."""
-    text = INSTALL_SH.read_text()
+    after ``ROOT_FHS_LAYOUT=true`` and before the branch's ``return 0``, so
+    non-root and Termux installs are unaffected. Bound the slice by the
+    function body (not "next return 0" in the whole file) so the assertion
+    can't accept an unreachable export."""
+    body = _resolve_install_layout_body()
 
     marker = 'ROOT_FHS_LAYOUT=true'
-    assert marker in text
-    after_marker = text.split(marker, 1)[1]
+    assert marker in body
+    after_marker = body.split(marker, 1)[1]
     return_idx = after_marker.find('return 0')
     export_idx = after_marker.find('UV_PYTHON_INSTALL_DIR')
-    assert export_idx != -1
-    assert export_idx < return_idx
+    assert export_idx != -1, "UV_PYTHON_INSTALL_DIR export missing from root-FHS branch"
+    assert return_idx != -1, "root-FHS branch must end with `return 0`"
+    assert export_idx < return_idx, (
+        "Export must precede the branch's `return 0` — otherwise unreachable"
+    )


### PR DESCRIPTION
Salvages #22494 (@wesleysimplicio's substantive fix, preserved per-commit) with a self-review test-hardening commit on top. Closes #21457.

## Why salvage instead of merging #22494 directly

Two reasons:

1. **Self-review caught real test-robustness issues** worth fixing before merge — see the second commit.
2. **There's a competing PR #26719** (@kronexoi, May 16) targeting the same bug with a worse shape: it hardcodes `export UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python"` instead of using `${UV_PYTHON_INSTALL_DIR:-/usr/local/share/uv/python}`, silently clobbering any caller-set override. #22494's `${VAR:-default}` is the right choice for an env var that uv users routinely export themselves. Picking #22494 + closing #26719 with credit is the right call.

## What this PR does

### Commit 1 — @wesleysimplicio's fix (cherry-picked, authorship preserved)

`install.sh` running as root on Linux with the new FHS layout (`/usr/local/lib/hermes-agent`) defaults uv-managed Python to `/root/.local/share/uv/python/`. That path isn't traversable for non-root users, so the shared `/usr/local/bin/hermes` wrapper fails with `bad interpreter: Permission denied` for everyone except root.

The fix adds two `export`s inside the `ROOT_FHS_LAYOUT=true` branch of `resolve_install_layout()`, pointing uv at `/usr/local/share/uv/{python,bin}` — world-readable. Uses the `${VAR:-default}` form so callers who pre-set `UV_PYTHON_INSTALL_DIR` or `UV_PYTHON_BIN_DIR` keep their override.

### Commit 2 — test hardening (self-review follow-up, attributed to me)

Two narrow fixes to the new test file, both surfaced by the self-review:

- **W2 — `encoding="utf-8"`** on `read_text()`. `scripts/install.sh` contains 48 em-dash (`—`) characters and ~1500 non-ASCII bytes total; on Windows with `cp1252` default locale, bare `read_text()` would raise `UnicodeDecodeError`. (The 11 other bare `read_text()` sites across 5 pre-existing `test_install_sh_*.py` files are a separate project-wide cleanup — out of scope for this PR.)
- **W3 — bound branch-containment by function body, not by "next `return 0`"**. The original test sliced from `ROOT_FHS_LAYOUT=true` to the next `return 0` anywhere in the file. `install.sh` has 5 additional `return 0` statements after `resolve_install_layout`'s; if a future maintainer hoists the export above another conditional with its own early-return, or inserts an early-return between the marker and the export, the old assertion would still pass while the export is unreachable. Now slices from `resolve_install_layout() {` to its `\n}\n` and asserts containment within that span.

## Verification

- ✅ Cherry-picked clean onto current `origin/main` (1908 commits since branch point, but per-file churn on `scripts/install.sh` doesn't overlap the patched lines).
- ✅ All 19 install.sh tests pass (`bash scripts/run_tests.sh tests/test_install_sh_*.py`).
- ✅ `bash -n scripts/install.sh` syntax-clean.
- ✅ `ruff check` on changed files: clean.
- ✅ **6-scenario empirical probe** — sourced `resolve_install_layout()` in a controlled shell and verified the exports trigger correctly for default root+FHS, are preserved when caller pre-sets them, do NOT trigger for non-root, macOS root, termux, explicit `--dir`, or legacy root installs with existing `.git`.
- ✅ **`UV_PYTHON_BIN_DIR` is NOT inert** — empirically verified that `uv python install` (called from `install.sh::check_python()` line 481) populates `UV_PYTHON_BIN_DIR/python3.x`. Both env vars are real and honored by uv ≥ 0.4.

## Credit

- **#22494** — @wesleysimplicio identified the bug, traced the root cause, and shipped the right `${VAR:-default}` fix.
- **#26719** — @kronexoi independently submitted the same fix a week later with a different shape (hardcoded export). Should be closed as superseded by this PR, with credit for the parallel work. Their Windows test cleanups (encoding="utf-8", symlink skip, `shutil.which("bash")` skip on `test_install_sh_symlink_stomp.py` and `test_install_sh_pythonpath_sanitization.py`) belong in a separate cross-platform test-stability PR — happy to file an issue tracking that follow-up if useful.

Closes #22494.
Closes #21457.
