### PR TITLE
fix(tools): guard Path.home() against PermissionError in has_direct_modal_credentials

### DIFF
--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -189,6 +189,20 @@ class TestHasDirectModalCredentials:
         with patch.object(Path, "home", return_value=tmp_path):
             assert has_direct_modal_credentials() is True
 
+    def test_home_dir_permission_denied(self, monkeypatch):
+        """PermissionError on Path.home() should not crash (issue #33525)."""
+        monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+        monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+        with patch.object(Path, "home", side_effect=PermissionError("denied")):
+            assert has_direct_modal_credentials() is False
+
+    def test_home_dir_permission_denied_with_env_vars(self, monkeypatch):
+        """PermissionError on Path.home() should not prevent env var detection."""
+        monkeypatch.setenv("MODAL_TOKEN_ID", "id-123")
+        monkeypatch.setenv("MODAL_TOKEN_SECRET", "sec-456")
+        with patch.object(Path, "home", side_effect=PermissionError("denied")):
+            assert has_direct_modal_credentials() is True
+
 
 # ---------------------------------------------------------------------------
 # prefers_gateway

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -58,9 +58,13 @@ def normalize_modal_mode(value: object | None) -> str:
 
 def has_direct_modal_credentials() -> bool:
     """Return True when direct Modal credentials/config are available."""
+    try:
+        modal_file_exists = (Path.home() / ".modal.toml").exists()
+    except (PermissionError, OSError):
+        modal_file_exists = False
     return bool(
         (os.getenv("MODAL_TOKEN_ID") and os.getenv("MODAL_TOKEN_SECRET"))
-        or (Path.home() / ".modal.toml").exists()
+        or modal_file_exists
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Guards `Path.home() / ".modal.toml"` in `has_direct_modal_credentials()` against `PermissionError` (and `OSError`).

When Hermes runs in Docker containers with `HOME=/root` but the process is the unprivileged `hermes` user (uid 10000), `Path.home()` resolves to `/root/`. Calling `.exists()` on a path under `/root/` raises `PermissionError: [Errno 13] Permission denied: '/root/.modal.toml'`. This crashes the dashboard `/api/skills` endpoint.

## Why

The `has_direct_modal_credentials()` function is called during skills page load (line 4479 in `web_server.py`) to evaluate tool requirements. In Docker, the dashboard service inherits `HOME=/root` from the container environment but runs as `hermes` user who can't read `/root/`.

## Changes

**`tools/tool_backend_helpers.py`** (1 file):
- Wrap `Path.home() / ".modal.toml"` in `try/except (PermissionError, OSError)`
- On error, treat as "no config file" — env vars still take priority

**`tests/tools/test_tool_backend_helpers.py`** (1 file):
- `test_home_dir_permission_denied`: verifies `PermissionError` returns `False` when no env vars set
- `test_home_dir_permission_denied_with_env_vars`: verifies env vars still work when `Path.home()` raises

## Testing

All 49 tests in `test_tool_backend_helpers.py` pass, including the 2 new ones:
- `test_home_dir_permission_denied` — `PermissionError` → `False` (no env vars)
- `test_home_dir_permission_denied_with_env_vars` — `PermissionError` → `True` (env vars set)

## Related

Fixes #33525

## Code Intelligence
- Analyzed: `tools/tool_backend_helpers.py:has_direct_modal_credentials` (callers: web_server.py skills endpoint, test_tool_backend_helpers.py, test_nous_subscription.py)
- Blast radius: LOW — single function, defensive change, no behavior change for non-Docker environments
- Related patterns: `Path.home()` usage in Docker containers with mixed user contexts
