### PR TITLE
fix(gateway): sync MEDIA: directive extension whitelist with extract_local_files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|bmp|tiff?|svg|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|tar|gz|tgz|bz2|xz|rar|7z|docx?|odt|rtf|xlsx?|xls|ods|pptx?|ppt|odp|key|txt|md|csv|tsv|json|xml|ya?ml|html?|htm|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -362,6 +362,50 @@ class TestExtractMedia:
         assert "[[as_document]]" not in cleaned
 
 
+    def test_media_tag_recognizes_html_and_data_extensions(self):
+        """MEDIA: tags with .html, .json, .svg, .md, .tar.gz etc. should be extracted."""
+        # HTML report
+        media, cleaned = BasePlatformAdapter.extract_media(
+            "MEDIA:/tmp/report.html"
+        )
+        assert len(media) == 1
+        assert media[0][0].endswith("report.html")
+
+        # JSON export
+        media, _ = BasePlatformAdapter.extract_media("MEDIA:/data/export.json")
+        assert len(media) == 1
+        assert media[0][0].endswith("export.json")
+
+        # SVG chart
+        media, _ = BasePlatformAdapter.extract_media("MEDIA:/charts/fig.svg")
+        assert len(media) == 1
+
+        # Markdown note
+        media, _ = BasePlatformAdapter.extract_media("MEDIA:/notes/readme.md")
+        assert len(media) == 1
+
+        # Archive formats
+        for ext in ("tar", "gz", "tgz", "bz2", "xz"):
+            media, _ = BasePlatformAdapter.extract_media(
+                f"MEDIA:/tmp/archive.{ext}"
+            )
+            assert len(media) == 1, f".{ext} should be recognized"
+
+        # Presentation formats
+        for ext in ("ppt", "odp", "key"):
+            media, _ = BasePlatformAdapter.extract_media(
+                f"MEDIA:/tmp/deck.{ext}"
+            )
+            assert len(media) == 1, f".{ext} should be recognized"
+
+    def test_media_tag_recognizes_image_formats_beyond_png_jpg(self):
+        """MEDIA: tags with .bmp, .tiff, .svg images should be extracted."""
+        for ext in ("bmp", "tiff", "svg"):
+            media, _ = BasePlatformAdapter.extract_media(
+                f"MEDIA:/tmp/image.{ext}"
+            )
+            assert len(media) == 1, f".{ext} should be recognized"
+
 class TestMediaDeliveryPathValidation:
     def _patch_roots(self, monkeypatch, *roots):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

`gateway/platforms/base.py` has two independent file-extension whitelists used for media routing:

1. **`extract_media()`** — parses explicit `MEDIA:<path>` directives from the model
2. **`extract_local_files()`** — finds bare local paths in response text

These whitelists had drifted out of sync. `extract_local_files` accepts `.html`, `.json`, `.svg`, `.md`, `.tar`, `.gz`, `.bmp`, `.tiff`, and many more — but the regex in `extract_media` did not. When the model emitted `MEDIA:/path/file.html`, the regex didn't match, the file was silently dropped, and `send_message` reported `success: true`. **Silent data loss with no log output.**

## Fix

Synced the `extract_media` regex extension group with `_LOCAL_MEDIA_EXTS` by adding all missing extensions:

- **Images:** `bmp`, `tiff`, `svg`
- **Documents:** `odt`, `rtf`, `md`
- **Spreadsheets/data:** `xls`, `ods`, `tsv`, `json`, `xml`, `yaml`, `yml`
- **Presentations:** `ppt`, `odp`, `key`
- **Archives:** `tar`, `gz`, `tgz`, `bz2`, `xz`
- **Web:** `html`, `htm`

Kept existing extras not in `_LOCAL_MEDIA_EXTS` (`epub`, `opus`, `apk`, `ipa`) since they're valid media types.

## Testing

- All 14 existing `TestExtractMedia` tests pass
- All 44 `test_extract_local_files` tests pass
- Added 2 regression tests covering the newly-recognized extensions

## Code Intelligence
- Analyzed: `gateway/platforms/base.py` `extract_media()` (line ~2416) and `_LOCAL_MEDIA_EXTS` (line ~2458)
- Blast radius: LOW — regex change only, no control flow modification
- Related patterns: `extract_local_files()` uses the same conceptual whitelist; the two must stay in sync

Fixes #31137
