### PR TITLE
fix(tools): check registered web search plugins in check_web_api_key

### DIFF
--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -343,3 +343,91 @@ class TestUnconfiguredErrorEnvelopeParity:
         assert "web_crawl requires Firecrawl" in result["error"]
         # Crucially: no per-page burying
         assert "results" not in result
+
+
+
+# ---------------------------------------------------------------------------
+# check_web_api_key — plugin-registered provider support
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWebApiKeyPluginProviders:
+    """check_web_api_key() must honour plugin-registered web search providers.
+
+    Issue #31873: third-party plugins (e.g. Kagi) that register via
+    ``ctx.register_web_search_provider()`` are silently dropped because
+    ``check_web_api_key()`` only knows about hardcoded backend names.
+    """
+
+    def test_returns_true_for_registered_plugin_provider(self, monkeypatch):
+        """A configured backend matching a registered plugin provider should
+        return True even if it is not in the hardcoded list."""
+        from tools import web_tools
+        from agent.web_search_provider import WebSearchProvider
+        from agent.web_search_registry import register_provider, _reset_for_tests
+
+        class FakeKagiProvider(WebSearchProvider):
+            @property
+            def name(self) -> str:
+                return "kagi"
+
+            def is_available(self) -> bool:
+                return True
+
+            async def search(self, query, limit=5, **kw):
+                return {"success": True, "data": {"web": []}}
+
+        _reset_for_tests()
+        register_provider(FakeKagiProvider())
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "kagi"})
+
+        try:
+            assert web_tools.check_web_api_key() is True
+        finally:
+            _reset_for_tests()
+
+    def test_returns_false_for_unavailable_plugin_provider(self, monkeypatch):
+        """A configured backend matching a registered but unavailable plugin
+        provider should return False."""
+        from tools import web_tools
+        from agent.web_search_provider import WebSearchProvider
+        from agent.web_search_registry import register_provider, _reset_for_tests
+
+        class FakeKagiProvider(WebSearchProvider):
+            @property
+            def name(self) -> str:
+                return "kagi"
+
+            def is_available(self) -> bool:
+                return False  # no API key set
+
+            async def search(self, query, limit=5, **kw):
+                return {"success": False, "error": "no key"}
+
+        _reset_for_tests()
+        register_provider(FakeKagiProvider())
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "kagi"})
+
+        try:
+            assert web_tools.check_web_api_key() is False
+        finally:
+            _reset_for_tests()
+
+    def test_returns_false_for_unknown_backend_no_providers(self, monkeypatch):
+        """An unknown backend with no registered providers and no hardcoded
+        keys should return False."""
+        from tools import web_tools
+        from agent.web_search_registry import _reset_for_tests
+
+        _reset_for_tests()
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "nonexistent"})
+
+        # Clear all hardcoded backend env vars
+        for key in ("EXA_API_KEY", "PARALLEL_API_KEY", "FIRECRAWL_API_KEY",
+                     "TAVILY_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+        try:
+            assert web_tools.check_web_api_key() is False
+        finally:
+            _reset_for_tests()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1369,6 +1369,17 @@ def check_web_api_key() -> bool:
     configured = _load_web_config().get("backend", "").lower().strip()
     if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
         return _is_backend_available(configured)
+    # Check if a plugin-registered web search provider matches the configured
+    # backend name.  This allows third-party plugins (e.g. Kagi) to pass the
+    # tool-availability gate without being hardcoded above.
+    if configured:
+        try:
+            from agent.web_search_registry import get_provider as _get_wsp
+            provider = _get_wsp(configured)
+            if provider is not None and provider.is_available():
+                return True
+        except Exception:
+            pass
     return any(
         _is_backend_available(backend)
         for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")


### PR DESCRIPTION
## What does this PR do?

`check_web_api_key()` in `tools/web_tools.py` only checked hardcoded backend names (exa, parallel, firecrawl, tavily, searxng, brave-free, ddgs). Third-party plugins that register via `ctx.register_web_search_provider()` (e.g. Kagi) were silently dropped — the tool registry's `check_fn` returned `False`, so `web_search` and `web_extract` never appeared in the tool list.

Now checks `agent.web_search_registry.get_provider()` for the configured backend name before falling back to hardcoded backends.
## Related Issue

Fixes #31873

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/web_tools.py`: `check_web_api_key()` now consults the web search registry for plugin-registered providers matching the configured backend name
- `tests/tools/test_web_providers.py`: 3 new tests covering registered plugin provider (True), unavailable plugin provider (False), and unknown backend (False)

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- Analyzed: `tools/web_tools.py:check_web_api_key()` (callers: tool registry check_fn, `hermes tools` CLI)
- Blast radius: LOW — only affects the tool-availability gate; no behavioral change for existing hardcoded backends
- Related patterns: `agent/web_search_registry.get_provider()` already used in `_resolve_web_search_backend()` at lines 808-812; this fix applies the same pattern to the availability check