### PR TITLE
test(kanban): align crash and waitpid guard tests

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1326,6 +1326,7 @@ def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
     from hermes_cli import kanban_db as kb
     import hermes_cli.kanban_db as _kb
 
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
     conn = kb.connect()
     try:
         run1 = kb.latest_run(conn, worker_env)

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -622,13 +622,20 @@ class TestKanbanWaitpidWindowsGuard:
     def test_source_gates_waitpid_loop(self):
         root = Path(__file__).resolve().parents[2]
         source = (root / "hermes_cli" / "kanban_db.py").read_text(encoding="utf-8")
-        # Find the waitpid call and confirm it's inside a POSIX gate.
+        # Find the waitpid call and confirm its function body exits on Windows
+        # before reaching POSIX-only os.waitpid/os.WNOHANG.
+        fn_idx = source.find("def reap_worker_zombies")
+        assert fn_idx > 0, "reap_worker_zombies must exist"
         idx = source.find("os.waitpid(-1, os.WNOHANG)")
         assert idx > 0, "waitpid call must exist"
-        # Look backwards up to 400 chars for the gate.
-        preamble = source[max(0, idx - 400):idx]
-        assert 'os.name != "nt"' in preamble or "os.name != 'nt'" in preamble, (
-            "os.waitpid(-1, os.WNOHANG) must sit behind an os.name != 'nt' guard"
+        preamble = source[fn_idx:idx]
+        assert (
+            'os.name != "nt"' in preamble
+            or "os.name != 'nt'" in preamble
+            or 'os.name == "nt"' in preamble
+            or "os.name == 'nt'" in preamble
+        ), (
+            "os.waitpid(-1, os.WNOHANG) must sit behind a Windows guard"
         )
 
 


### PR DESCRIPTION
## Summary
- Make the stale-run-id kanban test opt out of the new crash-detection grace window with `HERMES_KANBAN_CRASH_GRACE_SECONDS=0`.
- Make the Windows waitpid guard test inspect the `reap_worker_zombies()` function body instead of relying on a fixed 400-character lookback.

These are test-only updates for current `main` failures seen in PR CI, including #33356 and #33564.

## Validation
- `uv run --extra dev python -m pytest tests/tools/test_kanban_tools.py::test_worker_complete_rejects_stale_run_id tests/tools/test_windows_native_support.py::TestKanbanWaitpidWindowsGuard::test_source_gates_waitpid_loop -q`