### PR TITLE
fix(docker): patch OpenAI SDK parse_response crash for Codex endpoint (output: null)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,8 @@ RUN npm install --prefer-offline --no-audit && \
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity
+RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra anthropic --extra bedrock --extra azure-identity && \
+    python3 -c "import pathlib; [f.write_text(f.read_text().replace('for output in response.output:','for output in (response.output or []):')) or print('Patched',f) for f in pathlib.Path('/opt/hermes/.venv').rglob('_responses.py') if '_parsing' in str(f)]"
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.


### PR DESCRIPTION
## Problem

OpenAI Python SDK \>=2.37.0\ introduced a regression in \parse_response()\:

\\\python
# openai/lib/_parsing/_responses.py line ~61
for output in response.output:   # 💥 TypeError when output is None
\\\

The ChatGPT Codex endpoint (\chatgpt.com/backend-api/codex\) always returns \output: null\ in the final \esponse.completed\ SSE event when \store=false\ — and \store: false\ is **required** (the API rejects \store: true\ with 400). This means **every** Codex/gpt-5.5 response crashes with:

\\\
TypeError: 'NoneType' object is not iterable
\\\

The exception is caught upstream as a local validation error and the agent silently returns nothing, so the user only sees Hermes greet them but never reply.

## Fix

One-line Python guard applied in the same \RUN\ as \uv sync\ — patching in a later \RUN\ silently no-ops because \pathlib.rglob\ cannot traverse into cached overlay layers from a prior \RUN\.

\\\python
'for output in response.output:'
→ 'for output in (response.output or []):'
\\\

This is the minimal safe guard: an empty list short-circuits the loop cleanly, and the existing backfill logic in \_run_codex_stream()\ already handles the empty-output case.

## Upstream fix

The correct long-term fix is for OpenAI to ship SDK \>=2.37.1\ with the None guard. This patch ensures Docker users are not broken in the meantime regardless of which SDK version \uv\ resolves to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)