### PR TITLE
fix(memory_manager): handle structured content blocks in sanitize_context()

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -25,6 +25,7 @@ Usage in run_agent.py:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import inspect
@@ -51,8 +52,47 @@ _INTERNAL_NOTE_RE = re.compile(
 )
 
 
-def sanitize_context(text: str) -> str:
+def _memory_text(value: Any) -> str:
+    """Return a plain-text representation safe for memory providers.
+
+    Gateway/model content can occasionally be structured OpenAI-style content
+    blocks instead of a string.  Memory providers operate on text, so extract
+    human-readable text parts and replace non-text media with placeholders
+    instead of letting regex sanitizers crash on lists or dicts.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+                elif item.get("type") in {"image", "image_url", "input_image"}:
+                    parts.append("[image]")
+                elif item.get("type") in {"audio", "input_audio"}:
+                    parts.append("[audio]")
+                else:
+                    parts.append(json.dumps(item, ensure_ascii=False, sort_keys=True, default=str))
+            else:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    if isinstance(value, dict):
+        text = value.get("text") or value.get("content")
+        if isinstance(text, str):
+            return text
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    return str(value)
+
+
+def sanitize_context(text: Any) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
+    text = _memory_text(text)
     text = _INTERNAL_CONTEXT_RE.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -794,6 +794,20 @@ class TestMemoryContextFencing:
         assert "</memory-context>" not in result.lower()
         assert "datamore" in result
 
+    def test_sanitize_context_accepts_structured_content_blocks(self):
+        from agent.memory_manager import sanitize_context
+
+        result = sanitize_context([
+            {"type": "text", "text": "visible <memory-context>hidden</memory-context>"},
+            {"type": "image_url", "image_url": {"url": "https://example.test/x.png"}},
+            "tail",
+        ])
+
+        assert "visible" in result
+        assert "hidden" not in result
+        assert "[image]" in result
+        assert "tail" in result
+
     def test_fenced_block_separates_user_from_recall(self):
         from agent.memory_manager import build_memory_context_block
         prefetch = "## Holographic Memory\n- [0.9] user is named Alice"


### PR DESCRIPTION
## Problem

`sanitize_context()` is typed `str` but is sometimes handed **OpenAI-style structured content blocks** (a `list` of `{"type": ..., "text": ...}` dicts, or a bare `dict`) instead of a plain string — e.g. from the Codex `codex_responses` path. The regex `.sub()` calls then raise on non-string input (`TypeError` / `'NoneType' object is not iterable` further up the stack), breaking the turn.

## Fix

Add `_memory_text()` to coerce content to plain text **before** the regex sanitizers run:
- `str` → unchanged
- `list` → join text parts; media blocks (`image`/`image_url`/`input_image`, `audio`/`input_audio`) become `[image]` / `[audio]` placeholders; unknown blocks are JSON-encoded
- `dict` → extract `text`/`content`, else JSON-encode
- `None` → `""`

`sanitize_context` signature widened to `Any`; behaviour for existing `str` callers is unchanged.

## Test

Adds `test_sanitize_context_accepts_structured_content_blocks` — verifies text is preserved, fenced memory-context is still stripped, images become `[image]`, and trailing string parts survive.

Backwards compatible; no behaviour change for string inputs.