### PR TITLE
feat(conversation): pre-route tool-heavy turns to cascade delegate

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -260,6 +260,47 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
         )
 
 
+def _should_delegate_to_claude_code(user_message: Any) -> bool:
+    """Return True for high-confidence tool-heavy gateway requests.
+
+    This is deliberately narrower than "any message that might use a tool".
+    The normal LLM-decided meta-tool path still handles ambiguous cases; this
+    pre-route protects common operator flows where direct OAuth should never
+    burn a turn trying memory/chat before reaching the Claude Code cascade.
+
+    All matching uses ``str.startswith`` to avoid false positives from
+    negations mid-sentence ("please do NOT screenshot this" must not pre-route).
+    The substring-in approach would fire on those; prefix matching does not.
+
+    Gated by ``HERMES_DELEGATE_HEURISTICS`` (default "1"). Set to "0" or
+    "false" to disable and fall through to the normal conversation loop.
+    """
+    if os.environ.get("HERMES_DELEGATE_HEURISTICS", "1").lower() in ("0", "false", "no", "off"):
+        return False
+    if not isinstance(user_message, str):
+        return False
+    text = user_message.strip()
+    if not text:
+        return False
+    lowered = text.lower()
+    # High-confidence capture/memory flows that always need tools.
+    capture_prefixes = (
+        "capture this", "capture:", "/capture ", "save this thought",
+        "remember this:", "log this:", "write this to my vault",
+    )
+    if lowered.startswith(capture_prefixes):
+        return True
+    # High-confidence browser/terminal flows — prefix match only so that
+    # "please do NOT screenshot this" and similar negation constructs don't
+    # accidentally trigger the pre-route.
+    tool_prefixes = (
+        "browse to ", "screenshot", "search the web", "web search: ",
+        "run command", "run this command", "shell command",
+        "use playwright", "open browser", "inspect this page",
+    )
+    return lowered.startswith(tool_prefixes)
+
+
 def run_conversation(
     agent,
     user_message: str,
@@ -405,6 +446,64 @@ def run_conversation(
 
     # Initialize conversation (copy to avoid mutating the caller's list)
     messages = list(conversation_history) if conversation_history else []
+
+    # ── Pre-route: bypass the main loop for high-confidence tool-heavy turns ──
+    # When the delegate tool is available AND the message matches a tool-heavy
+    # pattern, skip the main loop entirely and call delegate_to_claude_code
+    # directly.  This saves one OAuth turn (the turn that would normally spin up
+    # the main agent just to pick the delegate meta-tool).  Gated by the
+    # HERMES_DELEGATE_HEURISTICS env var (default on).
+    if (
+        "delegate_to_claude_code" in getattr(agent, "valid_tool_names", set())
+        and _should_delegate_to_claude_code(user_message)
+    ):
+        logger.info(
+            "pre-routing tool-heavy turn to delegate_to_claude_code: session=%s platform=%s",
+            agent.session_id or "none",
+            agent.platform or "unknown",
+        )
+        if agent.status_callback:
+            try:
+                agent.status_callback("Delegating tool-heavy request to Claude Code...")
+            except Exception:
+                pass
+        try:
+            from tools.claude_code_delegate_tool import delegate_to_claude_code
+            # Count this as a user turn before early-returning so that
+            # memory-nudge counters accumulate correctly for pre-routed turns.
+            agent._user_turn_count = getattr(agent, "_user_turn_count", 0) + 1
+            raw_delegate_result = delegate_to_claude_code({
+                "prompt": str(user_message),
+                "timeout_s": int(os.environ.get("HERMES_DELEGATE_TIMEOUT_S", "120")),
+                "max_budget_usd": float(os.environ.get("HERMES_DELEGATE_MAX_BUDGET_USD", "1.0")),
+                "model": os.environ.get("HERMES_DELEGATE_MODEL", "sonnet"),
+            })
+            try:
+                delegate_result = json.loads(raw_delegate_result)
+            except ValueError:
+                # Non-JSON output is a valid response (plain text), not a failure.
+                delegate_result = {"success": True, "result": raw_delegate_result}
+            final_response = str(
+                delegate_result.get("result")
+                or delegate_result.get("error")
+                or raw_delegate_result
+            ).strip()
+            if not final_response:
+                final_response = "Claude Code delegation completed without a text result."
+            messages.append({"role": "user", "content": user_message})
+            messages.append({"role": "assistant", "content": final_response})
+            if hasattr(agent, "_persist_session"):
+                agent._persist_session(messages, conversation_history)
+            return {
+                "final_response": final_response,
+                "messages": messages,
+                "api_calls": 0,
+                "completed": bool(delegate_result.get("success", True)),
+                "delegate_result": delegate_result,
+            }
+        except Exception as exc:
+            logger.exception("delegate_to_claude_code pre-route failed; falling back to normal loop")
+            # Fall through to the normal conversation loop rather than surfacing a hard failure.
 
     # Hydrate todo store from conversation history (gateway creates a fresh
     # AIAgent per message, so the in-memory store is empty -- we need to

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -294,7 +294,7 @@ def _should_delegate_to_claude_code(user_message: Any) -> bool:
     # "please do NOT screenshot this" and similar negation constructs don't
     # accidentally trigger the pre-route.
     tool_prefixes = (
-        "browse to ", "screenshot", "search the web", "web search: ",
+        "browse to ", "screenshot ", "search the web", "web search: ",
         "run command", "run this command", "shell command",
         "use playwright", "open browser", "inspect this page",
     )
@@ -469,8 +469,10 @@ def run_conversation(
                 pass
         try:
             from tools.claude_code_delegate_tool import delegate_to_claude_code
-            # Count this as a user turn before early-returning so that
-            # memory-nudge counters accumulate correctly for pre-routed turns.
+            # Count this turn only on the success path (import succeeded).
+            # If the import fails and we fall through to the normal loop, the
+            # normal loop's own increment at the top of run_conversation handles
+            # it — keeping the total at exactly 1 increment per turn.
             agent._user_turn_count = getattr(agent, "_user_turn_count", 0) + 1
             raw_delegate_result = delegate_to_claude_code({
                 "prompt": str(user_message),

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -462,18 +462,9 @@ def run_conversation(
             agent.session_id or "none",
             agent.platform or "unknown",
         )
-        if agent.status_callback:
-            try:
-                agent.status_callback("Delegating tool-heavy request to Claude Code...")
-            except Exception:
-                pass
+        agent._emit_status("Delegating tool-heavy request to Claude Code...")
         try:
             from tools.claude_code_delegate_tool import delegate_to_claude_code
-            # Count this turn only on the success path (import succeeded).
-            # If the import fails and we fall through to the normal loop, the
-            # normal loop's own increment at the top of run_conversation handles
-            # it — keeping the total at exactly 1 increment per turn.
-            agent._user_turn_count = getattr(agent, "_user_turn_count", 0) + 1
             raw_delegate_result = delegate_to_claude_code({
                 "prompt": str(user_message),
                 "timeout_s": int(os.environ.get("HERMES_DELEGATE_TIMEOUT_S", "120")),
@@ -492,7 +483,15 @@ def run_conversation(
             ).strip()
             if not final_response:
                 final_response = "Claude Code delegation completed without a text result."
-            messages.append({"role": "user", "content": user_message})
+            # Count the turn only on the success path. The fallthrough path (any
+            # exception above) is counted by the normal loop's own increment,
+            # keeping the total at exactly one increment per run_conversation call.
+            agent._user_turn_count = getattr(agent, "_user_turn_count", 0) + 1
+            # Use persist_user_message when provided — gateway/API-server callers
+            # pass a clean version that should be stored instead of the raw
+            # user_message which may contain context wrappers (voice prefix, etc.).
+            _stored_user_msg = persist_user_message if persist_user_message is not None else user_message
+            messages.append({"role": "user", "content": _stored_user_msg})
             messages.append({"role": "assistant", "content": final_response})
             if hasattr(agent, "_persist_session"):
                 agent._persist_session(messages, conversation_history)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -70,6 +70,7 @@ CONFIGURABLE_TOOLSETS = [
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
+    ("claude_code_delegation", "↗ Claude Code Delegation", "delegate_to_claude_code (requires Claude CLI)"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
@@ -94,7 +95,7 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "claude_code_delegation"}
 
 
 def _xai_credentials_present() -> bool:

--- a/tests/agent/test_delegate_pre_route.py
+++ b/tests/agent/test_delegate_pre_route.py
@@ -1,0 +1,260 @@
+"""Tests for the pre-route heuristic in run_conversation.
+
+Covers _should_delegate_to_claude_code and the pre-route block that
+bypasses the main conversation loop for tool-heavy turns.
+"""
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _should_delegate_to_claude_code — unit tests
+# ---------------------------------------------------------------------------
+
+class TestShouldDelegate:
+    def _call(self, message: str, env: dict | None = None) -> bool:
+        from agent.conversation_loop import _should_delegate_to_claude_code
+        with patch.dict(os.environ, env or {}, clear=False):
+            return _should_delegate_to_claude_code(message)
+
+    # -- Flag disabled -------------------------------------------------------
+
+    def test_disabled_by_env_zero(self):
+        assert self._call("browse to example.com", {"HERMES_DELEGATE_HEURISTICS": "0"}) is False
+
+    def test_disabled_by_env_false(self):
+        assert self._call("screenshot", {"HERMES_DELEGATE_HEURISTICS": "false"}) is False
+
+    def test_disabled_by_env_off(self):
+        assert self._call("search the web", {"HERMES_DELEGATE_HEURISTICS": "off"}) is False
+
+    # -- Non-string / empty inputs -------------------------------------------
+
+    def test_non_string_returns_false(self):
+        from agent.conversation_loop import _should_delegate_to_claude_code
+        assert _should_delegate_to_claude_code(None) is False
+        assert _should_delegate_to_claude_code(42) is False
+        assert _should_delegate_to_claude_code([]) is False
+
+    def test_empty_string_returns_false(self):
+        assert self._call("") is False
+        assert self._call("   ") is False
+
+    # -- Capture prefixes ----------------------------------------------------
+
+    def test_capture_this(self):
+        assert self._call("capture this: interesting thought") is True
+
+    def test_capture_colon(self):
+        assert self._call("capture: some note here") is True
+
+    def test_slash_capture(self):
+        assert self._call("/capture idea for later") is True
+
+    def test_save_this_thought(self):
+        assert self._call("save this thought: remember X") is True
+
+    def test_remember_this_colon(self):
+        assert self._call("remember this: deadline friday") is True
+
+    def test_log_this(self):
+        assert self._call("log this: bug found in auth") is True
+
+    def test_write_to_vault(self):
+        assert self._call("write this to my vault: idea") is True
+
+    # -- Tool markers --------------------------------------------------------
+
+    def test_browse_to(self):
+        assert self._call("browse to https://example.com") is True
+
+    def test_screenshot(self):
+        assert self._call("screenshot the current page") is True
+
+    def test_screenshot_prefix_only(self):
+        """'take a screenshot' should NOT pre-route — doesn't start with 'screenshot'."""
+        assert self._call("take a screenshot of the current page") is False
+
+    def test_search_the_web(self):
+        assert self._call("search the web for recent news") is True
+
+    def test_web_search(self):
+        assert self._call("web search: python asyncio tutorial") is True
+
+    def test_run_command(self):
+        assert self._call("run command: ls -la") is True
+
+    def test_run_this_command(self):
+        assert self._call("run this command in the terminal") is True
+
+    def test_shell_command(self):
+        assert self._call("shell command: echo hello") is True
+
+    def test_use_playwright(self):
+        assert self._call("use playwright to fill the form") is True
+
+    def test_open_browser(self):
+        assert self._call("open browser and navigate to github") is True
+
+    def test_inspect_this_page(self):
+        assert self._call("inspect this page for accessibility issues") is True
+
+    # -- Non-matching messages -----------------------------------------------
+
+    def test_normal_chat_not_delegated(self):
+        assert self._call("what time is it?") is False
+
+    def test_memory_question_not_delegated(self):
+        assert self._call("what did I tell you about my project?") is False
+
+    def test_code_question_not_delegated(self):
+        assert self._call("explain this Python function to me") is False
+
+    def test_case_insensitive_marker(self):
+        assert self._call("BROWSE TO example.com") is True
+
+    def test_case_insensitive_capture(self):
+        assert self._call("Capture This: my idea") is True
+
+    # -- Negation guard (F3 fix: prefix-only prevents mid-sentence false positives) --
+
+    def test_negation_screenshot_not_delegated(self):
+        """'please do NOT screenshot this' should NOT pre-route."""
+        assert self._call("please do NOT screenshot this, just describe it") is False
+
+    def test_negation_run_command_not_delegated(self):
+        """'is it safe to run command X?' should NOT pre-route."""
+        assert self._call("is it safe to run command X without sudo?") is False
+
+    def test_negation_shell_command_not_delegated(self):
+        """'this is not a shell command' should NOT pre-route."""
+        assert self._call("this is not a shell command") is False
+
+    def test_negation_search_web_not_delegated(self):
+        """'don't search the web for this' should NOT pre-route."""
+        assert self._call("don't search the web for this, I know the answer") is False
+
+    def test_mid_sentence_browse_not_delegated(self):
+        """'I never said to browse to that page' should NOT pre-route."""
+        assert self._call("I never said to browse to that page") is False
+
+
+# ---------------------------------------------------------------------------
+# Pre-route block integration — tests that the route fires and returns early
+# ---------------------------------------------------------------------------
+
+class TestPreRouteBlock:
+    """Verify the pre-route block in run_conversation fires correctly."""
+
+    def _make_agent(self, valid_tool_names=None):
+        agent = MagicMock()
+        agent.valid_tool_names = valid_tool_names or {"delegate_to_claude_code"}
+        agent.session_id = "test-session"
+        agent.platform = "test"
+        agent.status_callback = None
+        agent._persist_session = MagicMock()
+        return agent
+
+    def test_pre_route_fires_and_returns_early(self):
+        """When heuristic matches and delegate tool is available, pre-route returns."""
+        agent = self._make_agent()
+        fake_result = json.dumps({"success": True, "result": "Done: opened browser"})
+
+        with patch("agent.conversation_loop._should_delegate_to_claude_code", return_value=True), \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code",
+                   return_value=fake_result):
+            from agent.conversation_loop import run_conversation
+            result = run_conversation(agent, "browse to example.com")
+
+        assert result["api_calls"] == 0
+        assert result["completed"] is True
+        assert "Done: opened browser" in result["final_response"]
+        assert result.get("delegate_result", {}).get("success") is True
+
+    def test_pre_route_skipped_when_tool_not_available(self):
+        """No pre-route when delegate_to_claude_code is not in valid_tool_names."""
+        agent = self._make_agent(valid_tool_names={"memory", "web_search"})
+        # If pre-route fires, it would call the delegate tool; if skipped,
+        # run_conversation falls into the main loop which we don't stub here —
+        # we only assert the pre-route doesn't trigger.
+        with patch("agent.conversation_loop._should_delegate_to_claude_code",
+                   return_value=True) as mock_heuristic, \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code") as mock_delegate:
+            # The main loop will fail (agent mocked), but we only care that
+            # delegate_to_claude_code was NOT called.
+            try:
+                from agent.conversation_loop import run_conversation
+                run_conversation(agent, "browse to example.com")
+            except Exception:
+                pass
+            mock_delegate.assert_not_called()
+
+    def test_pre_route_skipped_when_heuristic_returns_false(self):
+        """No pre-route when heuristic returns False."""
+        agent = self._make_agent()
+        with patch("agent.conversation_loop._should_delegate_to_claude_code",
+                   return_value=False), \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code") as mock_delegate:
+            try:
+                from agent.conversation_loop import run_conversation
+                run_conversation(agent, "what time is it?")
+            except Exception:
+                pass
+            mock_delegate.assert_not_called()
+
+    def test_pre_route_falls_through_on_exception(self):
+        """On delegate exception, pre-route falls through to normal loop."""
+        agent = self._make_agent()
+        with patch("agent.conversation_loop._should_delegate_to_claude_code", return_value=True), \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code",
+                   side_effect=RuntimeError("delegate unavailable")):
+            # Should NOT raise — should fall through to normal loop.
+            # Normal loop will fail too (agent mocked), but we expect a non-pre-route error.
+            try:
+                from agent.conversation_loop import run_conversation
+                result = run_conversation(agent, "browse to example.com")
+                # If it returned, the pre-route returned a failure dict
+                # (old code path) or fell through
+            except Exception as exc:
+                # The exception came from the normal loop, NOT from the pre-route
+                assert "delegate unavailable" not in str(exc), (
+                    "Pre-route exception should not propagate — should fall through"
+                )
+
+    def test_pre_route_handles_non_json_result(self):
+        """Non-JSON delegate result is returned as raw string with completed=True."""
+        agent = self._make_agent()
+        raw = "Done in 3 steps."
+        with patch("agent.conversation_loop._should_delegate_to_claude_code", return_value=True), \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code",
+                   return_value=raw):
+            from agent.conversation_loop import run_conversation
+            result = run_conversation(agent, "browse to example.com")
+
+        assert result["api_calls"] == 0
+        assert raw in result["final_response"]
+        # Non-JSON is a valid response, not a failure — completed must be True.
+        assert result["completed"] is True, (
+            "Non-JSON tool result was incorrectly marked completed=False"
+        )
+
+    def test_pre_route_increments_user_turn_count(self):
+        """Pre-routed turns must increment _user_turn_count for nudge logic to work."""
+        agent = self._make_agent()
+        agent._user_turn_count = 0
+        fake_result = json.dumps({"success": True, "result": "done"})
+        with patch("agent.conversation_loop._should_delegate_to_claude_code", return_value=True), \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code",
+                   return_value=fake_result):
+            from agent.conversation_loop import run_conversation
+            run_conversation(agent, "browse to example.com")
+
+        assert agent._user_turn_count == 1, (
+            "Pre-route must increment _user_turn_count so memory nudges accumulate"
+        )

--- a/tests/agent/test_delegate_pre_route.py
+++ b/tests/agent/test_delegate_pre_route.py
@@ -81,6 +81,14 @@ class TestShouldDelegate:
         """'take a screenshot' should NOT pre-route — doesn't start with 'screenshot'."""
         assert self._call("take a screenshot of the current page") is False
 
+    def test_screenshot_plural_not_delegated(self):
+        """'screenshots work...' should NOT pre-route — trailing space required (F3 fix)."""
+        assert self._call("screenshots work better than text descriptions") is False
+
+    def test_screenshot_question_not_delegated(self):
+        """'screenshots are broken...' should NOT pre-route — 'screenshot' must be followed by space."""
+        assert self._call("screenshots are broken in hermes, how do I debug?") is False
+
     def test_search_the_web(self):
         assert self._call("search the web for recent news") is True
 

--- a/tests/agent/test_delegate_pre_route.py
+++ b/tests/agent/test_delegate_pre_route.py
@@ -266,3 +266,45 @@ class TestPreRouteBlock:
         assert agent._user_turn_count == 1, (
             "Pre-route must increment _user_turn_count so memory nudges accumulate"
         )
+
+    def test_pre_route_no_double_count_on_delegate_exception(self):
+        """On delegate exception, _user_turn_count must NOT be incremented by the pre-route."""
+        agent = self._make_agent()
+        agent._user_turn_count = 0
+        with patch("agent.conversation_loop._should_delegate_to_claude_code", return_value=True), \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code",
+                   side_effect=RuntimeError("delegate failed after import")):
+            try:
+                from agent.conversation_loop import run_conversation
+                run_conversation(agent, "browse to example.com")
+            except Exception:
+                pass
+        # Normal loop increments once on fallthrough — count must be exactly 1.
+        # If pre-route incremented before the exception, then normal loop also
+        # increments on fallthrough, giving 2 (double-count).
+        assert agent._user_turn_count == 1, (
+            "Expected exactly 1 increment (normal loop); "
+            "got double-count — pre-route must not increment before delegate call"
+        )
+
+    def test_pre_route_uses_persist_user_message_for_history(self):
+        """Gateway/API-server callers pass persist_user_message; that cleaned version must be stored."""
+        agent = self._make_agent()
+        fake_result = json.dumps({"success": True, "result": "Done."})
+        raw_msg = "Voice context prefix: browse to example.com"
+        clean_msg = "browse to example.com"
+        with patch("agent.conversation_loop._should_delegate_to_claude_code", return_value=True), \
+             patch("tools.claude_code_delegate_tool.delegate_to_claude_code",
+                   return_value=fake_result):
+            from agent.conversation_loop import run_conversation
+            result = run_conversation(
+                agent, raw_msg, persist_user_message=clean_msg
+            )
+        # The persisted user message must be the clean version, not the raw wrapper
+        user_turn = next(
+            (m for m in result["messages"] if m.get("role") == "user"), None
+        )
+        assert user_turn is not None
+        assert user_turn["content"] == clean_msg, (
+            f"Expected clean persist_user_message in history, got: {user_turn['content']!r}"
+        )

--- a/tests/tools/test_claude_code_delegate_tool.py
+++ b/tests/tools/test_claude_code_delegate_tool.py
@@ -1,0 +1,348 @@
+"""Tests for tools/claude_code_delegate_tool.py."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+from tools.claude_code_delegate_tool import (
+    _as_float,
+    _as_int,
+    _command_for,
+    _existing_add_dirs,
+    _parse_stream_json,
+    _redacted_command,
+    _resolve_cwd,
+    _wrap_prompt,
+    check_claude_code_available,
+    delegate_to_claude_code,
+    DELEGATE_TO_CLAUDE_CODE_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# _as_int / _as_float
+# ---------------------------------------------------------------------------
+
+
+class TestAsInt:
+    def test_valid_value(self):
+        assert _as_int(42, 10, 0, 100) == 42
+
+    def test_string_coercion(self):
+        assert _as_int("42", 10, 0, 100) == 42
+
+    def test_below_minimum(self):
+        assert _as_int(-5, 10, 0, 100) == 0
+
+    def test_above_maximum(self):
+        assert _as_int(200, 10, 0, 100) == 100
+
+    def test_invalid_fallback(self):
+        assert _as_int("abc", 10, 0, 100) == 10
+
+    def test_none_fallback(self):
+        assert _as_int(None, 10, 0, 100) == 10
+
+
+class TestAsFloat:
+    def test_valid_value(self):
+        assert _as_float(1.5, 1.0, 0.0, 10.0) == 1.5
+
+    def test_string_coercion(self):
+        assert _as_float("2.5", 1.0, 0.0, 10.0) == 2.5
+
+    def test_below_minimum(self):
+        assert _as_float(-1.0, 1.0, 0.0, 10.0) == 0.0
+
+    def test_above_maximum(self):
+        assert _as_float(20.0, 1.0, 0.0, 10.0) == 10.0
+
+    def test_invalid_fallback(self):
+        assert _as_float("nope", 1.0, 0.0, 10.0) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_cwd
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCwd:
+    def test_empty_string_falls_back_to_home(self):
+        result = _resolve_cwd("")
+        assert result == Path.home()
+
+    def test_none_falls_back_to_home(self):
+        result = _resolve_cwd(None)
+        assert result == Path.home()
+
+    def test_nonexistent_path_falls_back_to_home(self):
+        result = _resolve_cwd("/nonexistent/path/that/should/not/exist")
+        assert result == Path.home()
+
+    def test_valid_directory(self, tmp_path):
+        result = _resolve_cwd(str(tmp_path))
+        assert result == tmp_path.resolve()
+
+
+# ---------------------------------------------------------------------------
+# _parse_stream_json
+# ---------------------------------------------------------------------------
+
+
+class TestParseStreamJson:
+    def test_empty_input(self):
+        result = _parse_stream_json("")
+        assert result["init"] == {}
+        assert result["final"] == {}
+        assert result["tool_calls"] == []
+        assert result["text"] == ""
+        assert result["parse_errors"] == 0
+
+    def test_init_event(self):
+        line = json.dumps({"type": "system", "subtype": "init", "model": "claude-sonnet"})
+        result = _parse_stream_json(line)
+        assert result["init"]["model"] == "claude-sonnet"
+
+    def test_text_extraction(self):
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "Hello world"}],
+            },
+        })
+        result = _parse_stream_json(line)
+        assert result["text"] == "Hello world"
+
+    def test_tool_call_extraction(self):
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": "read_file",
+                    "input": {"path": "/tmp/test.txt"},
+                }],
+            },
+        })
+        result = _parse_stream_json(line)
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["name"] == "read_file"
+
+    def test_result_event(self):
+        line = json.dumps({
+            "type": "result",
+            "result": "Task completed",
+            "session_id": "abc123",
+        })
+        result = _parse_stream_json(line)
+        assert result["final"]["result"] == "Task completed"
+
+    def test_parse_errors_counted(self):
+        lines = "not-json\nalso-not-json\n"
+        result = _parse_stream_json(lines)
+        assert result["parse_errors"] == 2
+        assert len(result["bad_lines"]) == 2
+
+    def test_bad_lines_capped_at_five(self):
+        lines = "\n".join(f"bad-line-{i}" for i in range(10))
+        result = _parse_stream_json(lines)
+        assert result["parse_errors"] == 10
+        assert len(result["bad_lines"]) == 5
+
+
+# ---------------------------------------------------------------------------
+# _redacted_command
+# ---------------------------------------------------------------------------
+
+
+class TestRedactedCommand:
+    def test_prompt_redacted(self):
+        cmd = ["claude", "-p", "secret prompt", "--model", "sonnet"]
+        result = _redacted_command(cmd)
+        assert result[2] == "<prompt>"
+        assert result[4] == "sonnet"
+
+    def test_no_prompt_flag(self):
+        cmd = ["claude", "--model", "sonnet"]
+        result = _redacted_command(cmd)
+        assert result == cmd
+
+    def test_original_not_mutated(self):
+        cmd = ["claude", "-p", "secret"]
+        _redacted_command(cmd)
+        assert cmd[2] == "secret"
+
+
+# ---------------------------------------------------------------------------
+# _wrap_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestWrapPrompt:
+    def test_prompt_included(self):
+        result = _wrap_prompt("do something")
+        assert "do something" in result
+
+    def test_runtime_context_present(self):
+        result = _wrap_prompt("test")
+        assert "Hermes Runtime Context" in result
+        assert "Response Contract" in result
+
+
+# ---------------------------------------------------------------------------
+# _command_for (security-gating)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandFor:
+    def test_skip_permissions_default_off(self):
+        """Without env var, --dangerously-skip-permissions must NOT appear."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_DELEGATE_SKIP_PERMISSIONS", None)
+            cmd = _command_for("test prompt", 1.0, "sonnet")
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_skip_permissions_enabled(self):
+        """With env var set to '1', flag must appear."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_SKIP_PERMISSIONS": "1"}):
+            cmd = _command_for("test prompt", 1.0, "sonnet")
+        assert "--dangerously-skip-permissions" in cmd
+
+    def test_skip_permissions_explicit_off(self):
+        """With env var set to '0', flag must NOT appear."""
+        with patch.dict(os.environ, {"HERMES_DELEGATE_SKIP_PERMISSIONS": "0"}):
+            cmd = _command_for("test prompt", 1.0, "sonnet")
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_model_in_command(self):
+        cmd = _command_for("prompt", 2.0, "opus")
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "opus"
+
+    def test_budget_in_command(self):
+        cmd = _command_for("prompt", 5.0, "sonnet")
+        assert "--max-budget-usd" in cmd
+        idx = cmd.index("--max-budget-usd")
+        assert cmd[idx + 1] == "5.0000"
+
+
+# ---------------------------------------------------------------------------
+# _existing_add_dirs
+# ---------------------------------------------------------------------------
+
+
+class TestExistingAddDirs:
+    def test_nonexistent_dirs_excluded(self):
+        """Dirs that don't exist on disk must not appear."""
+        with patch("tools.claude_code_delegate_tool.get_skills_dir",
+                    return_value=Path("/nonexistent/skills/path")):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("HERMES_DELEGATE_ADD_DIRS", None)
+                dirs = _existing_add_dirs()
+        assert "/nonexistent/skills/path" not in dirs
+
+    def test_extra_dirs_from_env(self, tmp_path):
+        """HERMES_DELEGATE_ADD_DIRS should be respected."""
+        extra_dir = tmp_path / "extra"
+        extra_dir.mkdir()
+        with patch("tools.claude_code_delegate_tool.get_skills_dir",
+                    return_value=Path("/nonexistent")):
+            with patch.dict(os.environ, {"HERMES_DELEGATE_ADD_DIRS": str(extra_dir)}):
+                dirs = _existing_add_dirs()
+        assert str(extra_dir.resolve()) in dirs
+
+    def test_hermes_home_not_in_add_dirs(self, tmp_path):
+        """get_hermes_home() must NOT appear — it contains secrets."""
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        with patch("tools.claude_code_delegate_tool.get_skills_dir",
+                    return_value=skills):
+            with patch("tools.claude_code_delegate_tool.get_hermes_home",
+                        return_value=tmp_path):
+                with patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop("HERMES_DELEGATE_ADD_DIRS", None)
+                    dirs = _existing_add_dirs()
+        # Only skills dir should be present, not hermes home root
+        assert str(skills.resolve()) in dirs
+        # hermes home itself should NOT be there (unless it equals skills)
+        resolved_home = str(tmp_path.resolve())
+        resolved_skills = str(skills.resolve())
+        if resolved_home != resolved_skills:
+            assert resolved_home not in dirs
+
+
+# ---------------------------------------------------------------------------
+# check_claude_code_available
+# ---------------------------------------------------------------------------
+
+
+class TestCheckClaudeCodeAvailable:
+    @patch("shutil.which", return_value="/usr/local/bin/claude")
+    def test_available(self, mock_which):
+        assert check_claude_code_available() is True
+
+    @patch("shutil.which", return_value=None)
+    def test_not_available(self, mock_which):
+        assert check_claude_code_available() is False
+
+
+# ---------------------------------------------------------------------------
+# delegate_to_claude_code (integration with mock subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestDelegateToClaudeCode:
+    def test_empty_prompt_returns_error(self):
+        result = json.loads(delegate_to_claude_code({"prompt": ""}))
+        assert "error" in str(result).lower() or result.get("success") is False
+
+    @patch("subprocess.Popen")
+    def test_successful_delegation(self, mock_popen_cls, tmp_path):
+        stream_output = json.dumps({
+            "type": "result",
+            "result": "Task done",
+            "session_id": "test-session",
+            "num_turns": 2,
+            "total_cost_usd": 0.05,
+        })
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (stream_output, "")
+        mock_proc.returncode = 0
+        mock_popen_cls.return_value = mock_proc
+
+        with patch("tools.claude_code_delegate_tool._get_log_root", return_value=tmp_path):
+            result = json.loads(delegate_to_claude_code({
+                "prompt": "test task",
+                "timeout_s": 30,
+            }))
+
+        assert result["success"] is True
+        assert result["status"] == "completed"
+        assert "Task done" in result["result"]
+
+    @patch("subprocess.Popen", side_effect=FileNotFoundError)
+    def test_missing_cli(self, mock_popen_cls, tmp_path):
+        with patch("tools.claude_code_delegate_tool._get_log_root", return_value=tmp_path):
+            result = json.loads(delegate_to_claude_code({"prompt": "test"}))
+
+        assert result["success"] is False
+        assert result["status"] == "missing_claude_cli"
+
+    def test_schema_has_required_fields(self):
+        schema = DELEGATE_TO_CLAUDE_CODE_SCHEMA
+        assert schema["name"] == "delegate_to_claude_code"
+        assert "prompt" in schema["parameters"]["required"]
+        props = schema["parameters"]["properties"]
+        assert "prompt" in props
+        assert "timeout_s" in props
+        assert "max_budget_usd" in props
+        assert "model" in props

--- a/tools/claude_code_delegate_tool.py
+++ b/tools/claude_code_delegate_tool.py
@@ -1,0 +1,429 @@
+"""Claude Code cascade delegation tool for Hermes.
+
+Spawns a Claude Code CLI subprocess (``claude -p``) that inherits the
+operator's OAuth credentials and native tool/MCP/skill surface.  The main
+Hermes agent exposes this meta-tool on its direct Anthropic OAuth path; the
+subprocess does the real tool-heavy work and bills as a first-party Claude
+Code request.
+
+Why this exists
+---------------
+Anthropic's OAuth subscription classifies some request shapes as "third-party
+extra usage" based on wire-format signals (tool name prefixes, system prompt
+size, total tool-schema bulk).  When the extra-usage bucket is empty the
+request fails with HTTP 400.  Claude Code CLI requests are classified as
+first-party regardless of payload shape.  This tool routes around the billing
+classifier by delegating tool-heavy turns to a CLI subprocess.
+
+The tool is intentionally small: Hermes' direct OAuth request only needs
+enough surface to ask Claude Code to do the real work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from hermes_constants import get_hermes_home, get_skills_dir
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 60
+MAX_TIMEOUT_SECONDS = 900
+DEFAULT_BUDGET_USD = 1.0
+MAX_BUDGET_USD = 10.0
+DEFAULT_MODEL = "sonnet"
+MAX_RESULT_CHARS = 6000
+
+
+def _get_log_root() -> Path:
+    return get_hermes_home() / "claude_delegate_logs"
+
+
+DELEGATE_TO_CLAUDE_CODE_SCHEMA = {
+    "name": "delegate_to_claude_code",
+    "description": (
+        "Delegate a tool-heavy request to a Claude Code subprocess with the "
+        "operator's full Claude Code tool surface, MCP servers, skills, and "
+        "OAuth subscription billing. Use this whenever the user asks to browse "
+        "the web, take a screenshot, run shell commands, inspect or write "
+        "files, or do any work that needs external tools. "
+        "DO NOT delegate for: "
+        "(a) self-introspection ('what voices/skills/model do you have'), "
+        "(b) self-configuration ('switch voice', 'enable/disable X'), "
+        "(c) requests that map to a slash command "
+        "(/tts-voice, /skills, /voice, /commands). "
+        "DO NOT delegate for simple chat or casual responses."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "The complete task for Claude Code. Include the user's exact "
+                    "request and any relevant conversation context."
+                ),
+            },
+            "timeout_s": {
+                "type": "integer",
+                "description": (
+                    "Hard wall-clock timeout in seconds. "
+                    f"Default {DEFAULT_TIMEOUT_SECONDS}; maximum {MAX_TIMEOUT_SECONDS}."
+                ),
+                "default": DEFAULT_TIMEOUT_SECONDS,
+                "minimum": 5,
+                "maximum": MAX_TIMEOUT_SECONDS,
+            },
+            "max_budget_usd": {
+                "type": "number",
+                "description": (
+                    "Claude Code --max-budget-usd cap. For subscription OAuth this "
+                    "is an API-equivalent guardrail, not API-key spend. Default 1.0."
+                ),
+                "default": DEFAULT_BUDGET_USD,
+                "minimum": 0.01,
+                "maximum": MAX_BUDGET_USD,
+            },
+            "cwd": {
+                "type": "string",
+                "description": (
+                    "Optional working directory for Claude Code. Defaults to the "
+                    "operator's home directory."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Claude Code model alias or full model id. Default: sonnet."
+                ),
+                "default": DEFAULT_MODEL,
+            },
+        },
+        "required": ["prompt"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _get_claude_bin() -> str:
+    return os.environ.get("HERMES_CLAUDE_CODE_BIN") or "claude"
+
+
+def check_claude_code_available() -> bool:
+    """Return True if the Claude Code CLI is installed and on PATH."""
+    return shutil.which(_get_claude_bin()) is not None
+
+
+def _as_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        coerced = default
+    return max(minimum, min(maximum, coerced))
+
+
+def _as_float(value: Any, default: float, minimum: float, maximum: float) -> float:
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        coerced = default
+    return max(minimum, min(maximum, coerced))
+
+
+def _resolve_cwd(raw_cwd: Any) -> Path:
+    if isinstance(raw_cwd, str) and raw_cwd.strip():
+        candidate = Path(raw_cwd).expanduser()
+    else:
+        candidate = Path.home()
+    try:
+        candidate = candidate.resolve()
+    except OSError:
+        candidate = Path.home()
+    if not candidate.exists() or not candidate.is_dir():
+        return Path.home()
+    return candidate
+
+
+def _existing_add_dirs() -> list[str]:
+    """Return ``--add-dir`` paths that actually exist on this host.
+
+    These give the subprocess visibility into Hermes' skill registry.
+    Paths that don't exist are silently skipped so the tool works on
+    fresh installs without special setup.
+    """
+    candidates = [
+        get_skills_dir(),       # ~/.hermes/skills (canonical)
+        # Do NOT add get_hermes_home() -- it contains config.yaml with
+        # secrets that a model-controlled prompt could exfiltrate.
+    ]
+    # Additional user-configured directories via env var (colon-separated).
+    extra = os.environ.get("HERMES_DELEGATE_ADD_DIRS", "").strip()
+    if extra:
+        for raw in extra.split(":"):
+            raw = raw.strip()
+            if raw:
+                candidates.append(Path(raw).expanduser())
+
+    dirs: list[str] = []
+    seen: set[str] = set()
+    for path in candidates:
+        try:
+            resolved = str(path.resolve())
+        except OSError:
+            continue
+        if path.is_dir() and resolved not in seen:
+            dirs.append(resolved)
+            seen.add(resolved)
+    return dirs
+
+
+def _wrap_prompt(prompt: str) -> str:
+    """Wrap the user's task in runtime context for the Claude Code subprocess."""
+    skills_dir = get_skills_dir()
+    lines = [
+        "You are Claude Code running as Hermes' delegated tool executor.",
+        "Complete the task end-to-end and return a concise result.",
+        "",
+        "# Hermes Runtime Context",
+        f"- Hermes skills directory: {skills_dir}",
+        "- For browser/screenshot requests, use Claude Code's native browser "
+        "or shell-accessible screenshot tooling.",
+        "- Do not ask Hermes to do another tool call. You are the tool-capable "
+        "worker.",
+        "",
+        "# User Task",
+        prompt.strip(),
+        "",
+        "# Response Contract",
+        "Return only the useful result. Include file paths for created notes, "
+        "screenshots, or other artifacts.",
+    ]
+    return "\n".join(lines)
+
+
+def _command_for(
+    prompt: str,
+    max_budget_usd: float,
+    model: str,
+) -> list[str]:
+    claude = _get_claude_bin()
+    skip_permissions = os.environ.get(
+        "HERMES_DELEGATE_SKIP_PERMISSIONS", "0",
+    ).lower() in ("1", "true", "yes", "on")
+
+    cmd = [
+        claude,
+        "-p", prompt,
+        "--output-format", "stream-json",
+        "--include-partial-messages",
+        "--verbose",
+        "--no-session-persistence",
+        "--max-budget-usd", f"{max_budget_usd:.4f}",
+        "--model", model or DEFAULT_MODEL,
+    ]
+    if skip_permissions:
+        cmd.append("--dangerously-skip-permissions")
+    for add_dir in _existing_add_dirs():
+        cmd.extend(["--add-dir", add_dir])
+    return cmd
+
+
+def _parse_stream_json(raw_stdout: str) -> Dict[str, Any]:
+    """Parse Claude Code's stream-json output into a structured result."""
+    final_result: Dict[str, Any] | None = None
+    init_event: Dict[str, Any] | None = None
+    tool_calls: list[Dict[str, Any]] = []
+    text_fragments: list[str] = []
+    parse_errors = 0
+    bad_lines: list[str] = []
+
+    for line in raw_stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError:
+            parse_errors += 1
+            if len(bad_lines) < 5:
+                bad_lines.append(line[:200])
+            continue
+
+        etype = event.get("type")
+        if etype == "system" and event.get("subtype") == "init":
+            init_event = event
+        elif etype == "assistant":
+            message = event.get("message") or {}
+            content = message.get("content") or []
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "tool_use":
+                        tool_calls.append({
+                            "name": block.get("name"),
+                            "input": block.get("input") or {},
+                        })
+                    elif block.get("type") == "text" and block.get("text"):
+                        text_fragments.append(str(block["text"]))
+        elif etype == "result":
+            final_result = event
+
+    return {
+        "init": init_event or {},
+        "final": final_result or {},
+        "tool_calls": tool_calls,
+        "text": "\n".join(t for t in text_fragments if t).strip(),
+        "parse_errors": parse_errors,
+        "bad_lines": bad_lines,
+    }
+
+
+def _redacted_command(cmd: list[str]) -> list[str]:
+    redacted = list(cmd)
+    if "-p" in redacted:
+        idx = redacted.index("-p")
+        if idx + 1 < len(redacted):
+            redacted[idx + 1] = "<prompt>"
+    return redacted
+
+
+def delegate_to_claude_code(args: dict, **kwargs) -> str:
+    """Execute a Claude Code subprocess and return the structured result."""
+    prompt = str(args.get("prompt") or "").strip()
+    if not prompt:
+        return tool_error("prompt is required")
+
+    timeout_s = _as_int(
+        args.get("timeout_s"), DEFAULT_TIMEOUT_SECONDS, 5, MAX_TIMEOUT_SECONDS,
+    )
+    max_budget_usd = _as_float(
+        args.get("max_budget_usd"), DEFAULT_BUDGET_USD, 0.01, MAX_BUDGET_USD,
+    )
+    model = str(args.get("model") or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+    cwd = _resolve_cwd(args.get("cwd"))
+    wrapped_prompt = _wrap_prompt(prompt)
+
+    log_root = _get_log_root()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    log_dir = log_root / f"{stamp}-{uuid.uuid4().hex[:8]}"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "prompt.txt").write_text(wrapped_prompt, encoding="utf-8")
+
+    cmd = _command_for(wrapped_prompt, max_budget_usd, model)
+    (log_dir / "command.json").write_text(
+        json.dumps(_redacted_command(cmd), indent=2), encoding="utf-8",
+    )
+
+    # Inherit the full parent environment so the subprocess can access the
+    # operator's OAuth credentials and tool configuration.
+    env = os.environ.copy()
+    # Ensure node (required by Claude Code) is on PATH even if the gateway
+    # process was started with a minimal environment.
+    node_bin = str(get_hermes_home() / "node" / "bin")
+    env["PATH"] = node_bin + os.pathsep + env.get("PATH", "")
+
+    stdout_path = log_dir / "stdout.jsonl"
+    stderr_path = log_dir / "stderr.log"
+    started = time.monotonic()
+    timed_out = False
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(cwd),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            raw_stdout, raw_stderr = proc.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            proc.kill()
+            raw_stdout, raw_stderr = proc.communicate(timeout=10)
+        exit_code = proc.returncode
+    except FileNotFoundError:
+        result: Dict[str, Any] = {
+            "success": False,
+            "status": "missing_claude_cli",
+            "error": (
+                "Claude Code CLI not found on PATH; "
+                "install @anthropic-ai/claude-code or set HERMES_CLAUDE_CODE_BIN."
+            ),
+            "log_dir": str(log_dir),
+        }
+        (log_dir / "result.json").write_text(
+            json.dumps(result, indent=2), encoding="utf-8",
+        )
+        return json.dumps(result, ensure_ascii=False)
+
+    duration_s = round(time.monotonic() - started, 2)
+    stdout_path.write_text(raw_stdout or "", encoding="utf-8")
+    stderr_path.write_text(raw_stderr or "", encoding="utf-8")
+
+    parsed = _parse_stream_json(raw_stdout or "")
+    final = parsed.get("final") or {}
+    final_text = str(final.get("result") or parsed.get("text") or "").strip()
+    truncated = len(final_text) > MAX_RESULT_CHARS
+    if truncated:
+        final_text = final_text[:MAX_RESULT_CHARS]
+    status = "timeout" if timed_out else "completed"
+    if not timed_out and exit_code != 0:
+        status = "error"
+    if final.get("is_error"):
+        status = "error"
+
+    result = {
+        "success": status == "completed",
+        "status": status,
+        "exit_code": exit_code,
+        "duration_seconds": duration_s,
+        "model_requested": model,
+        "model_used": (parsed.get("init") or {}).get("model"),
+        "session_id": (
+            final.get("session_id")
+            or (parsed.get("init") or {}).get("session_id")
+        ),
+        "num_turns": final.get("num_turns"),
+        "total_cost_usd": final.get("total_cost_usd"),
+        "result": final_text,
+        "truncated": truncated,
+        "tool_calls": (parsed.get("tool_calls") or [])[:20],
+        "log_dir": str(log_dir),
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+        "stderr_tail": (raw_stderr or "")[-2000:],
+        "parse_errors": parsed.get("parse_errors", 0),
+        "bad_lines": parsed.get("bad_lines", []),
+    }
+    (log_dir / "result.json").write_text(
+        json.dumps(result, indent=2), encoding="utf-8",
+    )
+    logger.info(
+        "delegate_to_claude_code: status=%s exit=%s duration=%.1fs model=%s cost=%s",
+        status, exit_code, duration_s, model,
+        final.get("total_cost_usd", "?"),
+    )
+    return json.dumps(result, ensure_ascii=False)
+
+
+registry.register(
+    name="delegate_to_claude_code",
+    toolset="claude_code_delegation",
+    schema=DELEGATE_TO_CLAUDE_CODE_SCHEMA,
+    handler=delegate_to_claude_code,
+    description=DELEGATE_TO_CLAUDE_CODE_SCHEMA["description"],
+    emoji="\u2197",  # ↗
+    check_fn=check_claude_code_available,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -240,6 +240,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "claude_code_delegation": {
+        "description": (
+            "Delegate tool-heavy work to a Claude Code subprocess using "
+            "first-party OAuth/subscription billing and Claude Code's full "
+            "tool/MCP/skill surface."
+        ),
+        "tools": ["delegate_to_claude_code"],
+        "includes": [],
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -360,6 +370,10 @@ TOOLSETS = {
     "hermes-api-server": {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
+            # Claude Code cascade delegation for tool-heavy OAuth turns.
+            # Listed here for API server completeness; gated by
+            # _DEFAULT_OFF_TOOLSETS + check_fn (requires Claude CLI).
+            "delegate_to_claude_code",
             # Web
             "web_search", "web_extract",
             # Terminal + process management


### PR DESCRIPTION
## Problem

When the main Hermes agent uses an Anthropic OAuth subscription, the simplest
way to avoid the billing classifier's "third-party extra usage" gate is to
expose only a `delegate_to_claude_code` meta-tool on the direct OAuth path
(see PR #33551). For tool-heavy requests, the agent picks the delegate tool and
routes to a Claude Code subprocess.

But that still burns one OAuth turn just to *choose* the delegate — for
requests like "browse to X" or "screenshot this", the choice is obvious.

## Solution

Add a pattern-matching pre-route that bypasses the LLM conversation loop
entirely for high-confidence tool-heavy requests, calling
`delegate_to_claude_code` directly at the top of `run_conversation()`.

## What changes

**`agent/conversation_loop.py`:**

- New function `_should_delegate_to_claude_code(user_message)` — checks
  `HERMES_DELEGATE_HEURISTICS` env var (default "1"), then matches against
  two prefix groups:
  - **Capture prefixes**: `capture this`, `capture:`, `/capture `,
    `save this thought`, `remember this:`, `log this:`,
    `write this to my vault`
  - **Tool prefixes**: `browse to `, `screenshot`, `search the web`,
    `web search: `, `run command`, `run this command`, `shell command`,
    `use playwright`, `open browser`, `inspect this page`

- Pre-route block at the top of `run_conversation()`: if the delegate tool
  is available and the heuristic matches, directly calls
  `delegate_to_claude_code` and returns early.

**Key design choices:**
- All matching uses `str.startswith()` — NOT `in` substring search — so
  `"please do NOT screenshot this"` and other negation constructs are not
  pre-routed.
- `_user_turn_count` is incremented before early return so memory-nudge
  counters accumulate correctly.
- Non-JSON delegate output is treated as success (plain text response is valid).
- `hasattr(_persist_session)` guard for agent types that lack the method.
- Falls through to the normal loop on any exception (never hard-fails the turn).

**Feature gating:**
Set `HERMES_DELEGATE_HEURISTICS=0` (or `false`, `no`, `off`) to disable
the pre-route entirely. The delegate tool still works via the normal LLM path.

**`tests/agent/test_delegate_pre_route.py`** (new, 39 tests):
- 34 tests for `_should_delegate_to_claude_code`: env flag, non-string,
  empty, all capture prefixes, all tool prefixes, non-matching, negation
  guard cases (5 tests verifying mid-sentence matches don't pre-route)
- 6 integration tests for the pre-route block: fires correctly, skipped when
  tool unavailable, skipped when heuristic returns False, falls through on
  exception, handles non-JSON result, increments `_user_turn_count`

## Depends on

PR #33551 (`feat(tools): add Claude Code cascade delegation tool`) —
the `tools.claude_code_delegate_tool` import must be available.

## Test plan

- [ ] `pytest tests/agent/test_delegate_pre_route.py` (39/39 pass)
- [ ] `HERMES_DELEGATE_HEURISTICS=0` → normal loop fires (no pre-route)
- [ ] `delegate_to_claude_code` not in `valid_tool_names` → no pre-route
- [ ] Exception during delegate → fall-through to normal loop (no user-visible error)