### PR TITLE
fix(cli): prevent SIGABRT on hermes -z process exit

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11033,14 +11033,25 @@ def _try_termux_fast_cli_launch() -> bool:
         _prepare_agent_startup(args)
         from hermes_cli.oneshot import run_oneshot
 
-        sys.exit(
-            run_oneshot(
-                args.oneshot,
-                model=getattr(args, "model", None),
-                provider=getattr(args, "provider", None),
-                toolsets=getattr(args, "toolsets", None),
-            )
+        rc = run_oneshot(
+            args.oneshot,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
         )
+        # Bypass Python interpreter finalizers. Native daemon threads from
+        # transitively-loaded extensions (aiohttp connectors, observability
+        # clients, etc.) can SIGABRT during finalize even after a clean
+        # run, surfacing to callers as exit code -6 / 134. That breaks any
+        # subprocess wrapper around `hermes -z` (MCP servers, cron jobs,
+        # CI). Oneshot has no interactive state to flush — SessionDB writes
+        # are synchronous — so os._exit() is safe and preserves rc.
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:
+            pass
+        os._exit(rc if isinstance(rc, int) else 0)
 
     if (args.resume or args.continue_last) and args.command is None:
         args.command = "chat"
@@ -14055,14 +14066,25 @@ Examples:
     if getattr(args, "oneshot", None):
         from hermes_cli.oneshot import run_oneshot
 
-        sys.exit(
-            run_oneshot(
-                args.oneshot,
-                model=getattr(args, "model", None),
-                provider=getattr(args, "provider", None),
-                toolsets=getattr(args, "toolsets", None),
-            )
+        rc = run_oneshot(
+            args.oneshot,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
         )
+        # Bypass Python interpreter finalizers. Native daemon threads from
+        # transitively-loaded extensions (aiohttp connectors, observability
+        # clients, etc.) can SIGABRT during finalize even after a clean
+        # run, surfacing to callers as exit code -6 / 134. That breaks any
+        # subprocess wrapper around `hermes -z` (MCP servers, cron jobs,
+        # CI). Oneshot has no interactive state to flush — SessionDB writes
+        # are synchronous — so os._exit() is safe and preserves rc.
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:
+            pass
+        os._exit(rc if isinstance(rc, int) else 0)
 
     # Handle top-level --resume / --continue as shortcut to chat
     if (args.resume or args.continue_last) and args.command is None:


### PR DESCRIPTION
## Problem

When `hermes -z "<prompt>"` runs, the agent loop completes cleanly and `run_oneshot()` returns `0`, but during Python interpreter finalization a native daemon thread from a transitively-loaded C extension can abort the process. The parent sees exit code `-6` / `134` and treats the run as failed — even though stdout already contains the correct response.

The native abort surfaces with **empty stderr** because it fires after log handlers have already flushed, making this a silent failure: callers see `worker exited with code -6` with no diagnostic trail.

### Repro

```bash
$ hermes -z "say hi" 2>/dev/null; echo "EXIT=$?"
Hi there.
EXIT=134
```

Same reproduces under `subprocess.run([...])` from Python:

```python
r = subprocess.run(["hermes", "-z", "say hi"], capture_output=True, text=True)
# r.returncode == -6
# r.stdout    == "Hi there.\n"   ← correct
# r.stderr    == ""              ← no diagnostic
```

With `PYTHONFAULTHANDLER=1`:

```
Hi there.
SystemExit: 0           ← oneshot returned cleanly
Fatal Python error: Aborted
Thread 0x...740 (most recent call first):
  <no Python frame>     ← pure native code in atexit/finalizer
Extension modules: yaml._yaml, _cffi_backend, charset_normalizer.*,
zstandard.backend_c, multidict._multidict, yarl._quoting_c, propcache._helpers_c,
aiohttp._http_writer, aiohttp._http_parser, aiohttp._websocket.*,
frozenlist._frozenlist, websockets.speedups (total: 18)
```

## Impact

Every subprocess wrapper around `hermes -z` is broken by this:

- MCP servers that shell out per task (e.g. delegation-handle wrappers)
- Cron jobs invoking the agent via the CLI
- CI pipelines using oneshot for non-interactive runs
- Any orchestration layer that checks `returncode == 0` before consuming stdout

This is particularly painful on local-LLM setups where `hermes -z` is the natural primitive for keeping the live model's context window clean — the workaround is to ignore the exit code, which masks real failures too.

## Fix

In both top-level oneshot dispatch sites in `hermes_cli/main.py` (the Termux fast-path and the main entry point), flush stdout/stderr then call `os._exit(rc)` instead of `sys.exit(rc)`. This bypasses Python finalizers entirely.

Safe for oneshot because:
- There is no interactive state to clean up
- SessionDB SQLite writes are synchronous (WAL is crash-safe regardless)
- The exit code is preserved verbatim

The interactive CLI and TUI paths are **not touched** — they continue to use clean shutdown for SessionDB connection pooling, prompt_toolkit teardown, and signal restoration.

## Test plan

Before:
```
$ hermes -z "say hi" 2>/dev/null; echo EXIT=$?
Hi there.
EXIT=134
```

After:
```
$ hermes -z "say hi" 2>/dev/null; echo EXIT=$?
Hi there.
EXIT=0
```

End-to-end test via a real MCP wrapper that shells out to `hermes -z`:

- Before the fix: every call returned `swiszard error: worker exited with code -6` and the worker output was discarded.
- After the fix: every call returns the worker's response string and propagates rc=0 cleanly.

## Notes

The root cause is a leaky C extension finalizer (likely in `aiohttp` connector cleanup or one of the websockets/multidict native modules), but tracking down which extension is impractical and the fix would still need to land in Hermes — oneshot is the place that can decide "we don't need finalizers here." This patch is the surgical, low-risk fix.
