### PR TITLE
Fix retired Gemini model aliases

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -33,6 +33,19 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 
+_GEMINI_MODEL_ALIASES = {
+    "gemini-3-flash": "gemini-3-flash-preview",
+    "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+    "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+}
+
+
+def _normalize_gemini_model_id(model: str) -> str:
+    normalized = str(model or "").strip()
+    if normalized.startswith("models/"):
+        normalized = normalized[len("models/") :]
+    return _GEMINI_MODEL_ALIASES.get(normalized, normalized)
+
 
 def is_native_gemini_base_url(base_url: str) -> bool:
     """Return True when the endpoint speaks Gemini's native REST API."""
@@ -880,6 +893,7 @@ class GeminiNativeClient:
         timeout: Any = None,
         **_: Any,
     ) -> Any:
+        model = _normalize_gemini_model_id(model)
         thinking_config = None
         if isinstance(extra_body, dict):
             thinking_config = extra_body.get("thinking_config") or extra_body.get("thinkingConfig")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -212,10 +212,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-2.5-pro",
     ],
     "gemini": [
+        "gemini-3.5-flash",
         "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
         "gemini-3-flash-preview",
-        "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite",
     ],
     "google-gemini-cli": [
         "gemini-3.1-pro-preview",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -91,8 +91,8 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-2.5-pro",
     ],
     "gemini": [
-        "gemini-3.1-pro-preview", "gemini-3-pro-preview",
-        "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
+        "gemini-3.5-flash", "gemini-3.1-pro-preview",
+        "gemini-3-flash-preview", "gemini-3.1-flash-lite",
     ],
     "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -198,6 +198,50 @@ def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatc
     assert response.choices[0].message.content == "hello"
 
 
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        ("gemini-3-flash", "gemini-3-flash-preview"),
+        ("gemini-3-pro-preview", "gemini-3.1-pro-preview"),
+        ("gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite"),
+        ("models/gemini-3-flash", "gemini-3-flash-preview"),
+        ("models/gemini-3.5-flash", "gemini-3.5-flash"),
+    ],
+)
+def test_native_client_normalizes_retired_model_ids(monkeypatch, requested, expected):
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    recorded = {}
+
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            return DummyResponse(
+                payload={
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": "hello"}]},
+                            "finishReason": "STOP",
+                        }
+                    ],
+                }
+            )
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("agent.gemini_native_adapter.httpx.Client", lambda *a, **k: DummyHTTP())
+
+    client = GeminiNativeClient(api_key="AIza-test", base_url="https://generativelanguage.googleapis.com/v1beta")
+    response = client.chat.completions.create(
+        model=requested,
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    assert recorded["url"] == f"https://generativelanguage.googleapis.com/v1beta/models/{expected}:generateContent"
+    assert response.model == expected
+
+
 def test_native_http_error_keeps_status_and_retry_after():
     from agent.gemini_native_adapter import gemini_http_error
 

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -132,6 +132,26 @@ class TestGeminiModelCatalog:
         assert "gemini" in _PROVIDER_MODELS
         assert len(_PROVIDER_MODELS["gemini"]) >= 1
 
+    def test_direct_gemini_catalog_uses_current_native_ids(self):
+        assert _PROVIDER_MODELS["gemini"] == [
+            "gemini-3.5-flash",
+            "gemini-3.1-pro-preview",
+            "gemini-3-flash-preview",
+            "gemini-3.1-flash-lite",
+        ]
+
+    def test_direct_gemini_catalog_excludes_retired_native_ids(self):
+        retired = {
+            "gemini-3-flash",
+            "gemini-3-pro-preview",
+            "gemini-3.1-flash-lite-preview",
+        }
+        assert retired.isdisjoint(_PROVIDER_MODELS["gemini"])
+
+    def test_aggregator_gemini_catalog_entries_are_unchanged(self):
+        assert "google/gemini-3.1-flash-lite-preview" in _PROVIDER_MODELS["gmi"]
+        assert "gemini-3-flash" in _PROVIDER_MODELS["opencode-zen"]
+
     def test_provider_label(self):
         assert "gemini" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["gemini"] == "Google AI Studio"


### PR DESCRIPTION
## Summary
- normalize retired native Gemini model IDs before calling Google AI Studio generateContent
- refresh the direct Gemini provider catalog to current native IDs
- add regression coverage for URL normalization, response metadata, and direct catalog contents

## Validation
- venv/bin/python -m pytest tests/agent/test_gemini_native_adapter.py tests/hermes_cli/test_gemini_provider.py -q
- venv/bin/python -m pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_gemini_provider.py tests/agent/test_gemini_native_adapter.py -q
- git diff --check
- live replay: retired IDs map to gemini-3-flash-preview, gemini-3.1-pro-preview, and gemini-3.1-flash-lite
- live catalog replay: all direct Gemini catalog entries returned HTTP 200

## Notes
- Only the native Google AI Studio Gemini catalog changed. Aggregator provider catalogs were intentionally left untouched because their endpoint model names may differ.