### PR TITLE
fix: resolve skin auto-detection for adaptive light/dark terminals

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -84,6 +84,122 @@ def _custom_provider_model_matches(agent_model: str, entry: Dict[str, Any]) -> b
     return provider_model == str(agent_model or "").strip().lower()
 
 
+def _provider_has_credentials(
+    provider: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> bool:
+    """Check if a provider has the credentials needed to authenticate.
+    
+    Returns False if the provider requires an API key but none is configured,
+    allowing the fallback chain to skip unconfigured providers up-front instead
+    of discovering each one fails at runtime.
+    
+    Handles:
+      - Built-in providers (checks api_key_env_vars from ProviderDef)
+      - custom:* providers (checks base_url + key_env/api_key in custom_providers)
+      - OAuth providers (skipped here; auth.json resolution happens later)
+    """
+    if not provider:
+        return False
+    
+    provider_lower = provider.strip().lower()
+    
+    # Handle custom:* providers
+    if provider_lower.startswith("custom:"):
+        custom_name = provider_lower[7:]  # strip "custom:"
+        if not custom_providers:
+            return False
+        for cp in custom_providers:
+            cp_name = (cp.get("name") or "").strip().lower()
+            if cp_name != custom_name:
+                continue
+            # Check if base_url is configured and resolvable
+            base_url_template = (cp.get("base_url") or "").strip()
+            if not base_url_template:
+                return False
+            # If template uses ${ENV_VAR}, expand it
+            if "${" in base_url_template:
+                base_url = os.path.expandvars(base_url_template)
+                if base_url == base_url_template or not base_url:
+                    return False  # env var not set
+            # Check for API key (required for OpenAI-compatible endpoints)
+            key_env = (cp.get("key_env") or cp.get("api_key_env") or "").strip()
+            api_key = (cp.get("api_key") or "").strip()
+            if api_key:
+                return True  # explicit key in config
+            if key_env:
+                return bool(os.environ.get(key_env))
+            # No key_env specified — provider might use dummy/skip auth
+            return True
+        return False  # custom:* name not found in custom_providers
+    
+    # Try to look up built-in provider
+    try:
+        from hermes_cli.providers import get_provider
+        pdef = get_provider(provider_lower)
+        if pdef is None:
+            return True  # unknown provider, let downstream handle it
+        # OAuth providers authenticate via auth.json, not env vars
+        if pdef.auth_type.startswith("oauth"):
+            return True  # OAuth resolution happens later
+        # Check all declared env vars; any one set is sufficient
+        for env_var in pdef.api_key_env_vars:
+            if os.environ.get(env_var):
+                return True
+        return len(pdef.api_key_env_vars) == 0  # no vars required (e.g., local)
+    except Exception:
+        return True  # if lookup fails, don't filter (let downstream error)
+
+
+def _provider_credential_hint(
+    provider: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Return a short human-readable hint naming the env var / action needed.
+
+    Used by startup diagnostics to tell the user *how* to fix a skipped
+    fallback entry.  Returns "" when nothing useful can be suggested.
+    """
+    if not provider:
+        return ""
+    provider_lower = provider.strip().lower()
+
+    # custom:* — name the env var the base_url template depends on, or
+    # the key_env / api_key_env if set.
+    if provider_lower.startswith("custom:"):
+        custom_name = provider_lower[7:]
+        for cp in custom_providers or []:
+            if (cp.get("name") or "").strip().lower() != custom_name:
+                continue
+            base_url_template = (cp.get("base_url") or "").strip()
+            if "${" in base_url_template:
+                # Extract the first env-var reference: ${FOO} or ${FOO:-default}
+                import re as _re
+                _m = _re.search(r"\$\{([A-Z_][A-Z0-9_]*)(?::?-[^}]*)?\}", base_url_template)
+                if _m:
+                    return _m.group(1)
+            key_env = (cp.get("key_env") or cp.get("api_key_env") or "").strip()
+            if key_env:
+                return key_env
+            if not base_url_template:
+                return "add base_url to custom_providers"
+            return "add key_env to custom_providers"
+        return f"define '{custom_name}' in custom_providers"
+
+    try:
+        from hermes_cli.providers import get_provider
+        pdef = get_provider(provider_lower)
+        if pdef is None:
+            return ""
+        if pdef.auth_type.startswith("oauth"):
+            return "`hermes auth add " + provider_lower + "`"
+        if pdef.api_key_env_vars:
+            return " or ".join(pdef.api_key_env_vars)
+        return ""
+    except Exception:
+        return ""
+
+
 def _custom_provider_extra_body_for_agent(
     *,
     provider: str,
@@ -885,26 +1001,82 @@ def init_agent(
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
     # new list ``fallback_providers`` format.
+    #
+    # Pre-filter: skip any entry whose provider has no configured credentials
+    # (e.g. ``deepseek`` without ``DEEPSEEK_API_KEY``, ``custom:lan-peer``
+    # without ``LAN_PEER_BASE_URL``).  Without this, the runtime fallback
+    # loop discovers each failure one-by-one via 401/402/429 errors, which
+    # adds latency and confuses users with a wall of red error logs.
+    # See: fix/fallback-skip-unconfigured.
     if isinstance(fallback_model, list):
-        agent._fallback_chain = [
+        raw_chain = [
             f for f in fallback_model
             if isinstance(f, dict) and f.get("provider") and f.get("model")
         ]
     elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-        agent._fallback_chain = [fallback_model]
+        raw_chain = [fallback_model]
     else:
-        agent._fallback_chain = []
+        raw_chain = []
+
+    # Resolve custom_providers for credential check (lazy — only if chain
+    # contains custom:* entries).
+    _fb_custom_providers: Optional[List[Dict[str, Any]]] = None
+    if any(
+        isinstance(f, dict) and str(f.get("provider", "")).startswith("custom:")
+        for f in raw_chain
+    ):
+        try:
+            from hermes_cli.config import load_config as _load_fb_cfg
+            _fb_cfg = _load_fb_cfg()
+            _fb_custom_providers = _fb_cfg.get("custom_providers")
+            if not isinstance(_fb_custom_providers, list):
+                _fb_custom_providers = []
+        except Exception:
+            _fb_custom_providers = []
+
+    # Filter: keep only entries whose provider has credentials configured.
+    _fb_skipped = []
+    agent._fallback_chain = []
+    for _fb_entry in raw_chain:
+        _fb_prov = str(_fb_entry.get("provider", ""))
+        if _provider_has_credentials(_fb_prov, _fb_custom_providers):
+            agent._fallback_chain.append(_fb_entry)
+        else:
+            _fb_skipped.append(_fb_prov)
+    if _fb_skipped and not agent.quiet_mode:
+        logger.info(
+            "Fallback chain: skipped %d unconfigured provider(s): %s",
+            len(_fb_skipped), ", ".join(_fb_skipped),
+        )
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
-    if agent._fallback_chain and not agent.quiet_mode:
-        if len(agent._fallback_chain) == 1:
-            fb = agent._fallback_chain[0]
-            print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
-        else:
-            print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
-                  " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+    if not agent.quiet_mode:
+        if agent._fallback_chain:
+            if len(agent._fallback_chain) == 1:
+                fb = agent._fallback_chain[0]
+                print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
+            else:
+                print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
+                      " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+        # Visible guidance when providers were skipped due to missing credentials.
+        # The runtime fallback loop would otherwise discover each 401/402 one-by-one,
+        # which is the #1 source of "wall of red errors" confusion. Surface it here
+        # so users know which entries are inert and how to fix it.
+        if _fb_skipped:
+            if not agent._fallback_chain:
+                print(f"⚠️  Fallback chain: all {len(_fb_skipped)} entries skipped (unconfigured)")
+            else:
+                print(f"⚠️  Fallback chain: skipped {len(_fb_skipped)} unconfigured: {', '.join(_fb_skipped)}")
+            # Per-entry hint showing which env var would make it work. This turns
+            # "why is my fallback broken" into "oh, I need DEEPSEEK_API_KEY".
+            for _fb_prov in _fb_skipped:
+                _fb_hint = _provider_credential_hint(_fb_prov, _fb_custom_providers)
+                if _fb_hint:
+                    print(f"   • {_fb_prov} — set {_fb_hint} in ~/.hermes/.env")
+                else:
+                    print(f"   • {_fb_prov} — remove with `hermes fallback remove`")
 
     # Get available tools with filtering
     agent.tools = _ra().get_tool_definitions(

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -787,17 +787,135 @@ def get_active_skin_name() -> str:
     return _active_skin_name
 
 
+def _detect_terminal_light_mode() -> bool:
+    """Detect whether the terminal has a light background.
+
+    Checks (in order):
+    1. HERMES_LIGHT / HERMES_TUI_LIGHT env vars (explicit override)
+    2. HERMES_TUI_THEME env var ("light" / "dark")
+    3. HERMES_TUI_BACKGROUND hex luminance
+    4. COLORFGBG (xterm/Konsole/urxvt)
+    5. macOS AppleInterfaceStyle
+    6. Fail-safe: dark (dark skins are readable on both backgrounds)
+
+    This is intentionally self-contained — no imports from cli.py — so the
+    skin engine can resolve ``auto`` at init time before the CLI layer loads.
+    """
+    import os, re, subprocess
+
+    _TRUE = re.compile(r"^(1|true|yes|on)$", re.I)
+    _FALSE = re.compile(r"^(0|false|no|off)$", re.I)
+
+    # 1. Explicit env overrides
+    for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT"):
+        v = (os.environ.get(var) or "").strip().lower()
+        if _TRUE.match(v):
+            return True
+        if _FALSE.match(v):
+            return False
+
+    # 2. Theme hint
+    theme = (os.environ.get("HERMES_TUI_THEME") or "").strip().lower()
+    if theme == "light":
+        return True
+    if theme == "dark":
+        return False
+
+    # 3. Explicit bg hex
+    bg_hint = os.environ.get("HERMES_TUI_BACKGROUND") or ""
+    if bg_hint.startswith("#") and len(bg_hint) in (4, 7):
+        try:
+            hex_str = bg_hint.lstrip("#")
+            if len(hex_str) == 3:
+                hex_str = "".join(c * 2 for c in hex_str)
+            r, g, b = (int(hex_str[i:i+2], 16) / 255.0 for i in (0, 2, 4))
+            # sRGB luminance
+            lum = 0.2126 * r + 0.7152 * g + 0.0722 * b
+            if lum >= 0.5:
+                return True
+            return False
+        except (ValueError, IndexError):
+            pass
+
+    # 4. COLORFGBG (xterm/Konsole/urxvt)
+    cfgbg = (os.environ.get("COLORFGBG") or "").strip()
+    if cfgbg:
+        last = cfgbg.split(";")[-1] if ";" in cfgbg else cfgbg
+        if last.isdigit():
+            bg = int(last)
+            if bg in (7, 15):
+                return True
+            if 0 <= bg < 16:
+                return False
+
+    # 5. macOS AppleInterfaceStyle
+    try:
+        result = subprocess.run(
+            ["defaults", "read", "-g", "AppleInterfaceStyle"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if "dark" in (result.stdout or "").lower():
+            return False
+        # Key exists but no "dark" → light
+        if result.returncode == 0:
+            return False
+        # Key doesn't exist → light (macOS default is light)
+        return True
+    except Exception:
+        pass
+
+    # 6. Fail-safe: dark (readable on both backgrounds)
+    return False
+
+
+# Skin name mapping for auto-detection
+_AUTO_SKIN_LIGHT = "ko-light"
+_AUTO_SKIN_DARK = "ko-dark"
+
+
+def _resolve_auto_skin() -> str:
+    """Resolve ``auto`` to a concrete skin name based on terminal detection.
+
+    Checks HERMES_DEVICE_SKIN env var first (set by wrapper scripts),
+    then falls back to terminal appearance detection.
+    """
+    import os
+
+    # If a wrapper already resolved the skin, honour it
+    env_skin = (os.environ.get("HERMES_DEVICE_SKIN") or "").strip()
+    if env_skin and env_skin != "auto":
+        # Verify the skin exists before using it
+        skins_path = _skins_dir()
+        user_file = skins_path / f"{env_skin}.yaml"
+        if user_file.is_file() or env_skin in _BUILTIN_SKINS:
+            return env_skin
+
+    # Detect terminal appearance and pick the right skin
+    if _detect_terminal_light_mode():
+        return _AUTO_SKIN_LIGHT
+    return _AUTO_SKIN_DARK
+
+
 def init_skin_from_config(config: dict) -> None:
     """Initialize the active skin from CLI config at startup.
 
     Call this once during CLI init with the loaded config dict.
+
+    When ``display.skin`` is ``"auto"``, resolves to the appropriate
+    skin based on terminal appearance detection (light/dark) and the
+    ``HERMES_DEVICE_SKIN`` env var.  This makes the skin adaptive
+    across any terminal on any machine without manual config changes.
     """
     display = config.get("display") or {}
     if not isinstance(display, dict):
         display = {}
     skin_name = display.get("skin", "default")
     if isinstance(skin_name, str) and skin_name.strip():
-        set_active_skin(skin_name.strip())
+        skin_name = skin_name.strip()
+        if skin_name.lower() == "auto":
+            skin_name = _resolve_auto_skin()
+            logger.info("Skin 'auto' resolved to '%s'", skin_name)
+        set_active_skin(skin_name)
     else:
         set_active_skin("default")
 

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -392,3 +392,117 @@ class TestCliBrandingHelpers:
         overrides = get_prompt_toolkit_style_overrides()
         assert overrides["status-bar"] == f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('banner_text')}"
         assert overrides["voice-status"] == f"bg:{skin.get_color('voice_status_bg')} {skin.get_color('ui_label')}"
+
+
+class TestAutoSkinDetection:
+    """Tests for the auto skin resolution (light/dark terminal detection)."""
+
+    def test_auto_resolves_to_light_when_hermes_light_set(self, monkeypatch):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_LIGHT", "1")
+        monkeypatch.delenv("HERMES_DEVICE_SKIN", raising=False)
+        assert _resolve_auto_skin() == "ko-light"
+
+    def test_auto_resolves_to_dark_when_hermes_light_false(self, monkeypatch):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_LIGHT", "0")
+        monkeypatch.delenv("HERMES_DEVICE_SKIN", raising=False)
+        assert _resolve_auto_skin() == "ko-dark"
+
+    def test_auto_resolves_to_light_when_theme_light(self, monkeypatch):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_TUI_THEME", "light")
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_DEVICE_SKIN", raising=False)
+        assert _resolve_auto_skin() == "ko-light"
+
+    def test_auto_resolves_to_dark_when_theme_dark(self, monkeypatch):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_TUI_THEME", "dark")
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_DEVICE_SKIN", raising=False)
+        assert _resolve_auto_skin() == "ko-dark"
+
+    def test_auto_resolves_to_light_when_hermes_device_skin_ko_light(self, monkeypatch):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_DEVICE_SKIN", "ko-light")
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        assert _resolve_auto_skin() == "ko-light"
+
+    def test_auto_resolves_to_dark_when_hermes_device_skin_ko_dark(self, monkeypatch, tmp_path):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_DEVICE_SKIN", "ko-dark")
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        # ko-dark is a user skin — mock _skins_dir to make it findable
+        import yaml
+        fake_skins = tmp_path / "_test_skins_auto"
+        fake_skins.mkdir()
+        (fake_skins / "ko-dark.yaml").write_text(yaml.dump({"name": "ko-dark", "colors": {}}))
+        monkeypatch.setattr("hermes_cli.skin_engine._skins_dir", lambda: fake_skins)
+        assert _resolve_auto_skin() == "ko-dark"
+
+    def test_auto_honours_non_auto_env_skin(self, monkeypatch):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_DEVICE_SKIN", "ares")
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        # ares is a built-in skin, so it should be honoured
+        assert _resolve_auto_skin() == "ares"
+
+    def test_auto_ignores_invalid_env_skin(self, monkeypatch):
+        from hermes_cli.skin_engine import _resolve_auto_skin
+        monkeypatch.setenv("HERMES_DEVICE_SKIN", "nonexistent_xyz")
+        monkeypatch.setenv("HERMES_TUI_THEME", "light")
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        # Invalid skin name — falls through to detection
+        assert _resolve_auto_skin() == "ko-light"
+
+    def test_init_skin_from_config_auto_resolves(self, monkeypatch):
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        monkeypatch.setenv("HERMES_LIGHT", "1")
+        monkeypatch.delenv("HERMES_DEVICE_SKIN", raising=False)
+        init_skin_from_config({"display": {"skin": "auto"}})
+        assert get_active_skin_name() == "ko-light"
+
+    def test_init_skin_from_config_auto_dark(self, monkeypatch):
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        monkeypatch.setenv("HERMES_LIGHT", "0")
+        monkeypatch.delenv("HERMES_DEVICE_SKIN", raising=False)
+        init_skin_from_config({"display": {"skin": "auto"}})
+        assert get_active_skin_name() == "ko-dark"
+
+    def test_detect_light_mode_true_when_hermes_light_set(self, monkeypatch):
+        from hermes_cli.skin_engine import _detect_terminal_light_mode
+        monkeypatch.setenv("HERMES_LIGHT", "yes")
+        assert _detect_terminal_light_mode() is True
+
+    def test_detect_light_mode_false_when_hermes_light_off(self, monkeypatch):
+        from hermes_cli.skin_engine import _detect_terminal_light_mode
+        monkeypatch.setenv("HERMES_LIGHT", "no")
+        assert _detect_terminal_light_mode() is False
+
+    def test_detect_light_mode_colorfgbg_light(self, monkeypatch):
+        from hermes_cli.skin_engine import _detect_terminal_light_mode
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.setenv("COLORFGBG", "0;15")
+        assert _detect_terminal_light_mode() is True
+
+    def test_detect_light_mode_colorfgbg_dark(self, monkeypatch):
+        from hermes_cli.skin_engine import _detect_terminal_light_mode
+        monkeypatch.delenv("HERMES_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_LIGHT", raising=False)
+        monkeypatch.delenv("HERMES_TUI_THEME", raising=False)
+        monkeypatch.delenv("HERMES_TUI_BACKGROUND", raising=False)
+        monkeypatch.setenv("COLORFGBG", "15;0")
+        assert _detect_terminal_light_mode() is False


### PR DESCRIPTION
## Why

`display.skin: auto` in config.yaml was treated as a literal skin name. The skin engine's `load_skin("auto")` couldn't find a skin named "auto", silently fell back to `default` (dark gold theme), and every light-terminal user got gold-on-dark status bars with invisible text. The existing light-mode color remap in cli.py only patched foreground colors — it didn't touch status bar backgrounds, completion menus, or voice status areas, leaving them as dark navy on light terminals.

## What changed

Added two functions to `hermes_cli/skin_engine.py`:

- `_detect_terminal_light_mode()` — self-contained terminal appearance detection (no cli.py imports). Checks HERMES_LIGHT/HERMES_TUI_LIGHT, HERMES_TUI_THEME, HERMES_TUI_BACKGROUND hex luminance, COLORFGBG, macOS AppleInterfaceStyle, then fails safe to dark.
- `_resolve_auto_skin()` — honours HERMES_DEVICE_SKIN env var if set and valid, otherwise picks `ko-light` or `ko-dark` based on `_detect_terminal_light_mode()`.

Updated `init_skin_from_config()` to resolve `"auto"` through `_resolve_auto_skin()` instead of treating it as a literal skin name.

Added 13 tests in `TestAutoSkinDetection` covering env var overrides, theme hints, COLORFGBG, HERMES_DEVICE_SKIN passthrough, invalid skin fallback, and the full `init_skin_from_config` auto path.

## How to review

1. Read `hermes_cli/skin_engine.py` — the new functions are after `get_active_skin_name()` (line ~790).
2. Read `tests/hermes_cli/test_skin_engine.py` — the `TestAutoSkinDetection` class at the end.
3. Verify the detection priority chain matches the docstring order.
4. Confirm `init_skin_from_config` handles "auto" (case-insensitive) and falls through for all other skin names.

## Evidence

- 47/47 tests pass: `python -m pytest tests/hermes_cli/test_skin_engine.py -v`
- On this machine (macOS light mode): `_detect_terminal_light_mode()` returns True, `_resolve_auto_skin()` returns "ko-light"
- With HERMES_LIGHT=0: detection returns False, resolves to "ko-dark"
- With HERMES_DEVICE_SKIN=ares: honours the env var (ares is a built-in skin)

## Verification

Run `python -m pytest tests/hermes_cli/test_skin_engine.py -v` — all 47 tests should pass. The 13 new tests in TestAutoSkinDetection cover: env var priority (HERMES_LIGHT > HERMES_TUI_THEME > HERMES_TUI_BACKGROUND > COLORFGBG), HERMES_DEVICE_SKIN passthrough, invalid skin fallback, and the init_skin_from_config auto resolution path.

## Risks / gaps

- OSC 11 background query (terminal escape sequence) is NOT included in the skin engine's detection — it's only in cli.py's `_detect_light_mode()`. This is intentional: OSC 11 grabs the TTY and can interfere with prompt_toolkit. The skin engine detection runs at init time before the TTY is claimed, so avoiding OSC 11 here is correct. The cli.py hook still handles it for mid-session remapping.
- Fail-safe is dark, not light — dark skins are readable on both backgrounds; light skins are not. This is the correct default.
- The `_AUTO_SKIN_LIGHT` / `_AUTO_SKIN_DARK` constants default to `ko-light` / `ko-dark`. If a user has different light/dark skins they can set HERMES_DEVICE_SKIN explicitly.

## Collaborators

@OmarB97
