### PR TITLE
Fix Kanban worker optional skill preload resolution

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5588,38 +5588,102 @@ def _resolve_hermes_argv() -> list[str]:
 
 
 def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
-    """True if the bundled ``kanban-worker`` skill resolves for the home the
-    spawned worker will run under.
+    """True if ``--skills kanban-worker`` is safe for the spawned worker.
 
-    The dispatcher injects ``--skills kanban-worker`` into every worker. When
-    the worker activates a profile (``hermes -p <name>``), its ``SKILLS_DIR``
-    becomes ``<profile_home>/skills`` — which on many profiles does NOT contain
-    the bundled skill (it ships in the *default* root home, not every
-    profile-scoped skills dir). Preloading a missing skill is fatal at CLI
-    startup (``ValueError: Unknown skill(s): kanban-worker``), aborting the
-    worker before the agent loop runs. Gate the flag on actual resolvability;
-    the kanban lifecycle contract is still injected via ``KANBAN_GUIDANCE``, so
-    omitting the flag only drops the supplementary pattern library.
+    The dispatcher *optionally* injects ``--skills kanban-worker`` so workers
+    get the supplementary pattern library. The mandatory lifecycle contract is
+    already injected via ``KANBAN_GUIDANCE`` in the system prompt, so workers
+    must still start when this reference skill is missing or ambiguous.
+
+    The child process resolves skills after profile activation, against that
+    profile's ``skills/`` directory plus its configured ``skills.external_dirs``.
+    Preloading a missing, ambiguous, disabled, or platform-incompatible skill is
+    fatal at CLI startup, so mirror those resolver gates here and only add the
+    flag when the worker profile can actually load the skill.
     """
     from pathlib import Path as _Path
 
-    # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
+    from agent.skill_utils import (
+        get_disabled_skill_names,
+        get_external_skills_dirs,
+        iter_skill_index_files,
+        parse_frontmatter,
+        skill_matches_platform,
+    )
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
     base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
-    skills_root = base / "skills"
-    if not skills_root.is_dir():
-        return False
-    # Canonical bundled location first (cheap), then a bounded scan for
-    # profiles that have it nested elsewhere.
-    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
-        return True
+    token = set_hermes_home_override(base)
     try:
-        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
-            if skill_md.is_file():
-                return True
-    except OSError:
-        pass
-    return False
+        all_dirs = []
+        skills_root = base / "skills"
+        if skills_root.exists():
+            all_dirs.append(skills_root)
+        all_dirs.extend(get_external_skills_dirs())
+
+        candidates: set[_Path] = set()
+        for search_dir in all_dirs:
+            direct_path = search_dir / "kanban-worker"
+            if direct_path.is_dir() and (direct_path / "SKILL.md").is_file():
+                candidates.add((direct_path / "SKILL.md").resolve())
+            elif direct_path.with_suffix(".md").is_file():
+                candidates.add(direct_path.with_suffix(".md").resolve())
+
+            try:
+                for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+                    if found_skill_md.parent.name == "kanban-worker" and found_skill_md.is_file():
+                        candidates.add(found_skill_md.resolve())
+            except OSError:
+                continue
+
+            try:
+                for found_md in search_dir.rglob("kanban-worker.md"):
+                    if found_md.name != "SKILL.md" and found_md.is_file():
+                        candidates.add(found_md.resolve())
+            except OSError:
+                continue
+
+        if len(candidates) > 1:
+            _log.warning(
+                "Skipping optional kanban-worker preload for %s: bare name is ambiguous across %d skills: %s",
+                base,
+                len(candidates),
+                "; ".join(str(p) for p in sorted(candidates)),
+            )
+            return False
+
+        if not candidates:
+            return False
+
+        skill_md = next(iter(candidates))
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+            frontmatter, _ = parse_frontmatter(content)
+        except Exception as exc:
+            _log.warning(
+                "Skipping optional kanban-worker preload for %s: failed to inspect %s: %s",
+                base,
+                skill_md,
+                exc,
+            )
+            return False
+
+        resolved_name = str(frontmatter.get("name") or skill_md.parent.name)
+        if resolved_name != "kanban-worker":
+            _log.warning(
+                "Skipping optional kanban-worker preload for %s: %s resolves to skill name %r",
+                base,
+                skill_md,
+                resolved_name,
+            )
+            return False
+        if resolved_name in get_disabled_skill_names():
+            return False
+        if not skill_matches_platform(frontmatter):
+            return False
+        return True
+    finally:
+        reset_hermes_home_override(token)
 
 
 def _worker_terminal_timeout_env(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1986,7 +1986,19 @@ class TestSharedBoardPaths:
 
         monkeypatch.setattr("subprocess.Popen", _FakePopen)
 
-        task = kb.Task(
+        task = self._spawn_task(tmp_path)
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        env = captured["env"]
+        assert env["HERMES_KANBAN_DB"] == str(default_home / "kanban.db")
+        assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(
+            default_home / "kanban" / "workspaces"
+        )
+        assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
+        assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
+
+    def _spawn_task(self, tmp_path):
+        return kb.Task(
             id="t_dispatch_env",
             title="x",
             body=None,
@@ -2004,15 +2016,160 @@ class TestSharedBoardPaths:
             tenant=None,
             branch_name="wt/t_dispatch_env",
         )
-        kb._default_spawn(task, str(tmp_path / "ws"))
 
-        env = captured["env"]
-        assert env["HERMES_KANBAN_DB"] == str(default_home / "kanban.db")
-        assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(
-            default_home / "kanban" / "workspaces"
+    def _write_skill(self, root, rel="devops/kanban-worker", frontmatter_extra=""):
+        skill_dir = root / rel
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: kanban-worker\n"
+            "description: worker\n"
+            f"{frontmatter_extra}"
+            "---\n"
+            "# Worker\n",
+            encoding="utf-8",
         )
-        assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
-        assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
+        return skill_dir
+
+    def test_kanban_worker_preload_true_when_unambiguous_local_skill(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        self._write_skill(profile_home / "skills")
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is True
+
+    def test_kanban_worker_preload_true_when_unambiguous_external_skill(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        external = tmp_path / "external-skills"
+        profile_home.mkdir(parents=True)
+        self._write_skill(external)
+        (profile_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external}\n",
+            encoding="utf-8",
+        )
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is True
+
+    def test_kanban_worker_preload_false_when_missing(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is False
+
+    def test_kanban_worker_preload_false_when_disabled(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        self._write_skill(profile_home / "skills")
+        (profile_home / "config.yaml").write_text(
+            "skills:\n  disabled:\n    - kanban-worker\n",
+            encoding="utf-8",
+        )
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is False
+
+    def test_kanban_worker_preload_false_when_disabled_for_worker_platform(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        self._write_skill(profile_home / "skills")
+        (profile_home / "config.yaml").write_text(
+            "skills:\n"
+            "  platform_disabled:\n"
+            "    cli:\n"
+            "      - kanban-worker\n",
+            encoding="utf-8",
+        )
+        self._set_home(monkeypatch, tmp_path, profile_home)
+        monkeypatch.setenv("HERMES_PLATFORM", "cli")
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is False
+
+    def test_kanban_worker_preload_false_when_platform_incompatible(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        self._write_skill(
+            profile_home / "skills",
+            frontmatter_extra="platforms:\n  - not-a-real-platform\n",
+        )
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is False
+
+    def test_kanban_worker_preload_false_when_frontmatter_name_mismatches(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        skill_dir = self._write_skill(profile_home / "skills")
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: other-worker\ndescription: worker\n---\n# Worker\n",
+            encoding="utf-8",
+        )
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is False
+
+    def test_kanban_worker_preload_false_when_ambiguous_with_external_dir(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        external = tmp_path / "external-skills"
+        profile_home.mkdir(parents=True)
+        self._write_skill(profile_home / "skills")
+        self._write_skill(external, rel="kanban-worker")
+        (profile_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external}\n",
+            encoding="utf-8",
+        )
+        self._set_home(monkeypatch, tmp_path, profile_home)
+
+        assert kb._kanban_worker_skill_available(str(profile_home)) is False
+
+    def test_dispatcher_skips_optional_kanban_worker_skill_when_ambiguous(
+        self, tmp_path, monkeypatch
+    ):
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "coder"
+        external = tmp_path / "external-skills"
+        profile_home.mkdir(parents=True)
+        self._write_skill(profile_home / "skills")
+        self._write_skill(external, rel="kanban-worker")
+        (profile_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external}\n",
+            encoding="utf-8",
+        )
+        self._set_home(monkeypatch, tmp_path, default_home)
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4242
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda profile: str(profile_home),
+        )
+
+        kb._default_spawn(self._spawn_task(tmp_path), str(tmp_path / "ws"))
+
+        cmd = captured["cmd"]
+        assert "--skills" not in cmd or "kanban-worker" not in cmd
+        assert captured["env"]["HERMES_HOME"] == str(profile_home)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Mirrors normal skill resolver gates before auto-preloading the optional `kanban-worker` skill for dispatched Kanban workers.
- Checks worker profile local skills plus `skills.external_dirs`, and skips the optional preload when the bare skill name is missing, ambiguous, disabled, platform-incompatible, or resolves to a different frontmatter name.
- Keeps worker startup resilient because the mandatory Kanban lifecycle guidance is still injected separately via `KANBAN_GUIDANCE`.
- Adds regression coverage for local/external skill resolution, disabled/platform-disabled gates, platform incompatibility, frontmatter mismatch, ambiguous external dirs, and dispatcher command construction.

## Testing
- `python -m pytest tests/hermes_cli/test_kanban_db.py -k 'kanban_worker_preload or dispatcher_skips_optional_kanban_worker_skill_when_ambiguous or dispatch' -q -o 'addopts='` — 37 passed
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='` — 181 passed
- `python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` — passed
- `scripts/run_tests.sh` — 26,761 passed, 2 failed in local orchestrator profile environment:
  - `tests/hermes_cli/test_backup.py::TestProfileRestoration::test_import_creates_profile_wrappers` saw an existing `/home/watzon/.hermes/profiles/orchestrator/home/.local/bin/researcher` alias and skipped wrapper creation.
  - `tests/tools/test_resolve_path.py::TestResolvePath::test_tilde_expansion` expected `Path.home()` to equal the profile home symlink path while `_resolve_path("~/notes.txt")` resolved to `/home/watzon/notes.txt`.
  - Both failures are unrelated to the Kanban worker skill preload changes and come from this profile's `home -> /home/watzon` setup.
