### PR TITLE
fix(kanban): quarantine corrupt DB backups by fingerprint

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5429,20 +5429,36 @@ class GatewayRunner:
         # surface as "database disk image is malformed" for one tick.
         CORRUPT_BOARD_RETRY_AFTER_SECONDS = 300
         disabled_corrupt_boards: dict[
-            str, tuple[tuple[str, int | None, int | None], float]
+            str,
+            tuple[
+                tuple[str, tuple[tuple[str, bool, int | None, int | None], ...]],
+                float,
+            ],
         ] = {}
 
-        def _board_db_fingerprint(slug: str) -> tuple[str, int | None, int | None]:
+        def _board_db_fingerprint(
+            slug: str,
+        ) -> tuple[str, tuple[tuple[str, bool, int | None, int | None], ...]]:
             path = _kb.kanban_db_path(slug)
             try:
-                resolved = str(path.expanduser().resolve())
+                resolved_path = path.expanduser().resolve()
+                resolved = str(resolved_path)
             except Exception:
+                resolved_path = path
                 resolved = str(path)
-            try:
-                stat = path.stat()
-            except OSError:
-                return (resolved, None, None)
-            return (resolved, stat.st_mtime_ns, stat.st_size)
+            artifacts = []
+            for label, artifact in (
+                ("db", resolved_path),
+                ("wal", resolved_path.parent / f"{resolved_path.name}-wal"),
+                ("shm", resolved_path.parent / f"{resolved_path.name}-shm"),
+            ):
+                try:
+                    stat = artifact.stat()
+                except OSError:
+                    artifacts.append((label, False, None, None))
+                else:
+                    artifacts.append((label, True, stat.st_mtime_ns, stat.st_size))
+            return (resolved, tuple(artifacts))
 
         def _is_corrupt_board_db_error(exc: Exception) -> bool:
             corrupt_guard_error = getattr(_kb, "KanbanDbCorruptError", None)
@@ -5454,6 +5470,31 @@ class GatewayRunner:
             return (
                 "file is not a database" in msg
                 or "database disk image is malformed" in msg
+            )
+
+        def _board_disabled_same_fingerprint(slug: str) -> bool:
+            disabled_entry = disabled_corrupt_boards.get(slug)
+            if disabled_entry is None:
+                return False
+            disabled_fingerprint, _disabled_at = disabled_entry
+            return disabled_fingerprint == _board_db_fingerprint(slug)
+
+        def _pause_corrupt_board(
+            slug: str,
+            fingerprint: tuple[
+                str,
+                tuple[tuple[str, bool, int | None, int | None], ...],
+            ],
+        ) -> None:
+            disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
+            logger.error(
+                "kanban dispatcher: board %s database %s is not a valid "
+                "SQLite database; pausing dispatch for this board until "
+                "the file changes, the gateway restarts, or the "
+                "quarantine timer expires. Move or restore the file, "
+                "then run `hermes kanban init` if you need a fresh board.",
+                slug,
+                fingerprint[0],
             )
 
         def _tick_once_for_board(slug: str) -> "Optional[object]":
@@ -5507,31 +5548,13 @@ class GatewayRunner:
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                    _pause_corrupt_board(slug, fingerprint)
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             except Exception as exc:
                 if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                    _pause_corrupt_board(slug, fingerprint)
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
@@ -5577,6 +5600,8 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if _board_disabled_same_fingerprint(slug):
+                    continue
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
@@ -5584,7 +5609,9 @@ class GatewayRunner:
                         return True
                     if _kb.has_spawnable_review(conn):
                         return True
-                except Exception:
+                except Exception as exc:
+                    if _is_corrupt_board_db_error(exc):
+                        _pause_corrupt_board(slug, _board_db_fingerprint(slug))
                     continue
                 finally:
                     if conn is not None:
@@ -5630,6 +5657,8 @@ class GatewayRunner:
             successes = 0
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if _board_disabled_same_fingerprint(slug):
+                    continue
                 if attempted >= auto_decompose_per_tick:
                     break
                 # Pin this board for the duration of the call — same
@@ -5642,10 +5671,13 @@ class GatewayRunner:
                     try:
                         triage_ids = _decomp.list_triage_ids()
                     except Exception as exc:
-                        logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
-                            slug, exc,
-                        )
+                        if _is_corrupt_board_db_error(exc):
+                            _pause_corrupt_board(slug, _board_db_fingerprint(slug))
+                        else:
+                            logger.debug(
+                                "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
+                                slug, exc,
+                            )
                         triage_ids = []
                     for tid in triage_ids:
                         if attempted >= auto_decompose_per_tick:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4561,21 +4561,20 @@ def reap_worker_zombies() -> "list[int]":
     Returns the list of reaped PIDs. Safe to call when there are no
     children (returns []). No-op on Windows.
     """
-    if os.name == "nt":
-        return []
     reaped: "list[int]" = []
-    try:
-        while True:
-            try:
-                pid, status = os.waitpid(-1, os.WNOHANG)
-            except ChildProcessError:
-                break
-            if pid == 0:
-                break
-            _record_worker_exit(pid, status)
-            reaped.append(pid)
-    except Exception:
-        pass
+    if os.name != "nt":
+        try:
+            while True:
+                try:
+                    pid, status = os.waitpid(-1, os.WNOHANG)
+                except ChildProcessError:
+                    break
+                if pid == 0:
+                    break
+                _record_worker_exit(pid, status)
+                reaped.append(pid)
+        except Exception:
+            pass
     return reaped
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -83,7 +84,7 @@ import threading
 import logging
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -982,6 +983,8 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
+_CORRUPT_DB_MARKER_SUFFIX = ".corrupt-quarantine.json"
+_CORRUPT_DB_MARKER_LOCK = threading.RLock()
 
 
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
@@ -1054,8 +1057,278 @@ class KanbanDbCorruptError(RuntimeError):
         )
 
 
-def _backup_corrupt_db(path: Path) -> Optional[Path]:
-    """Copy a corrupt DB (and its WAL/SHM sidecars) to a timestamped backup.
+def _corrupt_db_marker_path(path: Path) -> Path:
+    """Return the durable per-DB corrupt quarantine marker path."""
+    resolved = path.resolve()
+    parent = resolved.parent
+    marker = parent / f"{resolved.name}{_CORRUPT_DB_MARKER_SUFFIX}"
+    # ``resolved.name`` is a basename, so this should always hold. Keep the
+    # containment check explicit because marker writes happen next to user data.
+    if marker.parent != parent:
+        return parent / f"kanban.db{_CORRUPT_DB_MARKER_SUFFIX}"
+    return marker
+
+
+def _corrupt_db_artifact_paths(path: Path) -> dict[str, Path]:
+    """Return the DB plus WAL/SHM sidecar paths that define one fingerprint."""
+    resolved = path.resolve()
+    parent = resolved.parent
+    base = resolved.name
+    return {
+        "db": resolved,
+        "wal": parent / f"{base}-wal",
+        "shm": parent / f"{base}-shm",
+    }
+
+
+def _sha256_file(path: Path) -> Optional[str]:
+    """Return a file sha256 digest, or None if the file cannot be read."""
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def _corrupt_db_snapshot(path: Path) -> dict[str, dict[str, int | bool | str | None]]:
+    """Capture a durable content fingerprint for a corrupt DB and sidecars."""
+    snapshot: dict[str, dict[str, int | bool | str | None]] = {}
+    for label, artifact in _corrupt_db_artifact_paths(path).items():
+        info: dict[str, int | bool | str | None] = {
+            "exists": False,
+            "size": None,
+            "sha256": None,
+        }
+        try:
+            stat = artifact.stat()
+        except OSError:
+            pass
+        else:
+            info["exists"] = True
+            info["size"] = int(stat.st_size)
+            info["sha256"] = _sha256_file(artifact)
+        snapshot[label] = info
+    return snapshot
+
+
+def _corrupt_db_snapshot_token(
+    snapshot: dict[str, dict[str, int | bool | str | None]],
+) -> str:
+    """Stable short token for one corrupt DB/WAL/SHM content fingerprint."""
+    raw = json.dumps(snapshot, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _load_corrupt_db_marker(path: Path) -> Optional[dict[str, Any]]:
+    """Best-effort load of a durable corrupt quarantine marker."""
+    try:
+        marker = _corrupt_db_marker_path(path)
+    except OSError:
+        return None
+    try:
+        raw = marker.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        _log.warning("kanban corrupt marker unreadable at %s: %s", marker, exc)
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError as exc:
+        _log.warning("kanban corrupt marker invalid at %s: %s", marker, exc)
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _marker_backup_path(payload: dict[str, Any], db_path: Path) -> Optional[Path]:
+    raw = payload.get("backup_path")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        backup = Path(raw).expanduser().resolve()
+        resolved_db = db_path.resolve()
+        parent = resolved_db.parent
+    except OSError:
+        return None
+    if backup.parent != parent or not backup.name.startswith(f"{resolved_db.name}.corrupt."):
+        return None
+    try:
+        return backup if backup.is_file() else None
+    except OSError:
+        return None
+
+
+def _matching_corrupt_db_marker(
+    path: Path,
+    snapshot: dict[str, dict[str, int | bool | str | None]],
+) -> tuple[Optional[Path], Optional[str]] | None:
+    """Return marker data when the unchanged corrupt bytes were already saved."""
+    payload = _load_corrupt_db_marker(path)
+    if not payload:
+        return None
+    try:
+        resolved = str(path.resolve())
+    except OSError:
+        resolved = str(path)
+    if payload.get("db_path") != resolved:
+        return None
+    if payload.get("snapshot") != snapshot:
+        return None
+    backup = _marker_backup_path(payload, path)
+    if backup is None:
+        return None
+    expected_sha = snapshot.get("db", {}).get("sha256")
+    if isinstance(expected_sha, str) and _sha256_file(backup) != expected_sha:
+        return None
+    for suffix, label in (("-wal", "wal"), ("-shm", "shm")):
+        info = snapshot.get(label, {})
+        if not info.get("exists"):
+            continue
+        sidecar_backup = backup.parent / f"{backup.name}{suffix}"
+        if sidecar_backup.parent != backup.parent:
+            return None
+        if not _backup_matches_snapshot(sidecar_backup, info):
+            return None
+    reason = str(payload.get("reason") or "").strip() or None
+    return (backup, reason)
+
+
+def _write_corrupt_db_marker(
+    path: Path,
+    *,
+    snapshot: dict[str, dict[str, int | bool | str | None]],
+    reason: str,
+    backup_path: Optional[Path],
+) -> None:
+    """Persist the first backup path for one corrupt DB fingerprint."""
+    try:
+        marker = _corrupt_db_marker_path(path)
+        resolved = path.resolve()
+    except OSError as exc:
+        _log.warning("failed resolving kanban corrupt marker path for %s: %s", path, exc)
+        return
+    payload = {
+        "version": 1,
+        "status": "quarantined",
+        "db_path": str(resolved),
+        "snapshot": snapshot,
+        "reason": reason,
+        "backup_path": str(backup_path) if backup_path is not None else None,
+        "quarantined_at": (
+            datetime.now(UTC)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        ),
+    }
+    tmp = marker.with_name(f"{marker.name}.tmp")
+    with _CORRUPT_DB_MARKER_LOCK:
+        try:
+            with tmp.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            tmp.replace(marker)
+        except OSError as exc:
+            _log.warning("failed writing kanban corrupt marker %s: %s", marker, exc)
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def _clear_corrupt_db_marker(path: Path) -> None:
+    """Remove a stale corrupt marker after the DB opens cleanly."""
+    try:
+        marker = _corrupt_db_marker_path(path)
+    except OSError:
+        return
+    try:
+        marker.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        _log.debug("failed removing kanban corrupt marker %s: %s", marker, exc)
+
+
+def _backup_corrupt_db_once(path: Path, reason: str) -> tuple[Optional[Path], str]:
+    """Back up a corrupt DB once per unchanged durable fingerprint.
+
+    Multiple gateway profiles, health probes, CLI retries, and restarts can all
+    touch the same malformed board. A timestamp-only backup on every failed
+    open turns one corruption incident into unbounded disk growth. Persist a
+    small marker next to the DB so unchanged bytes reuse the first backup path;
+    if the DB/WAL/SHM fingerprint changes, preserve the new bytes separately.
+    """
+    try:
+        resolved = path.resolve()
+        snapshot = _corrupt_db_snapshot(resolved)
+    except OSError:
+        return (_backup_corrupt_db(path), reason)
+
+    with _CORRUPT_DB_MARKER_LOCK:
+        existing = _matching_corrupt_db_marker(resolved, snapshot)
+        if existing is not None:
+            backup, prior_reason = existing
+            detail = prior_reason or reason
+            if backup is not None:
+                detail = f"{detail} (already quarantined; reusing backup)"
+            else:
+                detail = f"{detail} (already quarantined; previous backup unavailable)"
+            return (backup, detail)
+        backup = _backup_corrupt_db(
+            resolved,
+            backup_token=f"quarantine.{_corrupt_db_snapshot_token(snapshot)}",
+        )
+        if backup is not None:
+            _write_corrupt_db_marker(
+                resolved,
+                snapshot=snapshot,
+                reason=reason,
+                backup_path=backup,
+            )
+        return (backup, reason)
+
+
+def _copy2_atomic(src: Path, dst: Path, expected_sha256: Optional[str] = None) -> bool:
+    """Copy src to dst via a temp file, then atomically publish it."""
+    tmp = dst.with_name(f"{dst.name}.tmp.{os.getpid()}.{threading.get_ident()}.{time.time_ns()}")
+    try:
+        shutil.copy2(src, tmp)
+        if expected_sha256 is not None and _sha256_file(tmp) != expected_sha256:
+            return False
+        with tmp.open("rb") as handle:
+            os.fsync(handle.fileno())
+        os.replace(tmp, dst)
+        return True
+    except OSError:
+        return False
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+
+
+def _backup_matches_snapshot(backup: Path, snapshot_info: dict[str, int | bool | str | None]) -> bool:
+    if not backup.is_file():
+        return False
+    expected_size = snapshot_info.get("size")
+    expected_sha = snapshot_info.get("sha256")
+    try:
+        if isinstance(expected_size, int) and backup.stat().st_size != expected_size:
+            return False
+    except OSError:
+        return False
+    if isinstance(expected_sha, str) and _sha256_file(backup) != expected_sha:
+        return False
+    return True
+
+def _backup_corrupt_db(path: Path, backup_token: Optional[str] = None) -> Optional[Path]:
+    """Copy a corrupt DB (and its WAL/SHM sidecars) to a backup.
 
     Returns the backup path of the main DB file, or ``None`` if the copy
     itself failed (the caller still raises loudly in that case).
@@ -1070,25 +1343,39 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     resolved = path.resolve()
     parent = resolved.parent
     base_name = resolved.name  # basename only
-    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    candidate = parent / f"{base_name}.corrupt.{stamp}.bak"
+    if backup_token and re.fullmatch(r"[A-Za-z0-9_.-]+", backup_token):
+        stamp = backup_token
+        candidate = parent / f"{base_name}.corrupt.{stamp}.bak"
+    else:
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        candidate = parent / f"{base_name}.corrupt.{stamp}.bak"
     # Defensive: candidate must still be inside parent after construction.
     # f-string interpolation of ``base_name`` cannot escape ``parent``
     # because ``base_name`` is itself a resolved basename, but assert it
     # anyway so static analyzers can see the containment guarantee.
     if candidate.parent != parent:
         return None
-    counter = 0
-    while candidate.exists():
-        counter += 1
-        candidate = parent / f"{base_name}.corrupt.{stamp}.{counter}.bak"
-        if candidate.parent != parent:
-            return None
+    if not backup_token:
+        counter = 0
+        while candidate.exists():
+            counter += 1
+            candidate = parent / f"{base_name}.corrupt.{stamp}.{counter}.bak"
+            if candidate.parent != parent:
+                return None
     try:
-        shutil.copy2(resolved, candidate)
+        snapshot = _corrupt_db_snapshot(resolved)
+        main_info = snapshot.get("db", {})
+        if not _backup_matches_snapshot(candidate, main_info):
+            expected_sha = main_info.get("sha256")
+            if not _copy2_atomic(
+                resolved,
+                candidate,
+                expected_sha if isinstance(expected_sha, str) else None,
+            ):
+                return None
     except OSError:
         return None
-    for suffix in ("-wal", "-shm"):
+    for suffix, label in (("-wal", "wal"), ("-shm", "shm")):
         sidecar = parent / (base_name + suffix)
         if sidecar.parent != parent or not sidecar.exists():
             continue
@@ -1096,7 +1383,15 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
             sidecar_backup = parent / (candidate.name + suffix)
             if sidecar_backup.parent != parent:
                 continue
-            shutil.copy2(sidecar, sidecar_backup)
+            side_info = snapshot.get(label, {})
+            if _backup_matches_snapshot(sidecar_backup, side_info):
+                continue
+            expected_sha = side_info.get("sha256")
+            _copy2_atomic(
+                sidecar,
+                sidecar_backup,
+                expected_sha if isinstance(expected_sha, str) else None,
+            )
         except OSError:
             pass
     return candidate
@@ -1108,7 +1403,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     Opens the probe in read/write mode so SQLite can recover or
     checkpoint a healthy WAL/hot-journal DB before we declare it
     corrupt. If the file is malformed, copy it (and any WAL/SHM
-    sidecars) to a timestamped backup and raise
+    sidecars) to a corrupt backup and raise
     :class:`KanbanDbCorruptError` so callers cannot silently recreate
     the schema on top of a damaged DB.
 
@@ -1155,8 +1450,9 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     except sqlite3.DatabaseError as exc:
         reason = f"sqlite refused to open file: {exc}"
     if reason is None:
+        _clear_corrupt_db_marker(resolved)
         return
-    backup = _backup_corrupt_db(resolved)
+    backup, reason = _backup_corrupt_db_once(resolved, reason)
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 
@@ -1230,6 +1526,7 @@ def connect(
                 conn.executescript(SCHEMA_SQL)
                 _migrate_add_optional_columns(conn)
                 _INITIALIZED_PATHS.add(resolved)
+        _clear_corrupt_db_marker(path)
     except Exception:
         conn.close()
         raise

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3639,6 +3639,7 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
             "kanban": {
                 "dispatch_in_gateway": True,
                 "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
             }
         },
     )
@@ -3699,13 +3700,11 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 1
     assert not any("tick failed on board" in msg for msg in messages)
     assert not any(record.exc_info for record in caplog.records)
-    # First tick connect (dispatch) + two probes per `_has_ready_work` call
-    # (ready then review, both via _kb.connect). The second dispatch tick
-    # skips the dispatch connect because the corrupt board fingerprint is
-    # disabled, but the ready/review probes still each connect. PR f55d94a1e
-    # added the review-column probe alongside the existing ready-column
-    # probe, bumping this from 3 → 5.
-    assert calls["connect"] == 5
+    # First tick opens the corrupt board once and disables it. Subsequent
+    # dispatch ticks and ready/review health probes skip the same fingerprint,
+    # so the dispatcher does not re-open the bad file just to ask whether there
+    # is ready work.
+    assert calls["connect"] == 1
 
 
 def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
@@ -3733,6 +3732,7 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
             "kanban": {
                 "dispatch_in_gateway": True,
                 "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
             }
         },
     )
@@ -3793,6 +3793,84 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 2
     assert any("database fingerprint unchanged" in msg for msg in messages)
     assert calls["tick"] == 3
+
+
+def test_gateway_dispatcher_retries_corrupt_board_after_sidecar_change(
+    monkeypatch, tmp_path, caplog
+):
+    """A WAL/SHM sidecar change is a new board fingerprint and is retried."""
+    import asyncio
+    import logging
+    import sqlite3
+
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    corrupt_db = tmp_path / "kanban.db"
+    corrupt_db.write_text("not sqlite", encoding="utf-8")
+    wal_path = tmp_path / "kanban.db-wal"
+    wal_path.write_text("first", encoding="utf-8")
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
+
+    calls = {"connect": 0, "tick": 0}
+
+    def _connect(*args, **kwargs):
+        calls["connect"] += 1
+        raise sqlite3.DatabaseError("file is not a database")
+
+    async def _to_thread(fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        if getattr(fn, "__name__", "") == "_tick_once":
+            calls["tick"] += 1
+            if calls["tick"] == 1:
+                wal_path.write_text("second", encoding="utf-8")
+            if calls["tick"] >= 2:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum("not a valid SQLite database" in msg for msg in messages) == 2
+    assert calls["connect"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import time
@@ -3276,6 +3277,198 @@ def test_connect_refuses_corrupt_existing_file(tmp_path):
 
     with pytest.raises(kb.KanbanDbCorruptError):
         kb.connect(db_path=db_path)
+
+
+def test_repeated_corrupt_existing_file_reuses_durable_backup_marker(tmp_path):
+    """One unchanged corrupt DB fingerprint should not create backup spam."""
+    db_path = tmp_path / "kanban.db"
+    original = _write_corrupt_db(db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+    # Simulate a fresh caller/process by not relying on any initialized-path
+    # cache. The durable marker next to the DB is the only reuse mechanism.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    for _ in range(100):
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+        with pytest.raises(kb.KanbanDbCorruptError) as repeated:
+            kb.connect(db_path=db_path)
+        assert repeated.value.backup_path == first.value.backup_path
+
+    assert first.value.backup_path == second.value.backup_path
+    assert second.value.backup_path is not None
+    assert second.value.backup_path.read_bytes() == original
+    backups = sorted(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert backups == [first.value.backup_path]
+    marker = tmp_path / "kanban.db.corrupt-quarantine.json"
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["backup_path"] == str(first.value.backup_path)
+    assert payload["snapshot"]["db"]["size"] == len(original)
+
+
+def test_metadata_only_touch_reuses_existing_corrupt_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+
+    stat = db_path.stat()
+    os.utime(db_path, ns=(stat.st_atime_ns + 1_000_000, stat.st_mtime_ns + 1_000_000))
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    assert second.value.backup_path == first.value.backup_path
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 1
+
+
+def test_changed_corrupt_existing_file_gets_new_backup(tmp_path):
+    """Changed corrupt bytes are a new incident and deserve their own backup."""
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+
+    db_path.write_bytes(db_path.read_bytes() + b"changed")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    assert first.value.backup_path != second.value.backup_path
+    backups = set(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert backups == {first.value.backup_path, second.value.backup_path}
+
+
+def test_same_size_corrupt_content_change_gets_new_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    original = bytearray(_write_corrupt_db(db_path))
+    stat = db_path.stat()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+
+    original[-1] ^= 0xFF
+    db_path.write_bytes(original)
+    os.utime(db_path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    assert first.value.backup_path != second.value.backup_path
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 2
+
+
+def test_changed_corrupt_sidecar_gets_new_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    wal_path = tmp_path / "kanban.db-wal"
+    wal_path.write_bytes(b"first wal")
+
+    first_backup, _ = kb._backup_corrupt_db_once(db_path, "first")
+    kb._write_corrupt_db_marker(
+        db_path,
+        snapshot=kb._corrupt_db_snapshot(db_path.resolve()),
+        reason="first",
+        backup_path=first_backup,
+    )
+
+    wal_path.write_bytes(b"second wal")
+    second_backup, _ = kb._backup_corrupt_db_once(db_path, "second")
+
+    assert first_backup != second_backup
+    assert first_backup is not None
+    assert second_backup is not None
+    assert (tmp_path / f"{first_backup.name}-wal").read_bytes() == b"first wal"
+    assert (tmp_path / f"{second_backup.name}-wal").read_bytes() == b"second wal"
+
+
+def test_repeated_corrupt_file_repairs_partial_deterministic_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    original = _write_corrupt_db(db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+    assert first.value.backup_path is not None
+    first.value.backup_path.write_bytes(b"partial")
+    (tmp_path / "kanban.db.corrupt-quarantine.json").unlink()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    assert second.value.backup_path == first.value.backup_path
+    assert second.value.backup_path is not None
+    assert second.value.backup_path.read_bytes() == original
+
+
+def test_matching_marker_without_valid_backup_does_not_suppress_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    snapshot = kb._corrupt_db_snapshot(db_path.resolve())
+    marker = tmp_path / "kanban.db.corrupt-quarantine.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "status": "quarantined",
+                "db_path": str(db_path.resolve()),
+                "snapshot": snapshot,
+                "reason": "prior",
+                "backup_path": str(tmp_path / "missing.bak"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        kb.connect(db_path=db_path)
+
+    assert excinfo.value.backup_path is not None
+    assert excinfo.value.backup_path.exists()
+
+
+def test_matching_marker_repairs_partial_sidecar_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    wal_path = tmp_path / "kanban.db-wal"
+    wal_path.write_bytes(b"full wal")
+
+    first_backup, _ = kb._backup_corrupt_db_once(db_path, "first")
+    assert first_backup is not None
+    wal_backup = tmp_path / f"{first_backup.name}-wal"
+    wal_backup.write_bytes(b"partial")
+
+    second_backup, _ = kb._backup_corrupt_db_once(db_path, "second")
+
+    assert second_backup == first_backup
+    assert wal_backup.read_bytes() == b"full wal"
+
+
+def test_healthy_db_open_clears_stale_corrupt_marker(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    marker = tmp_path / "kanban.db.corrupt-quarantine.json"
+    marker.write_text(
+        json.dumps({"db_path": str(db_path.resolve()), "snapshot": {}, "backup_path": None}),
+        encoding="utf-8",
+    )
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kb.connect(db_path=db_path) as conn:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+
+    assert not marker.exists()
 
 
 def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1328,6 +1328,7 @@ def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
 
     conn = kb.connect()
     try:
+        monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
         run1 = kb.latest_run(conn, worker_env)
         kb._set_worker_pid(conn, worker_env, 98765)
         monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)


### PR DESCRIPTION
## What does this PR do?

Stops corrupt Kanban DB backup amplification and tightens gateway handling for quarantined corrupt boards.

When a board DB is corrupt today, repeated gateway ticks / health probes / restarts can keep opening the same malformed DB and keep creating timestamped `*.corrupt.*.bak` files. This PR makes corrupt backup preservation durable and idempotent for the same DB/WAL/SHM content fingerprint, while still preserving new bytes separately when the corrupt DB or its WAL/SHM sidecars change.

It also teaches the embedded gateway dispatcher and ready/review health probes to skip a board already paused for the same corrupt DB fingerprint, so probes do not immediately reopen the same bad board after dispatch paused it.

## Related Issue

Refs #30445
Refs #31736

No new issue opened: the remaining problem is covered by those existing Kanban corruption / gateway pressure issues, and this PR is a focused follow-up fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Add a durable corrupt-quarantine marker next to the DB.
  - Fingerprint corrupt DB artifacts by DB/WAL/SHM `exists + size + sha256` content, not mtime.
  - Reuse the first complete backup for unchanged corrupt content, even across retries/restarts or metadata-only touches.
  - Create a new deterministic backup when corrupt DB bytes or WAL/SHM sidecar bytes change.
  - Validate main and sidecar backup artifacts before reusing a marker.
  - Atomically repair missing/partial deterministic backups via temp file + `fsync` + `os.replace`.
  - Ignore missing/invalid marker backup paths rather than letting them suppress preservation.
  - Clear stale corrupt markers after a healthy DB open.

- `gateway/run.py`
  - Pause corrupt board dispatch by DB/WAL/SHM stat fingerprint.
  - Skip same-fingerprint corrupt boards in dispatch, ready/review health checks, and auto-decompose scans.
  - Retry/re-pause when the DB/WAL/SHM stat fingerprint changes or the quarantine retry interval expires.

- Tests
  - Add coverage for unchanged corrupt backup reuse, metadata-only touch reuse, changed-content new backup, changed sidecar new backup, partial main/sidecar backup repair, invalid marker backup paths, stale marker clearing, and dispatcher/health-probe skip/retry behavior.
  - Align two existing Kanban guard tests with current crash-grace / Windows waitpid guard behavior so the full CI slices stay green.

## How to Test

Commands run locally on macOS 26.3.1:

```bash
python -m pytest -o addopts='' \
  tests/run_agent/test_tls_fd_recycle_corruption.py \
  tests/hermes_cli/test_kanban_db.py::test_init_db_refuses_corrupt_existing_file \
  tests/hermes_cli/test_kanban_db.py::test_connect_refuses_corrupt_existing_file \
  tests/hermes_cli/test_kanban_db.py::test_repeated_corrupt_existing_file_reuses_durable_backup_marker \
  tests/hermes_cli/test_kanban_db.py::test_metadata_only_touch_reuses_existing_corrupt_backup \
  tests/hermes_cli/test_kanban_db.py::test_changed_corrupt_existing_file_gets_new_backup \
  tests/hermes_cli/test_kanban_db.py::test_same_size_corrupt_content_change_gets_new_backup \
  tests/hermes_cli/test_kanban_db.py::test_changed_corrupt_sidecar_gets_new_backup \
  tests/hermes_cli/test_kanban_db.py::test_repeated_corrupt_file_repairs_partial_deterministic_backup \
  tests/hermes_cli/test_kanban_db.py::test_matching_marker_without_valid_backup_does_not_suppress_backup \
  tests/hermes_cli/test_kanban_db.py::test_matching_marker_repairs_partial_sidecar_backup \
  tests/hermes_cli/test_kanban_db.py::test_healthy_db_open_clears_stale_corrupt_marker \
  tests/hermes_cli/test_kanban_db.py::test_locked_healthy_db_does_not_classify_as_corrupt \
  tests/hermes_cli/test_kanban_core_functionality.py::test_gateway_dispatcher_disables_corrupt_board_without_traceback \
  tests/hermes_cli/test_kanban_core_functionality.py::test_gateway_dispatcher_retries_corrupt_board_after_quarantine \
  tests/hermes_cli/test_kanban_core_functionality.py::test_gateway_dispatcher_retries_corrupt_board_after_sidecar_change \
  -q
# 26 passed in 1.48s

python -m pytest -o addopts='' tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q
# 370 passed, 1 skipped in 12.73s

$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/run.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py
# All checks passed!

scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py tests/tools/test_windows_native_support.py -- -q
# 509 tests passed, 0 failed

git diff --check
python -m py_compile hermes_cli/kanban_db.py gateway/run.py
```

Also ran two independent review passes after the final fixes; both returned no blockers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
