### PR TITLE
feat(freebsd): add FreeBSD platform support to installer and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ If you already have Git installed, the installer detects it and uses that instea
 >
 > **Windows:** Native Windows is fully supported — the PowerShell one-liner above installs everything. If you'd rather use WSL2, the Linux command works there too. Native Windows install lives under `%LOCALAPPDATA%\hermes`; WSL2 installs under `~/.hermes` as on Linux.
 
+### FreeBSD (community port)
+
+FreeBSD is a community-maintained [Tier 2 platform](https://hermes-agent.nousresearch.com/docs/getting-started/platform-support#tier-2). Install `bash`, then run the standard installer — it detects FreeBSD and pulls all dependencies from `pkg`:
+
+```sh
+pkg install bash
+bash -c "$(curl -fsSL https://hermes-agent.nousresearch.com/install.sh)"
+```
+
+Authenticate with an API key (`hermes model`) rather than `claude setup-token` (a Linux/macOS binary), and enable browser tools by pointing `AGENT_BROWSER_EXECUTABLE_PATH` at a `pkg`-installed Chromium. Full details — rc.d service, browser setup, caveats — are in the [FreeBSD install guide](https://hermes-agent.nousresearch.com/docs/getting-started/installation#freebsd).
+
 After installation:
 
 ```bash

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1332,6 +1332,7 @@ def run_oauth_setup_token() -> Optional[str]:
     Returns the token string, or None if no credentials were obtained.
     Raises FileNotFoundError if the 'claude' CLI is not installed.
     """
+    import errno
     import shutil
     import subprocess
 
@@ -1349,6 +1350,21 @@ def run_oauth_setup_token() -> Optional[str]:
     try:
         subprocess.run([claude_path, "setup-token"])
     except (KeyboardInterrupt, EOFError):
+        return None
+    except OSError as e:
+        if e.errno != errno.ENOEXEC:
+            raise
+        # The claude binary exists but is not runnable on this platform —
+        # e.g. the npm package's Linux ELF binary on FreeBSD. Return None so
+        # the caller's manual paste-token prompt takes over.
+        print()
+        print(f"  Cannot execute '{claude_path}' on this platform.")
+        print("  The Claude Code binary is a Linux/macOS executable and cannot")
+        print("  run here (e.g. on FreeBSD).")
+        print()
+        print("  To get a setup-token, run this on a supported machine:")
+        print("    claude setup-token")
+        print("  Then paste the sk-ant-oat... token at the prompt below.")
         return None
 
     # Check if credentials were saved to Claude Code's config files

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -210,6 +210,8 @@ def _install_uv(target: Path) -> None:
 
     if system == "Windows":
         _install_uv_windows(env)
+    elif system == "FreeBSD":
+        _install_uv_freebsd(target)
     else:
         _install_uv_posix(env)
 
@@ -236,6 +238,26 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             os.unlink(installer_path)
         except OSError:
             pass
+
+
+def _install_uv_freebsd(target: Path) -> None:
+    """Link a system uv into the managed location.
+
+    The astral standalone installer ships no FreeBSD binaries, so the managed
+    contract (a working uv at ``$HERMES_HOME/bin/uv``) is satisfied by
+    symlinking a system uv — ``pkg install uv`` — into place instead of
+    downloading one. install.sh does the same on FreeBSD, so both bootstrap
+    paths resolve the identical binary.
+    """
+    system_uv = shutil.which("uv")
+    if not system_uv:
+        raise FileNotFoundError(
+            "No system uv found on FreeBSD (the astral.sh installer ships no "
+            "FreeBSD binary). Install it first: sudo pkg install uv"
+        )
+    if target.is_symlink() or target.exists():
+        target.unlink()
+    target.symlink_to(system_uv)
 
 
 def _install_uv_windows(env: dict[str, str]) -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17205,8 +17205,8 @@ def _maybe_open_browser(
 ) -> None:
     """Open the dashboard URL in the user's browser if appropriate.
 
-    Skips on headless Linux (no ``DISPLAY`` / ``WAYLAND_DISPLAY``) to avoid
-    TUI browsers (links, lynx) that would SIGHUP the server process.
+    Skips on headless Linux/FreeBSD (no ``DISPLAY`` / ``WAYLAND_DISPLAY``) to
+    avoid TUI browsers (links, lynx) that would SIGHUP the server process.
     Maps ``0.0.0.0`` / ``::`` binds to ``127.0.0.1`` so the browser opens
     a reachable URL.
     """
@@ -17215,15 +17215,17 @@ def _maybe_open_browser(
 
     import webbrowser
 
+    from hermes_constants import is_freebsd
+
     _has_display = (
-        sys.platform != "linux"
+        not (sys.platform == "linux" or is_freebsd())
         or bool(os.environ.get("DISPLAY"))
         or bool(os.environ.get("WAYLAND_DISPLAY"))
     )
     if not _has_display:
         _log.debug(
             "Skipping browser-open: no DISPLAY or WAYLAND_DISPLAY detected "
-            "(headless Linux). Pass --no-open to suppress this detection."
+            "(headless Linux/FreeBSD). Pass --no-open to suppress this detection."
         )
         return
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1019,6 +1019,16 @@ def is_termux() -> bool:
     return bool(os.getenv("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
 
 
+def is_freebsd() -> bool:
+    """Return True when running on FreeBSD.
+
+    ``sys.platform`` carries the major version Python was built on
+    (``freebsd13``, ``freebsd14``, ...), so match on the prefix rather than
+    an exact string.  Import-safe — no heavy deps.
+    """
+    return sys.platform.startswith("freebsd")
+
+
 _wsl_detected: bool | None = None
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -414,10 +414,12 @@ resolve_install_layout() {
         return 0
     fi
 
-    # Root on Linux: prefer FHS layout unless a legacy install already exists.
-    # macOS root installs keep the legacy layout because /usr/local/ on macOS
-    # is Homebrew territory and we don't want to fight that.
-    if [ "$OS" = "linux" ] && [ "$(id -u)" -eq 0 ]; then
+    # Root on Linux/FreeBSD: prefer FHS layout unless a legacy install already
+    # exists (/usr/local/lib is the conventional home for ports-installed
+    # software on FreeBSD too). macOS root installs keep the legacy layout
+    # because /usr/local/ on macOS is Homebrew territory and we don't want to
+    # fight that.
+    if { [ "$OS" = "linux" ] || [ "$OS" = "freebsd" ]; } && [ "$(id -u)" -eq 0 ]; then
         if [ -d "$HERMES_HOME/hermes-agent/.git" ]; then
             INSTALL_DIR="$HERMES_HOME/hermes-agent"
             log_info "Existing install detected at $INSTALL_DIR — keeping legacy layout"
@@ -433,7 +435,7 @@ resolve_install_layout() {
         # python.  See #21457.
         export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-/usr/local/share/uv/python}"
         export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-/usr/local/share/uv/bin}"
-        log_info "Root install on Linux — using FHS layout"
+        log_info "Root install on $OS — using FHS layout"
         log_info "  Code:    $INSTALL_DIR"
         log_info "  Command: /usr/local/bin/hermes"
         log_info "  Data:    $HERMES_HOME (unchanged)"
@@ -523,6 +525,11 @@ detect_os() {
             OS="macos"
             DISTRO="macos"
             ;;
+        FreeBSD*)
+            OS="freebsd"
+            DISTRO="freebsd"
+            DISTRO_VERSION=""
+            ;;
         CYGWIN*|MINGW*|MSYS*)
             OS="windows"
             DISTRO="windows"
@@ -561,6 +568,36 @@ install_uv() {
         UV_CMD="$_managed_uv"
         UV_VERSION=$($UV_CMD --version 2>/dev/null)
         log_success "Managed uv found ($UV_VERSION)"
+        return 0
+    fi
+
+    # FreeBSD: the astral.sh installer ships no FreeBSD binary, so satisfy the
+    # managed-uv contract by linking a system uv (pkg) into $HERMES_HOME/bin/uv
+    # instead of downloading one. hermes_cli/managed_uv.py mirrors this, so
+    # install.sh and `hermes update` still resolve the exact same path.
+    if [ "$OS" = "freebsd" ]; then
+        local _sys_uv
+        _sys_uv="$(command -v uv 2>/dev/null || true)"
+        if [ -z "$_sys_uv" ]; then
+            log_info "Installing uv via pkg..."
+            if [ "$(id -u)" -eq 0 ]; then
+                pkg install -y uv >/dev/null 2>&1 || true
+            elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+                sudo pkg install -y uv >/dev/null 2>&1 || true
+            fi
+            _sys_uv="$(command -v uv 2>/dev/null || true)"
+        fi
+        if [ -z "$_sys_uv" ]; then
+            log_error "Could not install uv on FreeBSD (astral.sh ships no FreeBSD binary)."
+            log_info "Install it, then re-run this installer:"
+            log_info "  sudo pkg install uv"
+            exit 1
+        fi
+        mkdir -p "$HERMES_HOME/bin"
+        ln -sf "$_sys_uv" "$_managed_uv"
+        UV_CMD="$_managed_uv"
+        UV_VERSION=$($UV_CMD --version 2>/dev/null)
+        log_success "Managed uv linked to system uv ($UV_VERSION)"
         return 0
     fi
 
@@ -645,7 +682,13 @@ check_python() {
         log_success "Python installed: $PYTHON_FOUND_VERSION"
     else
         log_error "Failed to install Python $PYTHON_VERSION"
-        log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
+        if [ "$OS" = "freebsd" ]; then
+            # uv's python-build-standalone downloads have no FreeBSD builds —
+            # a system Python from pkg is the supported source.
+            log_info "  sudo pkg install python${PYTHON_VERSION//./}"
+        else
+            log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
+        fi
         exit 1
     fi
 }
@@ -713,6 +756,16 @@ attempt_install_git() {
             command -v git >/dev/null 2>&1 && return 0
             return 1
             ;;
+        freebsd)
+            local sudo_cmd=""
+            if [ "$(id -u 2>/dev/null || echo 1000)" -ne 0 ]; then
+                command -v sudo >/dev/null 2>&1 && sudo_cmd="sudo"
+            fi
+            log_info "Installing Git via pkg..."
+            $sudo_cmd pkg install -y git >/dev/null 2>&1 || true
+            command -v git >/dev/null 2>&1 && return 0
+            return 1
+            ;;
     esac
     return 1
 }
@@ -768,6 +821,9 @@ check_git() {
             ;;
         android)
             log_info "  pkg install git"
+            ;;
+        freebsd)
+            log_info "  sudo pkg install git"
             ;;
         macos)
             log_info "  xcode-select --install"
@@ -837,6 +893,28 @@ install_node() {
             HAS_NODE=true
         else
             log_warn "Failed to install Node.js via pkg"
+            HAS_NODE=false
+        fi
+        return 0
+    fi
+
+    # FreeBSD: nodejs.org ships no FreeBSD tarballs — install from pkg instead.
+    # (Must come before the arch mapping below: FreeBSD's `uname -m` says
+    # "amd64", which the tarball path doesn't recognize.)
+    if [ "$OS" = "freebsd" ]; then
+        log_info "Installing Node.js via pkg..."
+        local _node_ok=false
+        if [ "$(id -u)" -eq 0 ]; then
+            pkg install -y node npm >/dev/null 2>&1 && _node_ok=true
+        elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo pkg install -y node npm >/dev/null 2>&1 && _node_ok=true
+        fi
+        if [ "$_node_ok" = true ] && command -v node >/dev/null 2>&1; then
+            log_success "Node.js $(node --version 2>/dev/null) installed via pkg"
+            HAS_NODE=true
+        else
+            log_warn "Could not auto-install Node.js on FreeBSD"
+            log_info "Install manually: sudo pkg install node npm"
             HAS_NODE=false
         fi
         return 0
@@ -1059,12 +1137,13 @@ install_system_packages() {
         return 0
     fi
 
-    # ── Linux: resolve package manager command ──
+    # ── Linux/FreeBSD: resolve package manager command ──
     local pkg_install=""
     case "$DISTRO" in
         ubuntu|debian) pkg_install="apt install -y"   ;;
         fedora)        pkg_install="dnf install -y"   ;;
         arch)          pkg_install="pacman -S --noconfirm" ;;
+        freebsd)       pkg_install="pkg install -y"   ;;
     esac
 
     if [ -n "$pkg_install" ]; then
@@ -1163,6 +1242,9 @@ show_manual_install_hint() {
             ;;
         android)
             log_info "  pkg install $pkg"
+            ;;
+        freebsd)
+            log_info "  sudo pkg install $pkg"
             ;;
         macos) log_info "  brew install $pkg" ;;
     esac
@@ -2213,6 +2295,12 @@ install_node_deps() {
                         log_warn "Playwright browser installation failed — install dependencies above and retry."
                     }
                     ;;
+                freebsd)
+                    log_warn "Playwright ships no FreeBSD browser builds — skipping bundled Chromium install."
+                    log_info "To enable browser tools, install Chromium from packages and point Hermes at it:"
+                    log_info "  sudo pkg install chromium"
+                    log_info "  export AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium"
+                    ;;
                 *)
                     log_warn "Playwright does not support automatic dependency installation on $DISTRO."
                     log_info "Install Chromium/browser system dependencies for your distribution, then run:"
@@ -2513,6 +2601,10 @@ ensure_browser() {
                     ;;
                 fedora|rhel|centos)
                     log_info "Try: sudo dnf install -y chromium"
+                    ;;
+                freebsd)
+                    log_info "Try: sudo pkg install chromium"
+                    log_info "Then: export AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium"
                     ;;
             esac
         }

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -291,6 +291,8 @@ else
                     sudo apt install -y ripgrep && INSTALLED=true
                 elif command -v dnf &> /dev/null; then
                     sudo dnf install -y ripgrep && INSTALLED=true
+                elif [ "$(uname -s)" = "FreeBSD" ] && command -v pkg &> /dev/null; then
+                    sudo pkg install -y ripgrep && INSTALLED=true
                 fi
             fi
 
@@ -315,6 +317,7 @@ else
             else
                 echo "    sudo apt install ripgrep     # Debian/Ubuntu"
                 echo "    brew install ripgrep         # macOS"
+                echo "    sudo pkg install ripgrep     # FreeBSD"
                 echo "    cargo install ripgrep        # With Rust (no sudo)"
             fi
             echo "    https://github.com/BurntSushi/ripgrep#installation"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -727,6 +727,41 @@ class TestRunOauthSetupToken:
 
         assert token is None
 
+    def test_returns_none_on_enoexec(self, monkeypatch, capsys):
+        """A claude binary that cannot execute on this platform falls back.
+
+        The npm package ships a Linux ELF binary; on FreeBSD exec'ing it
+        raises OSError(ENOEXEC). That must not crash the setup wizard —
+        run_oauth_setup_token returns None so the caller's manual
+        paste-token prompt takes over."""
+        import errno
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/claude")
+
+        with patch(
+            "subprocess.run",
+            side_effect=OSError(errno.ENOEXEC, "Exec format error"),
+        ):
+            token = run_oauth_setup_token()
+
+        assert token is None
+        out = capsys.readouterr().out
+        assert "Cannot execute" in out
+        assert "claude setup-token" in out
+
+    def test_reraises_other_oserrors(self, monkeypatch):
+        """Only ENOEXEC is a graceful fallback; other OS errors still surface."""
+        import errno
+
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/local/bin/claude")
+
+        with patch(
+            "subprocess.run",
+            side_effect=OSError(errno.EACCES, "Permission denied"),
+        ):
+            with pytest.raises(OSError):
+                run_oauth_setup_token()
+
 
 # ---------------------------------------------------------------------------
 # Model name normalization

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -253,3 +253,59 @@ class TestInstallUvInternals:
             mock_windows.assert_called_once()
             call_env = mock_windows.call_args[0][0]
             assert call_env["UV_INSTALL_DIR"] == str(tmp_path / "bin")
+
+
+# ---------------------------------------------------------------------------
+# FreeBSD: no astral binary — the managed path is a symlink to a system uv
+# ---------------------------------------------------------------------------
+
+class TestInstallUvFreeBSD:
+    def test_freebsd_dispatches_to_symlink_installer(self, tmp_path):
+        target = tmp_path / "bin" / "uv"
+        with patch("hermes_cli.managed_uv.platform.system", return_value="FreeBSD"), \
+             patch("hermes_cli.managed_uv._install_uv_freebsd") as mock_bsd:
+            from hermes_cli.managed_uv import _install_uv
+            _install_uv(target)
+            mock_bsd.assert_called_once_with(target)
+
+    def test_links_system_uv_into_managed_path(self, tmp_path):
+        """The managed contract ($HERMES_HOME/bin/uv, executable) must hold on
+        FreeBSD even though the binary comes from pkg, so install.sh and
+        `hermes update` keep resolving the exact same path as elsewhere."""
+        system_uv = tmp_path / "usr-local-bin" / "uv"
+        _make_executable(system_uv)
+        target = tmp_path / "bin" / "uv"
+        target.parent.mkdir(parents=True)
+
+        with patch("hermes_cli.managed_uv.shutil.which", return_value=str(system_uv)):
+            from hermes_cli.managed_uv import _install_uv_freebsd
+            _install_uv_freebsd(target)
+
+        assert target.is_symlink()
+        assert os.path.realpath(target) == os.path.realpath(system_uv)
+        assert os.access(target, os.X_OK)
+
+    def test_replaces_dangling_symlink(self, tmp_path):
+        """A pkg upgrade can leave the managed symlink dangling; re-linking heals it."""
+        system_uv = tmp_path / "usr-local-bin" / "uv"
+        _make_executable(system_uv)
+        target = tmp_path / "bin" / "uv"
+        target.parent.mkdir(parents=True)
+        target.symlink_to(tmp_path / "gone" / "uv")  # dangling
+
+        with patch("hermes_cli.managed_uv.shutil.which", return_value=str(system_uv)):
+            from hermes_cli.managed_uv import _install_uv_freebsd
+            _install_uv_freebsd(target)
+
+        assert os.path.realpath(target) == os.path.realpath(system_uv)
+
+    def test_without_system_uv_raises_actionable_error(self, tmp_path):
+        target = tmp_path / "bin" / "uv"
+        target.parent.mkdir(parents=True)
+
+        with patch("hermes_cli.managed_uv.shutil.which", return_value=None):
+            from hermes_cli.managed_uv import _install_uv_freebsd
+            with pytest.raises(FileNotFoundError, match="pkg install uv"):
+                _install_uv_freebsd(target)
+
+        assert not target.exists()

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -20,6 +20,7 @@ from hermes_constants import (
     hermes_managed_node_tree_present,
     iter_hermes_node_dirs,
     is_container,
+    is_freebsd,
     node_tool_runnable,
     parse_reasoning_effort,
     secure_parent_dir,
@@ -1170,3 +1171,18 @@ class TestWslPathTranslation:
         assert hermes_constants.translate_cwd_for_wsl_backend(r"\\wsl.localhost\Ubuntu\home\alex") == "/home/alex"
         # Already-POSIX paths pass through untouched.
         assert hermes_constants.translate_cwd_for_wsl_backend("/home/alex") == "/home/alex"
+
+
+class TestIsFreeBSD:
+    def test_true_on_versioned_platform_string(self, monkeypatch):
+        # sys.platform carries the build-time major version on FreeBSD
+        # ("freebsd13", "freebsd14", ...), so the check must be a prefix match.
+        import sys
+        monkeypatch.setattr(sys, "platform", "freebsd14")
+        assert is_freebsd() is True
+
+    def test_false_on_linux_and_darwin(self, monkeypatch):
+        import sys
+        for platform in ("linux", "darwin", "win32"):
+            monkeypatch.setattr(sys, "platform", platform)
+            assert is_freebsd() is False

--- a/tests/test_install_sh_freebsd.py
+++ b/tests/test_install_sh_freebsd.py
@@ -1,0 +1,215 @@
+"""Regression tests for the FreeBSD branches in install.sh.
+
+FreeBSD has no astral uv binary, no nodejs.org tarballs, and no Playwright
+browser builds — the installer sources those from pkg instead. The critical
+invariant is that the managed-uv contract still holds: whatever the source,
+the binary Hermes uses lives at ``$HERMES_HOME/bin/uv``, the same path
+``hermes_cli/managed_uv.py`` resolves at runtime.
+
+Behavioral tests source the relevant functions from install.sh in a stubbed
+shell (same harness style as test_install_sh_browser_install.py).
+"""
+
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+# ---------------------------------------------------------------------------
+# Text assertions
+# ---------------------------------------------------------------------------
+
+def test_detect_os_recognizes_freebsd() -> None:
+    text = INSTALL_SH.read_text()
+    assert 'FreeBSD*)' in text
+    assert 'OS="freebsd"' in text
+    assert 'DISTRO="freebsd"' in text
+
+
+def test_freebsd_browser_hint_uses_the_env_var_hermes_reads() -> None:
+    """The runtime consumes AGENT_BROWSER_EXECUTABLE_PATH (tools/browser_tool.py).
+
+    An earlier draft documented PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH, which
+    Hermes never reads — following that instruction configures nothing.
+    """
+    text = INSTALL_SH.read_text()
+    assert "export AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium" in text
+    assert "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH" not in text
+
+
+def test_freebsd_system_packages_resolve_to_pkg() -> None:
+    text = INSTALL_SH.read_text()
+    assert 'freebsd)       pkg_install="pkg install -y"   ;;' in text
+
+
+def test_freebsd_uv_branch_preserves_managed_location() -> None:
+    """uv may come from pkg, but it must be linked into $HERMES_HOME/bin/uv."""
+    text = INSTALL_SH.read_text()
+    assert 'ln -sf "$_sys_uv" "$_managed_uv"' in text
+    # Failure mode is actionable, not a dead astral.sh pointer.
+    assert "sudo pkg install uv" in text
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests
+# ---------------------------------------------------------------------------
+
+def _extract_functions(*names: str) -> str:
+    src = INSTALL_SH.read_text()
+    out = []
+    for name in names:
+        m = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", src,
+                      re.MULTILINE | re.DOTALL)
+        assert m, f"could not extract {name}() from install.sh"
+        # Drop full-line comments: install.sh's prose (e.g. "the runtime
+        # update path ... hermes update") would otherwise trip conftest's
+        # live-system guard, which scans the subprocess command string for
+        # hermes-update-shaped token sequences.
+        body = "\n".join(
+            line for line in m.group(0).splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        out.append(body)
+    return "\n\n".join(out)
+
+
+def _run_harness(body: str, script: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    harness = f"""
+log_info() {{ echo "INFO: $*"; }}
+log_success() {{ echo "SUCCESS: $*"; }}
+log_warn() {{ echo "WARN: $*"; }}
+log_error() {{ echo "ERROR: $*" >&2; }}
+
+{body}
+
+{script}
+"""
+    return subprocess.run(["bash", "-c", harness], capture_output=True,
+                          text=True, env={**os.environ, **(env or {})})
+
+
+def test_detect_os_sets_freebsd_vars() -> None:
+    body = _extract_functions("detect_os")
+    proc = _run_harness(body, """
+is_termux() { return 1; }
+uname() { echo "FreeBSD"; }
+detect_os
+echo "RESULT OS=$OS DISTRO=$DISTRO"
+""")
+    assert "RESULT OS=freebsd DISTRO=freebsd" in proc.stdout
+
+
+def _install_uv_harness(tmp: Path, *, uv_on_path: bool, pkg_works: bool,
+                        as_root: bool) -> subprocess.CompletedProcess:
+    """Drive install_uv() with OS=freebsd in a controlled PATH sandbox.
+
+    ``uv_on_path`` pre-creates a fake system uv; ``pkg_works`` makes the pkg
+    stub "install" one onto PATH; ``as_root`` controls the id(1) stub. sudo is
+    stubbed to always fail, so the non-root pkg path is never taken. PATH is
+    pinned to the sandbox bin plus /usr/bin:/bin (for mkdir/ln) so a real uv
+    on the developer's machine can never satisfy `command -v uv`.
+    """
+    sysbin = tmp / "sysbin"
+    sysbin.mkdir()
+    fake_uv = sysbin / "uv"
+    payload = tmp / "uv-payload"
+    payload.write_text("#!/bin/sh\necho 'uv 0.7.0 (fake)'\n")
+    payload.chmod(0o755)
+    if uv_on_path:
+        fake_uv.write_bytes(payload.read_bytes())
+        fake_uv.chmod(0o755)
+
+    body = _extract_functions("install_uv")
+    pkg_stub = (
+        f'pkg() {{ echo "pkg $*" >> "$RUNLOG"; cp "{payload}" "{fake_uv}"; '
+        f'chmod 755 "{fake_uv}"; }}'
+        if pkg_works
+        else 'pkg() { echo "pkg $*" >> "$RUNLOG"; return 1; }'
+    )
+    uid = "0" if as_root else "1000"
+    script = f"""
+OS=freebsd
+DISTRO=freebsd
+HERMES_HOME="{tmp}/.hermes"
+PATH="{sysbin}:/usr/bin:/bin"
+id() {{ echo {uid}; }}
+sudo() {{ return 1; }}
+{pkg_stub}
+install_uv
+echo "RESULT UV_CMD=$UV_CMD"
+"""
+    runlog = tmp / "runlog"
+    runlog.touch()
+    return _run_harness(body, script, env={"RUNLOG": str(runlog)})
+
+
+def test_install_uv_links_existing_system_uv_into_hermes_bin(tmp_path) -> None:
+    proc = _install_uv_harness(tmp_path, uv_on_path=True, pkg_works=False,
+                               as_root=False)
+    managed = tmp_path / ".hermes" / "bin" / "uv"
+    assert f"RESULT UV_CMD={managed}" in proc.stdout, proc.stdout + proc.stderr
+    assert managed.is_symlink()
+    assert os.path.realpath(managed) == os.path.realpath(tmp_path / "sysbin" / "uv")
+    # No pkg attempt needed when a system uv already exists.
+    assert "pkg install" not in (tmp_path / "runlog").read_text()
+
+
+def test_install_uv_falls_back_to_pkg_as_root(tmp_path) -> None:
+    proc = _install_uv_harness(tmp_path, uv_on_path=False, pkg_works=True,
+                               as_root=True)
+    managed = tmp_path / ".hermes" / "bin" / "uv"
+    assert f"RESULT UV_CMD={managed}" in proc.stdout, proc.stdout + proc.stderr
+    assert managed.is_symlink()
+    assert "pkg install -y uv" in (tmp_path / "runlog").read_text()
+
+
+def test_install_uv_fails_actionably_without_uv_or_pkg(tmp_path) -> None:
+    proc = _install_uv_harness(tmp_path, uv_on_path=False, pkg_works=False,
+                               as_root=True)
+    assert proc.returncode == 1
+    assert "astral.sh ships no FreeBSD binary" in proc.stderr
+    assert "sudo pkg install uv" in proc.stdout
+    assert not (tmp_path / ".hermes" / "bin" / "uv").exists()
+
+
+def _install_node_harness(tmp: Path, *, pkg_works: bool) -> subprocess.CompletedProcess:
+    body = _extract_functions("install_node")
+    pkg_stub = (
+        'pkg() { echo "pkg $*" >> "$RUNLOG"; return 0; }'
+        if pkg_works
+        else 'pkg() { echo "pkg $*" >> "$RUNLOG"; return 1; }'
+    )
+    node_stub = 'node() { echo "v22.14.0"; }' if pkg_works else ""
+    script = f"""
+OS=freebsd
+DISTRO=freebsd
+id() {{ echo 0; }}
+{pkg_stub}
+{node_stub}
+install_node
+echo "RESULT HAS_NODE=$HAS_NODE"
+"""
+    runlog = tmp / "runlog"
+    runlog.touch()
+    return _run_harness(body, script, env={"RUNLOG": str(runlog)})
+
+
+def test_install_node_uses_pkg_on_freebsd(tmp_path) -> None:
+    proc = _install_node_harness(tmp_path, pkg_works=True)
+    assert "RESULT HAS_NODE=true" in proc.stdout, proc.stdout + proc.stderr
+    assert "pkg install -y node npm" in (tmp_path / "runlog").read_text()
+    # Never falls through to the nodejs.org tarball path (no FreeBSD builds).
+    assert "Downloading" not in proc.stdout
+
+
+def test_install_node_pkg_failure_is_nonfatal_with_hint(tmp_path) -> None:
+    proc = _install_node_harness(tmp_path, pkg_works=False)
+    assert proc.returncode == 0
+    assert "RESULT HAS_NODE=false" in proc.stdout
+    assert "sudo pkg install node npm" in proc.stdout

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Installation"
-description: "Install Hermes Agent on Linux, macOS, WSL2, native Windows, or Android via Termux"
+description: "Install Hermes Agent on Linux, macOS, WSL2, native Windows, FreeBSD, or Android via Termux"
 ---
 
 # Installation
@@ -36,6 +36,54 @@ If you want to install & run Hermes Desktop after a command-line only install, s
 ```bash
 hermes desktop
 ```
+
+#### FreeBSD
+
+:::note Community port (Tier 2)
+FreeBSD support is a community-maintained [Tier 2 platform](./platform-support.md#tier-2). Tested on FreeBSD 14 (bare-metal and jails). Core chat, memory, skills, cron, and the messaging gateways work. Browser-based features (Playwright, dashboard chat pane) are **not** wired up — see below.
+:::
+
+Install `bash` first (the installer is a bash script), then run the standard installer:
+
+```sh
+pkg install bash    # if not already installed
+bash -c "$(curl -fsSL https://hermes-agent.nousresearch.com/install.sh)"
+```
+
+The installer detects FreeBSD and sources every dependency (Node.js, ripgrep, ffmpeg, uv) from `pkg` rather than the platform-specific binaries used elsewhere — the astral.sh `uv` installer and the nodejs.org tarballs have no FreeBSD builds. `uv` is linked into `$HERMES_HOME/bin/uv` so `hermes update` keeps working like on any other platform.
+
+**Authentication.** The Claude Code binary (`claude setup-token`) is a Linux/macOS executable and cannot run on FreeBSD. Use an API key instead — run `hermes model`, pick your provider (e.g. Anthropic or OpenRouter), and paste the key. If a `setup-token` OAuth flow is attempted, Hermes detects the unrunnable binary and falls back to a manual paste prompt.
+
+**Browser tools.** Playwright ships no FreeBSD browser builds, so the bundled Chromium download is skipped. To enable browser tools, install Chromium from packages and point Hermes at it:
+
+```sh
+sudo pkg install chromium
+export AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium
+```
+
+**Run at boot with rc.d.** To start the gateway automatically, create `/usr/local/etc/rc.d/hermes`:
+
+```sh
+#!/bin/sh
+# PROVIDE: hermes
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+. /etc/rc.subr
+name="hermes"
+rcvar="hermes_enable"
+command="/usr/local/bin/hermes"
+command_args="gateway start"
+load_rc_config $name
+run_rc_command "$1"
+```
+
+```sh
+chmod +x /usr/local/etc/rc.d/hermes
+sysrc hermes_enable=YES
+service hermes start
+```
+
+If you see `echoti: no such terminfo capability: colors`, set `export TERM=xterm-256color` in your shell profile.
 
 ### What the Installer Does
 

--- a/website/docs/getting-started/platform-support.md
+++ b/website/docs/getting-started/platform-support.md
@@ -34,6 +34,7 @@ PRs will be accepted to fix issues with them, but they will take precedence belo
 | ------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | **Android (Termux)** (aarch64) | [`install.sh`](./installation.md#linux--macos--wsl2--android-termux) | A few features are [not available](./termux.md#known-limitations-on-phones). |
 | **Nix** (MacOS, Linux, NixOS)  | [`install.sh`](./nix-setup.md)                                       | Breaks often due to node.js packaging woes. Best of luck~! &lt;3             |
+| **FreeBSD** (amd64)            | [`install.sh`](./installation.md#freebsd)                            | Community port. Dependencies come from `pkg`. Browser tools (Playwright/Chromium) are not available — install `chromium` from packages and set `AGENT_BROWSER_EXECUTABLE_PATH` to enable them. |
 
 ## Unsupported
 


### PR DESCRIPTION
## Summary

Port Hermes Agent to FreeBSD — the installer, core platform helpers, and
a runtime adapter for Linux ELF binaries — so Hermes runs on both bare-metal
and jail environments.

## Changes

### `feat(freebsd): add FreeBSD platform support` (b6abdfaf4)

**scripts/install.sh**
- `detect_os()`: recognise FreeBSD* → OS=freebsd, DISTRO=freebsd
- `resolve_install_layout()`: FHS root path `/usr/local/lib/hermes-agent` matching FreeBSD conventions
- `check_git()`: `sudo pkg install git` hint
- `install_node()`: `pkg install node npm`
- `install_system_packages()`: full FreeBSD `pkg` section
- `show_manual_install_hint()`: `sudo pkg install $pkg` for freebsd
- Playwright section: skip bundled-Chromium download, print instructions for system Chromium via ports

**setup-hermes.sh**
- `pkg install -y ripgrep` (guarded by `uname -s = FreeBSD`)
- Manual fallback hint: `sudo pkg install ripgrep`

**hermes_constants.py**
- New `is_freebsd()` helper

**hermes_cli/web_server.py**
- Replace `sys.platform != "linux"` with explicit allowlist {darwin, win32, cygwin} so FreeBSD servers correctly require DISPLAY/WAYLAND_DISPLAY before auto-opening a browser

### `fix(freebsd): install uv via pkg/pip instead of astral.sh` (816b5a4dc)

astral.sh install.sh rejects FreeBSD. Adds FreeBSD block in install_uv() that tries:
1. `sudo pkg install uv`
2. `pip3 install --user uv`

### `fix(freebsd): handle ENOEXEC when claude binary is a Linux ELF` (dce1fbc05)

Catches OSError(ENOEXEC) in run_oauth_setup_token(), prints clear explanation and manual workaround, returns None so caller falls through to paste-token prompt.

## Known Limitations

- **Playwright bundled Chromium**: no upstream FreeBSD binary; use system Chromium from ports
- **Tirith security scanner**: no FreeBSD Rust binary; auto-disabled
- **python-olm (Matrix extra)**: Linux-only wheels; skip [matrix] extra