### PR TITLE
fix: parse yolo status env consistently

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3747,7 +3747,7 @@ class HermesCLI:
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
 
-            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
+            yolo_active = is_truthy_value(os.getenv("HERMES_YOLO_MODE"))
             if width < 52:
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
                 if yolo_active:
@@ -3808,7 +3808,7 @@ class HermesCLI:
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
-            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
+            yolo_active = is_truthy_value(os.getenv("HERMES_YOLO_MODE"))
 
             if width < 52:
                 frags = [

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -239,6 +239,80 @@ class TestCLIStatusBar:
 
         assert "🗜️" not in text
 
+    def test_status_bar_text_treats_false_like_yolo_env_as_disabled(self, monkeypatch):
+        monkeypatch.setenv("HERMES_YOLO_MODE", "false")
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "YOLO" not in text
+
+    def test_status_bar_text_shows_yolo_for_truthy_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "⚠ YOLO" in text
+
+    def test_status_bar_fragments_treat_false_like_yolo_env_as_disabled(self, monkeypatch):
+        monkeypatch.setenv("HERMES_YOLO_MODE", "false")
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+
+        mock_app = MagicMock()
+        mock_app.output.get_size.return_value = MagicMock(columns=120)
+        with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+            frags = cli_obj._get_status_bar_fragments()
+        frag_text = "".join(text for _, text in frags)
+
+        assert "YOLO" not in frag_text
+
+    def test_status_bar_fragments_show_yolo_for_truthy_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._status_bar_visible = True
+
+        mock_app = MagicMock()
+        mock_app.output.get_size.return_value = MagicMock(columns=120)
+        with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+            frags = cli_obj._get_status_bar_fragments()
+        frag_text = "".join(text for _, text in frags)
+
+        assert "⚠ YOLO" in frag_text
+
     def test_compression_count_shown_in_medium_status_bar(self):
         cli_obj = _attach_agent(
             _make_cli(),


### PR DESCRIPTION
## Summary
- Parse `HERMES_YOLO_MODE` in the CLI status bar with `is_truthy_value(...)` instead of raw string truthiness.
- Add regression coverage for false-like and truthy YOLO env values in both status-bar text and prompt-toolkit fragments.

Closes #33605

## Test Plan
- `python -m pytest tests/cli/test_cli_status_bar.py tests/test_utils_truthy_values.py tests/tools/test_yolo_mode.py::TestYoloMode::test_false_like_yolo_values_do_not_bypass_dangerous_command -q -o 'addopts='`
