### PR TITLE
fix(cli): parse yolo env consistently in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3747,7 +3747,7 @@ class HermesCLI:
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
 
-            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
+            yolo_active = is_truthy_value(os.getenv("HERMES_YOLO_MODE"))
             if width < 52:
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
                 if yolo_active:
@@ -3808,7 +3808,7 @@ class HermesCLI:
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
-            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
+            yolo_active = is_truthy_value(os.getenv("HERMES_YOLO_MODE"))
 
             if width < 52:
                 frags = [

--- a/tests/cli/test_cli_background_status_indicator.py
+++ b/tests/cli/test_cli_background_status_indicator.py
@@ -9,6 +9,8 @@ finally block, so len() reflects truly-running tasks.
 import threading
 from datetime import datetime
 
+import pytest
+
 from cli import HermesCLI
 
 
@@ -102,6 +104,50 @@ def test_fragments_omit_bg_segment_when_idle():
     frags = cli_obj._get_status_bar_fragments()
     rendered = "".join(text for _style, text in frags)
     assert "▶" not in rendered
+
+
+@pytest.mark.parametrize("yolo_value", ["false", "0", "off", "no", ""])
+def test_yolo_false_like_values_do_not_show_indicator_in_plain_text(monkeypatch, yolo_value):
+    cli_obj = _make_cli()
+    monkeypatch.setenv("HERMES_YOLO_MODE", yolo_value)
+
+    text = cli_obj._build_status_bar_text(width=80)
+
+    assert "⚠ YOLO" not in text
+
+
+def test_truthy_yolo_value_shows_indicator_in_plain_text(monkeypatch):
+    cli_obj = _make_cli()
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    text = cli_obj._build_status_bar_text(width=80)
+
+    assert "⚠ YOLO" in text
+
+
+@pytest.mark.parametrize("yolo_value", ["false", "0", "off", "no", ""])
+def test_yolo_false_like_values_do_not_show_indicator_in_fragments(monkeypatch, yolo_value):
+    cli_obj = _make_cli()
+    cli_obj._status_bar_visible = True
+    cli_obj._get_tui_terminal_width = lambda: 120  # type: ignore[method-assign]
+    monkeypatch.setenv("HERMES_YOLO_MODE", yolo_value)
+
+    frags = cli_obj._get_status_bar_fragments()
+    rendered = "".join(text for _style, text in frags)
+
+    assert "⚠ YOLO" not in rendered
+
+
+def test_truthy_yolo_value_shows_indicator_in_fragments(monkeypatch):
+    cli_obj = _make_cli()
+    cli_obj._status_bar_visible = True
+    cli_obj._get_tui_terminal_width = lambda: 120  # type: ignore[method-assign]
+    monkeypatch.setenv("HERMES_YOLO_MODE", "true")
+
+    frags = cli_obj._get_status_bar_fragments()
+    rendered = "".join(text for _style, text in frags)
+
+    assert "⚠ YOLO" in rendered
 
 
 # ── Background terminal-process indicator (⚙ N) ───────────────────────────


### PR DESCRIPTION
## Summary of Changes
- Replaced raw `bool(os.getenv("HERMES_YOLO_MODE"))` checks with `is_truthy_value(...)` in the CLI status bar.
- Added regression tests covering false-like and truthy YOLO env values for both plain-text and fragment rendering.

## Optional Details
- This keeps the status bar aligned with Hermes' existing approval logic, so `false`, `0`, `off`, and `no` no longer show `⚠ YOLO`.

## Validation Plan
- `uv run pytest tests/cli/test_cli_background_status_indicator.py -q --timeout-method=thread`
- `uv run ruff check cli.py tests/cli/test_cli_background_status_indicator.py`

Closes #33605