### PR TITLE
fix(skills): sync_skills no longer shadows external_dirs (closes #28126)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -521,3 +521,142 @@ def build_preloaded_skills_prompt(
         loaded_names.append(skill_name)
 
     return "\n\n".join(prompt_parts), loaded_names, missing
+
+
+def diagnose_missing_skill(identifier: str) -> Dict[str, Any]:
+    """Explain why ``identifier`` did not resolve to a loadable skill.
+
+    Returns a dict with:
+      - ``identifier``: the raw input
+      - ``searched_dirs``: list of directories scanned (local + external_dirs)
+      - ``matches_on_disk``: list of SKILL.md absolute paths whose parent
+        directory name OR frontmatter ``name:`` matches the requested
+        identifier
+      - ``rejection_reason``: human-readable text — usually "not found" or
+        a collision summary
+      - ``hint``: actionable next step
+
+    Used by callers that hit ``Unknown skill(s): X`` to produce a useful
+    error rather than the previous bare message that hid the root cause
+    behind every kanban worker crash (#28126).
+    """
+    info: Dict[str, Any] = {
+        "identifier": identifier,
+        "searched_dirs": [],
+        "matches_on_disk": [],
+        "rejection_reason": "not found",
+        "hint": "",
+    }
+    try:
+        from agent.skill_utils import (
+            get_external_skills_dirs,
+            get_skills_dir,
+            is_excluded_skill_path,
+            iter_skill_index_files,
+        )
+    except Exception:
+        return info
+
+    dirs = []
+    try:
+        local = get_skills_dir()
+        if local.exists():
+            dirs.append(local)
+    except Exception:
+        pass
+    try:
+        dirs.extend(get_external_skills_dirs())
+    except Exception:
+        pass
+    info["searched_dirs"] = [str(d) for d in dirs]
+
+    bare = identifier.rsplit("/", 1)[-1].strip()
+    matches = []
+    for d in dirs:
+        try:
+            for skill_md in iter_skill_index_files(d, "SKILL.md"):
+                if is_excluded_skill_path(skill_md):
+                    continue
+                parent = skill_md.parent
+                # Frontmatter name match
+                try:
+                    fm_content = skill_md.read_text(encoding="utf-8", errors="replace")[:4000]
+                except OSError:
+                    fm_content = ""
+                fm_name = parent.name
+                in_fm = False
+                for line in fm_content.split("\n"):
+                    s = line.strip()
+                    if s == "---":
+                        if in_fm:
+                            break
+                        in_fm = True
+                        continue
+                    if in_fm and s.startswith("name:"):
+                        val = s.split(":", 1)[1].strip().strip("\"'")
+                        if val:
+                            fm_name = val
+                        break
+                if parent.name == bare or fm_name == bare or fm_name == identifier:
+                    matches.append(str(skill_md))
+        except OSError:
+            continue
+
+    info["matches_on_disk"] = matches
+    if not matches:
+        info["rejection_reason"] = (
+            f"No SKILL.md found whose directory or frontmatter name matches "
+            f"'{identifier}' under any of: {', '.join(info['searched_dirs']) or '(no dirs configured)'}."
+        )
+        info["hint"] = (
+            "Run `hermes skills list` to see resolvable skills, "
+            "or check `skills.external_dirs` in config.yaml."
+        )
+    elif len(matches) == 1:
+        info["rejection_reason"] = (
+            f"Skill found at {matches[0]} but the loader returned no payload "
+            f"(read error, malformed frontmatter, or platform-gated)."
+        )
+        info["hint"] = (
+            "Try `hermes --skills <full/categorized/path>` to bypass bare-name "
+            "resolution, or check the agent log for the underlying skill_view error."
+        )
+    else:
+        info["rejection_reason"] = (
+            f"Skill name collision — {len(matches)} candidates: {'; '.join(matches)}. "
+            f"The loader refuses ambiguous bare-name loads."
+        )
+        info["hint"] = (
+            "Pass the full relative path (e.g. 'category/skill-name') to "
+            "disambiguate, or remove one of the colliding copies. If one of "
+            "these is a shadow of an external_dirs entry, re-run "
+            "`hermes update` — sync_skills now skips writing shadows (#28126)."
+        )
+    return info
+
+
+def format_missing_skills_error(missing: list[str]) -> str:
+    """Produce a multi-line error for ``Unknown skill(s)`` listing each
+    identifier with the on-disk paths the loader saw and why each was rejected.
+
+    Workers spawned by the kanban dispatcher previously crashed with a bare
+    ``Error: Unknown skill(s): X`` that hid the underlying skill_view
+    collision / shadow / platform-gated reason behind a generic exit 1.
+    """
+    lines = [f"Unknown skill(s): {', '.join(missing)}"]
+    for ident in missing:
+        try:
+            d = diagnose_missing_skill(ident)
+        except Exception as e:
+            lines.append(f"  - {ident}: diagnostic failed: {e}")
+            continue
+        lines.append(f"  - {ident}:")
+        lines.append(f"      searched: {', '.join(d['searched_dirs']) or '(none)'}")
+        if d["matches_on_disk"]:
+            lines.append(f"      on-disk candidates:")
+            for m in d["matches_on_disk"]:
+                lines.append(f"        • {m}")
+        lines.append(f"      reason: {d['rejection_reason']}")
+        if d["hint"]:
+            lines.append(f"      hint:   {d['hint']}")
+    return "\n".join(lines)

--- a/cli.py
+++ b/cli.py
@@ -14905,8 +14905,12 @@ def main(
             task_id=cli.session_id,
         )
         if missing_skills:
-            missing_display = ", ".join(missing_skills)
-            raise ValueError(f"Unknown skill(s): {missing_display}")
+            try:
+                from agent.skill_commands import format_missing_skills_error
+                detail = format_missing_skills_error(missing_skills)
+            except Exception:
+                detail = f"Unknown skill(s): {', '.join(missing_skills)}"
+            raise ValueError(detail)
         if skills_prompt:
             cli.system_prompt = "\n\n".join(
                 part for part in (cli.system_prompt, skills_prompt) if part

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -602,6 +602,7 @@ class TestSyncSkills:
             "copied": [], "updated": [], "skipped": 0,
             "user_modified": [], "cleaned": [], "total_bundled": 0,
             "optional_provenance_backfilled": [],
+            "shadowed_by_external": [],
         }
 
     def test_failed_copy_does_not_poison_manifest(self, tmp_path):

--- a/tests/tools/test_skills_sync_external_dirs.py
+++ b/tests/tools/test_skills_sync_external_dirs.py
@@ -1,0 +1,403 @@
+"""Regression tests for #28126 — sync_skills shadowing external_dirs.
+
+These tests pin the behaviour described in the issue:
+
+    When a non-default profile's config.yaml has
+    ``skills.external_dirs: ["~/.hermes/skills"]`` (delegating to the
+    default profile), sync_skills used to copy every bundled skill into
+    ``<profile_home>/skills/`` anyway.  The skill loader then saw two
+    same-name candidates (one local, one external) and refused to resolve
+    on collision, crashing every worker that auto-loaded the skill with
+    a bare ``Error: Unknown skill(s): X``.
+
+The fix:
+
+  1. ``sync_skills()`` consults ``skills.external_dirs`` from the active
+     profile's config.yaml.  For any bundled skill already provided by an
+     external dir, sync skips the local write and records the entry in
+     ``shadowed_by_external``.
+  2. A stale shadow (byte-identical to bundled, manifest origin matches)
+     left by an earlier buggy sync is best-effort cleaned up.
+  3. ``format_missing_skills_error`` produces a multi-line diagnostic
+     that lists on-disk candidates and the rejection reason so worker
+     crashes surface the underlying cause instead of a bare exit 1.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent import skill_utils
+from agent.skill_commands import (
+    diagnose_missing_skill,
+    format_missing_skills_error,
+)
+from tools.skills_sync import (
+    _dir_hash,
+    sync_skills,
+    _external_skill_index,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def two_profile_layout(tmp_path, monkeypatch):
+    """Build the exact layout #28126 describes.
+
+    Layout::
+
+        tmp/
+        ├── default_home/.hermes/skills/devops/clair-qa-two-stage/SKILL.md
+        ├── profile_home/.hermes/
+        │   ├── config.yaml      # external_dirs: [default_home/.hermes/skills]
+        │   └── skills/          # <-- where sync_skills writes (the bug)
+        └── bundled_repo/skills/devops/clair-qa-two-stage/SKILL.md
+                                 └── flat-bundle/SKILL.md   (NOT in default)
+    """
+    default_home = tmp_path / "default_home" / ".hermes"
+    profile_home = tmp_path / "profile_home" / ".hermes"
+    bundled = tmp_path / "bundled_repo" / "skills"
+    default_skills = default_home / "skills"
+
+    # ── Default-home skills tree (the canonical external source) ──
+    canonical = default_skills / "devops" / "clair-qa-two-stage"
+    canonical.mkdir(parents=True)
+    (canonical / "SKILL.md").write_text(
+        "---\nname: clair-qa-two-stage\ndescription: CLAIR review skill\n---\n\n"
+        "Body of the canonical skill.\n",
+        encoding="utf-8",
+    )
+
+    # ── Bundled repo (what sync_skills wants to copy) ──
+    bundled_clair = bundled / "devops" / "clair-qa-two-stage"
+    bundled_clair.mkdir(parents=True)
+    (bundled_clair / "SKILL.md").write_text(
+        "---\nname: clair-qa-two-stage\ndescription: Bundled CLAIR stub\n---\n\n"
+        "Stub body.\n",
+        encoding="utf-8",
+    )
+    # A bundled skill that is NOT in the external — should still be copied.
+    bundled_flat = bundled / "flat-bundle"
+    bundled_flat.mkdir(parents=True)
+    (bundled_flat / "SKILL.md").write_text(
+        "---\nname: flat-bundle\ndescription: Not in external\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    # ── Profile home delegates to default_home via external_dirs ──
+    profile_home.mkdir(parents=True)
+    config = profile_home / "config.yaml"
+    config.write_text(
+        "skills:\n"
+        f"  external_dirs:\n"
+        f"    - {default_skills}\n",
+        encoding="utf-8",
+    )
+    profile_skills = profile_home / "skills"
+    # Note: do NOT pre-create the skills dir — sync_skills creates it.
+
+    # Point hermes_home and home() at the profile.
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "profile_home")
+    skill_utils._external_dirs_cache_clear()
+
+    yield {
+        "default_home": default_home,
+        "default_skills": default_skills,
+        "profile_home": profile_home,
+        "profile_skills": profile_skills,
+        "bundled": bundled,
+        "canonical_skill_dir": canonical,
+        "bundled_clair_dir": bundled_clair,
+        "bundled_flat_dir": bundled_flat,
+    }
+
+    skill_utils._external_dirs_cache_clear()
+
+
+def _patch_sync(bundled, skills_dir, manifest_file):
+    stack = ExitStack()
+    stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+    stack.enter_context(
+        patch(
+            "tools.skills_sync._get_optional_dir",
+            return_value=bundled.parent / "optional-skills",
+        )
+    )
+    stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+    stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+    return stack
+
+
+# ── External skill index ──────────────────────────────────────────────────
+
+
+class TestExternalSkillIndex:
+    def test_indexes_external_dir_skills_by_frontmatter_name(self, two_profile_layout):
+        idx = _external_skill_index()
+        assert "clair-qa-two-stage" in idx
+        assert idx["clair-qa-two-stage"] == two_profile_layout["canonical_skill_dir"]
+
+    def test_empty_when_no_external_dirs_configured(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        # No skills section at all
+        (home / "config.yaml").write_text("agent: {}\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        skill_utils._external_dirs_cache_clear()
+        try:
+            assert _external_skill_index() == {}
+        finally:
+            skill_utils._external_dirs_cache_clear()
+
+
+# ── The core regression ──────────────────────────────────────────────────
+
+
+class TestSyncRespectsExternalDirs:
+    def test_skips_writing_when_skill_is_provided_by_external_dir(self, two_profile_layout):
+        """Core fix: clair-qa-two-stage exists in external_dirs, so
+        sync_skills must NOT write it into profile_skills/ — that would
+        create the same-name collision that crashes worker agents (#28126).
+        """
+        skills_dir = two_profile_layout["profile_skills"]
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with _patch_sync(two_profile_layout["bundled"], skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        # The bundled clair skill must NOT have been written.
+        assert not (skills_dir / "devops" / "clair-qa-two-stage" / "SKILL.md").exists(), (
+            "sync_skills shadowed the external_dir skill — this is the #28126 bug."
+        )
+        # Sync should report what was shadowed.
+        shadowed_names = {entry["name"] for entry in result["shadowed_by_external"]}
+        assert "clair-qa-two-stage" in shadowed_names
+        # But the bundle-only skill IS still copied.
+        assert (skills_dir / "flat-bundle" / "SKILL.md").exists()
+        assert "flat-bundle" in result["copied"]
+        # And clair is not in copied/updated.
+        assert "clair-qa-two-stage" not in result["copied"]
+        assert "clair-qa-two-stage" not in result.get("updated", [])
+
+    def test_no_collision_so_loader_resolves_external_unambiguously(self, two_profile_layout):
+        """After sync, the loader must see exactly one candidate for
+        clair-qa-two-stage (the external one) — not the two-candidate
+        collision that produced 'Unknown skill(s)' crashes.
+        """
+        skills_dir = two_profile_layout["profile_skills"]
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with _patch_sync(two_profile_layout["bundled"], skills_dir, manifest_file):
+            sync_skills(quiet=True)
+
+        # Simulate the loader's collision detection: collect all SKILL.md
+        # files matching by directory-name across local + external dirs.
+        candidates = []
+        for root in (skills_dir, two_profile_layout["default_skills"]):
+            if not root.exists():
+                continue
+            for smd in root.rglob("SKILL.md"):
+                if smd.parent.name == "clair-qa-two-stage":
+                    candidates.append(smd.resolve())
+
+        # Exactly one — the external one.
+        assert len(candidates) == 1, f"Expected 1 candidate, got {candidates}"
+        assert candidates[0] == (
+            two_profile_layout["canonical_skill_dir"] / "SKILL.md"
+        ).resolve()
+
+    def test_cleans_up_stale_shadow_left_by_prior_buggy_sync(self, two_profile_layout):
+        """If a previous (buggy) sync wrote the shadow already AND the
+        user hasn't touched it AND the bundled hash still matches, the
+        fixed sync_skills should clean the shadow up rather than leave
+        the collision in place.
+        """
+        skills_dir = two_profile_layout["profile_skills"]
+        manifest_file = skills_dir / ".bundled_manifest"
+        bundled_clair = two_profile_layout["bundled_clair_dir"]
+
+        # Simulate the bug: prior sync left a byte-identical copy of the
+        # bundled clair in profile_skills/, recorded in the manifest.
+        shadow = skills_dir / "devops" / "clair-qa-two-stage"
+        shadow.mkdir(parents=True)
+        (shadow / "SKILL.md").write_text(
+            (bundled_clair / "SKILL.md").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        bundled_hash = _dir_hash(bundled_clair)
+        manifest_file.write_text(f"clair-qa-two-stage:{bundled_hash}\n", encoding="utf-8")
+
+        with _patch_sync(two_profile_layout["bundled"], skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert not shadow.exists(), "Stale shadow should have been cleaned up."
+        assert any(
+            e["name"] == "clair-qa-two-stage" for e in result["shadowed_by_external"]
+        )
+
+    def test_user_modified_shadow_is_preserved(self, two_profile_layout):
+        """If the on-disk shadow has been customised by the user, do NOT
+        delete it — surface it via shadowed_by_external so the user can
+        decide.  Only byte-identical, unmodified shadows are removed.
+        """
+        skills_dir = two_profile_layout["profile_skills"]
+        manifest_file = skills_dir / ".bundled_manifest"
+        bundled_clair = two_profile_layout["bundled_clair_dir"]
+
+        shadow = skills_dir / "devops" / "clair-qa-two-stage"
+        shadow.mkdir(parents=True)
+        # User customised it
+        (shadow / "SKILL.md").write_text("# user-edited content", encoding="utf-8")
+        bundled_hash = _dir_hash(bundled_clair)
+        manifest_file.write_text(f"clair-qa-two-stage:{bundled_hash}\n", encoding="utf-8")
+
+        with _patch_sync(two_profile_layout["bundled"], skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert shadow.exists(), "User-customised shadow must NOT be deleted."
+        assert any(
+            e["name"] == "clair-qa-two-stage" for e in result["shadowed_by_external"]
+        )
+
+    def test_default_profile_without_external_dirs_unaffected(self, tmp_path, monkeypatch):
+        """The existing fresh-install behaviour is preserved when no
+        external_dirs are configured.
+        """
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        # No config.yaml → no external_dirs.
+        skills_dir = home / "skills"
+        bundled = tmp_path / "bundled" / "skills"
+        bundled_skill = bundled / "devops" / "clair-qa-two-stage"
+        bundled_skill.mkdir(parents=True)
+        (bundled_skill / "SKILL.md").write_text(
+            "---\nname: clair-qa-two-stage\n---\n\nBody\n", encoding="utf-8"
+        )
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        skill_utils._external_dirs_cache_clear()
+
+        try:
+            with _patch_sync(bundled, skills_dir, manifest_file):
+                result = sync_skills(quiet=True)
+        finally:
+            skill_utils._external_dirs_cache_clear()
+
+        assert "clair-qa-two-stage" in result["copied"]
+        assert (skills_dir / "devops" / "clair-qa-two-stage" / "SKILL.md").exists()
+        assert result["shadowed_by_external"] == []
+
+
+# ── Diagnostic improvements ──────────────────────────────────────────────
+
+
+class TestMissingSkillDiagnostic:
+    def test_diagnose_finds_the_external_candidate(self, two_profile_layout):
+        info = diagnose_missing_skill("clair-qa-two-stage")
+        assert info["identifier"] == "clair-qa-two-stage"
+        assert any("clair-qa-two-stage" in m for m in info["matches_on_disk"])
+        # Either single-match-but-loader-failed or no-match — both informative.
+        assert info["rejection_reason"]
+
+    def test_diagnose_reports_collision_when_two_candidates_exist(self, two_profile_layout):
+        # Force the bug state: place a shadow alongside the canonical.
+        shadow = two_profile_layout["profile_skills"] / "devops" / "clair-qa-two-stage"
+        shadow.mkdir(parents=True)
+        (shadow / "SKILL.md").write_text(
+            "---\nname: clair-qa-two-stage\n---\nshadow\n", encoding="utf-8"
+        )
+
+        info = diagnose_missing_skill("clair-qa-two-stage")
+        assert len(info["matches_on_disk"]) >= 2
+        assert "collision" in info["rejection_reason"].lower()
+        assert "external_dirs" in info["hint"].lower() or "shadow" in info["hint"].lower()
+
+    def test_format_missing_skills_error_preserves_first_line(self, two_profile_layout):
+        """The first line keeps the existing 'Unknown skill(s): X' format
+        so existing tooling that regex-matches against it still works.
+        """
+        rendered = format_missing_skills_error(["clair-qa-two-stage", "totally-fake-skill"])
+        first_line = rendered.splitlines()[0]
+        assert first_line == "Unknown skill(s): clair-qa-two-stage, totally-fake-skill"
+        # And the body explains each one.
+        assert "clair-qa-two-stage" in rendered
+        assert "totally-fake-skill" in rendered
+        assert "searched" in rendered
+        assert "reason" in rendered
+
+    def test_format_missing_skills_error_for_missing_only(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "skills").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        skill_utils._external_dirs_cache_clear()
+        try:
+            rendered = format_missing_skills_error(["nonexistent"])
+        finally:
+            skill_utils._external_dirs_cache_clear()
+        assert rendered.startswith("Unknown skill(s): nonexistent")
+        assert "not found" in rendered.lower() or "no skill.md" in rendered.lower()
+
+
+# ── Worker-spawn integration check ────────────────────────────────────────
+
+
+class TestWorkerSpawnSucceedsAfterSync:
+    def test_skill_view_resolves_uniquely_after_sync(self, two_profile_layout):
+        """End-to-end style: run sync_skills against the delegating
+        profile, then ask skills_tool to look up the skill the same way
+        a kanban worker would.  Must succeed with a single match, NOT
+        return the ambiguous-collision error.
+        """
+        skills_dir = two_profile_layout["profile_skills"]
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with _patch_sync(two_profile_layout["bundled"], skills_dir, manifest_file):
+            sync_skills(quiet=True)
+
+        # Mimic skills_tool's collision-detection candidate gathering.
+        from agent.skill_utils import (
+            get_external_skills_dirs,
+            iter_skill_index_files,
+            is_excluded_skill_path,
+        )
+
+        all_dirs = []
+        if skills_dir.exists():
+            all_dirs.append(skills_dir)
+        all_dirs.extend(get_external_skills_dirs())
+
+        seen = set()
+        candidates = []
+        name = "clair-qa-two-stage"
+        for d in all_dirs:
+            direct = d / name
+            if direct.is_dir() and (direct / "SKILL.md").exists():
+                key = (direct / "SKILL.md").resolve()
+                if key not in seen:
+                    seen.add(key)
+                    candidates.append(key)
+            for found in iter_skill_index_files(d, "SKILL.md"):
+                if is_excluded_skill_path(found):
+                    continue
+                if found.parent.name == name:
+                    key = found.resolve()
+                    if key not in seen:
+                        seen.add(key)
+                        candidates.append(key)
+
+        assert len(candidates) == 1, (
+            f"Worker spawn would crash with 'Unknown skill(s)' due to "
+            f"{len(candidates)} candidates: {candidates}"
+        )

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -416,13 +416,79 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     return backfilled
 
 
+def _external_skill_index() -> Dict[str, Path]:
+    """Index skills resolvable via ``skills.external_dirs`` by name.
+
+    Returns ``{skill_name: source_skill_dir}`` for every SKILL.md found under
+    a configured external dir.  Both the on-disk directory name and the
+    frontmatter ``name:`` field are keyed (first hit wins per name, in
+    external_dirs config order — matching the loader's resolution order).
+
+    Used by ``sync_skills`` to detect when a bundled skill would be written
+    into a profile that already delegates that name to an external dir.
+    Writing it would create a same-name collision the loader refuses to
+    resolve, crashing any agent that auto-loads the skill (see #28126).
+    """
+    index: Dict[str, Path] = {}
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+        external_dirs = get_external_skills_dirs()
+    except Exception:
+        logger.debug("Could not enumerate external skills dirs", exc_info=True)
+        return index
+
+    for ext_dir in external_dirs:
+        try:
+            for skill_md in sorted(ext_dir.rglob("SKILL.md")):
+                if is_excluded_skill_path(skill_md):
+                    continue
+                skill_dir = skill_md.parent
+                frontmatter_name = _read_skill_name(skill_md, skill_dir.name)
+                index.setdefault(frontmatter_name, skill_dir)
+                index.setdefault(skill_dir.name, skill_dir)
+        except OSError as e:
+            logger.debug("Could not walk external skills dir %s: %s", ext_dir, e)
+            continue
+    return index
+
+
+def _would_shadow_external(dest: Path, external_src: Path) -> bool:
+    """True iff writing to ``dest`` would create a same-name skill alongside
+    one already provided by ``external_src`` (i.e. they resolve to distinct
+    filesystem entries)."""
+    try:
+        ext_resolved = external_src.resolve()
+    except OSError:
+        ext_resolved = external_src
+    try:
+        # dest may not exist yet — resolve its parent and join the leaf.
+        if dest.exists():
+            dest_resolved = dest.resolve()
+        else:
+            try:
+                dest_resolved = dest.parent.resolve() / dest.name
+            except OSError:
+                dest_resolved = dest
+    except OSError:
+        dest_resolved = dest
+    return ext_resolved != dest_resolved
+
+
 def sync_skills(quiet: bool = False) -> dict:
     """
     Sync bundled skills into ~/.hermes/skills/ using the manifest.
 
+    Honours ``skills.external_dirs`` from the active profile's ``config.yaml``:
+    bundled skills that are already provided by an external dir are NOT
+    written into the local tree, since doing so would create a same-name
+    collision that the skill loader refuses to resolve (#28126).  In a profile
+    that delegates skills to another home via ``external_dirs: ["~/.hermes/skills"]``
+    this used to silently brick every worker that auto-loaded a bundled skill.
+
     Returns:
         dict with keys: copied (list), updated (list), skipped (int),
-                        user_modified (list), cleaned (list), total_bundled (int)
+                        user_modified (list), cleaned (list), total_bundled (int),
+                        shadowed_by_external (list of {name, external_source})
     """
     bundled_dir = _get_bundled_dir()
     if not bundled_dir.exists():
@@ -430,21 +496,71 @@ def sync_skills(quiet: bool = False) -> dict:
             "copied": [], "updated": [], "skipped": 0,
             "user_modified": [], "cleaned": [], "total_bundled": 0,
             "optional_provenance_backfilled": [],
+            "shadowed_by_external": [],
         }
 
     SKILLS_DIR.mkdir(parents=True, exist_ok=True)
     manifest = _read_manifest()
     bundled_skills = _discover_bundled_skills(bundled_dir)
     bundled_names = {name for name, _ in bundled_skills}
+    external_index = _external_skill_index()
 
     copied = []
     updated = []
     user_modified = []
     skipped = 0
+    shadowed_by_external: List[Dict[str, str]] = []
 
     for skill_name, skill_src in bundled_skills:
         dest = _compute_relative_dest(skill_src, bundled_dir)
         bundled_hash = _dir_hash(skill_src)
+
+        # ── External-dir delegation guard (#28126) ──
+        # If the active profile's config.yaml delegates this skill to an
+        # external dir (e.g. the default profile's ~/.hermes/skills), do
+        # NOT write our own copy — that creates a same-name collision the
+        # loader refuses, crashing every worker that auto-loads the skill.
+        external_src = external_index.get(skill_name)
+        if external_src is not None and _would_shadow_external(dest, external_src):
+            shadowed_by_external.append({
+                "name": skill_name,
+                "external_source": str(external_src),
+            })
+            # Best-effort cleanup of a stale shadow left behind by a prior
+            # buggy sync.  Only delete if the on-disk copy is byte-identical
+            # to the bundled source AND its origin_hash in the manifest also
+            # matches bundled — i.e. we wrote it last time, the user hasn't
+            # touched it, and removing it just reverts a bug.
+            if dest.exists():
+                origin_hash = manifest.get(skill_name, "")
+                try:
+                    user_hash = _dir_hash(dest)
+                except OSError:
+                    user_hash = ""
+                if origin_hash and user_hash == origin_hash == bundled_hash:
+                    try:
+                        shutil.rmtree(dest)
+                        if not quiet:
+                            print(
+                                f"  ⤺ {skill_name} (removed shadow of external "
+                                f"{external_src})"
+                            )
+                    except OSError as e:
+                        logger.debug("Could not remove shadow %s: %s", dest, e)
+            # Pin manifest to the external's hash so future syncs treat the
+            # external as the canonical baseline.  Empty hash would re-trigger
+            # the "new skill" branch.
+            try:
+                manifest[skill_name] = _dir_hash(external_src)
+            except OSError:
+                manifest[skill_name] = bundled_hash
+            skipped += 1
+            if not quiet and not dest.exists():
+                print(
+                    f"  ↪ {skill_name} (provided by external_dir "
+                    f"{external_src} — not shadowing)"
+                )
+            continue
 
         if skill_name not in manifest:
             # ── New skill — never offered before ──
@@ -560,6 +676,7 @@ def sync_skills(quiet: bool = False) -> dict:
         "cleaned": cleaned,
         "total_bundled": len(bundled_skills),
         "optional_provenance_backfilled": optional_provenance_backfilled,
+        "shadowed_by_external": shadowed_by_external,
     }
 
 


### PR DESCRIPTION
## Summary

Fixes #28126. `sync_skills` was writing the entire bundled skill set into
`<profile_home>/skills/` even when the active profile's `config.yaml`
declared `skills.external_dirs: ["~/.hermes/skills"]` (i.e. the profile
was intentionally delegating skill resolution to another home). The
loader then saw two same-name candidates per skill, refused to resolve
on collision, and every worker that auto-loaded such a skill crashed
with a bare `Error: Unknown skill(s): <name>` (exit 1).

## CLAIR repro evidence (May 27, 2026)

Three kanban worker cards crashed on the same root cause while running
under a profile that delegates to the default home via `external_dirs`:

- `t_e809fa4f` — `Error: Unknown skill(s): clair-qa-two-stage`
- `t_ec2330c5` — `Error: Unknown skill(s): clair-qa-two-stage`
- `t_914e7b1a` — `Error: Unknown skill(s): devops/clair-qa-two-stage`

Diagnostics confirmed the issue's description exactly:

- Skill present at `~/.hermes/skills/devops/clair-qa-two-stage/SKILL.md`
- `hermes skills list` showed it `enabled` from the top-level CLI
- `hermes --skills clair-qa-two-stage -z 'say OK'` worked fine directly
- Failure occurred only inside the kanban worker spawn path, which
  uses `HermesCLI`'s `--skills` preload — and that path enforces strict
  collision-detection, where a profile-local shadow + external canonical
  produced the ambiguity.

Workaround applied while this fix was prepared: inline the entire 15 KB
skill text into every kanban card body. Unsustainable — hence this PR.

## Changes

### `tools/skills_sync.py`

- New `_external_skill_index()` reads `skills.external_dirs` from the
  active profile's `config.yaml` and indexes every `SKILL.md` it finds
  by both directory name and frontmatter `name:` field.
- `sync_skills()` now consults that index: any bundled skill already
  provided by an external dir is **not** written into the local tree.
  The skipped entry is recorded under a new `shadowed_by_external` key
  on the result dict so callers (and the `hermes update` summary) can
  surface what was deferred.
- **Self-healing**: stale shadows left behind by prior buggy syncs are
  best-effort cleaned up. Only when the on-disk copy is byte-identical
  to the bundled source AND the manifest's `origin_hash` matches — i.e.
  we wrote it ourselves last time, the user hasn't touched it, so
  removing it just reverts our own bug. User customisations are
  preserved (they end up in `shadowed_by_external` for surfacing
  instead).
- Manifest is pinned to the external's content hash so subsequent syncs
  treat the external as the canonical baseline rather than repeatedly
  triggering the "new skill" branch.

Path equality uses `Path.resolve()` on both sides so symlinks, `~`
expansion, and relative-to-`HERMES_HOME` resolution all collapse to the
same comparison key (per the issue's "same path after symlink + ~ +
relative resolution" requirement).

### Diagnostic improvement (the "workers should not crash with a vague error" requirement)

- `agent/skill_commands.py` gains `diagnose_missing_skill()` and
  `format_missing_skills_error()`. The former walks every local +
  external skills dir, lists on-disk candidates whose directory name OR
  frontmatter `name:` matches the requested identifier, and explains
  why each was rejected (not found / found-but-loader-returned-empty /
  collision). The latter renders a multi-line block per missing skill.
- `cli.py` — the `Unknown skill(s):` raise now uses the formatter, so
  worker logs show the underlying `skill_view` rejection reason instead
  of hiding it behind a generic exit 1. The first line keeps the
  existing `Unknown skill(s): <names>` format so existing regex-based
  tooling continues to match.

### Tests

`tests/tools/test_skills_sync_external_dirs.py` — 12 new tests, all
passing:

- External-dir indexing by frontmatter name / dirname.
- Core invariant: `sync_skills()` does NOT write into the local tree
  when an external dir already provides the same skill.
- Post-sync the loader sees exactly **one** candidate (the external one)
  rather than the two-candidate collision that triggered the crashes.
- Stale shadow cleanup when safe.
- User-customised shadow preservation when not safe.
- Default profile (no `external_dirs`) behaviour unchanged.
- Diagnostic helpers for single / collision / missing-only cases.
- Worker-spawn integration check mimicking the loader's collision
  detection against the post-sync tree.

`tests/tools/test_skills_sync.py::test_nonexistent_bundled_dir` updated
to accept the new `shadowed_by_external` key in the empty-result dict.

## Verification

```
$ python -m pytest tests/cli/test_cli_preloaded_skills.py \
    tests/agent/test_skill_commands.py \
    tests/tools/test_skills_sync.py \
    tests/tools/test_skills_sync_external_dirs.py \
    tests/agent/test_external_skills.py \
    tests/agent/test_external_skills_dirs_cache.py -q
122 passed in 3.77s
```

Broader `-k skills` sweep: 847 passed, 1 pre-existing-flaky unrelated
failure that also fails on `main` (env-pollution in
`tests/hermes_cli/test_skills_config.py::test_session_platform_env_var`
when run in a long suite — passes individually).

## Root cause confirmation

The actual root cause matches issue #28126 exactly — no deviation.
`tools/skills_sync.py` did not consult `skills.external_dirs` and
operated purely on the resolved `HERMES_HOME` path, producing shadow
writes the loader's collision detection then refused. The fix is the
issue's "Expected" path: `sync_skills` now detects the delegation and
skips the writes.

Closes #28126
