### PR TITLE
Fix shell injection in TUI quick_commands and /exec slash command

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import queue
+import shlex
 import subprocess
 import sys
 import threading
@@ -4954,9 +4955,20 @@ def _(rid, params: dict) -> dict:
     if name in qcmds:
         qc = qcmds[name]
         if qc.get("type") == "exec":
+            cmd = qc.get("command", "")
+            try:
+                from tools.approval import detect_dangerous_command
+
+                is_dangerous, _, desc = detect_dangerous_command(cmd)
+                if is_dangerous:
+                    return _err(
+                        rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
+                    )
+            except ImportError:
+                pass
             r = subprocess.run(
-                qc.get("command", ""),
-                shell=True,
+                shlex.split(cmd),
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -6981,7 +6993,7 @@ def _(rid, params: dict) -> dict:
         pass
     try:
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()
+            shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=30, cwd=os.getcwd()
         )
         return _ok(
             rid,


### PR DESCRIPTION
## Bug (Before)

Two RPC handlers in `tui_gateway/server.py` passed user-supplied command strings directly to `subprocess.run()` with `shell=True`:

1. **quick_commands exec** (line ~4957): The `command.dispatch` method resolved a quick-command name and executed its configured command via `subprocess.run(cmd, shell=True)` — allowing shell injection through malicious command arguments.

2. **/exec slash command** (line ~6984): The `shell.exec` method executed `subprocess.run(cmd, shell=True)` after only a `detect_dangerous_command` check — which only blocks a known blocklist, not arbitrary shell metacharacters.

## Fix (After)

Both paths now:
- Parse the command string with `shlex.split()` into a list of arguments
- Pass `shell=False` to `subprocess.run()` — preventing shell interpretation of `&`, `|`, `;`, `$`, backticks, etc.
- The quick_commands path also gains the `detect_dangerous_command` check that was missing

## Impact

An attacker who could send RPC requests to the TUI gateway could execute arbitrary shell commands on the host system with the privileges of the hermes-agent process. This is now prevented.