### PR TITLE
fix(hindsight): sanitize retained multimodal payloads

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -29,17 +29,20 @@ Or via $HERMES_HOME/hindsight/config.json (profile-scoped), falling back to
 from __future__ import annotations
 
 import asyncio
+import ast
 import atexit
 import importlib
 import json
 import logging
 import os
 import queue
+import re
 import threading
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
+from agent.memory_manager import sanitize_context
 from agent.memory_provider import MemoryProvider
 from hermes_constants import get_hermes_home
 from tools.registry import tool_error
@@ -59,6 +62,68 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_MAX_LITERAL_PARSE_CHARS = 2_000_000
+_DATA_URL_RE = re.compile(
+    r"data:[a-z0-9.+-]+/[a-z0-9.+-]+;base64,[a-z0-9+/=]+",
+    re.IGNORECASE,
+)
+_LONG_BASE64_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9+/=])(?=[A-Za-z0-9+/=]{512,}(?![A-Za-z0-9+/=]))"
+    r"(?=[A-Za-z0-9+/=]*[+/=])[A-Za-z0-9+/]{512,}={0,2}(?![A-Za-z0-9+/=])"
+)
+_IMAGE_RETRY_HINT_RE = re.compile(
+    r"\[If you need a closer look,\s*use vision_analyze with image_url:[^\]]+\]\s*",
+    re.IGNORECASE,
+)
+_IMAGE_FAILURE_HINT_RE = re.compile(
+    r"\[The user sent an image but[^\]]*(?:image_url|vision_analyze)[^\]]+\]\s*",
+    re.IGNORECASE,
+)
+_ATTACHMENT_HEADER_RE = re.compile(
+    r"\[Attached (?:image|audio|file):[^\]]+\]\s*(?:URI:\s*\S+\s*)?",
+    re.IGNORECASE,
+)
+_VISION_DESCRIPTION_RE = re.compile(
+    r"\[The user sent an image~ Here's what I can see:\n([\s\S]*?)\]\s*",
+    re.IGNORECASE,
+)
+_VOICE_TRANSCRIPT_RE = re.compile(
+    r"\[The user sent a voice message~ Here's what they said: \"([\s\S]*?)\"\]\s*",
+    re.IGNORECASE,
+)
+_MEDIA_BLOCK_TYPES = {
+    "audio",
+    "file",
+    "image",
+    "image_url",
+    "input_audio",
+    "input_file",
+    "input_image",
+    "resource",
+}
+_TEXT_BLOCK_TYPES = {"input_text", "text"}
+_BINARY_CARRIER_KEYS = {
+    "audio",
+    "base64",
+    "blob",
+    "b64_json",
+    "bytes",
+    "content_bytes",
+    "data",
+    "image_url",
+    "input_audio",
+    "input_image",
+    "media",
+    "source",
+}
+_TEXT_VALUE_KEYS = {
+    "analysis",
+    "caption",
+    "content",
+    "description",
+    "text",
+    "transcript",
+}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -70,6 +135,158 @@ _PROVIDER_DEFAULT_MODELS = {
     "lmstudio": "local-model",
     "openai_compatible": "your-model-name",
 }
+
+
+def _looks_like_binary_blob(value: str) -> bool:
+    """Return True for transport payloads, not ordinary prose/code."""
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if _DATA_URL_RE.search(stripped):
+        return True
+    compact = re.sub(r"\s+", "", stripped)
+    if len(compact) < 512:
+        return False
+    if not re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", compact):
+        return False
+    # Most natural language and source snippets will fail the alphabet check
+    # above. Require a plausible encoded length as an extra guard.
+    return len(compact) % 4 == 0
+
+
+def _strip_generated_media_wrappers(text: str) -> str:
+    """Keep semantic vision/STT text while removing retry transport hints."""
+    text = _VISION_DESCRIPTION_RE.sub(
+        lambda match: f"Image description:\n{match.group(1).strip()}\n",
+        text,
+    )
+    text = _VOICE_TRANSCRIPT_RE.sub(
+        lambda match: f"Voice transcript: {match.group(1).strip()}\n",
+        text,
+    )
+    text = _IMAGE_RETRY_HINT_RE.sub("", text)
+    text = _IMAGE_FAILURE_HINT_RE.sub("", text)
+    text = _ATTACHMENT_HEADER_RE.sub("", text)
+    return text
+
+
+def _sanitize_retain_text(text: str) -> str:
+    text = sanitize_context(text)
+    text = _strip_generated_media_wrappers(text)
+    text = _DATA_URL_RE.sub("", text)
+    text = _LONG_BASE64_TOKEN_RE.sub("", text)
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _parse_serialized_retain_content(text: str) -> Any | None:
+    stripped = text.strip()
+    if not stripped or stripped[0] not in "[{":
+        return None
+    if len(stripped) > _MAX_LITERAL_PARSE_CHARS:
+        return None
+    # Avoid parsing arbitrary prose that happens to start with a bracket.
+    structured_markers = (
+        '"type": "text"',
+        '"type":"text"',
+        '"type": "input_text"',
+        '"type":"input_text"',
+        "'type': 'text'",
+        "'type':'text'",
+        "'type': 'input_text'",
+        "'type':'input_text'",
+        "image_url",
+        "input_image",
+        "input_audio",
+        "data:",
+        "base64",
+    )
+    if not any(marker in stripped for marker in structured_markers):
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+    try:
+        return ast.literal_eval(stripped)
+    except (SyntaxError, ValueError, TypeError, MemoryError, RecursionError):
+        return None
+
+
+def _sanitize_structured_retain_content(value: Any, *, carrier_key: str = "") -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return ""
+    if isinstance(value, str):
+        if carrier_key in _BINARY_CARRIER_KEYS and _looks_like_binary_blob(value):
+            return ""
+        return _sanitize_retain_text(value)
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        parts = [_sanitize_structured_retain_content(item) for item in value]
+        return "\n".join(part for part in parts if part)
+    if isinstance(value, tuple):
+        parts = [_sanitize_structured_retain_content(item) for item in value]
+        return "\n".join(part for part in parts if part)
+    if not isinstance(value, dict):
+        return _sanitize_retain_text(str(value))
+
+    block_type = str(value.get("type", "") or "").strip().lower()
+    if block_type in _TEXT_BLOCK_TYPES:
+        for key in ("text", "content"):
+            if key in value:
+                return _sanitize_structured_retain_content(
+                    value.get(key), carrier_key=key
+                )
+        return ""
+    if block_type in _MEDIA_BLOCK_TYPES:
+        # Transport-only block. Keep an explicit caption/description if a
+        # caller included one, but drop URLs/data/blob fields.
+        parts = []
+        for key in ("caption", "description", "analysis", "transcript"):
+            if key in value:
+                part = _sanitize_structured_retain_content(
+                    value.get(key), carrier_key=key
+                )
+                if part:
+                    parts.append(part)
+        return "\n".join(parts)
+
+    if "content" in value and set(value).issubset({"role", "content", "timestamp"}):
+        return _sanitize_structured_retain_content(value.get("content"), carrier_key="content")
+
+    parts: list[str] = []
+    for key, nested in value.items():
+        key_text = str(key).strip().lower()
+        if key_text in _BINARY_CARRIER_KEYS:
+            if isinstance(nested, str) and not _looks_like_binary_blob(nested):
+                # A normal URL or short field can be meaningful outside media
+                # blocks; only binary-looking carrier values are removed.
+                parts.append(_sanitize_retain_text(nested))
+            continue
+        if key_text in _TEXT_VALUE_KEYS or isinstance(nested, (list, tuple, dict)):
+            part = _sanitize_structured_retain_content(nested, carrier_key=key_text)
+            if part:
+                parts.append(part)
+    return "\n".join(parts)
+
+
+def _sanitize_retain_content(value: Any) -> str:
+    """Normalize auto-retained turn content to semantic text.
+
+    Hermes can receive structured multimodal user content from ACP/gateway
+    adapters. Hindsight retain accepts text, so keep human-visible semantic
+    text and discard binary transport payloads before building the transcript.
+    """
+    if isinstance(value, str):
+        parsed = _parse_serialized_retain_content(value)
+        if parsed is not None:
+            return _sanitize_structured_retain_content(parsed)
+        return _sanitize_retain_text(value)
+    return _sanitize_structured_retain_content(value)
 
 
 def _parse_int_setting(value: Any, default: int) -> int:
@@ -1341,17 +1558,19 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
-    def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
+    def _build_turn_messages(self, user_content: Any, assistant_content: Any) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
+        clean_user_content = _sanitize_retain_content(user_content)
+        clean_assistant_content = _sanitize_retain_content(assistant_content)
         return [
             {
                 "role": "user",
-                "content": f"{self._retain_user_prefix}: {user_content}",
+                "content": f"{self._retain_user_prefix}: {clean_user_content}",
                 "timestamp": now,
             },
             {
                 "role": "assistant",
-                "content": f"{self._retain_assistant_prefix}: {assistant_content}",
+                "content": f"{self._retain_assistant_prefix}: {clean_assistant_content}",
                 "timestamp": now,
             },
         ]

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _sanitize_retain_content,
 )
 
 
@@ -861,6 +862,92 @@ class TestSyncTurn:
         assert "你好" in raw_json
         assert "👨‍👩‍👧‍👦" in raw_json
 
+    def test_sync_turn_sanitizes_structured_multimodal_payload(self, provider_with_config):
+        p = provider_with_config()
+        data_url = "data:image/jpeg;base64," + ("A" * 1024)
+        user_content = [
+            {"type": "text", "text": "Please remember that this chart is about Q4 revenue."},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ]
+
+        p.sync_turn(user_content, "The chart shows revenue rising in Q4.")
+        p._retain_queue.join()
+
+        raw_json = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        content = json.loads(raw_json)
+        assert content[0][0]["content"] == (
+            "User: Please remember that this chart is about Q4 revenue."
+        )
+        assert "The chart shows revenue rising in Q4." in content[0][1]["content"]
+        assert "data:image" not in raw_json
+        assert "base64" not in raw_json
+        assert "A" * 512 not in raw_json
+
+    def test_sync_turn_sanitizes_stringified_multimodal_payload(self, provider_with_config):
+        p = provider_with_config()
+        data_url = "data:image/png;base64," + ("B" * 1024)
+        user_content = str([
+            {"type": "text", "text": "The screenshot is from the onboarding flow."},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ])
+
+        p.sync_turn(user_content, "I see the onboarding flow screenshot.")
+        p._retain_queue.join()
+
+        raw_json = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        content = json.loads(raw_json)
+        assert content[0][0]["content"] == "User: The screenshot is from the onboarding flow."
+        assert "data:image" not in raw_json
+        assert "base64" not in raw_json
+        assert "B" * 512 not in raw_json
+
+    def test_retain_sanitizer_preserves_gateway_vision_description(self):
+        text = (
+            "[The user sent an image~ Here's what I can see:\n"
+            "A whiteboard shows the launch plan and the words 'ship Friday'.]\n"
+            "[If you need a closer look, use vision_analyze with "
+            "image_url: /tmp/hermes/images/abc123.png ~]\n\n"
+            "Can you turn this into tasks?"
+        )
+
+        clean = _sanitize_retain_content(text)
+
+        assert "Image description:" in clean
+        assert "ship Friday" in clean
+        assert "Can you turn this into tasks?" in clean
+        assert "vision_analyze" not in clean
+        assert "image_url" not in clean
+        assert "/tmp/hermes/images/abc123.png" not in clean
+
+    def test_retain_sanitizer_preserves_voice_transcript(self):
+        text = (
+            "[The user sent a voice message~ Here's what they said: "
+            "\"please remind me that the meeting moved to 3pm\"]"
+        )
+
+        clean = _sanitize_retain_content(text)
+
+        assert clean == "Voice transcript: please remind me that the meeting moved to 3pm"
+
+    def test_retain_sanitizer_keeps_non_binary_encoded_prose(self):
+        text = (
+            "The paper says the image is encoded by a vision transformer. "
+            "Short hash abc123def456 and https://example.com/data are meaningful here."
+        )
+
+        assert _sanitize_retain_content(text) == text
+
+    def test_retain_sanitizer_does_not_parse_arbitrary_json_with_type_field(self):
+        text = '{"type": "bug", "description": "encoded payload handling is broken"}'
+
+        assert _sanitize_retain_content(text) == text
+
+    def test_retain_sanitizer_keeps_long_non_media_tokens_without_base64_markers(self):
+        token = "A" * 600
+        text = f"Use this generated identifier in the migration test: {token}"
+
+        assert _sanitize_retain_content(text) == text
+
 
 # ---------------------------------------------------------------------------
 # Shutdown / writer tests
@@ -1548,4 +1635,3 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
-


### PR DESCRIPTION
## Summary
- sanitize Hindsight auto-retain turn content before building the retained transcript
- preserve semantic text from user text blocks, gateway vision descriptions, and voice transcripts
- drop multimodal transport payloads such as data URLs, image_url blocks, raw binary fields, and generated vision retry hints

## Why
Hermes can receive structured multimodal content from ACP/gateway adapters. The Hindsight plugin previously stringified that payload directly, which could retain large base64 image data and pollute extracted memories.

## Validation
- ./venv/bin/python -m ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py
- ./venv/bin/python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py
- ./scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py tests/agent/test_memory_session_switch.py