### PR TITLE
feat(image_gen/fal): add Krea 2 Medium + Large to FAL catalog

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -317,6 +317,54 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
         },
         "upscale": False,
     },
+    # Krea 2 — Krea's first foundation image model, day-0 partner launch on
+    # fal (2026-05-27). Same model family as our direct ``plugins/image_gen/krea``
+    # backend, exposed here for users who prefer to bill through their
+    # existing FAL key / Nous Portal subscription rather than register
+    # directly with Krea.  Both variants share the same parameter schema —
+    # only model id, price, and recommended use case differ.
+    "fal-ai/krea/v2/medium/text-to-image": {
+        "display": "Krea 2 Medium",
+        "speed": "~15-25s",
+        "strengths": "Illustration, anime, painting, expressive/artistic styles",
+        "price": "$0.030 (text) / $0.035 (style refs)",
+        "size_style": "aspect_ratio",
+        # Krea natively accepts 1:1, 4:3, 3:2, 16:9, 2.35:1, 4:5, 2:3, 9:16 —
+        # we map our 3 abstract ratios to the closest match.
+        "sizes": {
+            "landscape": "16:9",
+            "square": "1:1",
+            "portrait": "9:16",
+        },
+        "defaults": {
+            "creativity": "medium",
+        },
+        "supports": {
+            "prompt", "aspect_ratio", "creativity", "seed",
+            "image_style_references",
+        },
+        "upscale": False,
+    },
+    "fal-ai/krea/v2/large/text-to-image": {
+        "display": "Krea 2 Large",
+        "speed": "~25-60s",
+        "strengths": "Photorealism, raw textured looks (motion blur, grain, film)",
+        "price": "$0.060 (text) / $0.065 (style refs)",
+        "size_style": "aspect_ratio",
+        "sizes": {
+            "landscape": "16:9",
+            "square": "1:1",
+            "portrait": "9:16",
+        },
+        "defaults": {
+            "creativity": "medium",
+        },
+        "supports": {
+            "prompt", "aspect_ratio", "creativity", "seed",
+            "image_style_references",
+        },
+        "upscale": False,
+    },
 }
 
 # Default model is the fastest reasonable option. Kept cheap and sub-1s.


### PR DESCRIPTION
## Summary
Adds Krea 2 Medium + Krea 2 Large to the FAL_MODELS catalog. fal announced Krea 2 as a day-0 official API partner on 2026-05-27 — these model IDs are now selectable in `hermes tools` → Image Generation → FAL.ai alongside flux-2, gpt-image-2, nano-banana, etc.

This is the FAL-routed variant. The native-Krea-API plugin shipped in PR #33236 (`plugins/image_gen/krea/`) remains available for users who want to bill directly through Krea's API. Both converge on the same underlying model — pick the billing path you already have.

## Changes
- `tools/image_generation_tool.py` — two new `FAL_MODELS` entries:
  - `fal-ai/krea/v2/medium/text-to-image` ($0.030/image)
  - `fal-ai/krea/v2/large/text-to-image` ($0.060/image)

Both use `size_style: "aspect_ratio"` (mapping landscape→16:9, square→1:1, portrait→9:16) and `supports = {prompt, aspect_ratio, creativity, seed, image_style_references}`. No `num_inference_steps`/`guidance_scale`/`num_images` — Krea doesn't expose those, and the supports-set filter strips them defensively if the agent ever passes them.

## Parameter schema (per fal's API docs)
- `prompt` (required)
- `aspect_ratio` — `1:1, 4:3, 3:2, 16:9, 2.35:1, 4:5, 2:3, 9:16` (Krea native; we map our 3 abstract ratios into this set)
- `creativity` — `raw | low | medium | high` (default `medium`)
- `seed` — int (reproducibility)
- `image_style_references` — list of `{image_url, strength}`, max 10 per Krea's spec

## Nous Portal · managed-FAL gateway
This commit makes the IDs known to the catalog + picker. The Portal team will need to allowlist these two endpoint slugs on the `fal-queue` origin server-side for them to flow through the managed billing path. No code change needed on our end once that's done.

## Validation
| | Result |
|---|---|
| `tests/tools/test_image_generation.py` (catalog invariants) | 55/55 |
| `tests/tools/test_image_generation_env.py` | passing |
| Full image_gen suite + picker + managed-gateway tests | 189/189 |
| E2E payload construction (both variants × 3 aspect ratios × overrides) | `_build_fal_payload()` produces correct wire payload, supports-set filter strips unknown keys |

Not live-tested against fal yet — pending verifying the exact endpoint slug format (`fal-ai/krea/v2/...` vs `krea/v2/...`; both forms appear in fal's launch materials).

Refs: https://fal.ai/krea-2 · https://fal.ai/models/krea/v2/large/text-to-image/api · https://fal.ai/models/krea/v2/medium/text-to-image/api

## Infographic

![krea-on-fal](https://v3b.fal.media/files/b/0a9bf1a5/Pz1H8VJMuI6QkL9L1Dbx0_IZNoOoGM.png)
