### PR TITLE
feat: per-user profile routing for messaging platforms

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -181,58 +181,27 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     .env/config loading, script resolution, AIAgent construction, and downstream
     get_hermes_home() callers agree on the same home.
 
-    Some existing provider/config paths still load profile .env values through
-    os.environ, so profile jobs also snapshot and restore the process
-    environment on exit. tick() runs profile jobs sequentially to keep that
-    temporary mutation isolated from other scheduled jobs.
+    Delegates to :func:`hermes_cli.profile_context.profile_context` for the
+    heavy lifting (home override, .env loading, environment snapshot/restore).
+    This wrapper additionally maintains the cron module's ``_hermes_home``
+    variable so ``_get_hermes_home()`` resolves correctly for direct callers.
     """
-    raw_profile = str(profile or "").strip()
-    if not raw_profile:
-        yield None
-        return
+    from hermes_cli.profile_context import profile_context
 
     global _hermes_home
     prior_override = _hermes_home
-    env_snapshot = os.environ.copy()
 
-    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
-    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    with profile_context(profile or "", label=job_id) as normalized:
+        if normalized is not None:
+            from hermes_cli.profiles import resolve_profile_env
+            from pathlib import Path as _Path
+            try:
+                _hermes_home = _Path(resolve_profile_env(normalized)).resolve()
+            except Exception:
+                pass
+        yield normalized
 
-    normalized_profile = normalize_profile_name(raw_profile)
-    try:
-        profile_home = Path(resolve_profile_env(normalized_profile)).resolve()
-    except (FileNotFoundError, ValueError) as exc:
-        logger.warning(
-            "Job '%s': configured profile %r no longer valid (%s) — "
-            "falling back to scheduler default",
-            job_id, raw_profile, exc,
-        )
-        yield None
-        return
-
-    override_token = None
-    try:
-        override_token = set_hermes_home_override(profile_home)
-        _hermes_home = profile_home
-        logger.info(
-            "Job '%s': using Hermes profile '%s' (%s)",
-            job_id,
-            normalized_profile,
-            profile_home,
-        )
-        yield normalized_profile
-    finally:
-        _hermes_home = prior_override
-        if override_token is not None:
-            reset_hermes_home_override(override_token)
-        # Delta-based restore: remove added keys, restore changed keys.
-        # Avoids a brief window where other threads see an empty env.
-        added = set(os.environ.keys()) - set(env_snapshot.keys())
-        for k in added:
-            os.environ.pop(k, None)
-        for k, v in env_snapshot.items():
-            if os.environ.get(k) != v:
-                os.environ[k] = v
+    _hermes_home = prior_override
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7860,6 +7860,22 @@ class GatewayRunner:
         self._running_agents_ts[_quick_key] = time.time()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
+        # ── Per-user profile routing ─────────────────────────────────
+        # If the platform supports user→profile mapping (e.g.
+        # SLACK_USER_PROFILE_MAP), enter that profile's context so the
+        # agent runs with the target profile's config, model, memory,
+        # skills, and .env.  Restored in the finally block below.
+        _profile_ctx = None
+        try:
+            from hermes_cli.profile_context import resolve_user_profile, profile_context
+            _platform_str = source.platform.value if hasattr(source.platform, 'value') else str(source.platform)
+            _resolved_profile = resolve_user_profile(_platform_str, source.user_id)
+            if _resolved_profile:
+                _profile_ctx = profile_context(_resolved_profile, label=f"user:{source.user_id}")
+                _profile_ctx.__enter__()
+        except Exception:
+            pass
+
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
@@ -7892,6 +7908,12 @@ class GatewayRunner:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
         finally:
+            # ── Exit per-user profile context ───────────────────────
+            if _profile_ctx is not None:
+                try:
+                    _profile_ctx.__exit__(None, None, None)
+                except Exception:
+                    pass
             # If _run_agent replaced the sentinel with a real agent and
             # then cleaned it up, this is a no-op.  If we exited early
             # (exception, command fallthrough, etc.) the sentinel must

--- a/hermes_cli/profile_context.py
+++ b/hermes_cli/profile_context.py
@@ -1,0 +1,136 @@
+"""
+Reusable Hermes profile context manager.
+
+Provides :func:`profile_context` — a context manager that temporarily
+switches the process to a named Hermes profile, loading its .env,
+config, and home directory. Used by the cron scheduler (per-job profile
+overrides) and the messaging gateway (per-user profile routing).
+
+Thread-safety: snapshots and restores os.environ via delta-based restore.
+Not safe for concurrent use within the same process; callers must
+serialise (cron scheduler does this, gateway runs one agent per session).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def profile_context(profile_name: str, label: str = ""):
+    """Temporarily switch the process to a named Hermes profile.
+
+    While active:
+    - ``get_hermes_home()`` returns the profile directory
+    - ``os.environ`` reflects the profile's .env (loaded on top of the
+      current environment)
+    - .env loading uses ``load_hermes_dotenv`` so it honours the same
+      override / project-env rules as the rest of the Hermes codebase
+
+    On exit the previous ``HERMES_HOME`` override and environment are
+    restored exactly.  New keys added by the profile .env are removed;
+    changed keys are reverted to their prior values.
+
+    Parameters
+    ----------
+    profile_name:
+        Canonical profile name (e.g. ``"automations"``).  Passed through
+        ``normalize_profile_name`` so casing / whitespace is forgiving.
+    label:
+        Human-readable context tag for log messages (e.g. a job ID, user
+        ID, or session key).  If empty, profile_name is used.
+
+    Yields
+    ------
+    str | None
+        The normalized profile name on success, or ``None`` if the
+        profile could not be resolved (caller should fall back to the
+        default profile).
+    """
+    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    raw = str(profile_name or "").strip()
+    if not raw:
+        yield None
+        return
+
+    tag = label or raw
+    normalized = normalize_profile_name(raw)
+
+    try:
+        profile_home = Path(resolve_profile_env(normalized)).resolve()
+    except (FileNotFoundError, ValueError) as exc:
+        logger.warning(
+            "Profile context '%s': profile %r not valid (%s) — "
+            "falling back to default",
+            tag, raw, exc,
+        )
+        yield None
+        return
+
+    env_snapshot = os.environ.copy()
+    override_token = None
+
+    try:
+        override_token = set_hermes_home_override(profile_home)
+        # Load the profile's .env into the current process environment.
+        # This surfaces API keys, tokens, home-channel vars, etc. so
+        # downstream code that reads os.environ sees the right values.
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv(
+            hermes_home=profile_home,
+            project_env=None,  # don't re-load project .env
+        )
+
+        logger.info(
+            "Profile context '%s': using profile '%s' (%s)",
+            tag, normalized, profile_home,
+        )
+        yield normalized
+    finally:
+        if override_token is not None:
+            reset_hermes_home_override(override_token)
+        # Delta-based restore so concurrent threads are not disrupted.
+        added = set(os.environ.keys()) - set(env_snapshot.keys())
+        for k in added:
+            os.environ.pop(k, None)
+        for k, v in env_snapshot.items():
+            if os.environ.get(k) != v:
+                os.environ[k] = v
+
+
+def resolve_user_profile(platform: str, user_id: Optional[str]) -> Optional[str]:
+    """Resolve a platform user ID to a Hermes profile name.
+
+    Reads ``{PLATFORM}_USER_PROFILE_MAP`` from the environment.
+    Format: ``user_id1:profile1,user_id2:profile2,...``
+
+    Returns the profile name if the user is mapped, or ``None``.
+    """
+    if not user_id or not platform:
+        return None
+
+    env_var = f"{platform.upper()}_USER_PROFILE_MAP"
+    raw = os.getenv(env_var, "").strip()
+    if not raw:
+        return None
+
+    mappings = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if ":" not in pair:
+            continue
+        uid, profile = pair.split(":", 1)
+        mappings[uid.strip()] = profile.strip()
+
+    return mappings.get(user_id)


### PR DESCRIPTION
## Summary

Adds `{PLATFORM}_USER_PROFILE_MAP` environment variable that maps platform user IDs to Hermes profiles, enabling a single bot to route different users to fully isolated agent profiles.

## Changes

- **New: `hermes_cli/profile_context.py`** — reusable profile context manager extracted from cron/scheduler.py, with `resolve_user_profile()` helper for platform-agnostic routing
- **Refactor: `cron/scheduler.py`** — `_job_profile_context` now delegates to shared `profile_context()`, keeping its `_hermes_home` wrapper
- **Add: `gateway/run.py`** — resolve per-user profile before agent run, enter profile context (HERMES_HOME override + .env loading), restore on exit

## How to use

```bash
# .env
SLACK_USER_PROFILE_MAP=U01ADMIN:default,U01TEAM:automations
```

When a message arrives from `U01TEAM`, the gateway enters the `automations` profile context, loading its config, model, toolsets, memory, and .env. On exit, the original environment is fully restored.

## Testing

- [x] `profile_context` import and unit tests pass
- [x] `resolve_user_profile` maps users correctly
- [x] `_job_profile_context` (cron) works with refactored code
- [x] Gateway compiles and runs cleanly
- [x] Slack gateway reconnects with no errors

Closes #33548