### PR TITLE
Add native Responses web_search support

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -235,7 +235,13 @@ def _derive_responses_function_call_id(
 # ---------------------------------------------------------------------------
 
 def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
-    """Convert chat-completions tool schemas to Responses function-tool schemas."""
+    """Convert chat-completions tool schemas to Responses tool schemas.
+
+    Most Hermes tools stay as regular ``{"type":"function", ...}`` entries.
+    A small set of built-in Responses tools are exposed in Hermes as normal
+    function schemas for compatibility with non-Responses transports, then
+    rewritten here into their native Responses form.
+    """
     if not tools:
         return None
 
@@ -244,6 +250,10 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
         fn = item.get("function", {}) if isinstance(item, dict) else {}
         name = fn.get("name")
         if not isinstance(name, str) or not name.strip():
+            continue
+        name = name.strip()
+        if name == "web_search":
+            converted.append({"type": "web_search"})
             continue
         converted.append({
             "type": "function",
@@ -795,8 +805,12 @@ def _preflight_codex_api_kwargs(
         for idx, tool in enumerate(tools):
             if not isinstance(tool, dict):
                 raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
-            if tool.get("type") != "function":
-                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
+            tool_type = tool.get("type")
+            if tool_type == "web_search":
+                normalized_tools.append({"type": "web_search"})
+                continue
+            if tool_type != "function":
+                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool_type!r}.")
 
             name = tool.get("name")
             parameters = tool.get("parameters")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -36,6 +36,18 @@ class TestCodexTransportBasic:
         assert result[0]["type"] == "function"
         assert result[0]["name"] == "terminal"
 
+    def test_convert_tools_maps_web_search_to_native_responses_tool(self, transport):
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+            }
+        }]
+        result = transport.convert_tools(tools)
+        assert result == [{"type": "web_search"}]
+
 
 class TestCodexBuildKwargs:
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1093,6 +1093,16 @@ def test_preflight_codex_api_kwargs_allows_reasoning_and_temperature(monkeypatch
     assert result["max_output_tokens"] == 4096
 
 
+def test_preflight_codex_api_kwargs_allows_native_web_search_tool(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    kwargs = _codex_request_kwargs()
+    kwargs["tools"] = [{"type": "web_search"}]
+
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+    result = _preflight_codex_api_kwargs(kwargs)
+    assert result["tools"] == [{"type": "web_search"}]
+
+
 def test_preflight_codex_api_kwargs_allows_service_tier(monkeypatch):
     agent = _build_agent(monkeypatch)
     kwargs = _codex_request_kwargs()

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -642,6 +642,18 @@ class TestCheckWebApiKey:
                     assert check_web_api_key() is True
 
 
+class TestCapabilitySpecificWebChecks:
+    def test_search_check_accepts_native_backend(self):
+        with patch("tools.web_tools._load_web_config", return_value={"search_backend": "native"}):
+            from tools.web_tools import check_web_search_api_key
+            assert check_web_search_api_key() is True
+
+    def test_extract_check_rejects_native_backend_without_extract_provider(self):
+        with patch("tools.web_tools._load_web_config", return_value={"extract_backend": "native"}):
+            from tools.web_tools import check_web_extract_api_key
+            assert check_web_extract_api_key() is False
+
+
 def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -140,7 +140,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "native"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -228,6 +228,12 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "native":
+        cfg = _load_web_config()
+        return any(
+            str(cfg.get(key) or "").lower().strip() == "native"
+            for key in ("search_backend", "backend")
+        )
     return False
 
 
@@ -1363,16 +1369,46 @@ async def web_crawl_tool(
         return tool_error(error_msg)
 
 
-# Convenience function to check Firecrawl credentials
-def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+def check_web_search_api_key() -> bool:
+    """Check whether a search-capable backend is available.
+
+    ``native`` is a special-case for Responses-based models: Hermes exposes
+    ``web_search`` in the normal tool registry, but the Responses transport
+    rewrites it into the provider-native ``{"type":"web_search"}`` tool.
+    We only advertise it when the user explicitly configures
+    ``web.search_backend: native`` or ``web.backend: native``.
+    """
+    cfg = _load_web_config()
+    configured = (
+        str(cfg.get("search_backend") or "").lower().strip()
+        or str(cfg.get("backend") or "").lower().strip()
+    )
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai", "native"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
     )
+
+
+def check_web_extract_api_key() -> bool:
+    """Check whether an extract-capable backend is available."""
+    cfg = _load_web_config()
+    configured = (
+        str(cfg.get("extract_backend") or "").lower().strip()
+        or str(cfg.get("backend") or "").lower().strip()
+    )
+    if configured in {"exa", "parallel", "firecrawl", "tavily"}:
+        return _is_backend_available(configured)
+    return any(
+        _is_backend_available(backend)
+        for backend in ("exa", "parallel", "firecrawl", "tavily")
+    )
+
+
+def check_web_api_key() -> bool:
+    """Backward-compatible union of search/extract availability."""
+    return check_web_search_api_key() or check_web_extract_api_key()
 
 
 def check_auxiliary_model() -> bool:
@@ -1542,7 +1578,7 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
-    check_fn=check_web_api_key,
+    check_fn=check_web_search_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
@@ -1553,7 +1589,7 @@ registry.register(
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_api_key,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",


### PR DESCRIPTION
## Summary

Adds native Responses `web_search` support for Hermes when using the `codex_responses` transport.

Today Hermes exposes `web_search` through the normal tool registry, but the Responses adapter rewrites every tool into `{"type":"function", ...}` and preflight rejects non-function tools entirely. That blocks operators who want to use provider-native Responses web search instead of routing `web_search` through a separate backend such as Firecrawl, Tavily, or xAI.

This patch keeps the existing non-Responses behavior unchanged, while letting Responses-based sessions opt into native web search with:

```yaml
web:
  search_backend: native
```

## What changed

- map the Hermes `web_search` tool to native Responses `{"type":"web_search"}` in `agent/codex_responses_adapter.py`
- allow native `web_search` tools through Responses preflight validation
- split `tools/web_tools.py` availability checks into:
  - `check_web_search_api_key()`
  - `check_web_extract_api_key()`
- treat `web.search_backend: native` as an explicit search-only opt-in
- keep `check_web_api_key()` as a backward-compatible union helper

## Why this shape

`native` is intentionally scoped to search only here.

`web_extract` still requires a real extract-capable backend, and should not be advertised just because a Responses model can do native web search. Splitting the availability checks avoids exposing `web_extract` in configs where only native search is intended.

## Scope / non-goals

This PR is intentionally narrow:

- it does **not** change non-Responses transports
- it does **not** add provider-specific native extract support
- it does **not** attempt a broader server-side tool registry abstraction yet

That keeps the patch small and low-risk while unblocking the existing Hermes `web_search` tool on Responses-native providers.

## Tests

Added regression coverage for:

- Responses transport converts Hermes `web_search` into native `{"type":"web_search"}`
- Responses preflight accepts native `web_search`
- `check_web_search_api_key()` accepts `search_backend: native`
- `check_web_extract_api_key()` does not falsely accept `extract_backend: native`

## Related

- Related to #19320
