### PR TITLE
fix(slack): fall back to attachment text in thread context for bot messages

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2676,6 +2676,23 @@ class SlackAdapter(BasePlatformAdapter):
                     continue
 
                 msg_text = msg.get("text", "").strip()
+
+                # Some bot messages (e.g. Datadog, PagerDuty, Grafana) use the
+                # legacy Slack "attachments" format instead of top-level text.
+                # When the top-level text is empty, fall back to the first
+                # attachment's text or fallback field so the thread context is
+                # not silently dropped.
+                if not msg_text:
+                    for att in msg.get("attachments", []):
+                        att_text = att.get("text", "").strip()
+                        if att_text:
+                            msg_text = att_text
+                            break
+                        att_fallback = att.get("fallback", "").strip()
+                        if att_fallback:
+                            msg_text = att_fallback
+                            break
+
                 if not msg_text:
                     continue
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -472,6 +472,99 @@ class TestSlackThreadContext:
         assert "DO NOT INCLUDE THIS" not in context
 
     @pytest.mark.asyncio
+    async def test_fetch_thread_context_bot_attachments_fallback(self):
+        """Bot messages with empty top-level text but attachment content
+        (e.g. Datadog, PagerDuty alerts) should be included in thread context
+        by falling back to attachments[].text or attachments[].fallback."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "1000.0", "user": "U1", "text": "Parent"},
+                {
+                    "ts": "1000.05",
+                    "bot_id": "B_DATADOG",
+                    "user": "U_DD",
+                    "text": "",  # empty top-level text
+                    "attachments": [
+                        {
+                            "text": "CPU usage is at 98% on prod-server-01",
+                            "fallback": "CPU alert on prod-server-01",
+                        }
+                    ],
+                },
+                {"ts": "1000.1", "user": "U1", "text": "Current"},
+            ]
+        })
+        adapter._user_name_cache = {"U1": "Alice", "U_DD": "Datadog"}
+
+        context = await adapter._fetch_thread_context(
+            channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"
+        )
+
+        assert "CPU usage is at 98% on prod-server-01" in context
+        assert "Datadog" in context
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_context_bot_attachments_fallback_field(self):
+        """When attachments[].text is empty, fall back to attachments[].fallback."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "1000.0", "user": "U1", "text": "Parent"},
+                {
+                    "ts": "1000.05",
+                    "bot_id": "B_PAGERDUTY",
+                    "user": "U_PD",
+                    "text": "",
+                    "attachments": [
+                        {
+                            "text": "",
+                            "fallback": "Incident #1234: Service down in us-east-1",
+                        }
+                    ],
+                },
+                {"ts": "1000.1", "user": "U1", "text": "Current"},
+            ]
+        })
+        adapter._user_name_cache = {"U1": "Alice", "U_PD": "PagerDuty"}
+
+        context = await adapter._fetch_thread_context(
+            channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"
+        )
+
+        assert "Incident #1234: Service down in us-east-1" in context
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_context_empty_text_no_attachments_skipped(self):
+        """Messages with empty text AND empty/no attachments should still be skipped."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "1000.0", "user": "U1", "text": "Parent"},
+                {
+                    "ts": "1000.05",
+                    "bot_id": "B_EMPTY",
+                    "user": "U_EMPTY",
+                    "text": "",
+                    "attachments": [{"text": "", "fallback": ""}],
+                },
+                {"ts": "1000.1", "user": "U1", "text": "Current"},
+            ]
+        })
+        adapter._user_name_cache = {"U1": "Alice"}
+
+        context = await adapter._fetch_thread_context(
+            channel_id="C1", thread_ts="1000.0", current_ts="1000.1", team_id="T1"
+        )
+
+        # Only the parent message should appear, empty attachment message skipped
+        assert "Parent" in context
+        assert context.count("[thread parent]") == 1
+
+    @pytest.mark.asyncio
     async def test_fetch_thread_parent_text_from_cache(self):
         """_fetch_thread_parent_text should reuse the thread-context cache
         when it is warm, avoiding an extra conversations.replies call."""


### PR DESCRIPTION
## What does this PR do?

Bot messages from monitoring tools (Datadog, PagerDuty, Grafana, etc.) often use the legacy Slack "attachments" format instead of top-level text. When Hermes is @mentioned in a thread whose parent was posted by such a bot, the parent message is silently dropped from thread context because its top-level `text` field is empty — the actual content lives in `attachments[].text` or `attachments[].fallback`.

This fix adds a fallback: when `msg_text` is empty, the code now checks `attachments[].text` then `attachments[].fallback` before skipping the message.

## Related Issue

Fixes #33469

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `gateway/platforms/slack.py` `_fetch_thread_context` (callers: 1 — message handler)
- Blast radius: LOW — single function, additive fallback, no behavior change for existing non-empty text messages
- Related patterns: `_fetch_thread_parent_text` uses the same cache; no changes needed there since it has its own fallback logic

Fixes #33469