### PR TITLE
fix(codex-auth): wall-clock token-staleness floor + cross-profile shared store

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1132,6 +1132,7 @@ class CredentialPool:
             return _codex_access_token_is_expiring(
                 entry.access_token,
                 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+                last_refresh=getattr(entry, "last_refresh", None),
             )
         if self.provider == "xai-oauth":
             return auth_mod._xai_access_token_is_expiring(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -113,6 +113,28 @@ STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+# Wall-clock floor: refresh any access_token whose stored ``last_refresh`` is
+# older than this, regardless of what the JWT's ``exp`` claim says.  Codex
+# JWTs ship with ``exp`` values up to ~10 days in the future, but chatgpt.com's
+# Cloudflare layer enforces a shorter server-side TTL (observed ≥ a few hours,
+# < several days, exact threshold opaque to the client).  When the server-side
+# TTL expires, requests are *silently dropped* (no 401, no body — just a hung
+# read), so reactive refresh-on-401 never fires.  Defaults to 45 minutes — well
+# under any observed TTL, conservative against further upstream changes, and a
+# negligible cost (one HTTPS POST every 45 min on an agent whose calls already
+# carry seconds-to-minutes of reasoning latency).  Overridable via
+# ``HERMES_CODEX_TOKEN_MAX_AGE_SECONDS`` for operators that hit a tighter or
+# looser server-side TTL than we've observed.
+CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS = 45 * 60
+# Filename for the optional shared codex auth store.  Co-located with
+# ``NOUS_SHARED_STORE_FILENAME`` semantically — same directory layout, same
+# ``HERMES_SHARED_AUTH_DIR`` override, different per-provider file.  Used when
+# multiple Hermes profiles (typically multiple agents in a Docker fleet) all
+# authenticate against the same ChatGPT account: writing to a shared file
+# means one profile's refresh+rotation propagates to its siblings instead of
+# leaving them holding an already-consumed ``refresh_token`` (the failure mode
+# documented as ``refresh_token_reused`` in ``refresh_codex_oauth_pure``).
+CODEX_SHARED_STORE_FILENAME = "codex_auth.json"
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
@@ -1940,7 +1962,57 @@ def _nous_effective_provider_state(state: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _codex_access_token_is_expiring(access_token: Any, skew_seconds: int) -> bool:
+def _codex_access_token_is_expiring(
+    access_token: Any,
+    skew_seconds: int,
+    *,
+    last_refresh: Optional[str] = None,
+    max_age_seconds: Optional[int] = None,
+) -> bool:
+    """Decide whether the codex access token should be refreshed.
+
+    Two independent predicates, ORed:
+
+    1. **Wall-clock floor** (NEW).  If ``last_refresh`` is provided and parses
+       as ISO-8601 UTC, refresh when the stored token is older than
+       ``max_age_seconds`` (defaulting to
+       :data:`CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS`, also overridable via
+       ``HERMES_CODEX_TOKEN_MAX_AGE_SECONDS``).  This catches the case where
+       chatgpt.com's server-side TTL is shorter than the JWT's ``exp`` claim —
+       observed in production where JWTs advertise ``exp`` ~10 days out but
+       requests start hanging silently after a few hours.
+    2. **JWT exp + skew** (existing).  If the access_token is a JWT with an
+       ``exp`` claim and ``exp <= now + skew_seconds``, refresh.  Kept as a
+       secondary signal so operators using non-JWT tokens, or future tokens
+       whose ``exp`` is honored faithfully, still get correct behaviour.
+
+    If neither predicate is satisfiable (no ``last_refresh`` AND no parseable
+    ``exp``), return False — i.e. preserve the pre-existing conservative
+    behaviour for callers that don't yet plumb through ``last_refresh``.
+
+    Backward-compatible: existing two-positional-arg calls
+    (``access_token``, ``skew_seconds``) still work and exercise only the JWT
+    path, matching their prior behaviour exactly.
+    """
+    # Resolve the wall-clock cap.  Env var override beats the kwarg, which
+    # beats the module-level default.  Negative / zero / non-numeric values
+    # disable the wall-clock floor (operator opt-out).
+    if max_age_seconds is None:
+        env_max = os.getenv("HERMES_CODEX_TOKEN_MAX_AGE_SECONDS", "").strip()
+        if env_max:
+            try:
+                max_age_seconds = int(env_max)
+            except ValueError:
+                max_age_seconds = CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS
+        else:
+            max_age_seconds = CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS
+
+    if last_refresh and max_age_seconds and max_age_seconds > 0:
+        last_refresh_epoch = _parse_iso_timestamp(last_refresh)
+        if last_refresh_epoch is not None:
+            if (time.time() - last_refresh_epoch) >= float(max_age_seconds):
+                return True
+
     claims = _decode_jwt_claims(access_token)
     exp = claims.get("exp")
     if not isinstance(exp, (int, float)):
@@ -3325,6 +3397,232 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         _save_provider_state(auth_store, "openai-codex", state)
         _sync_codex_pool_entries(auth_store, tokens, last_refresh)
         _save_auth_store(auth_store)
+    # Propagate to the shared codex store (if any) so sibling profiles —
+    # typically other agents in a Docker fleet authed against the same
+    # ChatGPT account — pick up the rotated refresh_token before they
+    # spend their stale local copy and trip ``refresh_token_reused``.
+    _write_shared_codex_state(tokens, last_refresh)
+
+
+# -----------------------------------------------------------------------------
+# Codex shared OAuth store — mirrors the Nous shared-store pattern.
+#
+# When multiple Hermes profiles authenticate against the same ChatGPT account
+# (typically a Docker fleet of agents that share one user identity), each
+# profile's auth.json carries a copy of the same ``access_token`` +
+# ``refresh_token``.  Refresh tokens are single-use: as soon as one profile
+# rotates them, the other profiles' copies are invalidated server-side and
+# the next refresh on those profiles fails with ``refresh_token_reused``.
+#
+# The shared store gives all profiles under the same root a single source of
+# truth for codex OAuth.  Writes happen in lockstep with the profile-local
+# ``auth.json`` save (see ``_save_codex_tokens``).  Reads happen opportunistically
+# inside ``resolve_codex_runtime_credentials`` (see ``_merge_shared_codex_state``):
+# before deciding to spend the local refresh_token, we peek at the shared
+# file and adopt fresher tokens from there if a sibling has just refreshed.
+#
+# Honors ``HERMES_SHARED_AUTH_DIR`` — same env var used by Nous — so an
+# operator can co-locate both shared stores at a single bind-mounted path
+# without needing two override variables.
+# -----------------------------------------------------------------------------
+
+_codex_shared_lock_holder = threading.local()
+
+
+def _codex_shared_auth_dir() -> Path:
+    """Resolve the directory that holds the shared Codex token store.
+
+    Honors ``HERMES_SHARED_AUTH_DIR`` (the same variable Nous uses).
+    Defaults to ``<hermes-root>/shared/`` so all profiles under the same
+    Hermes root share the store without any extra configuration.
+    """
+    override = os.getenv("HERMES_SHARED_AUTH_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "shared"
+
+
+def _codex_shared_store_path() -> Path:
+    path = _codex_shared_auth_dir() / CODEX_SHARED_STORE_FILENAME
+    # Seat belt: mirrors the Nous shared-store guard.  Under pytest, refuse
+    # to read or write the real user's shared store unless tests have
+    # explicitly redirected via ``HERMES_SHARED_AUTH_DIR``.  Forgetting that
+    # in a fixture would otherwise corrupt cross-profile state.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        from hermes_constants import get_default_hermes_root
+        real_home_shared = (
+            get_default_hermes_root() / "shared" / CODEX_SHARED_STORE_FILENAME
+        ).resolve(strict=False)
+        try:
+            resolved = path.resolve(strict=False)
+        except Exception:
+            resolved = path
+        if resolved == real_home_shared:
+            raise RuntimeError(
+                f"Refusing to touch real user shared Codex auth store during test run: "
+                f"{path}. Set HERMES_SHARED_AUTH_DIR to a tmp_path in your test fixture."
+            )
+    return path
+
+
+@contextmanager
+def _codex_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Cross-profile lock for the shared Codex OAuth store.
+
+    Lock ordering invariant (mirrors Nous): if both this and
+    ``_auth_store_lock`` need to be held, acquire ``_auth_store_lock``
+    FIRST.  This keeps the lock graph acyclic across all auth code paths
+    that touch the shared store while a profile-local refresh is in
+    flight.
+    """
+    try:
+        lock_path = _codex_shared_store_path().with_suffix(".lock")
+    except RuntimeError:
+        # No HERMES_HOME yet (pre-setup), or pytest seat belt fired: skip locking.
+        yield
+        return
+
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # If we can't even create the parent directory, the shared store
+        # isn't usable.  Yield without locking; downstream best-effort
+        # read/write helpers will quietly skip the shared file.
+        yield
+        return
+
+    with _file_lock(
+        lock_path,
+        _codex_shared_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared Codex auth lock",
+    ):
+        yield
+
+
+def _read_shared_codex_state() -> Optional[Dict[str, Any]]:
+    """Read the shared Codex OAuth state, or None if not configured / unreadable.
+
+    Returns a dict with keys ``access_token``, ``refresh_token``,
+    ``last_refresh`` when populated.  Never raises — the shared store is
+    a convenience layer and the per-profile auth.json remains the source
+    of truth.
+    """
+    try:
+        path = _codex_shared_store_path()
+    except RuntimeError:
+        return None
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except Exception as exc:
+        logger.debug("Failed to read shared codex auth store at %s: %s", path, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _write_shared_codex_state(
+    tokens: Dict[str, Any],
+    last_refresh: Optional[str],
+) -> None:
+    """Persist fresh Codex tokens to the shared store (best-effort).
+
+    Swallows all failures after logging — the per-profile auth.json save
+    has already succeeded by the time this is called, so a shared-store
+    write failure must not break the operator's session.
+    """
+    if not isinstance(tokens, dict):
+        return
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+    if not access_token or not refresh_token:
+        # Nothing useful to share.
+        return
+    payload = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "last_refresh": last_refresh
+        or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "auth_mode": "chatgpt",
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    try:
+        with _codex_shared_store_lock():
+            path = _codex_shared_store_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.chmod(path.parent, 0o700)
+            except OSError:
+                pass
+            tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+            try:
+                fd = os.open(
+                    str(tmp_path),
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    stat.S_IRUSR | stat.S_IWUSR,
+                )
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(json.dumps(payload, indent=2) + "\n")
+                    handle.flush()
+                    try:
+                        os.fsync(handle.fileno())
+                    except OSError:
+                        pass
+                os.replace(str(tmp_path), str(path))
+            finally:
+                try:
+                    if tmp_path.exists():
+                        tmp_path.unlink()
+                except OSError:
+                    pass
+    except Exception as exc:
+        logger.debug("Failed to write shared codex auth store: %s", exc)
+
+
+def _merge_shared_codex_state(local_data: Dict[str, Any]) -> bool:
+    """Adopt fresher tokens from the shared store into a local-read dict.
+
+    Mutates ``local_data`` in place (matching ``_read_codex_tokens`` shape:
+    ``{"tokens": {...}, "last_refresh": ...}``).  Returns True iff
+    ``local_data`` was updated with a strictly newer ``last_refresh`` from
+    the shared store.
+
+    Used to short-circuit a refresh when a sibling profile has just
+    rotated the tokens: instead of spending the now-consumed local
+    refresh_token and tripping ``refresh_token_reused``, we adopt the
+    fresh pair the sibling already wrote.
+    """
+    if not isinstance(local_data, dict):
+        return False
+    shared = _read_shared_codex_state()
+    if not shared:
+        return False
+    shared_refresh = str(shared.get("refresh_token", "") or "").strip()
+    shared_access = str(shared.get("access_token", "") or "").strip()
+    if not shared_refresh or not shared_access:
+        return False
+
+    shared_last_refresh = shared.get("last_refresh")
+    local_last_refresh = local_data.get("last_refresh")
+    shared_epoch = _parse_iso_timestamp(shared_last_refresh) or 0.0
+    local_epoch = _parse_iso_timestamp(local_last_refresh) or 0.0
+    if shared_epoch <= local_epoch:
+        return False
+
+    # Shared store has a strictly newer refresh; adopt it locally.
+    local_tokens = local_data.get("tokens")
+    if not isinstance(local_tokens, dict):
+        local_tokens = {}
+        local_data["tokens"] = local_tokens
+    local_tokens["access_token"] = shared_access
+    local_tokens["refresh_token"] = shared_refresh
+    local_data["last_refresh"] = shared_last_refresh
+    return True
 
 
 def refresh_codex_oauth_pure(
@@ -3552,21 +3850,59 @@ def resolve_codex_runtime_credentials(
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
-        should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+        should_refresh = _codex_access_token_is_expiring(
+            access_token,
+            refresh_skew_seconds,
+            last_refresh=data.get("last_refresh"),
+        )
     if should_refresh:
         # Re-read under lock to avoid racing with other Hermes processes
         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
             data = _read_codex_tokens(_lock=False)
-            tokens = dict(data["tokens"])
-            access_token = str(tokens.get("access_token", "") or "").strip()
+
+            # Before spending the local refresh_token, check whether a sibling
+            # profile has already rotated tokens via the shared store.  If yes,
+            # adopt those fresh tokens and skip our own refresh — this avoids
+            # the ``refresh_token_reused`` 401 that single-use OAuth tokens
+            # produce when multiple profiles try to consume the same token.
+            # No-op when no shared store is configured / readable.  Skipped
+            # entirely when ``force_refresh`` is set so a deliberate rotation
+            # by the operator isn't silently substituted.
+            if not force_refresh and _merge_shared_codex_state(data):
+                tokens = dict(data["tokens"])
+                _save_codex_tokens(tokens, data.get("last_refresh"))
+                access_token = str(tokens.get("access_token", "") or "").strip()
+            else:
+                tokens = dict(data["tokens"])
+                access_token = str(tokens.get("access_token", "") or "").strip()
 
             should_refresh = bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
+                should_refresh = _codex_access_token_is_expiring(
+                    access_token,
+                    refresh_skew_seconds,
+                    last_refresh=data.get("last_refresh"),
+                )
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
-                access_token = str(tokens.get("access_token", "") or "").strip()
+                # Cross-profile serialization: hold the shared-store lock during
+                # refresh so concurrent siblings can't both consume the same
+                # single-use refresh_token.  Lock ordering matches the Nous
+                # invariant: ``_auth_store_lock`` is already held above; acquire
+                # ``_codex_shared_store_lock`` only inside it, never the other
+                # way around.
+                with _codex_shared_store_lock(timeout_seconds=max(refresh_timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+                    # Final check: another sibling may have just refreshed
+                    # while we were waiting on the shared lock.  If so, adopt
+                    # their tokens and skip our refresh.
+                    data = _read_codex_tokens(_lock=False)
+                    if _merge_shared_codex_state(data):
+                        tokens = dict(data["tokens"])
+                        _save_codex_tokens(tokens, data.get("last_refresh"))
+                        access_token = str(tokens.get("access_token", "") or "").strip()
+                    else:
+                        tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                        access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
@@ -5791,7 +6127,11 @@ def get_codex_auth_status() -> Dict[str, Any]:
                     getattr(entry, "runtime_api_key", None)
                     or getattr(entry, "access_token", "")
                 )
-                if api_key and not _codex_access_token_is_expiring(api_key, 0):
+                if api_key and not _codex_access_token_is_expiring(
+                    api_key,
+                    0,
+                    last_refresh=getattr(entry, "last_refresh", None),
+                ):
                     return {
                         "logged_in": True,
                         "auth_store": str(_auth_file_path()),
@@ -6481,7 +6821,11 @@ def _login_openai_codex(
             # here the token should be valid — but double-check before telling
             # the user "Login successful!".
             _resolved_key = existing.get("api_key", "")
-            if isinstance(_resolved_key, str) and _resolved_key and not _codex_access_token_is_expiring(_resolved_key, 60):
+            if isinstance(_resolved_key, str) and _resolved_key and not _codex_access_token_is_expiring(
+                _resolved_key,
+                60,
+                last_refresh=existing.get("last_refresh"),
+            ):
                 print("Existing Codex credentials found in Hermes auth store.")
                 try:
                     reuse = input("Use existing credentials? [Y/n]: ").strip().lower()

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -11,12 +11,20 @@ import yaml
 
 from hermes_cli.auth import (
     AuthError,
+    CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS,
+    CODEX_SHARED_STORE_FILENAME,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
+    _codex_access_token_is_expiring,
+    _codex_shared_auth_dir,
+    _codex_shared_store_path,
+    _merge_shared_codex_state,
     _read_codex_tokens,
+    _read_shared_codex_state,
     _save_codex_tokens,
     _import_codex_cli_tokens,
     _login_openai_codex,
+    _write_shared_codex_state,
     get_codex_auth_status,
     get_provider_auth_state,
     refresh_codex_oauth_pure,
@@ -25,8 +33,22 @@ from hermes_cli.auth import (
 )
 
 
-def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"):
-    """Write Codex tokens into the Hermes auth store."""
+def _setup_hermes_auth(
+    hermes_home: Path,
+    *,
+    access_token: str = "access",
+    refresh_token: str = "refresh",
+    last_refresh: str | None = None,
+):
+    """Write Codex tokens into the Hermes auth store.
+
+    ``last_refresh`` defaults to ``now`` so callers get a fresh-by-default
+    fixture.  Tests that need to exercise stale-token behaviour should pass an
+    explicit ISO-8601 UTC timestamp older than CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS.
+    """
+    from datetime import datetime, timezone
+    if last_refresh is None:
+        last_refresh = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     hermes_home.mkdir(parents=True, exist_ok=True)
     auth_store = {
         "version": 1,
@@ -37,7 +59,7 @@ def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refre
                     "access_token": access_token,
                     "refresh_token": refresh_token,
                 },
-                "last_refresh": "2026-02-26T00:00:00Z",
+                "last_refresh": last_refresh,
                 "auth_mode": "chatgpt",
             },
         },
@@ -579,3 +601,303 @@ def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypa
 
     assert called["device_login"] == 1
     assert called["tokens"]["access_token"] == "fresh-at"
+
+
+# -----------------------------------------------------------------------------
+# _codex_access_token_is_expiring — wall-clock floor on top of JWT exp.
+#
+# The JWT-exp-only predicate is insufficient because chatgpt.com's Cloudflare
+# layer enforces a server-side TTL much shorter than the JWT's declared exp
+# (observed in production: JWT exp ~10 days out, server starts silently
+# dropping requests after a few hours).  Adding ``last_refresh`` lets the
+# predicate trigger refresh on wall-clock age, regardless of what the JWT
+# claims.
+# -----------------------------------------------------------------------------
+
+def _jwt_no_exp() -> str:
+    """Return a JWT whose payload omits the ``exp`` claim entirely."""
+    encoded = base64.urlsafe_b64encode(json.dumps({"sub": "u"}).encode("utf-8")).rstrip(b"=").decode("utf-8")
+    return f"h.{encoded}.s"
+
+
+def _iso_now_minus(seconds: int) -> str:
+    """Return an ISO-8601 UTC timestamp ``seconds`` in the past."""
+    from datetime import datetime, timezone, timedelta
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def test_codex_access_token_is_expiring_jwt_exp_in_past_returns_true():
+    """Legacy: JWT exp in the past still triggers refresh (regression guard)."""
+    token = _jwt_with_exp(int(time.time()) - 60)
+    assert _codex_access_token_is_expiring(token, 0) is True
+
+
+def test_codex_access_token_is_expiring_jwt_exp_far_future_no_last_refresh_returns_false():
+    """Backward compat: callers that don't pass last_refresh see the original JWT-only behavior."""
+    token = _jwt_with_exp(int(time.time()) + 10 * 24 * 3600)  # 10 days out, matches real Codex JWTs
+    assert _codex_access_token_is_expiring(token, 120) is False
+
+
+def test_codex_access_token_is_expiring_fresh_last_refresh_returns_false():
+    """30-min-old last_refresh is under the 45-min default cap → no refresh."""
+    token = _jwt_with_exp(int(time.time()) + 10 * 24 * 3600)
+    assert _codex_access_token_is_expiring(
+        token, 120, last_refresh=_iso_now_minus(30 * 60)
+    ) is False
+
+
+def test_codex_access_token_is_expiring_stale_last_refresh_overrides_jwt_exp():
+    """THE PRODUCTION FIX.  JWT exp far future, but last_refresh is 50 min old → refresh.
+
+    Repro: JWTs from chatgpt.com/backend-api/codex carry exp ~10 days out,
+    so the legacy JWT-only predicate returns False forever.  Cloudflare
+    nevertheless silently drops requests once its server-side TTL elapses
+    (observed somewhere between a few hours and several days post-refresh).
+    The wall-clock floor on ``last_refresh`` catches this case.
+    """
+    token = _jwt_with_exp(int(time.time()) + 10 * 24 * 3600)
+    assert _codex_access_token_is_expiring(
+        token, 120, last_refresh=_iso_now_minus(50 * 60)
+    ) is True
+
+
+def test_codex_access_token_is_expiring_no_exp_but_stale_last_refresh_returns_true():
+    """JWT lacks exp; wall-clock alone triggers refresh."""
+    assert _codex_access_token_is_expiring(
+        _jwt_no_exp(), 120, last_refresh=_iso_now_minus(60 * 60)
+    ) is True
+
+
+def test_codex_access_token_is_expiring_no_exp_no_last_refresh_returns_false():
+    """Both signals absent → preserve original conservative behavior (no spurious refresh)."""
+    assert _codex_access_token_is_expiring(_jwt_no_exp(), 120) is False
+
+
+def test_codex_access_token_is_expiring_malformed_last_refresh_falls_through_to_jwt():
+    """Garbage in last_refresh must not crash; predicate falls through to JWT-exp path."""
+    fresh_token = _jwt_with_exp(int(time.time()) + 3600)
+    assert _codex_access_token_is_expiring(
+        fresh_token, 120, last_refresh="not-an-iso-timestamp"
+    ) is False
+    expired_token = _jwt_with_exp(int(time.time()) - 60)
+    assert _codex_access_token_is_expiring(
+        expired_token, 0, last_refresh="not-an-iso-timestamp"
+    ) is True
+
+
+def test_codex_access_token_is_expiring_env_var_overrides_max_age(monkeypatch):
+    """HERMES_CODEX_TOKEN_MAX_AGE_SECONDS env var tightens / loosens the cap."""
+    token = _jwt_with_exp(int(time.time()) + 10 * 24 * 3600)
+    last_refresh = _iso_now_minus(40 * 60)  # under 45-min default, over a 30-min override
+    assert _codex_access_token_is_expiring(token, 120, last_refresh=last_refresh) is False
+    monkeypatch.setenv("HERMES_CODEX_TOKEN_MAX_AGE_SECONDS", "1800")  # 30 min
+    assert _codex_access_token_is_expiring(token, 120, last_refresh=last_refresh) is True
+
+
+def test_codex_access_token_is_expiring_explicit_max_age_kwarg_overrides_default():
+    """Explicit ``max_age_seconds`` kwarg takes precedence over default; 0 disables wall-clock floor."""
+    token = _jwt_with_exp(int(time.time()) + 10 * 24 * 3600)
+    stale = _iso_now_minus(60 * 60)
+    assert _codex_access_token_is_expiring(
+        token, 120, last_refresh=stale, max_age_seconds=0
+    ) is False
+    assert _codex_access_token_is_expiring(
+        token, 120, last_refresh=stale, max_age_seconds=600
+    ) is True
+
+
+def test_codex_access_token_max_age_default_is_45_minutes():
+    """Documented value: 45 min.  Guard against silent default changes."""
+    assert CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS == 45 * 60
+
+
+# -----------------------------------------------------------------------------
+# Shared Codex auth store — cross-profile coordination via a single file.
+#
+# Use case: multiple Hermes profiles (e.g. a Docker fleet of agents) all
+# authenticate against the same ChatGPT account.  Without shared state, the
+# first profile to rotate the single-use refresh_token invalidates every
+# sibling's local copy and they trip ``refresh_token_reused`` on next refresh.
+# The shared store gives them a single source of truth.
+# -----------------------------------------------------------------------------
+
+def test_codex_shared_auth_dir_honors_env_override(tmp_path, monkeypatch):
+    """HERMES_SHARED_AUTH_DIR redirects the shared-store directory."""
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
+    assert _codex_shared_auth_dir() == tmp_path / "shared"
+
+
+def test_codex_shared_auth_dir_defaults_to_hermes_root_shared(tmp_path, monkeypatch):
+    """Default location is ``<hermes-root>/shared/`` when env var is unset."""
+    monkeypatch.delenv("HERMES_SHARED_AUTH_DIR", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    expected = _codex_shared_auth_dir()
+    # We don't assert the exact path (depends on platform & hermes_constants)
+    # but it must end in /shared and live somewhere under or alongside HERMES_HOME.
+    assert expected.name == "shared"
+
+
+def test_codex_shared_store_path_seat_belt_blocks_real_home(tmp_path, monkeypatch):
+    """Under pytest, refuse to touch the real user's shared store without override."""
+    monkeypatch.delenv("HERMES_SHARED_AUTH_DIR", raising=False)
+    # Force the default-resolution path to match the seat-belt target.
+    # We use a monkeypatch on get_default_hermes_root via the auth module's
+    # cached import — both sides need to agree for the seat-belt guard to fire.
+    from hermes_constants import get_default_hermes_root as real_get_root  # noqa: F401
+    with pytest.raises(RuntimeError, match="Refusing to touch real user shared Codex"):
+        _codex_shared_store_path()
+
+
+def test_codex_shared_store_path_with_override(tmp_path, monkeypatch):
+    """Override path bypasses the seat belt."""
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared_override"))
+    path = _codex_shared_store_path()
+    assert path == tmp_path / "shared_override" / CODEX_SHARED_STORE_FILENAME
+
+
+def test_read_shared_codex_state_returns_none_when_missing(tmp_path, monkeypatch):
+    """Missing shared file returns None, not an error."""
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
+    assert _read_shared_codex_state() is None
+
+
+def test_read_shared_codex_state_returns_dict(tmp_path, monkeypatch):
+    """Populated shared file is read back as a dict."""
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    shared_dir.mkdir()
+    payload = {
+        "access_token": "at-1",
+        "refresh_token": "rt-1",
+        "last_refresh": "2026-05-28T10:00:00.000000Z",
+    }
+    (shared_dir / CODEX_SHARED_STORE_FILENAME).write_text(json.dumps(payload))
+    state = _read_shared_codex_state()
+    assert state["access_token"] == "at-1"
+    assert state["refresh_token"] == "rt-1"
+
+
+def test_write_shared_codex_state_persists(tmp_path, monkeypatch):
+    """Writing shared state produces a readable file under HERMES_SHARED_AUTH_DIR."""
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state(
+        {"access_token": "at-w", "refresh_token": "rt-w"},
+        "2026-05-28T11:00:00.000000Z",
+    )
+    written = json.loads((shared_dir / CODEX_SHARED_STORE_FILENAME).read_text())
+    assert written["access_token"] == "at-w"
+    assert written["refresh_token"] == "rt-w"
+    assert written["last_refresh"] == "2026-05-28T11:00:00.000000Z"
+    assert written["auth_mode"] == "chatgpt"
+
+
+def test_write_shared_codex_state_skips_when_tokens_empty(tmp_path, monkeypatch):
+    """No-op write when either token is missing — don't pollute shared with garbage."""
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _write_shared_codex_state({"access_token": "at-only", "refresh_token": ""}, None)
+    assert not (shared_dir / CODEX_SHARED_STORE_FILENAME).exists()
+
+
+def test_merge_shared_codex_state_adopts_fresher(tmp_path, monkeypatch):
+    """Local state with stale last_refresh adopts fresher shared tokens."""
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    shared_dir.mkdir()
+    (shared_dir / CODEX_SHARED_STORE_FILENAME).write_text(json.dumps({
+        "access_token": "at-fresh",
+        "refresh_token": "rt-fresh",
+        "last_refresh": "2026-05-28T12:00:00.000000Z",
+    }))
+    local = {
+        "tokens": {"access_token": "at-stale", "refresh_token": "rt-stale"},
+        "last_refresh": "2026-05-28T10:00:00.000000Z",
+    }
+    assert _merge_shared_codex_state(local) is True
+    assert local["tokens"]["access_token"] == "at-fresh"
+    assert local["tokens"]["refresh_token"] == "rt-fresh"
+    assert local["last_refresh"] == "2026-05-28T12:00:00.000000Z"
+
+
+def test_merge_shared_codex_state_skips_when_local_is_newer(tmp_path, monkeypatch):
+    """Local fresher than shared → no merge, no mutation."""
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    shared_dir.mkdir()
+    (shared_dir / CODEX_SHARED_STORE_FILENAME).write_text(json.dumps({
+        "access_token": "at-old",
+        "refresh_token": "rt-old",
+        "last_refresh": "2026-05-28T10:00:00.000000Z",
+    }))
+    local = {
+        "tokens": {"access_token": "at-new", "refresh_token": "rt-new"},
+        "last_refresh": "2026-05-28T12:00:00.000000Z",
+    }
+    assert _merge_shared_codex_state(local) is False
+    assert local["tokens"]["access_token"] == "at-new"
+
+
+def test_merge_shared_codex_state_returns_false_when_shared_missing(tmp_path, monkeypatch):
+    """No shared store configured → merge is a clean no-op."""
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared-none"))
+    local = {
+        "tokens": {"access_token": "at", "refresh_token": "rt"},
+        "last_refresh": "2026-05-28T12:00:00.000000Z",
+    }
+    assert _merge_shared_codex_state(local) is False
+
+
+def test_save_codex_tokens_propagates_to_shared_store(tmp_path, monkeypatch):
+    """Saving local tokens also writes them to the shared store (if configured)."""
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    _save_codex_tokens(
+        {"access_token": "at-saved", "refresh_token": "rt-saved"},
+        last_refresh="2026-05-28T13:00:00.000000Z",
+    )
+    written = json.loads((shared_dir / CODEX_SHARED_STORE_FILENAME).read_text())
+    assert written["access_token"] == "at-saved"
+    assert written["refresh_token"] == "rt-saved"
+    assert written["last_refresh"] == "2026-05-28T13:00:00.000000Z"
+
+
+def test_resolve_adopts_shared_tokens_and_skips_refresh(tmp_path, monkeypatch):
+    """End-to-end: stale local + fresh shared → adopt shared, no network refresh."""
+    from datetime import datetime, timezone, timedelta
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    # Stale local — older than the 45-min wall-clock floor.
+    stale_ago = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    _setup_hermes_auth(
+        hermes_home,
+        access_token=_jwt_with_exp(int(time.time()) + 10 * 24 * 3600),
+        refresh_token="stale-rt",
+        last_refresh=stale_ago,
+    )
+    # Fresh shared — written by a "sibling profile" 5 seconds ago.
+    fresh_ago = (datetime.now(timezone.utc) - timedelta(seconds=5)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    shared_dir.mkdir()
+    (shared_dir / CODEX_SHARED_STORE_FILENAME).write_text(json.dumps({
+        "access_token": _jwt_with_exp(int(time.time()) + 10 * 24 * 3600),
+        "refresh_token": "fresh-rt-from-sibling",
+        "last_refresh": fresh_ago,
+    }))
+
+    # If the code under test calls the network, the test fails noisily.
+    def _explode(*a, **kw):
+        raise AssertionError("refresh should NOT fire when shared store has fresh tokens")
+    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _explode)
+
+    resolved = resolve_codex_runtime_credentials()
+    assert resolved["api_key"]  # non-empty
+    # Local store should now hold the sibling's tokens.
+    local_after = json.loads((hermes_home / "auth.json").read_text())
+    state = local_after["providers"]["openai-codex"]
+    assert state["tokens"]["refresh_token"] == "fresh-rt-from-sibling"
+    assert state["last_refresh"] == fresh_ago


### PR DESCRIPTION
# fix(codex-auth): wall-clock token-staleness floor + cross-profile shared store

## TL;DR

Two changes to `hermes_cli/auth.py`, both fixing real production failure modes seen on a 2026-05-27 Docker-fleet outage:

1. **`_codex_access_token_is_expiring` gains a wall-clock floor.** Codex JWTs advertise `exp` ~10 days out, but chatgpt.com enforces a shorter server-side TTL and *silently drops* requests with stale tokens (no 401 — just zero response bytes for 600 s). The wall-clock check on the stored `last_refresh` field catches what the JWT exp predicate misses.
2. **Optional cross-profile shared codex auth store.** Mirrors the existing `_nous_shared_auth_dir` pattern exactly. Lets multiple Hermes profiles authed against the same ChatGPT account coordinate refresh-token rotation so the first profile to rotate doesn't break the other N-1 with `refresh_token_reused`.

## The bug

A fleet of 8 agents running `hermes gateway run` started hanging on every codex call with:

```
⚠️  No response from provider for 600s
    (non-streaming, model: gpt-5.5). Aborting call.
```

Investigation (full evidence chain available; abbreviated here):

| Check | Result |
| --- | --- |
| `docker exec <agent> ss -tn \| grep CLOSE-WAIT` | Sockets to Cloudflare IPs (`172.64.155.209`, `104.18.32.47`) with `Recv-Q=25` |
| curl with the agent's auth, 8-day-old token, `--max-time 30` | `http_code=000 time_total=30.002s time_starttransfer=0.0s size_download=0` |
| Same curl after refreshing the OAuth access_token | `http_code=400 time_total=0.57s time_starttransfer=0.57s` |
| Decoded JWT exp on a freshly-refreshed token | `exp = now + 862,833 s = 10 days out` |
| `credential_pool.openai-codex[0].request_count` | `0` (despite dozens of real codex calls) |

The chain that breaks down today:

1. `_codex_access_token_is_expiring` is a JWT-`exp`-only check.
2. Codex tokens carry `exp` ten days in the future, so the predicate returns False indefinitely.
3. Chatgpt.com/Cloudflare nevertheless invalidates tokens server-side after a shorter TTL.
4. Past that TTL, requests are dropped silently (no `401`, no body — just a hung read).
5. The pool's reactive refresh-on-401 path therefore never fires.
6. After ~8 days a refresh still works (we verified by manual `refresh_codex_oauth_pure`), but no code path triggers it on its own.

The wall-clock fix is the minimum needed to make the existing refresh machinery actually run.

## Change 1: wall-clock floor on `_codex_access_token_is_expiring`

```python
def _codex_access_token_is_expiring(
    access_token: Any,
    skew_seconds: int,
    *,
    last_refresh: Optional[str] = None,
    max_age_seconds: Optional[int] = None,
) -> bool:
```

Two ORed predicates:

- **Wall-clock floor (NEW):** if `last_refresh` parses as ISO-8601 UTC and is older than `max_age_seconds` (default `CODEX_ACCESS_TOKEN_MAX_AGE_SECONDS = 45 * 60`, overridable via `HERMES_CODEX_TOKEN_MAX_AGE_SECONDS`), refresh.
- **JWT exp + skew (existing):** unchanged, preserved as a secondary signal for non-JWT or future-TTL-honoring tokens.

Backward-compatible: the existing two-positional-arg calls keep their old behavior exactly. Four call sites get `last_refresh` plumbed in where it was already available in scope (`resolve_codex_runtime_credentials` ×2, `get_codex_auth_status` pool branch, login-reuse check, and `CredentialPool._entry_needs_refresh`). One call site — `_import_codex_cli_tokens` checking imported tokens for *current* JWT validity — deliberately stays JWT-only since `last_refresh` for imported tokens is not reliably set.

**Default value rationale (45 min).** Observed TTL is bounded above by "still working after a few hours, broken by 8 days." 45 min sits well under any observed TTL with margin against further upstream changes, and an extra HTTPS POST every 45 min on an agent whose calls already carry seconds-to-minutes of reasoning latency is in the noise.

## Change 2: cross-profile shared codex auth store

Exact mirror of the existing Nous shared-store pattern (`_nous_shared_auth_dir`, `_nous_shared_store_path`, `_nous_shared_store_lock`). Honors the same `HERMES_SHARED_AUTH_DIR` env var so a single bind-mount path serves both providers.

New functions:

- `_codex_shared_auth_dir()` — directory resolution honoring `HERMES_SHARED_AUTH_DIR`, defaulting to `<hermes-root>/shared/`
- `_codex_shared_store_path()` — full path with pytest seat belt matching Nous's
- `_codex_shared_store_lock()` — cross-profile lock with documented ordering invariant (`_auth_store_lock` outer, this inner)
- `_read_shared_codex_state()` / `_write_shared_codex_state()` — atomic O_EXCL write + chmod 0o700 parent dir (matching `_save_auth_store`'s pattern)
- `_merge_shared_codex_state(local_data)` — adopts strictly-newer shared tokens into the local read-result; returns True iff merge happened

Wire-up:

- `_save_codex_tokens` propagates rotated tokens to the shared store after the local save succeeds (best-effort, never raises).
- `resolve_codex_runtime_credentials` checks the shared store *before* deciding to refresh. If a sibling profile rotated tokens while we were running, we adopt them and skip our own refresh. The shared-store lock then serializes any actual refresh across siblings so only one ever spends the live refresh_token.

This makes the canonical multi-agent topology (one ChatGPT identity, N profiles, each pinned to a Docker container) safe under refresh rotation. The operator's deploy-side change is one bind mount + one env var.

## Tests

`tests/hermes_cli/test_auth_codex_provider.py` gains 23 new test cases:

**Predicate (10 cases):**

- JWT exp in past → True (regression guard)
- JWT exp far future + no `last_refresh` → False (backward compat)
- JWT exp far future + fresh `last_refresh` (30 min) → False
- JWT exp far future + stale `last_refresh` (50 min) → **True** (the production fix)
- No exp + stale `last_refresh` → True
- No exp + no `last_refresh` → False (preserves conservative legacy behaviour)
- Malformed `last_refresh` → falls through to JWT predicate
- `HERMES_CODEX_TOKEN_MAX_AGE_SECONDS` env var overrides default
- Explicit `max_age_seconds` kwarg overrides default; 0 disables wall-clock check
- Default constant value pin

**Shared store (13 cases):**

- `HERMES_SHARED_AUTH_DIR` redirects path
- Default path resolution
- Pytest seat belt fires without env override
- Read missing → None
- Read populated → dict
- Write persist
- Write skips empty tokens (no shared file pollution)
- Merge adopts fresher
- Merge skips when local newer
- Merge no-shared → False
- `_save_codex_tokens` propagates to shared
- **End-to-end: stale local + fresh shared → adopt shared, no network refresh** (asserts via monkeypatched `_refresh_codex_auth_tokens` that the network is never called)

`_setup_hermes_auth` test fixture: default `last_refresh` is now `now` instead of a hardcoded 2026-02-26 timestamp. The old hardcoded value became "stale" under the new predicate and would have broken a dozen unrelated tests that never intended to exercise refresh.

**Test results:**

- `tests/hermes_cli/test_auth_codex_provider.py`: **46/46 pass.**
- Broader sweep: 5,480 pass, 11 skipped, 0 failures. (Excludes 6 test files for systemd / WSL / pip-install detection that fail in any non-systemd container.)

## Operator notes

For users running 1 profile against 1 ChatGPT account, no action needed — the wall-clock floor alone fixes the hang. The shared-store is dormant unless `HERMES_SHARED_AUTH_DIR` is set or `<hermes-root>/shared/codex_auth.json` exists.

For users running an N-profile Docker fleet against one ChatGPT account, two changes:

1. Add a bind mount per agent: host `./shared/codex-auth/` → container `/opt/data/shared/codex-auth/` (or wherever).
2. Set `HERMES_SHARED_AUTH_DIR=/opt/data/shared/codex-auth` per agent.

First refresh after deploy populates the shared file; subsequent refreshes on any sibling rotate atomically.

## Reproducer

```bash
# inside a failing agent (Docker, pre-fix):
TOKEN=$(jq -r '.credential_pool["openai-codex"][0].access_token' \
    /opt/data/profiles/$AGENT/auth.json)
curl -sS -w "%{http_code} %{time_total}s\n" --max-time 30 \
    -X POST https://chatgpt.com/backend-api/codex/responses \
    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
    -H "OpenAI-Beta: responses=experimental" \
    -d '{"model":"gpt-5.5","input":[{"role":"user","content":[{"type":"input_text","text":"x"}]}],"stream":false}'

# 8-day-old token → "000 30.002s"  (silent drop)
# post-refresh    → "400 0.57s"    (server responds)
```
