### PR TITLE
fix(kanban): recover worker protocol violation path

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -74,6 +74,87 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
+_KANBAN_TERMINAL_TOOLS = {"kanban_complete", "kanban_block"}
+
+
+def _assistant_tool_call_names(messages: List[Dict[str, Any]]) -> List[str]:
+    """Return function names from assistant tool calls in ``messages``."""
+    names: List[str] = []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            fn = call.get("function") or {}
+            name = fn.get("name") if isinstance(fn, dict) else None
+            if isinstance(name, str) and name:
+                names.append(name)
+    return names
+
+
+def _kanban_worker_called_terminal_tool(messages: List[Dict[str, Any]]) -> bool:
+    """True once a kanban worker attempted its required terminal transition."""
+    return any(name in _KANBAN_TERMINAL_TOOLS for name in _assistant_tool_call_names(messages))
+
+
+def _auto_block_kanban_worker_protocol_violation(
+    *,
+    messages: List[Dict[str, Any]],
+    final_response: Optional[str],
+    api_call_count: int,
+    effective_task_id: Optional[str],
+) -> bool:
+    """Fail closed when a kanban worker tries to finish with plain text only.
+
+    Kanban-dispatched workers have a stricter lifecycle than normal CLI chat:
+    every run must end by writing ``kanban_complete`` or ``kanban_block``.  A
+    model can still ignore that instruction and return a final text response.
+    Before this guard, the child process then exited rc=0 and the dispatcher
+    could only record a protocol-violation crash on the next tick.  That caused
+    devops/pm cards to loop as clean exits with no board handoff.
+
+    If the model never even attempted a terminal kanban tool call, write a
+    conservative block on its behalf so the board has a durable, actionable
+    state instead of a silent clean exit.  We intentionally do not auto-complete:
+    a text-only final response is not a reliable completion handoff.
+    """
+    kanban_task = os.environ.get("HERMES_KANBAN_TASK")
+    if not kanban_task or final_response is None:
+        return False
+    if _kanban_worker_called_terminal_tool(messages):
+        return False
+
+    preview = " ".join(str(final_response).split())[:240]
+    reason = (
+        "protocol-guard: worker produced a final text response without "
+        "calling kanban_complete or kanban_block; auto-blocked to prevent "
+        f"clean-exit protocol violation. api_calls={api_call_count}; "
+        f"final_response_preview={preview!r}"
+    )
+    try:
+        _ra().handle_function_call(
+            "kanban_block",
+            {"task_id": kanban_task, "reason": reason},
+            task_id=effective_task_id,
+        )
+        logger.warning(
+            "Auto-blocked kanban worker %s after text-only final response "
+            "without terminal kanban tool call (api_calls=%d)",
+            kanban_task,
+            api_call_count,
+        )
+        return True
+    except Exception:
+        logger.warning(
+            "Failed to auto-block kanban worker %s after text-only final "
+            "response without terminal kanban tool call",
+            kanban_task,
+            exc_info=True,
+        )
+        return False
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -4092,6 +4173,18 @@ def run_conversation(
                     _kanban_task,
                     exc_info=True,
                 )
+
+    # Kanban workers have a mandatory termination contract.  If a worker
+    # reaches a normal final text response without ever attempting
+    # kanban_complete/kanban_block, fail closed by blocking the task before the
+    # child exits rc=0; otherwise the dispatcher can only record a crash on its
+    # next PID sweep.
+    _auto_block_kanban_worker_protocol_violation(
+        messages=messages,
+        final_response=final_response,
+        api_call_count=api_call_count,
+        effective_task_id=effective_task_id,
+    )
 
     # Determine if conversation completed successfully
     completed = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4867,66 +4867,61 @@ class GatewayRunner:
                             continue
                         seen_db_paths.add(resolved_db_path)
                         try:
-                            conn = _kb.connect(board=slug)
+                            conn = _kb.get_connection(board=slug)
                         except Exception as exc:
                             logger.debug("kanban notifier: cannot open board %s: %s", slug, exc)
                             continue
-                        try:
-                            # `connect()` runs the schema + idempotent migration
-                            # on first open per process, so an explicit
-                            # `init_db()` here would be redundant. Worse:
-                            # `init_db()` deliberately busts the per-process
-                            # cache and re-runs the migration on a *second*
-                            # connection, which races the first and used to
-                            # log a benign but noisy `duplicate column name`
-                            # traceback (and intermittent "database is locked"
-                            # — issue #21378) on every gateway start against
-                            # a legacy DB. `_add_column_if_missing` now
-                            # tolerates that race, but we still skip the
-                            # redundant call to avoid the wasted work.
-                            subs = _kb.list_notify_subs(conn)
-                            if not subs:
-                                logger.debug("kanban notifier: board %s has no subscriptions", slug)
-                            for sub in subs:
-                                owner_profile = sub.get("notifier_profile") or None
-                                if owner_profile and owner_profile != notifier_profile:
-                                    logger.debug(
-                                        "kanban notifier: subscription for %s owned by profile %s; current profile %s skipping",
-                                        sub.get("task_id"), owner_profile, notifier_profile,
-                                    )
-                                    continue
-                                platform = (sub.get("platform") or "").lower()
-                                if platform not in active_platforms:
-                                    logger.debug(
-                                        "kanban notifier: subscription for %s on %s skipped; adapter not connected",
-                                        sub.get("task_id"), platform or "<missing>",
-                                    )
-                                    continue
-                                old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
-                                    conn,
-                                    task_id=sub["task_id"],
-                                    platform=sub["platform"],
-                                    chat_id=sub["chat_id"],
-                                    thread_id=sub.get("thread_id") or "",
-                                    kinds=TERMINAL_KINDS,
-                                )
-                                if not events:
-                                    continue
-                                task = _kb.get_task(conn, sub["task_id"])
+                        # `get_connection()` returns the per-process pooled
+                        # connection (one per board), so the schema + idempotent
+                        # migration only run on first open per process — never
+                        # re-running on every notifier tick. An explicit
+                        # `init_db()` here would be redundant; historically it
+                        # also raced the pooled connection and logged a benign
+                        # but noisy "duplicate column name" traceback plus
+                        # intermittent "database is locked" — issue #21378. We
+                        # skip it deliberately. The connection is owned by
+                        # kanban_db's pool; do not close it here.
+                        subs = _kb.list_notify_subs(conn)
+                        if not subs:
+                            logger.debug("kanban notifier: board %s has no subscriptions", slug)
+                        for sub in subs:
+                            owner_profile = sub.get("notifier_profile") or None
+                            if owner_profile and owner_profile != notifier_profile:
                                 logger.debug(
-                                    "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
-                                    len(events), sub["task_id"], slug, old_cursor, cursor,
+                                    "kanban notifier: subscription for %s owned by profile %s; current profile %s skipping",
+                                    sub.get("task_id"), owner_profile, notifier_profile,
                                 )
-                                deliveries.append({
-                                    "sub": sub,
-                                    "old_cursor": old_cursor,
-                                    "cursor": cursor,
-                                    "events": events,
-                                    "task": task,
-                                    "board": slug,
-                                })
-                        finally:
-                            conn.close()
+                                continue
+                            platform = (sub.get("platform") or "").lower()
+                            if platform not in active_platforms:
+                                logger.debug(
+                                    "kanban notifier: subscription for %s on %s skipped; adapter not connected",
+                                    sub.get("task_id"), platform or "<missing>",
+                                )
+                                continue
+                            old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
+                                conn,
+                                task_id=sub["task_id"],
+                                platform=sub["platform"],
+                                chat_id=sub["chat_id"],
+                                thread_id=sub.get("thread_id") or "",
+                                kinds=TERMINAL_KINDS,
+                            )
+                            if not events:
+                                continue
+                            task = _kb.get_task(conn, sub["task_id"])
+                            logger.debug(
+                                "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
+                                len(events), sub["task_id"], slug, old_cursor, cursor,
+                            )
+                            deliveries.append({
+                                "sub": sub,
+                                "old_cursor": old_cursor,
+                                "cursor": cursor,
+                                "events": events,
+                                "task": task,
+                                "board": slug,
+                            })
                     return deliveries
 
                 deliveries = await asyncio.to_thread(_collect)
@@ -5119,32 +5114,26 @@ class GatewayRunner:
         subscription. Unsub cursors in one board can't touch another's.
         """
         from hermes_cli import kanban_db as _kb
-        conn = _kb.connect(board=board)
-        try:
-            _kb.advance_notify_cursor(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-                new_cursor=cursor,
-            )
-        finally:
-            conn.close()
+        conn = _kb.get_connection(board=board)
+        _kb.advance_notify_cursor(
+            conn,
+            task_id=sub["task_id"],
+            platform=sub["platform"],
+            chat_id=sub["chat_id"],
+            thread_id=sub.get("thread_id") or "",
+            new_cursor=cursor,
+        )
 
     def _kanban_unsub(self, sub: dict, board: Optional[str] = None) -> None:
         from hermes_cli import kanban_db as _kb
-        conn = _kb.connect(board=board)
-        try:
-            _kb.remove_notify_sub(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-            )
-        finally:
-            conn.close()
+        conn = _kb.get_connection(board=board)
+        _kb.remove_notify_sub(
+            conn,
+            task_id=sub["task_id"],
+            platform=sub["platform"],
+            chat_id=sub["chat_id"],
+            thread_id=sub.get("thread_id") or "",
+        )
 
     def _kanban_rewind(
         self,
@@ -5155,19 +5144,16 @@ class GatewayRunner:
     ) -> None:
         """Sync helper: undo a claimed notification cursor after send failure."""
         from hermes_cli import kanban_db as _kb
-        conn = _kb.connect(board=board)
-        try:
-            _kb.rewind_notify_cursor(
-                conn,
-                task_id=sub["task_id"],
-                platform=sub["platform"],
-                chat_id=sub["chat_id"],
-                thread_id=sub.get("thread_id") or "",
-                claimed_cursor=claimed_cursor,
-                old_cursor=old_cursor,
-            )
-        finally:
-            conn.close()
+        conn = _kb.get_connection(board=board)
+        _kb.rewind_notify_cursor(
+            conn,
+            task_id=sub["task_id"],
+            platform=sub["platform"],
+            chat_id=sub["chat_id"],
+            thread_id=sub.get("thread_id") or "",
+            claimed_cursor=claimed_cursor,
+            old_cursor=old_cursor,
+        )
 
     async def _deliver_kanban_artifacts(
         self,
@@ -5434,7 +5420,6 @@ class GatewayRunner:
             opened explicitly so concurrent boards never share a
             connection handle or accidentally claim across each other.
             """
-            conn = None
             fingerprint = _board_db_fingerprint(slug)
             disabled_fingerprint = disabled_corrupt_boards.get(slug)
             if disabled_fingerprint == fingerprint:
@@ -5446,13 +5431,14 @@ class GatewayRunner:
                 )
                 disabled_corrupt_boards.pop(slug, None)
             try:
-                conn = _kb.connect(board=slug)
-                # `connect()` runs the schema + idempotent migration on
-                # first open per process; the previous explicit
-                # `init_db()` call here busted the per-process cache and
-                # re-ran the migration on a second connection, racing
-                # the first. See the matching comment in
-                # `_kanban_notifier_watcher` and issue #21378.
+                conn = _kb.get_connection(board=slug)
+                # `get_connection()` returns the per-process pooled connection,
+                # so the schema + idempotent migration only run on first open
+                # per process. The previous explicit `init_db()` call here
+                # busted the per-process cache and re-ran the migration on a
+                # second connection, racing the first. See the matching
+                # comment in `_kanban_notifier_watcher` and issue #21378. The
+                # connection is owned by kanban_db's pool — do not close it.
                 return _kb.dispatch_once(
                     conn,
                     board=slug,
@@ -5479,12 +5465,6 @@ class GatewayRunner:
             except Exception:
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
-            finally:
-                if conn is not None:
-                    try:
-                        conn.close()
-                    except Exception:
-                        pass
 
         def _tick_once() -> "list[tuple[str, Optional[object]]]":
             """Run one dispatch_once per board. Returns (slug, result) pairs.
@@ -5521,21 +5501,14 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
-                conn = None
                 try:
-                    conn = _kb.connect(board=slug)
+                    conn = _kb.get_connection(board=slug)
                     if _kb.has_spawnable_ready(conn):
                         return True
                     if _kb.has_spawnable_review(conn):
                         return True
                 except Exception:
                     continue
-                finally:
-                    if conn is not None:
-                        try:
-                            conn.close()
-                        except Exception:
-                            pass
             return False
 
         # Auto-decompose: turn fresh triage tasks into ready workgraphs
@@ -9599,17 +9572,14 @@ class GatewayRunner:
                     if platform_str and chat_id:
                         def _sub():
                             from hermes_cli import kanban_db as _kb
-                            conn = _kb.connect(board=requested_board)
-                            try:
-                                _kb.add_notify_sub(
-                                    conn, task_id=task_id,
-                                    platform=platform_str, chat_id=chat_id,
-                                    thread_id=thread_id or None,
-                                    user_id=user_id,
-                                    notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
-                                )
-                            finally:
-                                conn.close()
+                            conn = _kb.get_connection(board=requested_board)
+                            _kb.add_notify_sub(
+                                conn, task_id=task_id,
+                                platform=platform_str, chat_id=chat_id,
+                                thread_id=thread_id or None,
+                                user_id=user_id,
+                                notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
+                            )
                         await asyncio.to_thread(_sub)
                         output = (
                             output.rstrip()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -43,10 +43,13 @@ _STATUS_ICONS = {
 }
 
 
-def _fmt_ts(ts: Optional[int]) -> str:
+def _fmt_ts(ts: Any) -> str:
     if not ts:
         return ""
-    return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
+    try:
+        return time.strftime("%Y-%m-%d %H:%M", time.localtime(float(ts)))
+    except (TypeError, ValueError, OSError):
+        return "unknown time"
 
 
 def _fmt_task_line(t: kb.Task) -> str:
@@ -1269,7 +1272,7 @@ def _cmd_heartbeat(args: argparse.Namespace) -> int:
             conn,
             args.task_id,
             note=getattr(args, "note", None),
-            expected_run_id=_worker_run_id_for(args.task_id),
+            expected_run_id=_worker_run_id_for(args.task_id, conn),
         )
     if not ok:
         print(f"cannot heartbeat {args.task_id} (not running?)", file=sys.stderr)
@@ -1844,16 +1847,36 @@ def _cmd_comment(args: argparse.Namespace) -> int:
     return 0
 
 
-def _worker_run_id_for(task_id: str) -> Optional[int]:
+def _worker_run_id_for(task_id: str, conn: Optional[Any] = None) -> Optional[int]:
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return None
     raw = os.environ.get("HERMES_KANBAN_RUN_ID")
     if not raw:
         return None
     try:
-        return int(raw)
+        run_id = int(raw)
     except ValueError:
         return None
+
+    # Manual recovery sessions may inherit a stale HERMES_KANBAN_RUN_ID for
+    # a task that is already back in ready with current_run_id cleared. In
+    # that case, do not pass a CAS token or the operator cannot block/close
+    # the recovered ready task. If another run is currently active, keep the
+    # token so stale workers still fail closed.
+    try:
+        owns_conn = conn is None
+        if owns_conn:
+            conn = kb.connect()
+        try:
+            task = kb.get_task(conn, task_id) if conn is not None else None
+        finally:
+            if owns_conn and conn is not None:
+                conn.close()
+        if task is not None and task.current_run_id is None:
+            return None
+    except Exception:
+        pass
+    return run_id
 
 
 def _cmd_complete(args: argparse.Namespace) -> int:
@@ -1892,7 +1915,7 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 result=args.result,
                 summary=summary,
                 metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=_worker_run_id_for(tid, conn),
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
@@ -1942,7 +1965,7 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 conn,
                 tid,
                 reason=reason,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=_worker_run_id_for(tid, conn),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
@@ -1964,7 +1987,7 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
                 conn,
                 tid,
                 reason=reason,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=_worker_run_id_for(tid, conn),
             ):
                 failed.append(tid)
                 print(f"cannot schedule {tid}", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6152,7 +6152,17 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                 f"omitted; showing most recent {len(shown_c)})_"
             )
         for c in shown_c:
-            ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(c.created_at))
+            # Older/buggy event-mirroring paths wrote non-epoch strings into
+            # task_comments.created_at (for example JSON payloads from
+            # claimed/spawned events).  Worker prompt construction must be
+            # best-effort: one malformed legacy comment timestamp should not
+            # crash every dispatcher-spawned worker for the task.
+            c_ts = _to_epoch(c.created_at)
+            ts = (
+                time.strftime("%Y-%m-%d %H:%M", time.localtime(c_ts))
+                if c_ts is not None
+                else "unknown time"
+            )
             # Render author with explicit "comment from worker" framing so
             # operator-controlled HERMES_PROFILE values like "hermes-system"
             # or "operator" can't be misread by the next worker as a system

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -990,9 +990,6 @@ def _open_connection(
     resolved = str(path.resolve())
     path.parent.mkdir(parents=True, exist_ok=True)
     _validate_sqlite_header(path)
-    # For existing non-empty files, run integrity check BEFORE WAL setup
-    # so corrupt files are caught with KanbanDbCorruptError (not a raw
-    # DatabaseError from apply_wal_with_fallback).
     _stat = _try_stat(path)
     existing_nonempty = _stat is not None and _stat.st_size > 0
     conn = sqlite3.connect(
@@ -1005,22 +1002,39 @@ def _open_connection(
     try:
         with _INIT_LOCK:
             needs_init = resolved not in _INITIALIZED_PATHS
-            if existing_nonempty and needs_init:
-                # Integrity check on the MAIN connection BEFORE WAL setup —
-                # no separate probe connection. Catches genuinely corrupt
-                # files early and raises KanbanDbCorruptError.
-                _check_db_health(conn, path)
-            from hermes_state import apply_wal_with_fallback
-            apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-            conn.execute("PRAGMA synchronous=NORMAL")
-            conn.execute("PRAGMA foreign_keys=ON")
-            conn.execute("PRAGMA busy_timeout=30000")
+            # Run WAL setup + pragmas first. apply_wal_with_fallback may
+            # need to switch journal_mode on an existing WAL file, which
+            # requires that no other read/write transaction (including an
+            # implicit one from a prior integrity_check on this connection)
+            # be holding locks. Doing health check after WAL setup also
+            # means apply_wal_with_fallback handles its own DatabaseError
+            # surface uniformly.
+            try:
+                from hermes_state import apply_wal_with_fallback
+                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                conn.execute("PRAGMA synchronous=NORMAL")
+                conn.execute("PRAGMA foreign_keys=ON")
+                conn.execute("PRAGMA busy_timeout=30000")
+            except sqlite3.DatabaseError as exc:
+                # If WAL setup itself crashes on a malformed file, surface
+                # it as KanbanDbCorruptError (with a backup) so the caller
+                # gets a consistent error type — not a raw DatabaseError.
+                backup = _backup_corrupt_db(path)
+                raise KanbanDbCorruptError(
+                    path, backup, f"sqlite refused WAL setup: {exc}"
+                )
             if needs_init:
-                if not existing_nonempty:
-                    # New or empty file — health check after WAL setup.
+                # Integrity check on the MAIN connection — no separate
+                # probe connection. Catches genuinely corrupt files and
+                # raises KanbanDbCorruptError. Runs once per process per
+                # path (cached via _INITIALIZED_PATHS below).
+                if existing_nonempty:
                     _check_db_health(conn, path)
                 conn.executescript(SCHEMA_SQL)
                 _migrate_add_optional_columns(conn)
+                if not existing_nonempty:
+                    # New file: health check after schema is laid down.
+                    _check_db_health(conn, path)
                 _INITIALIZED_PATHS.add(resolved)
     except Exception:
         conn.close()
@@ -1288,9 +1302,14 @@ def init_db(
     # schema + migration pass unconditionally.
     with _INIT_LOCK:
         _INITIALIZED_PATHS.discard(resolved)
-    # connect() now returns a pooled connection — do NOT close it.
-    connect(path)
-    return path
+    # connect() returns a fresh non-pooled connection; close it after
+    # the schema/migration pass to release any locks. (get_connection()
+    # returns a pooled connection — that's the long-lived caller path.)
+    conn = connect(path)
+    try:
+        return path
+    finally:
+        conn.close()
 
 
 def _add_column_if_missing(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -70,6 +70,7 @@ new locking.
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import json
 import os
@@ -955,6 +956,161 @@ _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 
+# Singleton connection pool — one sqlite3.Connection per process+board.
+# Pattern mirrors hermes_state.py:SessionDB: persistent connection,
+# check_same_thread=False, lives for process lifetime, cleaned up via atexit.
+_connection_pool: dict[str, sqlite3.Connection] = {}
+_pool_lock = threading.Lock()
+
+
+def _try_stat(path: Path) -> Optional[os.stat_result]:
+    """Return ``path.stat()`` or ``None`` on any OSError (missing file, etc.)."""
+    try:
+        return path.stat()
+    except OSError:
+        return None
+
+
+def _open_connection(
+    *,
+    board: Optional[str] = None,
+    db_path: Optional[Path] = None,
+    pooled: bool = False,
+) -> sqlite3.Connection:
+    """Open and initialise a kanban DB connection (shared by connect + get_connection).
+
+    When *pooled* is True, the caller (``get_connection``) is responsible for
+    pool lookup/insertion and for holding ``_pool_lock`` — this function only
+    creates the raw connection and runs schema init.
+    """
+    if db_path is not None:
+        path = db_path
+    else:
+        path = kanban_db_path(board=board)
+    resolved = str(path.resolve())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _validate_sqlite_header(path)
+    # For existing non-empty files, run integrity check BEFORE WAL setup
+    # so corrupt files are caught with KanbanDbCorruptError (not a raw
+    # DatabaseError from apply_wal_with_fallback).
+    _stat = _try_stat(path)
+    existing_nonempty = _stat is not None and _stat.st_size > 0
+    conn = sqlite3.connect(
+        str(path),
+        check_same_thread=False,
+        timeout=30,
+        isolation_level=None,
+    )
+    conn.row_factory = sqlite3.Row
+    try:
+        with _INIT_LOCK:
+            needs_init = resolved not in _INITIALIZED_PATHS
+            if existing_nonempty and needs_init:
+                # Integrity check on the MAIN connection BEFORE WAL setup —
+                # no separate probe connection. Catches genuinely corrupt
+                # files early and raises KanbanDbCorruptError.
+                _check_db_health(conn, path)
+            from hermes_state import apply_wal_with_fallback
+            apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA foreign_keys=ON")
+            conn.execute("PRAGMA busy_timeout=30000")
+            if needs_init:
+                if not existing_nonempty:
+                    # New or empty file — health check after WAL setup.
+                    _check_db_health(conn, path)
+                conn.executescript(SCHEMA_SQL)
+                _migrate_add_optional_columns(conn)
+                _INITIALIZED_PATHS.add(resolved)
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
+def get_connection(
+    board: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> sqlite3.Connection:
+    """Return a persistent, thread-safe connection for this process+board.
+
+    On first call for a given DB path, opens the connection, enables WAL,
+    applies pragmas, and runs schema init. Subsequent calls return the same
+    connection — no per-call open/close churn, no transient WAL-index races.
+
+    Prefer this over ``connect()`` for long-running processes (gateway,
+    dispatcher, worker).
+    """
+    # Resolve the path without opening the connection so we can do pool lookup.
+    if db_path is not None:
+        path = db_path
+    else:
+        path = kanban_db_path(board=board)
+    resolved = str(path.resolve())
+    with _pool_lock:
+        if resolved in _connection_pool:
+            conn = _connection_pool[resolved]
+            # Defensive: if a caller closed the pooled connection (e.g. test
+            # teardown via conn.close()), rebuild it transparently.
+            try:
+                conn.execute("SELECT 1")
+            except sqlite3.ProgrammingError:
+                # Connection closed — remove stale entry and rebuild.
+                del _connection_pool[resolved]
+            else:
+                return conn
+        conn = _open_connection(board=board, db_path=db_path, pooled=True)
+        _connection_pool[resolved] = conn
+        return conn
+
+
+def _check_db_health(conn: sqlite3.Connection, db_path: Path) -> None:
+    """Run ``PRAGMA integrity_check`` on the given connection.
+
+    No separate probe connection — eliminates the false-positive corruption
+    detection path where a second connection with a different timeout sees
+    transient WAL states during checkpointing.
+
+    Raises :class:`KanbanDbCorruptError` if the integrity check fails.
+    """
+    try:
+        row = conn.execute("PRAGMA integrity_check").fetchone()
+    except sqlite3.DatabaseError as exc:
+        backup = _backup_corrupt_db(db_path)
+        raise KanbanDbCorruptError(
+            db_path, backup,
+            f"sqlite refused integrity check: {exc}",
+        )
+    if not row or (row[0] or "").lower() != "ok":
+        backup = _backup_corrupt_db(db_path)
+        raise KanbanDbCorruptError(
+            db_path, backup,
+            f"integrity_check returned {row[0] if row else '<no row>'!r}",
+        )
+
+
+def _cleanup_connections() -> None:
+    """Graceful shutdown: PASSIVE checkpoint + close all pooled connections.
+
+    Registered via ``atexit`` so normal gateway shutdowns drain the WAL before
+    closing. SIGKILL skips this (no atexit hooks run), which is acceptable —
+    WAL recovery on next open handles it.
+    """
+    with _pool_lock:
+        for conn in _connection_pool.values():
+            try:
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            except Exception:
+                pass
+            try:
+                conn.close()
+            except Exception:
+                pass
+        _connection_pool.clear()
+
+
+atexit.register(_cleanup_connections)
+
 
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
     """Return True for a TLS record header at ``data[offset:]``."""
@@ -1074,62 +1230,7 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     return candidate
 
 
-def _guard_existing_db_is_healthy(path: Path) -> None:
-    """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
 
-    Opens the probe in read/write mode so SQLite can recover or
-    checkpoint a healthy WAL/hot-journal DB before we declare it
-    corrupt. If the file is malformed, copy it (and any WAL/SHM
-    sidecars) to a timestamped backup and raise
-    :class:`KanbanDbCorruptError` so callers cannot silently recreate
-    the schema on top of a damaged DB.
-
-    Transient lock/busy errors (``sqlite3.OperationalError``) are NOT
-    treated as corruption; they propagate raw so the caller sees a
-    normal lock failure and no spurious ``.corrupt`` backup is made.
-
-    No-op for missing files, zero-byte files (treated as fresh), and
-    paths already proven healthy this process (cache hit).
-
-    Path-trust note: ``path`` arrives via :func:`connect`, which itself
-    resolves it from an explicit ``db_path`` argument, the
-    :func:`kanban_db_path` env-var chain, or the kanban-home default —
-    all sources Hermes treats as user-controlled-but-trusted on the
-    user's own machine. We additionally resolve the path here and
-    confine all filesystem writes to its parent directory so any
-    accidental ``..`` segments are collapsed before any I/O happens.
-    """
-    # Resolve before any I/O. ``Path.resolve()`` normalizes ``..`` and
-    # symlinks, giving us a canonical path whose parent dir we can pin.
-    try:
-        resolved = path.resolve()
-    except OSError:
-        return
-    try:
-        if not resolved.exists() or resolved.stat().st_size == 0:
-            return
-    except OSError:
-        return
-    if str(resolved) in _INITIALIZED_PATHS:
-        return
-    reason: Optional[str] = None
-    try:
-        probe = sqlite3.connect(str(resolved), timeout=5, isolation_level=None)
-        try:
-            row = probe.execute("PRAGMA integrity_check").fetchone()
-        finally:
-            probe.close()
-        if not row or (row[0] or "").lower() != "ok":
-            reason = f"integrity_check returned {row[0] if row else '<no row>'!r}"
-    except sqlite3.OperationalError:
-        # Lock contention, busy, transient IO — not corruption. Let it propagate.
-        raise
-    except sqlite3.DatabaseError as exc:
-        reason = f"sqlite refused to open file: {exc}"
-    if reason is None:
-        return
-    backup = _backup_corrupt_db(resolved)
-    raise KanbanDbCorruptError(resolved, backup, reason)
 
 
 def connect(
@@ -1139,11 +1240,15 @@ def connect(
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
+    Legacy wrapper — delegates to :func:`_open_connection` for a fresh
+    (non-pooled) connection. For persistent, pooled connections in
+    long-running processes, use :func:`get_connection`.
+
     WAL mode is enabled on every connection; it's a no-op after the first
     time but keeps the code robust if the DB file is ever re-created.
 
     The first connection to a given path auto-runs :func:`init_db` so
-    fresh installs and test harnesses that construct `connect()`
+    fresh installs and test harnesses that construct ``connect()``
     directly don't have to remember a separate init step. Subsequent
     connections skip the schema check via a module-level path cache.
 
@@ -1155,48 +1260,7 @@ def connect(
       ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
       ``<root>/kanban/current`` → ``default``.
     """
-    if db_path is not None:
-        path = db_path
-    else:
-        path = kanban_db_path(board=board)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
-    # and other invalid-header cases without opening a sqlite connection.
-    _validate_sqlite_header(path)
-    # Full integrity probe — catches corruption past the header (malformed
-    # pages, broken internal metadata). Cached per-path after first success
-    # via _INITIALIZED_PATHS so it only runs once per process per path.
-    _guard_existing_db_is_healthy(path)
-    resolved = str(path.resolve())
-    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
-    try:
-        conn.row_factory = sqlite3.Row
-        with _INIT_LOCK:
-            # WAL activation can take an exclusive lock while SQLite creates the
-            # sidecar files for a fresh database. Keep it in the same process-local
-            # critical section as schema initialization so concurrent gateway
-            # startup threads do not race before _INITIALIZED_PATHS is populated.
-            # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-            # falls back to DELETE with one WARNING so kanban stays usable there.
-            # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-            from hermes_state import apply_wal_with_fallback
-            apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-            conn.execute("PRAGMA synchronous=NORMAL")
-            conn.execute("PRAGMA foreign_keys=ON")
-            needs_init = resolved not in _INITIALIZED_PATHS
-            if needs_init:
-                # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
-                # migrations. Cached so subsequent connect() calls in the same
-                # process are cheap. The lock prevents same-process dispatcher
-                # threads from racing through the additive ALTER TABLE pass with
-                # stale PRAGMA snapshots during gateway startup.
-                conn.executescript(SCHEMA_SQL)
-                _migrate_add_optional_columns(conn)
-                _INITIALIZED_PATHS.add(resolved)
-    except Exception:
-        conn.close()
-        raise
-    return conn
+    return _open_connection(board=board, db_path=db_path)
 
 
 def init_db(
@@ -1224,8 +1288,8 @@ def init_db(
     # schema + migration pass unconditionally.
     with _INIT_LOCK:
         _INITIALIZED_PATHS.discard(resolved)
-    with contextlib.closing(connect(path)):
-        pass
+    # connect() now returns a pooled connection — do NOT close it.
+    connect(path)
     return path
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -121,7 +121,7 @@ def _conn(board: Optional[str] = None):
         kanban_db.init_db(board=board)
     except Exception as exc:
         log.warning("kanban init_db failed: %s", exc)
-    return kanban_db.connect(board=board)
+    return kanban_db.get_connection(board=board)
 
 
 # ---------------------------------------------------------------------------
@@ -372,116 +372,113 @@ def get_board(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        tasks = kanban_db.list_tasks(
-            conn,
-            tenant=tenant,
-            include_archived=include_archived,
-            workflow_template_id=workflow_template_id,
-            current_step_key=current_step_key,
+    tasks = kanban_db.list_tasks(
+        conn,
+        tenant=tenant,
+        include_archived=include_archived,
+        workflow_template_id=workflow_template_id,
+        current_step_key=current_step_key,
+    )
+    # Pre-fetch link counts per task (cheap: one query).
+    link_counts: dict[str, dict[str, int]] = {}
+    for row in conn.execute(
+        "SELECT parent_id, child_id FROM task_links"
+    ).fetchall():
+        link_counts.setdefault(row["parent_id"], {"parents": 0, "children": 0})[
+            "children"
+        ] += 1
+        link_counts.setdefault(row["child_id"], {"parents": 0, "children": 0})[
+            "parents"
+        ] += 1
+
+    # Comment + event counts (both cheap aggregates).
+    comment_counts: dict[str, int] = {
+        r["task_id"]: r["n"]
+        for r in conn.execute(
+            "SELECT task_id, COUNT(*) AS n FROM task_comments GROUP BY task_id"
         )
-        # Pre-fetch link counts per task (cheap: one query).
-        link_counts: dict[str, dict[str, int]] = {}
-        for row in conn.execute(
-            "SELECT parent_id, child_id FROM task_links"
-        ).fetchall():
-            link_counts.setdefault(row["parent_id"], {"parents": 0, "children": 0})[
-                "children"
-            ] += 1
-            link_counts.setdefault(row["child_id"], {"parents": 0, "children": 0})[
-                "parents"
-            ] += 1
+    }
 
-        # Comment + event counts (both cheap aggregates).
-        comment_counts: dict[str, int] = {
-            r["task_id"]: r["n"]
-            for r in conn.execute(
-                "SELECT task_id, COUNT(*) AS n FROM task_comments GROUP BY task_id"
-            )
-        }
+    # Progress rollup: for each parent, how many children are done / total.
+    # One pass over task_links joined with child status — cheaper than
+    # N per-task queries and the plugin uses it to render "N/M".
+    progress: dict[str, dict[str, int]] = {}
+    for row in conn.execute(
+        "SELECT l.parent_id AS pid, t.status AS cstatus "
+        "FROM task_links l JOIN tasks t ON t.id = l.child_id"
+    ).fetchall():
+        p = progress.setdefault(row["pid"], {"done": 0, "total": 0})
+        p["total"] += 1
+        if row["cstatus"] == "done":
+            p["done"] += 1
 
-        # Progress rollup: for each parent, how many children are done / total.
-        # One pass over task_links joined with child status — cheaper than
-        # N per-task queries and the plugin uses it to render "N/M".
-        progress: dict[str, dict[str, int]] = {}
-        for row in conn.execute(
-            "SELECT l.parent_id AS pid, t.status AS cstatus "
-            "FROM task_links l JOIN tasks t ON t.id = l.child_id"
-        ).fetchall():
-            p = progress.setdefault(row["pid"], {"done": 0, "total": 0})
-            p["total"] += 1
-            if row["cstatus"] == "done":
-                p["done"] += 1
+    # Diagnostics rollup for this board — see kanban_diagnostics.
+    # We get the full structured list per task AND a compact
+    # summary for the card badge (so cards don't carry the detail
+    # text; the drawer fetches that via /tasks/:id or /diagnostics).
+    diagnostics_per_task = _compute_task_diagnostics(conn, task_ids=None)
 
-        # Diagnostics rollup for this board — see kanban_diagnostics.
-        # We get the full structured list per task AND a compact
-        # summary for the card badge (so cards don't carry the detail
-        # text; the drawer fetches that via /tasks/:id or /diagnostics).
-        diagnostics_per_task = _compute_task_diagnostics(conn, task_ids=None)
+    latest_event_id = conn.execute(
+        "SELECT COALESCE(MAX(id), 0) AS m FROM task_events"
+    ).fetchone()["m"]
 
-        latest_event_id = conn.execute(
-            "SELECT COALESCE(MAX(id), 0) AS m FROM task_events"
-        ).fetchone()["m"]
+    columns: dict[str, list[dict]] = {c: [] for c in BOARD_COLUMNS}
+    if include_archived:
+        columns["archived"] = []
 
-        columns: dict[str, list[dict]] = {c: [] for c in BOARD_COLUMNS}
-        if include_archived:
-            columns["archived"] = []
+    # Batch-fetch the latest non-null run summary per task in one
+    # window-function query (avoids N+1 ``latest_summary`` calls
+    # for boards with hundreds of tasks). Truncated to a card-size
+    # preview here — the full text is available via /tasks/:id.
+    summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
 
-        # Batch-fetch the latest non-null run summary per task in one
-        # window-function query (avoids N+1 ``latest_summary`` calls
-        # for boards with hundreds of tasks). Truncated to a card-size
-        # preview here — the full text is available via /tasks/:id.
-        summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+    for t in tasks:
+        full = summary_map.get(t.id)
+        preview = (
+            full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
+        )
+        d = _task_dict(t, latest_summary=preview)
+        d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
+        d["comment_count"] = comment_counts.get(t.id, 0)
+        d["progress"] = progress.get(t.id)  # None when the task has no children
+        diags = diagnostics_per_task.get(t.id)
+        if diags:
+            # Full list goes into the payload so the drawer can render
+            # without a second round-trip. The board-level badge only
+            # needs the summary.
+            d["diagnostics"] = diags
+            d["warnings"] = _warnings_summary_from_diagnostics(diags)
+        col = t.status if t.status in columns else "todo"
+        columns[col].append(d)
 
-        for t in tasks:
-            full = summary_map.get(t.id)
-            preview = (
-                full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
-            )
-            d = _task_dict(t, latest_summary=preview)
-            d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
-            d["comment_count"] = comment_counts.get(t.id, 0)
-            d["progress"] = progress.get(t.id)  # None when the task has no children
-            diags = diagnostics_per_task.get(t.id)
-            if diags:
-                # Full list goes into the payload so the drawer can render
-                # without a second round-trip. The board-level badge only
-                # needs the summary.
-                d["diagnostics"] = diags
-                d["warnings"] = _warnings_summary_from_diagnostics(diags)
-            col = t.status if t.status in columns else "todo"
-            columns[col].append(d)
+    # Stable per-column ordering already applied by list_tasks
+    # (priority DESC, created_at ASC), keep as-is.
 
-        # Stable per-column ordering already applied by list_tasks
-        # (priority DESC, created_at ASC), keep as-is.
+    # List of known tenants for the UI filter dropdown.
+    tenants = [
+        r["tenant"]
+        for r in conn.execute(
+            "SELECT DISTINCT tenant FROM tasks WHERE tenant IS NOT NULL ORDER BY tenant"
+        )
+    ]
+    # List of distinct assignees for the lane-by-profile sub-grouping.
+    assignees = [
+        r["assignee"]
+        for r in conn.execute(
+            "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
+            "AND status != 'archived' ORDER BY assignee"
+        )
+    ]
 
-        # List of known tenants for the UI filter dropdown.
-        tenants = [
-            r["tenant"]
-            for r in conn.execute(
-                "SELECT DISTINCT tenant FROM tasks WHERE tenant IS NOT NULL ORDER BY tenant"
-            )
-        ]
-        # List of distinct assignees for the lane-by-profile sub-grouping.
-        assignees = [
-            r["assignee"]
-            for r in conn.execute(
-                "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
-                "AND status != 'archived' ORDER BY assignee"
-            )
-        ]
-
-        return {
-            "columns": [
-                {"name": name, "tasks": columns[name]} for name in columns.keys()
-            ],
-            "tenants": tenants,
-            "assignees": assignees,
-            "latest_event_id": int(latest_event_id),
-            "now": int(time.time()),
-        }
-    finally:
-        conn.close()
+    return {
+        "columns": [
+            {"name": name, "tasks": columns[name]} for name in columns.keys()
+        ],
+        "tenants": tenants,
+        "assignees": assignees,
+        "latest_event_id": int(latest_event_id),
+        "now": int(time.time()),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -501,49 +498,46 @@ def get_task(
 ):
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        if (run_state_type is None) ^ (run_state_name is None):
-            raise HTTPException(
-                status_code=400,
-                detail="run_state_type and run_state_name must be passed together or omitted",
+    if (run_state_type is None) ^ (run_state_name is None):
+        raise HTTPException(
+            status_code=400,
+            detail="run_state_type and run_state_name must be passed together or omitted",
+        )
+    if run_state_type is not None and run_state_type not in ("status", "outcome"):
+        raise HTTPException(
+            status_code=400,
+            detail="run_state_type must be 'status' or 'outcome'",
+        )
+    task = kanban_db.get_task(conn, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+    # Drawer/detail view returns the FULL summary (no truncation) so
+    # operators can read the complete worker handoff without making
+    # a second round-trip. Cards on /board carry a 200-char preview.
+    full_summary = kanban_db.latest_summary(conn, task_id)
+    task_d = _task_dict(task, latest_summary=full_summary)
+    # Attach diagnostics so the drawer's Diagnostics section can
+    # render recovery actions without a second round-trip.
+    diags = _compute_task_diagnostics(conn, task_ids=[task_id])
+    diag_list = diags.get(task_id) or []
+    if diag_list:
+        task_d["diagnostics"] = diag_list
+        task_d["warnings"] = _warnings_summary_from_diagnostics(diag_list)
+    return {
+        "task": task_d,
+        "comments": [_comment_dict(c) for c in kanban_db.list_comments(conn, task_id)],
+        "events": [_event_dict(e) for e in kanban_db.list_events(conn, task_id)],
+        "links": _links_for(conn, task_id),
+        "runs": [
+            _run_dict(r)
+            for r in kanban_db.list_runs(
+                conn,
+                task_id,
+                state_type=run_state_type,
+                state_name=run_state_name,
             )
-        if run_state_type is not None and run_state_type not in ("status", "outcome"):
-            raise HTTPException(
-                status_code=400,
-                detail="run_state_type must be 'status' or 'outcome'",
-            )
-        task = kanban_db.get_task(conn, task_id)
-        if task is None:
-            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
-        # Drawer/detail view returns the FULL summary (no truncation) so
-        # operators can read the complete worker handoff without making
-        # a second round-trip. Cards on /board carry a 200-char preview.
-        full_summary = kanban_db.latest_summary(conn, task_id)
-        task_d = _task_dict(task, latest_summary=full_summary)
-        # Attach diagnostics so the drawer's Diagnostics section can
-        # render recovery actions without a second round-trip.
-        diags = _compute_task_diagnostics(conn, task_ids=[task_id])
-        diag_list = diags.get(task_id) or []
-        if diag_list:
-            task_d["diagnostics"] = diag_list
-            task_d["warnings"] = _warnings_summary_from_diagnostics(diag_list)
-        return {
-            "task": task_d,
-            "comments": [_comment_dict(c) for c in kanban_db.list_comments(conn, task_id)],
-            "events": [_event_dict(e) for e in kanban_db.list_events(conn, task_id)],
-            "links": _links_for(conn, task_id),
-            "runs": [
-                _run_dict(r)
-                for r in kanban_db.list_runs(
-                    conn,
-                    task_id,
-                    state_type=run_state_type,
-                    state_name=run_state_name,
-                )
-            ],
-        }
-    finally:
-        conn.close()
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -605,8 +599,6 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
         return body
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -632,119 +624,116 @@ class UpdateTaskBody(BaseModel):
 def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        task = kanban_db.get_task(conn, task_id)
-        if task is None:
-            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+    task = kanban_db.get_task(conn, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"task {task_id} not found")
 
-        # --- assignee ----------------------------------------------------
-        if payload.assignee is not None:
-            try:
-                ok = kanban_db.assign_task(
-                    conn, task_id, payload.assignee or None,
-                )
-            except RuntimeError as e:
-                raise HTTPException(status_code=409, detail=str(e))
-            if not ok:
-                raise HTTPException(status_code=404, detail="task not found")
+    # --- assignee ----------------------------------------------------
+    if payload.assignee is not None:
+        try:
+            ok = kanban_db.assign_task(
+                conn, task_id, payload.assignee or None,
+            )
+        except RuntimeError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        if not ok:
+            raise HTTPException(status_code=404, detail="task not found")
 
-        # --- status -------------------------------------------------------
-        if payload.status is not None:
-            s = payload.status
-            ok = True
-            if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
-                )
-            elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
-            elif s == "scheduled":
-                ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
-            elif s == "ready":
-                # Re-open a blocked/scheduled task, or just an explicit status set.
-                current = kanban_db.get_task(conn, task_id)
-                if current and current.status in ("blocked", "scheduled"):
-                    ok = kanban_db.unblock_task(conn, task_id)
-                else:
-                    # Direct status write for drag-drop (todo -> ready etc).
-                    ok = _set_status_direct(conn, task_id, "ready")
-            elif s == "archived":
-                ok = kanban_db.archive_task(conn, task_id)
-            elif s == "running":
-                raise HTTPException(
-                    status_code=400,
-                    detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
-                )
-            elif s in ("todo", "triage", "scheduled"):
-                ok = _set_status_direct(conn, task_id, s)
+    # --- status -------------------------------------------------------
+    if payload.status is not None:
+        s = payload.status
+        ok = True
+        if s == "done":
+            ok = kanban_db.complete_task(
+                conn, task_id,
+                result=payload.result,
+                summary=payload.summary,
+                metadata=payload.metadata,
+            )
+        elif s == "blocked":
+            ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+        elif s == "scheduled":
+            ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
+        elif s == "ready":
+            # Re-open a blocked/scheduled task, or just an explicit status set.
+            current = kanban_db.get_task(conn, task_id)
+            if current and current.status in ("blocked", "scheduled"):
+                ok = kanban_db.unblock_task(conn, task_id)
             else:
-                raise HTTPException(status_code=400, detail=f"unknown status: {s}")
-            if not ok:
-                # For ``ready``, name the blocking parent(s) so the dashboard
-                # can render an actionable toast instead of a silent no-op.
-                # See #26744.
-                if s == "ready":
-                    blockers = _parents_blocking_ready(conn, task_id)
-                    if blockers:
-                        names = ", ".join(
-                            f"{p['title']!r} ({p['id']}, status={p['status']})"
-                            for p in blockers
-                        )
-                        raise HTTPException(
-                            status_code=409,
-                            detail=(
-                                f"Cannot move to 'ready': blocked by parent(s) "
-                                f"not done — {names}"
-                            ),
-                        )
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"status transition to {s!r} not valid from current state",
-                )
+                # Direct status write for drag-drop (todo -> ready etc).
+                ok = _set_status_direct(conn, task_id, "ready")
+        elif s == "archived":
+            ok = kanban_db.archive_task(conn, task_id)
+        elif s == "running":
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
+            )
+        elif s in ("todo", "triage", "scheduled"):
+            ok = _set_status_direct(conn, task_id, s)
+        else:
+            raise HTTPException(status_code=400, detail=f"unknown status: {s}")
+        if not ok:
+            # For ``ready``, name the blocking parent(s) so the dashboard
+            # can render an actionable toast instead of a silent no-op.
+            # See #26744.
+            if s == "ready":
+                blockers = _parents_blocking_ready(conn, task_id)
+                if blockers:
+                    names = ", ".join(
+                        f"{p['title']!r} ({p['id']}, status={p['status']})"
+                        for p in blockers
+                    )
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Cannot move to 'ready': blocked by parent(s) "
+                            f"not done — {names}"
+                        ),
+                    )
+            raise HTTPException(
+                status_code=409,
+                detail=f"status transition to {s!r} not valid from current state",
+            )
 
-        # --- priority -----------------------------------------------------
-        if payload.priority is not None:
-            with kanban_db.write_txn(conn):
-                conn.execute(
-                    "UPDATE tasks SET priority = ? WHERE id = ?",
-                    (int(payload.priority), task_id),
-                )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'reprioritized', ?, ?)",
-                    (task_id, json.dumps({"priority": int(payload.priority)}),
-                     int(time.time())),
-                )
+    # --- priority -----------------------------------------------------
+    if payload.priority is not None:
+        with kanban_db.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET priority = ? WHERE id = ?",
+                (int(payload.priority), task_id),
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'reprioritized', ?, ?)",
+                (task_id, json.dumps({"priority": int(payload.priority)}),
+                 int(time.time())),
+            )
 
-        # --- title / body -------------------------------------------------
-        if payload.title is not None or payload.body is not None:
-            with kanban_db.write_txn(conn):
-                sets, vals = [], []
-                if payload.title is not None:
-                    if not payload.title.strip():
-                        raise HTTPException(status_code=400, detail="title cannot be empty")
-                    sets.append("title = ?")
-                    vals.append(payload.title.strip())
-                if payload.body is not None:
-                    sets.append("body = ?")
-                    vals.append(payload.body)
-                vals.append(task_id)
-                conn.execute(
-                    f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals,
-                )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'edited', NULL, ?)",
-                    (task_id, int(time.time())),
-                )
+    # --- title / body -------------------------------------------------
+    if payload.title is not None or payload.body is not None:
+        with kanban_db.write_txn(conn):
+            sets, vals = [], []
+            if payload.title is not None:
+                if not payload.title.strip():
+                    raise HTTPException(status_code=400, detail="title cannot be empty")
+                sets.append("title = ?")
+                vals.append(payload.title.strip())
+            if payload.body is not None:
+                sets.append("body = ?")
+                vals.append(payload.body)
+            vals.append(task_id)
+            conn.execute(
+                f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals,
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'edited', NULL, ?)",
+                (task_id, int(time.time())),
+            )
 
-        updated = kanban_db.get_task(conn, task_id)
-        return {"task": _task_dict(updated) if updated else None}
-    finally:
-        conn.close()
+    updated = kanban_db.get_task(conn, task_id)
+    return {"task": _task_dict(updated) if updated else None}
 
 
 # ---------------------------------------------------------------------------
@@ -755,13 +744,10 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
 def delete_task(task_id: str, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        ok = kanban_db.delete_task(conn, task_id)
-        if not ok:
-            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
-        return {"deleted": True, "task_id": task_id}
-    finally:
-        conn.close()
+    ok = kanban_db.delete_task(conn, task_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+    return {"deleted": True, "task_id": task_id}
 
 
 def _parents_blocking_ready(
@@ -904,15 +890,12 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
         raise HTTPException(status_code=400, detail="body is required")
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        if kanban_db.get_task(conn, task_id) is None:
-            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
-        kanban_db.add_comment(
-            conn, task_id, author=payload.author or "dashboard", body=payload.body,
-        )
-        return {"ok": True}
-    finally:
-        conn.close()
+    if kanban_db.get_task(conn, task_id) is None:
+        raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+    kanban_db.add_comment(
+        conn, task_id, author=payload.author or "dashboard", body=payload.body,
+    )
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------
@@ -933,8 +916,6 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
         return {"ok": True}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    finally:
-        conn.close()
 
 
 @router.delete("/links")
@@ -945,11 +926,8 @@ def delete_link(
 ):
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        ok = kanban_db.unlink_tasks(conn, parent_id, child_id)
-        return {"ok": bool(ok)}
-    finally:
-        conn.close()
+    ok = kanban_db.unlink_tasks(conn, parent_id, child_id)
+    return {"ok": bool(ok)}
 
 
 # ---------------------------------------------------------------------------
@@ -981,88 +959,85 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
     results: list[dict] = []
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        for tid in ids:
-            entry: dict[str, Any] = {"id": tid, "ok": True}
-            try:
-                task = kanban_db.get_task(conn, tid)
-                if task is None:
-                    entry.update(ok=False, error="not found")
+    for tid in ids:
+        entry: dict[str, Any] = {"id": tid, "ok": True}
+        try:
+            task = kanban_db.get_task(conn, tid)
+            if task is None:
+                entry.update(ok=False, error="not found")
+                results.append(entry)
+                continue
+            if payload.archive:
+                if not kanban_db.archive_task(conn, tid):
+                    entry.update(ok=False, error="archive refused")
+            if payload.status is not None and not payload.archive:
+                s = payload.status
+                if s == "done":
+                    ok = kanban_db.complete_task(
+                        conn, tid,
+                        result=payload.result,
+                        summary=payload.summary,
+                        metadata=payload.metadata,
+                    )
+                elif s == "blocked":
+                    ok = kanban_db.block_task(conn, tid)
+                elif s == "ready":
+                    cur = kanban_db.get_task(conn, tid)
+                    if cur and cur.status in ("blocked", "scheduled"):
+                        ok = kanban_db.unblock_task(conn, tid)
+                    else:
+                        ok = _set_status_direct(conn, tid, "ready")
+                elif s == "running":
+                    entry.update(
+                        ok=False,
+                        error=(
+                            "Cannot set status to 'running' directly; "
+                            "use the dispatcher/claim path"
+                        ),
+                    )
                     results.append(entry)
                     continue
-                if payload.archive:
-                    if not kanban_db.archive_task(conn, tid):
-                        entry.update(ok=False, error="archive refused")
-                if payload.status is not None and not payload.archive:
-                    s = payload.status
-                    if s == "done":
-                        ok = kanban_db.complete_task(
-                            conn, tid,
-                            result=payload.result,
-                            summary=payload.summary,
-                            metadata=payload.metadata,
+                elif s == "scheduled":
+                    ok = kanban_db.schedule_task(conn, tid)
+                elif s in {"todo", "triage"}:
+                    ok = _set_status_direct(conn, tid, s)
+                else:
+                    entry.update(ok=False, error=f"unknown status {s!r}")
+                    results.append(entry)
+                    continue
+                if not ok:
+                    entry.update(ok=False, error=f"transition to {s!r} refused")
+            if payload.assignee is not None:
+                try:
+                    if payload.reclaim_first:
+                        ok = kanban_db.reassign_task(
+                            conn, tid, payload.assignee or None,
+                            reclaim_first=True,
                         )
-                    elif s == "blocked":
-                        ok = kanban_db.block_task(conn, tid)
-                    elif s == "ready":
-                        cur = kanban_db.get_task(conn, tid)
-                        if cur and cur.status in ("blocked", "scheduled"):
-                            ok = kanban_db.unblock_task(conn, tid)
-                        else:
-                            ok = _set_status_direct(conn, tid, "ready")
-                    elif s == "running":
-                        entry.update(
-                            ok=False,
-                            error=(
-                                "Cannot set status to 'running' directly; "
-                                "use the dispatcher/claim path"
-                            ),
-                        )
-                        results.append(entry)
-                        continue
-                    elif s == "scheduled":
-                        ok = kanban_db.schedule_task(conn, tid)
-                    elif s in {"todo", "triage"}:
-                        ok = _set_status_direct(conn, tid, s)
                     else:
-                        entry.update(ok=False, error=f"unknown status {s!r}")
-                        results.append(entry)
-                        continue
+                        ok = kanban_db.assign_task(
+                            conn, tid, payload.assignee or None,
+                        )
                     if not ok:
-                        entry.update(ok=False, error=f"transition to {s!r} refused")
-                if payload.assignee is not None:
-                    try:
-                        if payload.reclaim_first:
-                            ok = kanban_db.reassign_task(
-                                conn, tid, payload.assignee or None,
-                                reclaim_first=True,
-                            )
-                        else:
-                            ok = kanban_db.assign_task(
-                                conn, tid, payload.assignee or None,
-                            )
-                        if not ok:
-                            entry.update(ok=False, error="assign refused")
-                    except RuntimeError as e:
-                        entry.update(ok=False, error=str(e))
-                if payload.priority is not None:
-                    with kanban_db.write_txn(conn):
-                        conn.execute(
-                            "UPDATE tasks SET priority = ? WHERE id = ?",
-                            (int(payload.priority), tid),
-                        )
-                        conn.execute(
-                            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                            "VALUES (?, 'reprioritized', ?, ?)",
-                            (tid, json.dumps({"priority": int(payload.priority)}),
-                             int(time.time())),
-                        )
-            except Exception as e:  # defensive — one bad id shouldn't kill the batch
-                entry.update(ok=False, error=str(e))
-            results.append(entry)
-        return {"results": results}
-    finally:
-        conn.close()
+                        entry.update(ok=False, error="assign refused")
+                except RuntimeError as e:
+                    entry.update(ok=False, error=str(e))
+            if payload.priority is not None:
+                with kanban_db.write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET priority = ? WHERE id = ?",
+                        (int(payload.priority), tid),
+                    )
+                    conn.execute(
+                        "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                        "VALUES (?, 'reprioritized', ?, ?)",
+                        (tid, json.dumps({"priority": int(payload.priority)}),
+                         int(time.time())),
+                    )
+        except Exception as e:  # defensive — one bad id shouldn't kill the batch
+            entry.update(ok=False, error=str(e))
+        results.append(entry)
+    return {"results": results}
 
 
 # ---------------------------------------------------------------------------
@@ -1091,61 +1066,58 @@ def list_diagnostics(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        diags_by_task = _compute_task_diagnostics(conn, task_ids=None)
+    diags_by_task = _compute_task_diagnostics(conn, task_ids=None)
+    if not diags_by_task:
+        return {"diagnostics": [], "count": 0}
+
+    # Narrow by severity if asked.
+    if severity:
+        filtered: dict[str, list[dict]] = {}
+        for tid, dl in diags_by_task.items():
+            keep = [d for d in dl if kd.severity_at_or_above(d.get("severity"), severity)]
+            if keep:
+                filtered[tid] = keep
+        diags_by_task = filtered
         if not diags_by_task:
             return {"diagnostics": [], "count": 0}
 
-        # Narrow by severity if asked.
-        if severity:
-            filtered: dict[str, list[dict]] = {}
-            for tid, dl in diags_by_task.items():
-                keep = [d for d in dl if kd.severity_at_or_above(d.get("severity"), severity)]
-                if keep:
-                    filtered[tid] = keep
-            diags_by_task = filtered
-            if not diags_by_task:
-                return {"diagnostics": [], "count": 0}
+    # Pull the task rows we need in one query so we can include
+    # titles/statuses without a per-task lookup.
+    ids = list(diags_by_task.keys())
+    placeholders = ",".join(["?"] * len(ids))
+    rows = {
+        r["id"]: r
+        for r in conn.execute(
+            f"SELECT id, title, status, assignee FROM tasks WHERE id IN ({placeholders})",
+            tuple(ids),
+        ).fetchall()
+    }
 
-        # Pull the task rows we need in one query so we can include
-        # titles/statuses without a per-task lookup.
-        ids = list(diags_by_task.keys())
-        placeholders = ",".join(["?"] * len(ids))
-        rows = {
-            r["id"]: r
-            for r in conn.execute(
-                f"SELECT id, title, status, assignee FROM tasks WHERE id IN ({placeholders})",
-                tuple(ids),
-            ).fetchall()
-        }
+    out = []
+    for tid, dl in diags_by_task.items():
+        r = rows.get(tid)
+        out.append({
+            "task_id": tid,
+            "task_title": r["title"] if r else None,
+            "task_status": r["status"] if r else None,
+            "task_assignee": r["assignee"] if r else None,
+            "diagnostics": dl,
+        })
+    # Sort: highest severity first, then most recent.
+    from hermes_cli.kanban_diagnostics import SEVERITY_ORDER
+    sev_idx = {s: i for i, s in enumerate(SEVERITY_ORDER)}
+    def _sort_key(row):
+        top = row["diagnostics"][0]
+        return (
+            -sev_idx.get(top.get("severity"), -1),
+            -(top.get("last_seen_at") or 0),
+        )
+    out.sort(key=_sort_key)
 
-        out = []
-        for tid, dl in diags_by_task.items():
-            r = rows.get(tid)
-            out.append({
-                "task_id": tid,
-                "task_title": r["title"] if r else None,
-                "task_status": r["status"] if r else None,
-                "task_assignee": r["assignee"] if r else None,
-                "diagnostics": dl,
-            })
-        # Sort: highest severity first, then most recent.
-        from hermes_cli.kanban_diagnostics import SEVERITY_ORDER
-        sev_idx = {s: i for i, s in enumerate(SEVERITY_ORDER)}
-        def _sort_key(row):
-            top = row["diagnostics"][0]
-            return (
-                -sev_idx.get(top.get("severity"), -1),
-                -(top.get("last_seen_at") or 0),
-            )
-        out.sort(key=_sort_key)
-
-        return {
-            "diagnostics": out,
-            "count": sum(len(d["diagnostics"]) for d in out),
-        }
-    finally:
-        conn.close()
+    return {
+        "diagnostics": out,
+        "count": sum(len(d["diagnostics"]) for d in out),
+    }
 
 
 
@@ -1174,50 +1146,47 @@ def list_active_workers(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        rows = conn.execute(
-            """
-            SELECT
-                r.id          AS run_id,
-                r.task_id,
-                t.title       AS task_title,
-                t.status      AS task_status,
-                t.assignee    AS task_assignee,
-                r.profile,
-                r.worker_pid,
-                r.started_at,
-                r.claim_lock,
-                r.claim_expires,
-                r.last_heartbeat_at,
-                r.max_runtime_seconds
-            FROM task_runs r
-            JOIN tasks t ON t.id = r.task_id
-            WHERE r.ended_at IS NULL
-              AND r.worker_pid IS NOT NULL
-              AND t.status = 'running'
-            ORDER BY r.started_at ASC
-            """,
-        ).fetchall()
-        workers = [
-            {
-                "run_id": row["run_id"],
-                "task_id": row["task_id"],
-                "task_title": row["task_title"],
-                "task_status": row["task_status"],
-                "task_assignee": row["task_assignee"],
-                "profile": row["profile"],
-                "worker_pid": row["worker_pid"],
-                "started_at": row["started_at"],
-                "claim_lock": row["claim_lock"],
-                "claim_expires": row["claim_expires"],
-                "last_heartbeat_at": row["last_heartbeat_at"],
-                "max_runtime_seconds": row["max_runtime_seconds"],
-            }
-            for row in rows
-        ]
-        return {"workers": workers, "count": len(workers), "checked_at": int(time.time())}
-    finally:
-        conn.close()
+    rows = conn.execute(
+        """
+        SELECT
+            r.id          AS run_id,
+            r.task_id,
+            t.title       AS task_title,
+            t.status      AS task_status,
+            t.assignee    AS task_assignee,
+            r.profile,
+            r.worker_pid,
+            r.started_at,
+            r.claim_lock,
+            r.claim_expires,
+            r.last_heartbeat_at,
+            r.max_runtime_seconds
+        FROM task_runs r
+        JOIN tasks t ON t.id = r.task_id
+        WHERE r.ended_at IS NULL
+          AND r.worker_pid IS NOT NULL
+          AND t.status = 'running'
+        ORDER BY r.started_at ASC
+        """,
+    ).fetchall()
+    workers = [
+        {
+            "run_id": row["run_id"],
+            "task_id": row["task_id"],
+            "task_title": row["task_title"],
+            "task_status": row["task_status"],
+            "task_assignee": row["task_assignee"],
+            "profile": row["profile"],
+            "worker_pid": row["worker_pid"],
+            "started_at": row["started_at"],
+            "claim_lock": row["claim_lock"],
+            "claim_expires": row["claim_expires"],
+            "last_heartbeat_at": row["last_heartbeat_at"],
+            "max_runtime_seconds": row["max_runtime_seconds"],
+        }
+        for row in rows
+    ]
+    return {"workers": workers, "count": len(workers), "checked_at": int(time.time())}
 
 
 @router.get("/runs/{run_id}")
@@ -1233,13 +1202,10 @@ def get_run_endpoint(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        r = kanban_db.get_run(conn, run_id)
-        if r is None:
-            raise HTTPException(status_code=404, detail=f"run {run_id} not found")
-        return {"run": _run_dict(r)}
-    finally:
-        conn.close()
+    r = kanban_db.get_run(conn, run_id)
+    if r is None:
+        raise HTTPException(status_code=404, detail=f"run {run_id} not found")
+    return {"run": _run_dict(r)}
 
 
 @router.get("/runs/{run_id}/inspect")
@@ -1262,12 +1228,9 @@ def inspect_run_endpoint(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        r = kanban_db.get_run(conn, run_id)
-        if r is None:
-            raise HTTPException(status_code=404, detail=f"run {run_id} not found")
-    finally:
-        conn.close()
+    r = kanban_db.get_run(conn, run_id)
+    if r is None:
+        raise HTTPException(status_code=404, detail=f"run {run_id} not found")
 
     if r.ended_at is not None:
         return {"run_id": run_id, "alive": False, "reason": "run already ended"}
@@ -1333,19 +1296,16 @@ def reclaim_task_endpoint(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        ok = kanban_db.reclaim_task(conn, task_id, reason=payload.reason)
-        if not ok:
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    f"cannot reclaim {task_id}: not in a claimable state "
-                    "(not running, or unknown id)"
-                ),
-            )
-        return {"ok": True, "task_id": task_id}
-    finally:
-        conn.close()
+    ok = kanban_db.reclaim_task(conn, task_id, reason=payload.reason)
+    if not ok:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"cannot reclaim {task_id}: not in a claimable state "
+                "(not running, or unknown id)"
+            ),
+        )
+    return {"ok": True, "task_id": task_id}
 
 
 class SpecifyBody(BaseModel):
@@ -1424,24 +1384,21 @@ def reassign_task_endpoint(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        ok = kanban_db.reassign_task(
-            conn, task_id,
-            payload.profile or None,
-            reclaim_first=bool(payload.reclaim_first),
-            reason=payload.reason,
+    ok = kanban_db.reassign_task(
+        conn, task_id,
+        payload.profile or None,
+        reclaim_first=bool(payload.reclaim_first),
+        reason=payload.reason,
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"cannot reassign {task_id}: unknown id, or still "
+                "running (pass reclaim_first=true to release the claim first)"
+            ),
         )
-        if not ok:
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    f"cannot reassign {task_id}: unknown id, or still "
-                    "running (pass reclaim_first=true to release the claim first)"
-                ),
-            )
-        return {"ok": True, "task_id": task_id, "assignee": payload.profile or None}
-    finally:
-        conn.close()
+    return {"ok": True, "task_id": task_id, "assignee": payload.profile or None}
 
 
 # ---------------------------------------------------------------------------
@@ -1553,10 +1510,7 @@ def get_home_channels(
     if task_id:
         board = _resolve_board(board)
         conn = _conn(board=board)
-        try:
-            subs = kanban_db.list_notify_subs(conn, task_id)
-        finally:
-            conn.close()
+        subs = kanban_db.list_notify_subs(conn, task_id)
         for sub in subs:
             key = (
                 str(sub.get("platform") or ""),
@@ -1589,21 +1543,18 @@ def subscribe_home(task_id: str, platform: str, board: Optional[str] = Query(Non
         )
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        task = kanban_db.get_task(conn, task_id)
-        if task is None:
-            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
-        kanban_db.add_notify_sub(
-            conn,
-            task_id=task_id,
-            platform=platform,
-            chat_id=home["chat_id"],
-            thread_id=home["thread_id"] or None,
-            notifier_profile=_active_profile_name(),
-        )
-        return {"ok": True, "task_id": task_id, "home_channel": home}
-    finally:
-        conn.close()
+    task = kanban_db.get_task(conn, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+    kanban_db.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform=platform,
+        chat_id=home["chat_id"],
+        thread_id=home["thread_id"] or None,
+        notifier_profile=_active_profile_name(),
+    )
+    return {"ok": True, "task_id": task_id, "home_channel": home}
 
 
 @router.delete("/tasks/{task_id}/home-subscribe/{platform}")
@@ -1618,17 +1569,14 @@ def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(N
         )
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        kanban_db.remove_notify_sub(
-            conn,
-            task_id=task_id,
-            platform=platform,
-            chat_id=home["chat_id"],
-            thread_id=home["thread_id"] or None,
-        )
-        return {"ok": True, "task_id": task_id, "home_channel": home}
-    finally:
-        conn.close()
+    kanban_db.remove_notify_sub(
+        conn,
+        task_id=task_id,
+        platform=platform,
+        chat_id=home["chat_id"],
+        thread_id=home["thread_id"] or None,
+    )
+    return {"ok": True, "task_id": task_id, "home_channel": home}
 
 
 # ---------------------------------------------------------------------------
@@ -1645,10 +1593,7 @@ def get_stats(board: Optional[str] = Query(None)):
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        return kanban_db.board_stats(conn)
-    finally:
-        conn.close()
+    return kanban_db.board_stats(conn)
 
 
 @router.get("/assignees")
@@ -1662,10 +1607,7 @@ def get_assignees(board: Optional[str] = Query(None)):
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        return {"assignees": kanban_db.known_assignees(conn)}
-    finally:
-        conn.close()
+    return {"assignees": kanban_db.known_assignees(conn)}
 
 
 # ---------------------------------------------------------------------------
@@ -1688,10 +1630,7 @@ def get_task_log(
     """
     board = _resolve_board(board)
     conn = _conn(board=board)
-    try:
-        task = kanban_db.get_task(conn, task_id)
-    finally:
-        conn.close()
+    task = kanban_db.get_task(conn, task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"task {task_id} not found")
     content = kanban_db.read_worker_log(task_id, tail_bytes=tail, board=board)
@@ -1720,17 +1659,14 @@ def dispatch(
 ):
     board = _resolve_board(board)
     conn = _conn(board=board)
+    result = kanban_db.dispatch_once(
+        conn, dry_run=dry_run, max_spawn=max_n, board=board,
+    )
+    # DispatchResult is a dataclass.
     try:
-        result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
-        )
-        # DispatchResult is a dataclass.
-        try:
-            return asdict(result)
-        except TypeError:
-            return {"result": str(result)}
-    finally:
-        conn.close()
+        return asdict(result)
+    except TypeError:
+        return {"result": str(result)}
 
 
 # ---------------------------------------------------------------------------
@@ -1759,14 +1695,11 @@ def _board_counts(slug: str) -> dict[str, int]:
         path = kanban_db.kanban_db_path(board=slug)
         if not path.exists():
             return {}
-        conn = kanban_db.connect(board=slug)
-        try:
-            rows = conn.execute(
-                "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
-            ).fetchall()
-            return {r["status"]: int(r["n"]) for r in rows}
-        finally:
-            conn.close()
+        conn = kanban_db.get_connection(board=slug)
+        rows = conn.execute(
+            "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
+        ).fetchall()
+        return {r["status"]: int(r["n"]) for r in rows}
     except Exception:
         return {}
 
@@ -2168,32 +2101,29 @@ async def stream_events(ws: WebSocket):
             ws_board = None
 
         def _fetch_new(cursor_val: int) -> tuple[int, list[dict]]:
-            conn = kanban_db.connect(board=ws_board)
-            try:
-                rows = conn.execute(
-                    "SELECT id, task_id, run_id, kind, payload, created_at "
-                    "FROM task_events WHERE id > ? ORDER BY id ASC LIMIT 200",
-                    (cursor_val,),
-                ).fetchall()
-                out: list[dict] = []
-                new_cursor = cursor_val
-                for r in rows:
-                    try:
-                        payload = json.loads(r["payload"]) if r["payload"] else None
-                    except Exception:
-                        payload = None
-                    out.append({
-                        "id": r["id"],
-                        "task_id": r["task_id"],
-                        "run_id": r["run_id"],
-                        "kind": r["kind"],
-                        "payload": payload,
-                        "created_at": r["created_at"],
-                    })
-                    new_cursor = r["id"]
-                return new_cursor, out
-            finally:
-                conn.close()
+            conn = kanban_db.get_connection(board=ws_board)
+            rows = conn.execute(
+                "SELECT id, task_id, run_id, kind, payload, created_at "
+                "FROM task_events WHERE id > ? ORDER BY id ASC LIMIT 200",
+                (cursor_val,),
+            ).fetchall()
+            out: list[dict] = []
+            new_cursor = cursor_val
+            for r in rows:
+                try:
+                    payload = json.loads(r["payload"]) if r["payload"] else None
+                except Exception:
+                    payload = None
+                out.append({
+                    "id": r["id"],
+                    "task_id": r["task_id"],
+                    "run_id": r["run_id"],
+                    "kind": r["kind"],
+                    "payload": payload,
+                    "created_at": r["created_at"],
+                })
+                new_cursor = r["id"]
+            return new_cursor, out
 
         while True:
             cursor, events = await asyncio.to_thread(_fetch_new, cursor)

--- a/tests/agent/test_kanban_worker_protocol_guard.py
+++ b/tests/agent/test_kanban_worker_protocol_guard.py
@@ -1,0 +1,82 @@
+"""Tests for the kanban worker clean-exit protocol guard."""
+
+from types import SimpleNamespace
+
+from agent import conversation_loop
+
+
+def _tool_call(name: str):
+    return {
+        "id": f"call_{name}",
+        "type": "function",
+        "function": {"name": name, "arguments": "{}"},
+    }
+
+
+def test_kanban_worker_terminal_tool_detection():
+    assert not conversation_loop._kanban_worker_called_terminal_tool(
+        [{"role": "assistant", "content": "done"}]
+    )
+    assert conversation_loop._kanban_worker_called_terminal_tool(
+        [{"role": "assistant", "tool_calls": [_tool_call("kanban_complete")]}]
+    )
+    assert conversation_loop._kanban_worker_called_terminal_tool(
+        [{"role": "assistant", "tool_calls": [_tool_call("kanban_block")]}]
+    )
+
+
+def test_kanban_worker_text_only_final_response_auto_blocks(monkeypatch):
+    calls = []
+
+    fake_run_agent = SimpleNamespace(
+        handle_function_call=lambda name, args, task_id=None: calls.append(
+            (name, args, task_id)
+        )
+    )
+    monkeypatch.setattr(conversation_loop, "_ra", lambda: fake_run_agent)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test1234")
+
+    blocked = conversation_loop._auto_block_kanban_worker_protocol_violation(
+        messages=[{"role": "assistant", "content": "I am done"}],
+        final_response="I am done",
+        api_call_count=2,
+        effective_task_id="loop-task",
+    )
+
+    assert blocked is True
+    assert calls == [
+        (
+            "kanban_block",
+            {
+                "task_id": "t_test1234",
+                "reason": (
+                    "protocol-guard: worker produced a final text response without "
+                    "calling kanban_complete or kanban_block; auto-blocked to prevent "
+                    "clean-exit protocol violation. api_calls=2; "
+                    "final_response_preview='I am done'"
+                ),
+            },
+            "loop-task",
+        )
+    ]
+
+
+def test_kanban_worker_guard_skips_when_terminal_tool_was_called(monkeypatch):
+    calls = []
+    fake_run_agent = SimpleNamespace(
+        handle_function_call=lambda name, args, task_id=None: calls.append(
+            (name, args, task_id)
+        )
+    )
+    monkeypatch.setattr(conversation_loop, "_ra", lambda: fake_run_agent)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test1234")
+
+    blocked = conversation_loop._auto_block_kanban_worker_protocol_violation(
+        messages=[{"role": "assistant", "tool_calls": [_tool_call("kanban_complete")]}],
+        final_response="completed",
+        api_call_count=3,
+        effective_task_id=None,
+    )
+
+    assert blocked is False
+    assert calls == []

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2259,6 +2259,25 @@ def test_cli_show_json_carries_runs(kanban_home):
         assert "run_id" in e
 
 
+def test_cli_show_tolerates_malformed_comment_timestamp(kanban_home):
+    """Plain-text `hermes kanban show` must not crash on legacy rows that
+    stored event JSON in task_comments.created_at instead of an integer."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="legacy comment timestamp", assignee="worker")
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+            (tid, "worker", "protocol_violation", '{"pid": 123, "exit_code": 0}'),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = run_slash(f"show {tid}")
+    assert "unknown time" in out
+    assert "protocol_violation" in out
+
+
 # -------------------------------------------------------------------------
 # Pre-merge audit by @erosika (issue #16102 comment 4331125835) — fixes
 # -------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -202,6 +202,22 @@ def test_create_task_persists_worktree_branch_name(kanban_home, tmp_path):
     assert "Branch:   wt/t6-wire" in context
 
 
+def test_build_worker_context_tolerates_malformed_comment_timestamp(kanban_home):
+    """Legacy bad rows must not crash every worker prompt for a task."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="legacy comment timestamp")
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (tid, "legacy", "CLAIMED_EVENT_SHAPED_COMMENT", '{"lock":"x"}'),
+        )
+        context = kb.build_worker_context(conn, tid)
+
+    assert "Comment thread" in context
+    assert "unknown time" in context
+    assert "CLAIMED_EVENT_SHAPED_COMMENT" in context
+
+
 def test_branch_name_requires_worktree_workspace(kanban_home):
     with kb.connect() as conn, pytest.raises(ValueError, match="worktree"):
         kb.create_task(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2108,14 +2108,21 @@ def test_connect_falls_back_to_delete_on_locking_protocol(kanban_home, caplog):
     import sqlite3 as _sqlite3
     from unittest.mock import patch as _patch
 
-    # Clear module cache so a fresh connect() is attempted
+    # Clear module caches so a fresh connect() is attempted
     kb._INITIALIZED_PATHS.clear()
+    kb._connection_pool.clear()
 
     real_connect = _sqlite3.connect
 
     class _WalBlockingConnection(_sqlite3.Connection):
         def execute(self, sql, *args, **kwargs):  # type: ignore[override]
             if "journal_mode=wal" in sql.lower().replace(" ", ""):
+                # Roll back any implicit transaction before raising,
+                # otherwise the next execute fails with "database is locked".
+                try:
+                    super().rollback()
+                except Exception:
+                    pass
                 raise _sqlite3.OperationalError("locking protocol")
             return super().execute(sql, *args, **kwargs)
 

--- a/tests/stress/test_kanban_singleton_pool.py
+++ b/tests/stress/test_kanban_singleton_pool.py
@@ -1,0 +1,196 @@
+"""Stress tests for the Kanban singleton connection pool (``get_connection``).
+
+Validates that:
+
+  - ``get_connection`` returns the same connection for repeated calls
+  - Different boards get different connections
+  - 1000 rapid create+complete operations don't corrupt the DB
+  - Concurrent connections maintain integrity_check=ok
+  - Pool cleanup runs without errors
+"""
+
+from __future__ import annotations
+
+import atexit
+import concurrent.futures
+import os
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def pool_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a fresh kanban DB via get_connection."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Clear any state from other tests
+    kb._INITIALIZED_PATHS.clear()
+    kb._connection_pool.clear()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Singleton behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_get_connection_returns_same_object(pool_home):
+    """Two calls to get_connection() return the exact same connection."""
+    conn1 = kb.get_connection()
+    conn2 = kb.get_connection()
+    assert conn1 is conn2, "get_connection() must return the same connection"
+
+
+def test_get_connection_different_boards(pool_home):
+    """Different boards get different connections."""
+    # Create a second board
+    kb.create_board("projx")
+
+    conn_default = kb.get_connection(board="default")
+    conn_projx = kb.get_connection(board="projx")
+
+    assert conn_default is not conn_projx, (
+        "different boards must have different connections"
+    )
+
+
+def test_connect_is_backward_compatible(pool_home):
+    """connect() still works and returns a usable connection."""
+    conn = kb.connect()
+    # Verify it's a real sqlite3 connection
+    assert isinstance(conn, sqlite3.Connection)
+    # Verify we can use it
+    row = conn.execute("PRAGMA integrity_check").fetchone()
+    assert row[0].lower() == "ok"
+    conn.close()
+
+
+def test_pool_connection_is_thread_safe(pool_home):
+    """Multiple threads can use get_connection() without issues."""
+    conn = kb.get_connection()
+    t = kb.create_task(conn, title="thread-safety", assignee="test")
+
+    errors = []
+    results = []
+
+    def read_task():
+        try:
+            c = kb.get_connection()
+            task = kb.get_task(c, t)
+            results.append(task)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=read_task) for _ in range(10)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    assert len(errors) == 0, f"unexpected errors: {errors}"
+    assert all(r is not None and r.title == "thread-safety" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Integrity under load
+# ---------------------------------------------------------------------------
+
+
+def test_1000_rapid_operations_no_corruption(pool_home):
+    """1000 rapid create + complete operations; integrity_check stays ok."""
+    conn = kb.get_connection()
+
+    task_ids = []
+    # Create 1000 tasks
+    for i in range(1000):
+        t = kb.create_task(conn, title=f"load-test-{i}", assignee="test")
+        task_ids.append(t)
+
+    # Complete them all
+    for t in task_ids:
+        kb.complete_task(conn, t, summary="done")
+
+    # Verify integrity
+    row = conn.execute("PRAGMA integrity_check").fetchone()
+    assert row[0].lower() == "ok", (
+        f"integrity_check failed after 1000 ops: {row[0]}"
+    )
+
+    # Verify all tasks are done
+    for t in task_ids[:10]:  # spot check
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.status == "done"
+
+
+def test_concurrent_connections_integrity_ok(pool_home):
+    """Two connections writing concurrently; integrity_check stays ok."""
+    # Use separate connections (not the pool) to simulate concurrent access
+    conn1 = kb.connect()
+    conn2 = kb.connect()
+
+    errors = []
+    done = threading.Event()
+
+    def writer(conn, label):
+        try:
+            for i in range(100):
+                t = kb.create_task(conn, title=f"concurrent-{label}-{i}",
+                                   assignee="test")
+                kb.complete_task(conn, t, summary="done")
+        except Exception as e:
+            errors.append((label, e))
+        finally:
+            done.set()
+
+    t1 = threading.Thread(target=writer, args=(conn1, "A"))
+    t2 = threading.Thread(target=writer, args=(conn2, "B"))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    conn1.close()
+    conn2.close()
+
+    assert len(errors) == 0, f"concurrent writes failed: {errors}"
+
+    # Check integrity on a fresh connection
+    check_conn = kb.connect()
+    try:
+        row = check_conn.execute("PRAGMA integrity_check").fetchone()
+        assert row[0].lower() == "ok", (
+            f"integrity_check failed after concurrent writes: {row[0]}"
+        )
+    finally:
+        check_conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_atexit_cleanup_runs_without_errors(pool_home):
+    """_cleanup_connections() closes all pooled connections without error."""
+    conn = kb.get_connection()
+    t = kb.create_task(conn, title="cleanup-test", assignee="test")
+    kb.complete_task(conn, t, summary="done")
+
+    # Directly invoke cleanup
+    kb._cleanup_connections()
+
+    # Pool should be empty
+    assert len(kb._connection_pool) == 0, "pool should be empty after cleanup"
+
+    # Re-acquiring a connection should work (creates a new one)
+    conn2 = kb.get_connection()
+    assert isinstance(conn2, sqlite3.Connection)
+    assert conn2 is not conn, "should be a new connection after cleanup"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1359,6 +1359,37 @@ def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
     assert d.get("ok") is True
 
 
+def test_worker_block_allows_stale_env_run_id_after_reclaim(worker_env, monkeypatch):
+    """Manual recovery workers may inherit HERMES_KANBAN_RUN_ID after a task
+    has been reclaimed back to ready/current_run_id=NULL; block must still
+    work so the worker can satisfy its terminal-call contract."""
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        stale_run = kb.latest_run(conn, worker_env)
+        conn.execute(
+            "UPDATE tasks SET status='ready', current_run_id=NULL, claim_lock=NULL, claim_expires=NULL WHERE id=?",
+            (worker_env,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(stale_run.id))
+    out = kt._handle_block({"reason": "manual recovery block"})
+    d = json.loads(out)
+    assert d.get("ok") is True
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task.status == "blocked"
+    finally:
+        conn.close()
+
+
 def test_orchestrator_complete_any_task_allowed(monkeypatch, tmp_path):
     """Orchestrator profiles (no HERMES_KANBAN_TASK) can still complete
     any task via explicit task_id. The check only applies to workers."""

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -267,63 +267,60 @@ def _handle_show(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            task = kb.get_task(conn, tid)
-            if task is None:
-                return tool_error(f"task {tid} not found")
-            comments = kb.list_comments(conn, tid)
-            events = kb.list_events(conn, tid)
-            runs = kb.list_runs(conn, tid)
-            parents = kb.parent_ids(conn, tid)
-            children = kb.child_ids(conn, tid)
+        task = kb.get_task(conn, tid)
+        if task is None:
+            return tool_error(f"task {tid} not found")
+        comments = kb.list_comments(conn, tid)
+        events = kb.list_events(conn, tid)
+        runs = kb.list_runs(conn, tid)
+        parents = kb.parent_ids(conn, tid)
+        children = kb.child_ids(conn, tid)
 
-            def _task_dict(t):
-                return {
-                    "id": t.id, "title": t.title, "body": t.body,
-                    "assignee": t.assignee, "status": t.status,
-                    "tenant": t.tenant, "priority": t.priority,
-                    "workspace_kind": t.workspace_kind,
-                    "workspace_path": t.workspace_path,
-                    "created_by": t.created_by, "created_at": t.created_at,
-                    "started_at": t.started_at,
-                    "completed_at": t.completed_at,
-                    "result": t.result,
-                    "current_run_id": t.current_run_id,
-                    "model_override": t.model_override,
-                }
+        def _task_dict(t):
+            return {
+                "id": t.id, "title": t.title, "body": t.body,
+                "assignee": t.assignee, "status": t.status,
+                "tenant": t.tenant, "priority": t.priority,
+                "workspace_kind": t.workspace_kind,
+                "workspace_path": t.workspace_path,
+                "created_by": t.created_by, "created_at": t.created_at,
+                "started_at": t.started_at,
+                "completed_at": t.completed_at,
+                "result": t.result,
+                "current_run_id": t.current_run_id,
+                "model_override": t.model_override,
+            }
 
-            def _run_dict(r):
-                return {
-                    "id": r.id, "profile": r.profile,
-                    "status": r.status, "outcome": r.outcome,
-                    "summary": r.summary, "error": r.error,
-                    "metadata": r.metadata,
-                    "started_at": r.started_at, "ended_at": r.ended_at,
-                }
+        def _run_dict(r):
+            return {
+                "id": r.id, "profile": r.profile,
+                "status": r.status, "outcome": r.outcome,
+                "summary": r.summary, "error": r.error,
+                "metadata": r.metadata,
+                "started_at": r.started_at, "ended_at": r.ended_at,
+            }
 
-            return json.dumps({
-                "task": _task_dict(task),
-                "parents": parents,
-                "children": children,
-                "comments": [
-                    {"author": c.author, "body": c.body,
-                     "created_at": c.created_at}
-                    for c in comments
-                ],
-                "events": [
-                    {"kind": e.kind, "payload": e.payload,
-                     "created_at": e.created_at, "run_id": e.run_id}
-                    for e in events[-50:]   # cap; full log via CLI
-                ],
-                "runs": [_run_dict(r) for r in runs],
-                # Also surface the worker's own context block so the
-                # agent can include it directly if it wants. This is
-                # the same string build_worker_context returns to the
-                # dispatcher at spawn time.
-                "worker_context": kb.build_worker_context(conn, tid),
-            })
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        return json.dumps({
+            "task": _task_dict(task),
+            "parents": parents,
+            "children": children,
+            "comments": [
+                {"author": c.author, "body": c.body,
+                 "created_at": c.created_at}
+                for c in comments
+            ],
+            "events": [
+                {"kind": e.kind, "payload": e.payload,
+                 "created_at": e.created_at, "run_id": e.run_id}
+                for e in events[-50:]   # cap; full log via CLI
+            ],
+            "runs": [_run_dict(r) for r in runs],
+            # Also surface the worker's own context block so the
+            # agent can include it directly if it wants. This is
+            # the same string build_worker_context returns to the
+            # dispatcher at spawn time.
+            "worker_context": kb.build_worker_context(conn, tid),
+        })
     except ValueError as e:
         # Invalid board slug surfaces as ValueError from _normalize_board_slug.
         return tool_error(f"kanban_show: {e}")
@@ -357,35 +354,30 @@ def _handle_list(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            # Match CLI list: dependencies that cleared since the last
-            # dispatcher tick should be visible to orchestrators immediately.
-            promoted = kb.recompute_ready(conn)
-            # Fetch one extra row so model-facing output can report that
-            # a bounded listing was truncated without dumping the board.
-            rows = kb.list_tasks(
-                conn,
-                assignee=assignee,
-                status=status,
-                tenant=tenant,
-                include_archived=include_archived,
-                limit=limit + 1,
-            )
-            truncated = len(rows) > limit
-            tasks = rows[:limit]
-            return json.dumps({
-                "tasks": [_task_summary_dict(kb, conn, t) for t in tasks],
-                "count": len(tasks),
-                "limit": limit,
-                "truncated": truncated,
-                "next_limit": (
-                    min(limit * 2, KANBAN_LIST_MAX_LIMIT)
-                    if truncated and limit < KANBAN_LIST_MAX_LIMIT else None
-                ),
-                "promoted": promoted,
-            })
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        promoted = kb.recompute_ready(conn)
+        # Fetch one extra row so model-facing output can report that
+        # a bounded listing was truncated without dumping the board.
+        rows = kb.list_tasks(
+            conn,
+            assignee=assignee,
+            status=status,
+            tenant=tenant,
+            include_archived=include_archived,
+            limit=limit + 1,
+        )
+        truncated = len(rows) > limit
+        tasks = rows[:limit]
+        return json.dumps({
+            "tasks": [_task_summary_dict(kb, conn, t) for t in tasks],
+            "count": len(tasks),
+            "limit": limit,
+            "truncated": truncated,
+            "next_limit": (
+                min(limit * 2, KANBAN_LIST_MAX_LIMIT)
+                if truncated and limit < KANBAN_LIST_MAX_LIMIT else None
+            ),
+            "promoted": promoted,
+        })
     except ValueError as e:
         return tool_error(f"kanban_list: {e}")
     except Exception as e:
@@ -473,41 +465,38 @@ def _handle_complete(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            try:
-                ok = kb.complete_task(
-                    conn, tid,
-                    result=result, summary=summary, metadata=metadata,
-                    created_cards=created_cards,
-                    expected_run_id=_worker_run_id(tid),
-                )
-            except kb.HallucinatedCardsError as hall_err:
-                # Structured rejection — surface the phantom ids so the
-                # worker can retry with a corrected list or drop the
-                # field. Audit event already landed in the DB.
-                #
-                # The task itself was NOT mutated (the gate runs before
-                # the write txn), so the worker can simply call
-                # kanban_complete again. Spell that out — without it the
-                # model often interprets a tool_error as a terminal
-                # failure and either blocks or crashes the run instead
-                # of retrying. See #22923.
-                return tool_error(
-                    f"kanban_complete blocked: the following created_cards "
-                    f"do not exist or were not created by this worker: "
-                    f"{', '.join(hall_err.phantom)}. "
-                    f"Your task is still in-flight (no state change). "
-                    f"Retry kanban_complete with the same summary/metadata "
-                    f"and either drop these ids from created_cards, or pass "
-                    f"created_cards=[] to skip the card-claim check entirely."
-                )
-            if not ok:
-                return tool_error(
-                    f"could not complete {tid} (unknown id or already terminal)"
-                )
-            run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
-        finally:
-            pass  # pooled connection — lives for process lifetime
+            ok = kb.complete_task(
+                conn, tid,
+                result=result, summary=summary, metadata=metadata,
+                created_cards=created_cards,
+                expected_run_id=_worker_run_id(tid),
+            )
+        except kb.HallucinatedCardsError as hall_err:
+            # Structured rejection — surface the phantom ids so the
+            # worker can retry with a corrected list or drop the
+            # field. Audit event already landed in the DB.
+            #
+            # The task itself was NOT mutated (the gate runs before
+            # the write txn), so the worker can simply call
+            # kanban_complete again. Spell that out — without it the
+            # model often interprets a tool_error as a terminal
+            # failure and either blocks or crashes the run instead
+            # of retrying. See #22923.
+            return tool_error(
+                f"kanban_complete blocked: the following created_cards "
+                f"do not exist or were not created by this worker: "
+                f"{', '.join(hall_err.phantom)}. "
+                f"Your task is still in-flight (no state change). "
+                f"Retry kanban_complete with the same summary/metadata "
+                f"and either drop these ids from created_cards, or pass "
+                f"created_cards=[] to skip the card-claim check entirely."
+            )
+        if not ok:
+            return tool_error(
+                f"could not complete {tid} (unknown id or already terminal)"
+            )
+        run = kb.latest_run(conn, tid)
+        return _ok(task_id=tid, run_id=run.id if run else None)
     except ValueError as e:
         return tool_error(f"kanban_complete: {e}")
     except Exception as e:
@@ -531,21 +520,18 @@ def _handle_block(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            ok = kb.block_task(
-                conn, tid,
-                reason=reason,
-                expected_run_id=_worker_run_id(tid),
+        ok = kb.block_task(
+            conn, tid,
+            reason=reason,
+            expected_run_id=_worker_run_id(tid),
+        )
+        if not ok:
+            return tool_error(
+                f"could not block {tid} (unknown id or not in "
+                f"running/ready)"
             )
-            if not ok:
-                return tool_error(
-                    f"could not block {tid} (unknown id or not in "
-                    f"running/ready)"
-                )
-            run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        run = kb.latest_run(conn, tid)
+        return _ok(task_id=tid, run_id=run.id if run else None)
     except ValueError as e:
         return tool_error(f"kanban_block: {e}")
     except Exception as e:
@@ -575,28 +561,20 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            # Extend the claim TTL first. The dispatcher pins
-            # HERMES_KANBAN_CLAIM_LOCK in the worker env at spawn time
-            # (see _default_spawn in kanban_db.py); falling back to the
-            # default _claimer_id() covers locally-driven workers that
-            # never went through the dispatcher path.
-            claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
-            kb.heartbeat_claim(conn, tid, claimer=claim_lock)
+        claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+        kb.heartbeat_claim(conn, tid, claimer=claim_lock)
 
-            ok = kb.heartbeat_worker(
-                conn,
-                tid,
-                note=note,
-                expected_run_id=_worker_run_id(tid),
+        ok = kb.heartbeat_worker(
+            conn,
+            tid,
+            note=note,
+            expected_run_id=_worker_run_id(tid),
+        )
+        if not ok:
+            return tool_error(
+                f"could not heartbeat {tid} (unknown id or not running)"
             )
-            if not ok:
-                return tool_error(
-                    f"could not heartbeat {tid} (unknown id or not running)"
-                )
-            return _ok(task_id=tid)
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        return _ok(task_id=tid)
     except ValueError as e:
         return tool_error(f"kanban_heartbeat: {e}")
     except Exception as e:
@@ -628,11 +606,8 @@ def _handle_comment(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            cid = kb.add_comment(conn, tid, author=author, body=str(body))
-            return _ok(task_id=tid, comment_id=cid)
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        cid = kb.add_comment(conn, tid, author=author, body=str(body))
+        return _ok(task_id=tid, comment_id=cid)
     except ValueError as e:
         return tool_error(f"kanban_comment: {e}")
     except Exception as e:
@@ -688,35 +663,32 @@ def _handle_create(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            new_tid = kb.create_task(
-                conn,
-                title=str(title).strip(),
-                body=body,
-                assignee=str(assignee),
-                parents=tuple(parents),
-                tenant=tenant,
-                priority=int(priority) if priority is not None else 0,
-                workspace_kind=str(workspace_kind),
-                workspace_path=workspace_path,
-                triage=triage,
-                idempotency_key=idempotency_key,
-                max_runtime_seconds=(
-                    int(max_runtime_seconds)
-                    if max_runtime_seconds is not None else None
-                ),
-                skills=skills,
-                initial_status=str(initial_status),
-                created_by=os.environ.get("HERMES_PROFILE") or "worker",
-                session_id=session_id,
-            )
-            new_task = kb.get_task(conn, new_tid)
-            return _ok(
-                task_id=new_tid,
-                status=new_task.status if new_task else None,
-            )
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        new_tid = kb.create_task(
+            conn,
+            title=str(title).strip(),
+            body=body,
+            assignee=str(assignee),
+            parents=tuple(parents),
+            tenant=tenant,
+            priority=int(priority) if priority is not None else 0,
+            workspace_kind=str(workspace_kind),
+            workspace_path=workspace_path,
+            triage=triage,
+            idempotency_key=idempotency_key,
+            max_runtime_seconds=(
+                int(max_runtime_seconds)
+                if max_runtime_seconds is not None else None
+            ),
+            skills=skills,
+            initial_status=str(initial_status),
+            created_by=os.environ.get("HERMES_PROFILE") or "worker",
+            session_id=session_id,
+        )
+        new_task = kb.get_task(conn, new_tid)
+        return _ok(
+            task_id=new_tid,
+            status=new_task.status if new_task else None,
+        )
     except ValueError as e:
         return tool_error(f"kanban_create: {e}")
     except Exception as e:
@@ -738,13 +710,10 @@ def _handle_unblock(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            ok = kb.unblock_task(conn, str(tid))
-            if not ok:
-                return tool_error(f"could not unblock {tid} (not blocked or unknown)")
-            return _ok(task_id=str(tid), status="ready")
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        ok = kb.unblock_task(conn, str(tid))
+        if not ok:
+            return tool_error(f"could not unblock {tid} (not blocked or unknown)")
+        return _ok(task_id=str(tid), status="ready")
     except ValueError as e:
         return tool_error(f"kanban_unblock: {e}")
     except Exception as e:
@@ -761,11 +730,8 @@ def _handle_link(args: dict, **kw) -> str:
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
-        try:
-            kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
-            return _ok(parent_id=parent_id, child_id=child_id)
-        finally:
-            pass  # pooled connection — lives for process lifetime
+        kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
+        return _ok(parent_id=parent_id, child_id=child_id)
     except ValueError as e:
         # Covers cycle + self-parent rejections
         return tool_error(f"kanban_link: {e}")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -102,7 +102,7 @@ def _default_task_id(arg: Optional[str]) -> Optional[str]:
     return env_tid or None
 
 
-def _worker_run_id(task_id: str) -> Optional[int]:
+def _worker_run_id(conn: Any, task_id: str) -> Optional[int]:
     """Return this worker's dispatcher run id when it is scoped to task_id."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return None
@@ -110,9 +110,22 @@ def _worker_run_id(task_id: str) -> Optional[int]:
     if not raw:
         return None
     try:
-        return int(raw)
+        run_id = int(raw)
     except ValueError:
         return None
+
+    # Manual recovery sessions can inherit a stale run id while the task has
+    # already been reclaimed/promoted back to ready with no current_run_id.
+    # Dropping the CAS token in that state lets the worker follow the
+    # mandatory terminal-call contract; if a different run is active, keep the
+    # token so stale workers still fail closed.
+    try:
+        row = conn.execute("SELECT current_run_id FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if row is not None and row["current_run_id"] is None:
+            return None
+    except Exception:
+        pass
+    return run_id
 
 
 def _stamp_worker_session_metadata(
@@ -469,7 +482,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 conn, tid,
                 result=result, summary=summary, metadata=metadata,
                 created_cards=created_cards,
-                expected_run_id=_worker_run_id(tid),
+                expected_run_id=_worker_run_id(conn, tid),
             )
         except kb.HallucinatedCardsError as hall_err:
             # Structured rejection — surface the phantom ids so the
@@ -523,7 +536,7 @@ def _handle_block(args: dict, **kw) -> str:
         ok = kb.block_task(
             conn, tid,
             reason=reason,
-            expected_run_id=_worker_run_id(tid),
+            expected_run_id=_worker_run_id(conn, tid),
         )
         if not ok:
             return tool_error(
@@ -568,7 +581,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
             conn,
             tid,
             note=note,
-            expected_run_id=_worker_run_id(tid),
+            expected_run_id=_worker_run_id(conn, tid),
         )
         if not ok:
             return tool_error(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -165,7 +165,11 @@ def _connect(board: Optional[str] = None):
     """Import + connect lazily so the module imports cleanly in non-kanban
     contexts (e.g. test rigs that import every tool module).
 
-    When ``board`` is provided it's forwarded to :func:`kb.connect`, which
+    Returns a pooled, persistent connection via :func:`kb.get_connection`.
+    The connection lives for the process lifetime — do NOT call ``.close()``
+    on it (previously required; now a no-op).
+
+    When ``board`` is provided it's forwarded to :func:`kb.get_connection`, which
     routes the connection to that board's sqlite file. ``None`` (the
     default) preserves the legacy resolution chain
     (``HERMES_KANBAN_DB`` → ``HERMES_KANBAN_BOARD`` env → current symlink
@@ -173,7 +177,7 @@ def _connect(board: Optional[str] = None):
     the env-pinned active board without restarting Hermes.
     """
     from hermes_cli import kanban_db as kb
-    return kb, kb.connect(board=board)
+    return kb, kb.get_connection(board=board)
 
 
 def _ok(**fields: Any) -> str:
@@ -319,7 +323,7 @@ def _handle_show(args: dict, **kw) -> str:
                 "worker_context": kb.build_worker_context(conn, tid),
             })
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         # Invalid board slug surfaces as ValueError from _normalize_board_slug.
         return tool_error(f"kanban_show: {e}")
@@ -381,7 +385,7 @@ def _handle_list(args: dict, **kw) -> str:
                 "promoted": promoted,
             })
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         return tool_error(f"kanban_list: {e}")
     except Exception as e:
@@ -503,7 +507,7 @@ def _handle_complete(args: dict, **kw) -> str:
             run = kb.latest_run(conn, tid)
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         return tool_error(f"kanban_complete: {e}")
     except Exception as e:
@@ -541,7 +545,7 @@ def _handle_block(args: dict, **kw) -> str:
             run = kb.latest_run(conn, tid)
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         return tool_error(f"kanban_block: {e}")
     except Exception as e:
@@ -592,7 +596,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
                 )
             return _ok(task_id=tid)
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         return tool_error(f"kanban_heartbeat: {e}")
     except Exception as e:
@@ -628,7 +632,7 @@ def _handle_comment(args: dict, **kw) -> str:
             cid = kb.add_comment(conn, tid, author=author, body=str(body))
             return _ok(task_id=tid, comment_id=cid)
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         return tool_error(f"kanban_comment: {e}")
     except Exception as e:
@@ -712,7 +716,7 @@ def _handle_create(args: dict, **kw) -> str:
                 status=new_task.status if new_task else None,
             )
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         return tool_error(f"kanban_create: {e}")
     except Exception as e:
@@ -740,7 +744,7 @@ def _handle_unblock(args: dict, **kw) -> str:
                 return tool_error(f"could not unblock {tid} (not blocked or unknown)")
             return _ok(task_id=str(tid), status="ready")
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         return tool_error(f"kanban_unblock: {e}")
     except Exception as e:
@@ -761,7 +765,7 @@ def _handle_link(args: dict, **kw) -> str:
             kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
             return _ok(parent_id=parent_id, child_id=child_id)
         finally:
-            conn.close()
+            pass  # pooled connection — lives for process lifetime
     except ValueError as e:
         # Covers cycle + self-parent rejections
         return tool_error(f"kanban_link: {e}")


### PR DESCRIPTION
## Summary
- tolerate malformed legacy Kanban comment timestamps in worker context and CLI show paths
- auto-block text-only Kanban worker exits so the dispatcher stops respawning protocol-violating workers
- preserve/reuse Kanban pooled DB connections across gateway/dashboard/tools paths

## Verification
- `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_cli_show_tolerates_malformed_comment_timestamp tests/hermes_cli/test_kanban_db.py::test_build_worker_context_tolerates_malformed_comment_timestamp tests/tools/test_kanban_tools.py tests/agent/test_kanban_worker_protocol_guard.py tests/plugins/test_kanban_worker_runs.py -q -o 'addopts='`
- result: 98 passed, 1 warning
- manual dispatcher smoke already validated on board: `t_712e9ed6` devops and `t_a88ee836` pm completed via `kanban_complete`

## Kanban context
Fixes the devops/pm worker protocol violation loop that blocked task `t_3e6448d3` and downstream business cards.
