### PR TITLE
fix(config): coerce bare-string home_channel + improve api_server.key messages (fixes #33141, fixes #33207)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -317,10 +317,24 @@ class PlatformConfig:
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
+    def from_dict(cls, data: Dict[str, Any], platform: Optional["Platform"] = None) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
-            home_channel = HomeChannel.from_dict(data["home_channel"])
+            raw_hc = data["home_channel"]
+            # Gracefully handle plain-string home_channel values written by
+            # ``hermes config set platforms.<name>.home_channel <chat_id>``.
+            # The config setter stores bare strings, but the full structured
+            # form is ``{platform, chat_id, name}``.  When a bare string is
+            # found, wrap it into a proper dict so HomeChannel.from_dict can
+            # parse it, filling in the platform from the enclosing context.
+            # (ref: https://github.com/NousResearch/hermes-agent/issues/33141)
+            if isinstance(raw_hc, str):
+                raw_hc = {
+                    "platform": platform.value if platform else "local",
+                    "chat_id": raw_hc,
+                    "name": "Home",
+                }
+            home_channel = HomeChannel.from_dict(raw_hc)
 
         # gateway_restart_notification may be bridged into extra via the
         # shared-key loop in load_gateway_config(); check both top-level
@@ -594,7 +608,7 @@ class GatewayConfig:
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
+                platforms[platform] = PlatformConfig.from_dict(platform_data, platform=platform)
             except ValueError:
                 pass  # Skip unknown platforms
         

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -800,12 +800,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if not self._api_key:
             logger.warning(
                 "X-Hermes-Session-Key rejected: no API key configured. "
-                "Set API_SERVER_KEY to enable long-term memory scoping."
+                "Set API_SERVER_KEY or platforms.api_server.key to enable "
+                "long-term memory scoping."
             )
             return None, web.json_response(
                 _openai_error(
                     "X-Hermes-Session-Key requires API key authentication. "
-                    "Configure API_SERVER_KEY to enable this feature."
+                    "Configure API_SERVER_KEY or platforms.api_server.key "
+                    "in config.yaml to enable this feature."
                 ),
                 status=403,
             )
@@ -1097,13 +1099,14 @@ class APIServerAdapter(BasePlatformAdapter):
             if not self._api_key:
                 logger.warning(
                     "Session continuation via X-Hermes-Session-Id rejected: "
-                    "no API key configured.  Set API_SERVER_KEY to enable "
-                    "session continuity."
+                    "no API key configured.  Set API_SERVER_KEY or "
+                    "platforms.api_server.key to enable session continuity."
                 )
                 return web.json_response(
                     _openai_error(
                         "Session continuation requires API key authentication. "
-                        "Configure API_SERVER_KEY to enable this feature."
+                        "Configure API_SERVER_KEY or platforms.api_server.key "
+                        "in config.yaml to enable this feature."
                     ),
                     status=403,
                 )

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -703,3 +703,44 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestBareStringHomeChannel:
+    """Tests for #33141: ``hermes config set platforms.<name>.home_channel <chat_id>``
+    writes a plain string, but HomeChannel.from_dict expects a dict."""
+
+    def test_platformconfig_from_dict_string_home_channel(self):
+        """A bare-string home_channel is coerced into a proper HomeChannel."""
+        pc = PlatformConfig.from_dict(
+            {"enabled": True, "home_channel": "oc_b0b897cce6e70190959898f94fe8f9a8"},
+            platform=Platform.FEISHU,
+        )
+        assert pc.home_channel is not None
+        assert pc.home_channel.chat_id == "oc_b0b897cce6e70190959898f94fe8f9a8"
+        assert pc.home_channel.platform == Platform.FEISHU
+        assert pc.home_channel.name == "Home"
+
+    def test_platformconfig_from_dict_string_home_channel_no_platform(self):
+        """Bare string without platform context defaults to 'local'."""
+        pc = PlatformConfig.from_dict(
+            {"enabled": True, "home_channel": "12345"},
+        )
+        assert pc.home_channel is not None
+        assert pc.home_channel.chat_id == "12345"
+        assert pc.home_channel.platform == Platform.LOCAL
+
+    def test_gatewayconfig_from_dict_string_home_channel(self):
+        """Full GatewayConfig loading with a bare-string home_channel."""
+        data = {
+            "platforms": {
+                "feishu": {
+                    "enabled": True,
+                    "home_channel": "oc_test123",
+                },
+            },
+        }
+        config = GatewayConfig.from_dict(data)
+        hc = config.platforms[Platform.FEISHU].home_channel
+        assert hc is not None
+        assert hc.chat_id == "oc_test123"
+        assert hc.platform == Platform.FEISHU


### PR DESCRIPTION
## Summary

Two config-related fixes:

### #33141 — `home_channel` string type mismatch

`hermes config set platforms.<name>.home_channel <chat_id>` writes a plain string to `config.yaml`, but `HomeChannel.from_dict()` expects a dict `{platform, chat_id, name}`. This causes a `TypeError` on gateway startup or `send_message` calls.

**Fix:** `PlatformConfig.from_dict()` now detects bare-string `home_channel` values and wraps them into a proper dict using the enclosing platform context (passed via new optional `platform` parameter). `GatewayConfig.from_dict()` passes the platform when creating `PlatformConfig` instances.

### #33207 — Session continuation error messages only reference env var

Error messages for `X-Hermes-Session-Key` and `X-Hermes-Session-Id` validation only mention `API_SERVER_KEY` (env var), not the equivalent `platforms.api_server.key` in `config.yaml`. Users who configured the key via config.yaml see confusing messages.

**Fix:** Updated all 4 error/warning messages to reference both configuration paths: `API_SERVER_KEY or platforms.api_server.key in config.yaml`.

## Testing

- Added 3 new tests in `TestBareStringHomeChannel`:
  - `test_platformconfig_from_dict_string_home_channel` — bare string with platform context
  - `test_platformconfig_from_dict_string_home_channel_no_platform` — bare string without context (defaults to `local`)
  - `test_gatewayconfig_from_dict_string_home_channel` — full GatewayConfig loading
- All 51 tests in `tests/gateway/test_config.py` pass.

## Files Changed

- `gateway/config.py` — `PlatformConfig.from_dict()` accepts optional `platform` param; coerces bare-string `home_channel`; `GatewayConfig.from_dict()` passes platform
- `gateway/platforms/api_server.py` — 4 error/warning messages now mention `platforms.api_server.key`
- `tests/gateway/test_config.py` — 3 new test cases

Closes #33141, Closes #33207