### PR TITLE
fix(caching): honor prompt_caching.cache_ttl disable in config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -477,6 +477,10 @@ def init_agent(
     # config.yaml under prompt_caching.cache_ttl; unknown values keep "5m".
     # 1h tier costs 2x on write vs 1.25x for 5m, but amortizes across long
     # sessions with >5-minute pauses between turns (#14971).
+    #
+    # Setting cache_ttl to a falsy value (false / null / "off" / "disabled" /
+    # "no") disables prompt caching entirely. This is useful for OAuth
+    # subscription users where cache writes bill against "extra usage."
     agent._cache_ttl = "5m"
     try:
         from hermes_cli.config import load_config as _load_pc_cfg
@@ -485,6 +489,14 @@ def init_agent(
         _ttl = _pc_cfg.get("cache_ttl", "5m")
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl
+        elif (
+            _ttl is False
+            or _ttl is None
+            or str(_ttl).lower() in ("off", "false", "disabled", "no", "none")
+        ):
+            agent._use_prompt_caching = False
+            agent._use_native_cache_layout = False
+            agent._cache_ttl = None
     except Exception:
         pass
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -895,7 +895,9 @@ DEFAULT_CONFIG = {
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
-    # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    # cache_ttl: "5m" or "1h" (Anthropic-supported tiers). Other non-falsy
+    # values are silently ignored. Falsy values (false, null, "off",
+    # "disabled", "no") disable prompt caching entirely.
     "prompt_caching": {
         "cache_ttl": "5m",
     },

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -928,6 +928,32 @@ class TestInit:
             )
             assert a._cache_ttl == "5m"
 
+    @pytest.mark.parametrize(
+        "falsy_value", [False, None, "off", "false", "disabled", "no", "none"],
+    )
+    def test_prompt_caching_disabled_by_falsy_cache_ttl(self, falsy_value):
+        """Falsy cache_ttl values should fully disable prompt caching."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"cache_ttl": falsy_value}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._use_prompt_caching is False
+            assert a._use_native_cache_layout is False
+            assert a._cache_ttl is None
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")


### PR DESCRIPTION
## Summary

Allows operators to fully disable Anthropic prompt caching by setting `cache_ttl` to a falsy value in `config.yaml`.

### The problem

The existing `prompt_caching.cache_ttl` config only accepts `"5m"` or `"1h"`. Any other value (including `false`, `null`, `"off"`) is silently ignored, and caching remains enabled at the `"5m"` tier. This means:

- Operators who set `cache_ttl: false` expecting to disable caching see no effect
- Cache writes continue, incurring write costs (1.25x for 5m tier) that bill against "extra usage" on OAuth subscription
- There is no config lever to disable prompt caching without code changes

### The fix

After the existing `"5m"` / `"1h"` check, a new `elif` branch catches falsy values:

```yaml
# config.yaml
prompt_caching:
  cache_ttl: false    # also accepts: null, "off", "disabled", "no", "none"
```

When detected, sets:
- `agent._use_prompt_caching = False`
- `agent._use_native_cache_layout = False`
- `agent._cache_ttl = None`

### Changes

- **Modified:** `agent/agent_init.py` — falsy-value detection after existing TTL parsing
- **Modified:** `hermes_cli/config.py` — updated inline doc comment
- **Modified:** `tests/run_agent/test_run_agent.py` — parametrized test covering all 7 falsy variants

## Test plan

- [ ] `pytest tests/run_agent/test_run_agent.py -k cache_ttl` passes (existing + new tests)
- [ ] `cache_ttl: "5m"` still works (existing test)
- [ ] `cache_ttl: "1h"` still works (existing test)
- [ ] `cache_ttl: "30m"` (invalid) still falls back to "5m" (existing test)
- [ ] `cache_ttl: false` disables caching (new test, 7 variants)