### PR TITLE
fix(logging): suppress minisweagent console noise

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -62,6 +62,8 @@ _NOISY_LOGGERS = (
     "websockets",
     "charset_normalizer",
     "markdown_it",
+    "minisweagent",
+    "minisweagent.environment",
 )
 
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -147,6 +147,8 @@ class TestSetupLogging:
         assert logging.getLogger("openai").level >= logging.WARNING
         assert logging.getLogger("httpx").level >= logging.WARNING
         assert logging.getLogger("httpcore").level >= logging.WARNING
+        assert logging.getLogger("minisweagent").level >= logging.WARNING
+        assert logging.getLogger("minisweagent.environment").level >= logging.WARNING
 
     def test_writes_to_agent_log(self, hermes_home):
         hermes_logging.setup_logging(hermes_home=hermes_home)


### PR DESCRIPTION
## Summary\n- suppress  and  to WARNING in Hermes logging setup\n- keep Docker sandbox startup/debug chatter out of TUI  activity lines\n- add a regression assertion covering the noisy logger suppression list\n\n## Testing\n- ============================= test session starts ==============================
platform darwin -- Python 3.10.6, pytest-7.4.3, pluggy-1.5.0
rootdir: /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-1865-suppress-minisweagent-logs
configfile: pyproject.toml
plugins: flask-1.3.0, cov-4.1.0, asyncio-0.21.1, anyio-4.10.0, time-machine-2.14.1, hydra-core-1.3.2
asyncio: mode=strict
collected 50 items / 49 deselected / 1 selected

tests/test_hermes_logging.py .                                           [100%]

======================= 1 passed, 49 deselected in 0.06s =======================\n- All checks passed!\n- \n\n## CI note\nRecent company PRs #33582, #33576, and #33566 all show repeated  failures, so any matching red on this PR should be treated as preexisting unrelated baseline noise.\n\nFixes #1865