### PR TITLE
fix(feishu): extract content from template cards (fixes #33090)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -940,6 +940,34 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
     body_lines = _collect_card_lines(card_payload)
     actions = _collect_action_labels(card_payload)
 
+    # Template cards use {type: "template", data: {template_id, template_variable}}.
+    # The template_variable dict holds the actual text content that should be
+    # presented to the agent.  When a card is sent via template, the raw content
+    # lacks the resolved "elements" array, so _collect_card_lines returns empty.
+    # (ref: https://github.com/NousResearch/hermes-agent/issues/33090)
+    if not body_lines:
+        template_data = card_payload.get("data") if isinstance(card_payload, dict) else None
+        if isinstance(template_data, dict):
+            template_vars = template_data.get("template_variable")
+            if isinstance(template_vars, dict):
+                for _key, val in template_vars.items():
+                    if isinstance(val, str):
+                        normalized = _normalize_feishu_text(val)
+                        if normalized:
+                            body_lines.append(normalized)
+
+    # Fallback: some card payloads carry a top-level summary/description that
+    # is not nested inside elements (e.g. notification previews).
+    if not body_lines and not title:
+        body_lines = [
+            _normalize_feishu_text(v)
+            for v in (
+                card_payload.get("summary", ""),
+                card_payload.get("description", ""),
+            )
+            if isinstance(v, str) and _normalize_feishu_text(v)
+        ]
+
     lines: List[str] = []
     if title:
         lines.append(title)
@@ -949,7 +977,7 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
     if actions:
         lines.append(f"Actions: {', '.join(actions)}")
 
-    text_content = "\n".join(lines[:12]).strip() or FALLBACK_INTERACTIVE_TEXT
+    text_content = "\n".join(lines[:20]).strip() or FALLBACK_INTERACTIVE_TEXT
     return FeishuNormalizedMessage(
         raw_type=message_type,
         text_content=text_content,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -158,6 +158,58 @@ class TestFeishuMessageNormalization(unittest.TestCase):
             "Build Failed\nService: payments-api\nBranch: main\nView Logs\nRetry\nActions: View Logs, Retry",
         )
 
+    def test_normalize_template_card_extracts_template_variables(self):
+        """Template cards should extract template_variable content (#33090)."""
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="interactive",
+            raw_content=json.dumps(
+                {
+                    "type": "template",
+                    "data": {
+                        "template_id": "ctp_Aa9a8a34be56e",
+                        "template_variable": {
+                            "title_text": "Daily Report",
+                            "content_text": "Top pick: 600519 +3.2%",
+                            "detail_text": "Runner up: 000858 +2.1%",
+                        },
+                    },
+                }
+            ),
+        )
+
+        self.assertEqual(normalized.relation_kind, "interactive")
+        self.assertIn("Daily Report", normalized.text_content)
+        self.assertIn("600519", normalized.text_content)
+        self.assertIn("000858", normalized.text_content)
+        self.assertNotEqual(normalized.text_content, "[Interactive message]")
+
+    def test_normalize_template_card_wrapped_in_card_key(self):
+        """Template card wrapped in a 'card' key should also extract content."""
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="interactive",
+            raw_content=json.dumps(
+                {
+                    "card": {
+                        "type": "template",
+                        "data": {
+                            "template_id": "ctp_xxx",
+                            "template_variable": {
+                                "title": "Alert",
+                                "body": "Server CPU at 95%",
+                            },
+                        },
+                    }
+                }
+            ),
+        )
+
+        self.assertIn("Alert", normalized.text_content)
+        self.assertIn("95%", normalized.text_content)
+
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
     @patch.dict(os.environ, {


### PR DESCRIPTION
## Summary

Fixes #33090

### Problem

When a Feishu card message uses a **template** (`{type: "template", data: {template_id, template_variable}}`), the gateway only returns `"[Interactive message]"` instead of the actual card content. This happens because `_normalize_interactive_message` only extracts content from the `elements` array, which is absent in template cards.

### Fix

`_normalize_interactive_message` now falls back to extracting text from `data.template_variable` when the standard `elements`-based extraction returns empty. This covers:
- Direct template cards: `{type: "template", data: {template_variable: {...}}}`
- Wrapped template cards: `{card: {type: "template", data: {...}}}`

Additional improvements:
- Increased line limit from 12→20 for richer card content
- Added `summary`/`description` fallback for notification preview cards that lack both elements and template variables

## Testing

- Added 2 new tests:
  - `test_normalize_template_card_extracts_template_variables` — verifies template_variable extraction
  - `test_normalize_template_card_wrapped_in_card_key` — verifies wrapped template extraction
- All 200 Feishu tests pass (198 existing + 2 new)

## Files Changed

- `gateway/platforms/feishu.py` — `_normalize_interactive_message()` +28 lines
- `tests/gateway/test_feishu.py` — 2 new test cases