### PR TITLE
fix(docker): align HOME for dashboard and s6 gateway services

### DIFF
--- a/docker/s6-rc.d/dashboard/run
+++ b/docker/s6-rc.d/dashboard/run
@@ -19,6 +19,10 @@ case "${HERMES_DASHBOARD:-}" in
         ;;
 esac
 
+# with-contenv repopulates HOME from /init as /root. Reset it before
+# dropping privileges so HOME-anchored state lands under /opt/data.
+export HOME=/opt/data
+
 cd /opt/data
 # shellcheck disable=SC1091
 . /opt/hermes/.venv/bin/activate

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -566,8 +566,11 @@ class S6ServiceManager:
           1. Sources HERMES_HOME (and any extra env) via with-contenv —
              so e.g. ``-e HERMES_HOME=/data/hermes`` is honored at run
              time, not Python-substituted at registration time (OQ8-C).
-          2. Activates the bundled venv.
-          3. Drops to the hermes user and exec's
+          2. Resets ``HOME`` to ``/opt/data`` before the privilege drop
+             so with-contenv's root HOME does not leak into the
+             unprivileged gateway process.
+          3. Activates the bundled venv.
+          4. Drops to the hermes user and exec's
              ``hermes -p <profile> gateway run`` (or just ``hermes
              gateway run`` for the default profile — see below).
 
@@ -597,6 +600,7 @@ class S6ServiceManager:
             "#!/command/with-contenv sh",
             "# shellcheck shell=sh",
             "set -e",
+            "export HOME=/opt/data",
             "cd /opt/data",
             ". /opt/hermes/.venv/bin/activate",
         ]

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -536,6 +536,7 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
     assert run_path.is_file()
     assert run_path.stat().st_mode & 0o111  # executable
     run_text = run_path.read_text()
+    assert "export HOME=/opt/data" in run_text
     assert "hermes -p coder gateway run" in run_text
     assert "s6-setuidgid hermes" in run_text
 
@@ -569,6 +570,15 @@ def test_s6_register_extra_env_is_quoted(s6_scandir, fake_subprocess_run) -> Non
     # shlex.quote should have wrapped both values
     assert "export FOO='bar baz'" in run_text
     assert "export QUOTED='a'\"'\"'b'" in run_text
+
+
+def test_render_run_script_resets_home_before_exec() -> None:
+    from hermes_cli.service_manager import S6ServiceManager
+
+    run_text = S6ServiceManager._render_run_script("coder", {})
+
+    assert "export HOME=/opt/data" in run_text
+    assert "exec s6-setuidgid hermes hermes -p coder gateway run" in run_text
 
 
 def test_s6_register_rejects_invalid_profile_name(s6_scandir) -> None:

--- a/tests/test_docker_home_override_scripts.py
+++ b/tests/test_docker_home_override_scripts.py
@@ -1,0 +1,15 @@
+"""Regression tests for Docker HOME overrides under s6/with-contenv."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DASHBOARD_RUN = REPO_ROOT / "docker" / "s6-rc.d" / "dashboard" / "run"
+
+
+def test_dashboard_run_resets_home_before_dropping_privileges() -> None:
+    text = DASHBOARD_RUN.read_text(encoding="utf-8")
+
+    assert "#!/command/with-contenv sh" in text
+    assert "export HOME=/opt/data" in text
+    assert "exec s6-setuidgid hermes hermes dashboard" in text


### PR DESCRIPTION

## Summary

This brings the supervised Docker paths back in line with the HOME invariant introduced for the main container command path.

`docker/main-wrapper.sh` already resets `HOME=/opt/data` before dropping from root to the `hermes` user, but the supervised dashboard run script and dynamically generated s6 gateway run scripts were still inheriting `HOME=/root` from `with-contenv`. That left a parity gap between the direct CMD path and the supervised s6 paths.

## Parity Source

This PR is a parity follow-up to:

- 628aaea63a27e907507e404296333641e051e58b
- `fix(docker): propagate env through s6 to cont-init and main CMD`

That commit established the invariant that container processes running as the `hermes` user should resolve HOME under `/opt/data`, not `/root`. This PR applies the same invariant to the remaining supervised sibling paths.

## Problem

After `with-contenv`, supervised services can still see `HOME=/root` unless they explicitly reset it before `s6-setuidgid hermes`.

That meant:

- `docker/s6-rc.d/dashboard/run` could still run with root HOME semantics
- dynamically generated profile gateway run scripts from `S6ServiceManager._render_run_script()` could do the same

In practice, HOME-anchored state could end up resolving under `/root` or fail on permissions, depending on the library/tooling involved.

## Fix

- Add `export HOME=/opt/data` to `docker/s6-rc.d/dashboard/run`
- Add `export HOME=/opt/data` to the generated s6 gateway `run` script in `hermes_cli/service_manager.py`
- Add regression coverage for both paths

## Files Changed

- `docker/s6-rc.d/dashboard/run`
- `hermes_cli/service_manager.py`
- `tests/hermes_cli/test_service_manager.py`
- `tests/test_docker_home_override_scripts.py`

## Testing

### Tests run

```powershell
.venv\Scripts\python.exe -m pytest -o addopts= tests\hermes_cli\test_service_manager.py::test_render_run_script_resets_home_before_exec tests\test_docker_home_override_scripts.py -q

2 passed in 0.23s