### PR TITLE
fix(config): ignore corrupt install method stamp

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -449,7 +449,7 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
         method = (root / ".install_method").read_text(encoding="utf-8").strip().lower()
         if method in supported_methods:
             return method
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         pass
 
     # 2. Legacy home-scoped stamp — back-compat. Ignore a ``docker`` value
@@ -465,7 +465,7 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
         )
         if method in supported_methods and not (method == "docker" and not _running_in_container()):
             return method
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         pass
 
     managed = get_managed_system()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -296,7 +296,7 @@ _SUPPORTED_INSTALL_METHODS = frozenset({"apt", "docker", "nix", "nixos", "home-m
 def _install_method_stamp(path: Path) -> Optional[str]:
     try:
         method = path.read_text(encoding="utf-8").strip().lower()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     return method if method in _SUPPORTED_INSTALL_METHODS else None
 

--- a/tests/hermes_cli/test_pip_install_detection.py
+++ b/tests/hermes_cli/test_pip_install_detection.py
@@ -41,6 +41,36 @@ def test_stamp_file_takes_precedence(tmp_path):
         assert detect_install_method(project_root=tmp_path) == "docker"
 
 
+def test_invalid_code_scoped_stamp_falls_back_to_git(tmp_path):
+    """A corrupt code-scoped stamp must not block project detection."""
+    code = tmp_path / "code"
+    home = tmp_path / "home"
+    code.mkdir()
+    home.mkdir()
+    (code / ".git").mkdir()
+    (code / ".install_method").write_bytes(b"\xd0")
+
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=home):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=code) == "git"
+
+
+def test_invalid_home_scoped_stamp_falls_back_to_git(tmp_path):
+    """A corrupt legacy home stamp must not block project detection."""
+    code = tmp_path / "code"
+    home = tmp_path / "home"
+    code.mkdir()
+    home.mkdir()
+    (code / ".git").mkdir()
+    (home / ".install_method").write_bytes(b"\xd0")
+
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=home):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=code) == "git"
+
+
 @pytest.mark.parametrize("retired_method", ["pip", "homebrew"])
 def test_code_scoped_retired_stamp_falls_back_to_unknown(tmp_path, retired_method):
     """Removed install methods must not survive in an upgraded code stamp."""

--- a/tests/hermes_cli/test_pip_install_detection.py
+++ b/tests/hermes_cli/test_pip_install_detection.py
@@ -11,6 +11,36 @@ import pytest
 
 
 
+def test_invalid_code_scoped_stamp_falls_back_to_git(tmp_path):
+    """A corrupt code-scoped stamp must not block project detection."""
+    code = tmp_path / "code"
+    home = tmp_path / "home"
+    code.mkdir()
+    home.mkdir()
+    (code / ".git").mkdir()
+    (code / ".install_method").write_bytes(b"\xd0")
+
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=home):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=code) == "git"
+
+
+def test_invalid_home_scoped_stamp_falls_back_to_git(tmp_path):
+    """A corrupt legacy home stamp must not block project detection."""
+    code = tmp_path / "code"
+    home = tmp_path / "home"
+    code.mkdir()
+    home.mkdir()
+    (code / ".git").mkdir()
+    (home / ".install_method").write_bytes(b"\xd0")
+
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=home):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=code) == "git"
+
+
 def test_code_scoped_stamp_wins_over_home_stamp(tmp_path):
     """The stamp next to the running code is authoritative over $HERMES_HOME.
 


### PR DESCRIPTION
## What does this PR do?

Makes install-method detection tolerant of a corrupt `~/.hermes/.install_method` stamp file.

`detect_install_method()` already treats a missing/unreadable stamp as non-fatal and falls back to managed/container/git/pip detection. However, the stamp read only caught `OSError`; a malformed UTF-8 stamp raised `UnicodeDecodeError`, which could make `hermes update --check` or update-related recommendation paths crash before reaching the normal fallback logic.

This keeps the stamp as a best-effort hint: if it cannot be decoded, Hermes ignores it and continues with the existing detection order.

## Related Issue

Related / prior art:

- Related: #12881 and #12886 cover a similar `UnicodeDecodeError` symptom in the post-update interactive config-migration prompt (`input()`), but this PR fixes a separate path in `detect_install_method()`.
- Related: #27843 introduced install-method stamping and the `.install_method` read path that this PR hardens.

No dedicated issue exists for a corrupt `.install_method` stamp.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`
  - Catch `UnicodeDecodeError` alongside `OSError` in the shared `_install_method_stamp()` helper (stamp reading was consolidated there since this PR was opened), covering both the code-scoped and the legacy home-scoped stamp paths with one change.
  - Preserve the existing fallback behavior: managed install marker/env, container detection, git checkout, then pip fallback.
- `tests/hermes_cli/test_pip_install_detection.py`
  - Add invariant tests where `.install_method` contains invalid UTF-8 (`b"\xd0"`) — one per stamp location (code-scoped and home-scoped) — and detection falls back to the project `.git` marker instead of crashing. Both are red on main without the fix.

## How to Test

1. Focused regression/unit tests:

   ```bash
   python -m pytest tests/hermes_cli/test_pip_install_detection.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_managed_installs.py -q -o 'addopts='
   ```

   Result:

   ```text
   34 passed in 30.29s
   ```

2. Manual reproduction of the corrupt-stamp case:

   ```bash
   TMP=$(mktemp -d /tmp/hermes-pr-repro.XXXXXX)
   printf '\320' > "$TMP/.install_method"
   printf '_config_version: 24\nmodel:\n  provider: openrouter\n  default: test\n' > "$TMP/config.yaml"
   touch "$TMP/.env"
   HERMES_HOME="$TMP" hermes update --check
   ```

   Result after this change:

   ```text
   → Fetching from upstream...
   → Fetching from origin...
   ✓ Already up to date.
   ```

3. Static checks:

   ```bash
   python3 -m py_compile hermes_cli/config.py tests/hermes_cli/test_pip_install_detection.py
   ```

4. Independent pre-commit review:
   - No security scan hits in added lines.
   - Reviewer verdict: passed; no security concerns or logic errors.


5. Full-suite check attempted:

   ```bash
   python -m pytest tests/ -q
   ```

   Local result: the run did not reach a passing state. GitHub CI currently reports failures in unrelated Kanban/Windows-guard tests that are outside this PR's diff (`tests/tools/test_kanban_tools.py::test_worker_complete_rejects_stale_run_id` and `tests/tools/test_windows_native_support.py::TestKanbanWaitpidWindowsGuard::test_source_gates_waitpid_loop`). I also reproduced those two failures on `origin/main` at `2d5dcfabc`, where this PR's only changed files are not present.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux 6.17.9

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing option or workflow change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this only broadens error handling around `Path.read_text()` and preserves existing fallback detection
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused tests:

```text
..................................                                       [100%]
34 passed in 30.29s
```

Manual corrupt-stamp smoke test:

```text
exit=0
→ Fetching from upstream...
→ Fetching from origin...
✓ Already up to date.
```
