### PR TITLE
fix(gateway): support Docker /workspace media paths in gateway delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -888,6 +888,9 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
 def _media_delivery_allowed_roots() -> List[Path]:
     """Return roots from which model-emitted local media may be delivered."""
     roots = [Path(root) for root in MEDIA_DELIVERY_SAFE_ROOTS]
+    docker_workspace = _docker_workspace_host_root()
+    if docker_workspace is not None:
+        roots.append(docker_workspace)
     extra_roots = os.environ.get(MEDIA_DELIVERY_ALLOW_DIRS_ENV, "")
     for chunk in extra_roots.split(os.pathsep):
         for raw_root in chunk.split(","):
@@ -969,6 +972,64 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
+def _docker_workspace_container_path(candidate: Path) -> bool:
+    """Return True for absolute container paths rooted at ``/workspace``."""
+    if not candidate.is_absolute():
+        return False
+    try:
+        candidate.relative_to("/workspace")
+        return True
+    except ValueError:
+        return False
+
+
+def _docker_workspace_host_root() -> Optional[Path]:
+    """Return the host path backing Docker's default persistent ``/workspace``."""
+    if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+        return None
+    if os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower() not in {"1", "true", "yes", "on"}:
+        return None
+    if os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").strip().lower() in {"1", "true", "yes", "on"}:
+        return None
+
+    raw_volumes = os.getenv("TERMINAL_DOCKER_VOLUMES", "").strip()
+    if raw_volumes:
+        try:
+            import json as _json
+            parsed = _json.loads(raw_volumes)
+        except Exception:
+            parsed = []
+        if isinstance(parsed, list):
+            for spec in parsed:
+                if isinstance(spec, str) and ":/workspace" in spec:
+                    return None
+
+    try:
+        from tools.environments.base import get_sandbox_dir
+
+        root = (get_sandbox_dir() / "docker" / "default" / "workspace").resolve(strict=True)
+    except (ImportError, OSError, RuntimeError, ValueError):
+        return None
+    return root if root.is_dir() else None
+
+
+def _translate_docker_workspace_media_path(candidate: Path) -> Optional[Path]:
+    """Translate ``/workspace/...`` from a Docker container to its host path."""
+    if not _docker_workspace_container_path(candidate):
+        return None
+    host_workspace = _docker_workspace_host_root()
+    if host_workspace is None:
+        return None
+    try:
+        relative = candidate.relative_to("/workspace")
+        translated = (host_workspace / relative).resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if translated != host_workspace and not _path_is_within(translated, host_workspace):
+        return None
+    return translated
+
+
 def validate_media_delivery_path(path: str) -> Optional[str]:
     """Return a safe absolute file path for native media delivery, else None.
 
@@ -991,10 +1052,16 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not expanded.is_absolute():
         return None
 
-    try:
-        resolved = expanded.resolve(strict=True)
-    except (OSError, RuntimeError, ValueError):
+    translated = _translate_docker_workspace_media_path(expanded)
+    if translated is not None:
+        resolved = translated
+    elif _docker_workspace_container_path(expanded) and os.getenv("TERMINAL_ENV", "").strip().lower() == "docker":
         return None
+    else:
+        try:
+            resolved = expanded.resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            return None
 
     if not resolved.is_file():
         return None

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
@@ -373,6 +374,10 @@ class TestMediaDeliveryPathValidation:
         # specifically cover recency trust re-enable it themselves.
         monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
 
+    def _set_hermes_home(self, monkeypatch, hermes_home):
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return set_hermes_home_override(hermes_home)
+
     def test_allows_existing_file_inside_safe_root(self, tmp_path, monkeypatch):
         root = tmp_path / "media-cache"
         media_file = root / "voice.ogg"
@@ -534,6 +539,95 @@ class TestMediaDeliveryPathValidation:
 
         out = BasePlatformAdapter.filter_local_delivery_paths([str(fresh)])
         assert out == [str(fresh.resolve())]
+
+    def test_docker_workspace_media_path_translates_to_host_workspace(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        image = workspace / "foo.png"
+        image.parent.mkdir(parents=True)
+        image.write_bytes(b"fake image")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/foo.png") == str(image.resolve())
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_docker_root_media_path_is_not_translated_or_allowed(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        docker_home = hermes_home / "sandboxes" / "docker" / "default" / "home"
+        secret = docker_home / "foo.png"
+        secret.parent.mkdir(parents=True)
+        secret.write_bytes(b"do not send")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/root/foo.png") is None
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_docker_workspace_media_path_cannot_escape_workspace_via_dotdot(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        docker_home = hermes_home / "sandboxes" / "docker" / "default" / "home"
+        secret = docker_home / "secret.png"
+        workspace.mkdir(parents=True)
+        secret.parent.mkdir(parents=True)
+        secret.write_bytes(b"secret")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/../home/secret.png") is None
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_docker_workspace_media_path_cannot_escape_workspace_via_symlink(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        docker_home = hermes_home / "sandboxes" / "docker" / "default" / "home"
+        secret = docker_home / "secret.png"
+        workspace.mkdir(parents=True)
+        secret.parent.mkdir(parents=True)
+        secret.write_bytes(b"secret")
+        link = workspace / "escape"
+        try:
+            link.symlink_to(docker_home, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation is unavailable")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/escape/secret.png") is None
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_workspace_media_path_not_translated_for_non_docker_backend(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        image = workspace / "foo.png"
+        image.parent.mkdir(parents=True)
+        image.write_bytes(b"fake image")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/foo.png") is None
+        finally:
+            reset_hermes_home_override(token)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Translate Docker-backed `MEDIA:/workspace/...` paths to the host persistent workspace before gateway media delivery validation, and automatically allow that host workspace root for delivery.

This fixes the case where the gateway runs on the host, the agent writes media inside the Docker backend's persistent `/workspace`, and native media delivery currently drops the attachment as an unsafe path because the host cannot resolve the container-local path directly.

## Related Issue

Related to #466 and #31733.

## Type of Change

- 🐛 Bug fix
- ✅ Tests
- 🔒 Security-sensitive path validation change

## Changes Made

- Added Docker `/workspace` host-path translation in [`gateway/platforms/base.py`](gateway/platforms/base.py) before the existing media delivery allowlist / denylist / recency checks run.
- Automatically add the Docker persistent workspace host root to the media delivery allowed roots when the gateway is using the Docker terminal backend.
- Kept `/root/...` blocked by default.
- Rejected `..` traversal and symlink escape attempts out of the translated workspace root.
- Added gateway tests covering:
  - Docker `/workspace/...` positive translation
  - `/root/...` remaining rejected
  - `..` traversal rejection
  - symlink escape rejection
  - non-Docker backends not translating `/workspace/...`

## How to Test

1. Run the focused gateway suites:
   - `scripts/run_tests.sh tests/gateway/test_platform_base.py tests/gateway/test_send_image_file.py tests/gateway/test_tts_media_routing.py`
2. In a Docker-backed Hermes profile with persistent filesystem enabled, generate a file inside `/workspace`, for example `/workspace/hermes-media-test.png`.
3. Emit `MEDIA:/workspace/hermes-media-test.png` and confirm the gateway delivers the file natively instead of dropping it as an unsafe path.
4. Confirm `MEDIA:/root/...` is still rejected.

## Platform Tested

- macOS (`Darwin 25.5.0 arm64`)
- Python `3.13.11`

## Additional Notes

- Focused gateway tests passed locally after rebasing onto the latest upstream `main`.
- I also ran `./.venv/bin/python -m pytest tests/gateway -q -o 'addopts='`; in this local environment that broader suite still reports unrelated existing failures across several gateway/platform areas, so I am not claiming a fully green local `tests/gateway` run here.
- End-to-end secretary / WeChat validation is still pending outside this branch workflow.

