### PR TITLE
plumbing(model_tools, tools/registry): propagate session_id to tool dispatch

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -836,12 +836,14 @@ def handle_function_call(
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
+                session_id=session_id,
                 enabled_tools=sandbox_enabled,
             )
         else:
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
+                session_id=session_id,
                 user_task=user_task,
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -397,6 +397,21 @@ class ToolRegistry:
         entry = self.get_entry(name)
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
+        # Filter kwargs by handler signature so callers can pass cross-cutting
+        # context kwargs (e.g. session_id) without breaking handlers that
+        # don't declare them. Handlers opt in by listing the parameter or
+        # accepting **kwargs. Also fixes a pre-existing latent bug where
+        # handlers with fixed signatures TypeError silently inside the broad
+        # except below when called with unexpected kwargs (e.g. user_task).
+        try:
+            import inspect
+            sig = inspect.signature(entry.handler)
+            params = sig.parameters
+            accepts_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+            if not accepts_var_kw:
+                kwargs = {k: v for k, v in kwargs.items() if k in params}
+        except (TypeError, ValueError):
+            pass  # builtins / C-impls — pass through unchanged
         try:
             if entry.is_async:
                 from model_tools import _run_async


### PR DESCRIPTION
## Summary

`handle_function_call()` in `model_tools.py` receives a `session_id` parameter but doesn't propagate it to `registry.dispatch()` on either dispatch branch. The result: tool handlers can observe `session_id` indirectly through the `pre_tool_call` / `post_tool_call` hook boundaries, but cannot read it inside the handler body itself.

This small plumbing gap blocks plugin patterns where the tool dispatch boundary is the natural place to resolve session-scoped identity (per-session auth context, per-session memory routing, multi-tenant tool routing).

## What the PR does

**1. `model_tools.handle_function_call`** — pass `session_id` to both `registry.dispatch()` call sites alongside the existing `task_id` / `user_task` / `enabled_tools` kwargs.

**2. `tools/registry.ToolRegistry.dispatch`** — filter `**kwargs` by the handler's signature before invocation, so new context kwargs are non-breaking for handlers that don't accept them.

The signature filter has a useful side effect: it also fixes a latent pre-existing issue where handlers without `**kwargs` that don't list `user_task` already `TypeError` silently inside the broad `except Exception` below, masking the real error from the model.

## Backwards compatibility

Zero handler changes required.

- Handlers that want `session_id` add it to their signature with a default (matching the existing `task_id` convention).
- All other handlers continue to receive exactly the kwargs they accept; the filter strips anything they don't declare.
- C-implemented handlers (where `inspect.signature` raises) fall through to pass-through behavior — preserving today's semantics for that edge case.

## Use case

BLU's per-member-container architecture ships a BLU auth plugin that needs session-scoped identity at the tool dispatch boundary. Without this change, the plugin can observe identity in `pre_tool_call` (which fires before dispatch) and `post_tool_call` (which fires after) but cannot read it from inside the tool handler itself — meaning the handler can't make identity-dependent decisions during execution.

This is a generally-useful pattern beyond BLU's specific use case — any multi-tenant deployment that wants per-session tool routing benefits.

## Test plan

- [x] Existing test suite still green (registry/dispatch tests unchanged)
- [x] Manually verified end-to-end: tool handler that declares `session_id=None` parameter now receives it on dispatch
- [x] Manually verified handlers without `session_id` parameter still work (kwarg filter strips it)
- [x] Manually verified handlers with `**kwargs` receive the full kwargs (filter is no-op for var-keyword handlers)
- [ ] CI green on this branch

## Notes for reviewers

- The signature filter uses `inspect.signature()` with a `(TypeError, ValueError)` fallback. The fallback covers C-implemented functions whose signatures `inspect` cannot introspect — these are rare in the handler tree but the defensive path preserves today's behavior for them.
- A test recommendation: lock the filter behavior in `tests/agent/test_tool_dispatch.py` with one test for "handler accepts kwarg → passes through" and one for "handler doesn't accept kwarg → filtered out".
