### PR TITLE
tools/mcp_tool: tighten breaker-open error message to forbid agent-side bypass

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2324,8 +2324,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         f"MCP server '{server_name}' is unreachable after "
                         f"{_server_error_counts[server_name]} consecutive "
                         f"failures. Auto-retry available in ~{remaining}s. "
-                        f"Do NOT retry this tool yet — use alternative "
-                        f"approaches or ask the user to check the MCP server."
+                        f"Do NOT retry this tool yet. Do NOT bypass this server "
+                        f"by using terminal, built-in file tools, or direct "
+                        f"filesystem operations to achieve the same goal — those "
+                        f"writes skip validation and corrupt state. Pause work "
+                        f"that depends on this server and report the outage in "
+                        f"your summary so the operator can intervene."
                     )
                 }, ensure_ascii=False)
             # Cooldown elapsed → fall through as a half-open probe.


### PR DESCRIPTION
## Summary

The breaker-open error message returned by `_call` in `tools/mcp_tool.py`
currently advises agents to "use alternative approaches or ask the user to
check the MCP server" when a server is in the open-breaker cooldown window.

In observed deployments, LLM agents interpret "use alternative approaches"
as license to accomplish the same goal by bypassing the MCP server — e.g.,
writing files directly via the `terminal` tool or built-in file tools.
When the MCP server in question is a validation gateway, those direct
writes skip validation and corrupt state.

This change replaces the advisory with explicit anti-bypass language that:
- names the specific bypass paths to forbid (terminal, built-in file
  tools, direct filesystem operations)
- cites the consequence (writes skip validation and corrupt state)
- directs the agent to pause dependent work and report the outage

## Rationale

Across multiple agent sessions we observed the breaker-open state reliably
triggering validator-bypassed writes: the agent receives the breaker-open
error, treats "use alternative approaches" as guidance, and pivots to
terminal/built-in file writes that land unvalidated content. The breaker
mechanism itself is working correctly (the trips are legitimate); the
problem is purely the message's steering of the agent's next step.

## Scope

Single string-literal change to the breaker-open branch only. The
"is not connected" and transport-error paths are unchanged (they did not
exhibit the bypass pattern in our observations).

## Test plan

- [ ] Message text renders correctly (string-literal change, no logic change)
- [ ] No change to breaker gate/reset behavior