### PR TITLE
fix(cron): prevent perpetual-defer loop for slow recurring jobs (fixes #33315)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1048,7 +1048,12 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             rj["next_run_at"] = new_next
                             needs_save = True
                             break
-                    continue  # Skip this run
+                    # Fall through to due.append(job) — skip accumulated
+                    # missed slots (burst-catchup prevention) but still
+                    # execute once now.  Previously this was `continue`,
+                    # which caused perpetual-defer loops when a job's
+                    # execution time exceeded interval + grace.
+                    # (ref: https://github.com/NousResearch/hermes-agent/issues/33315)
 
             due.append(job)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -661,9 +661,13 @@ class TestGetDueJobs:
         assert due[0]["id"] == job["id"]
 
     def test_stale_past_due_skipped(self, tmp_cron_dir):
-        """Recurring jobs past their dynamic grace window are fast-forwarded, not fired.
+        """Recurring jobs past their dynamic grace window are fast-forwarded AND
+        still execute once (burst-catchup prevention + single execution).
 
         For an hourly job, grace = 30 min. Setting 35 min late exceeds the window.
+        The job should run now (not be silently skipped) and next_run_at should
+        be advanced to the next future slot.
+        (ref: https://github.com/NousResearch/hermes-agent/issues/33315)
         """
         job = create_job(prompt="Stale", schedule="every 1h")
         # Force next_run_at to 35 minutes ago (beyond the 30-min grace for hourly)
@@ -672,7 +676,9 @@ class TestGetDueJobs:
         save_jobs(jobs)
 
         due = get_due_jobs()
-        assert len(due) == 0
+        # Job executes once (no longer silently skipped)
+        assert len(due) == 1
+        assert due[0]["id"] == job["id"]
         # next_run_at should be fast-forwarded to the future
         updated = get_job(job["id"])
         from cron.jobs import _ensure_aware, _hermes_now


### PR DESCRIPTION
## Summary

Fixes #33315

### Problem

When a recurring cron job's execution time exceeds `interval + grace_period`, the scheduler enters a perpetual "missed → fast-forward → skip" loop. The job's `next_run_at` is correctly advanced to the next future slot, but `continue` silently skips execution. Result: the job effectively **never runs again**.

Observed in production: 42 consecutive "missed" events over 9 hours without a single execution.

### Fix

One-line change in `_get_due_jobs_locked()`: remove the `continue` after fast-forwarding `next_run_at`. The accumulated missed slots are still skipped (burst-catchup prevention via `compute_next_run(schedule, now)`), but the job now falls through to `due.append(job)` and **executes once**.

### Before/After

```python
# BEFORE: skip execution entirely
if (now - next_run_dt).total_seconds() > grace:
    new_next = compute_next_run(schedule, now.isoformat())
    # ... update next_run_at ...
    continue  # ← job never runs

# AFTER: execute once, skip accumulated slots
if (now - next_run_dt).total_seconds() > grace:
    new_next = compute_next_run(schedule, now.isoformat())
    # ... update next_run_at ...
    # fall through to due.append(job)
```

### Testing

- Updated `test_stale_past_due_skipped` to assert `len(due) == 1` (was `0`)
- All 373 cron tests pass