### PR TITLE
feat(mcp): support private catalog paths

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -6,10 +6,16 @@ entries via ``hermes mcp catalog`` or the interactive ``hermes mcp picker``,
 and install them with ``hermes mcp install <name>`` (or by toggling in the
 picker, which flows them through any required env/OAuth setup).
 
+Hermes can also read user-configured private catalog roots from
+``mcp_catalog_paths`` in config.yaml. Those entries use the same manifest
+schema, but are labeled ``private`` in the picker instead of inheriting the
+Nous-approved trust signal from the shipped ``optional-mcps/`` directory.
+
 Catalog policy:
-- Entries are added only by merging a PR into hermes-agent. Presence in the
-  ``optional-mcps/`` directory = Nous approval. No community tier, no trust
-  signals beyond "it's in the catalog".
+- Official entries are added only by merging a PR into hermes-agent. Presence
+  in the shipped ``optional-mcps/`` directory = Nous approval.
+- Private catalog paths are local/user-configured and show a separate trust
+  label; they do not become Nous-approved just because Hermes can list them.
 - Manifests pin transport details (commands, args, refs). MCPs are never
   auto-updated; users explicitly re-run ``hermes mcp install <name>`` to
   pull a new manifest version after a repo update.
@@ -106,6 +112,22 @@ class ToolsSpec:
     default_enabled: Optional[List[str]] = None
 
 
+@dataclass(frozen=True)
+class CatalogSource:
+    """One directory of MCP catalog manifests.
+
+    ``label`` is the user-facing source prefix accepted by ``get_entry`` and
+    ``hermes mcp install <label>/<name>``. ``trust_label`` is deliberately
+    separate so private/team catalogs can share a clear trust posture without
+    pretending to be Nous-reviewed.
+    """
+
+    label: str
+    path: Path
+    trust_label: str
+    is_official: bool = False
+
+
 @dataclass
 class CatalogEntry:
     name: str
@@ -116,7 +138,13 @@ class CatalogEntry:
     tools: ToolsSpec = field(default_factory=ToolsSpec)
     install: Optional[InstallSpec] = None
     post_install: str = ""
+    catalog_label: str = "official"
+    trust_label: str = "Nous-approved"
     manifest_path: Path = field(default_factory=Path)
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{self.catalog_label}/{self.name}"
 
 
 # ─── Manifest loader ─────────────────────────────────────────────────────────
@@ -131,6 +159,116 @@ def _catalog_root() -> Path:
     # Prefer the env-var override / packaged location; fall back to the repo's
     # optional-mcps/ next to the package (source checkout).
     return get_optional_mcps_dir(Path(__file__).parent.parent / "optional-mcps")
+
+
+def _expand_catalog_path(path_value: str) -> Path:
+    return Path(os.path.expandvars(os.path.expanduser(str(path_value)))).resolve()
+
+
+def _private_catalog_sources_from_config() -> List[CatalogSource]:
+    """Return user-configured private catalog roots.
+
+    Supported config shapes:
+
+    ``mcp_catalog_paths: {team: ~/mcps}``
+      Preferred shape; label is explicit and stable.
+
+    ``mcp_catalog_paths: [~/mcps, {label: team, path: ~/team-mcps}]``
+      Convenience shape for single/local catalogs.
+    """
+    try:
+        cfg = load_config()
+    except Exception as exc:
+        _CATALOG_DIAGNOSTICS.append(("mcp_catalog_paths", "invalid", str(exc)))
+        return []
+
+    raw = cfg.get("mcp_catalog_paths") or []
+    sources: List[CatalogSource] = []
+
+    def add_source(label: str, value: Any, *, index: int = 0) -> None:
+        if value is None or str(value).strip() == "":
+            _CATALOG_DIAGNOSTICS.append((str(label), "invalid", "empty catalog path"))
+            return
+        clean_label = str(label or "").strip() or (
+            "private" if index == 0 else f"private{index + 1}"
+        )
+        if clean_label == "official":
+            clean_label = "private"
+        sources.append(
+            CatalogSource(
+                label=clean_label,
+                path=_expand_catalog_path(str(value)),
+                trust_label="private",
+                is_official=False,
+            )
+        )
+
+    if isinstance(raw, dict):
+        for label, value in sorted(raw.items(), key=lambda item: str(item[0])):
+            add_source(str(label), value)
+    elif isinstance(raw, list):
+        for idx, item in enumerate(raw):
+            if isinstance(item, str):
+                add_source("private" if idx == 0 else f"private{idx + 1}", item, index=idx)
+            elif isinstance(item, dict):
+                label = item.get("label") or item.get("name") or (
+                    "private" if idx == 0 else f"private{idx + 1}"
+                )
+                add_source(str(label), item.get("path"), index=idx)
+            else:
+                _CATALOG_DIAGNOSTICS.append((
+                    f"mcp_catalog_paths[{idx}]",
+                    "invalid",
+                    f"expected string or mapping, got {type(item).__name__}",
+                ))
+    elif isinstance(raw, str):
+        add_source("private", raw)
+    elif raw:
+        _CATALOG_DIAGNOSTICS.append((
+            "mcp_catalog_paths",
+            "invalid",
+            f"expected mapping, list, or string, got {type(raw).__name__}",
+        ))
+
+    return sources
+
+
+def _private_catalog_sources_from_env() -> List[CatalogSource]:
+    """Optional wrapper/runtime hook for private catalogs.
+
+    ``HERMES_MCP_CATALOG_PATHS`` is pathsep-separated (``:`` on Unix,
+    ``;`` on Windows). Config.yaml remains the documented stable surface;
+    this hook keeps package-manager wrappers and tests ergonomic.
+    """
+    raw = os.getenv("HERMES_MCP_CATALOG_PATHS", "").strip()
+    if not raw:
+        return []
+    sources: List[CatalogSource] = []
+    for idx, part in enumerate([p for p in raw.split(os.pathsep) if p.strip()]):
+        label = "env" if idx == 0 else f"env{idx + 1}"
+        sources.append(
+            CatalogSource(
+                label=label,
+                path=_expand_catalog_path(part),
+                trust_label="private",
+                is_official=False,
+            )
+        )
+    return sources
+
+
+def _catalog_sources() -> List[CatalogSource]:
+    sources = [
+        CatalogSource(
+            label="official",
+            path=_catalog_root(),
+            trust_label="Nous-approved",
+            is_official=True,
+        )
+    ]
+    sources.extend(_private_catalog_sources_from_config())
+    sources.extend(_private_catalog_sources_from_env())
+    return sources
 
 
 def _parse_env_spec(raw: Any) -> EnvVarSpec:
@@ -148,8 +286,15 @@ def _parse_env_spec(raw: Any) -> EnvVarSpec:
     )
 
 
-def _parse_manifest(path: Path) -> CatalogEntry:
+def _parse_manifest(path: Path, source_meta: Optional[CatalogSource] = None) -> CatalogEntry:
     """Read and validate a manifest.yaml. Raise CatalogError on any problem."""
+    if source_meta is None:
+        source_meta = CatalogSource(
+            label="official",
+            path=path.parent.parent,
+            trust_label="Nous-approved",
+            is_official=True,
+        )
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
@@ -259,6 +404,8 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         tools=tools_spec,
         install=install,
         post_install=str(data.get("post_install") or ""),
+        catalog_label=source_meta.label,
+        trust_label=source_meta.trust_label,
         manifest_path=path,
     )
 
@@ -271,26 +418,41 @@ def list_catalog() -> List[CatalogEntry]:
     skip is surfaced via :func:`catalog_diagnostics` so the picker / catalog
     UIs can tell the user their Hermes is out of date.
     """
-    root = _catalog_root()
-    if not root.exists():
-        return []
     entries: List[CatalogEntry] = []
     _CATALOG_DIAGNOSTICS.clear()
-    for child in sorted(root.iterdir()):
-        manifest = child / "manifest.yaml"
-        if not manifest.is_file():
+    for source in _catalog_sources():
+        root = source.path
+        if not root.exists():
+            if not source.is_official:
+                _CATALOG_DIAGNOSTICS.append((
+                    source.label,
+                    "missing_catalog_path",
+                    f"configured MCP catalog path does not exist: {root}",
+                ))
             continue
-        try:
-            entries.append(_parse_manifest(manifest))
-        except CatalogError as exc:
-            msg = str(exc)
-            # Recognize the future-manifest error specifically so the UI can
-            # surface a more actionable nudge than "broken manifest".
-            if "manifest_version" in msg and "unsupported" in msg:
-                _CATALOG_DIAGNOSTICS.append((child.name, "future_manifest", msg))
-            else:
-                _CATALOG_DIAGNOSTICS.append((child.name, "invalid", msg))
+        if not root.is_dir():
+            _CATALOG_DIAGNOSTICS.append((
+                source.label,
+                "invalid",
+                f"configured MCP catalog path is not a directory: {root}",
+            ))
             continue
+        for child in sorted(root.iterdir()):
+            manifest = child / "manifest.yaml"
+            if not manifest.is_file():
+                continue
+            try:
+                entries.append(_parse_manifest(manifest, source_meta=source))
+            except CatalogError as exc:
+                msg = str(exc)
+                entry_name = child.name if source.is_official else f"{source.label}/{child.name}"
+                # Recognize the future-manifest error specifically so the UI can
+                # surface a more actionable nudge than "broken manifest".
+                if "manifest_version" in msg and "unsupported" in msg:
+                    _CATALOG_DIAGNOSTICS.append((entry_name, "future_manifest", msg))
+                else:
+                    _CATALOG_DIAGNOSTICS.append((entry_name, "invalid", msg))
+                continue
     return entries
 
 
@@ -308,16 +470,29 @@ def catalog_diagnostics() -> List[tuple]:
         understands. Update Hermes to install this entry.
       - ``invalid`` — manifest is malformed in some other way (caught by
         CI for shipped manifests; user-modified manifests can hit this).
+      - ``missing_catalog_path`` — a configured private catalog path does not
+        exist and was skipped.
     """
     return list(_CATALOG_DIAGNOSTICS)
 
 
 def get_entry(name: str) -> Optional[CatalogEntry]:
-    """Look up a single entry by name. ``official/<name>`` prefix accepted."""
-    if name.startswith("official/"):
-        name = name[len("official/"):]
+    """Look up a single entry by name.
+
+    ``official/<name>`` and private catalog prefixes such as ``team/<name>``
+    are accepted. Unqualified names continue to work when the manifest name is
+    unique enough for the user's configured catalogs.
+    """
+    catalog_prefix: Optional[str] = None
+    entry_name = name
+    if "/" in name:
+        catalog_prefix, entry_name = name.split("/", 1)
     for entry in list_catalog():
-        if entry.name == name:
+        if catalog_prefix is not None:
+            if entry.catalog_label == catalog_prefix and entry.name == entry_name:
+                return entry
+            continue
+        if entry.name == entry_name:
             return entry
     return None
 

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -29,6 +29,7 @@ See references/mcp-catalog.md (this repo's skill) for the manifest schema.
 
 from __future__ import annotations
 
+import copy
 import os
 import re
 import shutil
@@ -136,6 +137,7 @@ class CatalogEntry:
     transport: TransportSpec
     auth: AuthSpec
     tools: ToolsSpec = field(default_factory=ToolsSpec)
+    runtime: Dict[str, Any] = field(default_factory=dict)
     install: Optional[InstallSpec] = None
     post_install: str = ""
     catalog_label: str = "official"
@@ -286,6 +288,52 @@ def _parse_env_spec(raw: Any) -> EnvVarSpec:
     )
 
 
+_RUNTIME_KEYS = {"timeout", "connect_timeout", "sampling", "env", "headers"}
+
+
+def _parse_runtime_config(raw: Any, path: Path) -> Dict[str, Any]:
+    """Validate optional manifest runtime settings copied to mcp_servers."""
+    if raw in (None, ""):
+        return {}
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{path}: 'runtime' must be a mapping")
+
+    unknown = sorted(set(raw) - _RUNTIME_KEYS)
+    if unknown:
+        joined = ", ".join(unknown)
+        raise CatalogError(f"{path}: runtime contains unsupported key(s): {joined}")
+
+    runtime: Dict[str, Any] = {}
+    for key in ("timeout", "connect_timeout"):
+        if key not in raw:
+            continue
+        value = raw[key]
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+            raise CatalogError(f"{path}: runtime.{key} must be a positive number")
+        runtime[key] = value
+
+    for key in ("env", "headers"):
+        if key not in raw:
+            continue
+        value = raw[key]
+        if not isinstance(value, dict) or not all(
+            isinstance(k, str) and isinstance(v, (str, int, float, bool))
+            for k, v in value.items()
+        ):
+            raise CatalogError(
+                f"{path}: runtime.{key} must be a mapping of string keys to scalar values"
+            )
+        runtime[key] = {str(k): str(v) for k, v in value.items()}
+
+    if "sampling" in raw:
+        value = raw["sampling"]
+        if not isinstance(value, dict):
+            raise CatalogError(f"{path}: runtime.sampling must be a mapping")
+        runtime["sampling"] = copy.deepcopy(value)
+
+    return runtime
+
+
 def _parse_manifest(path: Path, source_meta: Optional[CatalogSource] = None) -> CatalogEntry:
     """Read and validate a manifest.yaml. Raise CatalogError on any problem."""
     if source_meta is None:
@@ -373,6 +421,8 @@ def _parse_manifest(path: Path, source_meta: Optional[CatalogSource] = None) -> 
             )
     tools_spec = ToolsSpec(default_enabled=default_enabled)
 
+    runtime = _parse_runtime_config(data.get("runtime"), path)
+
     install: Optional[InstallSpec] = None
     install_raw = data.get("install")
     if install_raw is not None:
@@ -402,6 +452,7 @@ def _parse_manifest(path: Path, source_meta: Optional[CatalogSource] = None) -> 
         transport=transport,
         auth=auth,
         tools=tools_spec,
+        runtime=runtime,
         install=install,
         post_install=str(data.get("post_install") or ""),
         catalog_label=source_meta.label,
@@ -648,6 +699,7 @@ def _build_server_config(
         cfg["url"] = t.url
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
+    cfg.update(copy.deepcopy(entry.runtime))
     return cfg
 
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -789,7 +789,7 @@ def mcp_command(args):
         run_picker()
         print(color("  Commands:", Colors.CYAN))
         _info("hermes mcp                                    Open the catalog picker (default)")
-        _info("hermes mcp catalog                            List Nous-approved MCPs")
+        _info("hermes mcp catalog                            List MCP catalog entries")
         _info("hermes mcp install <name>                     Install a catalog MCP")
         _info("hermes mcp serve                              Run as MCP server")
         _info("hermes mcp add <name> --url <endpoint>        Add a custom MCP server")

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -59,6 +59,8 @@ class _Row:
     name: str
     description: str
     status: str
+    catalog_label: str
+    trust_label: str
     entry: Optional[CatalogEntry] = None  # None for non-catalog (custom) rows
 
     @property
@@ -84,6 +86,8 @@ def _build_rows() -> List[_Row]:
                 name=entry.name,
                 description=entry.description,
                 status=status,
+                catalog_label=entry.catalog_label,
+                trust_label=entry.trust_label,
                 entry=entry,
             )
         )
@@ -98,13 +102,64 @@ def _build_rows() -> List[_Row]:
         status = _STATUS_CUSTOM_ENABLED if enabled else _STATUS_CUSTOM_DISABLED
         # Use the transport URL/command as the "description" for custom rows
         desc = cfg.get("url") or cfg.get("command") or "(no transport)"
-        rows.append(_Row(name=name, description=str(desc), status=status))
+        rows.append(
+            _Row(
+                name=name,
+                description=str(desc),
+                status=status,
+                catalog_label="custom",
+                trust_label="user-config",
+            )
+        )
 
     return rows
 
 
-def _format_row(row: _Row) -> str:
-    return f"{row.name:<18} {row.status:<24} {row.description}"
+def _format_row(
+    row: _Row,
+    *,
+    name_width: int = 18,
+    status_width: int = 24,
+    catalog_width: int = 12,
+    trust_width: int = 14,
+) -> str:
+    return (
+        f"{row.name:<{name_width}} {row.status:<{status_width}} "
+        f"{row.catalog_label:<{catalog_width}} {row.trust_label:<{trust_width}} "
+        f"{row.description}"
+    )
+
+
+def _print_catalog_diagnostics() -> None:
+    """Print actionable catalog diagnostics captured during list_catalog()."""
+    diags = catalog_diagnostics()
+    if not diags:
+        return
+
+    printed = False
+    future = [d for d in diags if d[1] == "future_manifest"]
+    for name, _, _msg in future:
+        if not printed:
+            print()
+            printed = True
+        print(color(
+            f"  ⚠ '{name}' requires a newer Hermes — run `hermes update` "
+            "to install this entry.",
+            Colors.YELLOW,
+        ))
+
+    other = [d for d in diags if d[1] != "future_manifest"]
+    for name, kind, msg in other:
+        if not printed:
+            print()
+            printed = True
+        print(color(
+            f"  ⚠ MCP catalog '{name}' skipped ({kind}): {msg}",
+            Colors.YELLOW,
+        ))
+
+    if printed:
+        print()
 
 
 # ─── Actions ──────────────────────────────────────────────────────────────────
@@ -234,35 +289,45 @@ def _print_rows_text(rows: List[_Row]) -> None:
     if not rows:
         print()
         print(color("  No MCPs in the catalog or configured.", Colors.DIM))
+        _print_catalog_diagnostics()
         print()
         return
 
     print()
     print(color("  MCP Catalog + configured servers:", Colors.CYAN + Colors.BOLD))
     print()
-    print(f"  {'Name':<18} {'Status':<24} Description")
-    print(f"  {'-' * 18} {'-' * 24} {'-' * 11}")
+    name_width = max(18, *(len(r.name) for r in rows))
+    status_width = max(24, *(len(r.status) for r in rows))
+    catalog_width = max(12, *(len(r.catalog_label) for r in rows))
+    trust_width = max(14, *(len(r.trust_label) for r in rows))
+    print(
+        f"  {'Name':<{name_width}} {'Status':<{status_width}} "
+        f"{'Catalog':<{catalog_width}} {'Trust':<{trust_width}} Description"
+    )
+    print(
+        f"  {'-' * name_width} {'-' * status_width} "
+        f"{'-' * catalog_width} {'-' * trust_width} {'-' * 11}"
+    )
     for row in rows:
-        print(f"  {_format_row(row)}")
+        print(
+            "  "
+            + _format_row(
+                row,
+                name_width=name_width,
+                status_width=status_width,
+                catalog_width=catalog_width,
+                trust_width=trust_width,
+            )
+        )
     print()
     print(color(
         "  Install: hermes mcp install <name>    Picker: hermes mcp",
         Colors.DIM,
     ))
 
-    # Surface manifest-version warnings so users know when their Hermes is
-    # too old to install everything in the catalog.
-    diags = catalog_diagnostics()
-    future = [d for d in diags if d[1] == "future_manifest"]
-    if future:
-        print()
-        for name, _, msg in future:
-            print(color(
-                f"  ⚠ '{name}' requires a newer Hermes — run `hermes update` "
-                "to install this entry.",
-                Colors.YELLOW,
-            ))
-        print()
+    # Surface manifest and configured-path warnings so users know when the
+    # catalog is shorter than their config implies.
+    _print_catalog_diagnostics()
     print()
 
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -200,6 +200,103 @@ class TestManifestParsing:
 
 
 # ---------------------------------------------------------------------------
+# Private catalog paths
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateCatalogPaths:
+    def test_configured_private_catalog_path_is_loaded_with_trust_label(
+        self, catalog_dir, tmp_path
+    ):
+        _write_manifest(catalog_dir, "official-demo", _basic_manifest("official-demo"))
+        private_dir = tmp_path / "private-mcps"
+        private_dir.mkdir()
+        _write_manifest(private_dir, "team-demo", _basic_manifest("team-demo"))
+
+        from hermes_cli.config import load_config, save_config
+        cfg = load_config()
+        cfg["mcp_catalog_paths"] = {"team": str(private_dir)}
+        save_config(cfg)
+
+        from hermes_cli.mcp_catalog import list_catalog
+
+        entries = list_catalog()
+        by_name = {entry.name: entry for entry in entries}
+        assert set(by_name) == {"official-demo", "team-demo"}
+        assert by_name["official-demo"].catalog_label == "official"
+        assert by_name["official-demo"].trust_label == "Nous-approved"
+        assert by_name["team-demo"].catalog_label == "team"
+        assert by_name["team-demo"].trust_label == "private"
+
+    def test_get_entry_accepts_private_catalog_prefix(self, catalog_dir, tmp_path):
+        private_dir = tmp_path / "private-mcps"
+        private_dir.mkdir()
+        _write_manifest(private_dir, "team-demo", _basic_manifest("team-demo"))
+
+        from hermes_cli.config import load_config, save_config
+        cfg = load_config()
+        cfg["mcp_catalog_paths"] = {"team": str(private_dir)}
+        save_config(cfg)
+
+        from hermes_cli.mcp_catalog import get_entry
+
+        assert get_entry("team/team-demo") is not None
+        assert get_entry("team-demo") is not None
+        assert get_entry("other/team-demo") is None
+
+    def test_install_by_prefixed_private_catalog_name(self, catalog_dir, tmp_path):
+        private_dir = tmp_path / "private-mcps"
+        private_dir.mkdir()
+        _write_manifest(private_dir, "team-demo", _basic_manifest("team-demo"))
+
+        from hermes_cli.config import load_config, save_config
+        cfg = load_config()
+        cfg["mcp_catalog_paths"] = {"team": str(private_dir)}
+        save_config(cfg)
+
+        from hermes_cli.mcp_picker import install_by_name
+
+        rc = install_by_name("team/team-demo")
+        assert rc == 0
+        assert "team-demo" in load_config().get("mcp_servers", {})
+
+    def test_picker_text_shows_catalog_trust_column(self, catalog_dir, tmp_path, capsys):
+        _write_manifest(catalog_dir, "official-demo", _basic_manifest("official-demo"))
+        private_dir = tmp_path / "private-mcps"
+        private_dir.mkdir()
+        _write_manifest(private_dir, "team-demo", _basic_manifest("team-demo"))
+
+        from hermes_cli.config import load_config, save_config
+        cfg = load_config()
+        cfg["mcp_catalog_paths"] = {"team": str(private_dir)}
+        save_config(cfg)
+
+        from hermes_cli.mcp_picker import show_catalog
+        show_catalog()
+        out = capsys.readouterr().out
+        assert "Catalog" in out
+        assert "official" in out
+        assert "Nous-approved" in out
+        assert "team" in out
+        assert "private" in out
+        assert "team-demo" in out
+
+    def test_picker_surfaces_missing_private_catalog_path_warning(
+        self, catalog_dir, tmp_path, capsys
+    ):
+        from hermes_cli.config import load_config, save_config
+        cfg = load_config()
+        cfg["mcp_catalog_paths"] = {"team": str(tmp_path / "missing-mcps")}
+        save_config(cfg)
+
+        from hermes_cli.mcp_picker import show_catalog
+        show_catalog()
+        out = capsys.readouterr().out
+        assert "team" in out
+        assert "configured MCP catalog path does not exist" in out
+
+
+# ---------------------------------------------------------------------------
 # Install flow
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -190,6 +190,20 @@ class TestManifestParsing:
 
         assert list_catalog() == []
 
+    def test_invalid_runtime_config_rejected(self, catalog_dir):
+        _write_manifest(
+            catalog_dir,
+            "demo",
+            _basic_manifest(runtime={"command": "nope"}),
+        )
+        from hermes_cli.mcp_catalog import catalog_diagnostics, list_catalog
+
+        assert list_catalog() == []
+        assert any(
+            "runtime contains unsupported key" in message
+            for _entry_name, _kind, message in catalog_diagnostics()
+        )
+
     def test_get_entry_strips_official_prefix(self, catalog_dir):
         _write_manifest(catalog_dir, "demo", _basic_manifest())
         from hermes_cli.mcp_catalog import get_entry
@@ -315,6 +329,32 @@ class TestInstall:
         assert servers["demo"]["command"] == "npx"
         assert servers["demo"]["args"] == ["-y", "demo-mcp"]
         assert servers["demo"]["enabled"] is True
+
+    def test_install_preserves_manifest_runtime_config(self, catalog_dir):
+        _write_manifest(
+            catalog_dir,
+            "demo",
+            _basic_manifest(
+                runtime={
+                    "timeout": 180,
+                    "connect_timeout": 90,
+                    "sampling": {"enabled": False},
+                    "env": {"DEMO_MODE": "safe"},
+                }
+            ),
+        )
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import load_config
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["command"] == "npx"
+        assert server["args"] == ["-y", "demo-mcp"]
+        assert server["timeout"] == 180
+        assert server["connect_timeout"] == 90
+        assert server["sampling"] == {"enabled": False}
+        assert server["env"] == {"DEMO_MODE": "safe"}
 
     def test_install_with_install_dir_substitution(self, catalog_dir, tmp_path):
         body = _basic_manifest(

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -15,6 +15,10 @@ For conceptual guidance, see:
 ## Root config shape
 
 ```yaml
+mcp_catalog_paths:
+  team: ~/.hermes/mcp-catalogs/team
+  personal: ~/src/my-hermes-mcps
+
 mcp_servers:
   <server_name>:
     command: "..."      # stdio servers
@@ -35,6 +39,32 @@ mcp_servers:
       resources: true
       prompts: true
 ```
+
+## Catalog path keys
+
+`mcp_catalog_paths` adds private/team MCP catalog roots to the built-in
+official catalog. Each configured root uses the same
+`<entry>/manifest.yaml` layout as `optional-mcps/`, but entries are surfaced
+with `Trust: private` in `hermes mcp catalog` and the picker.
+
+Supported shapes:
+
+```yaml
+# Preferred: explicit label -> path
+mcp_catalog_paths:
+  team: ~/.hermes/mcp-catalogs/team
+
+# Also accepted
+mcp_catalog_paths:
+  - ~/.hermes/mcp-catalogs/private
+  - label: team
+    path: ~/src/team-mcps
+```
+
+Use `hermes mcp install <name>` for unique manifest names, or
+`hermes mcp install <label>/<name>` when you want to select a specific catalog
+source. Private catalog entries should use unique manifest names so installing
+them does not collide with official or existing `mcp_servers` keys.
 
 ## Server keys
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -66,6 +66,34 @@ Use `hermes mcp install <name>` for unique manifest names, or
 source. Private catalog entries should use unique manifest names so installing
 them does not collide with official or existing `mcp_servers` keys.
 
+## Catalog manifest runtime keys
+
+Catalog manifests may include an optional `runtime` block for safe server
+settings that should be copied into the installed `mcp_servers.<name>` entry:
+
+```yaml
+manifest_version: 1
+name: browser_debug
+transport:
+  type: stdio
+  command: npx
+  args: ["-y", "chrome-devtools-mcp@0.25.0", "--headless"]
+auth:
+  type: none
+runtime:
+  timeout: 120
+  connect_timeout: 60
+  sampling:
+    enabled: false
+  env:
+    CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: "1"
+```
+
+Supported `runtime` keys are `timeout`, `connect_timeout`, `sampling`, `env`,
+and `headers`. Transport keys (`command`, `args`, `url`) stay under
+`transport`, and tool filters stay under `tools.default_enabled` so manifests
+cannot silently override unrelated server config fields.
+
 ## Server keys
 
 | Key | Type | Applies to | Meaning |

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -64,19 +64,21 @@ hermes mcp catalog        # plain-text list, scriptable
 hermes mcp install n8n    # install a catalog entry by name
 ```
 
-The picker shows each entry with its current status:
+The picker shows each entry with its current status, catalog source, and trust
+label:
 
 ```
-n8n          available              Manage and inspect n8n workflows from Hermes
-linear       enabled                Linear issue/project management (remote OAuth)
-github       installed (disabled)   GitHub repo + PR tools
+Name         Status                 Catalog    Trust          Description
+n8n          available              official   Nous-approved  Manage and inspect n8n workflows from Hermes
+linear       enabled                official   Nous-approved  Linear issue/project management (remote OAuth)
+james_ops    available              team       private        Team operational MCP pack
 ```
 
 Hit `Enter` on a row to install (and walk through any required credentials),
-enable, disable, or uninstall. Catalog entries are stored under
+enable, disable, or uninstall. Official catalog entries are stored under
 `optional-mcps/` in the hermes-agent repo — presence in that directory means
-Nous approval. There is no community submission tier; entries are added by
-merging a PR.
+Nous approval. There is no community submission tier; official entries are
+added by merging a PR.
 
 Catalog entries can require:
 
@@ -134,6 +136,40 @@ Manifests live at
 on GitHub. The picker also prints the manifest's `source:` URL at install
 time so you can quickly verify the upstream repo.
 
+### Private catalog paths
+
+For team or personal MCP packs, add private catalog roots to `config.yaml`
+under `mcp_catalog_paths`. Private entries use the same
+`manifest.yaml` schema as official entries, but the picker labels them
+`Trust: private` so they are never confused with Nous-reviewed catalog items.
+
+```yaml
+mcp_catalog_paths:
+  team: ~/.hermes/mcp-catalogs/team
+  personal: ~/src/my-hermes-mcps
+```
+
+Each configured path should contain one directory per MCP:
+
+```text
+~/.hermes/mcp-catalogs/team/
+  james_ops/
+    manifest.yaml
+```
+
+Install by normal name if it is unique, or by catalog-qualified name when you
+want to be explicit:
+
+```bash
+hermes mcp install james_ops
+hermes mcp install team/james_ops
+```
+
+For wrapper scripts and packaged installs, `HERMES_MCP_CATALOG_PATHS` can also
+point at additional private catalog roots using the platform path separator
+(`:` on macOS/Linux, `;` on Windows). Config.yaml is the recommended stable
+surface for normal use.
+
 ### Manifest version compatibility
 
 Manifests pin a `manifest_version`. The catalog is forward-compatible: if a
@@ -169,8 +205,10 @@ you want to opt into.
 MCPs are never auto-updated. Re-run `hermes mcp install <name>` to refresh
 after a Hermes update if a manifest version changed.
 
-To add an MCP to the catalog, open a PR against
+To add an MCP to the official Nous-approved catalog, open a PR against
 [`optional-mcps/`](https://github.com/NousResearch/hermes-agent/tree/main/optional-mcps).
+For private/team MCPs, keep the manifest in a configured `mcp_catalog_paths`
+root instead.
 
 ## Two kinds of MCP servers
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -170,6 +170,12 @@ point at additional private catalog roots using the platform path separator
 (`:` on macOS/Linux, `;` on Windows). Config.yaml is the recommended stable
 surface for normal use.
 
+Private manifests can include a `runtime` block for the server settings that
+should be copied into `mcp_servers.<name>` on install, such as longer timeouts,
+static non-secret env vars, HTTP headers, or `sampling: {enabled: false}` for
+externally maintained servers. Keep launch details in `transport` and tool
+selection defaults in `tools.default_enabled`.
+
 ### Manifest version compatibility
 
 Manifests pin a `manifest_version`. The catalog is forward-compatible: if a


### PR DESCRIPTION
## Summary
- Add `mcp_catalog_paths` so users/teams can list private MCP catalog roots alongside shipped `optional-mcps` entries.
- Preserve the trust boundary by labeling official entries as `Nous-approved`, private catalog entries as `private`, and manual config rows as `user-config`.
- Support `hermes mcp install <catalog>/<name>` for explicit private-source installs, plus warnings for invalid/missing private catalog paths.
- Add optional manifest `runtime` settings (`timeout`, `connect_timeout`, `sampling`, `env`, `headers`) so catalog installs can preserve safe MCP runtime defaults without letting manifests override transport/tool fields.
- Document the new config surfaces and catalog behavior.

## Verification
- `python -m pytest tests/hermes_cli/test_mcp_catalog.py -q` → 41 passed
- `python -m pytest tests/hermes_cli/test_mcp_*.py -q` → 95 passed
- `python -m py_compile hermes_cli/mcp_catalog.py hermes_cli/mcp_config.py hermes_cli/mcp_picker.py`
- `git diff --check -- hermes_cli/mcp_catalog.py hermes_cli/mcp_config.py hermes_cli/mcp_picker.py tests/hermes_cli/test_mcp_catalog.py website/docs/reference/mcp-config-reference.md website/docs/user-guide/features/mcp.md`
- Isolated smoke: `HERMES_MCP_CATALOG_PATHS=<tmp-catalog> hermes mcp catalog` listed `private_probe` as `env / private`
- Isolated smoke: `HERMES_MCP_CATALOG_PATHS=<tmp-catalog> hermes mcp install env/private_probe` wrote an enabled `mcp_servers.private_probe` config block and preserved runtime timeout/sampling/env settings
