### PR TITLE
fix(custom): normalize responses api mode alias

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -291,8 +291,11 @@ def init_agent(
     agent.provider = provider_name or ""
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
-        agent.api_mode = api_mode
+    normalized_api_mode = str(api_mode or "").strip().lower()
+    if normalized_api_mode == "responses":
+        normalized_api_mode = "codex_responses"
+    if normalized_api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+        agent.api_mode = normalized_api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
     elif agent.provider in {"xai", "xai-oauth"}:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -255,6 +255,8 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     """Validate an api_mode value from config. Returns None if invalid."""
     if isinstance(raw, str):
         normalized = raw.strip().lower()
+        if normalized == "responses":
+            normalized = "codex_responses"
         if normalized in _VALID_API_MODES:
             return normalized
     return None

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1000,6 +1000,28 @@ def test_model_config_api_mode(monkeypatch):
     assert resolved["base_url"] == "http://127.0.0.1:9208/v1"
 
 
+def test_model_config_responses_alias_normalized(monkeypatch):
+    """Legacy/user-facing ``responses`` should normalize to ``codex_responses``."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "http://127.0.0.1:9208/v1",
+            "api_mode": "responses",
+        },
+    )
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:9208/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "http://127.0.0.1:9208/v1"
+
+
 def test_model_config_api_mode_ignored_when_provider_differs(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "zai")
     monkeypatch.setattr(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1644,6 +1644,30 @@ def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/responses"
 
 
+def test_dump_api_request_debug_normalizes_responses_alias(monkeypatch, tmp_path):
+    """Explicit ``api_mode='responses'`` should still hit the Responses API."""
+    import json
+
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="deepseek-v4-pro",
+        provider="custom",
+        api_mode="responses",
+        base_url="http://127.0.0.1:9208/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+
+    dump_file = agent._dump_api_request_debug(_codex_request_kwargs(), reason="preflight")
+
+    payload = json.loads(dump_file.read_text())
+    assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/responses"
+
+
 def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path):
     """Debug dumps should show /chat/completions URL for chat_completions mode."""
     import json


### PR DESCRIPTION
## Summary
- normalize the user-facing `responses` api_mode alias to `codex_responses` for custom runtime resolution
- accept `AIAgent(api_mode="responses")` and route request dumps / live requests to `/responses` instead of silently falling back to `/chat/completions`
- add regressions for runtime-provider normalization and request-dump URL selection

## Testing
- uv run --frozen pytest -o addopts= tests/hermes_cli/test_runtime_provider_resolution.py -k 'model_config_api_mode or responses_alias_normalized'
- uv run --frozen pytest -o addopts= tests/run_agent/test_run_agent_codex_responses.py -k 'dump_api_request_debug_uses_responses_url or dump_api_request_debug_normalizes_responses_alias'
- uv run --frozen ruff check agent/agent_init.py hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_run_agent_codex_responses.py
- git diff --check

Fixes #33600
