### PR TITLE
fix(gateway): replay queued send_message mirrors

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -12,14 +12,16 @@ the full SessionStore machinery.
 import json
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
 _SESSIONS_DIR = get_hermes_home() / "sessions"
 _SESSIONS_INDEX = _SESSIONS_DIR / "sessions.json"
+_PENDING_MIRRORS_PATH = _SESSIONS_DIR / "pending_mirrors.json"
 
 
 def mirror_to_session(
@@ -36,26 +38,10 @@ def mirror_to_session(
     Finds the gateway session that matches the given platform + chat_id,
     then writes a mirror entry to both the JSONL transcript and SQLite DB.
 
-    Returns True if mirrored successfully, False if no matching session or error.
+    Returns True if mirrored immediately, False if it was queued or failed.
     All errors are caught -- this is never fatal.
     """
     try:
-        session_id = _find_session_id(
-            platform,
-            str(chat_id),
-            thread_id=thread_id,
-            user_id=user_id,
-        )
-        if not session_id:
-            logger.debug(
-                "Mirror: no session found for %s:%s:%s:%s",
-                platform,
-                chat_id,
-                thread_id,
-                user_id,
-            )
-            return False
-
         mirror_msg = {
             "role": "assistant",
             "content": message_text,
@@ -63,6 +49,28 @@ def mirror_to_session(
             "mirror": True,
             "mirror_source": source_label,
         }
+
+        session_id = _find_session_id(
+            platform,
+            str(chat_id),
+            thread_id=thread_id,
+            user_id=user_id,
+        )
+        if not session_id:
+            _queue_pending_mirror(
+                platform,
+                str(chat_id),
+                mirror_msg,
+                thread_id=thread_id,
+            )
+            logger.debug(
+                "Mirror: queued pending entry for %s:%s:%s:%s",
+                platform,
+                chat_id,
+                thread_id,
+                user_id,
+            )
+            return False
 
         _append_to_sqlite(session_id, mirror_msg)
 
@@ -147,6 +155,76 @@ def _find_session_id(
 
     best_entry = max(candidates, key=lambda entry: entry.get("updated_at", ""))
     return best_entry.get("session_id")
+
+
+def drain_pending_mirrors(
+    session_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> int:
+    """Replay queued mirror messages into a newly started session."""
+    key = _pending_mirror_key(platform, chat_id, thread_id=thread_id)
+    pending = _load_pending_mirrors()
+    messages = pending.pop(key, [])
+    if not messages:
+        return 0
+
+    _save_pending_mirrors(pending)
+
+    drained = 0
+    for message in messages:
+        try:
+            _append_to_sqlite(session_id, message)
+            drained += 1
+        except Exception as e:
+            logger.debug(
+                "Mirror pending replay failed for %s into %s: %s",
+                key,
+                session_id,
+                e,
+            )
+
+    return drained
+
+
+def _pending_mirror_key(
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> str:
+    return f"{platform.lower()}::{chat_id}::{thread_id or ''}"
+
+
+def _load_pending_mirrors() -> Dict[str, List[Dict[str, Any]]]:
+    if not _PENDING_MIRRORS_PATH.exists():
+        return {}
+
+    try:
+        with open(_PENDING_MIRRORS_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except Exception as e:
+        logger.debug("Mirror pending load failed: %s", e)
+
+    return {}
+
+
+def _save_pending_mirrors(data: Dict[str, List[Dict[str, Any]]]) -> None:
+    atomic_json_write(_PENDING_MIRRORS_PATH, data)
+
+
+def _queue_pending_mirror(
+    platform: str,
+    chat_id: str,
+    message: Dict[str, Any],
+    thread_id: Optional[str] = None,
+) -> None:
+    key = _pending_mirror_key(platform, chat_id, thread_id=thread_id)
+    pending = _load_pending_mirrors()
+    pending.setdefault(key, []).append(message)
+    _save_pending_mirrors(pending)
 
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8265,7 +8265,30 @@ class GatewayRunner:
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
-        
+
+        try:
+            from gateway.mirror import drain_pending_mirrors
+
+            drained = drain_pending_mirrors(
+                session_entry.session_id,
+                source.platform.value if source.platform else "",
+                str(source.chat_id),
+                thread_id=source.thread_id,
+            )
+            if drained:
+                logger.info(
+                    "Mirror: replayed %d pending message(s) into session %s",
+                    drained,
+                    session_entry.session_id,
+                )
+        except Exception as e:
+            logger.debug(
+                "Mirror pending replay failed for %s (%s): %s",
+                session_entry.session_id,
+                session_key,
+                e,
+            )
+
         # Build session context
         context = build_session_context(source, self.config, session_entry)
         

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 
 import gateway.mirror as mirror_mod
 from gateway.mirror import (
+    drain_pending_mirrors,
     mirror_to_session,
     _find_session_id,
 )
@@ -233,18 +234,41 @@ class TestMirrorToSession:
 
     def test_no_matching_session(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {})
+        pending_file = sessions_dir / "pending_mirrors.json"
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch.object(mirror_mod, "_PENDING_MIRRORS_PATH", pending_file):
             result = mirror_to_session("telegram", "99999", "Hello!")
 
         assert result is False
+        pending = json.loads(pending_file.read_text())
+        assert pending["telegram::99999::"][0]["content"] == "Hello!"
 
     def test_error_returns_false(self, tmp_path):
         with patch("gateway.mirror._find_session_id", side_effect=Exception("boom")):
             result = mirror_to_session("telegram", "123", "msg")
 
         assert result is False
+
+    def test_drain_pending_mirrors_replays_queued_message(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {})
+        pending_file = sessions_dir / "pending_mirrors.json"
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch.object(mirror_mod, "_PENDING_MIRRORS_PATH", pending_file), \
+             patch("gateway.mirror._append_to_sqlite") as mock_sqlite:
+            queued = mirror_to_session("telegram", "99999", "Hello later!", source_label="cli")
+            drained = drain_pending_mirrors("sess_new", "telegram", "99999")
+
+        assert queued is False
+        assert drained == 1
+        mock_sqlite.assert_called_once()
+        assert mock_sqlite.call_args[0][0] == "sess_new"
+        msg = mock_sqlite.call_args[0][1]
+        assert msg["content"] == "Hello later!"
+        assert json.loads(pending_file.read_text()) == {}
 
 
 class TestAppendToSqlite:


### PR DESCRIPTION
## Summary\n- queue send_message mirror entries when the target session does not exist yet\n- replay queued mirror messages into the first matching gateway session before transcript history loads\n- cover the queue-and-replay path with focused mirror regression tests\n\nCloses #33530\n\n## Proof\n- ============================= test session starts ==============================
platform darwin -- Python 3.10.6, pytest-7.4.3, pluggy-1.5.0
rootdir: /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-33530-send-message-mirror-queue
configfile: pyproject.toml
plugins: flask-1.3.0, cov-4.1.0, asyncio-0.21.1, anyio-4.10.0, time-machine-2.14.1, hydra-core-1.3.2
asyncio: mode=strict
collected 16 items

tests/gateway/test_mirror.py ................                            [100%]

============================== 16 passed in 0.29s ==============================\n- All checks passed!\n- \n\n## Attribution\n- no active linked PR or issue-thread claim found for #33530 at push time\n- recent company PR checks did not show a repeated shared-red cluster across the newest three company PRs