### PR TITLE
fix(feishu): correct topic reply anchor and remove invalid thread_id create API path

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -94,8 +94,8 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu" and thread_id:
+        return getattr(event, "message_id", None)
     return getattr(event, "message_id", None)
 
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4382,31 +4382,21 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await asyncio.to_thread(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request("thread_id", body)
+        # Feishu's create message API only supports open_id, chat_id, user_id,
+        # union_id, email as receive_id_type — "thread_id" is not valid.
+        # When no reply target exists (e.g. restart notifications), send to
+        # the main group chat via create API.
+        body = self._build_create_message_body(
+            receive_id=chat_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        if chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
         else:
-            body = self._build_create_message_body(
-                receive_id=chat_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            # Detect whether chat_id is a user open_id (DM) or a chat_id (group).
-            if chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
-            else:
-                receive_id_type = "chat_id"
-            request = self._build_create_message_request(receive_id_type, body)
+            receive_id_type = "chat_id"
+        request = self._build_create_message_request(receive_id_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -142,15 +142,14 @@ class TestFeishuFallbackThreadRouting:
     """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
 
     @pytest.mark.asyncio
-    async def test_create_uses_thread_id_when_available(self):
+    async def test_create_uses_chat_id_when_thread_id_present_but_no_reply(self):
         """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+        should use chat_id with receive_id_type='chat_id' (Feishu's create
+        API does not support 'thread_id' as receive_id_type)."""
         from gateway.platforms.feishu import FeishuAdapter
 
-        # We test the _send_raw_message method directly by mocking the client
         adapter = MagicMock(spec=FeishuAdapter)
 
-        # Set up the real _send_raw_message logic manually
         mock_client = MagicMock()
         mock_create_response = SimpleNamespace(
             success=lambda: True,
@@ -158,12 +157,10 @@ class TestFeishuFallbackThreadRouting:
         )
         mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
 
-        # Use the real implementation path
         adapter._client = mock_client
         adapter._build_create_message_body = FeishuAdapter._build_create_message_body
         adapter._build_create_message_request = FeishuAdapter._build_create_message_request
 
-        # Call _send_raw_message with reply_to=None and thread_id in metadata
         import json
         result = await FeishuAdapter._send_raw_message(
             adapter,
@@ -177,25 +174,22 @@ class TestFeishuFallbackThreadRouting:
         # Verify message.create was called (not message.reply)
         mock_client.im.v1.message.create.assert_called_once()
 
-        # The request should have receive_id_type="thread_id"
         call_args = mock_client.im.v1.message.create.call_args[0][0]
-        # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
-        # The contributor's branch had the lark SDK installed, the test environment
-        # may not — handle both shapes.
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
+        # receive_id should be chat_id (not thread_id), since Feishu's create
+        # API doesn't support thread_id as receive_id_type
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
             import json as _json
             receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
+        assert receive_id == "oc_main_chat", (
+            f"Expected receive_id='oc_main_chat', got '{receive_id}'"
         )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
+        # receive_id_type should be 'chat_id', not 'thread_id'
         receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
+        assert receive_id_type == "chat_id", (
+            f"Expected receive_id_type='chat_id', got '{receive_id_type}'"
         )
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -506,6 +506,35 @@ def test_base_gateway_replies_to_triggering_message_for_telegram_dm_topic():
     assert _reply_anchor_for_event(event) == "463"
 
 
+def test_base_gateway_reply_anchor_for_feishu_topic():
+    """Feishu topic/thread replies should anchor to the triggering message,
+    not to reply_to_message_id which may point to the main group's seed message."""
+    event = SimpleNamespace(
+        message_id="msg_in_topic_456",
+        reply_to_message_id="main_group_seed_123",
+        source=SimpleNamespace(
+            platform="feishu",
+            thread_id="omt_topic_abc",
+        ),
+    )
+    # Before the fix, this returned reply_to_message_id ("main_group_seed_123"),
+    # causing the reply to escape the topic into the main group.
+    assert _reply_anchor_for_event(event) == "msg_in_topic_456"
+
+
+def test_base_gateway_reply_anchor_for_feishu_topic_no_message_id():
+    """When message_id is None for a Feishu topic event, return None."""
+    event = SimpleNamespace(
+        message_id=None,
+        reply_to_message_id="main_group_seed_123",
+        source=SimpleNamespace(
+            platform="feishu",
+            thread_id="omt_topic_abc",
+        ),
+    )
+    assert _reply_anchor_for_event(event) is None
+
+
 @pytest.mark.asyncio
 async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegram_dm_topic(monkeypatch, tmp_path):
     """GatewayRunner's duplicate thread metadata must match the base helper."""


### PR DESCRIPTION
## What does this PR do?

Fixes two confirmed bugs in the Feishu adapter's topic/thread routing that cause messages to escape topics into the main group chat, and one invalid API usage that produces Feishu error 99992402.
---

### Bug 1: `_reply_anchor_for_event` returns wrong reply anchor for Feishu topics

**File:** `gateway/platforms/base.py`, lines 97-98

**Problem:** When replying to a message in a Feishu topic/thread, the function returned `event.reply_to_message_id` instead of `event.message_id`. The `reply_to_message_id` may point to the **main group's seed message** (the message that was replied to when creating the topic), not a message within the topic. This caused the reply API to use a main-group message as the parent, and the reply escaped the topic into the main group.

**Fix:** Return `event.message_id` instead, which is the actual message within the topic.

### Bug 2: `_send_raw_message` uses invalid `receive_id_type="thread_id"` for create API

**File:** `gateway/platforms/feishu.py`, `_send_raw_message` method

**Problem:** When there was a `thread_id` in metadata but no `effective_reply_to` (e.g. gateway restart notifications, streaming tool outputs), the code fell through to a create API branch that used `receive_id_type="thread_id"`. Feishu's create message API does **not** support `"thread_id"` as a valid `receive_id_type` — it only accepts `open_id`, `chat_id`, `user_id`, `union_id`, `email`. This caused Feishu to return error **99992402** ("field validation failed").

**Fix:** Removed the invalid `thread_id` → create API branch. When no reply target exists, messages now correctly use `chat_id` with the appropriate `receive_id_type`.

### Bug 3 (not addressed): `@mention` detection order

The issue also describes a detection-order problem in `_build_outbound_payload` where `_MARKDOWN_HINT_RE` is checked before `@mention` patterns. However, the current code has no `_build_at_mention_post_payload` function — this would be a **feature addition**, not a bug fix, and is out of scope for this PR.

---

## Related Issue

Fixes #33568

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- **Analyzed:** `_reply_anchor_for_event` (gateway/platforms/base.py) — called by GatewayStreamConsumer and GatewayRunner for all platform message routing
- **Analyzed:** `_send_raw_message` (gateway/platforms/feishu.py) — core outbound message path for Feishu adapter
- **Blast radius:** LOW — changes only affect Feishu topic/thread message routing; non-Feishu platforms and non-topic messages are unaffected
- **Related patterns:** Telegram topic routing (lines 91-96) already returns `message_id` for DM topics; this fix aligns Feishu with that pattern

## Tests

- Updated `test_stream_consumer_thread_routing.py` to match new behavior (chat_id instead of thread_id for create API)
- Added 2 regression tests in `test_telegram_thread_fallback.py` for Feishu topic reply anchoring
- All 201 feishu tests pass, all 101 platform_base tests pass, all 7 stream_consumer tests pass

## Checklist

- [x] One root cause per PR (two related bugs in Feishu topic routing)
- [x] Regression tests added
- [x] `git diff --stat upstream/main` shows only relevant files (4 files, +55 -42)
- [x] No unrelated changes