### PR TITLE
fix(lsp): detach installer stdin in TUI gateway

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -238,6 +238,7 @@ def _install_npm(
             capture_output=True,
             text=True,
             timeout=300,
+            stdin=subprocess.DEVNULL,
         )
         if proc.returncode != 0:
             logger.warning(
@@ -291,6 +292,7 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
             text=True,
             timeout=600,
             env=env,
+            stdin=subprocess.DEVNULL,
         )
         if proc.returncode != 0:
             logger.warning(
@@ -328,6 +330,7 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
             capture_output=True,
             text=True,
             timeout=300,
+            stdin=subprocess.DEVNULL,
         )
         if proc.returncode != 0:
             logger.warning(

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -94,6 +94,36 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     assert install_targets == ["pyright"]
 
 
+@pytest.mark.parametrize(
+    ("installer_name", "args", "which_map"),
+    [
+        ("_install_npm", ("pyright", "pyright-langserver"), {"npm": "/usr/bin/npm"}),
+        ("_install_go", ("golang.org/x/tools/gopls@latest", "gopls"), {"go": "/usr/bin/go"}),
+        ("_install_pip", ("python-lsp-server", "pylsp"), {}),
+    ],
+)
+def test_installers_do_not_inherit_gateway_stdin(
+    tmp_path, monkeypatch, installer_name, args, which_map
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return MagicMock(returncode=0, stderr="")
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda name: which_map.get(name))
+
+    getattr(install_mod, installer_name)(*args)
+
+    assert captured["kwargs"]["stdin"] is install_mod.subprocess.DEVNULL
+
+
 # ---------------------------------------------------------------------------
 # Fix 2: ``hermes lsp status`` surfaces shellcheck-missing for bash
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- stop LSP auto-install subprocesses from inheriting the TUI gateway stdin pipe
- apply the same stdin isolation to npm, go, and pip installer paths
- add regression coverage that asserts each installer uses `stdin=subprocess.DEVNULL`

## Why this is narrow
The reported crash path is the non-interactive LSP installer inside `agent/lsp/install.py`. This change only touches those installer subprocesses and the matching unit tests.

## Verification
- `uv run --frozen pytest -o addopts='' tests/agent/lsp/test_install_and_lint_fixes.py`
- `uv run --frozen ruff check agent/lsp/install.py tests/agent/lsp/test_install_and_lint_fixes.py`
- `git diff --check`

Closes #33299.
