### PR TITLE
fix(docker): preserve running gateways across restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1673,6 +1673,7 @@ class GatewayRunner:
     _restart_task_started: bool = False
     _restart_detached: bool = False
     _restart_via_service: bool = False
+    _preserve_running_state_on_signal_shutdown: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
@@ -1716,6 +1717,7 @@ class GatewayRunner:
         self._restart_task_started = False
         self._restart_detached = False
         self._restart_via_service = False
+        self._preserve_running_state_on_signal_shutdown = False
         self._stop_task: Optional[asyncio.Task] = None
         
         # Track running agents per session for interrupt support
@@ -6216,7 +6218,10 @@ class GatewayRunner:
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
 
             self._draining = False
-            self._update_runtime_status("stopped", self._exit_reason)
+            if self._preserve_running_state_on_signal_shutdown:
+                self._update_runtime_status("running", self._exit_reason)
+            else:
+                self._update_runtime_status("stopped", self._exit_reason)
             logger.info("Gateway stopped (total teardown %.2fs)", _phase_elapsed())
 
         self._stop_task = asyncio.create_task(_stop_impl())
@@ -18535,6 +18540,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             )
         else:
             _signal_initiated_shutdown = True
+            runner._preserve_running_state_on_signal_shutdown = True
             logger.info(
                 "Received %s — initiating shutdown",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -770,9 +770,9 @@ def _get_takeover_marker_path() -> Path:
     return home / _TAKEOVER_MARKER_FILENAME
 
 
-def _get_planned_stop_marker_path() -> Path:
+def _get_planned_stop_marker_path(hermes_home: Optional[Path] = None) -> Path:
     """Return the path to the intentional gateway stop marker file."""
-    home = get_hermes_home()
+    home = hermes_home or get_hermes_home()
     return home / _PLANNED_STOP_MARKER_FILENAME
 
 
@@ -883,7 +883,11 @@ def clear_takeover_marker() -> None:
         pass
 
 
-def write_planned_stop_marker(target_pid: int) -> bool:
+def write_planned_stop_marker(
+    target_pid: int,
+    *,
+    hermes_home: Optional[Path] = None,
+) -> bool:
     """Record that ``target_pid`` is being stopped intentionally.
 
     The gateway exits non-zero for unexpected SIGTERM so service managers can
@@ -898,7 +902,7 @@ def write_planned_stop_marker(target_pid: int) -> bool:
             "stopper_pid": os.getpid(),
             "written_at": _utc_now_iso(),
         }
-        _write_json_file(_get_planned_stop_marker_path(), record)
+        _write_json_file(_get_planned_stop_marker_path(hermes_home), record)
         return True
     except (OSError, PermissionError):
         return False

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -556,6 +556,27 @@ class S6ServiceManager:
         return f"{S6_SERVICE_PREFIX}{profile}"
 
     @staticmethod
+    def _profile_name_from_service_name(name: str) -> str:
+        return (
+            name[len(S6_SERVICE_PREFIX):]
+            if name.startswith(S6_SERVICE_PREFIX)
+            else name
+        )
+
+    def _write_planned_stop_marker_for_service(self, name: str) -> None:
+        from gateway.status import get_running_pid, write_planned_stop_marker
+        from hermes_cli.profiles import get_profile_dir
+
+        profile = self._profile_name_from_service_name(name)
+        profile_home = get_profile_dir(profile)
+        pid = get_running_pid(
+            profile_home / "gateway.pid",
+            cleanup_stale=False,
+        )
+        if pid is not None:
+            write_planned_stop_marker(pid, hermes_home=profile_home)
+
+    @staticmethod
     def _render_run_script(
         profile: str,
         extra_env: dict[str, str],
@@ -706,6 +727,7 @@ class S6ServiceManager:
             GatewayNotRegisteredError: no service directory for ``name``.
             S6CommandError: s6-svc exited non-zero for any other reason.
         """
+        self._write_planned_stop_marker_for_service(name)
         self._run_svc("-d", "stop", name)
 
     def restart(self, name: str) -> None:
@@ -715,6 +737,7 @@ class S6ServiceManager:
             GatewayNotRegisteredError: no service directory for ``name``.
             S6CommandError: s6-svc exited non-zero for any other reason.
         """
+        self._write_planned_stop_marker_for_service(name)
         self._run_svc("-t", "restart", name)
 
     def is_running(self, name: str) -> bool:

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -226,3 +226,50 @@ class TestCleanShutdownMarker:
             asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
 
         assert marker.exists(), ".clean_shutdown marker should exist after restart-stop too"
+
+    def test_signal_shutdown_preserves_running_runtime_state(self, tmp_path, monkeypatch):
+        """Unexpected signal shutdown should keep the prior running autostart state."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        monkeypatch.setattr("gateway.status.get_hermes_home", lambda: tmp_path)
+
+        from gateway.run import GatewayRunner
+        from gateway.status import read_runtime_status, write_runtime_status
+
+        write_runtime_status(gateway_state="running", exit_reason=None, restart_requested=False, active_agents=0)
+
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = False
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._preserve_running_state_on_signal_shutdown = True
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = "Received SIGTERM"
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        with patch("gateway.run.GatewayRunner._drain_active_agents", new_callable=AsyncMock, return_value=([], False)), \
+             patch("gateway.run.GatewayRunner._finalize_shutdown_agents"), \
+             patch("gateway.status.remove_pid_file"), \
+             patch("gateway.status.release_gateway_runtime_lock"), \
+             patch("tools.process_registry.process_registry") as mock_proc_reg, \
+             patch("tools.terminal_tool.cleanup_all_environments"), \
+             patch("tools.browser_tool.cleanup_all_browsers"):
+            mock_proc_reg.kill_all = MagicMock()
+
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(runner.stop())
+
+        runtime = read_runtime_status()
+        assert runtime is not None
+        assert runtime["gateway_state"] == "running"
+        assert runtime["exit_reason"] == "Received SIGTERM"

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -676,6 +676,68 @@ def test_s6_lifecycle_dispatches_to_s6_svc(
     assert flags == ["-u", "-d", "-t"]
 
 
+def test_s6_stop_writes_planned_stop_marker_for_profile_home(
+    s6_scandir,
+    fake_subprocess_run,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli.service_manager import S6ServiceManager
+
+    profile_home = s6_scandir / "profiles" / "coder-home"
+    profile_home.mkdir(parents=True)
+    (s6_scandir / "gateway-coder").mkdir()
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: profile_home,
+    )
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **kw: 4321)
+
+    captured: list[tuple[int, object]] = []
+
+    def _capture(pid: int, *, hermes_home=None):
+        captured.append((pid, hermes_home))
+        return True
+
+    monkeypatch.setattr("gateway.status.write_planned_stop_marker", _capture)
+
+    S6ServiceManager(scandir=s6_scandir).stop("gateway-coder")
+
+    assert captured == [(4321, profile_home)]
+    assert any(cmd[0] == "s6-svc" and "-d" in cmd for cmd in fake_subprocess_run)
+
+
+def test_s6_restart_skips_marker_when_gateway_not_running(
+    s6_scandir,
+    fake_subprocess_run,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli.service_manager import S6ServiceManager
+
+    profile_home = s6_scandir / "profiles" / "default-home"
+    profile_home.mkdir(parents=True)
+    (s6_scandir / "gateway-default").mkdir()
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: profile_home,
+    )
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **kw: None)
+
+    marker_calls: list[tuple[int, object]] = []
+
+    def _capture(pid: int, *, hermes_home=None):
+        marker_calls.append((pid, hermes_home))
+        return True
+
+    monkeypatch.setattr("gateway.status.write_planned_stop_marker", _capture)
+
+    S6ServiceManager(scandir=s6_scandir).restart("gateway-default")
+
+    assert marker_calls == []
+    assert any(cmd[0] == "s6-svc" and "-t" in cmd for cmd in fake_subprocess_run)
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle errors — friendly messages, not raw CalledProcessError
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #33597

## Summary
- preserve `running` in `gateway_state.json` when the gateway is torn down by an unexpected signal such as container restart
- write planned-stop markers for s6 `stop` and `restart` so explicit user actions still persist `stopped`
- cover the new shutdown-state and s6 marker behavior with targeted regression tests

## Testing
- `uv run --frozen pytest -o addopts= tests/gateway/test_clean_shutdown_marker.py tests/hermes_cli/test_service_manager.py`\n- `uv run --frozen ruff check gateway/run.py gateway/status.py hermes_cli/service_manager.py tests/gateway/test_clean_shutdown_marker.py tests/hermes_cli/test_service_manager.py`\n- `git diff --check`