### PR TITLE
feat: add platform tool profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -584,6 +584,11 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # Optional named groups of toolsets. Assign with platform_tool_profiles,
+    # e.g. platform_tool_profiles: {telegram: fast-chat}. Direct
+    # platform_toolsets entries remain the lower-level override.
+    "tool_profiles": {},
+    "platform_tool_profiles": {},
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).
@@ -3494,7 +3499,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions",
+    "sessions", "tool_profiles", "platform_tool_profiles",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1111,6 +1111,45 @@ def _parse_enabled_flag(value, default: bool = True) -> bool:
     return default
 
 
+def _get_tool_profile_names(config: dict, platform: str) -> Optional[List[str]]:
+    """Return configured toolset names for ``platform``'s named tool profile.
+
+    Config shape::
+
+        tool_profiles:
+          fast-chat: [memory, session_search, clarify]
+          coding: [terminal, file, code_execution, web]
+        platform_tool_profiles:
+          cli: coding
+          telegram: fast-chat
+
+    ``platform_toolsets`` remains the lower-level, explicit override. Profiles
+    are only consulted when no direct per-platform toolset list is configured.
+    """
+    platform_profiles = config.get("platform_tool_profiles") or {}
+    if not isinstance(platform_profiles, dict):
+        return None
+
+    profile_name = platform_profiles.get(platform)
+    if not isinstance(profile_name, str) or not profile_name.strip():
+        return None
+
+    profiles = config.get("tool_profiles") or {}
+    if not isinstance(profiles, dict):
+        return None
+
+    profile_toolsets = profiles.get(profile_name.strip())
+    if not isinstance(profile_toolsets, list):
+        logger.warning(
+            "Tool profile %r assigned to platform %r is missing or not a list; "
+            "falling back to platform defaults",
+            profile_name,
+            platform,
+        )
+        return None
+    return profile_toolsets
+
+
 def _get_platform_tools(
     config: dict,
     platform: str,
@@ -1121,16 +1160,20 @@ def _get_platform_tools(
     from toolsets import resolve_toolset, TOOLSETS
 
     platform_toolsets = config.get("platform_toolsets") or {}
-    toolset_names = platform_toolsets.get(platform)
+    toolset_names = platform_toolsets.get(platform) if isinstance(platform_toolsets, dict) else None
 
     if toolset_names is None or not isinstance(toolset_names, list):
-        plat_info = PLATFORMS.get(platform)
-        if plat_info:
-            default_ts = plat_info["default_toolset"]
+        profile_toolsets = _get_tool_profile_names(config, platform)
+        if profile_toolsets is not None:
+            toolset_names = profile_toolsets
         else:
-            # Plugin platform — derive toolset name from platform key
-            default_ts = f"hermes-{platform}"
-        toolset_names = [default_ts]
+            plat_info = PLATFORMS.get(platform)
+            if plat_info:
+                default_ts = plat_info["default_toolset"]
+            else:
+                # Plugin platform — derive toolset name from platform key
+                default_ts = f"hermes-{platform}"
+            toolset_names = [default_ts]
 
     # YAML may parse bare numeric names (e.g. ``12306:``) as int.
     # Normalise to str so downstream sorted() never mixes types.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -76,6 +76,49 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
 
 
+def test_get_platform_tools_uses_assigned_tool_profile():
+    config = {
+        "tool_profiles": {
+            "fast-chat": ["memory", "session_search", "clarify"],
+        },
+        "platform_tool_profiles": {"telegram": "fast-chat"},
+    }
+
+    enabled = _get_platform_tools(config, "telegram", include_default_mcp_servers=False)
+
+    assert {"memory", "session_search", "clarify"}.issubset(enabled)
+    assert "terminal" not in enabled
+    assert "file" not in enabled
+    assert "web" not in enabled
+
+
+def test_get_platform_tools_platform_toolsets_override_profile():
+    config = {
+        "tool_profiles": {"fast-chat": ["memory", "session_search", "clarify"]},
+        "platform_tool_profiles": {"cli": "fast-chat"},
+        "platform_toolsets": {"cli": ["terminal", "file"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "terminal" in enabled
+    assert "file" in enabled
+    assert "memory" not in enabled
+    assert "session_search" not in enabled
+
+
+def test_get_platform_tools_missing_profile_falls_back_to_default():
+    config = {
+        "tool_profiles": {},
+        "platform_tool_profiles": {"cli": "missing-profile"},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+    default = _get_platform_tools({}, "cli", include_default_mcp_servers=False)
+
+    assert enabled == default
+
+
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 


### PR DESCRIPTION
Summary

Adds optional named tool profiles for platform-specific toolset
selection.

This allows users to define reusable groups of toolsets and assign
them per platform, for example:

   tool_profiles:
     fast-chat:
       - memory
       - session_search
       - clarify
     coding:
       - terminal
       - file
       - code_execution
       - web

   platform_tool_profiles:
     telegram: fast-chat
     cli: coding

platform_toolsets remains the lower-level explicit override and still
takes precedence over assigned profiles.
Test Plan

- uv run ruff check hermes_cli/config.py hermes_cli/tools_config.py
tests/hermes_cli/test_tools_config.py
- git diff --check
- uv run --extra dev pytest tests/hermes_cli/test_tools_config.py

Result: 81 passed