### PR TITLE
fix(opencode-go): strip ambient bearer auth for anthropic routes

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -534,6 +534,15 @@ def _is_azure_anthropic_endpoint(base_url: str | None) -> bool:
     return (is_foundry_host or is_legacy_azoai_host) and "/anthropic" in path
 
 
+def _is_opencode_go_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for OpenCode Go's Anthropic-compatible Messages endpoint."""
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    normalized = normalized.rstrip("/").lower()
+    return normalized.startswith("https://opencode.ai/zen/go")
+
+
 def _common_betas_for_base_url(
     base_url: str | None,
     *,
@@ -558,6 +567,10 @@ def _common_betas_for_base_url(
     betas = list(_COMMON_BETAS)
     if _base_url_needs_context_1m_beta(base_url) and not drop_context_1m_beta:
         betas.append(_CONTEXT_1M_BETA)
+    if _is_opencode_go_anthropic_endpoint(base_url):
+        # OpenCode Go already routes Anthropic-compatible model endpoints and
+        # some upstreams reject or mis-handle Anthropic beta feature headers.
+        return []
     if _is_minimax_anthropic_endpoint(base_url):
         _stripped = {_TOOL_STREAMING_BETA, _CONTEXT_1M_BETA}
         return [b for b in betas if b not in _stripped]
@@ -639,6 +652,46 @@ def _build_anthropic_client_with_bearer_hook(
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
+def _build_opencode_go_anthropic_client(
+    api_key: str,
+    base_url: str = None,
+    timeout: float = None,
+):
+    """Create an Anthropic SDK client for OpenCode Go without ambient bearer auth."""
+    _anthropic_sdk = _get_anthropic_sdk()
+    if _anthropic_sdk is None:
+        raise ImportError(
+            "The 'anthropic' package is required for OpenCode Go Anthropic-style "
+            "endpoints. Install with: pip install 'anthropic>=0.39.0'"
+        )
+
+    normalize_proxy_env_vars()
+
+    from httpx import Client, Timeout
+
+    _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
+    timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0)
+
+    def _strip_ambient_authorization(request):
+        request.headers.pop("authorization", None)
+        request.headers["x-api-key"] = api_key
+
+    http_client = Client(
+        timeout=timeout_obj,
+        event_hooks={"request": [_strip_ambient_authorization]},
+    )
+
+    kwargs = {
+        "timeout": timeout_obj,
+        "http_client": http_client,
+        "api_key": api_key,
+    }
+    normalized_base_url = _normalize_base_url_text(base_url)
+    if normalized_base_url:
+        kwargs["base_url"] = normalized_base_url.rstrip("/")
+    return _anthropic_sdk.Anthropic(**kwargs)
+
+
 def build_anthropic_client(
     api_key,
     base_url: str = None,
@@ -711,6 +764,13 @@ def build_anthropic_client(
         normalized_base_url,
         drop_context_1m_beta=drop_context_1m_beta,
     )
+
+    if _is_opencode_go_anthropic_endpoint(normalized_base_url):
+        return _build_opencode_go_anthropic_client(
+            api_key,
+            normalized_base_url,
+            timeout=timeout,
+        )
 
     if _is_kimi_coding_endpoint(base_url):
         # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -171,6 +171,28 @@ class TestBuildAnthropicClient:
                 "anthropic-beta": "interleaved-thinking-2025-05-14"
             }
 
+    def test_opencode_go_anthropic_endpoint_strips_ambient_bearer_auth(self):
+        """OpenCode Go expects x-api-key only for Anthropic-compatible routes."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "opencode-go-secret",
+                base_url="https://opencode.ai/zen/go",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["api_key"] == "opencode-go-secret"
+            assert kwargs["base_url"] == "https://opencode.ai/zen/go"
+            assert "default_headers" not in kwargs
+
+            hooks = kwargs["http_client"].event_hooks["request"]
+            request = MagicMock()
+            request.headers = {
+                "authorization": "Bearer stale-ambient-key",
+                "x-api-key": "wrong-key",
+            }
+            hooks[0](request)
+            assert "authorization" not in request.headers
+            assert request.headers["x-api-key"] == "opencode-go-secret"
+
     def test_azure_foundry_anthropic_endpoint_uses_bearer_auth(self):
         """Azure AI Foundry's /anthropic endpoint requires Authorization: Bearer.
 


### PR DESCRIPTION
## Summary
- add an OpenCode Go Anthropic client path that removes ambient Authorization headers and sends the OpenCode Go key as x-api-key
- omit Anthropic beta headers for OpenCode Go Anthropic-compatible endpoints
- add regression coverage for the header rewrite behavior

## Why
qwen3.7-max on OpenCode Go uses the Anthropic Messages route. If the Anthropic SDK also carries an ambient Authorization bearer token, OpenCode Go/DashScope can reject the request with InvalidApiKey even when OPENCODE_GO_API_KEY is valid.

## Tests
- python -m py_compile agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py
- python -m pytest -o addopts="" tests/agent/test_anthropic_adapter.py -k "opencode_go_anthropic_endpoint_strips_ambient_bearer_auth or minimax_anthropic_endpoint_uses_bearer_auth_for_regular_api_keys"