### PR TITLE
fix(model): probe keyless user provider catalogs

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1497,6 +1497,7 @@ def list_authenticated_providers(
             # (see hermes_cli/main.py::_save_custom_provider); older
             # configs or hand-edited files may still use a list.
             cfg_models = ep_cfg.get("models", [])
+            has_explicit_models = bool(cfg_models)
             if isinstance(cfg_models, dict):
                 for m in cfg_models:
                     if m and m not in models_list:
@@ -1526,7 +1527,10 @@ def list_authenticated_providers(
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
-            if api_url and api_key and discover:
+            should_probe = bool(api_url) and bool(discover) and (
+                bool(api_key) or not has_explicit_models
+            )
+            if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models
                     live_models = fetch_api_models(api_key, api_url)

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -180,6 +180,52 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     assert user_prov["total_models"] == 2
 
 
+def test_list_authenticated_providers_probes_keyless_user_provider_when_models_empty(monkeypatch):
+    """Keyless ``providers:`` endpoints should still probe live /models.
+
+    Regression for #33595: Telegram /model only showed ``default_model`` for
+    local OpenAI-compatible endpoints declared under ``providers:`` when the
+    endpoint required no API key and ``models:`` was empty.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["some-model", "other-live-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    user_providers = {
+        "my-local": {
+            "name": "my-local",
+            "base_url": "http://192.168.0.107:1234/v1",
+            "api_key": "",
+            "default_model": "some-model",
+            "models": [],
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="my-local",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "my-local"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert calls == [("", "http://192.168.0.107:1234/v1")]
+    assert user_prov["models"] == ["some-model", "other-live-model"]
+    assert user_prov["total_models"] == 2
+
+
 def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
     """Dict-format ``models:`` without a ``default_model`` must still expose
     every dict key, not collapse to an empty list."""


### PR DESCRIPTION
## Summary
- probe live /v1/models for keyless user providers when only default_model is configured
- keep explicit models: subsets authoritative for keyless providers that opt into a fixed catalog
- add a regression test covering keyless Telegram /model discovery for providers:

## Testing
- uv run --frozen pytest -o addopts= tests/hermes_cli/test_user_providers_model_switch.py -k 'keyless_user_provider_when_models_empty or uses_live_models_for_user_provider'
- uv run --frozen ruff check hermes_cli/model_switch.py tests/hermes_cli/test_user_providers_model_switch.py
- git diff --check

Fixes #33595
