### PR TITLE
fix(gateway): route Mattermost replies to thread roots

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -109,6 +109,27 @@ class MattermostAdapter(BasePlatformAdapter):
             "Content-Type": "application/json",
         }
 
+    def _thread_root_id(
+        self,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Return the Mattermost thread root post ID for outbound delivery."""
+        if isinstance(metadata, dict) and metadata.get("thread_id"):
+            return str(metadata["thread_id"])
+        return reply_to
+
+    def _should_send_in_thread(
+        self,
+        thread_root: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        if not thread_root:
+            return False
+        if isinstance(metadata, dict) and metadata.get("thread_id"):
+            return True
+        return self._reply_mode == "thread"
+
     async def _api_get(self, path: str) -> Dict[str, Any]:
         """GET /api/v4/{path}."""
         import aiohttp
@@ -279,6 +300,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
+        thread_root = self._thread_root_id(reply_to, metadata)
 
         last_id = None
         for chunk in chunks:
@@ -286,12 +308,12 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                # Ensure root_id points to the thread root, not a reply.
-                # Mattermost rejects non-root post IDs as root_id.
-                resolved_root = await self._resolve_root_id(reply_to)
-                payload["root_id"] = resolved_root
+            # Mattermost requires root_id to be the thread root post, not a
+            # nested reply. Gateway callers pass that root in metadata.
+            if isinstance(metadata, dict) and metadata.get("thread_id"):
+                payload["root_id"] = thread_root
+            elif reply_to and self._reply_mode == "thread":
+                payload["root_id"] = await self._resolve_root_id(reply_to)
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -318,9 +340,13 @@ class MattermostAdapter(BasePlatformAdapter):
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
         """Send a typing indicator."""
+        payload: Dict[str, Any] = {"channel_id": chat_id}
+        thread_root = self._thread_root_id(metadata=metadata)
+        if thread_root:
+            payload["parent_id"] = thread_root
         await self._api_post(
             f"users/{self._bot_user_id}/typing",
-            {"channel_id": chat_id},
+            payload,
         )
 
     async def edit_message(
@@ -346,7 +372,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
-            chat_id, image_url, caption, reply_to, "image"
+            chat_id, image_url, caption, reply_to, "image", metadata=metadata
         )
 
     async def send_image_file(
@@ -359,7 +385,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
-            chat_id, image_path, caption, reply_to
+            chat_id, image_path, caption, reply_to, metadata=metadata
         )
 
     async def send_document(
@@ -373,7 +399,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
-            chat_id, file_path, caption, reply_to, file_name
+            chat_id, file_path, caption, reply_to, file_name, metadata=metadata
         )
 
     async def send_voice(
@@ -386,7 +412,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
-            chat_id, audio_path, caption, reply_to
+            chat_id, audio_path, caption, reply_to, metadata=metadata
         )
 
     async def send_video(
@@ -399,7 +425,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
-            chat_id, video_path, caption, reply_to
+            chat_id, video_path, caption, reply_to, metadata=metadata
         )
 
     def format_message(self, content: str) -> str:
@@ -423,12 +449,14 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         kind: str = "file",
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
+        thread_root = self._thread_root_id(reply_to, metadata)
         from tools.url_safety import is_safe_url
         if not is_safe_url(url):
             logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         import aiohttp
 
@@ -446,7 +474,7 @@ class MattermostAdapter(BasePlatformAdapter):
                             await asyncio.sleep(1.5 * (attempt + 1))
                             continue
                     if resp.status >= 400:
-                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
                     file_data = await resp.read()
                     ct = resp.content_type or "application/octet-stream"
                     break
@@ -455,22 +483,24 @@ class MattermostAdapter(BasePlatformAdapter):
                     await asyncio.sleep(1.5 * (attempt + 1))
                     continue
                 logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc)
-                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         if file_data is None:
             logger.warning("Mattermost: download returned no data for %s", url)
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         file_id = await self._upload_file(chat_id, file_data, fname, ct)
         if not file_id:
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         payload: Dict[str, Any] = {
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
+        if isinstance(metadata, dict) and metadata.get("thread_id"):
+            payload["root_id"] = thread_root
+        elif reply_to and self._reply_mode == "thread":
             payload["root_id"] = await self._resolve_root_id(reply_to)
 
         data = await self._api_post("posts", payload)
@@ -485,9 +515,12 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
+
+        thread_root = self._thread_root_id(reply_to, metadata)
 
         p = Path(file_path)
         if not p.exists():
@@ -509,7 +542,9 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
+        if isinstance(metadata, dict) and metadata.get("thread_id"):
+            payload["root_id"] = thread_root
+        elif reply_to and self._reply_mode == "thread":
             payload["root_id"] = await self._resolve_root_id(reply_to)
 
         data = await self._api_post("posts", payload)
@@ -541,6 +576,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         CHUNK = 5  # Mattermost post file_ids cap
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
+        thread_root = self._thread_root_id(metadata=metadata)
 
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
@@ -596,6 +632,8 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 }
+                if self._should_send_in_thread(thread_root, metadata):
+                    payload["root_id"] = thread_root
                 logger.info(
                     "Mattermost: sending %d image(s) as single post (chunk %d/%d)",
                     len(file_ids), chunk_idx + 1, len(chunks),

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -218,6 +218,31 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_prefers_metadata_thread_id(self):
+        """Mattermost root_id must be the thread root, not a nested reply."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post456"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="nested_post",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"
@@ -544,6 +569,120 @@ class TestMattermostFileUpload:
 
         assert result.success is True
         assert result.message_id == "post_with_file"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "path_arg", "helper_name"),
+        [
+            ("send_image", "https://img.example.com/cat.png", "_send_url_as_file"),
+            ("send_image_file", "/tmp/cat.png", "_send_local_file"),
+            ("send_voice", "/tmp/voice.ogg", "_send_local_file"),
+            ("send_video", "/tmp/video.mp4", "_send_local_file"),
+        ],
+    )
+    async def test_media_helpers_use_metadata_thread_id(
+        self, method_name, path_arg, helper_name
+    ):
+        """Media helpers should preserve metadata.thread_id for file posts."""
+        helper = AsyncMock(return_value=MagicMock(success=True, message_id="post_with_file"))
+        setattr(self.adapter, helper_name, helper)
+
+        method = getattr(self.adapter, method_name)
+        await method(
+            "channel_1",
+            path_arg,
+            reply_to="nested_post",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert helper.await_args.args[3] == "nested_post"
+        assert helper.await_args.kwargs["metadata"] == {"thread_id": "root_post"}
+
+    @pytest.mark.asyncio
+    async def test_send_document_uses_metadata_thread_id(self, tmp_path):
+        """File posts should use metadata.thread_id as the Mattermost root_id."""
+        self.adapter._reply_mode = "thread"
+        document = tmp_path / "report.txt"
+        document.write_text("hello", encoding="utf-8")
+
+        mock_upload_resp = AsyncMock()
+        mock_upload_resp.status = 200
+        mock_upload_resp.json = AsyncMock(return_value={
+            "file_infos": [{"id": "file_abc123"}]
+        })
+        mock_upload_resp.text = AsyncMock(return_value="")
+        mock_upload_resp.__aenter__ = AsyncMock(return_value=mock_upload_resp)
+        mock_upload_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_post_resp = AsyncMock()
+        mock_post_resp.status = 200
+        mock_post_resp.json = AsyncMock(return_value={"id": "post_with_file"})
+        mock_post_resp.text = AsyncMock(return_value="")
+        mock_post_resp.__aenter__ = AsyncMock(return_value=mock_post_resp)
+        mock_post_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(side_effect=[mock_upload_resp, mock_post_resp])
+
+        result = await self.adapter.send_document(
+            "channel_1",
+            str(document),
+            reply_to="nested_post",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args_list[-1][1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_images_uses_metadata_thread_id(self, tmp_path):
+        """Batched image posts should stay in the Mattermost thread."""
+        self.adapter._reply_mode = "thread"
+        image = tmp_path / "cat.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\nfake-image-data")
+
+        mock_upload_resp = AsyncMock()
+        mock_upload_resp.status = 200
+        mock_upload_resp.json = AsyncMock(return_value={
+            "file_infos": [{"id": "file_abc123"}]
+        })
+        mock_upload_resp.text = AsyncMock(return_value="")
+        mock_upload_resp.__aenter__ = AsyncMock(return_value=mock_upload_resp)
+        mock_upload_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_post_resp = AsyncMock()
+        mock_post_resp.status = 200
+        mock_post_resp.json = AsyncMock(return_value={"id": "post_with_file"})
+        mock_post_resp.text = AsyncMock(return_value="")
+        mock_post_resp.__aenter__ = AsyncMock(return_value=mock_post_resp)
+        mock_post_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(side_effect=[mock_upload_resp, mock_post_resp])
+
+        await self.adapter.send_multiple_images(
+            "channel_1",
+            [(f"file://{image}", "A cat")],
+            metadata={"thread_id": "root_post"},
+        )
+
+        payload = self.adapter._session.post.call_args_list[-1][1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
+    async def test_send_typing_uses_metadata_thread_id(self):
+        """Mattermost typing accepts parent_id for thread-scoped indicators."""
+        self.adapter._bot_user_id = "bot_user"
+        self.adapter._api_post = AsyncMock()
+
+        await self.adapter.send_typing(
+            "channel_1",
+            metadata={"thread_id": "root_post"},
+        )
+
+        self.adapter._api_post.assert_awaited_once_with(
+            "users/bot_user/typing",
+            {"channel_id": "channel_1", "parent_id": "root_post"},
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes Mattermost thread routing for outbound replies and attachments.

Mattermost requires `root_id` to be the root post of a thread. The gateway already passes that root through `metadata["thread_id"]`, but the Mattermost adapter did not consistently use it across outbound paths. For replies inside an existing thread, `reply_to` can be a nested post id, which can make replies, files, image batches, and typing indicators land outside the intended Mattermost thread or use the wrong post id.

This change makes Mattermost outbound delivery prefer `metadata["thread_id"]` for thread routing and applies it consistently to text replies, file/image/audio/video uploads, batched image posts, and typing indicators.

## Related Issue

No issue filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`
  - Resolve Mattermost thread roots from `metadata["thread_id"]`.
  - Prefer `metadata["thread_id"]` over `reply_to` when setting `root_id`.
  - Preserve existing `_resolve_root_id(reply_to)` behavior for `reply_to`-only threaded sends.
  - Preserve `metadata` through media helper methods.
  - Add `root_id` to `send_multiple_images()` batch posts.
  - Add `parent_id` to thread-scoped typing indicators.

- `tests/gateway/test_mattermost.py`
  - Add coverage for text replies, media helpers, document uploads, multi-image posts, and typing indicators.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_mattermost.py`.
2. Send a Mattermost reply from inside an existing thread.
3. Verify text replies, attachments, multi-image responses, and typing indicators stay in that thread.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update N/A
- [x] Cross-platform impact considered: Mattermost REST payload-only change
- [x] Tool descriptions/schemas update N/A

## Test Notes

- `scripts/run_tests.sh tests/gateway/test_mattermost.py` could not complete in my local venv because pytest was invoked with `--timeout` args while `pytest-timeout` was not installed there.
- Direct fallback for the same test file passed: `.venv/bin/python -m pytest tests/gateway/test_mattermost.py -o addopts="-m 'not integration'"` -> `51 passed`.
