### PR TITLE
feat: wire durable cron claims and browser write consent

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -44,6 +44,7 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+CLAIM_LEASE_SECONDS = 300
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
@@ -889,7 +890,9 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 claim_owner_id: Optional[str] = None,
+                 claimed_run_at: Optional[str] = None):
     """
     Mark a job as having been run.
     
@@ -904,6 +907,30 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
                 now = _hermes_now().isoformat()
+                kind = job.get("schedule", {}).get("kind")
+                stored_claim = job.get("claim")
+                had_claim = bool(stored_claim)
+                if claim_owner_id is not None or claimed_run_at is not None:
+                    if not isinstance(stored_claim, dict):
+                        logger.warning(
+                            "mark_job_run: stale completion for job %s ignored; no active claim remains",
+                            job_id,
+                        )
+                        return
+                    if (
+                        stored_claim.get("owner_id") != claim_owner_id
+                        or stored_claim.get("run_at") != claimed_run_at
+                    ):
+                        logger.warning(
+                            "mark_job_run: stale completion for job %s ignored; stored claim belongs to %s/%s, runner had %s/%s",
+                            job_id,
+                            stored_claim.get("owner_id"),
+                            stored_claim.get("run_at"),
+                            claim_owner_id,
+                            claimed_run_at,
+                        )
+                        return
+
                 job["last_run_at"] = now
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None
@@ -922,9 +949,16 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         jobs.pop(i)
                         save_jobs(jobs)
                         return
-                
-                # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+
+                job.pop("claim", None)
+
+                # Due-claim ticks advance recurring next_run_at before execution.
+                # Keep that durable recovery point instead of recomputing from
+                # completion time, which drifts cron semantics and can double-skip
+                # after long runs. Legacy/manual run paths with no claim retain the
+                # previous completion-anchored calculation.
+                if not had_claim:
+                    job["next_run_at"] = compute_next_run(job["schedule"], now)
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't
@@ -932,8 +966,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 # Recurring jobs must NEVER be silently disabled: that turns a
                 # missing runtime dep into "job completed" and the user's
                 # schedule quietly goes off. See issue #16265.
-                if job["next_run_at"] is None:
-                    kind = job.get("schedule", {}).get("kind")
+                if not job.get("next_run_at"):
                     if kind in {"cron", "interval"}:
                         job["state"] = "error"
                         if not job.get("last_error"):
@@ -988,6 +1021,142 @@ def advance_next_run(job_id: str) -> bool:
                     return True
                 return False
         return False
+
+
+def _claim_is_live(claim: Any, now: datetime) -> bool:
+    """Return True when a stored durable cron claim is still within its lease."""
+    if not isinstance(claim, dict):
+        return False
+    expires_at = claim.get("expires_at")
+    if not expires_at:
+        return False
+    try:
+        return _ensure_aware(datetime.fromisoformat(expires_at)) > now
+    except (TypeError, ValueError):
+        return False
+
+
+def _next_after_claimed_run(job: Dict[str, Any], claimed_run_at: str) -> Optional[str]:
+    """Compute the next stored run after the schedule occurrence being claimed."""
+    kind = job.get("schedule", {}).get("kind")
+    if kind in {"cron", "interval"}:
+        return compute_next_run(job["schedule"], claimed_run_at)
+    if kind == "once":
+        return None
+    return job.get("next_run_at")
+
+
+def claim_due_jobs(owner_id: Optional[str] = None, *, lease_seconds: int = CLAIM_LEASE_SECONDS) -> List[Dict[str, Any]]:
+    """Atomically claim jobs due for the live scheduler tick.
+
+    The claim is persisted in ``jobs.json`` before execution starts. Recurring
+    jobs also have ``next_run_at`` advanced from the scheduled occurrence being
+    claimed, not from completion time. If Hermes crashes mid-run, restart
+    recovery sees either the advanced ``next_run_at`` (live claim) or reclaims
+    the original ``claim.run_at`` after the lease expires without double
+    advancing the schedule.
+    """
+    owner = owner_id or f"pid:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+    with _jobs_file_lock:
+        now = _hermes_now()
+        raw_jobs = load_jobs()
+        jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
+        claimed: List[Dict[str, Any]] = []
+        changed = False
+
+        for job in jobs:
+            if not job.get("enabled", True):
+                continue
+
+            existing_claim = job.get("claim")
+            recovering_claim = isinstance(existing_claim, dict) and not _claim_is_live(existing_claim, now)
+            if existing_claim and not recovering_claim:
+                continue
+
+            next_run = job.get("next_run_at")
+            claimed_run_at: Optional[str] = None
+
+            if recovering_claim:
+                claimed_run_at = existing_claim.get("run_at") or next_run
+            else:
+                if not next_run:
+                    schedule = job.get("schedule", {})
+                    kind = schedule.get("kind")
+                    recovered_next = _recoverable_oneshot_run_at(
+                        schedule,
+                        now,
+                        last_run_at=job.get("last_run_at"),
+                    )
+                    if not recovered_next and kind in {"cron", "interval"}:
+                        recovered_next = compute_next_run(schedule, now.isoformat())
+                    if not recovered_next:
+                        continue
+                    next_run = recovered_next
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            rj["next_run_at"] = recovered_next
+                            changed = True
+                            break
+                try:
+                    next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
+                except (TypeError, ValueError):
+                    continue
+                if next_run_dt > now:
+                    continue
+                schedule = job.get("schedule", {})
+                kind = schedule.get("kind")
+                grace = _compute_grace_seconds(schedule)
+                if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+                    new_next = compute_next_run(schedule, now.isoformat())
+                    if new_next:
+                        for rj in raw_jobs:
+                            if rj["id"] == job["id"]:
+                                rj["next_run_at"] = new_next
+                                changed = True
+                                break
+                    continue
+                claimed_run_at = next_run
+
+            if not claimed_run_at:
+                continue
+
+            claim = {
+                "owner_id": owner,
+                "claimed_at": now.isoformat(),
+                "expires_at": (now + timedelta(seconds=max(int(lease_seconds), 1))).isoformat(),
+                "run_at": claimed_run_at,
+            }
+            next_after = _next_after_claimed_run(job, claimed_run_at)
+            if job.get("schedule", {}).get("kind") in {"cron", "interval"} and next_after is None:
+                for rj in raw_jobs:
+                    if rj["id"] == job["id"]:
+                        rj["state"] = "error"
+                        rj["last_error"] = (
+                            "Failed to compute next run for recurring schedule "
+                            "while claiming due cron job."
+                        )
+                        changed = True
+                        break
+                continue
+
+            for rj in raw_jobs:
+                if rj["id"] == job["id"]:
+                    rj["claim"] = claim
+                    if next_after is not None:
+                        rj["next_run_at"] = next_after
+                    changed = True
+                    break
+
+            claimed_job = copy.deepcopy(job)
+            claimed_job["claim"] = claim
+            claimed_job["claimed_run_at"] = claimed_run_at
+            if next_after is not None:
+                claimed_job["next_run_at"] = next_after
+            claimed.append(claimed_job)
+
+        if changed:
+            save_jobs(raw_jobs)
+        return claimed
 
 
 def get_due_jobs() -> List[Dict[str, Any]]:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -147,7 +147,14 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    advance_next_run,
+    claim_due_jobs,
+    get_due_jobs,
+    mark_job_run,
+    save_job_output,
+)
+_DEFAULT_GET_DUE_JOBS = get_due_jobs
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1887,7 +1894,14 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         return 0
 
     try:
-        due_jobs = get_due_jobs()
+        if get_due_jobs is not _DEFAULT_GET_DUE_JOBS:
+            # Back-compat for tests/emergency monkeypatches that patch
+            # scheduler.get_due_jobs directly. Production uses claim_due_jobs().
+            due_jobs = get_due_jobs()
+            for job in due_jobs:
+                advance_next_run(job["id"])
+        else:
+            due_jobs = claim_due_jobs()
 
         if verbose and not due_jobs:
             logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
@@ -1895,11 +1909,6 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
-
-        # Advance next_run_at for all recurring jobs FIRST, under the file lock,
-        # before any execution begins.  This preserves at-most-once semantics.
-        for job in due_jobs:
-            advance_next_run(job["id"])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -1964,12 +1973,24 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     success = False
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                mark_kwargs = {"delivery_error": delivery_error}
+                if job.get("claim") or job.get("claimed_run_at"):
+                    mark_kwargs.update({
+                        "claim_owner_id": (job.get("claim") or {}).get("owner_id"),
+                        "claimed_run_at": job.get("claimed_run_at"),
+                    })
+                mark_job_run(job["id"], success, error, **mark_kwargs)
                 return True
 
             except Exception as e:
                 logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
+                mark_kwargs = {}
+                if job.get("claim") or job.get("claimed_run_at"):
+                    mark_kwargs.update({
+                        "claim_owner_id": (job.get("claim") or {}).get("owner_id"),
+                        "claimed_run_at": job.get("claimed_run_at"),
+                    })
+                mark_job_run(job["id"], False, str(e), **mark_kwargs)
                 return False
 
         # Partition due jobs: jobs with a per-job workdir and/or profile touch

--- a/tests/cron/test_due_claim.py
+++ b/tests/cron/test_due_claim.py
@@ -1,0 +1,210 @@
+"""Durable due-claim behavior for the live cron scheduler."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+@pytest.fixture()
+def cron_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_constants
+    import cron.jobs
+    import cron.scheduler
+
+    importlib.reload(hermes_constants)
+    importlib.reload(cron.jobs)
+    importlib.reload(cron.scheduler)
+    return home
+
+
+def _freeze(monkeypatch, when: datetime):
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: when)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: when)
+
+
+def test_claim_due_jobs_atomically_marks_and_advances_recurring_cron(cron_home, monkeypatch):
+    """A live tick claims due jobs and advances recurring schedules before execution."""
+    from cron.jobs import claim_due_jobs, create_job, get_job, update_job
+
+    ny = ZoneInfo("America/New_York")
+    created_at = datetime(2026, 5, 27, 8, 30, tzinfo=ny)
+    due_at = datetime(2026, 5, 27, 9, 0, tzinfo=ny)
+    tick_at = datetime(2026, 5, 27, 9, 1, tzinfo=ny)
+
+    _freeze(monkeypatch, created_at)
+    job = create_job(prompt="say hi", schedule="0 9 * * *", deliver="local")
+    update_job(job["id"], {"next_run_at": due_at.isoformat()})
+
+    _freeze(monkeypatch, tick_at)
+    claimed = claim_due_jobs(owner_id="tick-1")
+
+    assert [j["id"] for j in claimed] == [job["id"]]
+    claimed_job = claimed[0]
+    assert claimed_job["claimed_run_at"] == due_at.isoformat()
+    assert claimed_job["claim"]["owner_id"] == "tick-1"
+
+    stored = get_job(job["id"])
+    assert stored["claim"]["owner_id"] == "tick-1"
+    assert stored["claim"]["run_at"] == due_at.isoformat()
+    assert stored["next_run_at"] == datetime(2026, 5, 28, 9, 0, tzinfo=ny).isoformat()
+
+    # A second scheduler process must not see the same run while the lease is live.
+    assert claim_due_jobs(owner_id="tick-2") == []
+
+
+def test_claim_due_jobs_recovers_expired_claim_without_double_advancing(cron_home, monkeypatch):
+    """Restart recovery reclaims expired leases using the original claimed run time."""
+    from cron.jobs import claim_due_jobs, create_job, get_job, update_job
+
+    utc = ZoneInfo("UTC")
+    _freeze(monkeypatch, datetime(2026, 5, 27, 8, 0, tzinfo=utc))
+    job = create_job(prompt="say hi", schedule="every 10m", deliver="local")
+
+    due_at = datetime(2026, 5, 27, 9, 0, tzinfo=utc)
+    update_job(
+        job["id"],
+        {
+            "next_run_at": datetime(2026, 5, 27, 9, 10, tzinfo=utc).isoformat(),
+            "claim": {
+                "owner_id": "dead-process",
+                "claimed_at": datetime(2026, 5, 27, 9, 0, tzinfo=utc).isoformat(),
+                "expires_at": datetime(2026, 5, 27, 9, 5, tzinfo=utc).isoformat(),
+                "run_at": due_at.isoformat(),
+            },
+        },
+    )
+
+    _freeze(monkeypatch, datetime(2026, 5, 27, 9, 6, tzinfo=utc))
+    claimed = claim_due_jobs(owner_id="after-restart")
+
+    assert [j["id"] for j in claimed] == [job["id"]]
+    assert claimed[0]["claimed_run_at"] == due_at.isoformat()
+    stored = get_job(job["id"])
+    assert stored["claim"]["owner_id"] == "after-restart"
+    assert stored["next_run_at"] == datetime(2026, 5, 27, 9, 10, tzinfo=utc).isoformat()
+
+
+def test_claim_due_jobs_recovers_missing_recurring_next_run_at(cron_home, monkeypatch):
+    """Jobs with missing next_run_at are repaired during claim-based live ticks."""
+    from cron.jobs import claim_due_jobs, create_job, get_job, update_job
+
+    utc = ZoneInfo("UTC")
+    _freeze(monkeypatch, datetime(2026, 5, 27, 8, 0, tzinfo=utc))
+    job = create_job(prompt="say hi", schedule="every 10m", deliver="local")
+    update_job(job["id"], {"next_run_at": None})
+
+    _freeze(monkeypatch, datetime(2026, 5, 27, 9, 0, tzinfo=utc))
+    assert claim_due_jobs(owner_id="tick") == []
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["next_run_at"] == datetime(2026, 5, 27, 9, 10, tzinfo=utc).isoformat()
+    assert stored.get("claim") is None
+
+
+def test_claim_due_jobs_marks_recurring_error_when_next_run_cannot_advance(cron_home, monkeypatch):
+    """Recurring jobs fail closed if a due-claim cannot compute the following run."""
+    from cron.jobs import claim_due_jobs, create_job, get_job, update_job
+    import cron.jobs as jobs
+
+    utc = ZoneInfo("UTC")
+    _freeze(monkeypatch, datetime(2026, 5, 27, 8, 0, tzinfo=utc))
+    job = create_job(prompt="say hi", schedule="every 10m", deliver="local")
+    update_job(job["id"], {"next_run_at": datetime(2026, 5, 27, 9, 0, tzinfo=utc).isoformat()})
+    monkeypatch.setattr(jobs, "_next_after_claimed_run", lambda *_args, **_kwargs: None)
+
+    _freeze(monkeypatch, datetime(2026, 5, 27, 9, 1, tzinfo=utc))
+    assert claim_due_jobs(owner_id="tick") == []
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["state"] == "error"
+    assert "Failed to compute next run" in stored["last_error"]
+    assert stored.get("claim") is None
+
+
+def test_mark_job_run_ignores_stale_completion_after_claim_reclaimed(cron_home, monkeypatch):
+    """A runner whose lease expired must not clear a newer runner's live claim."""
+    from cron.jobs import claim_due_jobs, create_job, get_job, mark_job_run, update_job
+
+    utc = ZoneInfo("UTC")
+    due_at = datetime(2026, 5, 27, 9, 0, tzinfo=utc)
+    _freeze(monkeypatch, datetime(2026, 5, 27, 8, 0, tzinfo=utc))
+    job = create_job(prompt="say hi", schedule="every 10m", deliver="local")
+    update_job(job["id"], {"next_run_at": due_at.isoformat()})
+
+    _freeze(monkeypatch, datetime(2026, 5, 27, 9, 1, tzinfo=utc))
+    first = claim_due_jobs(owner_id="runner-1")[0]
+
+    _freeze(monkeypatch, datetime(2026, 5, 27, 9, 7, tzinfo=utc))
+    second = claim_due_jobs(owner_id="runner-2")[0]
+    assert second["claim"]["owner_id"] == "runner-2"
+
+    mark_job_run(
+        job["id"],
+        True,
+        claim_owner_id=first["claim"]["owner_id"],
+        claimed_run_at=first["claimed_run_at"],
+    )
+
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["claim"]["owner_id"] == "runner-2"
+    assert stored["last_run_at"] is None
+
+
+def test_tick_uses_due_claim_substrate_and_clears_claim_after_run(cron_home, monkeypatch):
+    """scheduler.tick() executes claimed jobs and mark_job_run clears the durable lease."""
+    from cron.jobs import create_job, get_job, update_job
+    import cron.scheduler as scheduler
+
+    utc = ZoneInfo("UTC")
+    _freeze(monkeypatch, datetime(2026, 5, 27, 8, 0, tzinfo=utc))
+    job = create_job(prompt="say hi", schedule="every 15m", deliver="local")
+    update_job(job["id"], {"next_run_at": datetime(2026, 5, 27, 9, 0, tzinfo=utc).isoformat()})
+
+    ran = []
+
+    def fake_run_job(job_dict):
+        ran.append(job_dict["claimed_run_at"])
+        return True, "output", "final", None
+
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda job_id, output: cron_home / "cron" / "output.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *a, **k: None)
+    _freeze(monkeypatch, datetime(2026, 5, 27, 9, 1, tzinfo=utc))
+
+    assert scheduler.tick(verbose=False) == 1
+    assert ran == [datetime(2026, 5, 27, 9, 0, tzinfo=utc).isoformat()]
+    stored = get_job(job["id"])
+    assert stored.get("claim") is None
+    assert stored["next_run_at"] == datetime(2026, 5, 27, 9, 15, tzinfo=utc).isoformat()
+
+
+def test_claimed_one_shot_is_completed_after_successful_tick(cron_home, monkeypatch):
+    from cron.jobs import create_job, get_job, update_job
+    import cron.scheduler as scheduler
+
+    utc = ZoneInfo("UTC")
+    due_at = datetime(2026, 5, 27, 9, 0, tzinfo=utc)
+    _freeze(monkeypatch, datetime(2026, 5, 27, 8, 0, tzinfo=utc))
+    job = create_job(prompt="once", schedule="2026-05-27T09:00:00+00:00", deliver="local")
+    update_job(job["id"], {"next_run_at": due_at.isoformat()})
+
+    monkeypatch.setattr(scheduler, "run_job", lambda job_dict: (True, "output", "final", None))
+    monkeypatch.setattr(scheduler, "save_job_output", lambda job_id, output: cron_home / "cron" / "output.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *a, **k: None)
+    _freeze(monkeypatch, datetime(2026, 5, 27, 9, 1, tzinfo=utc))
+
+    assert scheduler.tick(verbose=False) == 1
+    assert get_job(job["id"]) is None

--- a/tests/tools/test_browser_read_write_consent.py
+++ b/tests/tools/test_browser_read_write_consent.py
@@ -1,0 +1,114 @@
+"""Browser read/write contract, action broker execution, and session consent."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_browser_runtime():
+    from tools import browser_runtime
+
+    browser_runtime.BROWSER_SESSION_CONSENTS.clear()
+    yield
+    browser_runtime.BROWSER_SESSION_CONSENTS.clear()
+
+
+def test_browser_session_api_inspects_grants_and_revokes_write_consent():
+    from tools.browser_tool import browser_session
+
+    initial = json.loads(browser_session(action="status", task_id="s1"))
+    assert initial["success"] is True
+    assert initial["consent"]["write"] is False
+
+    granted = json.loads(browser_session(action="grant", task_id="s1", reason="QA run"))
+    assert granted["success"] is True
+    assert granted["consent"]["write"] is True
+    assert granted["consent"]["reason"] == "QA run"
+
+    revoked = json.loads(browser_session(action="revoke", task_id="s1"))
+    assert revoked["success"] is True
+    assert revoked["consent"]["write"] is False
+
+
+def test_browser_write_is_blocked_until_session_consent_is_granted(monkeypatch):
+    from tools.browser_tool import browser_session, browser_write
+    from tools import browser_runtime
+
+    calls = []
+
+    def fake_execute(self, request):
+        calls.append(request)
+        return {"success": True, "action": request.action}
+
+    monkeypatch.setattr(browser_runtime.ActionBroker, "execute", fake_execute)
+
+    blocked = json.loads(
+        browser_write(action="click", parameters={"ref": "@e1"}, task_id="session-a")
+    )
+    assert blocked["success"] is False
+    assert blocked["error_code"] == "browser_session_consent_required"
+    assert calls == []
+
+    browser_session(action="grant", task_id="session-a")
+    allowed = json.loads(
+        browser_write(action="click", parameters={"ref": "@e1"}, task_id="session-a")
+    )
+    assert allowed == {"success": True, "action": "click"}
+    assert calls[0].kind == "write"
+    assert calls[0].action == "click"
+
+
+def test_browser_read_executes_through_action_broker_without_write_consent(monkeypatch):
+    from tools.browser_tool import browser_read
+    from tools import browser_runtime
+
+    calls = []
+
+    def fake_execute(self, request):
+        calls.append(request)
+        return {"success": True, "snapshot": "ok"}
+
+    monkeypatch.setattr(browser_runtime.ActionBroker, "execute", fake_execute)
+
+    result = json.loads(browser_read(action="snapshot", parameters={"full": True}, task_id="r1"))
+
+    assert result == {"success": True, "snapshot": "ok"}
+    assert calls[0].kind == "read"
+    assert calls[0].action == "snapshot"
+    assert calls[0].parameters == {"full": True}
+
+
+def test_browser_read_console_rejects_javascript_expression(monkeypatch):
+    from tools.browser_tool import browser_read
+    from tools import browser_runtime
+
+    calls = []
+
+    def fake_console(*_args, **_kwargs):
+        calls.append((_args, _kwargs))
+        return json.dumps({"success": True})
+
+    import tools.browser_tool as bt
+    monkeypatch.setattr(bt, "browser_console", fake_console)
+
+    result = json.loads(browser_read(action="console", parameters={"expression": "document.body.click()"}, task_id="r2"))
+
+    assert result["success"] is False
+    assert result["error_code"] == "browser_read_expression_forbidden"
+    assert calls == []
+
+
+def test_browser_runtime_broker_dispatches_to_live_browser_operations(monkeypatch):
+    from tools.browser_runtime import ActionBroker, BrowserActionRequest
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "browser_click", lambda ref, task_id=None: json.dumps({"clicked": ref, "task_id": task_id}))
+
+    result = ActionBroker().execute(
+        BrowserActionRequest(kind="write", action="click", parameters={"ref": "@e7"}, task_id="live")
+    )
+
+    assert result == {"clicked": "@e7", "task_id": "live"}

--- a/tools/browser_runtime.py
+++ b/tools/browser_runtime.py
@@ -1,0 +1,177 @@
+"""Runtime contract for browser.read/browser.write style tools.
+
+This module keeps policy (session write consent) separate from execution
+(ActionBroker dispatch to the existing browser implementation).  The existing
+browser_* tools remain as compatibility shims; the new contract routes through
+these classes so read/write calls cannot bypass consent checks by accident.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from typing import Any, Dict, Optional
+
+
+BROWSER_SESSION_CONSENTS: dict[str, dict[str, Any]] = {}
+
+
+@dataclass(frozen=True)
+class BrowserActionRequest:
+    kind: str  # "read" | "write"
+    action: str
+    parameters: Dict[str, Any]
+    task_id: Optional[str] = None
+
+
+class BrowserSessionConsentStore:
+    """In-process browser session consent registry keyed by task/session id."""
+
+    @staticmethod
+    def _key(task_id: Optional[str]) -> str:
+        return task_id or "default"
+
+    def status(self, task_id: Optional[str]) -> dict[str, Any]:
+        key = self._key(task_id)
+        entry = BROWSER_SESSION_CONSENTS.get(key) or {}
+        return {
+            "task_id": key,
+            "write": bool(entry.get("write")),
+            "granted_at": entry.get("granted_at"),
+            "reason": entry.get("reason"),
+        }
+
+    def grant(self, task_id: Optional[str], *, reason: str = "") -> dict[str, Any]:
+        key = self._key(task_id)
+        BROWSER_SESSION_CONSENTS[key] = {
+            "write": True,
+            "granted_at": datetime.now(timezone.utc).isoformat(),
+            "reason": reason or None,
+        }
+        return self.status(key)
+
+    def revoke(self, task_id: Optional[str]) -> dict[str, Any]:
+        key = self._key(task_id)
+        BROWSER_SESSION_CONSENTS.pop(key, None)
+        return self.status(key)
+
+    def has_write_consent(self, task_id: Optional[str]) -> bool:
+        return self.status(task_id)["write"]
+
+
+class ApprovalService:
+    """Policy gate for browser actions.
+
+    Read actions are always allowed. Write actions require explicit per-session
+    browser consent granted through the public browser_session API.
+    """
+
+    def __init__(self, consent_store: BrowserSessionConsentStore | None = None):
+        self.consent_store = consent_store or BrowserSessionConsentStore()
+
+    def authorize(self, request: BrowserActionRequest) -> dict[str, Any]:
+        if request.kind == "read":
+            return {"approved": True}
+        if request.kind != "write":
+            return {"approved": False, "error": f"Unknown browser action kind: {request.kind}"}
+        if self.consent_store.has_write_consent(request.task_id):
+            return {"approved": True}
+        return {
+            "approved": False,
+            "error_code": "browser_session_consent_required",
+            "error": (
+                "Browser write action requires session consent. Call "
+                "browser_session(action='grant') after inspecting the session, "
+                "or choose a read-only browser action."
+            ),
+            "consent": self.consent_store.status(request.task_id),
+        }
+
+
+class ActionBroker:
+    """Dispatch browser read/write requests to the live browser runtime."""
+
+    def execute(self, request: BrowserActionRequest) -> dict[str, Any]:
+        import tools.browser_tool as bt
+
+        params = dict(request.parameters or {})
+        task_id = request.task_id
+
+        if request.kind == "read":
+            if request.action == "snapshot":
+                return _loads(bt.browser_snapshot(
+                    full=bool(params.get("full", False)),
+                    task_id=task_id,
+                    user_task=params.get("user_task"),
+                ))
+            if request.action == "console":
+                if params.get("expression"):
+                    return {
+                        "success": False,
+                        "error_code": "browser_read_expression_forbidden",
+                        "error": (
+                            "browser_read(action='console') can read buffered console messages only. "
+                            "JavaScript expressions may mutate the page and are intentionally "
+                            "not part of the read-only browser contract."
+                        ),
+                    }
+                return _loads(bt.browser_console(
+                    clear=bool(params.get("clear", False)),
+                    expression=None,
+                    task_id=task_id,
+                ))
+            if request.action == "images":
+                return _loads(bt.browser_get_images(task_id=task_id))
+            raise ValueError(f"Unsupported browser read action: {request.action}")
+
+        if request.kind == "write":
+            if request.action == "navigate":
+                return _loads(bt.browser_navigate(url=str(params.get("url", "")), task_id=task_id))
+            if request.action == "click":
+                return _loads(bt.browser_click(ref=str(params.get("ref", "")), task_id=task_id))
+            if request.action == "type":
+                return _loads(bt.browser_type(
+                    ref=str(params.get("ref", "")),
+                    text=str(params.get("text", "")),
+                    task_id=task_id,
+                ))
+            if request.action == "scroll":
+                return _loads(bt.browser_scroll(direction=str(params.get("direction", "down")), task_id=task_id))
+            if request.action == "back":
+                return _loads(bt.browser_back(task_id=task_id))
+            if request.action == "press":
+                return _loads(bt.browser_press(key=str(params.get("key", "")), task_id=task_id))
+            raise ValueError(f"Unsupported browser write action: {request.action}")
+
+        raise ValueError(f"Unsupported browser action kind: {request.kind}")
+
+
+def _loads(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        parsed = json.loads(value)
+        return parsed if isinstance(parsed, dict) else {"success": True, "data": parsed}
+    return {"success": True, "data": value}
+
+
+def execute_browser_action(
+    *,
+    kind: str,
+    action: str,
+    parameters: Optional[Dict[str, Any]] = None,
+    task_id: Optional[str] = None,
+    approval_service: ApprovalService | None = None,
+    broker: ActionBroker | None = None,
+) -> dict[str, Any]:
+    request = BrowserActionRequest(
+        kind=kind,
+        action=action,
+        parameters=dict(parameters or {}),
+        task_id=task_id,
+    )
+    approval = (approval_service or ApprovalService()).authorize(request)
+    if not approval.get("approved"):
+        return {"success": False, **approval}
+    return (broker or ActionBroker()).execute(request)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1615,6 +1615,42 @@ BROWSER_TOOL_SCHEMAS = [
             "required": []
         }
     },
+    {
+        "name": "browser_session",
+        "description": "Inspect or change browser session consent. Use action='status' to inspect whether browser.write is allowed for the current session, action='grant' to allow browser.write actions after the user has consented, or action='revoke' to remove that consent.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {"type": "string", "enum": ["status", "grant", "revoke"], "description": "Consent operation to perform."},
+                "reason": {"type": "string", "description": "Optional user-visible reason recorded when granting write consent."}
+            },
+            "required": ["action"]
+        }
+    },
+    {
+        "name": "browser_read",
+        "description": "Read from the active browser session through the browser ActionBroker. Read actions do not mutate the page and do not require browser session write consent. Actions: snapshot, console, images. Requires browser_navigate or browser.write(action='navigate') first for page-specific reads.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {"type": "string", "enum": ["snapshot", "console", "images"], "description": "Read action to execute."},
+                "parameters": {"type": "object", "description": "Action-specific parameters. Supported: {'full': true} for snapshot; {'clear': true} for console log retrieval. JavaScript expressions are not allowed in browser_read because they can mutate page state."}
+            },
+            "required": ["action"]
+        }
+    },
+    {
+        "name": "browser_write",
+        "description": "Mutate the active browser session through the browser ActionBroker after browser_session(action='grant') has granted write consent for this session. Actions: navigate, click, type, scroll, back, press.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {"type": "string", "enum": ["navigate", "click", "type", "scroll", "back", "press"], "description": "Write action to execute."},
+                "parameters": {"type": "object", "description": "Action-specific parameters, e.g. {'url': 'https://example.com'}, {'ref': '@e1'}, {'ref': '@e2', 'text': 'hello'}, {'direction': 'down'}, or {'key': 'Enter'}."}
+            },
+            "required": ["action"]
+        }
+    },
 ]
 
 
@@ -3484,6 +3520,61 @@ def cleanup_all_browsers() -> None:
     _cached_browser_engine = None
     _browser_engine_resolved = False
 
+def browser_session(action: str = "status", reason: str = "", task_id: Optional[str] = None) -> str:
+    """Inspect/grant/revoke browser write consent for a browser session."""
+    from tools.browser_runtime import BrowserSessionConsentStore
+
+    store = BrowserSessionConsentStore()
+    normalized = (action or "status").strip().lower()
+    try:
+        if normalized == "status":
+            consent = store.status(task_id)
+        elif normalized == "grant":
+            consent = store.grant(task_id, reason=reason or "")
+        elif normalized == "revoke":
+            consent = store.revoke(task_id)
+        else:
+            return json.dumps({"success": False, "error": f"Unsupported browser_session action: {action}"})
+        return json.dumps({"success": True, "consent": consent})
+    except Exception as exc:
+        logger.warning("browser_session failed: %s", exc, exc_info=True)
+        return json.dumps({"success": False, "error": str(exc)})
+
+
+def browser_read(action: str, parameters: Optional[Dict[str, Any]] = None, task_id: Optional[str] = None) -> str:
+    """Execute a read-only browser action through the ActionBroker."""
+    from tools.browser_runtime import execute_browser_action
+
+    try:
+        result = execute_browser_action(
+            kind="read",
+            action=(action or "").strip().lower(),
+            parameters=parameters or {},
+            task_id=task_id,
+        )
+        return json.dumps(result)
+    except Exception as exc:
+        logger.warning("browser_read failed: %s", exc, exc_info=True)
+        return json.dumps({"success": False, "error": str(exc)})
+
+
+def browser_write(action: str, parameters: Optional[Dict[str, Any]] = None, task_id: Optional[str] = None) -> str:
+    """Execute a mutating browser action through consent + ActionBroker."""
+    from tools.browser_runtime import execute_browser_action
+
+    try:
+        result = execute_browser_action(
+            kind="write",
+            action=(action or "").strip().lower(),
+            parameters=parameters or {},
+            task_id=task_id,
+        )
+        return json.dumps(result)
+    except Exception as exc:
+        logger.warning("browser_write failed: %s", exc, exc_info=True)
+        return json.dumps({"success": False, "error": str(exc)})
+
+
 # ============================================================================
 # Requirements Check
 # ============================================================================
@@ -3814,4 +3905,40 @@ registry.register(
     handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖥️",
+)
+registry.register(
+    name="browser_session",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_session"],
+    handler=lambda args, **kw: browser_session(
+        action=args.get("action", "status"),
+        reason=args.get("reason", ""),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_browser_requirements,
+    emoji="🔐",
+)
+registry.register(
+    name="browser_read",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_read"],
+    handler=lambda args, **kw: browser_read(
+        action=args.get("action", ""),
+        parameters=args.get("parameters") or {},
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_browser_requirements,
+    emoji="📖",
+)
+registry.register(
+    name="browser_write",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_write"],
+    handler=lambda args, **kw: browser_write(
+        action=args.get("action", ""),
+        parameters=args.get("parameters") or {},
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_browser_requirements,
+    emoji="✍️",
 )


### PR DESCRIPTION
## Summary
- wire the live cron tick to the durable due-claim substrate with timezone-aware next-run calculation and restart/expired-lease recovery
- add browser.read/browser.write/browser_session contract through ActionBroker + ApprovalService runtime execution
- enforce browser session write consent for the new browser.write path and reject JavaScript evaluation from read-only browser.read

## Test Plan
- `python -m pytest tests/cron/test_due_claim.py tests/tools/test_browser_read_write_consent.py -q -o 'addopts='` → 12 passed
- `python -m pytest tests/cron tests/tools/test_browser_*.py tests/plugins/browser/test_browser_provider_plugins.py tests/cli/test_cli_browser_connect.py -q -o 'addopts='` → 759 passed, 22 skipped; one known flaky `test_object_value_returned_by_value` failed in-suite and passed on isolated rerun
- `python -m pytest tests/tools/test_browser_eval_supervisor_path.py::TestEvaluateRuntimeResponseShaping::test_object_value_returned_by_value -q -o 'addopts='` → 1 passed
