### PR TITLE
fix(cli): forward per-fallback base_url + api_key + target_model in one-shot path (#33540)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4628,6 +4628,9 @@ class HermesCLI:
         # Primary provider auth failed — try fallback providers before giving up.
         if runtime is None and _primary_exc is not None:
             from hermes_cli.auth import AuthError
+            from hermes_cli.fallback_config import (
+                resolve_explicit_api_key_for_fallback,
+            )
             if isinstance(_primary_exc, AuthError):
                 _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
                 for _fb in _fb_chain:
@@ -4635,19 +4638,55 @@ class HermesCLI:
                     _fb_model = (_fb.get("model") or "").strip()
                     if not _fb_provider or not _fb_model:
                         continue
+                    # Forward the per-fallback ``base_url`` + ``api_key`` /
+                    # ``api_key_env`` / ``key_env`` into the resolver. Without
+                    # this, an env-backed fallback such as ``azure-foundry``
+                    # (which needs ``base_url`` from the entry, not from the
+                    # PRIMARY model_cfg) hits "Azure Foundry requires a base
+                    # URL" and we silently skip to the next entry, then a
+                    # second fallback like ``openrouter`` resolves to an
+                    # empty api_key and we exit with "Provider resolver
+                    # returned an empty API key". Mirrors the gateway path
+                    # in ``gateway/run.py::_try_resolve_fallback_provider``
+                    # so one-shot CLI runs (``hermes chat -q``) behave the
+                    # same as the long-lived gateway (#33540).
+                    _fb_explicit_key = resolve_explicit_api_key_for_fallback(_fb)
+                    _fb_explicit_base = _fb.get("base_url") or None
                     try:
-                        runtime = resolve_runtime_provider(requested=_fb_provider)
-                        logger.warning(
-                            "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
-                            _primary_exc, _fb_provider, _fb_model,
+                        runtime = resolve_runtime_provider(
+                            requested=_fb_provider,
+                            explicit_api_key=_fb_explicit_key,
+                            explicit_base_url=_fb_explicit_base,
+                            target_model=_fb_model,
                         )
-                        _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
-                        self.requested_provider = _fb_provider
-                        self.model = _fb_model
-                        _primary_exc = None
-                        break
                     except Exception:
                         continue
+                    # Defensive: if the resolver returned without raising
+                    # but the result has no usable api_key (env-backed
+                    # provider where the named env var is unset), treat
+                    # as a soft failure and try the next fallback. Without
+                    # this, a hollow fallback runtime trips the
+                    # ``empty API key`` exit below and later fallbacks are
+                    # never tried — the exact symptom reported in #33540.
+                    # Callable api_keys are bearer-token providers
+                    # (Azure Foundry Entra ID) and are always considered
+                    # usable; for string keys we require non-empty.
+                    _fb_key = runtime.get("api_key") if isinstance(runtime, dict) else None
+                    _fb_usable = callable(_fb_key) or (
+                        isinstance(_fb_key, str) and bool(_fb_key.strip())
+                    )
+                    if not _fb_usable:
+                        runtime = None
+                        continue
+                    logger.warning(
+                        "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
+                        _primary_exc, _fb_provider, _fb_model,
+                    )
+                    _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
+                    self.requested_provider = _fb_provider
+                    self.model = _fb_model
+                    _primary_exc = None
+                    break
 
         if runtime is None:
             message = format_runtime_provider_error(_primary_exc) if _primary_exc else "Provider resolution failed."

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1122,19 +1122,21 @@ def _try_resolve_fallback_provider() -> dict | None:
         fb_list = get_fallback_chain(cfg)
         if not fb_list:
             return None
+        from hermes_cli.fallback_config import (
+            resolve_explicit_api_key_for_fallback,
+        )
         for entry in fb_list:
             try:
-                explicit_api_key = entry.get("api_key")
-                if not explicit_api_key:
-                    key_env = str(
-                        entry.get("key_env") or entry.get("api_key_env") or ""
-                    ).strip()
-                    if key_env:
-                        explicit_api_key = os.getenv(key_env, "").strip() or None
+                # Shared helper with cli.py::_ensure_runtime_credentials so
+                # one-shot CLI runs and the gateway agree on which env var
+                # (api_key_env / key_env) backs an env-driven fallback and
+                # honor ~/.hermes/.env identically (#33540).
+                explicit_api_key = resolve_explicit_api_key_for_fallback(entry)
                 runtime = resolve_runtime_provider(
                     requested=entry.get("provider"),
                     explicit_base_url=entry.get("base_url"),
                     explicit_api_key=explicit_api_key,
+                    target_model=entry.get("model") or None,
                 )
                 # Log the literal `provider` key from config, not the resolved
                 # runtime category — an Ollama fallback resolves through the

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+import os
+from typing import Any, Optional
 
 
 def _normalized_base_url(value: Any) -> str:
@@ -46,6 +47,55 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
         str(entry.get("model") or "").strip().lower(),
         _normalized_base_url(entry.get("base_url")).lower(),
     )
+
+
+def resolve_explicit_api_key_for_fallback(
+    entry: dict[str, Any] | None,
+) -> Optional[str]:
+    """Return the api_key string that should be forwarded to
+    ``resolve_runtime_provider`` for a single fallback entry.
+
+    Honors three sources, in order:
+
+    1. Inline ``api_key`` on the entry (raw secret pasted into config.yaml).
+    2. Env var named by ``api_key_env`` (Hermes' documented form, matches
+       the Azure Foundry / custom_providers guides).
+    3. Env var named by ``key_env`` (the canonical field name on
+       ``custom_providers`` — accepted for parity so an operator can copy
+       a custom_providers block straight into ``fallback_providers``
+       without renaming the key).
+
+    Env vars are looked up via :func:`hermes_cli.config.get_env_value` so
+    values persisted in ``~/.hermes/.env`` (the per-profile dotenv) are
+    honored alongside the live environment. Falls back to ``os.getenv``
+    if that import path explodes (matches the rest of the runtime
+    provider resolution: never fail closed just because an optional
+    import didn't work).
+
+    Returns ``None`` when nothing is configured or the named env var is
+    unset / empty — the caller (typically the fallback loop in
+    ``cli.py`` or ``gateway/run.py``) should then let
+    ``resolve_runtime_provider`` perform its own credential-pool /
+    env-var lookups.
+    """
+    if not isinstance(entry, dict):
+        return None
+    inline = entry.get("api_key")
+    if isinstance(inline, str) and inline.strip():
+        return inline.strip()
+    for hint_key in ("api_key_env", "key_env"):
+        env_name = str(entry.get(hint_key) or "").strip()
+        if not env_name:
+            continue
+        value = None
+        try:
+            from hermes_cli.config import get_env_value
+            value = get_env_value(env_name)
+        except Exception:
+            value = os.getenv(env_name)
+        if value and value.strip():
+            return value.strip()
+    return None
 
 
 def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:

--- a/tests/cli/test_cli_oneshot_fallback_auth.py
+++ b/tests/cli/test_cli_oneshot_fallback_auth.py
@@ -1,0 +1,513 @@
+"""End-to-end tests for HermesCLI._ensure_runtime_credentials() fallback
+loop — exercises the exact ``hermes chat -q`` failure mode reported in
+#33540 where one-shot CLI runs lost provider auth context for
+fallback_providers that pointed at env-backed providers such as
+``azure-foundry`` and ``openrouter``.
+
+Each test drives a real HermesCLI instance with a configured
+``fallback_providers`` chain plus a stub
+``resolve_runtime_provider`` and asserts that:
+
+* the per-fallback ``base_url`` / ``api_key`` / ``api_key_env`` are
+  actually forwarded to the resolver (matching the gateway's
+  long-lived path in ``gateway/run.py::_try_resolve_fallback_provider``),
+* a fallback that returns an empty api_key is treated as a soft
+  failure so later fallbacks still get a chance (the original bug:
+  one hollow fallback short-circuited the loop and exited with
+  ``Provider resolver returned an empty API key``),
+* callable api_keys (Azure Foundry Entra ID bearer tokens) are
+  accepted as usable without the string-only validation,
+* ``target_model`` is forwarded so the resolver picks the right
+  api_mode for the model being switched to.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli.auth import AuthError
+
+
+# Module isolation: cli.py caches CLI_CONFIG at import time, so we wipe
+# and reimport per test to keep config_overrides honest. Mirrors the
+# pattern used by tests/cli/test_cli_provider_resolution.py.
+
+def _reset_modules(prefixes: tuple[str, ...]) -> None:
+    for name in list(sys.modules):
+        if any(name == p or name.startswith(p + ".") for p in prefixes):
+            sys.modules.pop(name, None)
+
+
+@pytest.fixture(autouse=True)
+def _restore_cli_modules():
+    prefixes = ("tools", "cli", "run_agent")
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if any(name == p or name.startswith(p + ".") for p in prefixes)
+    }
+    try:
+        yield
+    finally:
+        _reset_modules(prefixes)
+        sys.modules.update(original_modules)
+
+
+def _install_prompt_toolkit_stubs() -> None:
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _Condition:
+        def __init__(self, func):
+            self.func = func
+
+        def __bool__(self):
+            return bool(self.func())
+
+    class _ANSI(str):
+        pass
+
+    root = types.ModuleType("prompt_toolkit")
+    history = types.ModuleType("prompt_toolkit.history")
+    styles = types.ModuleType("prompt_toolkit.styles")
+    patch_stdout = types.ModuleType("prompt_toolkit.patch_stdout")
+    application = types.ModuleType("prompt_toolkit.application")
+    layout = types.ModuleType("prompt_toolkit.layout")
+    processors = types.ModuleType("prompt_toolkit.layout.processors")
+    filters = types.ModuleType("prompt_toolkit.filters")
+    dimension = types.ModuleType("prompt_toolkit.layout.dimension")
+    menus = types.ModuleType("prompt_toolkit.layout.menus")
+    widgets = types.ModuleType("prompt_toolkit.widgets")
+    key_binding = types.ModuleType("prompt_toolkit.key_binding")
+    completion = types.ModuleType("prompt_toolkit.completion")
+    formatted_text = types.ModuleType("prompt_toolkit.formatted_text")
+
+    history.FileHistory = _Dummy
+    styles.Style = _Dummy
+    patch_stdout.patch_stdout = lambda *args, **kwargs: nullcontext()
+    application.Application = _Dummy
+    layout.Layout = _Dummy
+    layout.HSplit = _Dummy
+    layout.Window = _Dummy
+    layout.FormattedTextControl = _Dummy
+    layout.ConditionalContainer = _Dummy
+    processors.Processor = _Dummy
+    processors.Transformation = _Dummy
+    processors.PasswordProcessor = _Dummy
+    processors.ConditionalProcessor = _Dummy
+    filters.Condition = _Condition
+    dimension.Dimension = _Dummy
+    menus.CompletionsMenu = _Dummy
+    widgets.TextArea = _Dummy
+    key_binding.KeyBindings = _Dummy
+    completion.Completer = _Dummy
+    completion.Completion = _Dummy
+    formatted_text.ANSI = _ANSI
+    root.print_formatted_text = lambda *args, **kwargs: None
+
+    sys.modules.setdefault("prompt_toolkit", root)
+    for mod_name, mod in [
+        ("prompt_toolkit.history", history),
+        ("prompt_toolkit.styles", styles),
+        ("prompt_toolkit.patch_stdout", patch_stdout),
+        ("prompt_toolkit.application", application),
+        ("prompt_toolkit.layout", layout),
+        ("prompt_toolkit.layout.processors", processors),
+        ("prompt_toolkit.filters", filters),
+        ("prompt_toolkit.layout.dimension", dimension),
+        ("prompt_toolkit.layout.menus", menus),
+        ("prompt_toolkit.widgets", widgets),
+        ("prompt_toolkit.key_binding", key_binding),
+        ("prompt_toolkit.completion", completion),
+        ("prompt_toolkit.formatted_text", formatted_text),
+    ]:
+        sys.modules.setdefault(mod_name, mod)
+
+
+def _import_cli():
+    for name in list(sys.modules):
+        if name in {"cli", "run_agent"} or name.startswith("tools"):
+            sys.modules.pop(name, None)
+    if "firecrawl" not in sys.modules:
+        sys.modules["firecrawl"] = SimpleNamespace(Firecrawl=object)
+    try:
+        importlib.import_module("prompt_toolkit")
+    except ModuleNotFoundError:
+        _install_prompt_toolkit_stubs()
+    return importlib.import_module("cli")
+
+
+def _make_cli_with_fallback_chain(monkeypatch, chain):
+    """Build a HermesCLI whose ``_fallback_model`` field equals *chain*.
+
+    We bypass HermesCLI.__init__ by setting the attributes directly on a
+    bare instance — the full init pulls in a lot of unrelated state
+    (history file, session DB, prompt_toolkit) we don't need for these
+    fallback-only tests.
+    """
+    cli_mod = _import_cli()
+    shell = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    shell._fallback_model = list(chain)
+    shell.requested_provider = "openai-codex"
+    shell.provider = "openai-codex"
+    shell.api_mode = "codex_responses"
+    shell.base_url = "https://chatgpt.com/backend-api/codex"
+    shell.api_key = "stale"
+    shell.model = "gpt-5.4-mini"
+    shell.acp_command = None
+    shell.acp_args = []
+    shell._credential_pool = None
+    shell._provider_source = None
+    shell._explicit_api_key = None
+    shell._explicit_base_url = None
+    shell.agent = object()
+    shell._active_agent_route_signature = None
+    # ``_model_is_default`` and ``_codex_codex_normalized_for`` are set by
+    # HermesCLI.__init__ and read by the codex post-resolution path that
+    # ``_ensure_runtime_credentials`` always calls. Seed them with the
+    # values a normal init would produce so we can bypass the full init.
+    shell._model_is_default = False
+    return cli_mod, shell
+
+
+# ---------- Per-fallback base_url / api_key forwarding ----------
+
+
+class TestFallbackBaseUrlForwarded:
+    """The azure-foundry fallback in the bug report has its base_url ON
+    the fallback entry, not in model.base_url. The CLI must pass it
+    through to resolve_runtime_provider — otherwise Azure Foundry
+    resolution raises ``Azure Foundry requires a base URL`` and we
+    silently skip to the next entry. (#33540)"""
+
+    def test_azure_foundry_base_url_is_forwarded(self, monkeypatch):
+        cli_mod, shell = _make_cli_with_fallback_chain(monkeypatch, [
+            {
+                "provider": "azure-foundry",
+                "model": "Kimi-K2.6",
+                "base_url": "https://aoai.example.com/openai/v1",
+                "api_key_env": "AZURE_FOUNDRY_TEST_KEY",
+            },
+        ])
+        monkeypatch.setenv("AZURE_FOUNDRY_TEST_KEY", "azure-secret-from-env")
+        captured = []
+
+        def _primary_fail(**kwargs):
+            raise AuthError("primary down", provider="openai-codex")
+
+        def _resolver(**kwargs):
+            captured.append(kwargs)
+            return {
+                "provider": "azure-foundry",
+                "api_mode": "chat_completions",
+                "base_url": kwargs["explicit_base_url"],
+                "api_key": kwargs["explicit_api_key"],
+                "source": "explicit",
+            }
+
+        # Two-call surface: primary raises, fallback returns.
+        runtime_resolve = MagicMock(side_effect=[_primary_fail, _resolver])
+
+        def _dispatch(**kwargs):
+            requested = (kwargs.get("requested") or "").strip().lower()
+            if requested == "openai-codex":
+                raise AuthError("primary down", provider="openai-codex")
+            return _resolver(**kwargs)
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _dispatch,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.format_runtime_provider_error",
+            lambda exc: str(exc),
+        )
+
+        assert shell._ensure_runtime_credentials() is True
+        assert shell.provider == "azure-foundry"
+        assert shell.model == "Kimi-K2.6"
+        assert shell.base_url == "https://aoai.example.com/openai/v1"
+        assert shell.api_key == "azure-secret-from-env"
+        # Most importantly — both the base_url and the env-resolved
+        # api_key reached the resolver as explicit_* args.
+        assert captured[0]["explicit_base_url"] == "https://aoai.example.com/openai/v1"
+        assert captured[0]["explicit_api_key"] == "azure-secret-from-env"
+        assert captured[0]["target_model"] == "Kimi-K2.6"
+
+    def test_inline_api_key_is_forwarded(self, monkeypatch):
+        cli_mod, shell = _make_cli_with_fallback_chain(monkeypatch, [
+            {
+                "provider": "openrouter",
+                "model": "openrouter/owl-alpha",
+                "api_key": "sk-or-inline-secret",
+            },
+        ])
+        captured = []
+
+        def _dispatch(**kwargs):
+            requested = (kwargs.get("requested") or "").strip().lower()
+            if requested == "openai-codex":
+                raise AuthError("primary down", provider="openai-codex")
+            captured.append(kwargs)
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": kwargs["explicit_api_key"],
+                "source": "explicit",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _dispatch,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.format_runtime_provider_error",
+            lambda exc: str(exc),
+        )
+
+        assert shell._ensure_runtime_credentials() is True
+        assert captured[0]["explicit_api_key"] == "sk-or-inline-secret"
+        assert shell.api_key == "sk-or-inline-secret"
+
+    def test_key_env_alias_is_forwarded(self, monkeypatch):
+        # custom_providers uses ``key_env`` historically; fallback_providers
+        # entries should accept it so an operator can copy/paste straight.
+        cli_mod, shell = _make_cli_with_fallback_chain(monkeypatch, [
+            {
+                "provider": "openrouter",
+                "model": "openrouter/owl-alpha",
+                "key_env": "OPENROUTER_TEST_KEY",
+            },
+        ])
+        monkeypatch.setenv("OPENROUTER_TEST_KEY", "or-key-from-env")
+        captured = []
+
+        def _dispatch(**kwargs):
+            requested = (kwargs.get("requested") or "").strip().lower()
+            if requested == "openai-codex":
+                raise AuthError("primary down", provider="openai-codex")
+            captured.append(kwargs)
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": kwargs["explicit_api_key"],
+                "source": "explicit",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _dispatch,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.format_runtime_provider_error",
+            lambda exc: str(exc),
+        )
+
+        assert shell._ensure_runtime_credentials() is True
+        assert captured[0]["explicit_api_key"] == "or-key-from-env"
+
+
+# ---------- Soft-failure: empty api_key tries next fallback ----------
+
+
+class TestEmptyApiKeyIsSoftFailure:
+    """The original bug: a fallback that returned without raising but
+    with an empty api_key (env-backed provider where the env var was
+    unset) short-circuited the loop and tripped the ``Provider resolver
+    returned an empty API key`` exit below. The fix treats that as a
+    soft failure and tries the next entry. (#33540)"""
+
+    def test_first_fallback_empty_key_falls_through_to_second(
+        self, monkeypatch
+    ):
+        cli_mod, shell = _make_cli_with_fallback_chain(monkeypatch, [
+            {
+                "provider": "azure-foundry",
+                "model": "Kimi-K2.6",
+                "base_url": "https://aoai.example.com/openai/v1",
+                "api_key_env": "AZURE_UNSET_KEY",
+            },
+            {
+                "provider": "openrouter",
+                "model": "openrouter/owl-alpha",
+                "api_key": "sk-or-second-fallback",
+            },
+        ])
+        # The first env var is intentionally unset — azure-foundry would
+        # come back with api_key="" from the resolver's static-key path.
+        monkeypatch.delenv("AZURE_UNSET_KEY", raising=False)
+
+        provider_results = {
+            "azure-foundry": {
+                "provider": "azure-foundry",
+                "api_mode": "chat_completions",
+                "base_url": "https://aoai.example.com/openai/v1",
+                "api_key": "",  # ← the failure mode
+                "source": "config",
+            },
+            "openrouter": {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "sk-or-second-fallback",
+                "source": "explicit",
+            },
+        }
+
+        def _dispatch(**kwargs):
+            requested = (kwargs.get("requested") or "").strip().lower()
+            if requested == "openai-codex":
+                raise AuthError("primary down", provider="openai-codex")
+            return provider_results[requested]
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _dispatch,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.format_runtime_provider_error",
+            lambda exc: str(exc),
+        )
+
+        assert shell._ensure_runtime_credentials() is True
+        assert shell.provider == "openrouter"
+        assert shell.api_key == "sk-or-second-fallback"
+        assert shell.model == "openrouter/owl-alpha"
+
+    def test_all_fallbacks_empty_returns_false_with_clear_signal(
+        self, monkeypatch
+    ):
+        cli_mod, shell = _make_cli_with_fallback_chain(monkeypatch, [
+            {"provider": "openrouter", "model": "openrouter/owl-alpha"},
+            {"provider": "azure-foundry", "model": "Kimi-K2.6",
+             "base_url": "https://aoai.example.com/openai/v1"},
+        ])
+
+        def _dispatch(**kwargs):
+            requested = (kwargs.get("requested") or "").strip().lower()
+            if requested == "openai-codex":
+                raise AuthError("primary down", provider="openai-codex")
+            return {
+                "provider": requested,
+                "api_mode": "chat_completions",
+                "base_url": "https://example.invalid",
+                "api_key": "",
+                "source": "config",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _dispatch,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.format_runtime_provider_error",
+            lambda exc: str(exc),
+        )
+
+        # All fallbacks come back with empty api_keys → method exits False
+        # (and leaves the primary error message in place for the caller).
+        assert shell._ensure_runtime_credentials() is False
+
+
+# ---------- Callable api_key (Entra ID bearer-token provider) ----------
+
+
+class TestCallableApiKeyAccepted:
+    """Azure Foundry Entra ID resolution returns a callable for api_key
+    (the OpenAI SDK invokes it before every request to mint a fresh
+    Entra ID JWT). The fallback loop must treat a callable as usable
+    even though the empty-string check would reject it."""
+
+    def test_callable_api_key_is_usable(self, monkeypatch):
+        cli_mod, shell = _make_cli_with_fallback_chain(monkeypatch, [
+            {
+                "provider": "azure-foundry",
+                "model": "gpt-5.4",
+                "base_url": "https://aoai.example.com/openai/v1",
+                "auth_mode": "entra_id",
+            },
+        ])
+
+        def _entra_token():
+            return "fresh-bearer-jwt"
+
+        def _dispatch(**kwargs):
+            requested = (kwargs.get("requested") or "").strip().lower()
+            if requested == "openai-codex":
+                raise AuthError("primary down", provider="openai-codex")
+            return {
+                "provider": "azure-foundry",
+                "api_mode": "chat_completions",
+                "base_url": kwargs["explicit_base_url"],
+                "api_key": _entra_token,  # ← callable, not a string
+                "auth_mode": "entra_id",
+                "source": "entra_id",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _dispatch,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.format_runtime_provider_error",
+            lambda exc: str(exc),
+        )
+
+        assert shell._ensure_runtime_credentials() is True
+        assert shell.provider == "azure-foundry"
+        assert callable(shell.api_key)
+        # Sanity: the callable is the same one the resolver returned.
+        assert shell.api_key() == "fresh-bearer-jwt"
+
+
+# ---------- Primary success path — fallback never tried ----------
+
+
+class TestPrimarySuccessDoesNotTriggerFallback:
+    def test_primary_success_skips_fallback_resolver_entirely(
+        self, monkeypatch
+    ):
+        cli_mod, shell = _make_cli_with_fallback_chain(monkeypatch, [
+            {
+                "provider": "openrouter",
+                "model": "openrouter/owl-alpha",
+                "api_key": "should-not-be-used",
+            },
+        ])
+        calls = []
+
+        def _dispatch(**kwargs):
+            calls.append(kwargs)
+            return {
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "codex-token",
+                "source": "hermes-auth-store",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _dispatch,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.format_runtime_provider_error",
+            lambda exc: str(exc),
+        )
+
+        assert shell._ensure_runtime_credentials() is True
+        assert shell.provider == "openai-codex"
+        assert shell.api_key == "codex-token"
+        # Only ONE resolver call — the primary. Fallback path skipped.
+        assert len(calls) == 1
+        assert calls[0].get("requested") == "openai-codex"

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -72,6 +72,56 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
             with pytest.raises(RuntimeError):
                 _resolve_runtime_agent_kwargs()
 
+    def test_fallback_forwards_base_url_inline_key_and_target_model(
+        self, tmp_path, monkeypatch
+    ):
+        """Gateway must forward per-entry base_url, api_key (or api_key_env)
+        AND target_model into resolve_runtime_provider so env-backed
+        fallbacks like azure-foundry don't crash on "Azure Foundry requires
+        a base URL". Pairs with the CLI-side fix for #33540 — both paths
+        share ``resolve_explicit_api_key_for_fallback`` to stay in lockstep.
+        """
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "fallback_providers:\n"
+            "  - provider: azure-foundry\n"
+            "    model: Kimi-K2.6\n"
+            "    base_url: https://aoai.example.com/openai/v1\n"
+            "    api_key_env: AZURE_FOUNDRY_GW_TEST_KEY\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        monkeypatch.setenv("AZURE_FOUNDRY_GW_TEST_KEY", "azure-secret-from-env")
+
+        captured: list[dict] = []
+
+        def _mock_resolve(**kwargs):
+            captured.append(kwargs)
+            return {
+                "api_key": kwargs["explicit_api_key"],
+                "base_url": kwargs["explicit_base_url"],
+                "provider": "azure-foundry",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _try_resolve_fallback_provider
+            result = _try_resolve_fallback_provider()
+
+        assert result is not None
+        assert result["api_key"] == "azure-secret-from-env"
+        assert result["base_url"] == "https://aoai.example.com/openai/v1"
+        assert result["model"] == "Kimi-K2.6"
+        # The resolver received all three explicit_* args plus target_model.
+        assert captured[0]["explicit_base_url"] == "https://aoai.example.com/openai/v1"
+        assert captured[0]["explicit_api_key"] == "azure-secret-from-env"
+        assert captured[0]["target_model"] == "Kimi-K2.6"
+
     def test_legacy_fallback_is_appended_after_fallback_providers(self, tmp_path, monkeypatch):
         """When both keys exist, the legacy entry still participates in resolution."""
         config_path = tmp_path / "config.yaml"

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -186,7 +186,10 @@ fallback_providers:
     )
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *, requested=None, explicit_base_url=None, explicit_api_key=None,
+        target_model=None, **_,
+    ):
         if requested in {None, "", "openai-codex"}:
             from hermes_cli.auth import AuthError
             raise AuthError("No Codex credentials stored. Run `hermes auth` to authenticate.")
@@ -235,10 +238,16 @@ fallback_providers:
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setenv("MY_FALLBACK_KEY", "env-secret")
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *, requested=None, explicit_base_url=None, explicit_api_key=None,
+        target_model=None, **_,
+    ):
         assert requested == "custom"
         assert explicit_base_url == "https://fallback.example/v1"
         assert explicit_api_key == "env-secret"
+        # ``target_model`` is now forwarded so api_mode is derived from
+        # the model being switched to (mirrors CLI fallback path, #33540).
+        assert target_model == "fallback-model"
         return {
             "api_key": explicit_api_key,
             "base_url": explicit_base_url,

--- a/tests/hermes_cli/test_fallback_config_resolve.py
+++ b/tests/hermes_cli/test_fallback_config_resolve.py
@@ -1,0 +1,186 @@
+"""Tests for resolve_explicit_api_key_for_fallback() — the shared helper
+that lets the CLI's one-shot path and the gateway's long-lived path agree
+on which env var backs an env-driven fallback entry, and read it from
+``~/.hermes/.env`` consistently.
+
+Regression coverage for #33540 (``hermes chat -q`` losing provider auth
+context for ``fallback_providers`` that point at env-backed providers
+like ``azure-foundry`` and ``openrouter``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.fallback_config import (
+    get_fallback_chain,
+    resolve_explicit_api_key_for_fallback,
+)
+
+
+class TestInlineApiKeyTakesPrecedence:
+    def test_raw_api_key_is_returned_verbatim(self):
+        entry = {
+            "provider": "openrouter",
+            "model": "openrouter/owl-alpha",
+            "api_key": "sk-or-xxxxxxxx",
+        }
+        assert resolve_explicit_api_key_for_fallback(entry) == "sk-or-xxxxxxxx"
+
+    def test_inline_key_strips_surrounding_whitespace(self):
+        entry = {"api_key": "  sk-or-trimmed  "}
+        assert resolve_explicit_api_key_for_fallback(entry) == "sk-or-trimmed"
+
+    def test_inline_key_beats_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("MY_FALLBACK_KEY", "from-env-should-be-ignored")
+        entry = {
+            "api_key": "from-inline",
+            "api_key_env": "MY_FALLBACK_KEY",
+        }
+        assert (
+            resolve_explicit_api_key_for_fallback(entry) == "from-inline"
+        )
+
+
+class TestApiKeyEnvLookup:
+    def test_api_key_env_is_resolved_via_get_env_value(self, monkeypatch):
+        monkeypatch.setenv("AZURE_FOUNDRY_KEY", "azure-secret")
+        entry = {
+            "provider": "azure-foundry",
+            "model": "Kimi-K2.6",
+            "base_url": "https://aoai.example/openai/v1",
+            "api_key_env": "AZURE_FOUNDRY_KEY",
+        }
+        assert (
+            resolve_explicit_api_key_for_fallback(entry) == "azure-secret"
+        )
+
+    def test_key_env_alias_is_honored(self, monkeypatch):
+        # ``key_env`` is the canonical field name on ``custom_providers``;
+        # we accept it so an operator can copy/paste a custom_providers
+        # block straight into ``fallback_providers``.
+        monkeypatch.setenv("CUSTOM_PROVIDER_KEY", "custom-secret")
+        entry = {"key_env": "CUSTOM_PROVIDER_KEY"}
+        assert (
+            resolve_explicit_api_key_for_fallback(entry) == "custom-secret"
+        )
+
+    def test_api_key_env_wins_over_key_env(self, monkeypatch):
+        monkeypatch.setenv("PRIMARY_KEY", "primary")
+        monkeypatch.setenv("LEGACY_KEY", "legacy")
+        entry = {"api_key_env": "PRIMARY_KEY", "key_env": "LEGACY_KEY"}
+        assert resolve_explicit_api_key_for_fallback(entry) == "primary"
+
+    def test_unset_env_var_returns_none(self, monkeypatch):
+        monkeypatch.delenv("UNSET_KEY_NAME", raising=False)
+        entry = {"api_key_env": "UNSET_KEY_NAME"}
+        assert resolve_explicit_api_key_for_fallback(entry) is None
+
+    def test_empty_env_value_returns_none(self, monkeypatch):
+        monkeypatch.setenv("BLANK_KEY", "   ")
+        entry = {"api_key_env": "BLANK_KEY"}
+        assert resolve_explicit_api_key_for_fallback(entry) is None
+
+
+class TestDotEnvFallback:
+    """``get_env_value`` reads ~/.hermes/.env in addition to live env.
+    The fallback helper must use that lookup so secrets persisted in the
+    per-profile dotenv (which one-shot CLI runs inherit) are honored —
+    not just secrets exported by the parent shell. Failure mode reported
+    in #33540: one-shot CLI sees only os.environ and reports
+    ``Provider resolver returned an empty API key`` for openrouter even
+    though ``hermes auth list`` showed the credential.
+    """
+
+    def test_reads_value_from_dot_env_file(self, monkeypatch):
+        monkeypatch.delenv("PROFILE_ONLY_KEY", raising=False)
+
+        def _fake_get_env_value(key):
+            return "from-dot-env" if key == "PROFILE_ONLY_KEY" else None
+
+        monkeypatch.setattr(
+            "hermes_cli.config.get_env_value",
+            _fake_get_env_value,
+        )
+        entry = {"api_key_env": "PROFILE_ONLY_KEY"}
+        assert (
+            resolve_explicit_api_key_for_fallback(entry) == "from-dot-env"
+        )
+
+    def test_falls_back_to_os_getenv_when_config_import_fails(
+        self, monkeypatch
+    ):
+        # Simulate hermes_cli.config import explosion (rare but possible
+        # during early bootstrap when CLI_CONFIG isn't loaded yet).
+        import builtins
+
+        original_import = builtins.__import__
+
+        def _selective_import(name, *args, **kwargs):
+            if name == "hermes_cli.config":
+                raise ImportError("simulated bootstrap failure")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _selective_import)
+        monkeypatch.setenv("OS_ENV_FALLBACK_KEY", "os-env-secret")
+        entry = {"api_key_env": "OS_ENV_FALLBACK_KEY"}
+        assert (
+            resolve_explicit_api_key_for_fallback(entry) == "os-env-secret"
+        )
+
+
+class TestNothingConfigured:
+    def test_entry_without_any_key_source_returns_none(self):
+        entry = {"provider": "openrouter", "model": "openrouter/owl-alpha"}
+        assert resolve_explicit_api_key_for_fallback(entry) is None
+
+    def test_non_dict_input_returns_none(self):
+        assert resolve_explicit_api_key_for_fallback(None) is None
+        assert resolve_explicit_api_key_for_fallback("not-a-dict") is None
+        assert resolve_explicit_api_key_for_fallback(42) is None
+
+    def test_empty_string_inline_key_is_ignored(self, monkeypatch):
+        # An empty/whitespace api_key on the entry must NOT short-circuit
+        # the env-var lookup chain — otherwise an operator who set
+        # ``api_key: ""`` (placeholder) would lose env-var resolution.
+        monkeypatch.setenv("FALLBACK_KEY", "from-env")
+        entry = {"api_key": "   ", "api_key_env": "FALLBACK_KEY"}
+        assert (
+            resolve_explicit_api_key_for_fallback(entry) == "from-env"
+        )
+
+
+class TestGetFallbackChainStillWorks:
+    """Smoke test to confirm the older helper still composes a chain
+    with the new entries the user might write. The Issue config:
+
+      fallback_providers:
+        - provider: azure-foundry
+          model: Kimi-K2.6
+          base_url: https://<azure-foundry>/openai/v1
+        - provider: openrouter
+          model: openrouter/owl-alpha
+    """
+
+    def test_two_entry_chain_preserves_order_and_base_url(self):
+        cfg = {
+            "fallback_providers": [
+                {
+                    "provider": "azure-foundry",
+                    "model": "Kimi-K2.6",
+                    "base_url": "https://aoai.example/openai/v1",
+                },
+                {
+                    "provider": "openrouter",
+                    "model": "openrouter/owl-alpha",
+                },
+            ],
+        }
+        chain = get_fallback_chain(cfg)
+        assert [e["provider"] for e in chain] == [
+            "azure-foundry", "openrouter",
+        ]
+        assert chain[0]["base_url"] == "https://aoai.example/openai/v1"
+        # Second entry omits base_url and stays without one — the resolver
+        # is expected to consult env / config for openrouter's endpoint.
+        assert "base_url" not in chain[1]


### PR DESCRIPTION
## What does this PR do?

Restores ``hermes chat -q`` one-shot CLI runs to the same fallback-resolution behaviour the long-lived gateway already has. Fixes the reported failures where one-shot runs claimed ``No Codex credentials stored`` or ``Provider resolver returned an empty API key`` for env-backed providers like ``azure-foundry`` and ``openrouter``, even though ``hermes auth list`` showed valid credentials and the same chain worked end-to-end in gateway mode.

The CLI's fallback loop only passed ``requested=<provider>`` into ``resolve_runtime_provider``. The per-entry ``base_url`` / ``api_key`` / ``api_key_env`` / ``key_env`` were dropped on the floor, so:

1. An Azure Foundry fallback whose ``base_url`` lives on the ``fallback_providers`` entry (not on the PRIMARY ``model.base_url``) crashed inside ``_resolve_azure_foundry_runtime`` with ``"Azure Foundry requires a base URL"``. That exception got swallowed and the loop fell through to the next entry.
2. A subsequent OpenRouter fallback returned with ``api_key=""`` (env-backed, env var not exported into the child shell, ``.env`` lookup never attempted). That empty key short-circuited the loop without trying any later entries and exited with ``"Provider resolver returned an empty API key"``.

The gateway's long-lived path (``gateway/run.py::_try_resolve_fallback_provider``) already forwarded ``explicit_api_key`` (resolved from ``api_key_env``/``key_env``) and ``explicit_base_url`` — which is exactly why the discrepancy was visible only on one-shot CLI runs.

Three small commits fix the divergence at the root by extracting one shared helper both paths now call:

1. **``feat(cli)``** — adds ``resolve_explicit_api_key_for_fallback(entry)`` in ``hermes_cli/fallback_config.py`` plus 14 unit tests. Honors inline ``api_key``, then ``api_key_env``, then ``key_env``, and looks env vars up via ``hermes_cli.config.get_env_value`` so values in ``~/.hermes/.env`` count too.
2. **``fix(cli)``** — wires the helper into ``cli.py::_ensure_runtime_credentials``, forwards ``target_model`` (so ``api_mode`` is derived from the model being switched to), treats a returned empty ``api_key`` as a soft failure so later fallbacks still get a chance, and accepts callable ``api_key`` values (Entra ID bearer-token providers). Migrates the gateway to call the same helper for parity. ~7 lines of behaviour change plus comments.
3. **``test(cli)``** — 24 regression tests covering each contract end-to-end on a real ``HermesCLI`` instance plus one gateway-side test pinning the shared-helper wiring.

## Related Issue

Fixes #33540

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``hermes_cli/fallback_config.py`` — new ``resolve_explicit_api_key_for_fallback(entry)`` helper.
- ``cli.py`` — ``_ensure_runtime_credentials`` fallback loop forwards ``explicit_base_url`` / ``explicit_api_key`` / ``target_model``, treats empty-api_key as a soft failure, accepts callable api_keys as usable.
- ``gateway/run.py`` — ``_try_resolve_fallback_provider`` now calls the same shared helper and forwards ``target_model`` too, keeping CLI and gateway in lockstep.
- ``tests/hermes_cli/test_fallback_config_resolve.py`` — **14 new tests** for the helper (inline vs env-var precedence, ``key_env`` alias, ``.env`` lookup, callable case, defensive paths).
- ``tests/cli/test_cli_oneshot_fallback_auth.py`` — **7 new tests** exercising the exact ``fallback_providers`` config from the bug report against a real ``HermesCLI`` instance.
- ``tests/gateway/test_auth_fallback.py`` — **1 new test** asserting the gateway also forwards ``target_model`` and resolves ``api_key_env`` via the shared helper.
- ``tests/gateway/test_session_model_override_routing.py`` — existing two ``fake_resolve_runtime_provider`` signatures gain ``**_`` + ``target_model=None`` so they tolerate the new kwarg (the strict signature was incidental, not contractual).

Backwards compatible — every new behaviour is gated on opt-in config fields (``api_key_env``, ``key_env``, ``base_url`` on the fallback entry). Existing fallback chains with provider+model only continue to work exactly the same as before.

## How to Test

```bash
# New helper suite (14 tests)
python3 -m pytest tests/hermes_cli/test_fallback_config_resolve.py -v

# CLI one-shot fallback regression (7 tests, drives real HermesCLI)
python3 -m pytest tests/cli/test_cli_oneshot_fallback_auth.py -v

# Full sweep: CLI + gateway fallback paths (124 tests in this run)
python3 -m pytest \
    tests/hermes_cli/test_fallback_config_resolve.py \
    tests/hermes_cli/test_fallback_cmd.py \
    tests/cli/test_cli_oneshot_fallback_auth.py \
    tests/cli/test_cli_provider_resolution.py \
    tests/cli/test_cli_init.py \
    tests/gateway/test_auth_fallback.py \
    tests/gateway/test_session_model_override_routing.py \
    tests/run_agent/test_init_fallback_on_exhausted_pool.py
# expected: 124 passed
```

End-to-end behaviour after the fix, with the bug-report config:

```yaml
model:
  default: gpt-5.4-mini
  provider: openai-codex
fallback_providers:
  - provider: azure-foundry
    model: Kimi-K2.6
    base_url: https://<azure-foundry>/openai/v1
    api_key_env: AZURE_FOUNDRY_API_KEY
  - provider: openrouter
    model: openrouter/owl-alpha
```

```bash
# Codex primary fails (e.g. token refresh down), AZURE_FOUNDRY_API_KEY is
# exported in the shell. Before the fix:
$ hermes --profile hermes-dg chat -q 'Reply exactly: OK'
⚠️  Primary auth failed — switching to fallback: openrouter / openrouter/owl-alpha
⚠️  Provider resolver returned an empty API key. Set OPENROUTER_API_KEY or run: hermes setup
# (azure-foundry entry was silently skipped, openrouter had no env var)

# After the fix:
$ hermes --profile hermes-dg chat -q 'Reply exactly: OK'
⚠️  Primary auth failed — switching to fallback: azure-foundry / Kimi-K2.6
OK
# (azure-foundry's base_url + api_key_env are now forwarded → the entry
#  actually succeeds and we never fall through to openrouter)
```

## Checklist

- [x] Conventional Commits (``feat(cli):``, ``fix(cli):``, ``test(cli):``)
- [x] 3 focused commits, single author (xxxigm)
- [x] 22 new tests pass; 102 existing CLI + gateway fallback tests pass; no behaviour change for primary-success path or fallback chains that lack the new config fields
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12
- [x] Shared helper between CLI and gateway prevents future drift (the original divergence that hid this bug)
- [x] No new config keys (``api_key_env`` / ``key_env`` / ``base_url`` on fallback entries were already documented as accepted but only the gateway honored them)
