### PR TITLE
Fix session hijacking via unsafely relayed approval responses in TUI gateway

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4057,7 +4057,10 @@ def _respond(rid, params, key):
     entry = _pending.get(r)
     if not entry:
         return _err(rid, 4009, f"no pending {key} request")
-    _, ev = entry
+    pending_sid, ev = entry
+    session_id = params.get("session_id", "")
+    if pending_sid != session_id:
+        return _err(rid, 4009, "session mismatch")
     _answers[r] = params.get(key, "")
     ev.set()
     return _ok(rid, {"status": "ok"})


### PR DESCRIPTION
Before: the _respond() helper method passes a msg_id directly to approval.respond without verifying that the message belongs to the current session. An attacker who can send crafted messages to the TUI gateway (local socket) could respond to arbitrary approval messages from any session, including approving dangerous tool executions that the legitimate user has not yet responded to.

After: _respond() now extracts the pending entry's stored session ID (pending_sid) and compares it to the session_id in the incoming params before writing the answer and signalling the event. A session mismatch returns a 4009 error and the request is discarded, preventing cross-session injection.

Impact: Any local user or process with access to the TUI gateway socket could bypass approval prompts on unrelated sessions, potentially approving privileged operations (sudo commands, secret access, tool executions) without authorization.