### PR TITLE
fix: harden reliability safety gates

### DIFF
--- a/gateway/board_comms.py
+++ b/gateway/board_comms.py
@@ -1,0 +1,268 @@
+"""Board-room communication governor for Telegram gateway sends.
+
+This module is intentionally deterministic and side-effect-light: it only
+classifies proposed outbound Board replies, writes an append-only suppression
+log, and returns ALLOW/SUPPRESS.  It does not call Telegram or mutate sessions.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - import safety for partial installs
+    get_hermes_home = None  # type: ignore[assignment]
+
+
+DEFAULT_BOARD_CHAT_IDS = frozenset({"-1003817293915"})
+DEFAULT_ACK_WINDOW_SECONDS = 300
+
+_ACK_RE = re.compile(
+    r"^(?:\s*(?:prime\s+hermes\s*/\s*ezra|prime\s+hermes|ezra)\s*[:—\-–])?\s*"
+    r"(?:ack(?:nowledged)?|received|logged|noted|standing\s+by|holding|copy|roger|understood)"
+    r"(?:[.!\s]*(?:no\s+further\s+action(?:\s+needed)?|standing\s+by|with\s+you|board\s+thread\s+is\s+calm))*\s*[.!]*$",
+    re.IGNORECASE | re.DOTALL,
+)
+_STOP_KILL_RE = re.compile(r"\b(?:stop|kill|hold|quiet|silence)\b", re.IGNORECASE)
+_BOT_MENTION_RE = re.compile(r"@([A-Za-z0-9_]{4,64})")
+_CRITICAL_RE = re.compile(
+    r"\b(?:critical|failed|failure|error|blocked|blocker|degraded|unsafe|incident|outage|security|cannot|can't)\b",
+    re.IGNORECASE,
+)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off", "disabled"}
+
+
+def _csv_set(raw: Optional[str]) -> set[str]:
+    if not raw:
+        return set()
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def board_chat_ids() -> set[str]:
+    configured = _csv_set(os.environ.get("HERMES_BOARD_CHAT_IDS"))
+    return configured or set(DEFAULT_BOARD_CHAT_IDS)
+
+
+def own_bot_usernames() -> set[str]:
+    configured = _csv_set(os.environ.get("HERMES_BOARD_OWN_BOT_USERNAMES"))
+    defaults = {"mac_pro_hermes_bot", "hermes_ezra_ai_bot", "ezra_ai_bot", "hermes_bot"}
+    return {u.lstrip("@").lower() for u in (configured or defaults)}
+
+
+def agent_name() -> str:
+    return os.environ.get("HERMES_BOARD_AGENT_NAME", "Prime Hermes / Ezra")
+
+
+def _state_root() -> Path:
+    if os.environ.get("HERMES_BOARD_COMMS_STATE_DIR"):
+        return Path(os.environ["HERMES_BOARD_COMMS_STATE_DIR"])
+    if get_hermes_home is not None:
+        try:
+            return Path(get_hermes_home()) / "state" / "board-comms"
+        except Exception:
+            pass
+    return Path.home() / ".hermes" / "state" / "board-comms"
+
+
+def suppression_log_path() -> Path:
+    configured = os.environ.get("HERMES_BOARD_COMMS_SUPPRESSION_LOG")
+    if configured:
+        return Path(configured)
+    return _state_root() / "suppression.jsonl"
+
+
+def ack_state_path() -> Path:
+    configured = os.environ.get("HERMES_BOARD_COMMS_ACK_STATE")
+    if configured:
+        return Path(configured)
+    return _state_root() / "ack-state.json"
+
+
+def _plain(text: str) -> str:
+    text = re.sub(r"```.*?```", " ", text or "", flags=re.DOTALL)
+    text = re.sub(r"[`*_~>|#\[\]()]", "", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def is_ack_only(text: str) -> bool:
+    plain = _plain(text)
+    if not plain:
+        return False
+    if len(plain) > 180:
+        return False
+    if _ACK_RE.match(plain):
+        return True
+    # Common noisy Board acknowledgements with a little extra phrasing.
+    lower = plain.lower()
+    if lower in {
+        "no further action needed from prime hermes",
+        "no further action from prime hermes",
+        "prime hermes standing by",
+        "prime hermes is standing by",
+    }:
+        return True
+    return False
+
+
+@dataclass(frozen=True)
+class BoardDecision:
+    allow: bool
+    reason: str = "ALLOW"
+    detail: str = ""
+
+
+def _metadata(metadata: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+    return metadata if isinstance(metadata, Mapping) else {}
+
+
+def _board_context(metadata: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+    meta = _metadata(metadata)
+    ctx = meta.get("board_context")
+    return ctx if isinstance(ctx, Mapping) else {}
+
+
+def _is_board_chat(chat_id: str, metadata: Optional[Mapping[str, Any]]) -> bool:
+    meta = _metadata(metadata)
+    if meta.get("board_comms_force") is True:
+        return True
+    if meta.get("board_comms_disable") is True:
+        return False
+    return str(chat_id) in board_chat_ids()
+
+
+def _targeted_other_bot(inbound_text: str) -> bool:
+    if not inbound_text or not _STOP_KILL_RE.search(inbound_text):
+        return False
+    mentions = {m.group(1).lower() for m in _BOT_MENTION_RE.finditer(inbound_text)}
+    if not mentions:
+        return False
+    return not bool(mentions & own_bot_usernames())
+
+
+def _read_ack_state() -> dict[str, Any]:
+    path = ack_state_path()
+    try:
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+    return {}
+
+
+def _write_ack_state(data: Mapping[str, Any]) -> None:
+    path = ack_state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(dict(data), ensure_ascii=False, sort_keys=True), encoding="utf-8")
+        tmp.replace(path)
+    except Exception:
+        pass
+
+
+def _ack_key(chat_id: str, metadata: Optional[Mapping[str, Any]]) -> str:
+    meta = _metadata(metadata)
+    thread = meta.get("thread_id") or _board_context(metadata).get("thread_id") or ""
+    return f"{chat_id}:{thread}"
+
+
+def _recent_ack_exists(chat_id: str, metadata: Optional[Mapping[str, Any]], now: float) -> bool:
+    try:
+        window = float(os.environ.get("HERMES_BOARD_ACK_WINDOW_SECONDS", DEFAULT_ACK_WINDOW_SECONDS))
+    except (TypeError, ValueError):
+        window = DEFAULT_ACK_WINDOW_SECONDS
+    state = _read_ack_state()
+    last = state.get(_ack_key(chat_id, metadata))
+    try:
+        return bool(last is not None and now - float(last) <= window)
+    except (TypeError, ValueError):
+        return False
+
+
+def _record_ack(chat_id: str, metadata: Optional[Mapping[str, Any]], now: float) -> None:
+    state = _read_ack_state()
+    state[_ack_key(chat_id, metadata)] = now
+    _write_ack_state(state)
+
+
+def log_suppression(
+    *,
+    chat_id: str,
+    content: str,
+    reason: str,
+    detail: str = "",
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> None:
+    if not _env_bool("HERMES_BOARD_COMMS_LOG_SUPPRESSIONS", True):
+        return
+    ctx = dict(_board_context(metadata))
+    event = {
+        "ts": int(time.time()),
+        "agent": agent_name(),
+        "chat_id": str(chat_id),
+        "thread_id": str(_metadata(metadata).get("thread_id") or ctx.get("thread_id") or ""),
+        "reason": reason,
+        "detail": detail,
+        "inbound_text": str(ctx.get("inbound_text") or "")[:1000],
+        "inbound_user_id": str(ctx.get("user_id") or ""),
+        "inbound_user_name": str(ctx.get("user_name") or ""),
+        "inbound_is_bot": bool(ctx.get("is_bot")),
+        "proposed_reply": str(content or "")[:1200],
+    }
+    path = suppression_log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+    except Exception:
+        pass
+
+
+def evaluate_send(
+    *,
+    chat_id: str,
+    content: str,
+    metadata: Optional[Mapping[str, Any]] = None,
+    now: Optional[float] = None,
+) -> BoardDecision:
+    """Classify a proposed outbound Board message.
+
+    Return ALLOW for non-Board chats and for critical/status messages.  Return
+    SUPPRESS_* only for Board chats where the proposed reply is low-signal or
+    violates targeted-command discipline.
+    """
+    if not _env_bool("HERMES_BOARD_COMMS_ENABLED", True):
+        return BoardDecision(True)
+    if not _is_board_chat(str(chat_id), metadata):
+        return BoardDecision(True)
+
+    ctx = _board_context(metadata)
+    inbound_text = str(ctx.get("inbound_text") or "")
+    inbound_is_bot = bool(ctx.get("is_bot"))
+    proposed = content or ""
+    current = time.time() if now is None else now
+    ack_only = is_ack_only(proposed)
+
+    if _targeted_other_bot(inbound_text) and not _CRITICAL_RE.search(proposed):
+        return BoardDecision(False, "SUPPRESS_TARGETED_OTHER_BOT", "Anthony targeted a different bot/lane with stop/kill/hold/quiet")
+
+    if ack_only:
+        if inbound_is_bot:
+            return BoardDecision(False, "SUPPRESS_BOT_TO_BOT_ACK", "Bot-originated message produced acknowledgement-only reply")
+        return BoardDecision(False, "SUPPRESS_ACK_ONLY", "Acknowledgement-only Board reply is below the public signal bar")
+
+    return BoardDecision(True)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -22,6 +22,13 @@ from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
 
+try:
+    from gateway.board_comms import evaluate_send as _evaluate_board_send
+    from gateway.board_comms import log_suppression as _log_board_suppression
+except Exception:  # pragma: no cover - board-comms governor is best-effort
+    _evaluate_board_send = None  # type: ignore[assignment]
+    _log_board_suppression = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 # Audio file extensions Hermes recognizes for native audio delivery.
@@ -97,6 +104,62 @@ def _reply_anchor_for_event(event) -> str | None:
     if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
+
+
+def _board_comms_metadata_for_event(event: "MessageEvent", metadata: dict | None) -> dict:
+    """Attach inbound Board context to outbound send metadata."""
+    meta = dict(metadata or {})
+    source = getattr(event, "source", None)
+    ctx = dict(meta.get("board_context") or {})
+    ctx.setdefault("inbound_text", getattr(event, "text", "") or "")
+    ctx.setdefault("user_id", getattr(source, "user_id", "") or "")
+    ctx.setdefault("user_name", getattr(source, "user_name", "") or "")
+    ctx.setdefault("is_bot", bool(getattr(source, "is_bot", False)))
+    thread_id = getattr(source, "thread_id", None)
+    if thread_id is not None:
+        meta.setdefault("thread_id", thread_id)
+    meta["board_context"] = ctx
+    return meta
+
+
+def _board_send_allowed(chat_id: str, content: str, metadata: dict | None) -> bool:
+    """Return False when the Board comms governor suppresses an outbound send."""
+    decision = _board_send_decision(chat_id, content, metadata)
+    return bool(getattr(decision, "allow", True))
+
+
+def _board_send_decision(chat_id: str, content: str, metadata: dict | None):
+    """Evaluate and log the Board comms decision for a proposed send."""
+    if _evaluate_board_send is None:
+        return None
+    try:
+        decision = _evaluate_board_send(
+            chat_id=str(chat_id),
+            content=content,
+            metadata=metadata,
+        )
+    except Exception as exc:
+        logger.debug("board_comms evaluate_send failed: %s", exc)
+        return None
+    if getattr(decision, "allow", True):
+        return decision
+    try:
+        if _log_board_suppression is not None:
+            _log_board_suppression(
+                chat_id=str(chat_id),
+                content=content,
+                reason=getattr(decision, "reason", "SUPPRESS_BOARD_COMMS"),
+                detail=getattr(decision, "detail", ""),
+                metadata=metadata,
+            )
+    except Exception as exc:
+        logger.debug("board_comms log_suppression failed: %s", exc)
+    logger.info(
+        "Board comms suppressed outbound message to %s: %s",
+        chat_id,
+        getattr(decision, "reason", "SUPPRESS_BOARD_COMMS"),
+    )
+    return decision
 
 
 def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bool:
@@ -3342,9 +3405,10 @@ class BasePlatformAdapter(ABC):
                 )
                 try:
                     _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                    _thread_meta = _board_comms_metadata_for_event(event, _thread_meta)
                     response = await self._message_handler(event)
                     _text, _eph_ttl = self._unwrap_ephemeral(response)
-                    if _text:
+                    if _text and _board_send_allowed(event.source.chat_id, _text, _thread_meta):
                         _r = await self._send_with_retry(
                             chat_id=event.source.chat_id,
                             content=_text,
@@ -3392,9 +3456,10 @@ class BasePlatformAdapter(ABC):
                         _thread_meta = _thread_metadata_for_source(
                             event.source, _reply_anchor_for_event(event)
                         )
+                        _thread_meta = _board_comms_metadata_for_event(event, _thread_meta)
                         response = await self._message_handler(event)
                         _text, _eph_ttl = self._unwrap_ephemeral(response)
-                        if _text:
+                        if _text and _board_send_allowed(event.source.chat_id, _text, _thread_meta):
                             _r = await self._send_with_retry(
                                 chat_id=event.source.chat_id,
                                 content=_text,
@@ -3494,6 +3559,7 @@ class BasePlatformAdapter(ABC):
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        delivery_suppressed = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -3511,6 +3577,7 @@ class BasePlatformAdapter(ABC):
         
         # Start continuous typing indicator (refreshes every 2 seconds)
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        _thread_metadata = _board_comms_metadata_for_event(event, _thread_metadata)
         _keep_typing_kwargs = {"metadata": _thread_metadata}
         try:
             _keep_typing_sig = inspect.signature(self._keep_typing)
@@ -3599,6 +3666,14 @@ class BasePlatformAdapter(ABC):
                 if local_files:
                     logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
                 
+                # Evaluate Board text suppression before TTS/media dispatch so
+                # a voice-triggered acknowledgement cannot bypass the public
+                # send-boundary guard via audio caption delivery.
+                text_send_decision = _board_send_decision(event.source.chat_id, text_content, _thread_metadata) if text_content else None
+                text_send_allowed_by_board = bool(getattr(text_send_decision, "allow", True))
+                if text_content and not text_send_allowed_by_board:
+                    delivery_suppressed = True
+
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
@@ -3607,6 +3682,7 @@ class BasePlatformAdapter(ABC):
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
                         and text_content
+                        and text_send_allowed_by_board
                         and not media_files):
                     try:
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
@@ -3650,7 +3726,12 @@ class BasePlatformAdapter(ABC):
                             pass
 
                 # Send the text portion
-                if text_content and not _tts_caption_delivered:
+                text_send_allowed = bool(
+                    text_content
+                    and not _tts_caption_delivered
+                    and text_send_allowed_by_board
+                )
+                if text_send_allowed:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     _reply_anchor = _reply_anchor_for_event(event)
                     # Mark final response messages for notification delivery.
@@ -3664,7 +3745,9 @@ class BasePlatformAdapter(ABC):
                         _thread_metadata = dict(_thread_metadata)
                         _thread_metadata["notify"] = True
                     else:
-                        _thread_metadata = {"notify": True}
+                        _thread_metadata = _board_comms_metadata_for_event(
+                            event, {"notify": True}
+                        )
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
@@ -3797,7 +3880,7 @@ class BasePlatformAdapter(ABC):
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 
             # Determine overall success for the processing hook
-            processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            processing_ok = delivery_succeeded if delivery_attempted else (delivery_suppressed or not bool(response))
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -279,6 +279,41 @@ _STILL_WORKING_EXCEPTION_RE = re.compile(
     re.IGNORECASE,
 )
 
+_PUBLIC_RUNTIME_ARTIFACT_PATTERNS = (
+    re.compile(
+        r"^\s*\W*\s*empty\s+response\s+from\s+model\s+[—-]\s+retrying\s*\(\s*\d+\s*/\s*\d+\s*\)\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*\W*\s*operation\s+interrupted:\s+waiting\s+for\s+model\s+response\s+\([0-9.]+s\s+elapsed\)\.?\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*\W*\s*the\s+model\s+returned\s+no\s+response\s+after\s+processing\s+tool\s+results\.\s+this\s+can\s+happen\s+with\s+some\s+models\s+[—-]\s+try\s+again\s+or\s+rephrase\s+your\s+question\.\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*\W*\s*processing\s+completed\s+but\s+no\s+response\s+was\s+generated\.\s+this\s+may\s+be\s+a\s+transient\s+error\s+[—-]\s+try\s+sending\s+your\s+message\s+again\.\s*$",
+        re.IGNORECASE,
+    ),
+)
+_PUBLIC_CHAT_TYPES = {"group", "supergroup", "channel", "thread", "forum"}
+
+
+def _should_suppress_public_runtime_artifact(text: str, source: Any) -> bool:
+    """Keep gateway/runtime failure boilerplate out of public rooms.
+
+    DMs can still surface retry/no-response notices because they help the user
+    decide whether to resend. Group/forum/channel contexts should not receive
+    runtime artifacts as if they were conversational assistant output.
+    """
+    if not text:
+        return False
+    chat_type = str(getattr(source, "chat_type", "") or "").strip().lower()
+    if chat_type not in _PUBLIC_CHAT_TYPES:
+        return False
+    return any(pattern.match(str(text).strip()) for pattern in _PUBLIC_RUNTIME_ARTIFACT_PATTERNS)
+
 
 def _looks_like_gateway_provider_error(text: str) -> bool:
     """True when text is infrastructure/provider failure, not normal content.
@@ -415,7 +450,12 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return _lint_telegram_closeout_packet(redacted)
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+def _prepare_gateway_status_message(
+    platform: Any,
+    event_type: str,
+    message: str,
+    source: Any = None,
+) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery."""
     text = str(message or "").strip()
     if not text:
@@ -425,6 +465,8 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
 
     text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
+        return None
+    if _should_suppress_public_runtime_artifact(text, source):
         return None
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
@@ -8933,6 +8975,17 @@ class GatewayRunner:
                 agent_result, response, history_len=len(history),
             )
             response = _sanitize_gateway_final_response(source.platform, response)
+            suppress_public_runtime_response = _should_suppress_public_runtime_artifact(
+                response, source
+            )
+            if suppress_public_runtime_response:
+                logger.info(
+                    "Suppressing public runtime artifact for %s/%s: %s",
+                    getattr(source.platform, "value", source.platform),
+                    getattr(source, "chat_type", ""),
+                    _redact_gateway_user_facing_secrets(response)[:160],
+                )
+                response = ""
 
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
@@ -9229,6 +9282,8 @@ class GatewayRunner:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
 
+            if suppress_public_runtime_response:
+                return None
             return response
             
         except Exception as e:
@@ -16567,6 +16622,7 @@ class GatewayRunner:
                 source.platform,
                 event_type,
                 message,
+                source=source,
             )
             if prepared_message is None:
                 logger.debug(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -261,6 +261,24 @@ _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_TELEGRAM_STATUS_PACKET_TITLE = "Status / Proof / Changed / Next"
+_TELEGRAM_BLOCKER_PACKET_TITLE = "BLOCKER PACKET"
+
+_TELEGRAM_CLOSEOUT_SHAPE_RE = re.compile(
+    r"^\s*(?:status|completion|complete|completed|done|fixed|shipped)\s*[:\-]",
+    re.IGNORECASE,
+)
+_TELEGRAM_BLOCKER_SHAPE_RE = re.compile(
+    r"^\s*(?:blocked|blocker|blocker\s+packet|halted|stalled)\s*[:\-]",
+    re.IGNORECASE,
+)
+_TELEGRAM_PACKET_FIELD_RE = re.compile(r"^\s*([A-Za-z][A-Za-z /]+?)\s*:\s*(.*)$")
+
+_STILL_WORKING_EXCEPTION_RE = re.compile(
+    r"\b(artifact|proof|blocker|blocked|approval|decision|needed from|user.*needed|requires user)\b",
+    re.IGNORECASE,
+)
+
 
 def _looks_like_gateway_provider_error(text: str) -> bool:
     """True when text is infrastructure/provider failure, not normal content.
@@ -285,6 +303,100 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
 
 
+def _extract_packet_fields(text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    current_key = ""
+    for raw_line in str(text or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _TELEGRAM_PACKET_FIELD_RE.match(line)
+        if match:
+            key = match.group(1).strip().lower()
+            value = match.group(2).strip()
+            fields[key] = value
+            current_key = key
+        elif current_key:
+            fields[current_key] = (fields.get(current_key, "") + " " + line).strip()
+    return fields
+
+
+def _telegram_closeout_needs_lint(text: str) -> bool:
+    body = str(text or "").strip()
+    if not body:
+        return False
+    if _TELEGRAM_STATUS_PACKET_TITLE in body or _TELEGRAM_BLOCKER_PACKET_TITLE in body:
+        return False
+    return bool(_TELEGRAM_CLOSEOUT_SHAPE_RE.search(body) or _TELEGRAM_BLOCKER_SHAPE_RE.search(body))
+
+
+def _format_telegram_status_packet(text: str) -> str:
+    fields = _extract_packet_fields(text)
+    status = fields.get("status") or fields.get("completion") or fields.get("done") or fields.get("completed") or fields.get("fixed") or "Completed/status update."
+    proof = fields.get("proof") or fields.get("evidence") or "Not provided in original closeout."
+    changed = fields.get("changed") or fields.get("change") or fields.get("changes") or "Not provided in original closeout."
+    next_step = fields.get("next") or fields.get("next safe action") or fields.get("next action") or "Not provided in original closeout."
+    return (
+        f"{_TELEGRAM_STATUS_PACKET_TITLE}\n"
+        f"Status: {status}\n"
+        f"Proof: {proof}\n"
+        f"Changed: {changed}\n"
+        f"Next: {next_step}"
+    )
+
+
+def _format_telegram_blocker_packet(text: str) -> str:
+    fields = _extract_packet_fields(text)
+    blocked_on = fields.get("blocked on") or fields.get("blocked") or fields.get("blocker") or fields.get("status") or str(text or "").strip()
+    needed = fields.get("needed from anthony") or fields.get("needed") or fields.get("ask") or "Explicit user decision/approval."
+    risk = fields.get("risk if skipped") or fields.get("risk") or "Unscoped or unsafe action could proceed without the required decision."
+    next_safe = fields.get("next safe action") or fields.get("next") or "Wait for user response or provide a narrower safe alternative."
+    return (
+        f"{_TELEGRAM_BLOCKER_PACKET_TITLE}\n"
+        f"Blocked on: {blocked_on}\n"
+        f"Needed from Anthony: {needed}\n"
+        f"Risk if skipped: {risk}\n"
+        f"Next safe action: {next_safe}"
+    )
+
+
+def _lint_telegram_closeout_packet(text: str) -> str:
+    body = str(text or "")
+    if not _telegram_closeout_needs_lint(body):
+        return body
+    if _TELEGRAM_BLOCKER_SHAPE_RE.search(body):
+        return _format_telegram_blocker_packet(body)
+    return _format_telegram_status_packet(body)
+
+
+def _should_send_still_working_notice(elapsed_mins: int, status_detail: str, state: dict[str, Any]) -> bool:
+    """Return whether a Telegram still-working notice carries new signal.
+
+    Suppress duplicate status pings after two repeats, and suppress routine
+    pings past 20 minutes unless they include a new artifact/proof/blocker or
+    need a user decision.
+    """
+    detail = str(status_detail or "").strip()
+    signature = re.sub(r"\b\d+\b", "#", detail.lower())
+    has_exception = bool(_STILL_WORKING_EXCEPTION_RE.search(detail))
+    repeat_count = int(state.get("repeat_count", 0))
+    last_signature = state.get("signature")
+
+    if signature != last_signature:
+        repeat_count = 0
+    repeat_count += 1
+
+    state["signature"] = signature
+    state["repeat_count"] = repeat_count
+    state["last_elapsed_mins"] = elapsed_mins
+
+    if has_exception:
+        return True
+    if elapsed_mins >= 20:
+        return False
+    return repeat_count <= 2
+
+
 def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     """Sanitize final gateway replies before sending them to high-noise chats.
 
@@ -300,7 +412,7 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
-    return redacted
+    return _lint_telegram_closeout_packet(redacted)
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
@@ -316,7 +428,7 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return None
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
-    return text
+    return _lint_telegram_closeout_packet(text)
 
 
 async def _send_or_update_status_coro(adapter, chat_id, status_key, content, metadata):
@@ -17448,6 +17560,7 @@ class GatewayRunner:
         ):
             _NOTIFY_INTERVAL = None
         _notify_start = time.time()
+        _still_working_notice_state: dict[str, Any] = {}
 
         async def _notify_long_running():
             if _NOTIFY_INTERVAL is None:
@@ -17493,6 +17606,12 @@ class GatewayRunner:
                             _status_detail = " — " + ", ".join(_parts)
                     except Exception:
                         pass
+                if not _should_send_still_working_notice(
+                    _elapsed_mins,
+                    _status_detail,
+                    _still_working_notice_state,
+                ):
+                    continue
                 _heartbeat_text = f"⏳ Working — {_elapsed_mins} min{_status_detail}"
                 try:
                     _notify_res = None

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -194,22 +194,21 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "copilot-acp",
     ],
     "copilot": [
-        "gpt-5.4",
-        "gpt-5.4-mini",
-        "gpt-5-mini",
-        "gpt-5.3-codex",
-        "gpt-5.2-codex",
-        "gpt-4.1",
-        "gpt-4o",
-        "gpt-4o-mini",
         "claude-sonnet-4.6",
-        "claude-sonnet-4",
         "claude-sonnet-4.5",
         "claude-haiku-4.5",
-        "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
-        "gemini-3-flash-preview",
-        "gemini-2.5-pro",
+        "claude-opus-4.7",
+        "claude-opus-4.6",
+        "claude-opus-4.6-fast",
+        "claude-opus-4.5",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.3-codex",
+        "gpt-5.2-codex",
+        "gpt-5.2",
+        "gpt-5.4-mini",
+        "gpt-5-mini",
+        "gpt-4.1",
     ],
     "gemini": [
         "gemini-3.1-pro-preview",
@@ -2253,8 +2252,10 @@ def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
     if not model_id:
         return False
 
-    if item.get("model_picker_enabled") is False:
-        return False
+    # Hidden-from-picker preview/default models can still be chat-capable and
+    # callable by Hermes. Ignore model_picker_enabled here; endpoint/type
+    # filtering below removes embeddings and non-text tools without repeating
+    # the 2026-05 Copilot drift where Claude Opus models were silently hidden.
 
     capabilities = item.get("capabilities")
     if isinstance(capabilities, dict):

--- a/tests/gateway/test_board_comms.py
+++ b/tests/gateway/test_board_comms.py
@@ -1,0 +1,60 @@
+import json
+
+from gateway.board_comms import evaluate_send, is_ack_only, log_suppression
+
+
+def test_ack_only_detection():
+    assert is_ack_only("Acknowledged.")
+    assert is_ack_only("Prime Hermes — standing by.")
+    assert not is_ack_only("Status: Foundry Hermes is degraded; cleanup routed.")
+
+
+def test_non_board_chat_allowed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_BOARD_COMMS_STATE_DIR", str(tmp_path))
+    decision = evaluate_send(chat_id="123", content="Acknowledged.", metadata={})
+    assert decision.allow
+
+
+def test_targeted_other_bot_stop_kill_suppressed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_BOARD_COMMS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("HERMES_BOARD_CHAT_IDS", "-1003817293915")
+    decision = evaluate_send(
+        chat_id="-1003817293915",
+        content="Acknowledged. Prime Hermes standing by.",
+        metadata={
+            "thread_id": "1",
+            "board_context": {
+                "inbound_text": "@foundry_hermes_bot stop kill",
+                "is_bot": False,
+            },
+        },
+    )
+    assert not decision.allow
+    assert decision.reason == "SUPPRESS_TARGETED_OTHER_BOT"
+
+
+def test_bot_origin_ack_suppressed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_BOARD_COMMS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("HERMES_BOARD_CHAT_IDS", "-1003817293915")
+    decision = evaluate_send(
+        chat_id="-1003817293915",
+        content="Received. Standing by.",
+        metadata={"board_context": {"inbound_text": "Acknowledged.", "is_bot": True}},
+    )
+    assert not decision.allow
+    assert decision.reason == "SUPPRESS_BOT_TO_BOT_ACK"
+
+
+def test_board_ack_only_suppressed_and_logged(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_BOARD_COMMS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("HERMES_BOARD_CHAT_IDS", "-1003817293915")
+    metadata = {"thread_id": "1", "board_context": {"inbound_text": "Ping", "is_bot": False}}
+    decision = evaluate_send(chat_id="-1003817293915", content="Acknowledged.", metadata=metadata, now=1000)
+    assert not decision.allow
+    assert decision.reason == "SUPPRESS_ACK_ONLY"
+
+    log_suppression(chat_id="-1003817293915", content="Acknowledged.", reason=decision.reason, metadata=metadata)
+    log_path = tmp_path / "suppression.jsonl"
+    row = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert row["reason"] == "SUPPRESS_ACK_ONLY"
+    assert row["thread_id"] == "1"

--- a/tests/gateway/test_board_comms_integration.py
+++ b/tests/gateway/test_board_comms_integration.py
@@ -1,0 +1,114 @@
+import asyncio
+from unittest.mock import ANY, AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+)
+from gateway.session import SessionSource
+
+
+class _BoardAdapter(BasePlatformAdapter):
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_adapter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_BOARD_COMMS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("HERMES_BOARD_CHAT_IDS", "-1003817293915")
+    adapter = _BoardAdapter(PlatformConfig(enabled=True, token="t"), Platform.TELEGRAM)
+    adapter._keep_typing = AsyncMock()
+    adapter._run_processing_hook = AsyncMock()
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="sent"))
+    return adapter
+
+
+def _board_event(text="ping", *, is_bot=False, message_type=MessageType.TEXT):
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1003817293915",
+            chat_type="group",
+            thread_id="1",
+            user_id="u1",
+            user_name="Tester",
+            is_bot=is_bot,
+        ),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_board_ack_only_response_suppressed_at_send_boundary(monkeypatch, tmp_path):
+    adapter = _make_adapter(tmp_path, monkeypatch)
+
+    async def handler(event):
+        return "Acknowledged."
+
+    adapter._message_handler = handler
+
+    await adapter._process_message_background(_board_event(), "session-key")
+
+    adapter._send_with_retry.assert_not_called()
+    adapter._run_processing_hook.assert_any_await(
+        "on_processing_complete",
+        ANY,
+        ProcessingOutcome.SUCCESS,
+    )
+    assert (tmp_path / "suppression.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_board_voice_ack_response_does_not_bypass_via_tts(monkeypatch, tmp_path):
+    adapter = _make_adapter(tmp_path, monkeypatch)
+    adapter.play_tts = AsyncMock()
+    monkeypatch.setattr(adapter, "_should_auto_tts_for_chat", lambda chat_id: True)
+
+    async def handler(event):
+        return "Acknowledged."
+
+    adapter._message_handler = handler
+
+    await adapter._process_message_background(
+        _board_event(message_type=MessageType.VOICE),
+        "session-key",
+    )
+
+    adapter.play_tts.assert_not_called()
+    adapter._send_with_retry.assert_not_called()
+    adapter._run_processing_hook.assert_any_await(
+        "on_processing_complete",
+        ANY,
+        ProcessingOutcome.SUCCESS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_board_status_response_allowed_at_send_boundary(monkeypatch, tmp_path):
+    adapter = _make_adapter(tmp_path, monkeypatch)
+
+    async def handler(event):
+        return "Status: Foundry Hermes is degraded; cleanup routed."
+
+    adapter._message_handler = handler
+
+    await adapter._process_message_background(_board_event(), "session-key")
+
+    adapter._send_with_retry.assert_awaited_once()

--- a/tests/gateway/test_public_runtime_artifact_suppression.py
+++ b/tests/gateway/test_public_runtime_artifact_suppression.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.run import (
+    _prepare_gateway_status_message,
+    _should_suppress_public_runtime_artifact,
+)
+
+
+def _source(chat_type: str):
+    return SimpleNamespace(chat_type=chat_type)
+
+
+def test_suppresses_empty_response_fallback_in_public_group():
+    assert _should_suppress_public_runtime_artifact(
+        "⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your question.",
+        _source("group"),
+    )
+
+
+def test_suppresses_operation_interrupted_in_public_thread():
+    assert _should_suppress_public_runtime_artifact(
+        "Operation interrupted: waiting for model response (2.3s elapsed).",
+        _source("thread"),
+    )
+
+
+def test_suppresses_retry_boilerplate_in_public_group():
+    assert _should_suppress_public_runtime_artifact(
+        "⚠️ Empty response from model — retrying (1/3)",
+        _source("supergroup"),
+    )
+
+
+def test_suppresses_processing_completed_no_response_fallback_in_public_group():
+    assert _should_suppress_public_runtime_artifact(
+        "⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.",
+        _source("group"),
+    )
+
+
+def test_keeps_same_runtime_notice_visible_in_dm():
+    assert not _should_suppress_public_runtime_artifact(
+        "⚠️ The model returned no response after processing tool results. This can happen with some models — try again or rephrase your question.",
+        _source("dm"),
+    )
+
+
+def test_does_not_suppress_normal_public_answer():
+    assert not _should_suppress_public_runtime_artifact(
+        "Here is the requested proof summary.",
+        _source("group"),
+    )
+
+
+def test_does_not_suppress_public_answer_that_mentions_runtime_phrase():
+    assert not _should_suppress_public_runtime_artifact(
+        "If your process logs say Operation interrupted, check the gateway log before retrying.",
+        _source("group"),
+    )
+
+
+def test_does_not_suppress_public_answer_starting_with_runtime_phrase():
+    assert not _should_suppress_public_runtime_artifact(
+        "Operation interrupted means the OS delivered SIGINT; here is how to debug it.",
+        _source("group"),
+    )
+
+
+def test_status_callback_suppresses_public_retry_artifact():
+    assert _prepare_gateway_status_message(
+        Platform.TELEGRAM,
+        "warn",
+        "⚠️ Empty response from model — retrying (1/3)",
+        source=_source("supergroup"),
+    ) is None
+
+
+def test_status_callback_keeps_dm_retry_artifact():
+    message = "⚠️ Empty response from model — retrying (1/3)"
+    assert _prepare_gateway_status_message(
+        Platform.TELEGRAM,
+        "warn",
+        message,
+        source=_source("dm"),
+    ) == message

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -4,6 +4,7 @@ from gateway.config import Platform
 from gateway.run import (
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
+    _should_send_still_working_notice,
 )
 
 
@@ -81,3 +82,58 @@ def test_telegram_final_response_keeps_normal_answers():
     answer = "Here is the clean summary you asked for."
 
     assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer
+
+
+def test_telegram_closeout_status_is_rewritten_to_exact_packet():
+    """Completion/status closeouts need the canonical packet before Telegram send."""
+    raw = "Status: fixed\nProof: pytest passed"
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "Status / Proof / Changed / Next" in sanitized
+    assert "Status:" in sanitized
+    assert "Proof:" in sanitized
+    assert "Changed:" in sanitized
+    assert "Next:" in sanitized
+
+
+def test_telegram_blocker_is_rewritten_to_exact_blocker_packet():
+    """Blocker-shaped closeouts need the canonical blocker packet before send."""
+    raw = "Blocked: need Anthony to approve the gateway restart."
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "BLOCKER PACKET" in sanitized
+    assert "Blocked on:" in sanitized
+    assert "Needed from Anthony:" in sanitized
+    assert "Risk if skipped:" in sanitized
+    assert "Next safe action:" in sanitized
+
+
+def test_telegram_status_callback_gets_closeout_linter():
+    """Status callbacks are linted too, not only final responses."""
+    raw = "Completion: deployed\nProof: smoke test passed"
+
+    sanitized = _prepare_gateway_status_message(Platform.TELEGRAM, "status", raw)
+
+    assert sanitized is not None
+    assert "Status / Proof / Changed / Next" in sanitized
+
+
+
+def test_still_working_notice_suppresses_after_two_repeats():
+    """Repeated still-working notices should go quiet unless detail changes."""
+    state = {}
+
+    assert _should_send_still_working_notice(3, " — iteration 1/90, running: terminal", state)
+    assert _should_send_still_working_notice(6, " — iteration 1/90, running: terminal", state)
+    assert not _should_send_still_working_notice(9, " — iteration 1/90, running: terminal", state)
+    assert _should_send_still_working_notice(12, " — iteration 2/90, running: pytest", state)
+
+
+def test_still_working_notice_suppresses_after_twenty_minutes_without_new_artifact():
+    state = {}
+
+    assert _should_send_still_working_notice(3, " — iteration 1/90, running: terminal", state)
+    assert not _should_send_still_working_notice(21, " — iteration 1/90, running: terminal", state)
+    assert _should_send_still_working_notice(24, " — blocker packet ready; user approval needed", state)

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -18,11 +18,14 @@ def test_copilot_picker_keeps_curated_copilot_models_when_live_catalog_unavailab
     assert copilot is not None
     assert "gpt-5.4" in copilot["models"]
     assert "claude-sonnet-4.6" in copilot["models"]
-    assert "claude-sonnet-4" in copilot["models"]
     assert "claude-sonnet-4.5" in copilot["models"]
     assert "claude-haiku-4.5" in copilot["models"]
-    assert "gemini-3.1-pro-preview" in copilot["models"]
-    assert "claude-opus-4.6" not in copilot["models"]
+    assert "claude-opus-4.7" in copilot["models"]
+    assert "claude-opus-4.6" in copilot["models"]
+    assert "claude-opus-4.6-fast" in copilot["models"]
+    assert "claude-opus-4.5" in copilot["models"]
+    assert "gpt-5.5" in copilot["models"]
+    assert "gpt-5.2" in copilot["models"]
 
 
 @patch.dict(os.environ, {"GH_TOKEN": "test-key"}, clear=False)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -222,30 +222,35 @@ class TestProviderModelIds:
              patch("hermes_cli.models._fetch_github_models", return_value=["gpt-5.4", "claude-sonnet-4.6"]):
             assert provider_model_ids("copilot-acp") == ["gpt-5.4", "claude-sonnet-4.6"]
 
-    def test_copilot_falls_back_to_curated_defaults_without_stale_opus(self):
+    def test_copilot_falls_back_to_cli_synced_curated_defaults(self):
         with patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value="gh-token"), \
              patch("hermes_cli.models._fetch_github_models", return_value=None):
             ids = provider_model_ids("copilot")
 
+        assert "gpt-5.5" in ids
         assert "gpt-5.4" in ids
+        assert "gpt-5.2" in ids
+        assert "gpt-5.2-codex" in ids
         assert "claude-sonnet-4.6" in ids
-        assert "claude-sonnet-4" in ids
         assert "claude-sonnet-4.5" in ids
         assert "claude-haiku-4.5" in ids
-        assert "gemini-3.1-pro-preview" in ids
-        assert "claude-opus-4.6" not in ids
+        assert "claude-opus-4.7" in ids
+        assert "claude-opus-4.6" in ids
+        assert "claude-opus-4.6-fast" in ids
+        assert "claude-opus-4.5" in ids
+        assert "claude-sonnet-4" not in ids
+        assert "gemini-3.1-pro-preview" not in ids
 
     def test_copilot_acp_falls_back_to_copilot_defaults(self):
         with patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value="gh-token"), \
              patch("hermes_cli.models._fetch_github_models", return_value=None):
             ids = provider_model_ids("copilot-acp")
 
+        assert "gpt-5.5" in ids
         assert "gpt-5.4" in ids
         assert "claude-sonnet-4.6" in ids
-        assert "claude-sonnet-4" in ids
-        assert "gemini-3.1-pro-preview" in ids
+        assert "claude-opus-4.7" in ids
         assert "copilot-acp" not in ids
-        assert "claude-opus-4.6" not in ids
 
 
 # -- fetch_api_models --------------------------------------------------------
@@ -304,7 +309,7 @@ class TestFetchApiModels:
         assert probe["resolved_base_url"] == "https://api.githubcopilot.com"
         assert probe["used_fallback"] is False
 
-    def test_fetch_github_model_catalog_filters_non_chat_models(self):
+    def test_fetch_github_model_catalog_ignores_model_picker_disabled_for_chat_models(self):
         class _Resp:
             def __enter__(self):
                 return self
@@ -313,13 +318,13 @@ class TestFetchApiModels:
                 return False
 
             def read(self):
-                return b'{"data": [{"id": "gpt-5.4", "model_picker_enabled": true, "supported_endpoints": ["/responses"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}, {"id": "text-embedding-3-small", "model_picker_enabled": true, "capabilities": {"type": "embedding"}}]}'
+                return b'{"data": [{"id": "claude-opus-4.7", "model_picker_enabled": false, "supported_endpoints": ["/chat/completions"], "capabilities": {"type": "chat", "supports": {}}}, {"id": "text-embedding-3-small", "model_picker_enabled": false, "capabilities": {"type": "embedding"}}]}'
 
         with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
             catalog = fetch_github_model_catalog("gh-token")
 
         assert catalog is not None
-        assert [item["id"] for item in catalog] == ["gpt-5.4"]
+        assert [item["id"] for item in catalog] == ["claude-opus-4.7"]
 
 
 class TestGithubReasoningEfforts:
@@ -355,6 +360,7 @@ class TestCopilotNormalization:
 
     def test_copilot_api_mode_gpt5_uses_responses(self):
         """GPT-5+ models should use Responses API (matching opencode)."""
+        assert copilot_model_api_mode("gpt-5.5") == "codex_responses"
         assert copilot_model_api_mode("gpt-5.4") == "codex_responses"
         assert copilot_model_api_mode("gpt-5.4-mini") == "codex_responses"
         assert copilot_model_api_mode("gpt-5.3-codex") == "codex_responses"
@@ -368,11 +374,9 @@ class TestCopilotNormalization:
     def test_copilot_api_mode_non_gpt5_uses_chat(self):
         """Non-GPT-5 models use Chat Completions."""
         assert copilot_model_api_mode("gpt-4.1") == "chat_completions"
-        assert copilot_model_api_mode("gpt-4o") == "chat_completions"
-        assert copilot_model_api_mode("gpt-4o-mini") == "chat_completions"
         assert copilot_model_api_mode("claude-sonnet-4.6") == "chat_completions"
-        assert copilot_model_api_mode("claude-opus-4.6") == "chat_completions"
-        assert copilot_model_api_mode("gemini-2.5-pro") == "chat_completions"
+        assert copilot_model_api_mode("claude-opus-4.7") == "chat_completions"
+        assert copilot_model_api_mode("claude-opus-4.6-fast") == "chat_completions"
 
     def test_copilot_api_mode_with_catalog_both_endpoints(self):
         """When catalog shows both endpoints, model ID pattern wins."""

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -12,6 +12,7 @@ import tools.approval as approval_module
 from tools.approval import (
     _get_approval_mode,
     _smart_approve,
+    approve_permanent,
     approve_session,
     detect_dangerous_command,
     is_approved,
@@ -534,19 +535,99 @@ class TestPatternKeyUniqueness:
         )
         _clear_session(session)
 
-    def test_legacy_find_key_still_approves_find_exec(self):
-        """Old allowlist entry 'find' should keep approving the matching command."""
+    def test_legacy_find_key_no_longer_authorizes_without_scope(self):
+        """Old string allowlist entry 'find' is review-only, not durable authority."""
         _, key_exec, _ = detect_dangerous_command("find . -exec rm {} \\;")
         with mock_patch.object(approval_module, "_permanent_approved", set()):
-            load_permanent({"find"})
-            assert is_approved("legacy-find", key_exec) is True
+            with mock_patch.object(approval_module, "_scoped_approval_records", {}):
+                load_permanent({"find"})
+                assert is_approved("legacy-find", key_exec) is False
 
-    def test_legacy_find_key_still_approves_find_delete(self):
-        """Old colliding allowlist entry 'find' should remain backwards compatible."""
+    def test_scoped_legacy_find_record_still_approves_find_exec(self):
+        """A scoped record using the old alias still approves matching commands."""
+        _, key_exec, _ = detect_dangerous_command("find . -exec rm {} \\;")
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            with mock_patch.object(approval_module, "_scoped_approval_records", {}):
+                load_permanent([
+                    {
+                        "pattern_key": "find",
+                        "action": "delete matched files",
+                        "system": "local-terminal",
+                        "credential_spend_risk": "filesystem delete risk",
+                        "expiration": "2099-01-01T00:00:00+00:00",
+                        "owner": "Anthony",
+                    }
+                ])
+                assert is_approved("legacy-find", key_exec) is True
+
+    def test_legacy_find_key_no_longer_approves_find_delete(self):
+        """Old colliding allowlist entry 'find' must not remain broad authority."""
         _, key_delete, _ = detect_dangerous_command("find . -name '*.tmp' -delete")
         with mock_patch.object(approval_module, "_permanent_approved", set()):
-            load_permanent({"find"})
-            assert is_approved("legacy-find", key_delete) is True
+            with mock_patch.object(approval_module, "_scoped_approval_records", {}):
+                load_permanent({"find"})
+                assert is_approved("legacy-find", key_delete) is False
+
+    def test_scoped_legacy_find_record_still_approves_find_delete(self):
+        """A scoped legacy alias keeps migration compatibility without string authority."""
+        _, key_delete, _ = detect_dangerous_command("find . -name '*.tmp' -delete")
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            with mock_patch.object(approval_module, "_scoped_approval_records", {}):
+                load_permanent([
+                    {
+                        "pattern_key": "find",
+                        "action": "delete matched files",
+                        "system": "local-terminal",
+                        "credential_spend_risk": "filesystem delete risk",
+                        "expiration": "2099-01-01T00:00:00+00:00",
+                        "owner": "Anthony",
+                    }
+                ])
+                assert is_approved("legacy-find", key_delete) is True
+
+
+class TestScopedApprovalRecords:
+    def test_permanent_approval_requires_scoped_record_fields(self):
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            record = approve_permanent(
+                "rm:recursive",
+                action="delete temp files",
+                system="local-terminal",
+                credential_spend_risk="none",
+                expiration="2099-01-01T00:00:00+00:00",
+                owner="Anthony",
+            )
+
+            assert record["pattern_key"] == "rm:recursive"
+            assert record["action"] == "delete temp files"
+            assert record["system"] == "local-terminal"
+            assert record["credential_spend_risk"] == "none"
+            assert record["expiration"] == "2099-01-01T00:00:00+00:00"
+            assert record["owner"] == "Anthony"
+            assert is_approved("scoped", "rm:recursive") is True
+
+    def test_scoped_approval_rejects_missing_required_metadata(self):
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            try:
+                approve_permanent("rm:recursive")
+            except ValueError as exc:
+                assert "scoped approval" in str(exc).lower()
+            else:
+                raise AssertionError("approve_permanent accepted an unscoped permanent approval")
+
+    def test_expired_scoped_approval_does_not_authorize(self):
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            with mock_patch.object(approval_module, "_scoped_approval_records", {}):
+                approve_permanent(
+                    "rm:expired",
+                    action="delete temp files",
+                    system="local-terminal",
+                    credential_spend_risk="none",
+                    expiration="2000-01-01T00:00:00+00:00",
+                    owner="Anthony",
+                )
+
+                assert is_approved("scoped", "rm:expired") is False
 
 
 class TestFullCommandAlwaysShown:
@@ -571,12 +652,12 @@ class TestFullCommandAlwaysShown:
             result = prompt_dangerous_approval(long_cmd, "recursive delete")
         assert result == "session"
 
-    def test_always_with_long_command(self):
-        """Pressing 'a' approves always with long commands."""
+    def test_scoped_approval_with_long_command(self):
+        """Pressing 'a' creates the scoped durable approval path with long commands."""
         long_cmd = "rm -rf " + "d" * 200
         with mock_patch("builtins.input", return_value="a"):
             result = prompt_dangerous_approval(long_cmd, "recursive delete")
-        assert result == "always"
+        assert result == "scoped"
 
     def test_deny_with_long_command(self):
         """Pressing 'd' denies with long commands."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -5,7 +5,7 @@ This module is the single source of truth for the dangerous command system:
 - Per-session approval state (thread-safe, keyed by session_key)
 - Approval prompting (CLI interactive + gateway async)
 - Smart approval via auxiliary LLM (auto-approve low-risk commands)
-- Permanent allowlist persistence (config.yaml)
+- Scoped approval persistence (config.yaml command_allowlist records)
 """
 
 import contextvars
@@ -16,7 +16,8 @@ import sys
 import threading
 import time
 import unicodedata
-from typing import Optional
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
 from hermes_cli.config import cfg_get
 
 from utils import env_var_enabled, is_truthy_value
@@ -494,7 +495,16 @@ _lock = threading.Lock()
 _pending: dict[str, dict] = {}
 _session_approved: dict[str, set] = {}
 _session_yolo: set[str] = set()
-_permanent_approved: set = set()
+_permanent_approved: set = set()  # Legacy read-only compatibility surface.
+_scoped_approval_records: dict[str, list[dict[str, Any]]] = {}
+_SCOPED_APPROVAL_FIELDS = (
+    "pattern_key",
+    "action",
+    "system",
+    "credential_spend_risk",
+    "expiration",
+    "owner",
+)
 
 # =========================================================================
 # Blocking gateway approval (mirrors CLI's synchronous input() flow)
@@ -636,64 +646,202 @@ def is_current_session_yolo_enabled() -> bool:
     return is_session_yolo_enabled(get_current_session_key(default=""))
 
 
+def _parse_scoped_approval_expiration(value: str) -> datetime:
+    """Parse an ISO-ish expiration timestamp into an aware UTC datetime."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("scoped approval requires expiration")
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError("scoped approval expiration must be ISO-8601") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _scoped_approval_is_active(record: dict[str, Any], now: datetime | None = None) -> bool:
+    try:
+        expiration = _parse_scoped_approval_expiration(record.get("expiration", ""))
+    except ValueError:
+        return False
+    now = now or datetime.now(timezone.utc)
+    return expiration > now
+
+
+def _coerce_scoped_approval_record(item: Any) -> dict[str, Any] | None:
+    """Return a normalized scoped approval record, or None for legacy strings."""
+    if isinstance(item, str):
+        # Legacy command_allowlist strings are not silently converted into live
+        # authority. They remain visible in config for manual review/migration.
+        return None
+    if not isinstance(item, dict):
+        return None
+    record = {field: str(item.get(field, "")).strip() for field in _SCOPED_APPROVAL_FIELDS}
+    if any(not record[field] for field in _SCOPED_APPROVAL_FIELDS):
+        return None
+    if not _scoped_approval_is_active(record):
+        return None
+    return record
+
+
+def _store_scoped_approval_record(record: dict[str, Any]) -> None:
+    _scoped_approval_records.setdefault(record["pattern_key"], []).append(record)
+    # Keep legacy introspection/tests able to see which keys have an active
+    # scoped grant, without treating arbitrary legacy strings as authority.
+    _permanent_approved.add(record["pattern_key"])
+
+
+def _active_scoped_approval_for_aliases(aliases: set[str]) -> dict[str, Any] | None:
+    for alias in aliases:
+        for record in list(_scoped_approval_records.get(alias, [])):
+            if _scoped_approval_is_active(record):
+                return record
+        # Prune expired/malformed records opportunistically.
+        if alias in _scoped_approval_records:
+            active = [r for r in _scoped_approval_records[alias] if _scoped_approval_is_active(r)]
+            if active:
+                _scoped_approval_records[alias] = active
+            else:
+                _scoped_approval_records.pop(alias, None)
+                _permanent_approved.discard(alias)
+    return None
+
+
+def build_scoped_approval_record(
+    pattern_key: str,
+    *,
+    action: str,
+    system: str,
+    credential_spend_risk: str,
+    expiration: str,
+    owner: str,
+) -> dict[str, str]:
+    """Create a validated scoped approval record for durable authority."""
+    record = {
+        "pattern_key": str(pattern_key or "").strip(),
+        "action": str(action or "").strip(),
+        "system": str(system or "").strip(),
+        "credential_spend_risk": str(credential_spend_risk or "").strip(),
+        "expiration": str(expiration or "").strip(),
+        "owner": str(owner or "").strip(),
+    }
+    missing = [field for field, value in record.items() if not value]
+    if missing:
+        raise ValueError(f"scoped approval missing required metadata: {', '.join(missing)}")
+    _parse_scoped_approval_expiration(record["expiration"])
+    return record
+
+
+def scoped_approval_record_for_command(pattern_key: str, description: str, *, owner: str = "Anthony") -> dict[str, str]:
+    """Build the default bounded record for an explicit long-lived approval."""
+    expiration = (datetime.now(timezone.utc) + timedelta(days=30)).replace(microsecond=0).isoformat()
+    return build_scoped_approval_record(
+        pattern_key,
+        action=description or pattern_key,
+        system="local-terminal",
+        credential_spend_risk="dangerous-command / local-system risk",
+        expiration=expiration,
+        owner=owner,
+    )
+
+
 def is_approved(session_key: str, pattern_key: str) -> bool:
-    """Check if a pattern is approved (session-scoped or permanent).
+    """Check if a pattern is approved by session state or active scoped record.
 
     Accept both the current canonical key and the legacy regex-derived key so
-    existing command_allowlist entries continue to work after key migrations.
+    session approvals continue to work after key migrations. Legacy durable
+    command_allowlist strings are loaded for review but are not authority unless
+    represented as scoped approval records with action/system/risk/expiration/owner.
     """
     aliases = _approval_key_aliases(pattern_key)
     with _lock:
-        if any(alias in _permanent_approved for alias in aliases):
+        if _active_scoped_approval_for_aliases(aliases) is not None:
             return True
         session_approvals = _session_approved.get(session_key, set())
         return any(alias in session_approvals for alias in aliases)
 
 
-def approve_permanent(pattern_key: str):
-    """Add a pattern to the permanent allowlist."""
+def approve_permanent(
+    pattern_key: str,
+    *,
+    action: str | None = None,
+    system: str | None = None,
+    credential_spend_risk: str | None = None,
+    expiration: str | None = None,
+    owner: str | None = None,
+):
+    """Store a scoped approval record; unscoped permanent approvals are refused."""
+    if not all([action, system, credential_spend_risk, expiration, owner]):
+        raise ValueError(
+            "scoped approval requires action, system, credential_spend_risk, "
+            "expiration, and owner"
+        )
+    record = build_scoped_approval_record(
+        pattern_key,
+        action=action or "",
+        system=system or "",
+        credential_spend_risk=credential_spend_risk or "",
+        expiration=expiration or "",
+        owner=owner or "",
+    )
     with _lock:
-        _permanent_approved.add(pattern_key)
+        _store_scoped_approval_record(record)
+    return dict(record)
 
 
-def load_permanent(patterns: set):
-    """Bulk-load permanent allowlist entries from config."""
+def load_permanent(patterns):
+    """Bulk-load scoped approval records from config, ignoring legacy strings."""
     with _lock:
-        _permanent_approved.update(patterns)
+        for item in patterns or set():
+            record = _coerce_scoped_approval_record(item)
+            if record:
+                _store_scoped_approval_record(record)
 
 
 
 # =========================================================================
-# Config persistence for permanent allowlist
+# Config persistence for scoped approval records
 # =========================================================================
 
-def load_permanent_allowlist() -> set:
-    """Load permanently allowed command patterns from config.
+def load_permanent_allowlist() -> list:
+    """Load scoped command approval records from config.
 
-    Also syncs them into the approval module so is_approved() works for
-    patterns added via 'always' in a previous session.
+    Legacy string entries in command_allowlist are returned for visibility but
+    intentionally do not authorize future commands. Durable authority now needs
+    action, system, credential_spend_risk, expiration, and owner.
     """
     try:
         from hermes_cli.config import load_config
         config = load_config()
-        patterns = set(config.get("command_allowlist", []) or [])
-        if patterns:
-            load_permanent(patterns)
-        return patterns
+        records = list(config.get("command_allowlist", []) or [])
+        if records:
+            load_permanent(records)
+        return records
     except Exception as e:
-        logger.warning("Failed to load permanent allowlist: %s", e)
-        return set()
+        logger.warning("Failed to load scoped approval records: %s", e)
+        return []
 
 
-def save_permanent_allowlist(patterns: set):
-    """Save permanently allowed command patterns to config."""
+def save_permanent_allowlist(patterns):
+    """Save active scoped approval records to config."""
     try:
         from hermes_cli.config import load_config, save_config
         config = load_config()
-        config["command_allowlist"] = list(patterns)
+        if patterns is _permanent_approved or patterns is None:
+            records = [dict(record) for values in _scoped_approval_records.values() for record in values]
+        else:
+            records = []
+            for item in patterns or []:
+                record = _coerce_scoped_approval_record(item)
+                if record:
+                    records.append(dict(record))
+        config["command_allowlist"] = records
         save_config(config)
     except Exception as e:
-        logger.warning("Could not save allowlist: %s", e)
+        logger.warning("Could not save scoped approval records: %s", e)
 
 
 # =========================================================================
@@ -708,13 +856,13 @@ def prompt_dangerous_approval(command: str, description: str,
 
     Args:
         allow_permanent: When False, hide the [a]lways option (used when
-            tirith warnings are present, since broad permanent allowlisting
+            tirith warnings are present, since broad durable allowlisting
             is inappropriate for content-level security findings).
         approval_callback: Optional callback registered by the CLI for
             prompt_toolkit integration. Signature:
             (command, description, *, allow_permanent=True) -> str.
 
-    Returns: 'once', 'session', 'always', or 'deny'
+    Returns: 'once', 'session', 'scoped', or 'deny'
     """
     if timeout_seconds is None:
         timeout_seconds = _get_approval_timeout()
@@ -795,12 +943,12 @@ def prompt_dangerous_approval(command: str, description: str,
             elif choice in {'s', 'session'}:
                 print(t("approval.allowed_session"))
                 return "session"
-            elif choice in {'a', 'always'}:
+            elif choice in {'a', 'always', 'scoped'}:
                 if not allow_permanent:
                     print(t("approval.allowed_session"))
                     return "session"
-                print(t("approval.allowed_always"))
-                return "always"
+                print("Approved as a scoped approval record (30-day default; metadata required).")
+                return "scoped"
             else:
                 print(t("approval.denied"))
                 return "deny"
@@ -1011,10 +1159,11 @@ def check_dangerous_command(command: str, env_type: str,
 
     if choice == "session":
         approve_session(session_key, pattern_key)
-    elif choice == "always":
+    elif choice in {"always", "scoped"}:
+        record = scoped_approval_record_for_command(pattern_key, description)
         approve_session(session_key, pattern_key)
-        approve_permanent(pattern_key)
-        save_permanent_allowlist(_permanent_approved)
+        approve_permanent(**record)
+        save_permanent_allowlist(None)
 
     return {"approved": True, "message": None}
 
@@ -1341,12 +1490,13 @@ def check_all_command_guards(command: str, env_type: str,
 
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
-                if choice == "session" or (choice == "always" and is_tirith):
+                if choice == "session" or (choice in {"always", "scoped"} and is_tirith):
                     approve_session(session_key, key)
-                elif choice == "always":
+                elif choice in {"always", "scoped"}:
+                    record = scoped_approval_record_for_command(key, combined_desc)
                     approve_session(session_key, key)
-                    approve_permanent(key)
-                    save_permanent_allowlist(_permanent_approved)
+                    approve_permanent(**record)
+                    save_permanent_allowlist(None)
                 # choice == "once": no persistence — command allowed this
                 # single time only, matching the CLI's behavior.
 
@@ -1417,18 +1567,19 @@ def check_all_command_guards(command: str, env_type: str,
 
     # Persist approval for each warning individually
     for key, _, is_tirith in warnings:
-        if choice == "session" or (choice == "always" and is_tirith):
-            # tirith: session only (no permanent broad allowlisting)
+        if choice == "session" or (choice in {"always", "scoped"} and is_tirith):
+            # tirith: session only (no broad durable allowlisting)
             approve_session(session_key, key)
-        elif choice == "always":
-            # dangerous patterns: permanent allowed
+        elif choice in {"always", "scoped"}:
+            # dangerous patterns: scoped approval record only
+            record = scoped_approval_record_for_command(key, combined_desc)
             approve_session(session_key, key)
-            approve_permanent(key)
-            save_permanent_allowlist(_permanent_approved)
+            approve_permanent(**record)
+            save_permanent_allowlist(None)
 
     return {"approved": True, "message": None,
             "user_approved": True, "description": combined_desc}
 
 
-# Load permanent allowlist from config on module import
+# Load scoped approval records from config on module import
 load_permanent_allowlist()


### PR DESCRIPTION
## Summary
- hardens Telegram/gateway reliability safety behavior
- updates scoped approval records away from permanent approvals
- repairs Copilot model catalog validation expectations

## Verification
- Python compile passed
- memory-kbase-usage-gate direct probe passed
- gbrain direct probe passed
- gateway tests passed: 36 passed
- approval tests passed: 193 passed
- Copilot/model tests passed: 116 passed
- Copilot watchdog direct probe passed

## Proof note
Fork branch: Antman316:ezra/reliability-safety-gates-20260527
HEAD: 35be319f69f986b8658f7895fc3bbd6afae54b22