### PR TITLE
fix(cli): make banner update state branch-aware

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -151,8 +151,57 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
-def _check_via_local_git(repo_dir: Path) -> Optional[int]:
-    """Count commits behind origin/main in a local checkout."""
+def _git_current_branch(repo_dir: Path) -> Optional[str]:
+    """Return the current branch name, or None when detached/unknown."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    branch = (result.stdout or "").strip()
+    if not branch or branch == "HEAD":
+        return None
+    return branch
+
+
+def _git_ref_exists(repo_dir: Path, rev: str) -> bool:
+    """Return whether a git revision exists locally."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", rev],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
+
+
+def _resolve_local_git_compare_ref(repo_dir: Path) -> Optional[str]:
+    """Pick the remote ref that update-related banner state should track."""
+    branch = _git_current_branch(repo_dir)
+    if branch and branch != "main":
+        branch_ref = f"origin/{branch}"
+        if _git_ref_exists(repo_dir, branch_ref):
+            return branch_ref
+
+    default_ref = "origin/main"
+    if _git_ref_exists(repo_dir, default_ref):
+        return default_ref
+    return None
+
+
+def _check_via_local_git(repo_dir: Path, compare_ref: Optional[str] = None) -> Optional[int]:
+    """Count commits behind the active remote ref in a local checkout."""
     try:
         subprocess.run(
             ["git", "fetch", "origin", "--quiet"],
@@ -162,9 +211,13 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     except Exception:
         pass  # Offline or timeout — use stale refs, that's fine
 
+    compare_ref = compare_ref or _resolve_local_git_compare_ref(repo_dir)
+    if not compare_ref:
+        return None
+
     try:
         result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            ["git", "rev-list", "--count", f"HEAD..{compare_ref}"],
             capture_output=True, text=True, timeout=5,
             cwd=str(repo_dir),
         )
@@ -222,7 +275,8 @@ def check_for_updates() -> Optional[int]:
 
     Two paths: if ``HERMES_REVISION`` is set (nix builds embed it), compare
     it to upstream main via ``git ls-remote``. Otherwise look for a local
-    git checkout and count commits behind ``origin/main``.
+    git checkout and count commits behind the current branch's remote ref,
+    falling back to ``origin/main`` when needed.
 
     Returns the number of commits behind, ``UPDATE_AVAILABLE_NO_COUNT`` (-1)
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
@@ -231,8 +285,15 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir = None
+    compare_ref = None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
+    if not embedded_rev:
+        repo_dir = _resolve_repo_dir()
+        if repo_dir is not None:
+            compare_ref = _resolve_local_git_compare_ref(repo_dir)
+
+    # Read cache — invalidate if the embedded rev or tracked compare ref changed.
     now = time.time()
     try:
         if cache_file.exists():
@@ -240,6 +301,7 @@ def check_for_updates() -> Optional[int]:
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
+                and cached.get("compare_ref") == compare_ref
             ):
                 return cached.get("behind")
     except Exception:
@@ -248,19 +310,22 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             behind = check_via_pypi()
         else:
-            behind = _check_via_local_git(repo_dir)
+            behind = _check_via_local_git(repo_dir, compare_ref=compare_ref)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "ts": now,
+                    "behind": behind,
+                    "rev": embedded_rev,
+                    "compare_ref": compare_ref,
+                }
+            )
+        )
     except Exception:
         pass
 
@@ -305,7 +370,11 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
     if repo_dir is None:
         return None
 
-    upstream = _git_short_hash(repo_dir, "origin/main")
+    compare_ref = _resolve_local_git_compare_ref(repo_dir)
+    if not compare_ref:
+        return None
+
+    upstream = _git_short_hash(repo_dir, compare_ref)
     local = _git_short_hash(repo_dir, "HEAD")
     if not upstream or not local:
         return None
@@ -313,7 +382,7 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
     ahead = 0
     try:
         result = subprocess.run(
-            ["git", "rev-list", "--count", "origin/main..HEAD"],
+            ["git", "rev-list", "--count", f"{compare_ref}..HEAD"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -46,6 +46,8 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     (repo_dir / ".git").mkdir(parents=True)
 
     results = {
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): MagicMock(returncode=0, stdout="main\n"),
+        ("git", "rev-parse", "--verify", "--quiet", "origin/main"): MagicMock(returncode=0, stdout=""),
         ("git", "rev-parse", "--short=8", "origin/main"): MagicMock(returncode=0, stdout="b2f477a3\n"),
         ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="af8aad31\n"),
         ("git", "rev-list", "--count", "origin/main..HEAD"): MagicMock(returncode=0, stdout="3\n"),
@@ -61,3 +63,55 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
         state = banner.get_git_banner_state(repo_dir)
 
     assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
+
+
+def test_get_git_banner_state_uses_current_branch_remote_ref(tmp_path):
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    results = {
+        ("git", "rev-parse", "--abbrev-ref", "HEAD"): MagicMock(returncode=0, stdout="bb/gui\n"),
+        ("git", "rev-parse", "--verify", "--quiet", "origin/bb/gui"): MagicMock(returncode=0, stdout=""),
+        ("git", "rev-parse", "--short=8", "origin/bb/gui"): MagicMock(returncode=0, stdout="c0ffee12\n"),
+        ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="af8aad31\n"),
+        ("git", "rev-list", "--count", "origin/bb/gui..HEAD"): MagicMock(returncode=0, stdout="2\n"),
+    }
+
+    def fake_run(cmd, **kwargs):
+        key = tuple(cmd)
+        if key not in results:
+            raise AssertionError(f"unexpected command: {cmd}")
+        return results[key]
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        state = banner.get_git_banner_state(repo_dir)
+
+    assert state == {"upstream": "c0ffee12", "local": "af8aad31", "ahead": 2}
+
+
+def test_check_for_updates_cache_is_scoped_to_compare_ref(tmp_path):
+    from hermes_cli import banner
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    cache_file = hermes_home / ".update_check"
+    cache_file.write_text('{"ts": 9999999999, "behind": 7, "rev": null, "compare_ref": "origin/main"}')
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    with (
+        patch.object(banner, "get_hermes_home", return_value=hermes_home),
+        patch.object(banner, "_resolve_repo_dir", return_value=repo_dir),
+        patch.object(banner, "_resolve_local_git_compare_ref", return_value="origin/bb/gui"),
+        patch.object(banner, "_check_via_local_git", return_value=2) as mock_check,
+    ):
+        behind = banner.check_for_updates()
+
+    assert behind == 2
+    assert mock_check.call_count == 1
+    assert mock_check.call_args.args == (repo_dir,)
+    assert mock_check.call_args.kwargs == {"compare_ref": "origin/bb/gui"}
+    assert '"compare_ref": "origin/bb/gui"' in cache_file.read_text()

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -26,10 +26,21 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(
+        json.dumps(
+            {
+                "ts": time.time(),
+                "behind": 3,
+                "compare_ref": "origin/main",
+            }
+        )
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with (
+        patch("hermes_cli.banner._resolve_local_git_compare_ref", return_value="origin/main"),
+        patch("hermes_cli.banner.subprocess.run") as mock_run,
+    ):
         result = check_for_updates()
 
     assert result == 3
@@ -46,12 +57,15 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
 
     # Write an expired cache (timestamp far in the past)
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
+    cache_file.write_text(json.dumps({"ts": 0, "behind": 1, "compare_ref": "origin/main"}))
 
     mock_result = MagicMock(returncode=0, stdout="5\n")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+    with (
+        patch("hermes_cli.banner._resolve_local_git_compare_ref", return_value="origin/main"),
+        patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run,
+    ):
         result = check_for_updates()
 
     assert result == 5


### PR DESCRIPTION
## Summary
Fixes a state parity gap between branch-aware update operations and localized system surfaces by making the startup banner visualization and the `.update_check` cache model completely branch-aware.

## Why This Is Merge-Worthy
A behavior divergence existed between the branch-aware core update mechanics and adjacent interface surfaces. While a recent update introduced specific branch tracking capabilities to the update engine, the terminal welcome banner and the 6-hour filesystem cache block still evaluated remote drift metrics exclusively against a hard-coded `origin/main` target. Consequently, users operating on custom engineering or feature branches saw erroneous ahead/behind status logs or inherited invalid configuration keys from stale cache payloads.

## Parity Reference Source
This modification directly aligns interface surfaces with the invariant established in:
- Commit: 9d3e9316f4a42bf13401ef004fe17db1a99eb990
- Message: `feat(cli): add --branch flag to hermes update`

## Scope of Changes
- **hermes_cli/banner.py**: Refactored git state resolution paths to evaluate active branch tracking parameters dynamically (`origin/<current-branch>`) before utilizing traditional `origin/main` fallbacks.
- **hermes_cli/banner.py**: Extended the `.update_check` local storage configuration schema to scope valid entry arrays explicitly by their resolved `compare_ref` parameters.
- **tests/hermes_cli/test_banner_git_state.py**: Injected target regression checks mapping proper isolated cache storage keys and specific remote target selections.

## Verified Test Suites
Targeted git state resolution checks and branch-flag update regressions completed with absolute success:
- `tests/hermes_cli/test_banner_git_state.py`
- `tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFlag`
- `tests/hermes_cli/test_cmd_update.py::TestCmdUpdateCheckBranchFlag`

```text
15 passed, 0 failed
