### PR TITLE
fix(gateway): add canonical cache paths to MEDIA_DELIVERY_SAFE_ROOTS

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -835,11 +835,19 @@ MEDIA_DELIVERY_SAFE_ROOTS = (
     VIDEO_CACHE_DIR,
     DOCUMENT_CACHE_DIR,
     SCREENSHOT_CACHE_DIR,
+    # Legacy paths (pre-consolidation layout)
     _HERMES_HOME / "image_cache",
     _HERMES_HOME / "audio_cache",
     _HERMES_HOME / "video_cache",
     _HERMES_HOME / "document_cache",
     _HERMES_HOME / "browser_screenshots",
+    # Canonical cache paths — always safe, even when get_hermes_dir() resolves
+    # to a legacy location (old_path.exists() takes precedence).
+    _HERMES_HOME / "cache" / "images",
+    _HERMES_HOME / "cache" / "audio",
+    _HERMES_HOME / "cache" / "videos",
+    _HERMES_HOME / "cache" / "documents",
+    _HERMES_HOME / "cache" / "screenshots",
 )
 
 # Default recency window for trusting freshly-produced files (seconds).

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -903,3 +903,37 @@ class TestProxyKwargsForAiohttp:
             sess_kw, req_kw = proxy_kwargs_for_aiohttp("http://proxy:8080")
             assert sess_kw == {}
             assert req_kw == {"proxy": "http://proxy:8080"}
+
+class TestMediaDeliverySafeRootsDefaults:
+    """Verify default MEDIA_DELIVERY_SAFE_ROOTS includes both legacy and canonical paths."""
+
+    def test_includes_canonical_cache_paths(self):
+        """Canonical ~/.hermes/cache/{images,audio,...} paths must be in safe roots
+        even when get_hermes_dir() resolves to a legacy location."""
+        from gateway.platforms.base import MEDIA_DELIVERY_SAFE_ROOTS, _HERMES_HOME
+
+        canonical = {
+            _HERMES_HOME / "cache" / "images",
+            _HERMES_HOME / "cache" / "audio",
+            _HERMES_HOME / "cache" / "videos",
+            _HERMES_HOME / "cache" / "documents",
+            _HERMES_HOME / "cache" / "screenshots",
+        }
+        roots_set = set(MEDIA_DELIVERY_SAFE_ROOTS)
+        missing = canonical - roots_set
+        assert not missing, f"Canonical cache paths missing from MEDIA_DELIVERY_SAFE_ROOTS: {missing}"
+
+    def test_includes_legacy_paths(self):
+        """Legacy ~/.hermes/{image_cache,audio_cache,...} paths must be in safe roots."""
+        from gateway.platforms.base import MEDIA_DELIVERY_SAFE_ROOTS, _HERMES_HOME
+
+        legacy = {
+            _HERMES_HOME / "image_cache",
+            _HERMES_HOME / "audio_cache",
+            _HERMES_HOME / "video_cache",
+            _HERMES_HOME / "document_cache",
+            _HERMES_HOME / "browser_screenshots",
+        }
+        roots_set = set(MEDIA_DELIVERY_SAFE_ROOTS)
+        missing = legacy - roots_set
+        assert not missing, f"Legacy cache paths missing from MEDIA_DELIVERY_SAFE_ROOTS: {missing}"


### PR DESCRIPTION
## What does this PR do?

`MEDIA_DELIVERY_SAFE_ROOTS` missed the canonical `~/.hermes/cache/` paths when `get_hermes_dir()` resolved to a legacy location. This caused valid Hermes-managed media artifacts to be silently filtered out before gateway delivery.
## Related Issue

Fixes #33549

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- **Analyzed:** `MEDIA_DELIVERY_SAFE_ROOTS` (gateway/platforms/base.py, line 830) — used by `_media_delivery_allowed_roots()` → `validate_media_delivery_path()` → `filter_media_delivery_paths()`
- **Blast radius:** LOW — adds safe paths, does not remove or change existing behavior
- **Related patterns:** `get_hermes_dir()` backward compatibility (hermes_constants.py:197) — new installs use canonical paths, existing installs keep legacy paths

## Tests

- Added `TestMediaDeliverySafeRootsDefaults` in `test_platform_base.py` verifying both canonical and legacy paths are present
- All 11 existing `TestMediaDeliveryPathValidation` tests pass
- 2 files changed, +42 lines

## Checklist

- [x] One root cause per PR
- [x] Regression tests added
- [x] `git diff --stat upstream/main` shows only relevant files (2 files)
- [x] No unrelated changes