### PR TITLE
Add non-agentic scheduled auto-update support under hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8369,6 +8369,136 @@ def _resolve_update_branch(args) -> str:
     return (getattr(args, "branch", None) or "main").strip() or "main"
 
 
+def _get_update_check_result(
+    branch: str = "main",
+    *,
+    branch_explicit: bool = False,
+    announce: bool = False,
+) -> dict:
+    """Return structured data for the existing ``hermes update --check`` path.
+
+    Kept next to ``_cmd_update_check`` so the CLI preview and Phase 1
+    auto-update runner share the same fetch/compare behavior.
+    """
+    from hermes_cli.config import detect_install_method
+
+    method = detect_install_method(PROJECT_ROOT)
+    if method == "pip":
+        from hermes_cli import __version__
+        from hermes_cli.banner import check_via_pypi
+
+        result = check_via_pypi()
+        if result is None:
+            raise RuntimeError("Could not reach PyPI to check for updates.")
+        return {
+            "install_method": "pip",
+            "branch": branch,
+            "branch_explicit": branch_explicit,
+            "branch_ignored": bool(branch_explicit and branch != "main"),
+            "current_version": __version__,
+            "latest_version": "",
+            "compare_ref": "pypi",
+            "behind": int(result),
+            "update_available": bool(result),
+        }
+
+    git_dir = PROJECT_ROOT / ".git"
+    if not git_dir.exists():
+        raise RuntimeError("Not a git repository — cannot check for updates.")
+
+    git_cmd = ["git"]
+    if sys.platform == "win32":
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+
+    if branch == "main":
+        if announce:
+            print("→ Fetching from upstream...")
+        fetch_result = subprocess.run(
+            git_cmd + ["fetch", "upstream"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if fetch_result.returncode != 0:
+            if announce:
+                print("→ Fetching from origin...")
+            fetch_result = subprocess.run(
+                git_cmd + ["fetch", "origin"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            compare_branch = f"origin/{branch}"
+        else:
+            compare_branch = f"upstream/{branch}"
+    else:
+        if announce:
+            print("→ Fetching from origin...")
+        fetch_result = subprocess.run(
+            git_cmd + ["fetch", "origin"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        compare_branch = f"origin/{branch}"
+
+    if fetch_result.returncode != 0:
+        stderr = fetch_result.stderr.strip()
+        if "Could not resolve host" in stderr or "unable to access" in stderr:
+            raise RuntimeError("Network error — cannot reach the remote repository.")
+        if "Authentication failed" in stderr or "could not read Username" in stderr:
+            raise RuntimeError("Authentication failed — check your git credentials or SSH key.")
+        first = stderr.splitlines()[0] if stderr else "unknown error"
+        raise RuntimeError(f"Failed to fetch: {first}")
+
+    verify_result = subprocess.run(
+        git_cmd + ["rev-parse", "--verify", "--quiet", compare_branch],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if verify_result.returncode != 0:
+        raise RuntimeError(
+            f"Branch '{branch}' not found on {compare_branch.split('/', 1)[0]}."
+        )
+
+    rev_result = subprocess.run(
+        git_cmd + ["rev-list", f"HEAD..{compare_branch}", "--count"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    behind = int(rev_result.stdout.strip())
+
+    current_result = subprocess.run(
+        git_cmd + ["rev-parse", "--short", "HEAD"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    latest_result = subprocess.run(
+        git_cmd + ["rev-parse", "--short", compare_branch],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    return {
+        "install_method": "git",
+        "branch": branch,
+        "branch_explicit": branch_explicit,
+        "branch_ignored": False,
+        "current_version": current_result.stdout.strip(),
+        "latest_version": latest_result.stdout.strip(),
+        "compare_ref": compare_branch,
+        "behind": behind,
+        "update_available": behind > 0,
+    }
+
+
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     """Implement ``hermes update --check``: fetch and report without installing.
 
@@ -8381,106 +8511,46 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     on a PyPI install we surface a one-line notice instead of silently
     dropping the flag.
     """
-    from hermes_cli.config import detect_install_method
-    method = detect_install_method(PROJECT_ROOT)
-    if method == "pip":
-        from hermes_cli.config import recommended_update_command
-        from hermes_cli.banner import check_via_pypi
-        if branch_explicit and branch != "main":
-            print(f"⚠ --branch is ignored for PyPI installs (would have checked '{branch}').")
-        result = check_via_pypi()
-        if result is None:
+    try:
+        result = _get_update_check_result(
+            branch=branch,
+            branch_explicit=branch_explicit,
+            announce=True,
+        )
+    except RuntimeError as exc:
+        msg = str(exc)
+        if msg.startswith("Could not reach PyPI"):
             print("✗ Could not reach PyPI to check for updates.")
-            sys.exit(1)
-        elif result == 0:
+        elif msg.startswith("Not a git repository"):
+            print("✗ Not a git repository — cannot check for updates.")
+        elif msg.startswith("Network error"):
+            print("✗ Network error — cannot reach the remote repository.")
+        elif msg.startswith("Authentication failed"):
+            print(f"✗ {msg}")
+        elif msg.startswith("Branch "):
+            print(f"✗ {msg}")
+        elif msg.startswith("Failed to fetch:"):
+            print("✗ Failed to fetch.")
+            detail = msg.partition(":")[2].strip()
+            if detail:
+                print(f"  {detail}")
+        else:
+            print(f"✗ {msg}")
+        sys.exit(1)
+
+    if result["install_method"] == "pip":
+        from hermes_cli.config import recommended_update_command
+        if result.get("branch_ignored"):
+            print(f"⚠ --branch is ignored for PyPI installs (would have checked '{branch}').")
+        if result["behind"] == 0:
             print("✓ Already up to date.")
         else:
             print("⚕ Update available on PyPI.")
             print(f"  Run '{recommended_update_command()}' to install.")
         return
 
-    git_dir = PROJECT_ROOT / ".git"
-    if not git_dir.exists():
-        print("✗ Not a git repository — cannot check for updates.")
-        sys.exit(1)
-
-    git_cmd = ["git"]
-    if sys.platform == "win32":
-        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
-
-    # Fetch both origin and upstream; prefer upstream as the canonical reference.
-    # Note: upstream/<branch> may not exist for non-main branches (a fork's
-    # bb/gui has no upstream counterpart), so when the caller picks a
-    # non-default branch we skip the upstream probe and use origin directly.
-    if branch == "main":
-        print("→ Fetching from upstream...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch", "upstream"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-        )
-        if fetch_result.returncode != 0:
-            # Fallback to origin if upstream doesn't exist
-            print("→ Fetching from origin...")
-            fetch_result = subprocess.run(
-                git_cmd + ["fetch", "origin"],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-            )
-            upstream_exists = False
-            compare_branch = f"origin/{branch}"
-        else:
-            upstream_exists = True
-            compare_branch = f"upstream/{branch}"
-    else:
-        # Non-default branch: compare against origin/<branch> directly.
-        print("→ Fetching from origin...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-        )
-        upstream_exists = False
-        compare_branch = f"origin/{branch}"
-
-    if fetch_result.returncode != 0:
-        stderr = fetch_result.stderr.strip()
-        if "Could not resolve host" in stderr or "unable to access" in stderr:
-            print("✗ Network error — cannot reach the remote repository.")
-        elif "Authentication failed" in stderr or "could not read Username" in stderr:
-            print("✗ Authentication failed — check your git credentials or SSH key.")
-        else:
-            print("✗ Failed to fetch.")
-            if stderr:
-                print(f"  {stderr.splitlines()[0]}")
-        sys.exit(1)
-
-    # Verify the compare ref actually exists before asking rev-list about it.
-    # Without this, `git rev-list HEAD..origin/<bogus> --count` exits 128 and
-    # (with check=True) raises CalledProcessError, surfacing a Python
-    # traceback. Friendlier to detect-and-report.
-    verify_result = subprocess.run(
-        git_cmd + ["rev-parse", "--verify", "--quiet", compare_branch],
-        cwd=PROJECT_ROOT,
-        capture_output=True,
-        text=True,
-    )
-    if verify_result.returncode != 0:
-        print(f"✗ Branch '{branch}' not found on {compare_branch.split('/', 1)[0]}.")
-        sys.exit(1)
-
-    rev_result = subprocess.run(
-        git_cmd + ["rev-list", f"HEAD..{compare_branch}", "--count"],
-        cwd=PROJECT_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    behind = int(rev_result.stdout.strip())
-
+    compare_branch = result["compare_ref"]
+    behind = int(result["behind"])
     if behind == 0:
         print("✓ Already up to date.")
     else:
@@ -13533,6 +13603,97 @@ Examples:
         action="store_true",
         default=False,
         help="Windows: proceed with the update even when another hermes.exe is detected. The concurrent process will likely cause WinError 32 warnings and may leave a reboot-deferred .exe replacement.",
+    )
+    update_subparsers = update_parser.add_subparsers(dest="update_subcommand")
+    update_auto_parser = update_subparsers.add_parser(
+        "auto",
+        help="Auto-update run-now and scheduler commands",
+        description=(
+            "Auto-update commands. `run-now` reuses the existing update flow. "
+            "`enable` installs a user-level schedule (launchd on macOS, "
+            "systemd user timer on Linux when available). These commands do not "
+            "install WebUI hooks, notifications, rollback, or a Hermes daemon."
+        ),
+    )
+    update_auto_subparsers = update_auto_parser.add_subparsers(
+        dest="auto_subcommand",
+        required=True,
+    )
+    update_auto_enable = update_auto_subparsers.add_parser(
+        "enable",
+        help="Enable scheduled auto-update",
+        description=(
+            "Enable a user-level schedule that runs `hermes update auto run-now` "
+            "at the requested local time. macOS uses a user LaunchAgent; Linux "
+            "uses a user systemd timer when available."
+        ),
+    )
+    update_auto_enable.add_argument(
+        "--time",
+        required=True,
+        metavar="HH:MM",
+        help="Local 24-hour time to run the scheduled update, for example 03:00.",
+    )
+    update_auto_enable.set_defaults(
+        func=lambda args: __import__(
+            "hermes_cli.update_auto",
+            fromlist=["cmd_auto_enable"],
+        ).cmd_auto_enable(args)
+    )
+    update_auto_disable = update_auto_subparsers.add_parser(
+        "disable",
+        help="Disable scheduled auto-update",
+        description=(
+            "Disable and remove only the Hermes auto-update user-level schedule. "
+            "This does not remove unrelated launchd, systemd, or cron jobs."
+        ),
+    )
+    update_auto_disable.set_defaults(
+        func=lambda args: __import__(
+            "hermes_cli.update_auto",
+            fromlist=["cmd_auto_disable"],
+        ).cmd_auto_disable(args)
+    )
+    update_auto_status = update_auto_subparsers.add_parser(
+        "status",
+        help="Show auto-update scheduler and last-run status",
+        description=(
+            "Show the manual auto-update status file, including the last run, "
+            "version fields, backup path, error, scheduler type/path, and log path."
+        ),
+    )
+    update_auto_status.set_defaults(
+        func=lambda args: __import__(
+            "hermes_cli.update_auto",
+            fromlist=["cmd_auto_status"],
+        ).cmd_auto_status(args)
+    )
+    update_auto_run_now = update_auto_subparsers.add_parser(
+        "run-now",
+        help="Run one manual non-agentic auto-update pass now",
+        description=(
+            "Run one manual non-agentic update pass now. This reuses the existing "
+            "`hermes update` flow, requires a pre-update backup before applying "
+            "changes, uses no LLM/model calls, and writes status/log files."
+        ),
+    )
+    update_auto_run_now.add_argument(
+        "--branch",
+        default=None,
+        metavar="NAME",
+        help="Update against this branch instead of the default (main).",
+    )
+    update_auto_run_now.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Pass through the existing Windows concurrent-process override.",
+    )
+    update_auto_run_now.set_defaults(
+        func=lambda args: __import__(
+            "hermes_cli.update_auto",
+            fromlist=["cmd_auto_run_now"],
+        ).cmd_auto_run_now(args)
     )
     update_parser.set_defaults(func=cmd_update)
 

--- a/hermes_cli/update_auto.py
+++ b/hermes_cli/update_auto.py
@@ -1,0 +1,662 @@
+"""Auto-update scaffolding for ``hermes update auto``.
+
+Scheduling is intentionally a thin wrapper around ``hermes update auto
+run-now``. This module records stable status, writes an append-only human log,
+and delegates the real update work back to the existing ``hermes update``
+implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+STATUS_FILENAME = "update-status.json"
+LOG_FILENAME = "update.log"
+LAUNCHD_LABEL = "com.hermes.agent.auto-update"
+SYSTEMD_BASENAME = "hermes-auto-update"
+
+STATUS_NOT_CONFIGURED = "not_configured"
+STATUS_RUNNING = "running"
+STATUS_SUCCESS = "success"
+STATUS_UP_TO_DATE = "up_to_date"
+STATUS_CHECK_FAILED = "check_failed"
+STATUS_BACKUP_FAILED = "backup_failed"
+STATUS_UPDATE_FAILED = "update_failed"
+STATUS_HEALTH_FAILED = "health_failed"
+
+EXIT_CHECK_FAILED = 10
+EXIT_BACKUP_FAILED = 11
+EXIT_UPDATE_FAILED = 12
+EXIT_HEALTH_FAILED = 13
+
+DEFAULT_STATUS: dict[str, Any] = {
+    "mode": "manual",
+    "enabled": False,
+    "schedule": None,
+    "schedulerType": None,
+    "schedulerPath": None,
+    "lastRunAt": None,
+    "status": STATUS_NOT_CONFIGURED,
+    "previousVersion": None,
+    "latestVersion": None,
+    "currentVersion": None,
+    "backupPath": None,
+    "error": None,
+    "logPath": None,
+}
+
+
+class AutoUpdateError(RuntimeError):
+    def __init__(self, status: str, message: str, exit_code: int) -> None:
+        super().__init__(message)
+        self.status = status
+        self.exit_code = exit_code
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def get_status_path() -> Path:
+    return get_hermes_home() / "state" / STATUS_FILENAME
+
+
+def get_log_path() -> Path:
+    return get_hermes_home() / "logs" / LOG_FILENAME
+
+
+def get_stdout_log_path() -> Path:
+    return get_hermes_home() / "logs" / "update-auto.out.log"
+
+
+def get_stderr_log_path() -> Path:
+    return get_hermes_home() / "logs" / "update-auto.err.log"
+
+
+def read_status() -> dict[str, Any]:
+    path = get_status_path()
+    if not path.exists():
+        return dict(DEFAULT_STATUS, logPath=str(get_log_path()))
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return dict(DEFAULT_STATUS, logPath=str(get_log_path()))
+    if not isinstance(data, dict):
+        return dict(DEFAULT_STATUS, logPath=str(get_log_path()))
+    merged = dict(DEFAULT_STATUS)
+    for key in DEFAULT_STATUS:
+        if key in data:
+            merged[key] = data[key]
+    if not merged.get("logPath"):
+        merged["logPath"] = str(get_log_path())
+    return merged
+
+
+def write_status(status: dict[str, Any]) -> Path:
+    path = get_status_path()
+    payload = dict(DEFAULT_STATUS)
+    payload.update(status)
+    payload["mode"] = payload.get("mode") or "manual"
+    payload["enabled"] = bool(payload.get("enabled", False))
+    if not payload.get("logPath"):
+        payload["logPath"] = str(get_log_path())
+
+    from utils import atomic_json_write
+
+    atomic_json_write(path, payload, indent=2, sort_keys=True)
+    return path
+
+
+def update_status_fields(**fields: Any) -> Path:
+    status = read_status()
+    status.update(fields)
+    return write_status(status)
+
+
+def append_log(
+    event: str,
+    *,
+    result: str | None = None,
+    previous_version: str | None = None,
+    latest_version: str | None = None,
+    current_version: str | None = None,
+    backup_path: str | None = None,
+    error: str | None = None,
+) -> Path:
+    path = get_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = {
+        "event": event,
+        "result": result,
+        "previous": previous_version,
+        "latest": latest_version,
+        "current": current_version,
+        "backup": backup_path,
+        "error": error,
+    }
+    parts = [f"{key}={value}" for key, value in fields.items() if value is not None]
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{_utc_now()} {' '.join(parts)}\n")
+    return path
+
+
+def _current_version() -> str | None:
+    from hermes_cli.main import PROJECT_ROOT
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip() or None
+    except Exception:
+        try:
+            from hermes_cli import __version__
+
+            return __version__
+        except Exception:
+            return None
+
+
+def _verify_health() -> tuple[bool, str]:
+    """Return a lightweight post-update health verdict.
+
+    A full ``hermes doctor`` run can perform provider/network checks and may be
+    slow or flaky in unattended contexts. Phase 1 uses the existing gateway
+    runtime status file instead: it is local, non-destructive, and fails only
+    when the gateway explicitly reports a failed terminal state.
+    """
+    try:
+        from gateway.status import read_runtime_status
+    except Exception as exc:
+        return False, f"could not import gateway status helpers: {exc}"
+
+    runtime = read_runtime_status()
+    if not runtime:
+        return True, "no gateway runtime status present"
+
+    state = str(runtime.get("gateway_state") or "")
+    if state in {"startup_failed", "failed", "stopped"}:
+        reason = runtime.get("exit_reason") or "gateway reported unhealthy state"
+        return False, str(reason)
+    return True, f"gateway state: {state or 'unknown'}"
+
+
+def _status_payload(
+    *,
+    status: str,
+    last_run_at: str,
+    previous_version: str | None = None,
+    latest_version: str | None = None,
+    current_version: str | None = None,
+    backup_path: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    existing = read_status()
+    return {
+        "mode": existing.get("mode") or "manual",
+        "enabled": bool(existing.get("enabled", False)),
+        "schedule": existing.get("schedule"),
+        "schedulerType": existing.get("schedulerType"),
+        "schedulerPath": existing.get("schedulerPath"),
+        "lastRunAt": last_run_at,
+        "status": status,
+        "previousVersion": previous_version,
+        "latestVersion": latest_version,
+        "currentVersion": current_version,
+        "backupPath": backup_path,
+        "error": error,
+        "logPath": str(get_log_path()),
+    }
+
+
+def _display(value: Any, default: str = "-") -> str:
+    if value is None or value == "":
+        return default
+    return str(value)
+
+
+def cmd_auto_status(_args) -> None:
+    status = read_status()
+    enabled = bool(status.get("enabled"))
+    print("Hermes auto-update status")
+    print("  Phase:            2 (scheduled wrapper around run-now)")
+    print(f"  Mode:             {_display(status.get('mode'), 'manual')}")
+    print(f"  Enabled:          {'yes' if enabled else 'no'}")
+    print(f"  Schedule:         {_display(status.get('schedule'), 'not configured')}")
+    print(f"  Scheduler:        {_display(status.get('schedulerType'), 'not configured')}")
+    print(f"  Scheduler path:   {_display(status.get('schedulerPath'))}")
+    print(f"  Last run:         {_display(status.get('lastRunAt'), 'never')}")
+    print(f"  Last result:      {_display(status.get('status'), 'unknown')}")
+    print(f"  Previous version: {_display(status.get('previousVersion'))}")
+    print(f"  Latest known:     {_display(status.get('latestVersion'))}")
+    print(f"  Current version:  {_display(status.get('currentVersion') or _current_version())}")
+    print(f"  Backup path:      {_display(status.get('backupPath'))}")
+    print(f"  Last error:       {_display(status.get('error'))}")
+    print(f"  Detailed log:     {_display(status.get('logPath') or get_log_path())}")
+
+
+def _run_existing_update(args, branch: str | None) -> None:
+    from hermes_cli.main import cmd_update
+
+    update_args = SimpleNamespace(
+        gateway=False,
+        check=False,
+        no_backup=True,
+        backup=False,
+        yes=True,
+        branch=branch,
+        force=getattr(args, "force", False),
+    )
+    try:
+        cmd_update(update_args)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+        if code != 0:
+            raise AutoUpdateError(
+                STATUS_UPDATE_FAILED,
+                f"update failed with exit code {code}",
+                EXIT_UPDATE_FAILED,
+            ) from exc
+
+
+def _parse_time(value: str) -> tuple[int, int, str]:
+    raw = (value or "").strip()
+    if not re.fullmatch(r"\d{2}:\d{2}", raw):
+        raise ValueError("time must use HH:MM format, for example 03:00")
+    hour_s, minute_s = raw.split(":", 1)
+    hour = int(hour_s)
+    minute = int(minute_s)
+    if hour > 23 or minute > 59:
+        raise ValueError("time must be a valid 24-hour HH:MM value")
+    return hour, minute, f"{hour:02d}:{minute:02d}"
+
+
+def _hermes_command_prefix() -> list[str]:
+    argv0 = Path(sys.argv[0])
+    if argv0.name and not argv0.name.startswith("python"):
+        resolved = shutil.which(str(argv0)) if not argv0.is_absolute() else str(argv0)
+        if resolved:
+            return [resolved]
+
+    hermes = shutil.which("hermes")
+    if hermes:
+        return [hermes]
+
+    from hermes_cli.main import PROJECT_ROOT
+
+    return [sys.executable, str(PROJECT_ROOT / "hermes_cli" / "main.py")]
+
+
+def _scheduled_command() -> list[str]:
+    return _hermes_command_prefix() + ["update", "auto", "run-now"]
+
+
+def _launchd_plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+
+
+def _launchd_target() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _run_launchctl(args: list[str]) -> subprocess.CompletedProcess:
+    cmd = ["launchctl"] + args
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
+
+
+def _enable_launchd(hour: int, minute: int, schedule: str) -> tuple[str, Path]:
+    plist_path = _launchd_plist_path()
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    get_log_path().parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "Label": LAUNCHD_LABEL,
+        "ProgramArguments": _scheduled_command(),
+        "StartCalendarInterval": {"Hour": hour, "Minute": minute},
+        "EnvironmentVariables": {"HERMES_HOME": str(get_hermes_home())},
+        "StandardOutPath": str(get_stdout_log_path()),
+        "StandardErrorPath": str(get_stderr_log_path()),
+        "RunAtLoad": False,
+    }
+    with plist_path.open("wb") as handle:
+        plistlib.dump(payload, handle, sort_keys=True)
+
+    target = _launchd_target()
+    _run_launchctl(["bootout", target, str(plist_path)])
+    result = _run_launchctl(["bootstrap", target, str(plist_path)])
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(detail or "launchctl bootstrap failed")
+    _run_launchctl(["enable", f"{target}/{LAUNCHD_LABEL}"])
+    return "launchd", plist_path
+
+
+def _disable_launchd() -> tuple[str, Path, bool]:
+    plist_path = _launchd_plist_path()
+    existed = plist_path.exists()
+    target = _launchd_target()
+    _run_launchctl(["bootout", target, str(plist_path)])
+    if existed:
+        plist_path.unlink()
+    return "launchd", plist_path, existed
+
+
+def _systemd_user_dir() -> Path:
+    return Path.home() / ".config" / "systemd" / "user"
+
+
+def _systemd_paths() -> tuple[Path, Path]:
+    root = _systemd_user_dir()
+    return root / f"{SYSTEMD_BASENAME}.service", root / f"{SYSTEMD_BASENAME}.timer"
+
+
+def _systemctl_user(args: list[str]) -> subprocess.CompletedProcess:
+    cmd = ["systemctl", "--user"] + args
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
+
+
+def _systemd_available() -> bool:
+    if not shutil.which("systemctl"):
+        return False
+    try:
+        result = subprocess.run(
+            ["systemctl", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def _enable_systemd(hour: int, minute: int, schedule: str) -> tuple[str, Path]:
+    if not _systemd_available():
+        raise RuntimeError("systemd user services are not available")
+
+    service_path, timer_path = _systemd_paths()
+    service_path.parent.mkdir(parents=True, exist_ok=True)
+    get_log_path().parent.mkdir(parents=True, exist_ok=True)
+
+    command = " ".join(shlex.quote(part) for part in _scheduled_command())
+    service_path.write_text(
+        "\n".join(
+            [
+                "[Unit]",
+                "Description=Hermes Agent auto-update",
+                "",
+                "[Service]",
+                "Type=oneshot",
+                f"Environment=HERMES_HOME={shlex.quote(str(get_hermes_home()))}",
+                f"ExecStart={command}",
+                f"StandardOutput=append:{get_stdout_log_path()}",
+                f"StandardError=append:{get_stderr_log_path()}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    timer_path.write_text(
+        "\n".join(
+            [
+                "[Unit]",
+                "Description=Run Hermes Agent auto-update",
+                "",
+                "[Timer]",
+                f"OnCalendar=*-*-* {hour:02d}:{minute:02d}:00",
+                "Persistent=true",
+                "",
+                "[Install]",
+                "WantedBy=timers.target",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _systemctl_user(["daemon-reload"])
+    result = _systemctl_user(["enable", "--now", timer_path.name])
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(detail or "systemctl --user enable --now failed")
+    return "systemd-user", timer_path
+
+
+def _disable_systemd() -> tuple[str, Path, bool]:
+    service_path, timer_path = _systemd_paths()
+    existed = service_path.exists() or timer_path.exists()
+    if shutil.which("systemctl"):
+        _systemctl_user(["disable", "--now", timer_path.name])
+    service_path.unlink(missing_ok=True)
+    timer_path.unlink(missing_ok=True)
+    if shutil.which("systemctl"):
+        _systemctl_user(["daemon-reload"])
+    return "systemd-user", timer_path, existed
+
+
+def _enable_scheduler(hour: int, minute: int, schedule: str) -> tuple[str, Path]:
+    if sys.platform == "darwin":
+        return _enable_launchd(hour, minute, schedule)
+    if sys.platform.startswith("linux"):
+        return _enable_systemd(hour, minute, schedule)
+    raise RuntimeError(f"auto-update scheduling is not supported on {sys.platform}")
+
+
+def _disable_scheduler(status: dict[str, Any]) -> tuple[str | None, Path | None, bool]:
+    scheduler = status.get("schedulerType")
+    if scheduler == "launchd" or sys.platform == "darwin":
+        kind, path, existed = _disable_launchd()
+        return kind, path, existed
+    if scheduler == "systemd-user" or sys.platform.startswith("linux"):
+        kind, path, existed = _disable_systemd()
+        return kind, path, existed
+    return None, None, False
+
+
+def cmd_auto_enable(args) -> None:
+    try:
+        hour, minute, schedule = _parse_time(getattr(args, "time", ""))
+        scheduler_type, scheduler_path = _enable_scheduler(hour, minute, schedule)
+    except ValueError as exc:
+        print(f"✗ Invalid schedule time: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    except Exception as exc:
+        print(f"✗ Could not enable auto-update scheduler: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    update_status_fields(
+        mode="scheduled",
+        enabled=True,
+        schedule=schedule,
+        schedulerType=scheduler_type,
+        schedulerPath=str(scheduler_path),
+        logPath=str(get_log_path()),
+    )
+    print("✓ Hermes auto-update scheduled.")
+    print(f"  Time:      {schedule}")
+    print(f"  Scheduler: {scheduler_type}")
+    print(f"  Path:      {scheduler_path}")
+    print("  Command:   hermes update auto run-now")
+
+
+def cmd_auto_disable(_args) -> None:
+    status = read_status()
+    try:
+        scheduler_type, scheduler_path, removed = _disable_scheduler(status)
+    except Exception as exc:
+        print(f"✗ Could not disable auto-update scheduler: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    was_enabled = bool(status.get("enabled"))
+
+    update_status_fields(
+        mode="manual",
+        enabled=False,
+        schedule=None,
+        schedulerType=None,
+        schedulerPath=None,
+        logPath=str(get_log_path()),
+    )
+    if removed or was_enabled:
+        print("✓ Hermes auto-update disabled.")
+        if scheduler_path:
+            print(f"  Removed: {scheduler_path}" if removed else f"  Scheduler path: {scheduler_path}")
+    else:
+        print("Hermes auto-update is already disabled.")
+
+
+def cmd_auto_run_now(args) -> None:
+    from hermes_cli.backup import create_pre_update_backup
+    from hermes_cli.main import _get_update_check_result, _resolve_update_branch
+
+    branch = _resolve_update_branch(args)
+    previous_version = _current_version()
+    latest_version: str | None = None
+    current_version: str | None = previous_version
+    backup_path: str | None = None
+    started_at = _utc_now()
+
+    write_status(
+        _status_payload(
+            status=STATUS_RUNNING,
+            last_run_at=started_at,
+            previous_version=previous_version,
+            current_version=current_version,
+        )
+    )
+    append_log(
+        "start",
+        result=STATUS_RUNNING,
+        previous_version=previous_version,
+        current_version=current_version,
+    )
+
+    try:
+        try:
+            check = _get_update_check_result(
+                branch=branch,
+                branch_explicit=bool(getattr(args, "branch", None)),
+            )
+        except Exception as exc:
+            raise AutoUpdateError(
+                STATUS_CHECK_FAILED,
+                f"update check failed: {exc}",
+                EXIT_CHECK_FAILED,
+            ) from exc
+
+        latest_version = check.get("latest_version") or None
+        if not check.get("update_available"):
+            current_version = _current_version()
+            payload = _status_payload(
+                status=STATUS_UP_TO_DATE,
+                last_run_at=started_at,
+                previous_version=previous_version,
+                latest_version=latest_version,
+                current_version=current_version,
+            )
+            write_status(payload)
+            append_log(
+                "end",
+                result=STATUS_UP_TO_DATE,
+                previous_version=previous_version,
+                latest_version=latest_version,
+                current_version=current_version,
+            )
+            print("✓ Already up to date.")
+            return
+
+        backup = create_pre_update_backup()
+        if backup is None:
+            raise AutoUpdateError(
+                STATUS_BACKUP_FAILED,
+                "pre-update backup failed; aborting update",
+                EXIT_BACKUP_FAILED,
+            )
+        backup_path = str(backup)
+
+        _run_existing_update(args, getattr(args, "branch", None))
+
+        ok, detail = _verify_health()
+        if not ok:
+            raise AutoUpdateError(
+                STATUS_HEALTH_FAILED,
+                f"post-update health check failed: {detail}",
+                EXIT_HEALTH_FAILED,
+            )
+
+        current_version = _current_version()
+        payload = _status_payload(
+            status=STATUS_SUCCESS,
+            last_run_at=started_at,
+            previous_version=previous_version,
+            latest_version=latest_version,
+            current_version=current_version,
+            backup_path=backup_path,
+        )
+        write_status(payload)
+        append_log(
+            "end",
+            result=STATUS_SUCCESS,
+            previous_version=previous_version,
+            latest_version=latest_version,
+            current_version=current_version,
+            backup_path=backup_path,
+        )
+        print("✓ Auto-update run complete.")
+    except AutoUpdateError as exc:
+        current_version = _current_version()
+        payload = _status_payload(
+            status=exc.status,
+            last_run_at=started_at,
+            previous_version=previous_version,
+            latest_version=latest_version,
+            current_version=current_version,
+            backup_path=backup_path,
+            error=str(exc),
+        )
+        write_status(payload)
+        append_log(
+            "end",
+            result=exc.status,
+            previous_version=previous_version,
+            latest_version=latest_version,
+            current_version=current_version,
+            backup_path=backup_path,
+            error=str(exc),
+        )
+        print(f"✗ Auto-update run failed ({exc.status}): {exc}", file=sys.stderr)
+        raise SystemExit(exc.exit_code) from exc

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -484,6 +484,10 @@ class TestCmdUpdateCheckBranchFlag:
 
         cmd_update(args)
 
+        out = capsys.readouterr().out
+        assert "Fetching from origin" in out
+        assert "Update available: 2 commits behind origin/bb/gui" in out
+
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
         # Non-main branch skips upstream probe entirely.
         assert not any("fetch" in c and "upstream" in c for c in commands), commands
@@ -537,6 +541,10 @@ class TestCmdUpdateCheckBranchFlag:
         args = SimpleNamespace(check=True, branch=None)
 
         cmd_update(args)
+
+        out = capsys.readouterr().out
+        assert "Fetching from upstream" in out
+        assert "Already up to date" in out
 
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
         # Should have tried upstream first.

--- a/tests/hermes_cli/test_update_auto.py
+++ b/tests/hermes_cli/test_update_auto.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import json
+import plistlib
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import update_auto
+
+
+def _args(**overrides):
+    base = {"branch": None, "force": False}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _read_status(hermes_home):
+    return json.loads((hermes_home / "state" / "update-status.json").read_text(encoding="utf-8"))
+
+
+def test_write_status_uses_stable_schema_and_profile_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "profile-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    path = update_auto.write_status(
+        {
+            "status": update_auto.STATUS_SUCCESS,
+            "previousVersion": "old",
+            "latestVersion": "new",
+            "currentVersion": "new",
+            "backupPath": "/tmp/backup.zip",
+        }
+    )
+
+    assert path == hermes_home / "state" / "update-status.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert list(data) == sorted(update_auto.DEFAULT_STATUS)
+    assert data["mode"] == "manual"
+    assert data["enabled"] is False
+    assert data["schedule"] is None
+    assert data["status"] == update_auto.STATUS_SUCCESS
+    assert data["backupPath"] == "/tmp/backup.zip"
+    assert data["error"] is None
+    assert data["logPath"] == str(hermes_home / "logs" / "update.log")
+
+
+def test_status_output_when_no_status_file_exists(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "abc123")
+
+    update_auto.cmd_auto_status(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Phase:            2 (scheduled wrapper around run-now)" in out
+    assert "Mode:             manual" in out
+    assert "Enabled:          no" in out
+    assert "Schedule:         not configured" in out
+    assert "Scheduler:        not configured" in out
+    assert "Last run:         never" in out
+    assert "Last result:      not_configured" in out
+    assert "Current version:  abc123" in out
+    assert str(hermes_home / "logs" / "update.log") in out
+
+
+def test_status_output_after_failure(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    update_auto.write_status(
+        {
+            "lastRunAt": "2026-05-27T12:00:00+00:00",
+            "status": update_auto.STATUS_HEALTH_FAILED,
+            "previousVersion": "abc123",
+            "latestVersion": "def456",
+            "currentVersion": "def456",
+            "backupPath": str(hermes_home / "backups" / "pre-update.zip"),
+            "error": "gateway startup failed",
+        }
+    )
+
+    update_auto.cmd_auto_status(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Enabled:          no" in out
+    assert "Schedule:         not configured" in out
+    assert "Last result:      health_failed" in out
+    assert "Previous version: abc123" in out
+    assert "Latest known:     def456" in out
+    assert "Current version:  def456" in out
+    assert "gateway startup failed" in out
+
+
+def test_status_output_tolerates_corrupt_status_file(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    status_path = hermes_home / "state" / "update-status.json"
+    status_path.parent.mkdir(parents=True)
+    status_path.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "abc123")
+
+    update_auto.cmd_auto_status(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Last result:      not_configured" in out
+    assert "Current version:  abc123" in out
+
+
+def _set_macos_scheduler_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(update_auto.sys, "platform", "darwin")
+    monkeypatch.setattr(update_auto.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(update_auto, "_hermes_command_prefix", lambda: ["hermes"])
+    calls = []
+
+    def fake_launchctl(args):
+        calls.append(args)
+        return subprocess.CompletedProcess(["launchctl"] + args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_auto, "_run_launchctl", fake_launchctl)
+    return hermes_home, calls
+
+
+def test_enable_creates_expected_launchd_plist_on_macos(tmp_path, monkeypatch, capsys):
+    hermes_home, calls = _set_macos_scheduler_env(tmp_path, monkeypatch)
+
+    update_auto.cmd_auto_enable(_args(time="03:00"))
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{update_auto.LAUNCHD_LABEL}.plist"
+    assert plist_path.exists()
+    with plist_path.open("rb") as handle:
+        plist = plistlib.load(handle)
+    assert plist["Label"] == update_auto.LAUNCHD_LABEL
+    assert plist["ProgramArguments"] == ["hermes", "update", "auto", "run-now"]
+    assert plist["StartCalendarInterval"] == {"Hour": 3, "Minute": 0}
+    assert plist["EnvironmentVariables"] == {"HERMES_HOME": str(hermes_home)}
+    assert plist["StandardOutPath"] == str(hermes_home / "logs" / "update-auto.out.log")
+    assert plist["StandardErrorPath"] == str(hermes_home / "logs" / "update-auto.err.log")
+    assert any(call[0] == "bootstrap" for call in calls)
+    assert any(call[0] == "enable" for call in calls)
+
+    status = _read_status(hermes_home)
+    assert status["enabled"] is True
+    assert status["mode"] == "scheduled"
+    assert status["schedule"] == "03:00"
+    assert status["schedulerType"] == "launchd"
+    assert status["schedulerPath"] == str(plist_path)
+    out = capsys.readouterr().out
+    assert "Hermes auto-update scheduled" in out
+    assert "03:00" in out
+
+
+def test_enable_is_idempotent_and_updates_existing_launchd_plist(tmp_path, monkeypatch):
+    hermes_home, _calls = _set_macos_scheduler_env(tmp_path, monkeypatch)
+
+    update_auto.cmd_auto_enable(_args(time="03:00"))
+    update_auto.cmd_auto_enable(_args(time="04:30"))
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / f"{update_auto.LAUNCHD_LABEL}.plist"
+    with plist_path.open("rb") as handle:
+        plist = plistlib.load(handle)
+    assert plist["StartCalendarInterval"] == {"Hour": 4, "Minute": 30}
+    status = _read_status(hermes_home)
+    assert status["enabled"] is True
+    assert status["schedule"] == "04:30"
+
+
+def test_disable_removes_only_hermes_launchd_plist(tmp_path, monkeypatch, capsys):
+    hermes_home, calls = _set_macos_scheduler_env(tmp_path, monkeypatch)
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True)
+    hermes_plist = launch_agents / f"{update_auto.LAUNCHD_LABEL}.plist"
+    other_plist = launch_agents / "com.example.other.plist"
+    hermes_plist.write_text("hermes", encoding="utf-8")
+    other_plist.write_text("other", encoding="utf-8")
+    update_auto.write_status(
+        {
+            "enabled": True,
+            "mode": "scheduled",
+            "schedule": "03:00",
+            "schedulerType": "launchd",
+            "schedulerPath": str(hermes_plist),
+        }
+    )
+
+    update_auto.cmd_auto_disable(_args())
+
+    assert not hermes_plist.exists()
+    assert other_plist.exists()
+    assert any(call[0] == "bootout" for call in calls)
+    status = _read_status(hermes_home)
+    assert status["enabled"] is False
+    assert status["schedule"] is None
+    assert status["schedulerType"] is None
+    assert status["schedulerPath"] is None
+    assert "disabled" in capsys.readouterr().out
+
+
+def test_disable_is_idempotent_when_launchd_plist_missing(tmp_path, monkeypatch, capsys):
+    hermes_home, calls = _set_macos_scheduler_env(tmp_path, monkeypatch)
+
+    update_auto.cmd_auto_disable(_args())
+
+    assert calls
+    status = _read_status(hermes_home)
+    assert status["enabled"] is False
+    assert status["schedule"] is None
+    assert "already disabled" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("bad_time", ["3:00", "24:00", "03:60", "0300", "ab:cd"])
+def test_enable_rejects_invalid_time_without_launchctl(tmp_path, monkeypatch, bad_time, capsys):
+    _hermes_home, calls = _set_macos_scheduler_env(tmp_path, monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        update_auto.cmd_auto_enable(_args(time=bad_time))
+
+    assert exc.value.code == 2
+    assert calls == []
+    assert "Invalid schedule time" in capsys.readouterr().err
+
+
+def _set_linux_scheduler_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(update_auto.sys, "platform", "linux")
+    monkeypatch.setattr(update_auto.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(update_auto, "_hermes_command_prefix", lambda: ["hermes"])
+    monkeypatch.setattr(update_auto.shutil, "which", lambda name: "/usr/bin/systemctl" if name == "systemctl" else None)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_auto.subprocess, "run", fake_run)
+    return hermes_home, calls
+
+
+def test_enable_creates_expected_systemd_user_timer_on_linux(tmp_path, monkeypatch):
+    hermes_home, calls = _set_linux_scheduler_env(tmp_path, monkeypatch)
+
+    update_auto.cmd_auto_enable(_args(time="03:00"))
+
+    systemd_dir = tmp_path / ".config" / "systemd" / "user"
+    service_path = systemd_dir / "hermes-auto-update.service"
+    timer_path = systemd_dir / "hermes-auto-update.timer"
+    service_text = service_path.read_text(encoding="utf-8")
+    timer_text = timer_path.read_text(encoding="utf-8")
+    assert "ExecStart=hermes update auto run-now" in service_text
+    assert f"Environment=HERMES_HOME={hermes_home}" in service_text
+    assert f"StandardOutput=append:{hermes_home / 'logs' / 'update-auto.out.log'}" in service_text
+    assert "OnCalendar=*-*-* 03:00:00" in timer_text
+    assert "Persistent=true" in timer_text
+    assert ["systemctl", "--version"] in calls
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    assert ["systemctl", "--user", "enable", "--now", "hermes-auto-update.timer"] in calls
+
+    status = _read_status(hermes_home)
+    assert status["enabled"] is True
+    assert status["schedule"] == "03:00"
+    assert status["schedulerType"] == "systemd-user"
+    assert status["schedulerPath"] == str(timer_path)
+
+
+def test_disable_removes_only_hermes_systemd_user_files(tmp_path, monkeypatch):
+    hermes_home, calls = _set_linux_scheduler_env(tmp_path, monkeypatch)
+    systemd_dir = tmp_path / ".config" / "systemd" / "user"
+    systemd_dir.mkdir(parents=True)
+    service_path = systemd_dir / "hermes-auto-update.service"
+    timer_path = systemd_dir / "hermes-auto-update.timer"
+    other_timer = systemd_dir / "other.timer"
+    service_path.write_text("service", encoding="utf-8")
+    timer_path.write_text("timer", encoding="utf-8")
+    other_timer.write_text("other", encoding="utf-8")
+    update_auto.write_status(
+        {
+            "enabled": True,
+            "mode": "scheduled",
+            "schedule": "03:00",
+            "schedulerType": "systemd-user",
+            "schedulerPath": str(timer_path),
+        }
+    )
+
+    update_auto.cmd_auto_disable(_args())
+
+    assert not service_path.exists()
+    assert not timer_path.exists()
+    assert other_timer.exists()
+    assert ["systemctl", "--user", "disable", "--now", "hermes-auto-update.timer"] in calls
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    status = _read_status(hermes_home)
+    assert status["enabled"] is False
+    assert status["schedule"] is None
+
+
+def test_status_output_shows_enabled_schedule(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    update_auto.write_status(
+        {
+            "enabled": True,
+            "mode": "scheduled",
+            "schedule": "03:00",
+            "schedulerType": "launchd",
+            "schedulerPath": "/tmp/com.hermes.agent.auto-update.plist",
+            "status": update_auto.STATUS_SUCCESS,
+        }
+    )
+
+    update_auto.cmd_auto_status(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Enabled:          yes" in out
+    assert "Schedule:         03:00" in out
+    assert "Scheduler:        launchd" in out
+    assert "Scheduler path:   /tmp/com.hermes.agent.auto-update.plist" in out
+
+
+def test_run_now_preserves_scheduler_configuration(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    update_auto.write_status(
+        {
+            "enabled": True,
+            "mode": "scheduled",
+            "schedule": "03:00",
+            "schedulerType": "launchd",
+            "schedulerPath": "/tmp/hermes.plist",
+        }
+    )
+
+    from hermes_cli import backup
+    from hermes_cli import main as hm
+
+    monkeypatch.setattr(
+        hm,
+        "_get_update_check_result",
+        lambda **_kw: {"update_available": False, "latest_version": "same"},
+    )
+    monkeypatch.setattr(
+        backup,
+        "create_pre_update_backup",
+        lambda: pytest.fail("backup should not run when already up to date"),
+    )
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "same")
+
+    update_auto.cmd_auto_run_now(_args())
+
+    status = _read_status(hermes_home)
+    assert status["enabled"] is True
+    assert status["mode"] == "scheduled"
+    assert status["schedule"] == "03:00"
+    assert status["schedulerType"] == "launchd"
+    assert status["schedulerPath"] == "/tmp/hermes.plist"
+    assert status["status"] == update_auto.STATUS_UP_TO_DATE
+
+
+def test_run_now_success_reuses_existing_update_flow_and_logs(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import backup
+    from hermes_cli import main as hm
+
+    update_calls = []
+    monkeypatch.setattr(
+        hm,
+        "_get_update_check_result",
+        lambda **_kw: {
+            "update_available": True,
+            "current_version": "oldsha",
+            "latest_version": "newsha",
+            "behind": 1,
+        },
+    )
+    monkeypatch.setattr(
+        backup,
+        "create_pre_update_backup",
+        lambda: hermes_home / "backups" / "pre-update.zip",
+    )
+    monkeypatch.setattr(hm, "cmd_update", lambda args: update_calls.append(args))
+    versions = iter(["oldsha", "newsha"])
+    monkeypatch.setattr(update_auto, "_current_version", lambda: next(versions))
+    monkeypatch.setattr(update_auto, "_verify_health", lambda: (True, "ok"))
+
+    update_auto.cmd_auto_run_now(_args())
+
+    assert len(update_calls) == 1
+    called_args = update_calls[0]
+    assert called_args.yes is True
+    assert called_args.no_backup is True
+    assert called_args.backup is False
+    data = _read_status(hermes_home)
+    assert data["status"] == update_auto.STATUS_SUCCESS
+    assert data["previousVersion"] == "oldsha"
+    assert data["latestVersion"] == "newsha"
+    assert data["currentVersion"] == "newsha"
+    assert data["backupPath"].endswith("pre-update.zip")
+    assert data["error"] is None
+    log_text = (hermes_home / "logs" / "update.log").read_text(encoding="utf-8")
+    assert "event=start" in log_text
+    assert "event=end result=success" in log_text
+    assert "previous=oldsha" in log_text
+    assert "latest=newsha" in log_text
+    assert "current=newsha" in log_text
+    assert "backup=" in log_text
+    assert "Auto-update run complete" in capsys.readouterr().out
+
+
+def test_run_now_up_to_date_skips_backup_and_update(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import backup
+    from hermes_cli import main as hm
+
+    monkeypatch.setattr(
+        hm,
+        "_get_update_check_result",
+        lambda **_kw: {
+            "update_available": False,
+            "current_version": "same",
+            "latest_version": "same",
+            "behind": 0,
+        },
+    )
+    monkeypatch.setattr(
+        backup,
+        "create_pre_update_backup",
+        lambda: pytest.fail("backup should not run when already up to date"),
+    )
+    monkeypatch.setattr(
+        hm,
+        "cmd_update",
+        lambda _args: pytest.fail("update should not run when already up to date"),
+    )
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "same")
+
+    update_auto.cmd_auto_run_now(_args())
+
+    data = _read_status(hermes_home)
+    assert data["status"] == update_auto.STATUS_UP_TO_DATE
+    assert data["backupPath"] is None
+    assert data["error"] is None
+    log_text = (hermes_home / "logs" / "update.log").read_text(encoding="utf-8")
+    assert "event=start" in log_text
+    assert "event=end result=up_to_date" in log_text
+    assert "Already up to date" in capsys.readouterr().out
+
+
+def test_run_now_records_check_failure(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import main as hm
+
+    monkeypatch.setattr(hm, "_get_update_check_result", lambda **_kw: (_ for _ in ()).throw(RuntimeError("network down")))
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "old")
+
+    with pytest.raises(SystemExit) as exc:
+        update_auto.cmd_auto_run_now(_args())
+
+    assert exc.value.code == update_auto.EXIT_CHECK_FAILED
+    data = _read_status(hermes_home)
+    assert data["status"] == update_auto.STATUS_CHECK_FAILED
+    assert "network down" in data["error"]
+    assert "check_failed" in capsys.readouterr().err
+
+
+def test_run_now_aborts_when_backup_fails(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import backup
+    from hermes_cli import main as hm
+
+    monkeypatch.setattr(hm, "_get_update_check_result", lambda **_kw: {"update_available": True, "latest_version": "new"})
+    monkeypatch.setattr(backup, "create_pre_update_backup", lambda: None)
+    monkeypatch.setattr(hm, "cmd_update", lambda _args: pytest.fail("update must not run without backup"))
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "old")
+
+    with pytest.raises(SystemExit) as exc:
+        update_auto.cmd_auto_run_now(_args())
+
+    assert exc.value.code == update_auto.EXIT_BACKUP_FAILED
+    data = _read_status(hermes_home)
+    assert data["status"] == update_auto.STATUS_BACKUP_FAILED
+    assert "backup failed" in data["error"]
+    assert data["backupPath"] is None
+    assert "backup_failed" in capsys.readouterr().err
+
+
+def test_run_now_records_update_failure(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import backup
+    from hermes_cli import main as hm
+
+    monkeypatch.setattr(hm, "_get_update_check_result", lambda **_kw: {"update_available": True, "latest_version": "new"})
+    monkeypatch.setattr(
+        backup,
+        "create_pre_update_backup",
+        lambda: hermes_home / "backups" / "pre-update.zip",
+    )
+    monkeypatch.setattr(hm, "cmd_update", lambda _args: (_ for _ in ()).throw(SystemExit(7)))
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "old")
+
+    with pytest.raises(SystemExit) as exc:
+        update_auto.cmd_auto_run_now(_args())
+
+    assert exc.value.code == update_auto.EXIT_UPDATE_FAILED
+    data = _read_status(hermes_home)
+    assert data["status"] == update_auto.STATUS_UPDATE_FAILED
+    assert "exit code 7" in data["error"]
+    assert data["backupPath"].endswith("pre-update.zip")
+    assert "update_failed" in capsys.readouterr().err
+
+
+def test_run_now_records_health_failure_after_update(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import backup
+    from hermes_cli import main as hm
+
+    monkeypatch.setattr(hm, "_get_update_check_result", lambda **_kw: {"update_available": True, "latest_version": "new"})
+    monkeypatch.setattr(
+        backup,
+        "create_pre_update_backup",
+        lambda: hermes_home / "backups" / "pre-update.zip",
+    )
+    monkeypatch.setattr(hm, "cmd_update", lambda _args: None)
+    monkeypatch.setattr(update_auto, "_current_version", lambda: "old")
+    monkeypatch.setattr(update_auto, "_verify_health", lambda: (False, "gateway startup failed"))
+
+    with pytest.raises(SystemExit) as exc:
+        update_auto.cmd_auto_run_now(_args())
+
+    assert exc.value.code == update_auto.EXIT_HEALTH_FAILED
+    data = _read_status(hermes_home)
+    assert data["status"] == update_auto.STATUS_HEALTH_FAILED
+    assert "health check failed" in data["error"]
+    assert "gateway startup failed" in data["error"]
+    assert "health_failed" in capsys.readouterr().err

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -79,7 +79,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes profile` | Manage profiles — multiple isolated Hermes instances. |
 | `hermes completion` | Print shell completion scripts (bash/zsh/fish). |
 | `hermes version` | Show version information. |
-| `hermes update` | Pull latest code and reinstall dependencies (git installs), or check PyPI and `pip install --upgrade` (pip installs). `--check` previews without installing; `--backup` takes a pre-pull `HERMES_HOME` snapshot. |
+| `hermes update` | Pull latest code and reinstall dependencies (git installs), or check PyPI and `pip install --upgrade` (pip installs). `--check` previews without installing; `--backup` takes a pre-pull `HERMES_HOME` backup. Auto-update commands live under `hermes update auto`. |
 | `hermes uninstall` | Remove Hermes from the system. |
 
 ## `hermes chat`
@@ -1251,7 +1251,11 @@ hermes completion fish > ~/.config/fish/completions/hermes.fish
 ## `hermes update`
 
 ```bash
-hermes update [--check] [--backup] [--restart-gateway]
+hermes update [--check] [--backup] [--yes]
+hermes update auto status
+hermes update auto run-now
+hermes update auto enable --time "03:00"
+hermes update auto disable
 ```
 
 Pulls the latest `hermes-agent` code and reinstalls dependencies in your venv, then re-runs the post-install hooks (MCP servers, skills sync, completion install). Safe to run on a live install.
@@ -1261,8 +1265,71 @@ Pulls the latest `hermes-agent` code and reinstalls dependencies in your venv, t
 | Option | Description |
 |--------|-------------|
 | `--check` | Print the current commit and the latest `origin/main` commit side by side, and exit 0 if in sync or 1 if behind. Does not pull, install, or restart anything. |
-| `--backup` | Create a labeled pre-update snapshot of `HERMES_HOME` (config, auth, sessions, skills, pairing data) before pulling. Default is **off** — the previous always-backup behavior was adding minutes to every update on large homes. Flip it on permanently via `update.backup: true` in `config.yaml`. |
-| `--restart-gateway` | After a successful update, restart the running gateway service. Implies `--all` semantics if multiple profiles are installed. |
+| `--backup` | Create a full pre-update backup of `HERMES_HOME` before pulling. Default is **off** because large homes can take minutes to archive. Flip it on permanently via `updates.pre_update_backup: true` in `config.yaml`. |
+| `--yes`, `-y` | Assume yes for interactive prompts where possible. API-key entry is skipped; run `hermes config migrate` separately for those. |
+
+### `hermes update auto`
+
+Automatic updates are a thin scheduler around `hermes update auto run-now`.
+They do not run inside a Hermes daemon and do not call an LLM or spend model
+tokens. Phase 2 adds user-level scheduling only; it does not add WebUI
+integration, notifications, or rollback automation.
+
+| Command | Description |
+|---------|-------------|
+| `hermes update auto status` | Show whether scheduled auto-update is enabled, the configured schedule, scheduler type/path, last run result, version fields, backup path, last error, and log path. |
+| `hermes update auto run-now` | Run one non-agentic manual update pass now. It checks for an available update, requires a pre-update backup, reuses the existing `hermes update` flow in non-interactive mode, performs a lightweight local gateway-runtime health check, and records status in `HERMES_HOME/state/update-status.json` plus a human-readable log in `HERMES_HOME/logs/update.log`. |
+| `hermes update auto enable --time "03:00"` | Enable a user-level schedule that runs `hermes update auto run-now` daily at the local 24-hour `HH:MM` time. Re-running the command safely updates the existing Hermes schedule. |
+| `hermes update auto disable` | Disable and remove only the Hermes auto-update schedule. It is safe to run when already disabled. |
+
+Scheduler behavior:
+
+- **macOS:** writes `~/Library/LaunchAgents/com.hermes.agent.auto-update.plist`
+  and loads it with `launchctl bootstrap` for the current GUI user session.
+- **Linux:** writes user-level systemd service/timer files under
+  `~/.config/systemd/user/` and enables the timer with `systemctl --user`
+  when user systemd is available.
+- **No root:** scheduling is user-level and does not require `sudo`.
+- **No cron fallback:** Phase 2 does not add or edit crontabs.
+
+Status and logs:
+
+```json
+{
+  "mode": "manual",
+  "enabled": false,
+  "schedule": null,
+  "schedulerType": null,
+  "schedulerPath": null,
+  "lastRunAt": null,
+  "status": "not_configured",
+  "previousVersion": null,
+  "latestVersion": null,
+  "currentVersion": null,
+  "backupPath": null,
+  "error": null,
+  "logPath": null
+}
+```
+
+`HERMES_HOME/state/update-status.json` stores this status. Detailed run logs
+are appended to `HERMES_HOME/logs/update.log`; scheduled stdout/stderr go to
+`HERMES_HOME/logs/update-auto.out.log` and
+`HERMES_HOME/logs/update-auto.err.log`.
+
+`status` is one of `not_configured`, `running`, `success`, `up_to_date`,
+`check_failed`, `backup_failed`, `update_failed`, or `health_failed`.
+Unavailable values are written as `null`, not empty strings.
+
+Troubleshooting:
+
+- Run `hermes update auto status` to see the scheduler path and last result.
+- Run `hermes update auto run-now` manually to test the update path without
+  waiting for the next scheduled time.
+- To manually disable on macOS, run `hermes update auto disable` or remove the
+  LaunchAgent plist named above and boot it out with `launchctl`.
+- To manually disable on Linux systemd, run `hermes update auto disable` or
+  `systemctl --user disable --now hermes-auto-update.timer`.
 
 Additional behavior:
 


### PR DESCRIPTION
# Summary

This PR extends the existing `hermes update` namespace with non-agentic auto-update support while reusing the existing Hermes update flow instead of introducing a separate updater.

Added commands:

```bash
hermes update auto status
hermes update auto run-now
hermes update auto enable --time "03:00"
hermes update auto disable
```

The scheduler is intentionally implemented as a thin wrapper around:

```bash
hermes update auto run-now
```

No daemon/background service, LLM calls, WebUI integration, notifications, or rollback system were added.

# Implementation Details

- Reuses existing `cmd_update()` behavior
- Reuses existing update-check/update flow
- Adds structured update status tracking
- Adds human-readable update logs
- Adds safe pre-update backup enforcement
- Adds lightweight post-update health verification
- Adds idempotent scheduler enable/disable behavior
- Uses existing profile-aware Hermes path helpers

# Scheduler Behavior

macOS:

- Uses user LaunchAgent: `~/Library/LaunchAgents/com.hermes.agent.auto-update.plist`

Linux:

- Uses user systemd timers: `~/.config/systemd/user/hermes-auto-update.timer`

Unsupported platforms fail clearly.

# Status + Logs

Status:

```text
HERMES_HOME/state/update-status.json
```

Logs:

```text
HERMES_HOME/logs/update.log
HERMES_HOME/logs/update-auto.out.log
HERMES_HOME/logs/update-auto.err.log
```

# Safety

- No sudo/root required
- Scheduler only modifies Hermes-owned scheduler files
- Backup failure aborts update
- Distinct failure states and exit codes
- No silent failures
- No model/LLM/token usage

# Testing

Auto-update tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_auto.py
```

Result: 23 passed

Update regression tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_check.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_yes_flag.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_concurrent_quarantine.py tests/hermes_cli/test_update_config_clears_custom_fields.py tests/hermes_cli/test_update_hangup_protection.py tests/hermes_cli/test_update_post_pull_syntax_guard.py tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_update_zip_symlink_reject.py tests/cli/test_update_command.py tests/gateway/test_update_command.py tests/gateway/test_update_streaming.py
```

Result: 190 passed

Backup tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_backup.py
```

Result: 99 passed

Ruff:

```bash
venv/bin/python -m ruff check hermes_cli/main.py hermes_cli/update_auto.py tests/hermes_cli/test_update_auto.py tests/hermes_cli/test_cmd_update.py
```

Result: passed

Syntax validation:

```bash
venv/bin/python -m py_compile hermes_cli/main.py hermes_cli/update_auto.py tests/hermes_cli/test_update_auto.py tests/hermes_cli/test_cmd_update.py
```

Result: passed

# Risks / Limitations

- Linux scheduling requires user systemd
- Windows scheduling is not implemented
- No rollback support
- Health checks intentionally remain lightweight/local
- No WebUI visibility yet
- No notifications/reporting yet

# Deferred Follow-Up Work

- notifications after scheduled runs
- WebUI scheduler visibility
- rollback strategy
- richer health checks
- Windows Task Scheduler support
- multi-profile scheduler UX
