### PR TITLE
feat(agent): support system prompt section overrides via HERMES_PROMPT_OVERRIDES_JSON

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -114,6 +114,62 @@ def _strip_yaml_frontmatter(content: str) -> str:
     return content
 
 
+# ---------------------------------------------------------------------------
+# Optional prompt-section overrides (opt-in via HERMES_PROMPT_OVERRIDES_JSON).
+#
+# External tooling (e.g. research / eval harnesses) can override the named
+# string-constant prompt sections defined below — without patching this file —
+# by pointing the env var at a JSON file of {SECTION_NAME: new_text}. When the
+# env var is unset there is no behavioral change.
+#
+# The applier is defined here but invoked once at the end of this module (after
+# every constant exists) by ``_apply_prompt_overrides(globals())``. Running it
+# last lets a single loop cover every str constant with no per-constant
+# boilerplate. A broken override file must never break Hermes startup, so every
+# failure path logs and falls back to the built-in defaults.
+# ---------------------------------------------------------------------------
+
+def _apply_prompt_overrides(namespace: dict) -> None:
+    """Override string-typed module constants from HERMES_PROMPT_OVERRIDES_JSON.
+
+    No-op unless the env var is set. Only constants that are currently strings
+    are overridable; dict-typed constants (e.g. PLATFORM_HINTS) and unknown
+    keys are ignored.
+    """
+    path = os.environ.get("HERMES_PROMPT_OVERRIDES_JSON")
+    if not path:
+        return
+    try:
+        # utf-8-sig tolerates a UTF-8 BOM from Windows GUI editors
+        # (CONTRIBUTING.md, Cross-Platform Compatibility rule 4).
+        with open(path, encoding="utf-8-sig") as f:
+            overrides = json.load(f)
+    except Exception:
+        logger.warning(
+            "Could not load prompt overrides from HERMES_PROMPT_OVERRIDES_JSON=%s; "
+            "using built-in defaults",
+            path,
+            exc_info=True,
+        )
+        return
+    if not isinstance(overrides, dict):
+        logger.warning(
+            "Prompt overrides at HERMES_PROMPT_OVERRIDES_JSON=%s must be a JSON object "
+            "of {section_name: text}; got %s. Using built-in defaults",
+            path,
+            type(overrides).__name__,
+        )
+        return
+    for name, value in overrides.items():
+        if isinstance(namespace.get(name), str) and isinstance(value, str):
+            namespace[name] = value
+        else:
+            logger.debug(
+                "Ignoring prompt override %r: not a known string-typed prompt section",
+                name,
+            )
+
+
 # =========================================================================
 # Constants
 # =========================================================================
@@ -1449,3 +1505,8 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     if not sections:
         return ""
     return "# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n" + "\n".join(sections)
+
+
+# Apply HERMES_PROMPT_OVERRIDES_JSON now that every prompt-section constant
+# above is defined. No-op unless the env var is set (see top of module).
+_apply_prompt_overrides(globals())

--- a/tests/agent/test_prompt_overrides.py
+++ b/tests/agent/test_prompt_overrides.py
@@ -1,0 +1,177 @@
+"""Tests for the HERMES_PROMPT_OVERRIDES_JSON prompt-section override hook.
+
+The hook lets external tooling override named string-constant prompt sections
+in ``agent.prompt_builder`` at module load, with zero behavioral change when
+the env var is unset. These tests reload the module under different env/file
+conditions and assert on the resulting constants and log output.
+"""
+
+import importlib
+import json
+import logging
+import os
+
+import pytest
+
+import agent.prompt_builder as prompt_builder
+
+# A representative spread of the named string-constant sections the hook is
+# meant to cover. Not exhaustive — enough to prove the loop touches the right
+# constants and leaves the rest alone.
+_CANONICAL_SECTIONS = (
+    "DEFAULT_AGENT_IDENTITY",
+    "MEMORY_GUIDANCE",
+    "SESSION_SEARCH_GUIDANCE",
+    "SKILLS_GUIDANCE",
+    "TOOL_USE_ENFORCEMENT_GUIDANCE",
+)
+
+# Captured before any test mutates the module. Pop the env var and reload first
+# so the baseline is the built-in default regardless of the caller's shell: the
+# sanctioned runner (scripts/run_tests.sh) runs under `env -i`, but a bare
+# `pytest` with HERMES_PROMPT_OVERRIDES_JSON exported would otherwise capture
+# already-overridden values, since the hook applies at import time.
+os.environ.pop("HERMES_PROMPT_OVERRIDES_JSON", None)
+importlib.reload(prompt_builder)
+_BASELINE = {name: getattr(prompt_builder, name) for name in _CANONICAL_SECTIONS}
+
+_LOGGER_NAME = "agent.prompt_builder"
+
+
+@pytest.fixture(autouse=True)
+def _restore_module():
+    """Reload prompt_builder with a clean env after each test.
+
+    importlib.reload re-applies overrides against module globals, so without
+    this an override from one test would leak into the next.
+    """
+    yield
+    os.environ.pop("HERMES_PROMPT_OVERRIDES_JSON", None)
+    importlib.reload(prompt_builder)
+
+
+def _write_overrides(tmp_path, payload, *, encoding="utf-8"):
+    path = tmp_path / "overrides.json"
+    path.write_text(json.dumps(payload), encoding=encoding)
+    return path
+
+
+def test_defaults_unchanged_when_env_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_PROMPT_OVERRIDES_JSON", raising=False)
+    importlib.reload(prompt_builder)
+    for name, baseline in _BASELINE.items():
+        assert getattr(prompt_builder, name) == baseline
+
+
+def test_override_applies_to_named_section(monkeypatch, tmp_path):
+    sentinel = "OVERRIDDEN MEMORY GUIDANCE — for test only"
+    path = _write_overrides(tmp_path, {"MEMORY_GUIDANCE": sentinel})
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(path))
+
+    importlib.reload(prompt_builder)
+
+    assert prompt_builder.MEMORY_GUIDANCE == sentinel
+    # Sections not named in the override file keep their defaults.
+    assert prompt_builder.SKILLS_GUIDANCE == _BASELINE["SKILLS_GUIDANCE"]
+
+
+def test_utf8_bom_file_is_tolerated(monkeypatch, tmp_path):
+    sentinel = "BOM-prefixed override"
+    path = _write_overrides(
+        tmp_path, {"MEMORY_GUIDANCE": sentinel}, encoding="utf-8-sig"
+    )
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(path))
+
+    importlib.reload(prompt_builder)
+
+    assert prompt_builder.MEMORY_GUIDANCE == sentinel
+
+
+def test_missing_file_warns_and_preserves_defaults(monkeypatch, tmp_path, caplog):
+    missing = tmp_path / "does_not_exist.json"
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(missing))
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        importlib.reload(prompt_builder)
+
+    assert prompt_builder.MEMORY_GUIDANCE == _BASELINE["MEMORY_GUIDANCE"]
+    assert any(
+        r.levelno == logging.WARNING and "HERMES_PROMPT_OVERRIDES_JSON" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_malformed_json_warns_and_preserves_defaults(monkeypatch, tmp_path, caplog):
+    path = tmp_path / "bad.json"
+    path.write_text("{ this is not valid json", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(path))
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        importlib.reload(prompt_builder)
+
+    assert prompt_builder.MEMORY_GUIDANCE == _BASELINE["MEMORY_GUIDANCE"]
+    assert any(
+        r.name == _LOGGER_NAME
+        and r.levelno == logging.WARNING
+        and "HERMES_PROMPT_OVERRIDES_JSON" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_unknown_key_logged_at_debug_and_known_keys_applied(monkeypatch, tmp_path, caplog):
+    sentinel = "OVERRIDDEN MEMORY GUIDANCE"
+    path = _write_overrides(
+        tmp_path,
+        {"MEMORY_GUIDANCE": sentinel, "NOT_A_REAL_SECTION": "ignored"},
+    )
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(path))
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        importlib.reload(prompt_builder)
+
+    assert prompt_builder.MEMORY_GUIDANCE == sentinel
+    assert any(
+        r.levelno == logging.DEBUG and "NOT_A_REAL_SECTION" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_non_object_json_warns_and_preserves_defaults(monkeypatch, tmp_path, caplog):
+    # A top-level JSON array/string/number is a whole-file mistake: warn and
+    # fall back to defaults rather than crashing on .items().
+    path = _write_overrides(tmp_path, ["MEMORY_GUIDANCE", "not an object"])
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(path))
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        importlib.reload(prompt_builder)
+
+    assert prompt_builder.MEMORY_GUIDANCE == _BASELINE["MEMORY_GUIDANCE"]
+    assert any(
+        r.levelno == logging.WARNING and "must be a JSON object" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_non_string_value_for_known_section_is_ignored(monkeypatch, tmp_path):
+    # The loop gates on the override VALUE being a str, so a numeric value for a
+    # real section is dropped: the constant keeps its default and stays a str.
+    # Guards against a future refactor that coerces values into the prompt.
+    path = _write_overrides(tmp_path, {"MEMORY_GUIDANCE": 123})
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(path))
+
+    importlib.reload(prompt_builder)
+
+    assert prompt_builder.MEMORY_GUIDANCE == _BASELINE["MEMORY_GUIDANCE"]
+    assert isinstance(prompt_builder.MEMORY_GUIDANCE, str)
+
+
+def test_dict_typed_constant_is_not_overridable(monkeypatch, tmp_path):
+    # PLATFORM_HINTS is dict[str, str], not str. The loop gates on the existing
+    # value being a str, so dict-typed constants are skipped entirely.
+    path = _write_overrides(tmp_path, {"PLATFORM_HINTS": "this should be ignored"})
+    monkeypatch.setenv("HERMES_PROMPT_OVERRIDES_JSON", str(path))
+
+    importlib.reload(prompt_builder)
+
+    assert isinstance(prompt_builder.PLATFORM_HINTS, dict)
+    assert "this should be ignored" not in repr(prompt_builder.PLATFORM_HINTS)


### PR DESCRIPTION
## What

Adds an opt-in hook to `agent/prompt_builder.py`. When the env var `HERMES_PROMPT_OVERRIDES_JSON` points at a JSON file of `{SECTION_NAME: new_text}`, the named string-constant prompt sections (`MEMORY_GUIDANCE`, `SKILLS_GUIDANCE`, `SESSION_SEARCH_GUIDANCE`, `TOOL_USE_ENFORCEMENT_GUIDANCE`, …) are overridden at module load. When the env var is unset there is **zero behavioral change**.

A single loop applies overrides to every `str`-typed module-level constant, so new sections are covered with no per-constant boilerplate. The applier is defined near the top of the module but invoked once at the **end** of the module (`_apply_prompt_overrides(globals())`), after every constant is defined — that ordering is what lets the loop cover all of them.

## Why

This small hook helps unlock Phase 3 of https://github.com/NousResearch/hermes-agent-self-evolution. Without an env-scoped hook, the alternatives are (a) patch-and-restore `prompt_builder.py` per trial — racy under concurrent evolutions and leaves the file dirty on crash — or (b) a plugin that monkey-patches module constants at import time, which is brittle to import-order changes. The env var gives clean per-subprocess isolation that survives refactors.

## Design notes

- **Fail-safe at startup.** Any IO or parse failure (missing file, malformed JSON, non-object JSON) logs a `warning` (`exc_info=True` for the IO/parse case) and falls back to the built-in defaults. A broken override file can never break Hermes startup.
- **`utf-8-sig`** is used when opening the file, to tolerate a UTF-8 BOM written by Windows GUI editors (per `CONTRIBUTING.md` → Cross-Platform Compatibility, rule 4).
- **Dict-typed constants are skipped.** `PLATFORM_HINTS` is a `dict[str, str]`, not a `str`. The loop gates on the existing constant being a `str`, so dict-typed constants (and any future non-string constant) are ignored with a debug log. This is the simplest correct option; a `PLATFORM_HINTS.cli`-style dotted-key scheme was considered and intentionally left out.
- Unknown keys are ignored with a debug log; known keys in the same file still apply.

## How to test

Automated (7 + 2 cases — unset/baseline, override-applied, BOM tolerance, missing file, malformed JSON, non-object JSON, unknown key, non-string value, dict-skip):

```
scripts/run_tests.sh tests/agent/test_prompt_overrides.py -- -q
```

Manual smoke:

```
printf '{"MEMORY_GUIDANCE": "test override"}' > /tmp/overrides.json
HERMES_PROMPT_OVERRIDES_JSON=/tmp/overrides.json hermes chat -q "hi"
```

## Platforms tested

macOS (darwin). The `utf-8-sig` path is exercised on macOS via `test_utf8_bom_file_is_tolerated` (same code path), but I have not run on Linux or Windows.

## Verified locally

Run on macOS (`hermes v0.14.0`, Python 3.11):

- **Unit tests** — `scripts/run_tests.sh tests/agent/test_prompt_overrides.py -- -q` → **9 passed** (the cases listed above). Existing prompt tests stay green: `tests/agent/test_prompt_builder.py`, `test_prompt_caching.py`, `test_system_prompt_restore.py` → **147 passed**. `ruff check` clean.
- **Startup smoke** — `HERMES_PROMPT_OVERRIDES_JSON=<file> hermes chat -q "hi"` started cleanly and exited 0: the hook doesn't break startup when the env var is set.
- **End-to-end A/B** (proves the override reaches the *live* system prompt, not just that startup is clean) — overrode the guidance sections with a directive to begin the reply with a unique sentinel token, then ran `hermes chat -q "hello"` twice:
  - **without** the env var → sentinel absent (0 occurrences)
  - **with** the env var → the model's reply began with the sentinel (1 occurrence)

  This confirms the full chain in a real process: env var → file read (`utf-8-sig`) → `globals()` mutation → `from agent.prompt_builder import …` binding in the consumer → assembled system prompt → model output. It also exercised multi-section override (four keys in one file).
