### PR TITLE
feat(tools): add Claude Code cascade delegation tool

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -70,6 +70,7 @@ CONFIGURABLE_TOOLSETS = [
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
+    ("claude_code_delegation", "↗ Claude Code Delegation", "delegate_to_claude_code (requires Claude CLI)"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
@@ -94,7 +95,7 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "claude_code_delegation"}
 
 
 def _xai_credentials_present() -> bool:

--- a/tests/tools/test_claude_code_delegate_tool.py
+++ b/tests/tools/test_claude_code_delegate_tool.py
@@ -1,0 +1,348 @@
+"""Tests for tools/claude_code_delegate_tool.py."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+from tools.claude_code_delegate_tool import (
+    _as_float,
+    _as_int,
+    _command_for,
+    _existing_add_dirs,
+    _parse_stream_json,
+    _redacted_command,
+    _resolve_cwd,
+    _wrap_prompt,
+    check_claude_code_available,
+    delegate_to_claude_code,
+    DELEGATE_TO_CLAUDE_CODE_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# _as_int / _as_float
+# ---------------------------------------------------------------------------
+
+
+class TestAsInt:
+    def test_valid_value(self):
+        assert _as_int(42, 10, 0, 100) == 42
+
+    def test_string_coercion(self):
+        assert _as_int("42", 10, 0, 100) == 42
+
+    def test_below_minimum(self):
+        assert _as_int(-5, 10, 0, 100) == 0
+
+    def test_above_maximum(self):
+        assert _as_int(200, 10, 0, 100) == 100
+
+    def test_invalid_fallback(self):
+        assert _as_int("abc", 10, 0, 100) == 10
+
+    def test_none_fallback(self):
+        assert _as_int(None, 10, 0, 100) == 10
+
+
+class TestAsFloat:
+    def test_valid_value(self):
+        assert _as_float(1.5, 1.0, 0.0, 10.0) == 1.5
+
+    def test_string_coercion(self):
+        assert _as_float("2.5", 1.0, 0.0, 10.0) == 2.5
+
+    def test_below_minimum(self):
+        assert _as_float(-1.0, 1.0, 0.0, 10.0) == 0.0
+
+    def test_above_maximum(self):
+        assert _as_float(20.0, 1.0, 0.0, 10.0) == 10.0
+
+    def test_invalid_fallback(self):
+        assert _as_float("nope", 1.0, 0.0, 10.0) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_cwd
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCwd:
+    def test_empty_string_falls_back_to_home(self):
+        result = _resolve_cwd("")
+        assert result == Path.home()
+
+    def test_none_falls_back_to_home(self):
+        result = _resolve_cwd(None)
+        assert result == Path.home()
+
+    def test_nonexistent_path_falls_back_to_home(self):
+        result = _resolve_cwd("/nonexistent/path/that/should/not/exist")
+        assert result == Path.home()
+
+    def test_valid_directory(self, tmp_path):
+        result = _resolve_cwd(str(tmp_path))
+        assert result == tmp_path.resolve()
+
+
+# ---------------------------------------------------------------------------
+# _parse_stream_json
+# ---------------------------------------------------------------------------
+
+
+class TestParseStreamJson:
+    def test_empty_input(self):
+        result = _parse_stream_json("")
+        assert result["init"] == {}
+        assert result["final"] == {}
+        assert result["tool_calls"] == []
+        assert result["text"] == ""
+        assert result["parse_errors"] == 0
+
+    def test_init_event(self):
+        line = json.dumps({"type": "system", "subtype": "init", "model": "claude-sonnet"})
+        result = _parse_stream_json(line)
+        assert result["init"]["model"] == "claude-sonnet"
+
+    def test_text_extraction(self):
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "Hello world"}],
+            },
+        })
+        result = _parse_stream_json(line)
+        assert result["text"] == "Hello world"
+
+    def test_tool_call_extraction(self):
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": "read_file",
+                    "input": {"path": "/tmp/test.txt"},
+                }],
+            },
+        })
+        result = _parse_stream_json(line)
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["name"] == "read_file"
+
+    def test_result_event(self):
+        line = json.dumps({
+            "type": "result",
+            "result": "Task completed",
+            "session_id": "abc123",
+        })
+        result = _parse_stream_json(line)
+        assert result["final"]["result"] == "Task completed"
+
+    def test_parse_errors_counted(self):
+        lines = "not-json\nalso-not-json\n"
+        result = _parse_stream_json(lines)
+        assert result["parse_errors"] == 2
+        assert len(result["bad_lines"]) == 2
+
+    def test_bad_lines_capped_at_five(self):
+        lines = "\n".join(f"bad-line-{i}" for i in range(10))
+        result = _parse_stream_json(lines)
+        assert result["parse_errors"] == 10
+        assert len(result["bad_lines"]) == 5
+
+
+# ---------------------------------------------------------------------------
+# _redacted_command
+# ---------------------------------------------------------------------------
+
+
+class TestRedactedCommand:
+    def test_prompt_redacted(self):
+        cmd = ["claude", "-p", "secret prompt", "--model", "sonnet"]
+        result = _redacted_command(cmd)
+        assert result[2] == "<prompt>"
+        assert result[4] == "sonnet"
+
+    def test_no_prompt_flag(self):
+        cmd = ["claude", "--model", "sonnet"]
+        result = _redacted_command(cmd)
+        assert result == cmd
+
+    def test_original_not_mutated(self):
+        cmd = ["claude", "-p", "secret"]
+        _redacted_command(cmd)
+        assert cmd[2] == "secret"
+
+
+# ---------------------------------------------------------------------------
+# _wrap_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestWrapPrompt:
+    def test_prompt_included(self):
+        result = _wrap_prompt("do something")
+        assert "do something" in result
+
+    def test_runtime_context_present(self):
+        result = _wrap_prompt("test")
+        assert "Hermes Runtime Context" in result
+        assert "Response Contract" in result
+
+
+# ---------------------------------------------------------------------------
+# _command_for (security-gating)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandFor:
+    def test_skip_permissions_default_off(self):
+        """Without env var, --dangerously-skip-permissions must NOT appear."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_DELEGATE_SKIP_PERMISSIONS", None)
+            cmd = _command_for("test prompt", 1.0, "sonnet")
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_skip_permissions_enabled(self):
+        """With env var set to '1', flag must appear."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_SKIP_PERMISSIONS": "1"}):
+            cmd = _command_for("test prompt", 1.0, "sonnet")
+        assert "--dangerously-skip-permissions" in cmd
+
+    def test_skip_permissions_explicit_off(self):
+        """With env var set to '0', flag must NOT appear."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_SKIP_PERMISSIONS": "0"}):
+            cmd = _command_for("test prompt", 1.0, "sonnet")
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_model_in_command(self):
+        cmd = _command_for("prompt", 2.0, "opus")
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "opus"
+
+    def test_budget_in_command(self):
+        cmd = _command_for("prompt", 5.0, "sonnet")
+        assert "--max-budget-usd" in cmd
+        idx = cmd.index("--max-budget-usd")
+        assert cmd[idx + 1] == "5.0000"
+
+
+# ---------------------------------------------------------------------------
+# _existing_add_dirs
+# ---------------------------------------------------------------------------
+
+
+class TestExistingAddDirs:
+    def test_nonexistent_dirs_excluded(self):
+        """Dirs that don't exist on disk must not appear."""
+        with patch("tools.claude_code_delegate_tool.get_skills_dir",
+                    return_value=Path("/nonexistent/skills/path")):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("HERMES_DELEGATE_ADD_DIRS", None)
+                dirs = _existing_add_dirs()
+        assert "/nonexistent/skills/path" not in dirs
+
+    def test_extra_dirs_from_env(self, tmp_path):
+        """HERMES_DELEGATE_ADD_DIRS should be respected."""
+        extra_dir = tmp_path / "extra"
+        extra_dir.mkdir()
+        with patch("tools.claude_code_delegate_tool.get_skills_dir",
+                    return_value=Path("/nonexistent")):
+            with patch.dict(os.environ, {"HERMES_DELEGATE_ADD_DIRS": str(extra_dir)}):
+                dirs = _existing_add_dirs()
+        assert str(extra_dir.resolve()) in dirs
+
+    def test_hermes_home_not_in_add_dirs(self, tmp_path):
+        """get_hermes_home() must NOT appear — it contains secrets."""
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        with patch("tools.claude_code_delegate_tool.get_skills_dir",
+                    return_value=skills):
+            with patch("tools.claude_code_delegate_tool.get_hermes_home",
+                        return_value=tmp_path):
+                with patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop("HERMES_DELEGATE_ADD_DIRS", None)
+                    dirs = _existing_add_dirs()
+        # Only skills dir should be present, not hermes home root
+        assert str(skills.resolve()) in dirs
+        # hermes home itself should NOT be there (unless it equals skills)
+        resolved_home = str(tmp_path.resolve())
+        resolved_skills = str(skills.resolve())
+        if resolved_home != resolved_skills:
+            assert resolved_home not in dirs
+
+
+# ---------------------------------------------------------------------------
+# check_claude_code_available
+# ---------------------------------------------------------------------------
+
+
+class TestCheckClaudeCodeAvailable:
+    @patch("shutil.which", return_value="/usr/local/bin/claude")
+    def test_available(self, mock_which):
+        assert check_claude_code_available() is True
+
+    @patch("shutil.which", return_value=None)
+    def test_not_available(self, mock_which):
+        assert check_claude_code_available() is False
+
+
+# ---------------------------------------------------------------------------
+# delegate_to_claude_code (integration with mock subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestDelegateToClaudeCode:
+    def test_empty_prompt_returns_error(self):
+        result = json.loads(delegate_to_claude_code({"prompt": ""}))
+        assert "error" in str(result).lower() or result.get("success") is False
+
+    @patch("subprocess.Popen")
+    def test_successful_delegation(self, mock_popen_cls, tmp_path):
+        stream_output = json.dumps({
+            "type": "result",
+            "result": "Task done",
+            "session_id": "test-session",
+            "num_turns": 2,
+            "total_cost_usd": 0.05,
+        })
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (stream_output, "")
+        mock_proc.returncode = 0
+        mock_popen_cls.return_value = mock_proc
+
+        with patch("tools.claude_code_delegate_tool._get_log_root", return_value=tmp_path):
+            result = json.loads(delegate_to_claude_code({
+                "prompt": "test task",
+                "timeout_s": 30,
+            }))
+
+        assert result["success"] is True
+        assert result["status"] == "completed"
+        assert "Task done" in result["result"]
+
+    @patch("subprocess.Popen", side_effect=FileNotFoundError)
+    def test_missing_cli(self, mock_popen_cls, tmp_path):
+        with patch("tools.claude_code_delegate_tool._get_log_root", return_value=tmp_path):
+            result = json.loads(delegate_to_claude_code({"prompt": "test"}))
+
+        assert result["success"] is False
+        assert result["status"] == "missing_claude_cli"
+
+    def test_schema_has_required_fields(self):
+        schema = DELEGATE_TO_CLAUDE_CODE_SCHEMA
+        assert schema["name"] == "delegate_to_claude_code"
+        assert "prompt" in schema["parameters"]["required"]
+        props = schema["parameters"]["properties"]
+        assert "prompt" in props
+        assert "timeout_s" in props
+        assert "max_budget_usd" in props
+        assert "model" in props

--- a/tools/claude_code_delegate_tool.py
+++ b/tools/claude_code_delegate_tool.py
@@ -1,0 +1,429 @@
+"""Claude Code cascade delegation tool for Hermes.
+
+Spawns a Claude Code CLI subprocess (``claude -p``) that inherits the
+operator's OAuth credentials and native tool/MCP/skill surface.  The main
+Hermes agent exposes this meta-tool on its direct Anthropic OAuth path; the
+subprocess does the real tool-heavy work and bills as a first-party Claude
+Code request.
+
+Why this exists
+---------------
+Anthropic's OAuth subscription classifies some request shapes as "third-party
+extra usage" based on wire-format signals (tool name prefixes, system prompt
+size, total tool-schema bulk).  When the extra-usage bucket is empty the
+request fails with HTTP 400.  Claude Code CLI requests are classified as
+first-party regardless of payload shape.  This tool routes around the billing
+classifier by delegating tool-heavy turns to a CLI subprocess.
+
+The tool is intentionally small: Hermes' direct OAuth request only needs
+enough surface to ask Claude Code to do the real work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from hermes_constants import get_hermes_home, get_skills_dir
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 60
+MAX_TIMEOUT_SECONDS = 900
+DEFAULT_BUDGET_USD = 1.0
+MAX_BUDGET_USD = 10.0
+DEFAULT_MODEL = "sonnet"
+MAX_RESULT_CHARS = 6000
+
+
+def _get_log_root() -> Path:
+    return get_hermes_home() / "claude_delegate_logs"
+
+
+DELEGATE_TO_CLAUDE_CODE_SCHEMA = {
+    "name": "delegate_to_claude_code",
+    "description": (
+        "Delegate a tool-heavy request to a Claude Code subprocess with the "
+        "operator's full Claude Code tool surface, MCP servers, skills, and "
+        "OAuth subscription billing. Use this whenever the user asks to browse "
+        "the web, take a screenshot, run shell commands, inspect or write "
+        "files, or do any work that needs external tools. "
+        "DO NOT delegate for: "
+        "(a) self-introspection ('what voices/skills/model do you have'), "
+        "(b) self-configuration ('switch voice', 'enable/disable X'), "
+        "(c) requests that map to a slash command "
+        "(/tts-voice, /skills, /voice, /commands). "
+        "DO NOT delegate for simple chat or casual responses."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "The complete task for Claude Code. Include the user's exact "
+                    "request and any relevant conversation context."
+                ),
+            },
+            "timeout_s": {
+                "type": "integer",
+                "description": (
+                    "Hard wall-clock timeout in seconds. "
+                    f"Default {DEFAULT_TIMEOUT_SECONDS}; maximum {MAX_TIMEOUT_SECONDS}."
+                ),
+                "default": DEFAULT_TIMEOUT_SECONDS,
+                "minimum": 5,
+                "maximum": MAX_TIMEOUT_SECONDS,
+            },
+            "max_budget_usd": {
+                "type": "number",
+                "description": (
+                    "Claude Code --max-budget-usd cap. For subscription OAuth this "
+                    "is an API-equivalent guardrail, not API-key spend. Default 1.0."
+                ),
+                "default": DEFAULT_BUDGET_USD,
+                "minimum": 0.01,
+                "maximum": MAX_BUDGET_USD,
+            },
+            "cwd": {
+                "type": "string",
+                "description": (
+                    "Optional working directory for Claude Code. Defaults to the "
+                    "operator's home directory."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Claude Code model alias or full model id. Default: sonnet."
+                ),
+                "default": DEFAULT_MODEL,
+            },
+        },
+        "required": ["prompt"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _get_claude_bin() -> str:
+    return os.environ.get("HERMES_CLAUDE_CODE_BIN") or "claude"
+
+
+def check_claude_code_available() -> bool:
+    """Return True if the Claude Code CLI is installed and on PATH."""
+    return shutil.which(_get_claude_bin()) is not None
+
+
+def _as_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        coerced = default
+    return max(minimum, min(maximum, coerced))
+
+
+def _as_float(value: Any, default: float, minimum: float, maximum: float) -> float:
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        coerced = default
+    return max(minimum, min(maximum, coerced))
+
+
+def _resolve_cwd(raw_cwd: Any) -> Path:
+    if isinstance(raw_cwd, str) and raw_cwd.strip():
+        candidate = Path(raw_cwd).expanduser()
+    else:
+        candidate = Path.home()
+    try:
+        candidate = candidate.resolve()
+    except OSError:
+        candidate = Path.home()
+    if not candidate.exists() or not candidate.is_dir():
+        return Path.home()
+    return candidate
+
+
+def _existing_add_dirs() -> list[str]:
+    """Return ``--add-dir`` paths that actually exist on this host.
+
+    These give the subprocess visibility into Hermes' skill registry.
+    Paths that don't exist are silently skipped so the tool works on
+    fresh installs without special setup.
+    """
+    candidates = [
+        get_skills_dir(),       # ~/.hermes/skills (canonical)
+        # Do NOT add get_hermes_home() -- it contains config.yaml with
+        # secrets that a model-controlled prompt could exfiltrate.
+    ]
+    # Additional user-configured directories via env var (colon-separated).
+    extra = os.environ.get("HERMES_DELEGATE_ADD_DIRS", "").strip()
+    if extra:
+        for raw in extra.split(":"):
+            raw = raw.strip()
+            if raw:
+                candidates.append(Path(raw).expanduser())
+
+    dirs: list[str] = []
+    seen: set[str] = set()
+    for path in candidates:
+        try:
+            resolved = str(path.resolve())
+        except OSError:
+            continue
+        if path.is_dir() and resolved not in seen:
+            dirs.append(resolved)
+            seen.add(resolved)
+    return dirs
+
+
+def _wrap_prompt(prompt: str) -> str:
+    """Wrap the user's task in runtime context for the Claude Code subprocess."""
+    skills_dir = get_skills_dir()
+    lines = [
+        "You are Claude Code running as Hermes' delegated tool executor.",
+        "Complete the task end-to-end and return a concise result.",
+        "",
+        "# Hermes Runtime Context",
+        f"- Hermes skills directory: {skills_dir}",
+        "- For browser/screenshot requests, use Claude Code's native browser "
+        "or shell-accessible screenshot tooling.",
+        "- Do not ask Hermes to do another tool call. You are the tool-capable "
+        "worker.",
+        "",
+        "# User Task",
+        prompt.strip(),
+        "",
+        "# Response Contract",
+        "Return only the useful result. Include file paths for created notes, "
+        "screenshots, or other artifacts.",
+    ]
+    return "\n".join(lines)
+
+
+def _command_for(
+    prompt: str,
+    max_budget_usd: float,
+    model: str,
+) -> list[str]:
+    claude = _get_claude_bin()
+    skip_permissions = os.environ.get(
+        "HERMES_DELEGATE_SKIP_PERMISSIONS", "0",
+    ).lower() in ("1", "true", "yes", "on")
+
+    cmd = [
+        claude,
+        "-p", prompt,
+        "--output-format", "stream-json",
+        "--include-partial-messages",
+        "--verbose",
+        "--no-session-persistence",
+        "--max-budget-usd", f"{max_budget_usd:.4f}",
+        "--model", model or DEFAULT_MODEL,
+    ]
+    if skip_permissions:
+        cmd.append("--dangerously-skip-permissions")
+    for add_dir in _existing_add_dirs():
+        cmd.extend(["--add-dir", add_dir])
+    return cmd
+
+
+def _parse_stream_json(raw_stdout: str) -> Dict[str, Any]:
+    """Parse Claude Code's stream-json output into a structured result."""
+    final_result: Dict[str, Any] | None = None
+    init_event: Dict[str, Any] | None = None
+    tool_calls: list[Dict[str, Any]] = []
+    text_fragments: list[str] = []
+    parse_errors = 0
+    bad_lines: list[str] = []
+
+    for line in raw_stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError:
+            parse_errors += 1
+            if len(bad_lines) < 5:
+                bad_lines.append(line[:200])
+            continue
+
+        etype = event.get("type")
+        if etype == "system" and event.get("subtype") == "init":
+            init_event = event
+        elif etype == "assistant":
+            message = event.get("message") or {}
+            content = message.get("content") or []
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "tool_use":
+                        tool_calls.append({
+                            "name": block.get("name"),
+                            "input": block.get("input") or {},
+                        })
+                    elif block.get("type") == "text" and block.get("text"):
+                        text_fragments.append(str(block["text"]))
+        elif etype == "result":
+            final_result = event
+
+    return {
+        "init": init_event or {},
+        "final": final_result or {},
+        "tool_calls": tool_calls,
+        "text": "\n".join(t for t in text_fragments if t).strip(),
+        "parse_errors": parse_errors,
+        "bad_lines": bad_lines,
+    }
+
+
+def _redacted_command(cmd: list[str]) -> list[str]:
+    redacted = list(cmd)
+    if "-p" in redacted:
+        idx = redacted.index("-p")
+        if idx + 1 < len(redacted):
+            redacted[idx + 1] = "<prompt>"
+    return redacted
+
+
+def delegate_to_claude_code(args: dict, **kwargs) -> str:
+    """Execute a Claude Code subprocess and return the structured result."""
+    prompt = str(args.get("prompt") or "").strip()
+    if not prompt:
+        return tool_error("prompt is required")
+
+    timeout_s = _as_int(
+        args.get("timeout_s"), DEFAULT_TIMEOUT_SECONDS, 5, MAX_TIMEOUT_SECONDS,
+    )
+    max_budget_usd = _as_float(
+        args.get("max_budget_usd"), DEFAULT_BUDGET_USD, 0.01, MAX_BUDGET_USD,
+    )
+    model = str(args.get("model") or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+    cwd = _resolve_cwd(args.get("cwd"))
+    wrapped_prompt = _wrap_prompt(prompt)
+
+    log_root = _get_log_root()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    log_dir = log_root / f"{stamp}-{uuid.uuid4().hex[:8]}"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "prompt.txt").write_text(wrapped_prompt, encoding="utf-8")
+
+    cmd = _command_for(wrapped_prompt, max_budget_usd, model)
+    (log_dir / "command.json").write_text(
+        json.dumps(_redacted_command(cmd), indent=2), encoding="utf-8",
+    )
+
+    # Inherit the full parent environment so the subprocess can access the
+    # operator's OAuth credentials and tool configuration.
+    env = os.environ.copy()
+    # Ensure node (required by Claude Code) is on PATH even if the gateway
+    # process was started with a minimal environment.
+    node_bin = str(get_hermes_home() / "node" / "bin")
+    env["PATH"] = node_bin + os.pathsep + env.get("PATH", "")
+
+    stdout_path = log_dir / "stdout.jsonl"
+    stderr_path = log_dir / "stderr.log"
+    started = time.monotonic()
+    timed_out = False
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(cwd),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            raw_stdout, raw_stderr = proc.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            proc.kill()
+            raw_stdout, raw_stderr = proc.communicate(timeout=10)
+        exit_code = proc.returncode
+    except FileNotFoundError:
+        result: Dict[str, Any] = {
+            "success": False,
+            "status": "missing_claude_cli",
+            "error": (
+                "Claude Code CLI not found on PATH; "
+                "install @anthropic-ai/claude-code or set HERMES_CLAUDE_CODE_BIN."
+            ),
+            "log_dir": str(log_dir),
+        }
+        (log_dir / "result.json").write_text(
+            json.dumps(result, indent=2), encoding="utf-8",
+        )
+        return json.dumps(result, ensure_ascii=False)
+
+    duration_s = round(time.monotonic() - started, 2)
+    stdout_path.write_text(raw_stdout or "", encoding="utf-8")
+    stderr_path.write_text(raw_stderr or "", encoding="utf-8")
+
+    parsed = _parse_stream_json(raw_stdout or "")
+    final = parsed.get("final") or {}
+    final_text = str(final.get("result") or parsed.get("text") or "").strip()
+    truncated = len(final_text) > MAX_RESULT_CHARS
+    if truncated:
+        final_text = final_text[:MAX_RESULT_CHARS]
+    status = "timeout" if timed_out else "completed"
+    if not timed_out and exit_code != 0:
+        status = "error"
+    if final.get("is_error"):
+        status = "error"
+
+    result = {
+        "success": status == "completed",
+        "status": status,
+        "exit_code": exit_code,
+        "duration_seconds": duration_s,
+        "model_requested": model,
+        "model_used": (parsed.get("init") or {}).get("model"),
+        "session_id": (
+            final.get("session_id")
+            or (parsed.get("init") or {}).get("session_id")
+        ),
+        "num_turns": final.get("num_turns"),
+        "total_cost_usd": final.get("total_cost_usd"),
+        "result": final_text,
+        "truncated": truncated,
+        "tool_calls": (parsed.get("tool_calls") or [])[:20],
+        "log_dir": str(log_dir),
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+        "stderr_tail": (raw_stderr or "")[-2000:],
+        "parse_errors": parsed.get("parse_errors", 0),
+        "bad_lines": parsed.get("bad_lines", []),
+    }
+    (log_dir / "result.json").write_text(
+        json.dumps(result, indent=2), encoding="utf-8",
+    )
+    logger.info(
+        "delegate_to_claude_code: status=%s exit=%s duration=%.1fs model=%s cost=%s",
+        status, exit_code, duration_s, model,
+        final.get("total_cost_usd", "?"),
+    )
+    return json.dumps(result, ensure_ascii=False)
+
+
+registry.register(
+    name="delegate_to_claude_code",
+    toolset="claude_code_delegation",
+    schema=DELEGATE_TO_CLAUDE_CODE_SCHEMA,
+    handler=delegate_to_claude_code,
+    description=DELEGATE_TO_CLAUDE_CODE_SCHEMA["description"],
+    emoji="\u2197",  # ↗
+    check_fn=check_claude_code_available,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -240,6 +240,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "claude_code_delegation": {
+        "description": (
+            "Delegate tool-heavy work to a Claude Code subprocess using "
+            "first-party OAuth/subscription billing and Claude Code's full "
+            "tool/MCP/skill surface."
+        ),
+        "tools": ["delegate_to_claude_code"],
+        "includes": [],
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -360,6 +370,10 @@ TOOLSETS = {
     "hermes-api-server": {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
+            # Claude Code cascade delegation for tool-heavy OAuth turns.
+            # Listed here for API server completeness; gated by
+            # _DEFAULT_OFF_TOOLSETS + check_fn (requires Claude CLI).
+            "delegate_to_claude_code",
             # Web
             "web_search", "web_extract",
             # Terminal + process management


### PR DESCRIPTION
## Summary

Adds `delegate_to_claude_code`, a tool that spawns a Claude Code CLI subprocess (`claude -p`) for tool-heavy turns. This routes around Anthropic's OAuth subscription billing classifier, which classifies some request shapes as "third-party extra usage" and rejects them with HTTP 400 when the extra-usage bucket is empty.

### The problem

Anthropic's OAuth subscription (Claude Pro / Pro Max) gates requests to a separate "extra usage" billing bucket based on wire-format signals:

| Trigger | Threshold |
|---|---|
| Tool names with `mcp_` prefix | Any single tool with that prefix |
| System prompt size | ≥4 KB |
| Total tool-schema JSON bulk | ≥~30 KB |

When the extra-usage bucket is empty, the request fails with HTTP 400 `"You're out of extra usage."` This affects all Hermes installations using OAuth subscription authentication (not API key).

Claude Code CLI requests are classified as first-party regardless of payload shape.

### The solution

A new tool (`delegate_to_claude_code`) that:
- Spawns `claude -p` with stream-json output and a configurable budget cap
- Passes Hermes' skill directory via `--add-dir` for subprocess context
- Logs prompts, commands, stdout, and stderr per invocation for debuggability
- Includes `check_fn` that probes for Claude CLI installation (tool won't appear if CLI is missing)
- **Default off** via `_DEFAULT_OFF_TOOLSETS`; operators opt in via `hermes tools`
- `--dangerously-skip-permissions` gated by `HERMES_DELEGATE_SKIP_PERMISSIONS` env var (default: off)
- Extra `--add-dir` paths configurable via `HERMES_DELEGATE_ADD_DIRS` env var (colon-separated)

### Changes

- **New:** `tools/claude_code_delegate_tool.py` — the tool implementation
- **New:** `tests/tools/test_claude_code_delegate_tool.py` — unit tests covering helpers, security gating, and mock-subprocess integration
- **Modified:** `toolsets.py` — adds `claude_code_delegation` toolset + registers in `hermes-api-server` composite
- **Modified:** `hermes_cli/tools_config.py` — adds `CONFIGURABLE_TOOLSETS` entry + `_DEFAULT_OFF_TOOLSETS`

### Security considerations

- The subprocess prompt is model-controlled. `--add-dir` only includes the skills directory (not `~/.hermes` root, which contains `config.yaml` with credentials).
- `--dangerously-skip-permissions` is off by default; requires explicit opt-in via env var.
- Full parent environment is inherited (necessary for OAuth credential access).
- Subprocess is isolated: no session persistence, budget-capped, wall-clock timeout.

## Test plan

- [ ] `pytest tests/tools/test_claude_code_delegate_tool.py` passes
- [ ] Tool does not appear in model tool list when Claude CLI is not installed
- [ ] Tool appears when enabled via `hermes tools` and Claude CLI is available
- [ ] Delegation succeeds with a simple prompt (`"What is 2+2?"`)
- [ ] Timeout kills subprocess correctly
- [ ] `HERMES_DELEGATE_SKIP_PERMISSIONS=0` (default) does not include the flag
- [ ] `HERMES_DELEGATE_SKIP_PERMISSIONS=1` includes the flag