### PR TITLE
fix(cron): harden ticker thread, null-safe deliver, and BSM env loader

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1394,11 +1394,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     try:
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
-        from dotenv import load_dotenv
-        try:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
-        except UnicodeDecodeError:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
+        # Use load_hermes_dotenv() which handles encoding fallback, .env
+        # sanitization, and BSM secret resolution — consistent with the
+        # gateway and CLI entry points.
+        # (ref: https://github.com/NousResearch/hermes-agent/issues/33465)
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv(hermes_home=_get_hermes_home())
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17627,72 +17627,83 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
     while not stop_event.is_set():
+        # Wrap the ENTIRE loop body in a top-level try/except so that
+        # unexpected errors in channel-directory refreshes, cache cleanup,
+        # curator runs, etc. never kill the ticker thread silently.
+        # (ref: https://github.com/NousResearch/hermes-agent/issues/32895)
         try:
-            cron_tick(verbose=False, adapters=adapters, loop=loop)
-        except Exception as e:
-            logger.debug("Cron tick error: %s", e)
-
-        tick_count += 1
-
-        if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
             try:
-                from gateway.channel_directory import build_channel_directory
-                if loop is not None:
-                    # build_channel_directory is async (Slack web calls), and
-                    # this ticker runs in a background thread. Schedule onto
-                    # the gateway event loop and wait briefly for completion
-                    # so refresh failures are still logged via the except.
-                    fut = safe_schedule_threadsafe(
-                        build_channel_directory(adapters), loop,
-                        logger=logger,
-                        log_message="Channel directory refresh scheduling error",
+                cron_tick(verbose=False, adapters=adapters, loop=loop)
+            except Exception as e:
+                logger.debug("Cron tick error: %s", e)
+
+            tick_count += 1
+
+            if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
+                try:
+                    from gateway.channel_directory import build_channel_directory
+                    if loop is not None:
+                        # build_channel_directory is async (Slack web calls), and
+                        # this ticker runs in a background thread. Schedule onto
+                        # the gateway event loop and wait briefly for completion
+                        # so refresh failures are still logged via the except.
+                        fut = safe_schedule_threadsafe(
+                            build_channel_directory(adapters), loop,
+                            logger=logger,
+                            log_message="Channel directory refresh scheduling error",
+                        )
+                        if fut is not None:
+                            fut.result(timeout=30)
+                except Exception as e:
+                    logger.debug("Channel directory refresh error: %s", e)
+
+            if tick_count % IMAGE_CACHE_EVERY == 0:
+                try:
+                    removed = cleanup_image_cache(max_age_hours=24)
+                    if removed:
+                        logger.info("Image cache cleanup: removed %d stale file(s)", removed)
+                except Exception as e:
+                    logger.debug("Image cache cleanup error: %s", e)
+                try:
+                    removed = cleanup_document_cache(max_age_hours=24)
+                    if removed:
+                        logger.info("Document cache cleanup: removed %d stale file(s)", removed)
+                except Exception as e:
+                    logger.debug("Document cache cleanup error: %s", e)
+
+            if tick_count % PASTE_SWEEP_EVERY == 0:
+                try:
+                    deleted, remaining = _sweep_expired_pastes()
+                    if deleted:
+                        logger.info(
+                            "Paste sweep: deleted %d expired paste(s), %d pending",
+                            deleted, remaining,
+                        )
+                except Exception as e:
+                    logger.debug("Paste sweep error: %s", e)
+
+            # Curator — piggy-back on the existing cron ticker so long-running
+            # gateways get weekly skill maintenance without needing restarts.
+            # maybe_run_curator() is internally gated by config.interval_hours
+            # (7 days by default), so CURATOR_EVERY is just the poll rate — the
+            # real work only fires once per config interval.
+            if tick_count % CURATOR_EVERY == 0:
+                try:
+                    from agent.curator import maybe_run_curator
+                    maybe_run_curator(
+                        idle_for_seconds=float("inf"),
+                        on_summary=lambda msg: logger.info("curator: %s", msg),
                     )
-                    if fut is not None:
-                        fut.result(timeout=30)
-            except Exception as e:
-                logger.debug("Channel directory refresh error: %s", e)
+                except Exception as e:
+                    logger.debug("Curator tick error: %s", e)
 
-        if tick_count % IMAGE_CACHE_EVERY == 0:
-            try:
-                removed = cleanup_image_cache(max_age_hours=24)
-                if removed:
-                    logger.info("Image cache cleanup: removed %d stale file(s)", removed)
-            except Exception as e:
-                logger.debug("Image cache cleanup error: %s", e)
-            try:
-                removed = cleanup_document_cache(max_age_hours=24)
-                if removed:
-                    logger.info("Document cache cleanup: removed %d stale file(s)", removed)
-            except Exception as e:
-                logger.debug("Document cache cleanup error: %s", e)
+            stop_event.wait(timeout=interval)
+        except Exception:
+            logger.error(
+                "Cron ticker loop iteration failed — will retry next cycle",
+                exc_info=True,
+            )
 
-        if tick_count % PASTE_SWEEP_EVERY == 0:
-            try:
-                deleted, remaining = _sweep_expired_pastes()
-                if deleted:
-                    logger.info(
-                        "Paste sweep: deleted %d expired paste(s), %d pending",
-                        deleted, remaining,
-                    )
-            except Exception as e:
-                logger.debug("Paste sweep error: %s", e)
-
-        # Curator — piggy-back on the existing cron ticker so long-running
-        # gateways get weekly skill maintenance without needing restarts.
-        # maybe_run_curator() is internally gated by config.interval_hours
-        # (7 days by default), so CURATOR_EVERY is just the poll rate — the
-        # real work only fires once per config interval.
-        if tick_count % CURATOR_EVERY == 0:
-            try:
-                from agent.curator import maybe_run_curator
-                maybe_run_curator(
-                    idle_for_seconds=float("inf"),
-                    on_summary=lambda msg: logger.info("curator: %s", msg),
-                )
-            except Exception as e:
-                logger.debug("Curator tick error: %s", e)
-
-        stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -67,7 +67,9 @@ def cron_list(show_all: bool = False):
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        # Guard against null/None deliver value — key may exist with None value
+        # (ref: https://github.com/NousResearch/hermes-agent/issues/32896)
+        deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -224,12 +224,24 @@ class TestRunJobProfileContext:
         monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
 
         import dotenv
+        from hermes_cli import env_loader
 
         def fake_load_dotenv(path, *_a, **_kw):
             observed.setdefault("dotenv_paths", []).append(str(path))
             return True
 
         monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+
+        # Also mock load_hermes_dotenv (cron/scheduler.py now uses this
+        # instead of bare load_dotenv — ref #33465)
+        def fake_load_hermes_dotenv(*, hermes_home=None, project_env=None):
+            from pathlib import Path
+            # Use hermes_home if provided (profile-aware), else HERMES_HOME
+            home = Path(hermes_home) if hermes_home else Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+            observed.setdefault("dotenv_paths", []).append(str(home / ".env"))
+            return [home / ".env"]
+
+        monkeypatch.setattr(env_loader, "load_hermes_dotenv", fake_load_hermes_dotenv)
 
     def test_run_job_sets_and_restores_profile_home(
         self, isolated_cron_profile_home, monkeypatch
@@ -281,6 +293,19 @@ class TestRunJobProfileContext:
             return True
 
         monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+
+        # Also mock load_hermes_dotenv for consistency with the scheduler
+        from hermes_cli import env_loader
+        def fake_load_hermes_dotenv(*, hermes_home=None, project_env=None):
+            from pathlib import Path
+            home = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+            observed.setdefault("dotenv_paths", []).append(str(home / ".env"))
+            os.environ["HERMES_PROFILE_TEST_SHARED"] = "profile-value"
+            os.environ["HERMES_PROFILE_TEST_ONLY"] = "profile-only"
+            os.environ["HERMES_CRON_TIMEOUT"] = "123"
+            return [home / ".env"]
+
+        monkeypatch.setattr(env_loader, "load_hermes_dotenv", fake_load_hermes_dotenv)
 
         job = {
             "id": "env-profile",


### PR DESCRIPTION
## Summary

Three cron bugs fixed in one PR (root cause cluster: **cron lifecycle fragility**).

### Bug 1 — Ticker thread stops silently ([#32895](https://github.com/NousResearch/hermes-agent/issues/32895)) P1

**Root cause:** `_start_cron_ticker()` in `gateway/run.py` wraps `cron_tick()` in try/except, but the rest of the while loop body (channel directory refresh, cache cleanup, curator run) runs **outside** any exception handler. An unexpected error in any of these kills the thread with no error log.

**Fix:** Wrap the **entire** while loop body in a top-level `try/except Exception` with `logger.error(..., exc_info=True)`. The thread now survives any single-iteration failure and retries on the next cycle.

### Bug 2 — `hermes cron list` crashes on null deliver ([#32896](https://github.com/NousResearch/hermes-agent/issues/32896)) P2

**Root cause:** `job.get("deliver", ["local"])` returns `None` when the key exists but has a `null` value. Then `", ".join(None)` throws `TypeError`.

**Fix:** `job.get("deliver") or ["local"]` — handles both missing key AND null value.

### Bug 3 — Cron uses bare `load_dotenv()` instead of `load_hermes_dotenv()` ([#33465](https://github.com/NousResearch/hermes-agent/issues/33465)) P2

**Root cause:** `cron/scheduler.py` calls `from dotenv import load_dotenv` directly, skipping BSM secret resolution, `.env` sanitization, and encoding fallback that `load_hermes_dotenv()` provides. Cron jobs needing BSM-managed credentials fail with HTTP 401.

**Fix:** Replace with `from hermes_cli.env_loader import load_hermes_dotenv` and call `load_hermes_dotenv(hermes_home=_get_hermes_home())` to preserve profile-aware path resolution.

## Files Changed

| File | Change |
|------|--------|
| `gateway/run.py` | Wrap entire ticker while body in try/except |
| `cron/scheduler.py` | `load_dotenv()` → `load_hermes_dotenv(hermes_home=...)` |
| `hermes_cli/cron.py` | `job.get("deliver", [...])` → `job.get("deliver") or [...]` |
| `tests/cron/test_cron_profile.py` | Mock `load_hermes_dotenv` in profile tests |

## Testing

- 381 tests passed (`tests/cron/`, `tests/hermes_cli/test_cron.py`, `tests/hermes_cli/test_env_loader.py`)
- Updated profile context tests to mock the new `load_hermes_dotenv` call

Closes #32895, Closes #32896, Closes #33465