### PR TITLE
fix(cron): skip idle config loads in scheduler tick

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1889,8 +1889,9 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     try:
         due_jobs = get_due_jobs()
 
-        if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+        if not due_jobs:
+            if verbose:
+                logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
             return 0
 
         if verbose:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2584,3 +2584,16 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == str(fast.resolve())
+
+
+def test_tick_skips_config_load_when_no_jobs_due(tmp_path):
+    """Idle cron ticks should return before config/home churn."""
+    from cron import scheduler as sched
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler.get_due_jobs", return_value=[]), \
+         patch("cron.scheduler.load_config") as mock_load_config:
+        result = sched.tick(verbose=False)
+
+    assert result == 0
+    mock_load_config.assert_not_called()


### PR DESCRIPTION
## Summary
- return from `cron.scheduler.tick()` immediately when no jobs are due
- avoid the idle `load_config()` call that re-runs `ensure_hermes_home()` every cron tick
- add a regression test that locks the no-due-jobs branch to zero config loads

## Testing
- `uv run --frozen pytest -o addopts= tests/cron/test_scheduler.py -k 'tick_skips_config_load_when_no_jobs_due or tick_marks_empty_response_as_error'`\n- `uv run --frozen ruff check cron/scheduler.py tests/cron/test_scheduler.py`\n- `git diff --check`\n\nFixes #33453