### PR TITLE
test(kanban): align two tests with recent kanban hardening

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1326,6 +1326,14 @@ def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
     from hermes_cli import kanban_db as kb
     import hermes_cli.kanban_db as _kb
 
+    # detect_crashed_workers now gates each running task behind a
+    # launch-window grace period (c002668ff) so a freshly-spawned worker
+    # whose PID isn't yet visible on /proc isn't reclaimed. The fixture
+    # creates the task moments before this assertion, so the grace
+    # period (default 30s) would skip the liveness check. Zero it out
+    # for this test — we WANT immediate reclamation here.
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
     conn = kb.connect()
     try:
         run1 = kb.latest_run(conn, worker_env)

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -625,10 +625,21 @@ class TestKanbanWaitpidWindowsGuard:
         # Find the waitpid call and confirm it's inside a POSIX gate.
         idx = source.find("os.waitpid(-1, os.WNOHANG)")
         assert idx > 0, "waitpid call must exist"
-        # Look backwards up to 400 chars for the gate.
+        # Look backwards up to 400 chars for the gate. Accept either form:
+        #   `if os.name != "nt":` (run iff POSIX), or
+        #   `if os.name == "nt": return []` (early-return guard).
+        # Both correctly keep the waitpid loop off Windows; the early-return
+        # form is stronger because the rest of the function never runs.
         preamble = source[max(0, idx - 400):idx]
-        assert 'os.name != "nt"' in preamble or "os.name != 'nt'" in preamble, (
-            "os.waitpid(-1, os.WNOHANG) must sit behind an os.name != 'nt' guard"
+        guard_patterns = (
+            'os.name != "nt"',
+            "os.name != 'nt'",
+            'os.name == "nt"',  # early-return guard
+            "os.name == 'nt'",
+        )
+        assert any(p in preamble for p in guard_patterns), (
+            "os.waitpid(-1, os.WNOHANG) must sit behind an os.name guard "
+            f"(checked patterns: {guard_patterns})"
         )
 
 


### PR DESCRIPTION
## Summary
Realign two stale test expectations with recent kanban hardening commits. Both tests reproduce verbatim on `origin/main` in a clean env; neither relates to in-flight work, but they're blocking the kanban CI shard for any downstream PR (caught while watching #33564). Filing as a separate fix-it PR per green-CI-policy.

## Root causes (one per test)
- **`tests/tools/test_kanban_tools.py::test_worker_complete_rejects_stale_run_id`** — c002668ff `fix(kanban): add grace period to detect_crashed_workers` gates each running task behind a launch-window grace period (default 30s) so freshly-spawned workers whose PID isn't yet visible on `/proc` aren't reclaimed. The test creates the `worker_env` fixture moments before asserting reclamation, so the grace skips the liveness check and `detect_crashed_workers` returns `[]`. Fix: set `HERMES_KANBAN_CRASH_GRACE_SECONDS=0` to restore immediate-reclaim semantics the assertion expects.
- **`tests/tools/test_windows_native_support.py::TestKanbanWaitpidWindowsGuard::test_source_gates_waitpid_loop`** — ffdc937c1 `fix(kanban): hoist zombie reaper out of dispatch_once` reshaped `reap_worker_zombies` to use an early-return Windows guard (`if os.name == "nt": return []`) instead of an inverted gate (`if os.name != "nt":`). Both correctly keep `os.waitpid(-1, os.WNOHANG)` off Windows; the early-return form is stronger because the rest of the function never runs. Fix: accept either gate pattern in the source-scan assertion.

## Validation
| | Before | After |
|---|---|---|
| `test_worker_complete_rejects_stale_run_id` | FAIL on main | PASS |
| `test_source_gates_waitpid_loop` | FAIL on main | PASS |
| `tests/tools/test_kanban_tools.py + test_windows_native_support.py` | 137/139 | 139/139 |

## Unblocks
- #33564 (`fix(kanban): close kanban.db FD after every connect()`) — CI shows the same two failures, both pre-existing per this PR.
- Any other downstream PR that hits `test (1)` or `test (2)` shards.
