### PR TITLE
fix(kanban): honor max_in_progress in CLI dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -184,6 +184,34 @@ def _check_dispatcher_presence() -> tuple[bool, str]:
     )
 
 
+def _load_dispatch_max_in_progress() -> Optional[int]:
+    """Return ``kanban.max_in_progress`` from config.yaml, if valid.
+
+    The gateway dispatcher already honors this knob. Manual CLI dispatch
+    should mirror it so local runs respect the configured running-task cap.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        return None
+
+    raw_max_in_progress = (cfg.get("kanban", {}) or {}).get("max_in_progress")
+    if raw_max_in_progress is None:
+        return None
+
+    try:
+        max_in_progress = int(raw_max_in_progress)
+    except (TypeError, ValueError):
+        return None
+
+    if max_in_progress < 1:
+        return None
+
+    return max_in_progress
+
+
 # ---------------------------------------------------------------------------
 # Argparse builder
 # ---------------------------------------------------------------------------
@@ -2092,6 +2120,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             conn,
             dry_run=args.dry_run,
             max_spawn=args.max,
+            max_in_progress=_load_dispatch_max_in_progress(),
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
         )
     if getattr(args, "json", False):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -171,6 +172,46 @@ def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'b' --assignee bob")
     out = kc.run_slash("dispatch --dry-run")
     assert "Spawned:" in out
+
+
+def test_cmd_dispatch_honors_config_max_in_progress(kanban_home, monkeypatch):
+    from hermes_cli import config as hermes_config
+
+    seen_kwargs = {}
+
+    def fake_dispatch_once(conn, **kwargs):
+        seen_kwargs.update(kwargs)
+        return SimpleNamespace(
+            reclaimed=[],
+            crashed=[],
+            timed_out=[],
+            stale=[],
+            auto_blocked=[],
+            promoted=0,
+            spawned=[],
+            skipped_unassigned=[],
+            skipped_nonspawnable=[],
+        )
+
+    monkeypatch.setattr(kb, "dispatch_once", fake_dispatch_once)
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"kanban": {"max_in_progress": 2}},
+    )
+
+    rc = kc._cmd_dispatch(
+        argparse.Namespace(
+            dry_run=True,
+            max=None,
+            failure_limit=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
+            json=True,
+        )
+    )
+
+    assert rc == 0
+    assert seen_kwargs["max_in_progress"] == 2
+    assert seen_kwargs["max_spawn"] is None
 
 
 def test_run_slash_context_output_format(kanban_home):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -642,6 +642,8 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
         [--log-retention-days N]
 ```
 
+The CLI dispatch command also honors `kanban.max_in_progress` from `config.yaml`, matching the gateway dispatcher’s running-task cap.
+
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.


### PR DESCRIPTION
## Summary of Changes
- Teach `hermes kanban dispatch` to load `kanban.max_in_progress` from `config.yaml` and forward it to `dispatch_once()`.
- Add a regression test covering CLI dispatch honoring the config cap.
- Document the CLI behavior in the kanban user guide.

## Optional Details
- Manual dispatch now mirrors the gateway dispatcher’s running-task limit instead of only respecting `--max`.
- Invalid or missing `kanban.max_in_progress` values are ignored safely.

Closes #33488

## Validation Plan
- `pytest -o addopts='' tests/hermes_cli/test_kanban_db.py -k 'max_in_progress' -q`
- `pytest -o addopts='' tests/hermes_cli/test_kanban_cli.py -k 'cmd_dispatch_honors_config_max_in_progress' -q`