### PR TITLE
fix(docker): tee supervised gateway stdout to docker logs

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -628,6 +628,38 @@ class S6ServiceManager:
         — so a container started with ``-e HERMES_HOME=/data/hermes``
         gets its logs under /data/hermes/logs/..., not the build-time
         default.
+
+        Output routing — the script is two action directives, applied
+        per line, in order:
+
+          1. ``1`` (forward to stdout) — propagates the line up the
+             s6-supervise pipeline to /init's stdout, which is the
+             container's stdout, which is ``docker logs``. Without
+             this, supervised stdout would be terminated inside
+             s6-log and never reach the container's log stream;
+             users would have to ``docker exec`` and ``tail`` the
+             file just to see startup banners. (Python's ``logging``
+             module defaults to stderr, which s6-supervise leaves
+             unfiltered — so warnings/errors already reach docker
+             logs. This change is specifically about the rich-console
+             banner output and other plain stdout writes.)
+          2. ``T <log_dir>`` — also write a timestamped copy to the
+             rotated log directory (``current`` + archived ``@*.s``
+             files). This is what ``hermes logs`` reads and what
+             persists across container restarts via the volume mount.
+
+        ``T`` is non-sticky: it only prefixes lines for the next
+        action directive. We deliberately put ``T`` between ``1``
+        and the log dir (not before ``1``) so:
+
+          * ``docker logs`` shows raw lines — Python's logging
+            formatter has its own timestamps, and ``docker logs
+            --timestamps`` adds a third layer when desired. No
+            double-stamping in the most common reading path.
+          * The persisted file gets s6-log's own ISO 8601 timestamp
+            so even output that lacked a Python-logger timestamp
+            (rich banners, third-party libs' raw prints) is
+            correlatable in ``current``.
         """
         import shlex
         prof = shlex.quote(profile)
@@ -638,7 +670,7 @@ class S6ServiceManager:
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
             f'mkdir -p "$log_dir"\n'
             f'chown -R hermes:hermes "$log_dir" 2>/dev/null || true\n'
-            f'exec s6-setuidgid hermes s6-log n10 s1000000 T "$log_dir"\n'
+            f'exec s6-setuidgid hermes s6-log 1 n10 s1000000 T "$log_dir"\n'
         )
 
     # -- lifecycle ---------------------------------------------------------

--- a/tests/docker/test_gateway_run_supervised.py
+++ b/tests/docker/test_gateway_run_supervised.py
@@ -327,3 +327,69 @@ def test_dashboard_supervised_when_env_set(
     assert _svstat_wants_up(container_name, "dashboard"), (
         f"dashboard slot not up: {_svstat(container_name, 'dashboard')!r}"
     )
+
+
+def test_supervised_gateway_stdout_reaches_docker_logs(
+    built_image: str, container_name: str,
+) -> None:
+    """The supervised gateway's stdout — including the rich-console
+    startup banner — must reach ``docker logs``, not just the rotated
+    log file under ``${HERMES_HOME}/logs/gateways/<profile>/current``.
+
+    Without the ``1`` action directive in ``_render_log_run``, s6-log
+    swallows the gateway's stdout into the file and ``docker logs``
+    only sees stderr (Python ``logging`` defaults to stderr). That's
+    a poor user experience: the iconic "Hermes Gateway Starting…"
+    banner with the ⚕ symbol is the most visible "yes, your gateway
+    started" signal, and forcing users to ``docker exec`` + ``tail``
+    the log file just to see it is friction users don't expect.
+
+    With the ``1`` directive, s6-log forwards every line to its own
+    stdout (which propagates up through the s6-supervise pipeline to
+    /init's stdout = container stdout = ``docker logs``) AND also
+    writes a timestamped copy to the rotated file. Best of both.
+
+    We assert by looking for the literal banner glyph (``⚕``) — a
+    distinctive character that won't appear in stderr-routed
+    Python-logging output, so its presence in ``docker logs`` proves
+    the stdout-tee is working.
+    """
+    subprocess.run(
+        ["docker", "run", "-d", "--name", container_name, built_image,
+         "gateway", "run"],
+        check=True, capture_output=True, timeout=30,
+    )
+    # Banner is printed during gateway startup — give it time to
+    # initialize past the imports + config-load phase.
+    time.sleep(8)
+
+    logs = subprocess.run(
+        ["docker", "logs", container_name],
+        capture_output=True, text=True, timeout=10,
+    )
+    combined = logs.stdout + logs.stderr
+
+    # The banner ⚕ symbol is the load-bearing assertion — it's unique
+    # to gateway startup stdout output and won't appear in stderr
+    # (Python logging) or s6 boot messages.
+    assert "⚕" in combined or "Hermes Gateway Starting" in combined, (
+        "Supervised gateway's stdout banner did not reach docker logs. "
+        "This means the `1` action directive in _render_log_run isn't "
+        "forwarding stdout to /init. "
+        f"docker logs (last 2000 chars):\n{combined[-2000:]}\n"
+        f"file contents:\n{_sh(container_name, 'cat /opt/data/logs/gateways/default/current').stdout}"
+    )
+
+    # Cross-check: the same banner must also be in the rotated log
+    # file (we kept the file destination, just added stdout). The
+    # file version has s6-log's ISO 8601 timestamp prefix; the
+    # docker logs version is raw.
+    file_contents = _sh(
+        container_name, "cat /opt/data/logs/gateways/default/current",
+    ).stdout
+    assert "⚕" in file_contents or "Hermes Gateway Starting" in file_contents, (
+        "Banner also missing from rotated log file — the file "
+        "destination may have been dropped by the new s6-log script. "
+        f"File contents:\n{file_contents}"
+    )
+

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -555,6 +555,16 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
     assert "/opt/data/logs/gateways/coder" not in log_text, (
         "log_dir was hard-coded; must use ${HERMES_HOME} at run time"
     )
+    # `1` action directive forwards lines to stdout BEFORE the file
+    # destination so the supervised gateway's stdout (including the
+    # rich-console banner and plain print() output) reaches docker
+    # logs, not just the rotated file. See _render_log_run's docstring
+    # for the full output-routing rationale.
+    assert "s6-log 1 " in log_text, (
+        "log/run must include the `1` action directive before the file "
+        "destination so supervised stdout reaches docker logs. Saw: "
+        f"{log_text!r}"
+    )
 
     # s6-svscanctl -a was invoked against the scandir
     assert any(

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -49,6 +49,15 @@ You'll see a one-line breadcrumb in `docker logs` confirming the upgrade. To opt
 This behavior applies to the s6-based image only. Earlier (tini-based) images still run `gateway run` as the foreground main process.
 :::
 
+:::note Where gateway logs go
+Inside the s6 image, the supervised gateway's output is tee'd to two destinations:
+
+- **`docker logs <container>`** — every line in real time (raw, no extra prefix). This is the same stream you'd get from a foreground gateway, so existing `docker logs --follow` / `--timestamps` / log-shipper integrations work unchanged.
+- **`${HERMES_HOME}/logs/gateways/<profile>/current`** (mapped to `~/.hermes/logs/gateways/<profile>/current` on the host via the volume mount) — rotated, with an ISO 8601 timestamp prepended per line. Rotation is 10 archives × 1 MB each, so it can't fill the disk. This is what `hermes logs` reads and what survives container restarts.
+
+The per-profile reconciler keeps a separate audit log at `${HERMES_HOME}/logs/container-boot.log` — one line per profile per container boot, recording whether each gateway was restored to its prior state.
+:::
+
 Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond `127.0.0.1` inside the container, also set `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (minimum 8 characters — generate one with `openssl rand -hex 32`). Example:
 
 ```sh


### PR DESCRIPTION
## Summary

Follow-up to #33583 (the `gateway run` auto-supervise redirect).

Before this fix, the supervised gateway's **stdout** was swallowed by `s6-log` into the rotated file at `${HERMES_HOME}/logs/gateways/<profile>/current` and never reached `docker logs`. Operational signal lived in two places, depending on which fd a given log line went to:

| Stream | Where it went today | Result |
|---|---|---|
| Python `logging` (stderr) | `docker logs` ✓ | warnings/errors visible |
| Rich-console banners, `print()`, raw stdout writes | rotated file only ✗ | hidden from `docker logs` |

Users running `docker run … gateway run` against the s6 image would see *partial* output in `docker logs` (warnings yes, the iconic ⚕ Hermes Gateway Starting banner no), conclude something was broken, and have to `docker exec` + tail the file to find the missing pieces.

## Fix

Add the `1` s6-log action directive before the file destination so each line is forwarded to s6-log's stdout — which propagates up through the s6-supervise pipeline to /init's stdout = container stdout = `docker logs`. The file destination is **preserved as a second destination**, so the rotated log (with ISO 8601 timestamps) still exists for `hermes logs` and for survival across container restarts.

```diff
- exec s6-setuidgid hermes s6-log    n10 s1000000 T "$log_dir"
+ exec s6-setuidgid hermes s6-log  1 n10 s1000000 T "$log_dir"
```

## Trade-off: timestamps

`T` is non-sticky in s6-log — it only prefixes lines for the *next* action directive. Putting `T` between `1` and the file (not before `1`) means:

- **`docker logs`** shows raw lines. Python's logging formatter already has its own timestamps, and `docker logs --timestamps` adds another layer when desired. No double-stamping in the common reading path.
- **The rotated file** gets s6-log's ISO 8601 timestamp so even output that lacked a Python-logger timestamp (rich banners, third-party raw prints) is correlatable in `current`.

## Verification

### Unit test

New assertion in `test_service_manager.py` locks the `s6-log 1 ` directive into the rendered run-script. **Mutation-tested**: reverted the source to the pre-fix script (no `1`); the assert caught it cleanly with a clear failure message naming the missing directive.

### Docker harness test

New `test_supervised_gateway_stdout_reaches_docker_logs` (in `tests/docker/test_gateway_run_supervised.py`):
- Builds the image
- Runs `docker run -d <image> gateway run`
- Asserts the unique `⚕` banner glyph (or "Hermes Gateway Starting" text) reaches `docker logs`
- Cross-asserts the same banner is also in the rotated log file (so we haven't lost the file destination)

**End-to-end mutation-tested**: built a deliberately-broken image without the `1` directive; the test failed exactly as designed, with the diagnostic showing the banner present in `current` but absent from `docker logs`.

### Regression sweep

- `tests/hermes_cli/` — 5,561 tests pass, 0 fail
- `tests/docker/` — 27 tests pass (5 existing in `test_gateway_run_supervised.py` + the new one, plus 21 in the other 7 docker test files), 0 fail

## Docs

`website/docs/user-guide/docker.md` gains a new `:::note Where gateway logs go` admonition documenting both destinations explicitly (the supervised stdout → docker logs, the rotated file → `hermes logs` reads it, persisted via volume mount) plus the audit log at `${HERMES_HOME}/logs/container-boot.log`. The existing `:::tip Gateway runs supervised` admonition's claim that "`docker logs` shows the supervised gateway's output" — which was previously aspirational — is now actually correct.

## Files

| File | Change |
|---|---|
| `hermes_cli/service_manager.py` | One-character fix on the s6-log invocation (`1 ` insertion) + expanded docstring explaining the routing |
| `tests/hermes_cli/test_service_manager.py` | New assertion locking the `1` directive |
| `tests/docker/test_gateway_run_supervised.py` | New harness test verifying end-to-end stdout flow |
| `website/docs/user-guide/docker.md` | New `:::note Where gateway logs go` admonition |