### PR TITLE
feat: activity-aware clarify timeout — reset deadline on user interaction

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11155,6 +11155,18 @@ class HermesCLI:
             "Use your best judgement to make the choice and proceed."
         )
 
+    def _clarify_touch_deadline(self) -> None:
+        """Reset the clarify timeout deadline on user activity.
+
+        Called whenever the user interacts during a clarify prompt
+        (keystroke, selection change, text input) — proves they are
+        not AFK and the timer should restart from now.
+        """
+        import time as _time
+        if self._clarify_state and self._clarify_deadline:
+            timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+            self._clarify_deadline = _time.monotonic() + timeout
+
     def _sudo_password_callback(self) -> str:
         """
         Prompt for sudo password through the prompt_toolkit UI.
@@ -12852,6 +12864,7 @@ class HermesCLI:
             """Move selection up in clarify choices."""
             if self._clarify_state:
                 self._clarify_state["selected"] = max(0, self._clarify_state["selected"] - 1)
+                self._clarify_touch_deadline()
                 event.app.invalidate()
 
         @kb.add('down', filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext))
@@ -12861,6 +12874,7 @@ class HermesCLI:
                 choices = self._clarify_state.get("choices") or []
                 max_idx = len(choices)  # last index is the "Other" option
                 self._clarify_state["selected"] = min(max_idx, self._clarify_state["selected"] + 1)
+                self._clarify_touch_deadline()
                 event.app.invalidate()
 
         # Number keys for quick clarify selection (1-9, 0 for 10th item)
@@ -12885,6 +12899,12 @@ class HermesCLI:
             # 1-9 select items 0-8, 0 selects item 9 (10thitem)
             _idx = 9 if _num == 0 else _num - 1
             kb.add(str(_num), filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext))(_make_clarify_number_handler(_idx))
+
+        # Activity-aware clarify timeout: any keystroke during a pending
+        # clarify resets the deadline — proves the user is not AFK.
+        @kb.add('<any>', filter=Condition(lambda: bool(self._clarify_state)))
+        def clarify_activity(event):
+            self._clarify_touch_deadline()
 
         # --- Dangerous command approval: arrow-key navigation ---
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6897,6 +6897,10 @@ class GatewayRunner:
         try:
             from tools import clarify_gateway as _clarify_mod
             _pending_clarify = _clarify_mod.get_pending_for_session(_quick_key)
+            if _pending_clarify is not None:
+                # Any user message while a clarify is pending proves the
+                # user is not AFK — reset the deadline.
+                _clarify_mod.touch_clarify_deadline(_pending_clarify.clarify_id)
         except Exception:
             _pending_clarify = None
         if _pending_clarify is not None:

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -54,6 +54,7 @@ class _ClarifyEntry:
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
+    deadline: float = 0.0       # monotonic deadline, touched on user activity
 
     def signature(self) -> Dict[str, object]:
         return {
@@ -120,10 +121,12 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     except Exception:  # pragma: no cover - optional
         touch_activity_if_due = None
 
-    deadline = time.monotonic() + max(timeout, 0.0)
+    # Store deadline on the entry so touch_clarify_deadline() can reset it
+    # on user activity (cursor movement, typing, etc.).
+    entry.deadline = time.monotonic() + max(timeout, 0.0)
     activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
     while True:
-        remaining = deadline - time.monotonic()
+        remaining = entry.deadline - time.monotonic()
         if remaining <= 0:
             break
         if entry.event.wait(timeout=min(1.0, remaining)):
@@ -159,6 +162,32 @@ def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
             return False
     entry.response = str(response) if response is not None else ""
     entry.event.set()
+    return True
+
+
+def touch_clarify_deadline(clarify_id: str, timeout: Optional[float] = None) -> bool:
+    """Reset the clarify timeout on user activity.
+
+    When the user interacts (cursor movement, typing, any message),
+    the clarify deadline should restart — proves they are not AFK.
+
+    Args:
+        clarify_id: The clarify entry to touch.
+        timeout: New timeout in seconds. If None, reads from config
+                 (same as get_clarify_timeout()).
+
+    Returns True if an entry was found and deadline updated, False otherwise.
+    """
+    with _lock:
+        entry = _entries.get(clarify_id)
+    if entry is None:
+        return False
+
+    if timeout is None:
+        timeout = float(get_clarify_timeout())
+
+    import time as _time
+    entry.deadline = _time.monotonic() + timeout
     return True
 
 


### PR DESCRIPTION
## Problem

When the clarify tool asks the user a question, the timeout (`clarify_timeout`, default 600s) counts down regardless of user activity. If the user is actively reading/thinking/typing but hasn't submitted yet, the clarify expires — frustrating when the user is mid-typing.

## Solution

Reset the clarify deadline whenever the user interacts:

- **CLI**: any keystroke (`<any>` key binding) during a pending clarify resets `_clarify_deadline`
- **Gateway**: any incoming message (even slash commands) while a clarify is pending calls `touch_clarify_deadline()`

This proves the user is not AFK and deserves a fresh timeout window.

## Changes

| File | Change |
|------|--------|
| `cli.py` | New `_clarify_touch_deadline()` method; `<any>` key handler + up/down arrow handlers |
| `tools/clarify_gateway.py` | New `deadline` field on `_ClarifyEntry`; `touch_clarify_deadline()` function; `wait_for_response()` reads mutable deadline |
| `gateway/run.py` | `_handle_message` calls `touch_clarify_deadline()` on any user message during pending clarify |

## Testing

- Gateway: integration tested — register → touch at 0.05s (resets to 10s) → resolve at 0.2s → wait_for_response with 0.1s timeout → returns `'B'` (deadline was reset before expiry)
- CLI: syntax-verified via `py_compile`

Closes #33567