### PR TITLE
fix(voice): honor PIPEWIRE_REMOTE in PortAudio fallback checks

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -265,6 +265,46 @@ class TestDetectAudioEnvironment:
         assert result["warnings"] == []
         assert any("container" in n.lower() for n in result.get("notices", []))
 
+    def test_docker_with_pipewire_remote_and_no_devices_allows_voice(self, monkeypatch):
+        """PIPEWIRE_REMOTE should bypass empty PortAudio device lists in Docker."""
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.delenv("PULSE_SERVER", raising=False)
+        monkeypatch.setenv("PIPEWIRE_REMOTE", "/run/user/1000/pipewire-0")
+        monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+
+        sd = MagicMock()
+        sd.query_devices.return_value = []
+        monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (sd, MagicMock()))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is True
+        assert result["warnings"] == []
+        assert any("host audio forwarding" in n.lower() for n in result.get("notices", []))
+
+    def test_docker_with_pipewire_remote_and_query_failure_allows_voice(self, monkeypatch):
+        """PIPEWIRE_REMOTE should bypass PortAudio query failures in Docker."""
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.delenv("PULSE_SERVER", raising=False)
+        monkeypatch.setenv("PIPEWIRE_REMOTE", "/run/user/1000/pipewire-0")
+        monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+
+        sd = MagicMock()
+        sd.query_devices.side_effect = RuntimeError("boom")
+        monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (sd, MagicMock()))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is True
+        assert result["warnings"] == []
+        assert any("host audio forwarding" in n.lower() for n in result.get("notices", []))
+
     def test_docker_without_audio_forwarding_blocks_voice(self, monkeypatch):
         """Docker without PULSE_SERVER/PIPEWIRE_REMOTE keeps blocking voice mode."""
         monkeypatch.delenv("SSH_CLIENT", raising=False)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -97,6 +97,9 @@ def detect_audio_environment() -> dict:
     termux_mic_cmd = _termux_microphone_command()
     termux_app_installed = _termux_api_app_installed()
     termux_capture = bool(termux_mic_cmd and termux_app_installed)
+    has_forwarded_audio = bool(
+        os.environ.get('PULSE_SERVER') or os.environ.get('PIPEWIRE_REMOTE')
+    )
 
     # SSH detection
     if any(os.environ.get(v) for v in ('SSH_CLIENT', 'SSH_TTY', 'SSH_CONNECTION')):
@@ -108,7 +111,7 @@ def detect_audio_environment() -> dict:
     # (issue #21203).  Only block when no forwarding is configured.
     from hermes_constants import is_container
     if is_container():
-        if os.environ.get('PULSE_SERVER') or os.environ.get('PIPEWIRE_REMOTE'):
+        if has_forwarded_audio:
             notices.append("Running inside container (Docker/Podman/LXC) with host audio forwarding")
         else:
             warnings.append(
@@ -143,17 +146,22 @@ def detect_audio_environment() -> dict:
         try:
             devices = sd.query_devices()
             if not devices:
-                if os.environ.get('PULSE_SERVER'):
-                    notices.append("No PortAudio devices detected but PULSE_SERVER is set -- continuing")
+                if has_forwarded_audio:
+                    notices.append(
+                        "No PortAudio devices detected but host audio forwarding is configured -- continuing"
+                    )
                 elif termux_capture:
                     notices.append("No PortAudio devices detected, but Termux:API microphone capture is available")
                 else:
                     warnings.append("No audio input/output devices detected")
         except Exception:
             # In WSL with PulseAudio, device queries can fail even though
-            # recording/playback works fine. Don't block if PULSE_SERVER is set.
-            if os.environ.get('PULSE_SERVER'):
-                notices.append("Audio device query failed but PULSE_SERVER is set -- continuing")
+            # recording/playback works fine. Don't block if host audio
+            # forwarding is configured.
+            if has_forwarded_audio:
+                notices.append(
+                    "Audio device query failed but host audio forwarding is configured -- continuing"
+                )
             elif termux_capture:
                 notices.append("PortAudio device query failed, but Termux:API microphone capture is available")
             else:


### PR DESCRIPTION
## Summary

This fixes a parity gap introduced after 81a4f280d24e2ab77e1a10196c0a601838716111 (`fix(voice): honor PULSE_SERVER/PIPEWIRE_REMOTE inside Docker`).

That commit established the invariant that Docker voice mode should treat `PIPEWIRE_REMOTE` the same way as `PULSE_SERVER` when host audio forwarding is configured. The initial container gate was updated, but the later PortAudio fallback paths still only special-cased `PULSE_SERVER`.

As a result, Docker users with PipeWire forwarding could still get false negatives when:
- `sd.query_devices()` returned no devices
- `sd.query_devices()` raised during probing

This change centralizes forwarded-audio detection and applies it consistently across:
- container environment gating
- empty PortAudio device-list handling
- PortAudio query failure handling

## Tests

Added regression coverage for the two missed Docker + `PIPEWIRE_REMOTE` cases:
- empty PortAudio device list
- PortAudio query failure

## Validation

Ran:
- `uv run --frozen pytest --timeout_method=thread tests/tools/test_voice_mode.py -k "docker_with_pulse_server or docker_with_pipewire_remote or docker_without_audio_forwarding" -q`
- `uv run --frozen pytest --timeout_method=thread tests/tools/test_voice_cli_integration.py -q`
- `uv run --frozen pytest --timeout_method=thread tests/gateway/test_voice_command.py -q`

Results:
- `5 passed`
- `84 passed`
- `160 passed, 21 skipped`