### PR TITLE
feat(platforms/api_server): add extra.lean to skip agent rule injection

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -699,6 +699,12 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        # When set, skip auto-injection of SOUL.md / AGENTS.md / .cursorrules and
+        # persistent memory for every request — matching what the CLI and tui_gateway
+        # do via HERMES_IGNORE_RULES. Intended for programmatic consumers
+        # (classification, structured extraction, JSON-mode automation) that would
+        # otherwise pay the agent rule/memory preamble on every call.
+        self._lean: bool = bool(extra.get("lean", False))
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -1012,6 +1018,11 @@ class APIServerAdapter(BasePlatformAdapter):
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
             gateway_session_key=gateway_session_key,
+            # Honor platforms.api_server.extra.lean so programmatic consumers can
+            # opt out of agent rule/memory injection, mirroring the CLI's
+            # HERMES_IGNORE_RULES path.
+            skip_context_files=self._lean,
+            skip_memory=self._lean,
         )
         return agent
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -338,6 +338,86 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_lean_mode_skips_rules_and_memory(self, monkeypatch):
+        """extra.lean=true must forward skip_context_files=True and skip_memory=True to AIAgent.
+
+        Programmatic consumers (classification, structured extraction, JSON-mode
+        automation) use this to opt out of SOUL.md / AGENTS.md / .cursorrules
+        and persistent-memory injection per-request.
+        """
+        captured = _LeanCaptured()
+        _install_create_agent_fakes(monkeypatch, captured)
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"lean": True}))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        assert adapter._lean is True
+        adapter._create_agent(session_id="api-session-lean")
+
+        assert captured.kwargs["skip_context_files"] is True
+        assert captured.kwargs["skip_memory"] is True
+
+    def test_create_agent_default_keeps_rules_and_memory(self, monkeypatch):
+        """Default (extra.lean absent or false) must keep the existing behavior:
+        AIAgent receives skip_context_files=False and skip_memory=False so
+        SOUL.md / AGENTS.md / .cursorrules and persistent memory load as before.
+        """
+        captured = _LeanCaptured()
+        _install_create_agent_fakes(monkeypatch, captured)
+
+        # No extra at all — confirms backwards-compat for configs that predate the flag.
+        adapter_default = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter_default, "_ensure_session_db", lambda: None)
+        assert adapter_default._lean is False
+        adapter_default._create_agent(session_id="api-session-default")
+        assert captured.kwargs["skip_context_files"] is False
+        assert captured.kwargs["skip_memory"] is False
+
+        # Explicit lean=false behaves the same as the default.
+        captured.kwargs.clear()
+        adapter_false = APIServerAdapter(PlatformConfig(enabled=True, extra={"lean": False}))
+        monkeypatch.setattr(adapter_false, "_ensure_session_db", lambda: None)
+        assert adapter_false._lean is False
+        adapter_false._create_agent(session_id="api-session-false")
+        assert captured.kwargs["skip_context_files"] is False
+        assert captured.kwargs["skip_memory"] is False
+
+
+class _LeanCaptured:
+    """Holds AIAgent __init__ kwargs captured by the FakeAgent in lean-mode tests."""
+
+    def __init__(self):
+        self.kwargs: dict = {}
+
+
+def _install_create_agent_fakes(monkeypatch, captured: "_LeanCaptured") -> None:
+    """Install the same monkeypatch stack used by test_create_agent_forwards_config_reasoning_effort.
+
+    Spies on AIAgent's __init__ so callers can assert on the kwargs that
+    APIServerAdapter._create_agent forwards.
+    """
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.kwargs.update(kwargs)
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai-codex",
+            "base_url": "https://example.test/v1",
+            "api_mode": "codex_responses",
+        },
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.5")
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config",
+        staticmethod(lambda: {}),
+    )
+    monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
 
 # ---------------------------------------------------------------------------
 # Auth checking

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -345,6 +345,22 @@ The default bind address (`127.0.0.1`) is for local-only use. Browser access is 
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name on `/v1/models`. Defaults to profile name, or `hermes-agent` for default profile. |
 
+### Lean mode (programmatic consumers)
+
+Set `platforms.api_server.extra.lean: true` in your gateway config to skip auto-injection of `SOUL.md`, `AGENTS.md`, `.cursorrules`, and persistent memory on every request — the same opt-out the CLI and tui_gateway expose through `HERMES_IGNORE_RULES`. Default is `false`, so existing behavior is unchanged.
+
+Use it when calling the API server programmatically for content classification, structured extraction, or JSON-mode automation, where the agent rule/memory preamble would otherwise be ~12K wasted tokens per request:
+
+```yaml
+platforms:
+  api_server:
+    enabled: true
+    extra:
+      lean: true   # skip SOUL.md / AGENTS.md / .cursorrules / persistent memory
+```
+
+Trade-off: the agent loses its persona and project context, so it should not be set on a deployment that doubles as a conversational assistant. Run two profiles if you need both behaviors.
+
 ### config.yaml
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Add an opt-in `extra.lean` boolean (default `false`) under `platforms.api_server.extra`. When set, `APIServerAdapter._create_agent` passes `skip_context_files=True` and `skip_memory=True` to `AIAgent` — the same opt-out the CLI exposes via `--ignore-rules` and `tui_gateway` exposes via the `HERMES_IGNORE_RULES` env var (see `cli.py:4990-4991`, `tui_gateway/server.py:2055-2056`).

Default behavior is unchanged. Existing configs that don't set the field keep loading `SOUL.md`, `AGENTS.md`, `.cursorrules`, and persistent memory exactly as before.

## Related Issue

<!-- No prior issue; happy to open one if maintainers prefer. The motivation
section below covers the production symptoms in detail. -->

Fixes #

## Why

The api_server platform always wraps each request in the full agent loop, auto-injecting `SOUL.md`, `AGENTS.md`, `.cursorrules`, and persistent memory at `agent/agent_init.py:1073` / `agent/system_prompt.py:90,263`. That's the right default for OpenAI-compatible frontends (Open WebUI, LobeChat, LibreChat) where users want the Hermes persona.

It's the wrong default for **programmatic consumers**:

- **Content classification** ("classify this support ticket as billing/auth/feature")
- **Structured extraction** ("pull the line items out of this invoice JSON")
- **JSON-mode automation** (an upstream service that just wants `response_format: json_schema`)

For those workloads, the agent rule/memory preamble adds ~12K tokens to every request with no benefit — the agent's persona and project context aren't being used.

## Before / After numbers (production deployment)

Smoke-tested on a live Hermes-Agent v0.14.0 deployment (Raspberry Pi, gateway running) with an identical brand-domain LinkedIn classification payload before and after applying the patch:

| Metric | `lean: false` (default) | `lean: true` | Delta |
|---|---|---|---|
| `prompt_tokens` | 14,386 | 823 | **−94.3 % (17.5×)** |
| `completion_tokens` | 38 | 41 | +3 |
| `total_tokens` | 14,424 | 864 | −94.0 % |
| End-to-end latency | 6.17 s | 4.08 s | **−34 %** |

Classifier verdict was functionally identical:

```
before: {"domain": "brand", "confidence": 0.97, "reasoning": "engineering leadership and platform architecture"}
after:  {"domain": "brand", "confidence": 0.95, "reasoning": "engineering leadership, architecture, and platforms"}
```

Both runs are well above the 0.8 acceptance threshold; no quality loss observed. The exact reduction will vary with the size of each user's `AGENTS.md` / `.cursorrules` / memory snapshot, but on a roughly vanilla install the ~12 K-token preamble dominates short classification payloads.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `gateway/platforms/api_server.py`
  - `__init__`: read `extra.get("lean", False)` into `self._lean` next to the other `extra.*` reads (host/port/key/cors_origins/model_name pattern).
  - `_create_agent`: forward `skip_context_files=self._lean, skip_memory=self._lean` to `AIAgent(...)`.
  - +11 lines of production code, no refactors, no changes to public function signatures.
- `tests/gateway/test_api_server.py`
  - `TestAdapterInit.test_create_agent_lean_mode_skips_rules_and_memory` — asserts `lean=True` forwards both skip flags as `True`.
  - `TestAdapterInit.test_create_agent_default_keeps_rules_and_memory` — asserts default (no field) and explicit `lean=False` both forward `False`.
  - Reuses the same `monkeypatch` setup pattern as the existing `test_create_agent_forwards_config_reasoning_effort` test, factored into a small `_install_create_agent_fakes` helper.
- `website/docs/user-guide/features/api-server.md`
  - New `### Lean mode (programmatic consumers)` subsection under `## Configuration` with a YAML snippet and the persona/context trade-off documented.

## How to Test

1. Run the new tests in isolation:
   ```
   scripts/run_tests.sh tests/gateway/test_api_server.py -- -k "lean_mode or default_keeps_rules" -v
   ```
   Both pass on this branch (1.4 s wall).
2. Run the full api_server test suite for regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_bind_guard.py tests/gateway/test_api_server_normalize.py tests/gateway/test_api_server_multimodal.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server_toolset.py tests/gateway/test_api_server_jobs.py tests/gateway/test_session_api.py tests/gateway/test_weak_credential_guard.py tests/gateway/test_sse_agent_cancel.py tests/gateway/test_config.py tests/gateway/test_session_reset_notify.py
   ```
   375 / 375 pass on this branch (4.3 s wall).
3. End-to-end smoke (the source of the table above): enable the api_server with `platforms.api_server.extra.lean: true`, point any OpenAI-compatible client at `/v1/chat/completions`, and observe `usage.prompt_tokens` in the response drop by roughly the size of your `AGENTS.md` + `SOUL.md` + memory snapshot.

## Design

- **Opt-in, additive, default unchanged.** Configs without `lean:` get the same `AIAgent(skip_context_files=False, skip_memory=False)` as before.
- **Matches the existing `extra.{host,port,key,cors_origins,model_name}` pattern** in `gateway/platforms/api_server.py:689-700` — single boolean read in `__init__`, stored on the adapter, forwarded at the AIAgent boundary.
- **Mirrors the CLI / tui_gateway / feishu_comment precedent** of allowing `skip_context_files` / `skip_memory` to be flipped at the per-platform AIAgent boundary rather than via a process-wide env var (`cli.py:4990-4991`, `tui_gateway/server.py:2055-2056`, `gateway/platforms/feishu_comment.py:1082-1083`).
- **Naming — `lean` (noun) rather than `skip_rules` (skip_<noun> pattern).** This switch bundles multiple skips (`skip_context_files` + `skip_memory`, plausibly more in the future); an aggregate mode reads more honestly as a noun than as a sum of individual `skip_*` flags. The codebase's existing `skip_<noun>` pattern (`skip_attachments` in `gateway/platforms/email.py:264`) fits single-thing opt-outs; `lean` fits an aggregate-mode toggle.
- **No new state, no new code paths.** The change is two assignment lines and two extra kwargs to an existing `AIAgent(...)` call.

## Alternatives considered

1. **Env var** (`API_SERVER_LEAN` or similar). Rejected: an env var has gateway-wide blast radius and requires a `systemd`/launchd unit edit to flip, which is operationally heavier than a per-deployment `extra.lean: true` line. The other api_server config knobs (host/port/key/cors_origins/model_name) all support both env var and `extra.*`, but those map to ops-level concerns (binding, auth) where env vars are idiomatic; lean mode is a per-deployment app concern. Happy to add an env var alias if maintainers want one.
2. **Re-using `HERMES_IGNORE_RULES`** for the api_server adapter. Rejected: `HERMES_IGNORE_RULES` has gateway-wide semantics in `tui_gateway/server.py:2055-2056` — turning it on would also strip rules from any other platform sharing the gateway process. This is a per-platform decision.
3. **Per-request opt-out** (e.g. an `X-Hermes-Skip-Rules` header). Rejected for this PR: would require auth gating to prevent unauthenticated clients from suppressing project context, plus a longer test matrix. The config-knob form covers the production use case (a dedicated lean deployment) without adding new auth surface.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(platforms/api_server): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the api_server test suite (375 tests across 12 files) and all pass
- [x] I've added tests for my changes (two new tests in `TestAdapterInit`)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0), Python 3.12.13 — plus the production smoke test above on Raspberry Pi (Linux, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/api-server.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no `api_server` block exists there today
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, this is a pure-Python config-read change with no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Full local test run summary (this branch):

```
=== Summary: 12 files, 375 tests passed, 0 failed (100% complete) in 4.3s ===
```

New tests in isolation:

```
=== Summary: 1 files, 2 tests passed, 0 failed in 1.4s ===
```
