### PR TITLE
fix(gateway): add generic skill command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7620,6 +7620,51 @@ class GatewayRunner:
         if canonical == "reload-skills":
             return await self._handle_reload_skills_command(event)
 
+        if canonical == "skill":
+            args = event.get_command_args().strip()
+            if not args:
+                return (
+                    "Usage: /skill <name> [prompt]\n"
+                    "Example: `/skill hermes-agent explain the config`"
+                )
+            skill_name, _, user_instruction = args.partition(" ")
+            try:
+                from agent.skill_commands import (
+                    build_skill_invocation_message,
+                    get_skill_commands,
+                    resolve_skill_command_key,
+                )
+
+                skill_cmds = get_skill_commands()
+                cmd_key = resolve_skill_command_key(skill_name)
+                if cmd_key is None:
+                    _unavail_msg = _check_unavailable_skill(skill_name)
+                    if _unavail_msg:
+                        return _unavail_msg
+                    return (
+                        f"Unknown skill `{skill_name}`. "
+                        "Usage: /skill <name> [prompt]"
+                    )
+
+                # Check per-platform disabled status before executing.
+                _skill_name = skill_cmds[cmd_key].get("name", "")
+                _plat = source.platform.value if source.platform else None
+                if _plat and _skill_name:
+                    from agent.skill_utils import get_disabled_skill_names as _get_plat_disabled
+                    if _skill_name in _get_plat_disabled(platform=_plat):
+                        return (
+                            f"The **{_skill_name}** skill is disabled for {_plat}.\n"
+                            f"Enable it with: `hermes skills config`"
+                        )
+
+                msg = build_skill_invocation_message(
+                    cmd_key, user_instruction.strip(), task_id=_quick_key
+                )
+                if msg:
+                    event.text = msg
+            except Exception as e:
+                logger.debug("Generic /skill dispatch failed (non-fatal): %s", e)
+
         if canonical == "bundles":
             return await self._handle_bundles_command(event)
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -167,6 +167,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("skills", "Search, install, inspect, or manage skills",
                "Tools & Skills", cli_only=True,
                subcommands=("search", "browse", "inspect", "install", "audit")),
+    CommandDef("skill", "Load a skill by name and send an instruction to the agent",
+               "Tools & Skills", gateway_only=True, args_hint="<name> [prompt]"),
     CommandDef("bundles", "List skill bundles (aliases /<name> for multiple skills)",
                "Tools & Skills"),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
@@ -519,6 +521,7 @@ _TELEGRAM_MENU_PRIORITY = (
     "resume",
     "sessions",
     "model",
+    "skill",
     # Maintenance / diagnostics — the ones that prompted this priority list.
     "debug",
     "restart",
@@ -1081,6 +1084,11 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
         if not _is_gateway_available(cmd, overrides):
             continue
         for alias in cmd.aliases:
+            # Slack apps are capped at 50 native slash commands.  Prefer the
+            # shorter /q alias and Telegram-parity commands over /tasks, which
+            # remains reachable as /agents or /hermes tasks.
+            if alias == "tasks":
+                continue
             # Skip aliases that only differ from canonical by case/punctuation
             # normalization (already covered by _add dedup).
             _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")

--- a/tests/gateway/test_gateway_skill_command.py
+++ b/tests/gateway/test_gateway_skill_command.py
@@ -1,0 +1,102 @@
+"""Gateway generic /skill command tests."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_cli.commands import telegram_bot_commands
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_id="m1",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="user-1",
+            chat_id="chat-1",
+            user_name="tester",
+            chat_type="dm",
+        ),
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)})
+    runner.adapters = {Platform.TELEGRAM: SimpleNamespace(send=AsyncMock(), _pending_messages={})}
+    runner.pairing_store = MagicMock()
+    runner.session_store = MagicMock()
+    runner.hooks = SimpleNamespace(emit_collect=AsyncMock(return_value=[]))
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._update_prompt_pending = {}
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._is_user_authorized = lambda source: True
+    runner._session_key_for_source = lambda source: "telegram:chat-1:user-1"
+    runner._is_telegram_topic_root_lobby = lambda source: False
+    runner._begin_session_run_generation = lambda key: 1
+    return runner
+
+
+def test_generic_skill_command_is_registered_in_telegram_menu():
+    """The stable /skill entry must stay visible even when individual skills overflow Telegram's menu."""
+    assert any(name == "skill" for name, _description in telegram_bot_commands())
+
+
+@pytest.mark.asyncio
+async def test_generic_skill_command_loads_skill_and_forwards_instruction(monkeypatch):
+    """/skill <name> should load any skill even when it is absent from Telegram's 100-command menu."""
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/hermes-agent": {"name": "hermes-agent", "description": "Configure Hermes"}},
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands.resolve_skill_command_key",
+        lambda command: "/hermes-agent" if command in {"hermes-agent", "hermes_agent"} else None,
+    )
+
+    seen = {}
+
+    def _build(cmd_key, user_instruction="", task_id=None):
+        seen["cmd_key"] = cmd_key
+        seen["instruction"] = user_instruction
+        seen["task_id"] = task_id
+        return f"SKILL::{cmd_key}::{user_instruction}"
+
+    monkeypatch.setattr("agent.skill_commands.build_skill_invocation_message", _build)
+
+    runner = _make_runner()
+
+    async def _capture(event, source, quick_key, run_generation):
+        seen["event_text"] = event.text
+        seen["quick_key"] = quick_key
+        seen["run_generation"] = run_generation
+        return "agent-response"
+
+    runner._handle_message_with_agent = _capture
+
+    result = await runner._handle_message(_make_event("/skill hermes_agent explique la config"))
+
+    assert result == "agent-response"
+    assert seen["cmd_key"] == "/hermes-agent"
+    assert seen["instruction"] == "explique la config"
+    assert seen["event_text"] == "SKILL::/hermes-agent::explique la config"
+
+
+@pytest.mark.asyncio
+async def test_generic_skill_command_requires_skill_name():
+    runner = _make_runner()
+
+    result = await runner._handle_message(_make_event("/skill"))
+
+    assert "Usage: /skill <name>" in result
+    assert "hermes-agent" in result


### PR DESCRIPTION
## Summary
- Add a stable gateway /skill <name> [prompt] command that loads any registered skill by name.
- Expose /skill in Telegram's command menu with priority so it survives command-menu caps.
- Keep Slack native slash registration within its 50-command cap by preferring /q over the duplicate /tasks alias.
- Add gateway tests for menu registration, skill forwarding, and usage text.

## Test Plan
- pytest -q tests/gateway/test_gateway_skill_command.py
- pytest -q tests/hermes_cli/test_commands.py tests/gateway/test_gateway_skill_command.py