### PR TITLE
fix: accept absolute paths and validate existence in _validate_cron_script_path

### DIFF
--- a/tests/tools/test_cronjob_script_validation.py
+++ b/tests/tools/test_cronjob_script_validation.py
@@ -1,0 +1,213 @@
+"""Tests for _validate_cron_script_path in tools/cronjob_tools.py.
+
+Validates two fixes:
+  1. Absolute paths within scripts_dir are accepted (write_file returns
+     absolute paths, so the LLM naturally passes them to the cron tool)
+  2. Script existence is checked at creation time (not 60s later at the
+     next scheduler tick)
+
+Both fixes align _validate_cron_script_path with the resolution logic
+already used by _run_job_script in cron/scheduler.py.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    (hermes_home / "scripts").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+    return hermes_home
+
+
+class TestAbsolutePathNormalization:
+    """Absolute paths within scripts_dir should be accepted, not rejected."""
+
+    def test_absolute_path_within_scripts_dir_accepted(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "monitor.py").write_text("print('ok')")
+
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path(str(scripts_dir / "monitor.py"))
+        assert err is None, f"Absolute path within scripts_dir should be accepted, got: {err}"
+
+    def test_absolute_path_outside_scripts_dir_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("/etc/passwd")
+        assert err is not None, "Absolute path outside scripts_dir should be rejected"
+
+    def test_absolute_path_nonexistent_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path(str(scripts_dir / "nope.py"))
+        assert err is not None
+        assert "not found" in err.lower()
+
+    def test_create_with_absolute_path_succeeds(self, cron_env, monkeypatch):
+        """The natural LLM flow: write_file returns absolute path, pass it to cronjob."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+        script_path = scripts_dir / "a-share-test.py"
+        script_path.write_text("print('ok')")
+
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 1h",
+                prompt="Analyze A-shares",
+                script=str(script_path),
+            )
+        )
+        assert result["success"] is True
+
+
+class TestExistenceValidation:
+    """Script must exist at creation time — fail fast, not at scheduler tick."""
+
+    def test_nonexistent_script_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("does_not_exist.py")
+        assert err is not None, "Non-existent script should be rejected"
+        assert "not found" in err.lower()
+
+    def test_existing_script_accepted(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "monitor.py").write_text("print('ok')")
+
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("monitor.py")
+        assert err is None, f"Existing script should be accepted, got: {err}"
+
+    def test_nonexistent_script_in_subdirectory_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("checks/check_sumitaro.py")
+        assert err is not None
+
+    def test_existing_script_in_subdirectory_accepted(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "checks").mkdir()
+        (scripts_dir / "checks" / "check_sumitaro.py").write_text("print('ok')")
+
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("checks/check_sumitaro.py")
+        assert err is None, f"Existing script in subdirectory should be accepted, got: {err}"
+
+    def test_create_with_nonexistent_script_fails(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 1h",
+                prompt="Monitor things",
+                script="check_sumitaro.py",
+            )
+        )
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_create_with_existing_script_succeeds(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "monitor.py").write_text("print('ok')")
+
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 1h",
+                prompt="Monitor things",
+                script="monitor.py",
+            )
+        )
+        assert result["success"] is True
+        assert result["job"]["script"] == "monitor.py"
+
+
+class TestIsFileCheck:
+    """Directories and non-files must be rejected even if they exist."""
+
+    def test_directory_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "mydir").mkdir()
+
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("mydir")
+        assert err is not None
+        assert "not a file" in err.lower()
+
+    def test_directory_absolute_path_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "mydir").mkdir()
+
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path(str(scripts_dir / "mydir"))
+        assert err is not None
+        assert "not a file" in err.lower()
+
+
+class TestSecurityBoundary:
+    """Traversal and escape attempts must still be blocked."""
+
+    def test_traversal_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("../../etc/passwd")
+        assert err is not None
+
+    def test_tilde_nonexistent_user_rejected(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        err = _validate_cron_script_path("~nonexistent_user_xyz/foo.py")
+        assert err is not None
+
+    def test_empty_script_still_allowed(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        assert _validate_cron_script_path(None) is None
+        assert _validate_cron_script_path("") is None
+        assert _validate_cron_script_path("  ") is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -343,9 +343,10 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Validate a cron job script path at the API boundary.
 
-    Scripts must be relative paths that resolve within HERMES_HOME/scripts/.
-    Absolute paths and ~ expansion are rejected to prevent arbitrary script
-    execution via prompt injection.
+    Both absolute and relative paths are accepted and resolved against
+    HERMES_HOME/scripts/ (same logic as ``_run_job_script`` in
+    ``cron/scheduler.py``). The resolved path must be contained within
+    the scripts directory and must point to an existing file.
 
     Returns an error string if blocked, else None (valid).
     """
@@ -356,26 +357,39 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 
     raw = script.strip()
 
-    # Reject absolute paths and ~ expansion at the API boundary.
-    # Only relative paths within ~/.hermes/scripts/ are allowed.
-    if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
-        return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
-            f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename."
-        )
-
-    # Validate containment after resolution
-    from tools.path_security import validate_within_dir
-
+    # Resolve exactly like _run_job_script() in cron/scheduler.py:
+    # accept both absolute and relative paths, resolve against scripts_dir,
+    # then enforce containment + existence.
     scripts_dir = get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
-    containment_error = validate_within_dir(scripts_dir / raw, scripts_dir)
-    if containment_error:
+
+    p = Path(raw)
+    try:
+        p = p.expanduser()
+    except (RuntimeError, KeyError):
         return (
-            f"Script path escapes the scripts directory via traversal: {raw!r}"
+            f"Cannot expand '~' in script path: {raw!r}. "
+            f"Use a relative filename or absolute path within {scripts_dir}."
+        )
+    resolved = p.resolve() if p.is_absolute() else (scripts_dir / p).resolve()
+
+    try:
+        resolved.relative_to(scripts_dir.resolve())
+    except ValueError:
+        return (
+            f"Script path resolves outside the scripts directory: {raw!r}. "
+            f"Place scripts in {scripts_dir} and use just the filename."
         )
 
+    if not resolved.exists():
+        return (
+            f"Script not found: {resolved}. "
+            f"Place the script in {scripts_dir} before creating the job."
+        )
+    if not resolved.is_file():
+        return (
+            f"Script path is not a file: {resolved}"
+        )
     return None
 
 


### PR DESCRIPTION
## Summary

`_validate_cron_script_path` rejects absolute paths and doesn't check whether the script file exists. This creates two problems:

- **Absolute path rejection:** `write_file` returns absolute paths (e.g. `/opt/data/scripts/monitor.py`), so the LLM naturally passes them to the cron tool — which rejects them, wasting an API round-trip for self-correction. Meanwhile `_run_job_script` in `cron/scheduler.py` already accepts absolute paths.

- **Missing existence check:** A job referencing a non-existent script is silently created and only fails ~60s later at the next scheduler tick. `workdir` and `profile` both validate existence at creation time; `script` should too.

## Fix

Aligns `_validate_cron_script_path` with the resolution logic already used by `_run_job_script` in `cron/scheduler.py`:

1. Accept both absolute and relative paths
2. Resolve absolute paths directly, relative paths under `scripts_dir`
3. Check containment within `scripts_dir` (security boundary preserved)
4. Validate the script exists and is a file

Single function rewrite, ~30 lines changed in `tools/cronjob_tools.py`.

## Tests

15 tests in `tests/tools/test_cronjob_script_validation.py` across four categories:

- **Absolute path normalization** (4): within scripts_dir accepted, outside rejected, nonexistent rejected, end-to-end create succeeds
- **Existence validation** (6): nonexistent rejected, existing accepted, subdirectory paths, end-to-end create with both
- **Is-file check** (2): directories rejected for both relative and absolute paths
- **Security boundary** (3): traversal blocked, tilde expansion for nonexistent users blocked, empty/None script still allowed

## Test plan

- [ ] Run `pytest tests/tools/test_cronjob_script_validation.py -v` — all 15 tests pass
- [ ] Run `pytest tests/tools/test_cronjob_tools.py -v` — existing tests unaffected
- [ ] Manual: create a cron job with absolute path from `write_file` output — should succeed
- [ ] Manual: create a cron job referencing nonexistent script — should fail immediately with clear error