### PR TITLE
fix(codex): prefer stable auto-default over gpt-5.5

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3992,13 +3992,13 @@ class HermesCLI:
         if self._model_is_default:
             fallback_model = "gpt-5.3-codex"
             try:
-                from hermes_cli.codex_models import get_codex_model_ids
+                from hermes_cli.codex_models import get_codex_model_ids, pick_default_codex_model
 
                 available = get_codex_model_ids(
                     access_token=self.api_key if self.api_key else None,
                 )
                 if available:
-                    fallback_model = available[0]
+                    fallback_model = pick_default_codex_model(available)
             except Exception:
                 pass
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -43,6 +43,20 @@ DEFAULT_CODEX_MODELS: List[str] = [
     # live discovery will pick them up automatically via _fetch_models_from_api.
 ]
 
+# Auto-selected defaults should be boring and reliable. The /model picker still
+# shows the full discovery order, including gpt-5.5, but when Hermes needs to
+# choose on the user's behalf we prefer the slugs that have worked consistently
+# on ChatGPT Codex OAuth accounts. See #21444 for the gpt-5.5 silent-hang
+# symptom history.
+SAFE_DEFAULT_CODEX_MODELS: tuple[str, ...] = (
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+)
+
+_DEFAULT_AVOID_MODELS = {"gpt-5.5"}
+
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex",)),
@@ -77,6 +91,31 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
             seen.add(synthetic_model)
 
     return ordered
+
+
+def pick_default_codex_model(model_ids: List[str]) -> str:
+    """Choose the safest default model from a discovered Codex lineup.
+
+    This is intentionally different from discovery order. Live discovery sorts
+    by Codex backend priority, but some ChatGPT Codex OAuth accounts accept
+    gpt-5.5 requests and then emit no stream events or errors for minutes. When
+    Hermes is auto-picking a model for an untouched default, prefer the known
+    good slugs first and keep gpt-5.5 opt-in.
+    """
+    ordered = [model.strip() for model in model_ids if isinstance(model, str) and model.strip()]
+    if not ordered:
+        return "gpt-5.3-codex"
+
+    available = set(ordered)
+    for preferred in SAFE_DEFAULT_CODEX_MODELS:
+        if preferred in available:
+            return preferred
+
+    for model in ordered:
+        if model not in _DEFAULT_AVOID_MODELS:
+            return model
+
+    return ordered[0]
 
 
 def _fetch_models_from_api(access_token: str) -> List[str]:

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -1,7 +1,11 @@
 import json
 from unittest.mock import patch
 
-from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
+from hermes_cli.codex_models import (
+    DEFAULT_CODEX_MODELS,
+    get_codex_model_ids,
+    pick_default_codex_model,
+)
 
 
 def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch):
@@ -75,6 +79,18 @@ def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypat
         "gpt-5.4",
         "gpt-5.3-codex-spark",
     ]
+
+
+def test_pick_default_codex_model_prefers_stable_slug_over_gpt_5_5():
+    assert pick_default_codex_model(["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"]) == "gpt-5.4"
+
+
+def test_pick_default_codex_model_falls_back_to_first_non_avoided_slug():
+    assert pick_default_codex_model(["gpt-5.5", "gpt-5.6-preview"]) == "gpt-5.6-preview"
+
+
+def test_pick_default_codex_model_returns_gpt_5_5_when_it_is_the_only_option():
+    assert pick_default_codex_model(["gpt-5.5"]) == "gpt-5.5"
 
 
 def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
@@ -357,12 +373,12 @@ class TestNormalizeModelForProvider:
         assert cli._model_is_default is True
         with patch(
             "hermes_cli.codex_models.get_codex_model_ids",
-            return_value=["gpt-5.3-codex", "gpt-5.4"],
+            return_value=["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
         ):
             changed = cli._normalize_model_for_provider("openai-codex")
         assert changed is True
-        # Uses first from available list
-        assert cli.model == "gpt-5.3-codex"
+        # Uses the safe auto-default, not raw discovery priority.
+        assert cli.model == "gpt-5.4"
 
     def test_default_fallback_when_api_fails(self):
         """No model configured falls back to gpt-5.3-codex when API unreachable."""


### PR DESCRIPTION
## Summary
- add a helper that chooses a safe default Codex model instead of blindly taking discovery priority
- keep gpt-5.5 available in the picker, but make untouched default auto-selection prefer gpt-5.4 / gpt-5.3-codex lineups
- add regression coverage for the gpt-5.5 silent-hang path described in #21444

## Why
Some ChatGPT Codex OAuth accounts intermittently accept `gpt-5.5` and then emit no stream events or non-streaming response for many minutes. Hermes already warns about that backend-side pattern, but untouched defaults could still auto-select `gpt-5.5` because live discovery orders by backend priority. This PR keeps `gpt-5.5` opt-in while making automatic default selection boring and reliable.

## Testing
- pytest -q tests/hermes_cli/test_codex_models.py tests/cli/test_cli_provider_resolution.py