### PR TITLE
fix(skills): sync_skills no longer shadows external_dirs (closes #28126)

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -179,6 +179,80 @@ class TestComputeRelativeDest:
         assert dest.name == "simple"
 
 
+class TestExternalDirsIndexing:
+    """Tests for external_dirs awareness in sync_skills."""
+
+    def _setup_bundled(self, tmp_path):
+        """Create a fake bundled skills directory."""
+        bundled = tmp_path / "bundled_skills"
+        (bundled / "devops" / "clair-qa").mkdir(parents=True)
+        (bundled / "devops" / "clair-qa" / "SKILL.md").write_text("# bundled clair")
+        (bundled / "creative" / "ascii-art").mkdir(parents=True)
+        (bundled / "creative" / "ascii-art" / "SKILL.md").write_text("# bundled ascii")
+        return bundled
+
+    def _setup_external(self, tmp_path):
+        """Create a fake external skills directory."""
+        ext_dir = tmp_path / "external_skills"
+        (ext_dir / "devops" / "clair-qa").mkdir(parents=True)
+        (ext_dir / "devops" / "clair-qa" / "SKILL.md").write_text("# external clair")
+        (ext_dir / "devops" / "clair-qa" / "main.py").write_text("print('ext')")
+        return ext_dir
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        return stack
+
+    def test_shadowed_skill_skipped_and_deferred(self, tmp_path):
+        """When external dir provides the skill, sync_skills should not write it locally."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        ext_dir = self._setup_external(tmp_path)
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("agent.skill_utils.get_external_skills_dirs", return_value=[ext_dir]):
+                result = sync_skills(quiet=True)
+
+        assert "clair-qa" in result["shadowed_by_external"]
+        assert "clair-qa" not in result["copied"]
+        assert "ascii-art" in result["copied"]
+        assert not (skills_dir / "devops" / "clair-qa").exists()
+
+    def test_shadowed_skill_records_in_manifest(self, tmp_path):
+        """Manifest should record the hash for shadowed skills."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        ext_dir = self._setup_external(tmp_path)
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("agent.skill_utils.get_external_skills_dirs", return_value=[ext_dir]):
+                result = sync_skills(quiet=True)
+                manifest = _read_manifest()
+
+        bundled_hash = _dir_hash(bundled / "devops" / "clair-qa")
+        assert manifest["clair-qa"] == bundled_hash
+
+    def test_no_external_dirs_unchanged(self, tmp_path):
+        """Without external_dirs, all bundled skills should be copied normally."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+                result = sync_skills(quiet=True)
+
+        assert "clair-qa" in result["copied"]
+        assert "ascii-art" in result["copied"]
+        assert result["shadowed_by_external"] == []
+
+
 class TestSyncSkills:
     def _setup_bundled(self, tmp_path):
         """Create a fake bundled skills directory."""

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -27,7 +27,7 @@ import os
 import shutil
 from pathlib import Path
 from hermes_constants import get_bundled_skills_dir, get_hermes_home
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,35 @@ def _get_bundled_dir() -> Path:
     path from this source file.
     """
     return get_bundled_skills_dir(Path(__file__).parent.parent / "skills")
+
+
+def _build_external_skill_index() -> Set[str]:
+    """Index every skill available in external_dirs by name and directory path.
+
+    Returns a set of skill names that are already provided by external dirs.
+    Used to prevent sync_skills from shadowing externally-delegated skills.
+    """
+    try:
+        from agent.skill_utils import get_external_skills_dirs, _external_dirs_cache_clear
+    except ImportError:
+        return set()
+
+    # Clear the external dirs cache so our patch takes effect
+    _external_dirs_cache_clear()
+
+    external_names: Set[str] = set()
+    for ext_dir in get_external_skills_dirs():
+        for skill_md in ext_dir.rglob("SKILL.md"):
+            if "/.git/" in str(skill_md) or "/.github/" in str(skill_md):
+                continue
+            skill_dir = skill_md.parent
+            # Index by directory name (how _find_skill resolves skills)
+            external_names.add(skill_dir.name)
+            # Also index by frontmatter name (alternate identifier)
+            frontmatter_name = _read_skill_name(skill_md, "")
+            if frontmatter_name:
+                external_names.add(frontmatter_name)
+    return external_names
 
 
 def _read_manifest() -> Dict[str, str]:
@@ -191,6 +220,9 @@ def sync_skills(quiet: bool = False) -> dict:
     manifest = _read_manifest()
     bundled_skills = _discover_bundled_skills(bundled_dir)
     bundled_names = {name for name, _ in bundled_skills}
+    # Index of skills already provided by external_dirs (skip writing them)
+    external_index = _build_external_skill_index()
+    shadowed_by_external: List[str] = []
 
     copied = []
     updated = []
@@ -203,6 +235,30 @@ def sync_skills(quiet: bool = False) -> dict:
 
         if skill_name not in manifest:
             # ── New skill — never offered before ──
+            # If an external dir already provides this skill, skip writing
+            # to the local tree (avoids shadow collision at load time).
+            if skill_name in external_index:
+                shadowed_by_external.append(skill_name)
+                skipped += 1
+                if not quiet:
+                    print(
+                        f"  ⇢ {skill_name} (deferred to external_dirs, "
+                        "not written to local tree)"
+                    )
+                manifest[skill_name] = bundled_hash
+                # Self-healing: remove stale local shadow if it exists and
+                # was written by a prior buggy sync (origin_hash matches
+                # bundled — meaning we wrote it, not the user).
+                if dest.exists():
+                    origin_hash = manifest.get(skill_name, "")
+                    user_hash = _dir_hash(dest)
+                    if (origin_hash == bundled_hash == user_hash
+                            and skill_name in bundled_names):
+                        # We wrote it, user didn't touch it — clean it up.
+                        shutil.rmtree(dest, ignore_errors=True)
+                        if not quiet:
+                            print(f"  ✓ removed stale shadow of {skill_name}")
+                continue
             try:
                 if dest.exists():
                     # User already has a skill with the same name — don't overwrite.
@@ -313,6 +369,7 @@ def sync_skills(quiet: bool = False) -> dict:
         "user_modified": user_modified,
         "cleaned": cleaned,
         "total_bundled": len(bundled_skills),
+        "shadowed_by_external": shadowed_by_external,
     }
 
 


### PR DESCRIPTION
## Summary

Fixes #28126 (via #33552 as duplicate).

### Problem

`sync_skills` was unconditionally writing every bundled skill into
`<profile_home>/skills/` even when the active profile's `config.yaml`
declared `skills.external_dirs: ["~/.hermes/skills"]`. The skill loader
then saw two candidates for the same skill name (local shadow +
external canonical), refused to resolve on collision, and every kanban
worker that auto-loaded such a skill crashed with:

```
Error: Unknown skill(s): clair-qa-two-stage
```

Three kanban worker cards crashed on the same root cause (May 27, 2026).

### Root cause

`tools/skills_sync.py` did not consult `skills.external_dirs`. It
operated purely on the resolved `HERMES_HOME` path, producing local
shadow writes that the loader's collision detection then refused.

### Fix

1. **`_build_external_skill_index()`** — new function that indexes every
   skill available in external dirs (by directory name and frontmatter
   `name:` field), clearing the module-level cache first so test patches
   take effect.

2. **`sync_skills()`** — before writing a new bundled skill, checks the
   external index. If the name is already provided externally, the bundled
   write is skipped entirely. The hash is still recorded in the manifest
   so subsequent syncs treat it as already handled.

3. **Self-healing** — when a shadowed skill already exists on disk and
   `origin_hash == bundled_hash == user_hash` (we wrote it, user didn't
   touch it), the stale local shadow is removed automatically.

4. **`shadowed_by_external` key** — added to the `sync_skills()` return
   dict so `hermes update` summary can surface what was deferred.

### Verification

```
$ python -m pytest tests/tools/test_skills_sync.py -q
48 passed in 8.90s
```

`-k skills` sweep: 847 passed, 1 pre-existing-flaky unrelated failure.

### Files changed

- `tools/skills_sync.py` (+63/-1)
- `tests/tools/test_skills_sync.py` (+69)

Closes #28126
