### PR TITLE
Apply least-privilege execute permissions on installed binaries

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -423,7 +423,7 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
                 except OSError:
                     pass
                 return None, "cross_device_copy_failed"
-        os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR)
 
         verification = "cosign + SHA-256" if cosign_verified else "SHA-256 only"
         logger.info("tirith installed to %s (%s)", dest, verification)


### PR DESCRIPTION
## BUG

When installing the tirith binary via the auto-install flow (cross-device copy path in ), the chmod call unconditionally added execute bits for all permission classes:

```python
os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
```

This made the installed binary world-executable, violating the principle of least privilege.

## FIX

Restrict the execute bit to the owner only:

```python
os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR)
```

## IMPACT

After cosign/SHA-256 verification of the downloaded binary, the installer now only sets the owner execute bit (S_IXUSR), removing group and world execute bits. This prevents non-owner users from executing the binary unless explicitly permitted by the system administrator through group membership or ACLs.