### PR TITLE
feat: add companion context audit snapshots

### DIFF
--- a/agent/companion_audit.py
+++ b/agent/companion_audit.py
@@ -1,0 +1,223 @@
+"""Companion audit/context snapshots for dashboard-visible oversight.
+
+This module writes append-only JSONL records under ``$HERMES_HOME/audit`` so
+profile-scoped companion agents have a durable, inspectable trail of what
+context was sent to the model on each turn/API call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+_MAX_PREVIEW_CHARS = 4000
+_MAX_RESULT_PREVIEW_CHARS = 2000
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _today_file(root: Path | None = None) -> Path:
+    home = root or get_hermes_home()
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return home / "audit" / f"{day}.jsonl"
+
+
+def _safe_preview(value: Any, limit: int = _MAX_PREVIEW_CHARS) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        except Exception:
+            text = str(value)
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"… [truncated {len(text) - limit} chars]"
+
+
+def _content_text(message: dict[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return _safe_preview(content)
+
+
+def _tool_names(tools: Iterable[Any] | None) -> list[str]:
+    names: list[str] = []
+    for tool in tools or []:
+        name = None
+        if isinstance(tool, dict):
+            if isinstance(tool.get("function"), dict):
+                name = tool["function"].get("name")
+            name = name or tool.get("name")
+        if isinstance(name, str) and name and name not in names:
+            names.append(name)
+    return sorted(names)
+
+
+def _parse_arguments(raw: Any) -> Any:
+    if not isinstance(raw, str):
+        return raw
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw
+
+
+def _extract_tool_attempts(request_messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    results_by_id: dict[str, str] = {}
+    for msg in request_messages:
+        if msg.get("role") == "tool":
+            call_id = msg.get("tool_call_id")
+            if isinstance(call_id, str):
+                results_by_id[call_id] = _safe_preview(
+                    _content_text(msg),
+                    limit=_MAX_RESULT_PREVIEW_CHARS,
+                )
+
+    attempts: list[dict[str, Any]] = []
+    for msg in request_messages:
+        for tc in msg.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            raw_fn = tc.get("function")
+            fn: dict[str, Any] = raw_fn if isinstance(raw_fn, dict) else {}
+            call_id = tc.get("id")
+            entry = {
+                "id": call_id or "",
+                "name": fn.get("name") or tc.get("name") or "unknown",
+                "arguments": _parse_arguments(fn.get("arguments")),
+            }
+            if isinstance(call_id, str) and call_id in results_by_id:
+                entry["result_preview"] = results_by_id[call_id]
+            attempts.append(entry)
+    return attempts
+
+
+def resolve_active_profile_name(root: Path | None = None) -> str:
+    """Return profile name for the current Hermes home.
+
+    ``~/.hermes`` -> ``default``; ``~/.hermes/profiles/<name>`` -> ``<name>``.
+    """
+    import os
+
+    explicit = os.environ.get("HERMES_PROFILE", "").strip()
+    if explicit:
+        return explicit
+    try:
+        home = (root or get_hermes_home()).resolve()
+        parts = home.parts
+        if len(parts) >= 2 and parts[-2] == "profiles":
+            return parts[-1]
+    except Exception:
+        pass
+    return "default"
+
+
+def write_turn_snapshot(
+    *,
+    session_id: str,
+    profile: str | None = None,
+    platform: str | None = None,
+    user_message: str | None = None,
+    assistant_response: str | None = None,
+    system_prompt: str | None = None,
+    request_messages: list[dict[str, Any]] | None = None,
+    tools: Iterable[Any] | None = None,
+    enabled_toolsets: list[str] | None = None,
+    memory_context: str | None = None,
+    plugin_context: str | None = None,
+    api_call_count: int | None = None,
+    approx_input_tokens: int | None = None,
+    request_char_count: int | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+    output_path: Path | None = None,
+) -> dict[str, Any]:
+    """Append one companion audit/context snapshot and return the event."""
+    request_messages = request_messages or []
+    system_prompt = system_prompt or ""
+    tool_names = _tool_names(tools)
+    event = {
+        "schema_version": 1,
+        "event": "turn_context_snapshot",
+        "timestamp": _utc_timestamp(),
+        "timestamp_unix": time.time(),
+        "session_id": session_id,
+        "profile": profile or "default",
+        "platform": platform or "",
+        "user_message": _safe_preview(user_message),
+        "assistant_response": _safe_preview(assistant_response),
+        "model": model or "",
+        "provider": provider or "",
+        "context": {
+            "system_prompt_sha256": hashlib.sha256(system_prompt.encode("utf-8")).hexdigest() if system_prompt else "",
+            "system_prompt_char_count": len(system_prompt),
+            "system_prompt_preview": _safe_preview(system_prompt),
+            "memory_context_present": bool(memory_context),
+            "memory_context_preview": _safe_preview(memory_context),
+            "plugin_context_present": bool(plugin_context),
+            "plugin_context_preview": _safe_preview(plugin_context),
+            "enabled_toolsets": list(enabled_toolsets or []),
+        },
+        "request": {
+            "api_call_count": api_call_count,
+            "message_count": len(request_messages),
+            "approx_input_tokens": approx_input_tokens,
+            "request_char_count": request_char_count,
+        },
+        "tools": {
+            "available": tool_names,
+            "available_count": len(tool_names),
+        },
+        "tool_attempts": _extract_tool_attempts(request_messages),
+    }
+
+    path = output_path or _today_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+    return event
+
+
+def iter_audit_events(root: Path | None = None) -> Iterable[dict[str, Any]]:
+    audit_dir = (root or get_hermes_home()) / "audit"
+    if not audit_dir.exists():
+        return
+    for path in sorted(audit_dir.glob("*.jsonl"), reverse=True):
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        yield json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            continue
+
+
+def iter_session_audit_events(session_id: str, root: Path | None = None) -> Iterable[dict[str, Any]]:
+    for event in iter_audit_events(root=root) or []:
+        if event.get("session_id") == session_id:
+            yield event

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -964,6 +964,29 @@ def run_conversation(
             api_messages, tools=agent.tools or None
         )
 
+        try:
+            from agent.companion_audit import resolve_active_profile_name, write_turn_snapshot
+            write_turn_snapshot(
+                session_id=agent.session_id or "",
+                profile=resolve_active_profile_name(),
+                platform=agent.platform or "",
+                user_message=original_user_message if isinstance(original_user_message, str) else "",
+                assistant_response=None,
+                system_prompt=effective_system,
+                request_messages=list(api_messages),
+                tools=agent.tools or [],
+                enabled_toolsets=list(agent.enabled_toolsets or []),
+                memory_context=_ext_prefetch_cache,
+                plugin_context=_plugin_user_context,
+                api_call_count=api_call_count,
+                approx_input_tokens=approx_tokens,
+                request_char_count=total_chars,
+                model=agent.model,
+                provider=agent.provider,
+            )
+        except Exception as exc:
+            logger.debug("companion audit snapshot failed: %s", exc)
+
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens
         )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2547,6 +2547,16 @@ async def get_session_messages(session_id: str):
         db.close()
 
 
+@app.get("/api/sessions/{session_id}/audit")
+async def get_session_audit(session_id: str):
+    """Return append-only context/audit snapshots for a session."""
+    from agent.companion_audit import iter_session_audit_events
+
+    events = list(iter_session_audit_events(session_id))
+    events.sort(key=lambda e: e.get("timestamp_unix") or e.get("timestamp") or 0)
+    return {"session_id": session_id, "count": len(events), "events": events}
+
+
 @app.delete("/api/sessions/{session_id}")
 async def delete_session_endpoint(session_id: str):
     from hermes_state import SessionDB

--- a/tests/agent/test_companion_audit.py
+++ b/tests/agent/test_companion_audit.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+
+
+def test_write_turn_snapshot_creates_session_filterable_jsonl(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.companion_audit import iter_session_audit_events, write_turn_snapshot
+
+    event = write_turn_snapshot(
+        session_id="session-123",
+        profile="builderwrx-eddie",
+        platform="telegram",
+        user_message="Can Eddie ask Codex to look at Kestrel?",
+        assistant_response=None,
+        system_prompt="SYSTEM PROMPT TEXT",
+        request_messages=[
+            {"role": "system", "content": "SYSTEM PROMPT TEXT"},
+            {"role": "user", "content": "hello\n\n<memory-context>known fact</memory-context>"},
+        ],
+        tools=[{"function": {"name": "clarify"}}, {"function": {"name": "memory"}}],
+        enabled_toolsets=["safe", "memory"],
+        memory_context="known fact",
+        plugin_context="plugin fact",
+        api_call_count=1,
+        approx_input_tokens=42,
+        request_char_count=100,
+        model="gpt-test",
+        provider="openai",
+    )
+
+    assert event["session_id"] == "session-123"
+    assert event["profile"] == "builderwrx-eddie"
+    assert event["context"]["system_prompt_sha256"]
+    assert event["context"]["system_prompt_preview"] == "SYSTEM PROMPT TEXT"
+    assert event["context"]["memory_context_present"] is True
+    assert event["context"]["plugin_context_present"] is True
+    assert event["tools"]["available"] == ["clarify", "memory"]
+    assert event["tool_attempts"] == []
+
+    audit_files = list((tmp_path / "audit").glob("*.jsonl"))
+    assert len(audit_files) == 1
+    line = audit_files[0].read_text(encoding="utf-8").strip()
+    assert json.loads(line)["session_id"] == "session-123"
+
+    events = list(iter_session_audit_events("session-123"))
+    assert len(events) == 1
+    assert events[0]["request"]["message_count"] == 2
+
+
+def test_turn_snapshot_extracts_tool_attempts_from_conversation_history(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.companion_audit import write_turn_snapshot
+
+    event = write_turn_snapshot(
+        session_id="session-tools",
+        profile="default",
+        platform="telegram",
+        user_message="do thing",
+        assistant_response=None,
+        system_prompt="system",
+        request_messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {"name": "send_message", "arguments": '{"target":"telegram"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "name": "send_message", "content": '{"ok": false}'},
+        ],
+        tools=[],
+        enabled_toolsets=[],
+    )
+
+    assert event["tool_attempts"] == [
+        {
+            "id": "call-1",
+            "name": "send_message",
+            "arguments": {"target": "telegram"},
+            "result_preview": '{"ok": false}',
+        }
+    ]

--- a/tests/hermes_cli/test_web_server_session_audit.py
+++ b/tests/hermes_cli/test_web_server_session_audit.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_session_audit_endpoint_returns_profile_scoped_context_snapshots(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    (audit_dir / "2026-05-27.jsonl").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "event": "turn_context_snapshot",
+                "timestamp": "2026-05-27T12:00:00+00:00",
+                "timestamp_unix": 1,
+                "session_id": "visible-session",
+                "profile": "builderwrx-eddie",
+                "context": {"enabled_toolsets": ["safe"]},
+                "tools": {"available": ["clarify"]},
+                "tool_attempts": [],
+            }
+        )
+        + "\n"
+        + json.dumps({"session_id": "other-session", "event": "turn_context_snapshot"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    resp = client.get("/api/sessions/visible-session/audit")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["session_id"] == "visible-session"
+    assert body["count"] == 1
+    assert body["events"][0]["profile"] == "builderwrx-eddie"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -178,6 +178,8 @@ export const api = {
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
     fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
+  getSessionAudit: (id: string) =>
+    fetchJSON<SessionAuditResponse>(`/api/sessions/${encodeURIComponent(id)}/audit`),
   getSessionLatestDescendant: (id: string) =>
     fetchJSON<SessionLatestDescendantResponse>(
       `/api/sessions/${encodeURIComponent(id)}/latest-descendant`,
@@ -575,6 +577,52 @@ export interface SessionMessage {
 export interface SessionMessagesResponse {
   session_id: string;
   messages: SessionMessage[];
+}
+
+export interface SessionAuditEvent {
+  schema_version?: number;
+  event?: string;
+  timestamp?: string;
+  timestamp_unix?: number;
+  session_id: string;
+  profile?: string;
+  platform?: string;
+  user_message?: string;
+  assistant_response?: string;
+  model?: string;
+  provider?: string;
+  context?: {
+    system_prompt_sha256?: string;
+    system_prompt_char_count?: number;
+    system_prompt_preview?: string;
+    memory_context_present?: boolean;
+    memory_context_preview?: string;
+    plugin_context_present?: boolean;
+    plugin_context_preview?: string;
+    enabled_toolsets?: string[];
+  };
+  request?: {
+    api_call_count?: number | null;
+    message_count?: number;
+    approx_input_tokens?: number | null;
+    request_char_count?: number | null;
+  };
+  tools?: {
+    available?: string[];
+    available_count?: number;
+  };
+  tool_attempts?: Array<{
+    id?: string;
+    name?: string;
+    arguments?: unknown;
+    result_preview?: string;
+  }>;
+}
+
+export interface SessionAuditResponse {
+  session_id: string;
+  count: number;
+  events: SessionAuditEvent[];
 }
 
 export interface LogsResponse {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -27,6 +27,7 @@ import {
 import { api } from "@/lib/api";
 import type {
   SessionInfo,
+  SessionAuditEvent,
   SessionMessage,
   SessionSearchResult,
   StatusResponse,
@@ -255,6 +256,83 @@ function MessageList({
   );
 }
 
+function AuditPanel({ events }: { events: SessionAuditEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <div className="rounded border border-border bg-muted/20 p-3 text-sm text-muted-foreground">
+        No context audit snapshots recorded for this session yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+        <Database className="h-3.5 w-3.5" />
+        Context audit snapshots
+      </div>
+      {events.map((event, idx) => {
+        const context = event.context ?? {};
+        const request = event.request ?? {};
+        const tools = event.tools ?? {};
+        const attempts = event.tool_attempts ?? [];
+        return (
+          <div key={`${event.timestamp ?? "audit"}-${idx}`} className="border border-border bg-background p-3">
+            <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <Badge tone="secondary" className="text-xs">
+                {event.profile ?? "default"}
+              </Badge>
+              <span>{event.platform || "local"}</span>
+              <span>API call {request.api_call_count ?? idx + 1}</span>
+              {event.timestamp && <span>{event.timestamp}</span>}
+            </div>
+            <div className="grid gap-2 text-xs sm:grid-cols-2">
+              <div>
+                <div className="font-semibold text-foreground">Model</div>
+                <div className="text-muted-foreground">{event.provider || "unknown"} / {event.model || "unknown"}</div>
+              </div>
+              <div>
+                <div className="font-semibold text-foreground">Request</div>
+                <div className="text-muted-foreground">
+                  {request.message_count ?? 0} messages · {request.approx_input_tokens ?? "?"} est. tokens
+                </div>
+              </div>
+              <div>
+                <div className="font-semibold text-foreground">System prompt</div>
+                <div className="break-all text-muted-foreground">
+                  {context.system_prompt_char_count ?? 0} chars · {(context.system_prompt_sha256 ?? "").slice(0, 12) || "no hash"}
+                </div>
+              </div>
+              <div>
+                <div className="font-semibold text-foreground">Context injections</div>
+                <div className="text-muted-foreground">
+                  memory: {context.memory_context_present ? "yes" : "no"} · plugins: {context.plugin_context_present ? "yes" : "no"}
+                </div>
+              </div>
+            </div>
+            {context.enabled_toolsets && context.enabled_toolsets.length > 0 && (
+              <div className="mt-2 text-xs text-muted-foreground">
+                Toolsets: {context.enabled_toolsets.join(", ")}
+              </div>
+            )}
+            {tools.available && tools.available.length > 0 && (
+              <div className="mt-2 text-xs text-muted-foreground">
+                Available tools: {tools.available.slice(0, 20).join(", ")}
+                {tools.available.length > 20 ? ` +${tools.available.length - 20} more` : ""}
+              </div>
+            )}
+            {attempts.length > 0 && (
+              <div className="mt-2 text-xs text-muted-foreground">
+                Tool attempts: {attempts.map((attempt) => attempt.name ?? "unknown").join(", ")}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function SessionRow({
   session,
   snippet,
@@ -273,21 +351,27 @@ function SessionRow({
   resumeInChatEnabled: boolean;
 }) {
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
+  const [auditEvents, setAuditEvents] = useState<SessionAuditEvent[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { t } = useI18n();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isExpanded && messages === null && !loading) {
+    if (isExpanded && (messages === null || auditEvents === null) && !loading) {
       setLoading(true);
-      api
-        .getSessionMessages(session.id)
-        .then((resp) => setMessages(resp.messages))
+      Promise.all([
+        api.getSessionMessages(session.id),
+        api.getSessionAudit(session.id).catch(() => ({ events: [] })),
+      ])
+        .then(([messagesResp, auditResp]) => {
+          setMessages(messagesResp.messages);
+          setAuditEvents(auditResp.events);
+        })
         .catch((err) => setError(String(err)))
         .finally(() => setLoading(false));
     }
-  }, [isExpanded, session.id, messages, loading]);
+  }, [isExpanded, session.id, messages, auditEvents, loading]);
 
   const sourceInfo = (session.source
     ? SOURCE_CONFIG[session.source]
@@ -416,7 +500,10 @@ function SessionRow({
             </p>
           )}
           {messages && messages.length > 0 && (
-            <MessageList messages={messages} highlight={searchQuery} />
+            <>
+              <MessageList messages={messages} highlight={searchQuery} />
+              <AuditPanel events={auditEvents ?? []} />
+            </>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add append-only per-turn companion/context audit snapshots for model requests.
- Expose session audit records through `/api/sessions/{session_id}/audit`.
- Render context audit snapshots inside the dashboard Sessions detail view.

## Why
This gives operators a visible proof trail for companion profiles: what profile/platform/model was used, what context injections were present, which toolsets/tools were visible, and which prior tool attempts/results were in the request context.

## Test Plan
- [x] `python -m pytest tests/agent/test_companion_audit.py tests/hermes_cli/test_web_server_session_audit.py -q`
- [x] `python -m pytest tests/run_agent/test_run_agent.py -q`
- [x] `cd web && npm ci && npm run build`

## Notes
- Implemented from a clean worktree based on `origin/main`.
- Does not include unrelated local dirty files from the default working tree.
