### PR TITLE
fix(cron): pull Bitwarden Secrets Manager secrets in run_job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1481,6 +1481,19 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except UnicodeDecodeError:
             load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
 
+        # Pull Bitwarden Secrets Manager secrets into os.environ so cron jobs
+        # resolve BSM-managed credentials the same way the gateway and CLI do.
+        # Without this, jobs see the .env placeholder string and fail with
+        # HTTP 401. The _APPLIED_HOMES process-level dedup added in #32271
+        # (de76f4d) makes calling this on every tick effectively free after the
+        # first successful pull. Any failure is logged and swallowed — BSM
+        # must never block job execution.
+        try:
+            from hermes_cli.env_loader import _apply_external_secret_sources
+            _apply_external_secret_sources(_get_hermes_home())
+        except Exception:
+            logger.debug("BSM secret apply failed", exc_info=True)
+
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1489,8 +1489,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # first successful pull. Any failure is logged and swallowed — BSM
         # must never block job execution.
         try:
-            from hermes_cli.env_loader import _apply_external_secret_sources
-            _apply_external_secret_sources(_get_hermes_home())
+            from hermes_cli.env_loader import apply_external_secret_sources
+            apply_external_secret_sources(_get_hermes_home())
         except Exception:
             logger.debug("BSM secret apply failed", exc_info=True)
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -55,7 +55,7 @@ def get_secret_source(env_var: str) -> str | None:
 def reset_secret_source_cache() -> None:
     """Forget which HERMES_HOME paths have already had external secrets applied.
 
-    The first call to ``_apply_external_secret_sources(home_path)`` in a
+    The first call to ``apply_external_secret_sources(home_path)`` in a
     process pulls from Bitwarden (or other configured backend), records the
     applied keys in ``_SECRET_SOURCES``, and remembers ``home_path`` so
     subsequent calls in the same process are no-ops.  Call this to force the
@@ -242,12 +242,12 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
-    _apply_external_secret_sources(home_path)
+    apply_external_secret_sources(home_path)
 
     return loaded
 
 
-def _apply_external_secret_sources(home_path: Path) -> None:
+def apply_external_secret_sources(home_path: Path) -> None:
     """Pull secrets from external sources (currently Bitwarden) into env.
 
     Runs AFTER dotenv loads so .env values are visible (we use them to
@@ -263,6 +263,11 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     ``reset_secret_source_cache()`` if you need to force a re-pull
     (tests, future ``hermes secrets bitwarden sync`` from a long-running
     process).
+
+    Exposed as a public name so callers outside ``load_hermes_dotenv()``
+    (notably ``cron/scheduler.py:run_job``, which does its own dotenv
+    reload per tick) can reuse the same code path without reaching into
+    a name-mangled private symbol.
     """
     home_key = str(Path(home_path).resolve())
     if home_key in _APPLIED_HOMES:
@@ -321,6 +326,12 @@ def _apply_external_secret_sources(home_path: Path) -> None:
             f"  Bitwarden Secrets Manager: {warn}",
             file=sys.stderr,
         )
+
+
+# Backward-compatible alias: existing tests / out-of-tree callers may still
+# import the private name.  Keep the alias so they don't break; new callers
+# should use the public ``apply_external_secret_sources`` instead.
+_apply_external_secret_sources = apply_external_secret_sources
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2597,3 +2597,154 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == str(fast.resolve())
+
+
+class TestRunJobBSMSecretResolution:
+    """run_job must pull Bitwarden Secrets Manager secrets into os.environ.
+
+    Regression for #33465: the cron scheduler previously called bare
+    ``dotenv.load_dotenv()`` and never invoked the BSM apply path. Any
+    cron job that needed a BSM-managed credential saw the .env placeholder
+    instead of the real value and failed with HTTP 401. The gateway
+    resolved BSM secrets fine because it goes through ``load_hermes_dotenv()``;
+    cron must do equivalent work.
+    """
+
+    _RUNTIME = {
+        "api_key": "test-key",
+        "base_url": "https://example.invalid/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+    }
+
+    @pytest.fixture(autouse=True)
+    def _import_run_agent_eagerly(self):
+        """Import run_agent before the test sets HERMES_HOME=tmp_path.
+
+        run_agent.py runs ``load_hermes_dotenv()`` at module-import time. If we
+        let ``patch("run_agent.AIAgent")`` trigger that import inside the test
+        body, the module-level dotenv load picks up our tmp_path-rooted
+        HERMES_HOME and calls _apply_external_secret_sources for us — masking
+        whether the scheduler itself is doing the work. Force run_agent to
+        load once, with the ambient HERMES_HOME, before the test starts."""
+        import run_agent  # noqa: F401
+
+    def test_run_job_applies_bitwarden_secrets(self, tmp_path, monkeypatch):
+        """BSM apply must run during run_job so the secret lands in os.environ
+        before AIAgent is constructed."""
+        from agent.secret_sources.bitwarden import FetchResult
+        from hermes_cli import env_loader
+
+        # Clean per-process dedup state so the apply path actually runs.
+        env_loader._SECRET_SOURCES.clear()
+        env_loader.reset_secret_source_cache()
+
+        (tmp_path / "config.yaml").write_text(
+            "secrets:\n"
+            "  bitwarden:\n"
+            "    enabled: true\n"
+            "    project_id: test-project\n"
+            "    access_token_env: BWS_ACCESS_TOKEN\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        api_key_during_init: dict = {}
+
+        class _FakeAgent:
+            def __init__(self, **_kw):
+                # Snapshot the env at the moment AIAgent is constructed —
+                # this is when the agent reads credentials.
+                api_key_during_init["value"] = os.environ.get("ANTHROPIC_API_KEY")
+
+            def run_conversation(self, *_a, **_kw):
+                return {"final_response": "ok", "messages": []}
+
+            def close(self):
+                pass
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 0.0}
+
+        def _fake_apply(**_kwargs):
+            # Mirror the real apply_bitwarden_secrets contract: secrets that
+            # land in `applied` must also be written to os.environ. The
+            # callers (env_loader, our cron fix) rely on this.
+            os.environ["ANTHROPIC_API_KEY"] = "sk-ant-from-bitwarden"
+            return FetchResult(
+                secrets={"ANTHROPIC_API_KEY": "sk-ant-from-bitwarden"},
+                applied=["ANTHROPIC_API_KEY"],
+            )
+
+        import agent.secret_sources.bitwarden as bw_module
+        monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _fake_apply)
+
+        job = {"id": "bsm-job", "name": "bsm", "prompt": "hi"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent", _FakeAgent):
+            success, _output, _response, error = run_job(job)
+
+        assert success is True, f"run_job failed: {error!r}"
+        # The BSM value must be visible in os.environ by the time AIAgent
+        # is constructed. Before #33465 this was None because cron never
+        # ran the BSM apply step.
+        assert api_key_during_init["value"] == "sk-ant-from-bitwarden", (
+            "ANTHROPIC_API_KEY was not populated from Bitwarden during "
+            "run_job; the BSM apply step is missing from the scheduler."
+        )
+        # Origin tracking must still record where the value came from.
+        assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "bitwarden"
+
+        env_loader._SECRET_SOURCES.clear()
+        env_loader.reset_secret_source_cache()
+
+    def test_run_job_does_not_crash_when_bsm_apply_raises(self, tmp_path, monkeypatch):
+        """A failure in the BSM apply path must never block job execution —
+        the cron scheduler swallows the error and continues."""
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCES.clear()
+        env_loader.reset_secret_source_cache()
+
+        (tmp_path / "config.yaml").write_text(
+            "secrets:\n"
+            "  bitwarden:\n"
+            "    enabled: true\n"
+            "    project_id: test-project\n"
+            "    access_token_env: BWS_ACCESS_TOKEN\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        def _boom(**_kwargs):
+            raise RuntimeError("simulated BSM backend failure")
+
+        import agent.secret_sources.bitwarden as bw_module
+        monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _boom)
+
+        job = {"id": "bsm-fail-job", "name": "bsm-fail", "prompt": "hi"}
+
+        fake_db = MagicMock()
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _output, _response, error = run_job(job)
+
+        # Job must still succeed — BSM failures cannot block cron execution.
+        assert success is True, f"run_job failed when BSM raised: {error!r}"
+
+        env_loader._SECRET_SOURCES.clear()
+        env_loader.reset_secret_source_cache()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2624,20 +2624,36 @@ class TestRunJobBSMSecretResolution:
         run_agent.py runs ``load_hermes_dotenv()`` at module-import time. If we
         let ``patch("run_agent.AIAgent")`` trigger that import inside the test
         body, the module-level dotenv load picks up our tmp_path-rooted
-        HERMES_HOME and calls _apply_external_secret_sources for us — masking
+        HERMES_HOME and calls apply_external_secret_sources for us — masking
         whether the scheduler itself is doing the work. Force run_agent to
         load once, with the ambient HERMES_HOME, before the test starts."""
         import run_agent  # noqa: F401
+
+    @pytest.fixture(autouse=True)
+    def _isolate_secret_source_state(self):
+        """Reset env_loader's per-process secret-source state around every test.
+
+        Both ``_SECRET_SOURCES`` (the bitwarden-origin label cache) and the
+        ``_APPLIED_HOMES`` dedup set are process-global. Clearing only at
+        end-of-test would leak state into sibling tests if an assertion fails
+        first; the autouse setup+teardown form guarantees cleanup even on
+        failure. ``test_scheduler.py`` is large and many tests share env state.
+        """
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCES.clear()
+        env_loader.reset_secret_source_cache()
+        try:
+            yield
+        finally:
+            env_loader._SECRET_SOURCES.clear()
+            env_loader.reset_secret_source_cache()
 
     def test_run_job_applies_bitwarden_secrets(self, tmp_path, monkeypatch):
         """BSM apply must run during run_job so the secret lands in os.environ
         before AIAgent is constructed."""
         from agent.secret_sources.bitwarden import FetchResult
         from hermes_cli import env_loader
-
-        # Clean per-process dedup state so the apply path actually runs.
-        env_loader._SECRET_SOURCES.clear()
-        env_loader.reset_secret_source_cache()
 
         (tmp_path / "config.yaml").write_text(
             "secrets:\n"
@@ -2701,17 +2717,9 @@ class TestRunJobBSMSecretResolution:
         # Origin tracking must still record where the value came from.
         assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "bitwarden"
 
-        env_loader._SECRET_SOURCES.clear()
-        env_loader.reset_secret_source_cache()
-
     def test_run_job_does_not_crash_when_bsm_apply_raises(self, tmp_path, monkeypatch):
         """A failure in the BSM apply path must never block job execution —
         the cron scheduler swallows the error and continues."""
-        from hermes_cli import env_loader
-
-        env_loader._SECRET_SOURCES.clear()
-        env_loader.reset_secret_source_cache()
-
         (tmp_path / "config.yaml").write_text(
             "secrets:\n"
             "  bitwarden:\n"
@@ -2745,6 +2753,3 @@ class TestRunJobBSMSecretResolution:
 
         # Job must still succeed — BSM failures cannot block cron execution.
         assert success is True, f"run_job failed when BSM raised: {error!r}"
-
-        env_loader._SECRET_SOURCES.clear()
-        env_loader.reset_secret_source_cache()


### PR DESCRIPTION
## What does this PR do?

The cron scheduler called bare `dotenv.load_dotenv()` and never invoked the Bitwarden Secrets Manager (BSM) apply path. Any cron job that needed a BSM-managed credential (Discord token, provider API key, etc.) saw the `.env` placeholder string instead of the real value and failed with HTTP 401, while the gateway and the CLI happily resolved the same secrets via `load_hermes_dotenv()`.

This PR adds a follow-up call to `_apply_external_secret_sources(_get_hermes_home())` immediately after the existing dotenv reload in `_run_job_impl`, so cron picks up the same secrets the gateway does. The `_APPLIED_HOMES` process-level dedup added in #32271 (`de76f4d`) makes calling this on every tick effectively free after the first successful pull. A failing BSM backend must never block job execution, so the call is wrapped in a `debug`-logged `try/except`.

### Why additive instead of switching to `load_hermes_dotenv()`?

The issue's suggested fix is to replace `from dotenv import load_dotenv; load_dotenv(...)` with `load_hermes_dotenv(...)`. I chose the minimal additive change instead for two reasons:

- 19 existing cron tests patch `dotenv.load_dotenv` directly (see `tests/cron/test_scheduler.py`, `tests/cron/test_cron_profile.py`, `tests/cron/test_cron_workdir.py`). `load_hermes_dotenv` binds `load_dotenv` at module-import time inside `hermes_cli/env_loader.py`, so those patches would no longer intercept and the test suite would need a coordinated rewrite.
- `load_hermes_dotenv` also loads a `project_env` (`<repo>/.env`) when passed one. The scheduler has never loaded a project env, so switching to it would silently broaden the load surface beyond what the bug requires.

The bug is specifically the missing BSM apply step. Calling `_apply_external_secret_sources` directly delivers exactly that, leaves the existing dotenv flow (and its test contract) untouched, and is the same step `load_hermes_dotenv` itself invokes after its dotenv calls. `_apply_external_secret_sources` is already a stable, directly-tested API (see `tests/test_env_loader_secret_sources.py` and `tests/test_bitwarden_secrets.py`).

## Related Issue

Fixes #33465

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — after the dotenv reload in `_run_job_impl`, lazily import `_apply_external_secret_sources` and call it with the cron job's HERMES_HOME so BSM secrets land in `os.environ` before `AIAgent` is constructed; swallow any exception with a `debug` log so a failing backend can't block job execution.
- `tests/cron/test_scheduler.py` — add `TestRunJobBSMSecretResolution` with two cases: (1) BSM-enabled config makes the apply path put `ANTHROPIC_API_KEY` into `os.environ` before `AIAgent` init; (2) a raising BSM backend does not block `run_job`. An autouse fixture imports `run_agent` eagerly so its module-level `load_hermes_dotenv` runs once against the ambient HERMES_HOME and doesn't mask whether the scheduler itself is invoking the apply path.

## How to Test

1. Reproduce the bug on `origin/main` (before this PR): configure `~/.hermes/config.yaml` with `secrets.bitwarden.enabled: true` and a valid BSM project, set the provider API key value only in BSM (not in `.env`), and observe that any cron-scheduled job receives HTTP 401 on first tick while the gateway resolves the same key cleanly.
2. With this PR applied, the same cron job picks up the BSM-managed key and runs without 401.
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/cron/test_scheduler.py::TestRunJobBSMSecretResolution -v` — both new cases pass.
4. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/cron/ tests/test_env_loader_secret_sources.py tests/test_bitwarden_secrets.py -v` — 215 existing + new tests all pass; no regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (inline comments cover the *why*)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (the apply path is platform-agnostic; behaves identically on Windows, macOS, and Linux)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

> Audited siblings: confirmed the only other in-process entrypoints that need BSM applied (`cli.py`, `gateway/run.py`, `trajectory_compressor.py`, `hermes_cli/main.py`, `acp_adapter/entry.py`, `tui_gateway/server.py`, `tools/mcp_tool.py`, `gateway/platforms/feishu_comment_rules.py`, `hermes_cli/doctor.py`, `hermes_cli/dump.py`, `scripts/discord-voice-doctor.py`) all already call `load_hermes_dotenv()` at module-import time and therefore already invoke `_apply_external_secret_sources`. The cron scheduler was the lone gap. No widening needed.

## Screenshots / Logs

_N/A._