### PR TITLE
feat: per-platform busy_input_mode override via display.platforms

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -21,7 +21,10 @@ config migration (version bump) automatically moves the old format into the new
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+_log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Overrideable display settings and their global defaults
@@ -159,7 +162,10 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
 }
 
 # Canonical set of per-platform overrideable keys (for validation).
-OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
+# busy_input_mode is overrideable per platform but has no _GLOBAL_DEFAULTS
+# entry because its global default is managed by _load_busy_input_mode() in
+# the gateway runner (config/env var), not by the display_config module.
+OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys()) | {"busy_input_mode"}
 
 
 def resolve_display_setting(
@@ -185,6 +191,14 @@ def resolve_display_setting(
     Returns
     -------
     The resolved value, or *fallback* if nothing is configured.
+
+    .. note::
+
+        ``busy_input_mode`` is in ``OVERRIDEABLE_KEYS`` but has no
+        ``_GLOBAL_DEFAULTS`` entry because its global default is managed by
+        ``_load_busy_input_mode()`` in the gateway runner (config/env var),
+        not by this module.  Callers **must** pass a *fallback* for this key;
+        without one the resolver returns ``None`` when no config is set.
     """
     display_cfg = user_config.get("display") or {}
 
@@ -194,7 +208,9 @@ def resolve_display_setting(
     if isinstance(plat_overrides, dict):
         val = plat_overrides.get(setting)
         if val is not None:
-            return _normalise(setting, val)
+            normalised = _normalise(setting, val)
+            if normalised is not None:
+                return normalised
 
     # 1b. Backward compat: display.tool_progress_overrides.<platform>
     if setting == "tool_progress":
@@ -202,7 +218,9 @@ def resolve_display_setting(
         if isinstance(legacy, dict):
             val = legacy.get(platform_key)
             if val is not None:
-                return _normalise(setting, val)
+                normalised = _normalise(setting, val)
+                if normalised is not None:
+                    return normalised
 
     # 2. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is
@@ -210,7 +228,9 @@ def resolve_display_setting(
     if setting != "streaming":
         val = display_cfg.get(setting)
         if val is not None:
-            return _normalise(setting, val)
+            normalised = _normalise(setting, val)
+            if normalised is not None:
+                return normalised
 
     # 3. Built-in platform default
     plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)
@@ -274,4 +294,14 @@ def _normalise(setting: str, value: Any) -> Any:
             return int(value)
         except (TypeError, ValueError):
             return 0
+    if setting == "busy_input_mode":
+        raw = str(value).strip().lower()
+        if raw in {"queue", "steer", "interrupt"}:
+            return raw
+        _log.warning(
+            "Invalid busy_input_mode=%r — expected interrupt/queue/steer; "
+            "skipping (will fall through to next resolution level)",
+            value,
+        )
+        return None
     return value

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9902,6 +9902,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
+            # Resolve the per-platform busy_input_mode once for this priority
+            # running-agent path, so display.platforms.<platform>.busy_input_mode
+            # overrides apply here too — not only in
+            # _handle_active_session_busy_message. Falls back to the global,
+            # env-loaded self._busy_input_mode when there is no override.
+            from gateway.display_config import resolve_display_setting
+            _effective_busy_mode = resolve_display_setting(
+                _load_gateway_config(),
+                _platform_config_key(source.platform),
+                "busy_input_mode",
+                self._busy_input_mode,
+            )
+
             _telegram_followup_grace = float(
                 os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
             )
@@ -9920,7 +9933,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 adapter = self._adapter_for_source(source)
                 if adapter:
-                    if self._busy_input_mode == "queue":
+                    if _effective_busy_mode == "queue":
                         self._enqueue_fifo(_quick_key, event, adapter)
                     else:
                         merge_pending_message_event(
@@ -9958,11 +9971,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
-            if self._busy_input_mode == "queue":
+            if _effective_busy_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
-            if self._busy_input_mode == "steer":
+            if _effective_busy_mode == "steer":
                 # Steer mode: inject text into the running agent mid-run via
                 # agent.steer().  Falls back to queue semantics if the payload
                 # is empty, the agent lacks steer(), or steer() rejects.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5648,7 +5648,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         running_agent = self._running_agents.get(session_key)
 
-        effective_mode = self._busy_input_mode
+        # Resolve per-platform busy_input_mode (display.platforms.<platform>.busy_input_mode)
+        # falling back to the global/env-loaded self._busy_input_mode.
+        #
+        # Precedence note: self._busy_input_mode is loaded at startup by
+        # _load_busy_input_mode() which honours HERMES_GATEWAY_BUSY_INPUT_MODE
+        # env var > config.display.busy_input_mode.  The display_config resolver
+        # reads display.busy_input_mode at resolution level 2, which outranks
+        # the env var.  This is safe because startup syncs the config value into
+        # the env var (run.py:1130), so the two always agree.  If that sync
+        # is ever removed, an externally-set env var would be silently ignored
+        # for platforms without an explicit display override.
+        from gateway.display_config import resolve_display_setting
+        gw_config = _load_gateway_config()
+        plat_key = _platform_config_key(event.source.platform)
+        effective_mode = resolve_display_setting(
+            gw_config,
+            plat_key,
+            "busy_input_mode",
+            self._busy_input_mode,
+        )
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
         if (
             event.message_type == MessageType.TEXT
@@ -5789,8 +5808,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         status_parts = []
         busy_ack_detail_enabled = bool(
             resolve_display_setting(
-                _load_gateway_config(),
-                _platform_config_key(event.source.platform),
+                gw_config,
+                plat_key,
                 "busy_ack_detail",
                 True,
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3007,6 +3007,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._service_tier = self._load_service_tier()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
+        self._busy_input_mode_by_platform = self._load_busy_input_mode_by_platform()
         self._busy_text_mode = self._load_busy_text_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
@@ -5126,6 +5127,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return "interrupt"
 
     @staticmethod
+    def _load_busy_input_mode_by_platform() -> dict[str, str]:
+        """Startup snapshot of display.platforms.<platform>.busy_input_mode.
+
+        Loaded once like _load_busy_input_mode(), so changing an override in
+        config requires a gateway restart, matching the global mode's
+        lifecycle. Keeping this off the per-message path preserves the busy
+        handler's invariant that no config is read inside the ack cooldown.
+        Invalid values are dropped here (with a warning from _normalise) so
+        resolution falls back to the global mode.
+        """
+        from gateway.display_config import _normalise
+
+        cfg = _load_gateway_runtime_config()
+        platforms = cfg_get(cfg, "display", "platforms", default=None)
+        overrides: dict[str, str] = {}
+        if isinstance(platforms, dict):
+            for plat, settings in platforms.items():
+                if not isinstance(settings, dict):
+                    continue
+                val = settings.get("busy_input_mode")
+                if val is None:
+                    continue
+                normalised = _normalise("busy_input_mode", val)
+                if normalised is not None:
+                    overrides[str(plat)] = normalised
+        return overrides
+
+    def _effective_busy_input_mode(self, platform: "Platform") -> str:
+        """busy_input_mode for *platform*: per-platform override or global."""
+        overrides = getattr(self, "_busy_input_mode_by_platform", None) or {}
+        return overrides.get(_platform_config_key(platform), self._busy_input_mode)
+
+    @staticmethod
     def _load_busy_text_mode() -> str:
         """Resolve normal busy TEXT follow-up behavior.
 
@@ -5648,26 +5682,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         running_agent = self._running_agents.get(session_key)
 
-        # Resolve per-platform busy_input_mode (display.platforms.<platform>.busy_input_mode)
-        # falling back to the global/env-loaded self._busy_input_mode.
-        #
-        # Precedence note: self._busy_input_mode is loaded at startup by
-        # _load_busy_input_mode() which honours HERMES_GATEWAY_BUSY_INPUT_MODE
-        # env var > config.display.busy_input_mode.  The display_config resolver
-        # reads display.busy_input_mode at resolution level 2, which outranks
-        # the env var.  This is safe because startup syncs the config value into
-        # the env var (run.py:1130), so the two always agree.  If that sync
-        # is ever removed, an externally-set env var would be silently ignored
-        # for platforms without an explicit display override.
-        from gateway.display_config import resolve_display_setting
-        gw_config = _load_gateway_config()
-        plat_key = _platform_config_key(event.source.platform)
-        effective_mode = resolve_display_setting(
-            gw_config,
-            plat_key,
-            "busy_input_mode",
-            self._busy_input_mode,
-        )
+        # Per-platform busy_input_mode override (display.platforms.<platform>),
+        # resolved from the startup-loaded snapshot so this per-message path
+        # never reads config (the ack-cooldown debounce below relies on that).
+        effective_mode = self._effective_busy_input_mode(event.source.platform)
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
         if (
             event.message_type == MessageType.TEXT
@@ -5808,8 +5826,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         status_parts = []
         busy_ack_detail_enabled = bool(
             resolve_display_setting(
-                gw_config,
-                plat_key,
+                _load_gateway_config(),
+                _platform_config_key(event.source.platform),
                 "busy_ack_detail",
                 True,
             )
@@ -9902,18 +9920,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            # Resolve the per-platform busy_input_mode once for this priority
-            # running-agent path, so display.platforms.<platform>.busy_input_mode
-            # overrides apply here too — not only in
-            # _handle_active_session_busy_message. Falls back to the global,
-            # env-loaded self._busy_input_mode when there is no override.
-            from gateway.display_config import resolve_display_setting
-            _effective_busy_mode = resolve_display_setting(
-                _load_gateway_config(),
-                _platform_config_key(source.platform),
-                "busy_input_mode",
-                self._busy_input_mode,
-            )
+            # Per-platform busy_input_mode override for the priority
+            # running-agent path too, sharing the startup-loaded resolution
+            # with _handle_active_session_busy_message.
+            _effective_busy_mode = self._effective_busy_input_mode(source.platform)
 
             _telegram_followup_grace = float(
                 os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -98,6 +98,13 @@ def _make_adapter(platform_val="telegram"):
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
 
+    @pytest.fixture(autouse=True)
+    def _no_gateway_config(self, monkeypatch):
+        """Mock _load_gateway_config to return empty dict so tests control
+        busy_input_mode purely via runner._busy_input_mode."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
     @pytest.mark.asyncio
     async def test_handle_message_queue_mode_queues_without_interrupt(self):
         """Runner queue mode must not interrupt an active agent for text follow-ups."""
@@ -869,3 +876,237 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", agent, executor_task=live_task
         ) is True
+# ---------------------------------------------------------------------------
+# Per-platform busy_input_mode override
+# ---------------------------------------------------------------------------
+
+class TestPerPlatformBusyInputMode:
+    """busy_input_mode can be overridden per platform via display.platforms.<platform>."""
+
+    @pytest.mark.asyncio
+    async def test_platform_steer_overrides_global_interrupt(self, monkeypatch):
+        """sendblue configured as steer, global is interrupt — sendblue gets steer."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "busy_input_mode": "interrupt",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "steer"},
+                    },
+                }
+            },
+        )
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"  # global default
+        adapter = _make_adapter(platform_val="sendblue")
+
+        event = _make_event(text="steer this", platform_val="sendblue")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        # Steer was used — agent was NOT interrupted
+        agent.steer.assert_called_once_with("steer this")
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_platform_interrupt_overrides_global_steer(self, monkeypatch):
+        """sendblue configured as interrupt, global is steer — sendblue gets interrupt."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "busy_input_mode": "steer",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "interrupt"},
+                    },
+                }
+            },
+        )
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"  # global default
+        adapter = _make_adapter(platform_val="sendblue")
+
+        event = _make_event(text="interrupt this", platform_val="sendblue")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 600
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        # Interrupt was used — agent was NOT steered
+        agent.interrupt.assert_called_once_with("interrupt this")
+        if hasattr(agent, "steer"):
+            agent.steer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_platform_uses_global(self, monkeypatch):
+        """telegram has no platform override — falls back to global busy_input_mode."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "busy_input_mode": "queue",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "steer"},
+                    },
+                }
+            },
+        )
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        runner._busy_text_mode = "queue"  # realistic production default
+        adapter = _make_adapter(platform_val="telegram")
+
+        event = _make_event(text="queue me", platform_val="telegram")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        # With busy_text_mode="queue" + effective_mode="queue", the handler
+        # returns False (early exit for text in queue mode). The actual queueing
+        # is handled by the caller via the adapter's _pending_messages.
+        assert result is False
+        agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_per_platform_interrupt_demoted_with_subagents(self, monkeypatch):
+        """Per-platform interrupt override also gets demoted to queue when
+        subagents are active (#30170 interaction)."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "busy_input_mode": "queue",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "interrupt"},
+                    },
+                }
+            },
+        )
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter(platform_val="sendblue")
+
+        event = _make_event(text="don't kill my subagents", platform_val="sendblue")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        # Parent with active subagents
+        parent = MagicMock()
+        parent._active_children = [MagicMock()]
+        runner._running_agents[sk] = parent
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        # Per-platform interrupt demoted to queue — parent.interrupt NOT called
+        parent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_per_platform_value_through_handler(self, monkeypatch):
+        """Invalid per-platform busy_input_mode falls through to global,
+        not silently forced to interrupt."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "busy_input_mode": "steer",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "steerr"},  # typo
+                    },
+                }
+            },
+        )
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter(platform_val="sendblue")
+
+        event = _make_event(text="should steer not interrupt", platform_val="sendblue")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        # Typo in platform override → skipped → global "steer" used
+        agent.steer.assert_called_once_with("should steer not interrupt")
+        agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_per_platform_steer_fallback_to_queue_when_agent_pending(self, monkeypatch):
+        """Per-platform steer falls back to queue when agent is still starting."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "busy_input_mode": "interrupt",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "steer"},
+                    },
+                }
+            },
+        )
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter(platform_val="sendblue")
+
+        event = _make_event(text="arrived too early", platform_val="sendblue")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        # Agent is still being set up — sentinel in place
+        runner._running_agents[sk] = _sentinel
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        # Steer can't work with sentinel → falls back to queue
+        mock_merge.assert_called_once()
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert "Queued for the next turn" in content

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -881,28 +881,19 @@ class TestLongRunningNotificationOwnership:
 # ---------------------------------------------------------------------------
 
 class TestPerPlatformBusyInputMode:
-    """busy_input_mode can be overridden per platform via display.platforms.<platform>."""
+    """busy_input_mode can be overridden per platform via display.platforms.<platform>.
+
+    Overrides are loaded once at startup into runner._busy_input_mode_by_platform
+    (see GatewayRunner._load_busy_input_mode_by_platform), so these tests set the
+    map directly; the loader itself is covered by TestBusyInputModeByPlatformLoader.
+    """
 
     @pytest.mark.asyncio
-    async def test_platform_steer_overrides_global_interrupt(self, monkeypatch):
-        """sendblue configured as steer, global is interrupt — sendblue gets steer."""
-        import gateway.run as _gr
-
-        monkeypatch.setattr(
-            _gr,
-            "_load_gateway_config",
-            lambda: {
-                "display": {
-                    "busy_input_mode": "interrupt",
-                    "platforms": {
-                        "sendblue": {"busy_input_mode": "steer"},
-                    },
-                }
-            },
-        )
-
+    async def test_platform_steer_overrides_global_interrupt(self):
+        """sendblue configured as steer, global is interrupt: sendblue gets steer."""
         runner, _sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"  # global default
+        runner._busy_input_mode_by_platform = {"sendblue": "steer"}
         adapter = _make_adapter(platform_val="sendblue")
 
         event = _make_event(text="steer this", platform_val="sendblue")
@@ -916,31 +907,17 @@ class TestPerPlatformBusyInputMode:
         with patch("gateway.run.merge_pending_message_event") as mock_merge:
             await runner._handle_active_session_busy_message(event, sk)
 
-        # Steer was used — agent was NOT interrupted
+        # Steer was used; the agent was NOT interrupted.
         agent.steer.assert_called_once_with("steer this")
         agent.interrupt.assert_not_called()
         mock_merge.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_platform_interrupt_overrides_global_steer(self, monkeypatch):
-        """sendblue configured as interrupt, global is steer — sendblue gets interrupt."""
-        import gateway.run as _gr
-
-        monkeypatch.setattr(
-            _gr,
-            "_load_gateway_config",
-            lambda: {
-                "display": {
-                    "busy_input_mode": "steer",
-                    "platforms": {
-                        "sendblue": {"busy_input_mode": "interrupt"},
-                    },
-                }
-            },
-        )
-
+    async def test_platform_interrupt_overrides_global_steer(self):
+        """sendblue configured as interrupt, global is steer: sendblue gets interrupt."""
         runner, _sentinel = _make_runner()
         runner._busy_input_mode = "steer"  # global default
+        runner._busy_input_mode_by_platform = {"sendblue": "interrupt"}
         adapter = _make_adapter(platform_val="sendblue")
 
         event = _make_event(text="interrupt this", platform_val="sendblue")
@@ -954,35 +931,22 @@ class TestPerPlatformBusyInputMode:
         with patch("gateway.run.merge_pending_message_event"):
             await runner._handle_active_session_busy_message(event, sk)
 
-        # Interrupt was used — agent was NOT steered
+        # Interrupt was used; the agent was NOT steered.
         agent.interrupt.assert_called_once_with("interrupt this")
         if hasattr(agent, "steer"):
             agent.steer.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_priority_path_honors_per_platform_queue_override(self, monkeypatch):
+    async def test_priority_path_honors_per_platform_queue_override(self):
         """The PRIORITY running-agent path (_handle_message) must honor a
         display.platforms.<platform>.busy_input_mode override, not only the
         normal busy handler. Global is interrupt; sendblue overrides to queue,
         so the priority path must queue (not interrupt) the follow-up."""
-        import gateway.run as _gr
         from gateway.run import GatewayRunner
-
-        monkeypatch.setattr(
-            _gr,
-            "_load_gateway_config",
-            lambda: {
-                "display": {
-                    "busy_input_mode": "interrupt",
-                    "platforms": {
-                        "sendblue": {"busy_input_mode": "queue"},
-                    },
-                }
-            },
-        )
 
         runner, _sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"  # global default
+        runner._busy_input_mode_by_platform = {"sendblue": "queue"}
         adapter = _make_adapter(platform_val="sendblue")
 
         event = _make_event(text="queue me", platform_val="sendblue")
@@ -1009,25 +973,11 @@ class TestPerPlatformBusyInputMode:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_unconfigured_platform_uses_global(self, monkeypatch):
-        """telegram has no platform override — falls back to global busy_input_mode."""
-        import gateway.run as _gr
-
-        monkeypatch.setattr(
-            _gr,
-            "_load_gateway_config",
-            lambda: {
-                "display": {
-                    "busy_input_mode": "queue",
-                    "platforms": {
-                        "sendblue": {"busy_input_mode": "steer"},
-                    },
-                }
-            },
-        )
-
+    async def test_unconfigured_platform_uses_global(self):
+        """telegram has no platform override: falls back to global busy_input_mode."""
         runner, _sentinel = _make_runner()
         runner._busy_input_mode = "queue"
+        runner._busy_input_mode_by_platform = {"sendblue": "steer"}
         runner._busy_text_mode = "queue"  # realistic production default
         adapter = _make_adapter(platform_val="telegram")
 
@@ -1047,26 +997,24 @@ class TestPerPlatformBusyInputMode:
         agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_per_platform_interrupt_demoted_with_subagents(self, monkeypatch):
-        """Per-platform interrupt override also gets demoted to queue when
-        subagents are active (#30170 interaction)."""
-        import gateway.run as _gr
-
-        monkeypatch.setattr(
-            _gr,
-            "_load_gateway_config",
-            lambda: {
-                "display": {
-                    "busy_input_mode": "queue",
-                    "platforms": {
-                        "sendblue": {"busy_input_mode": "interrupt"},
-                    },
-                }
-            },
-        )
-
+    async def test_missing_override_map_falls_back_to_global(self):
+        """A runner without the startup map attribute (e.g. constructed by
+        older tests via object.__new__) must still resolve the global mode."""
         runner, _sentinel = _make_runner()
         runner._busy_input_mode = "queue"
+        if hasattr(runner, "_busy_input_mode_by_platform"):
+            del runner._busy_input_mode_by_platform
+
+        event = _make_event(text="hi", platform_val="telegram")
+        assert runner._effective_busy_input_mode(event.source.platform) == "queue"
+
+    @pytest.mark.asyncio
+    async def test_per_platform_interrupt_demoted_with_subagents(self):
+        """Per-platform interrupt override also gets demoted to queue when
+        subagents are active (#30170 interaction)."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        runner._busy_input_mode_by_platform = {"sendblue": "interrupt"}
         adapter = _make_adapter(platform_val="sendblue")
 
         event = _make_event(text="don't kill my subagents", platform_val="sendblue")
@@ -1081,21 +1029,83 @@ class TestPerPlatformBusyInputMode:
         with patch("gateway.run.merge_pending_message_event"):
             await runner._handle_active_session_busy_message(event, sk)
 
-        # Per-platform interrupt demoted to queue — parent.interrupt NOT called
+        # Per-platform interrupt demoted to queue; parent.interrupt NOT called.
         parent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_invalid_per_platform_value_through_handler(self, monkeypatch):
-        """Invalid per-platform busy_input_mode falls through to global,
-        not silently forced to interrupt."""
+    async def test_per_platform_steer_fallback_to_queue_when_agent_pending(self):
+        """Per-platform steer falls back to queue when agent is still starting."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._busy_input_mode_by_platform = {"sendblue": "steer"}
+        adapter = _make_adapter(platform_val="sendblue")
+
+        event = _make_event(text="arrived too early", platform_val="sendblue")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        # Agent is still being set up; sentinel in place.
+        runner._running_agents[sk] = _sentinel
+        runner._queue_or_replace_pending_event = MagicMock()
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        # Steer can't work with the sentinel, so the event is queued for the
+        # next turn (via the FIFO path, #43066) and the ack says so.
+        runner._queue_or_replace_pending_event.assert_called_once_with(sk, event)
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert "Queued for the next turn" in content
+
+
+class TestBusyInputModeByPlatformLoader:
+    """GatewayRunner._load_busy_input_mode_by_platform() builds the startup map."""
+
+    def test_valid_overrides_loaded_invalid_dropped(self, monkeypatch):
+        """Valid per-platform values land in the map; a typo is dropped at load
+        time so runtime resolution falls back to the global mode."""
         import gateway.run as _gr
+        from gateway.run import GatewayRunner
 
         monkeypatch.setattr(
             _gr,
-            "_load_gateway_config",
+            "_load_gateway_runtime_config",
             lambda: {
                 "display": {
-                    "busy_input_mode": "steer",
+                    "busy_input_mode": "interrupt",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "Steer"},  # normalised
+                        "telegram": {"busy_input_mode": "steerr"},  # typo: dropped
+                        "discord": {"busy_ack_detail": False},  # unrelated key
+                        "weird": "not-a-dict",  # tolerated
+                    },
+                }
+            },
+        )
+
+        assert GatewayRunner._load_busy_input_mode_by_platform() == {
+            "sendblue": "steer"
+        }
+
+    def test_no_platforms_section_yields_empty_map(self, monkeypatch):
+        import gateway.run as _gr
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr(_gr, "_load_gateway_runtime_config", lambda: {})
+        assert GatewayRunner._load_busy_input_mode_by_platform() == {}
+
+    @pytest.mark.asyncio
+    async def test_dropped_invalid_value_reaches_global_through_handler(self, monkeypatch):
+        """End to end: a typo'd override is dropped by the loader and the
+        handler then uses the global mode (steer), not interrupt."""
+        import gateway.run as _gr
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_runtime_config",
+            lambda: {
+                "display": {
                     "platforms": {
                         "sendblue": {"busy_input_mode": "steerr"},  # typo
                     },
@@ -1104,7 +1114,10 @@ class TestPerPlatformBusyInputMode:
         )
 
         runner, _sentinel = _make_runner()
-        runner._busy_input_mode = "interrupt"
+        runner._busy_input_mode = "steer"  # global
+        runner._busy_input_mode_by_platform = (
+            GatewayRunner._load_busy_input_mode_by_platform()
+        )
         adapter = _make_adapter(platform_val="sendblue")
 
         event = _make_event(text="should steer not interrupt", platform_val="sendblue")
@@ -1115,47 +1128,9 @@ class TestPerPlatformBusyInputMode:
         agent.steer = MagicMock(return_value=True)
         runner._running_agents[sk] = agent
 
-        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+        with patch("gateway.run.merge_pending_message_event"):
             await runner._handle_active_session_busy_message(event, sk)
 
-        # Typo in platform override → skipped → global "steer" used
+        # Typo in platform override was dropped at load; global "steer" used.
         agent.steer.assert_called_once_with("should steer not interrupt")
         agent.interrupt.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_per_platform_steer_fallback_to_queue_when_agent_pending(self, monkeypatch):
-        """Per-platform steer falls back to queue when agent is still starting."""
-        import gateway.run as _gr
-
-        monkeypatch.setattr(
-            _gr,
-            "_load_gateway_config",
-            lambda: {
-                "display": {
-                    "busy_input_mode": "interrupt",
-                    "platforms": {
-                        "sendblue": {"busy_input_mode": "steer"},
-                    },
-                }
-            },
-        )
-
-        runner, _sentinel = _make_runner()
-        runner._busy_input_mode = "interrupt"
-        adapter = _make_adapter(platform_val="sendblue")
-
-        event = _make_event(text="arrived too early", platform_val="sendblue")
-        sk = build_session_key(event.source)
-        runner.adapters[event.source.platform] = adapter
-
-        # Agent is still being set up — sentinel in place
-        runner._running_agents[sk] = _sentinel
-
-        with patch("gateway.run.merge_pending_message_event") as mock_merge:
-            await runner._handle_active_session_busy_message(event, sk)
-
-        # Steer can't work with sentinel → falls back to queue
-        mock_merge.assert_called_once()
-        call_kwargs = adapter._send_with_retry.call_args
-        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Queued for the next turn" in content

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -960,6 +960,55 @@ class TestPerPlatformBusyInputMode:
             agent.steer.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_priority_path_honors_per_platform_queue_override(self, monkeypatch):
+        """The PRIORITY running-agent path (_handle_message) must honor a
+        display.platforms.<platform>.busy_input_mode override, not only the
+        normal busy handler. Global is interrupt; sendblue overrides to queue,
+        so the priority path must queue (not interrupt) the follow-up."""
+        import gateway.run as _gr
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "display": {
+                    "busy_input_mode": "interrupt",
+                    "platforms": {
+                        "sendblue": {"busy_input_mode": "queue"},
+                    },
+                }
+            },
+        )
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"  # global default
+        adapter = _make_adapter(platform_val="sendblue")
+
+        event = _make_event(text="queue me", platform_val="sendblue")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        running_agent = MagicMock()
+        # A real activity summary so the stale-eviction path (if reached) and
+        # the interrupt/ack path in RED don't trip on MagicMock comparisons.
+        running_agent.get_activity_summary.return_value = {
+            "seconds_since_activity": 1,
+            "last_activity_desc": "running",
+            "api_call_count": 1,
+            "max_iterations": 10,
+        }
+        runner._running_agents[sk] = running_agent
+        runner._queue_or_replace_pending_event = MagicMock()
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        # Per-platform queue override honored on the priority path.
+        runner._queue_or_replace_pending_event.assert_called_once_with(sk, event)
+        running_agent.interrupt.assert_not_called()
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_unconfigured_platform_uses_global(self, monkeypatch):
         """telegram has no platform override — falls back to global busy_input_mode."""
         import gateway.run as _gr

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -607,3 +607,106 @@ class TestReasoningStyle:
 
         config = {"display": {"reasoning_style": "SUBTEXT"}}
         assert resolve_display_setting(config, "telegram", "reasoning_style") == "subtext"
+# ---------------------------------------------------------------------------
+# busy_input_mode: normalise + per-platform resolution
+# ---------------------------------------------------------------------------
+
+class TestBusyInputModeNormalise:
+    """busy_input_mode normalises to valid values."""
+
+    def test_valid_queue(self):
+        from gateway.display_config import _normalise
+        assert _normalise("busy_input_mode", "queue") == "queue"
+
+    def test_valid_steer(self):
+        from gateway.display_config import _normalise
+        assert _normalise("busy_input_mode", "steer") == "steer"
+
+    def test_valid_interrupt(self):
+        from gateway.display_config import _normalise
+        assert _normalise("busy_input_mode", "interrupt") == "interrupt"
+
+    def test_case_insensitive(self):
+        from gateway.display_config import _normalise
+        assert _normalise("busy_input_mode", "Steer") == "steer"
+        assert _normalise("busy_input_mode", "QUEUE") == "queue"
+
+    def test_invalid_value_returns_none(self):
+        """Invalid busy_input_mode values return None so the resolver
+        skips them and falls through to the next resolution level."""
+        from gateway.display_config import _normalise
+        assert _normalise("busy_input_mode", "banana") is None
+        assert _normalise("busy_input_mode", "") is None
+        assert _normalise("busy_input_mode", None) is None
+
+    def test_invalid_per_platform_skips_to_global(self):
+        """A bad per-platform value falls through to the global user setting."""
+        from gateway.display_config import resolve_display_setting
+        config = {
+            "display": {
+                "busy_input_mode": "steer",
+                "platforms": {
+                    "sendblue": {"busy_input_mode": "steerr"},  # typo
+                },
+            }
+        }
+        # Typo in platform override → skipped → falls through to global "steer"
+        assert resolve_display_setting(config, "sendblue", "busy_input_mode", "interrupt") == "steer"
+
+    def test_invalid_global_skips_to_fallback(self):
+        """A bad global value falls through to the fallback parameter."""
+        from gateway.display_config import resolve_display_setting
+        config = {
+            "display": {
+                "busy_input_mode": "banana",
+            }
+        }
+        assert resolve_display_setting(config, "telegram", "busy_input_mode", "queue") == "queue"
+
+    def test_not_in_global_defaults_but_in_overrideable_keys(self):
+        """busy_input_mode is overrideable per platform but not in _GLOBAL_DEFAULTS
+        (its global default is managed by _load_busy_input_mode in the gateway)."""
+        from gateway.display_config import _GLOBAL_DEFAULTS, OVERRIDEABLE_KEYS
+        assert "busy_input_mode" not in _GLOBAL_DEFAULTS
+        assert "busy_input_mode" in OVERRIDEABLE_KEYS
+
+
+class TestBusyInputModeResolution:
+    """busy_input_mode resolves through the per-platform override chain."""
+
+    def test_platform_override_wins(self):
+        from gateway.display_config import resolve_display_setting
+        config = {
+            "display": {
+                "busy_input_mode": "interrupt",
+                "platforms": {
+                    "sendblue": {"busy_input_mode": "steer"},
+                },
+            }
+        }
+        assert resolve_display_setting(config, "sendblue", "busy_input_mode") == "steer"
+        assert resolve_display_setting(config, "telegram", "busy_input_mode") == "interrupt"
+
+    def test_global_fallback_when_no_platform_override(self):
+        from gateway.display_config import resolve_display_setting
+        config = {"display": {"busy_input_mode": "queue"}}
+        assert resolve_display_setting(config, "telegram", "busy_input_mode") == "queue"
+        assert resolve_display_setting(config, "sendblue", "busy_input_mode") == "queue"
+
+    def test_builtin_default_when_no_config(self):
+        """With no _GLOBAL_DEFAULTS entry, resolve returns the fallback parameter."""
+        from gateway.display_config import resolve_display_setting
+        # No config, no platform default, no global default → returns fallback
+        assert resolve_display_setting({}, "telegram", "busy_input_mode", "interrupt") == "interrupt"
+        assert resolve_display_setting({}, "telegram", "busy_input_mode") is None
+
+    def test_platform_override_normalised(self):
+        from gateway.display_config import resolve_display_setting
+        config = {
+            "display": {
+                "platforms": {
+                    "sendblue": {"busy_input_mode": "STEER"},
+                },
+            }
+        }
+        assert resolve_display_setting(config, "sendblue", "busy_input_mode") == "steer"

--- a/tests/gateway/test_subagent_protection_30170.py
+++ b/tests/gateway/test_subagent_protection_30170.py
@@ -210,6 +210,14 @@ class TestBusyHandlerDemotesInterruptForSubagents:
     """The Phase-1 fix from #30170: parent.interrupt() must NOT fire when
     the parent is currently driving subagents."""
 
+    @pytest.fixture(autouse=True)
+    def _no_gateway_config(self, monkeypatch):
+        """Mock _load_gateway_config to return empty dict so tests control
+        busy_input_mode purely via runner._busy_input_mode, not the real
+        display config on disk."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
     @pytest.mark.asyncio
     async def test_does_not_call_interrupt_when_subagents_active(self) -> None:
         runner = _make_runner()

--- a/tests/gateway/test_subagent_protection_30170.py
+++ b/tests/gateway/test_subagent_protection_30170.py
@@ -210,14 +210,6 @@ class TestBusyHandlerDemotesInterruptForSubagents:
     """The Phase-1 fix from #30170: parent.interrupt() must NOT fire when
     the parent is currently driving subagents."""
 
-    @pytest.fixture(autouse=True)
-    def _no_gateway_config(self, monkeypatch):
-        """Mock _load_gateway_config to return empty dict so tests control
-        busy_input_mode purely via runner._busy_input_mode, not the real
-        display config on disk."""
-        import gateway.run as _gr
-        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
-
     @pytest.mark.asyncio
     async def test_does_not_call_interrupt_when_subagents_active(self) -> None:
         runner = _make_runner()


### PR DESCRIPTION
## What does this PR do?

Makes `busy_input_mode` (interrupt/queue/steer) overridable per messaging platform via `display.platforms.<platform>.busy_input_mode` in config.yaml.

This matters because different platforms have fundamentally different interaction patterns. SMS and Telegram are the clearest example: Telegram supports message editing, threading, and real-time back-and-forth — interrupt mode works great there. SMS is fire-and-forget with no edit support — every message is permanent, and a user texting a follow-up mid-task probably just wants it queued, not to blow up the current run. Similarly, a bridge like Sendblue that supports steering mid-run can opt into `steer` while keeping the safer `queue` as the global default for everything else.

The global `display.busy_input_mode` still works as the fallback for unconfigured platforms. Invalid values now warn and fall through to the next resolution level instead of silently coercing to `interrupt`.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/display_config.py`: Added `_normalise` handler for `busy_input_mode` (validates + warns on invalid values), added to `OVERRIDEABLE_KEYS`, updated `resolve_display_setting` to skip `None` from normalisation so invalid values fall through instead of coercing
- `gateway/run.py`: `_handle_active_session_busy_message` now resolves `busy_input_mode` via `resolve_display_setting()` with per-platform override support, cached `_load_gateway_config()` to avoid duplicate calls, added precedence documentation for env-sync dependency
- `tests/gateway/test_display_config.py`: 10 new tests covering normalisation, resolution priority, invalid value fallthrough
- `tests/gateway/test_busy_session_ack.py`: 7 new tests covering per-platform override integration, subagent demotion interaction, invalid value handling through the live handler, realistic `_busy_text_mode`
- `tests/gateway/test_subagent_protection_30170.py`: Added autouse fixture to mock `_load_gateway_config` so tests control mode via `runner._busy_input_mode` (isolation from real config on disk)

## How to Test

1. Run the affected test files:
   ```
   venv/bin/python -m pytest tests/gateway/test_display_config.py tests/gateway/test_busy_session_ack.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_restart_drain.py -q
   ```
2. Verify 103 tests pass
3. Test config override:
   ```yaml
   display:
     busy_input_mode: interrupt
     platforms:
       sendblue:
         busy_input_mode: steer
   ```
4. Verify a typo like `steerr` logs a warning and falls through to the global value (not silently forced to interrupt)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — docstring on `resolve_display_setting` documents the `busy_input_mode` asymmetry
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — uses existing `display.platforms` structure
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — gateway-only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A