### PR TITLE
docs(messaging): add footnote explaining Email typing is protocol limitation

### DIFF
--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -21,7 +21,7 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | SMS | — | — | — | — | — | — | — |
-| Email | — | ✅ | ✅ | ✅ | — | — | — |
+| Email | — | ✅ | ✅ | ✅ | — | — [^email-typing] | — |
 | Home Assistant | — | — | — | — | — | — | — |
 | Mattermost | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
 | Matrix | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -38,6 +38,8 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | ntfy | — | — | — | — | — | — | — |
 
 **Voice** = TTS audio replies and/or voice message transcription. **Images** = send/receive images. **Files** = send/receive file attachments. **Threads** = threaded conversations. **Reactions** = emoji reactions on messages. **Typing** = typing indicator while processing. **Streaming** = progressive message updates via editing.
+
+[^email-typing]: Email typing indicators are inherently unsupported by the IMAP/SMTP protocol. The `send_typing()` method is implemented as a no-op (see `gateway/platforms/email.py`). This is a fundamental protocol limitation, not a missing Hermes implementation — it cannot be added without a real-time protocol like WebSocket.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
Adds a footnote to the messaging/email docs explaining that the typing indicator behavior is a protocol limitation, not a bug.

## Changes
- Added footnote to email/messaging documentation

## Checklist
- [x] Follows repo conventions
- [x] Single-focus change
- [x] No unrelated changes