### PR TITLE
fix(gateway): restore session transcript fallback

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -740,6 +740,76 @@ class SessionStore:
             except OSError as e:
                 logger.debug("Could not remove temp file %s: %s", tmp_path, e)
             raise
+
+    def _transcript_path(self, session_id: str) -> Path:
+        """Return the legacy JSONL transcript path for a session."""
+        return self.sessions_dir / f"{session_id}.jsonl"
+
+    def _append_transcript_jsonl(self, session_id: str, message: Dict[str, Any]) -> None:
+        """Append one transcript entry to the JSONL fallback log."""
+        try:
+            self.sessions_dir.mkdir(parents=True, exist_ok=True)
+            path = self._transcript_path(session_id)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(message, ensure_ascii=False, default=str))
+                f.write("\n")
+        except OSError as e:
+            logger.debug("Failed to append transcript JSONL for %s: %s", session_id, e)
+
+    def _rewrite_transcript_jsonl(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        """Rewrite the JSONL fallback log for a session."""
+        path = self._transcript_path(session_id)
+        if not messages:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.debug("Failed to remove empty transcript JSONL for %s: %s", session_id, e)
+            return
+
+        import tempfile
+
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.sessions_dir), suffix=".tmp", prefix=f".{session_id}_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                for message in messages:
+                    f.write(json.dumps(message, ensure_ascii=False, default=str))
+                    f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+            atomic_replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError as e:
+                logger.debug("Could not remove temp file %s: %s", tmp_path, e)
+            raise
+
+    def _load_transcript_jsonl(self, session_id: str) -> List[Dict[str, Any]]:
+        """Load transcript entries from the JSONL fallback log."""
+        path = self._transcript_path(session_id)
+        if not path.exists():
+            return []
+        try:
+            messages: List[Dict[str, Any]] = []
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    payload = json.loads(line)
+                    if isinstance(payload, dict):
+                        messages.append(payload)
+            return messages
+        except (OSError, json.JSONDecodeError) as e:
+            logger.debug("Failed to load transcript JSONL for %s: %s", session_id, e)
+            return []
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
@@ -1257,6 +1327,7 @@ class SessionStore:
                      _flush_messages_to_session_db(), preventing the
                      duplicate-write bug (#860).
         """
+        self._append_transcript_jsonl(session_id, message)
         if self._db and not skip_db:
             try:
                 self._db.append_message(
@@ -1286,8 +1357,9 @@ class SessionStore:
         """Replace the entire transcript for a session with new messages.
 
         Used by /retry, /undo, and /compress to persist modified conversation
-        history. state.db is the canonical store.
+        history. state.db stays canonical; JSONL is a recovery fallback.
         """
+        self._rewrite_transcript_jsonl(session_id, messages)
         if self._db:
             try:
                 self._db.replace_messages(session_id, messages)
@@ -1297,17 +1369,19 @@ class SessionStore:
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
 
-        state.db is the canonical store. The legacy JSONL fallback was removed
-        in spec 002 — pre-DB sessions on existing disks have already been
-        migrated (their DB row holds the full message history).
+        Prefer state.db. Fall back to the JSONL transcript when DB is
+        unavailable or returns no rows, so cached gateway sessions can still
+        resume after DB write failures or corruption.
         """
         if not self._db:
-            return []
+            return self._load_transcript_jsonl(session_id)
         try:
-            return self._db.get_messages_as_conversation(session_id)
+            messages = self._db.get_messages_as_conversation(session_id)
+            if messages:
+                return messages
         except Exception as e:
             logger.debug("Could not load messages from DB: %s", e)
-            return []
+        return self._load_transcript_jsonl(session_id)
 
 
 def build_session_context(

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -545,8 +545,8 @@ class TestSessionStoreRewriteTranscript:
         assert reloaded == []
 
 
-class TestLoadTranscriptDBOnly:
-    """After spec 002, load_transcript reads only from state.db."""
+class TestLoadTranscriptFallback:
+    """SessionStore prefers DB but can fall back to JSONL transcripts."""
 
     def test_db_only_returns_empty_for_nonexistent(self, tmp_path, monkeypatch):
         import hermes_state
@@ -556,7 +556,7 @@ class TestLoadTranscriptDBOnly:
         result = store.load_transcript("nonexistent")
         assert result == []
 
-    def test_db_only_returns_messages(self, tmp_path, monkeypatch):
+    def test_db_returns_messages_when_present(self, tmp_path, monkeypatch):
         import hermes_state
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
         config = GatewayConfig()
@@ -570,6 +570,30 @@ class TestLoadTranscriptDBOnly:
         assert len(result) == 2
         assert result[0]["content"] == "db-q"
         assert result[1]["content"] == "db-a"
+
+    def test_falls_back_to_jsonl_when_db_has_no_rows(self, tmp_path, monkeypatch):
+        import hermes_state
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        sid = "jsonl_fallback_session"
+        store._db.create_session(session_id=sid, source="gateway", model="m")
+
+        (tmp_path / f"{sid}.jsonl").write_text(
+            '\n'.join(
+                [
+                    json.dumps({"role": "user", "content": "from-jsonl-q"}),
+                    json.dumps({"role": "assistant", "content": "from-jsonl-a"}),
+                ]
+            )
+            + '\n',
+            encoding="utf-8",
+        )
+
+        result = store.load_transcript(sid)
+        assert len(result) == 2
+        assert result[0]["content"] == "from-jsonl-q"
+        assert result[1]["content"] == "from-jsonl-a"
 
 
 class TestSessionStoreSwitchSession:

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -170,10 +170,10 @@ class TestFlushDeduplication:
 # ---------------------------------------------------------------------------
 
 class TestAppendToTranscriptSkipDb:
-    """Verify skip_db=True skips the SQLite write."""
+    """Verify skip_db=True skips SQLite but keeps the JSONL fallback."""
 
     def test_skip_db_prevents_sqlite_write(self, tmp_path):
-        """With skip_db=True and a real DB, message does NOT appear in SQLite."""
+        """With skip_db=True, SQLite stays empty but JSONL still advances."""
         from gateway.config import GatewayConfig
         from gateway.session import SessionStore
         from hermes_state import SessionDB
@@ -196,6 +196,11 @@ class TestAppendToTranscriptSkipDb:
         # SQLite should NOT have the message
         rows = db.get_messages(session_id)
         assert len(rows) == 0, f"Expected 0 DB rows with skip_db=True, got {len(rows)}"
+        transcript_path = tmp_path / f"{session_id}.jsonl"
+        assert transcript_path.exists()
+        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["content"] == "hello world"
 
     def test_default_writes_to_sqlite(self, tmp_path):
         """Without skip_db, message appears in SQLite."""


### PR DESCRIPTION
## Summary
- restore JSONL transcript writes in `SessionStore.append_to_transcript` and rewrites in `rewrite_transcript`
- fall back to the JSONL backup when DB transcript rows are missing or unreadable
- add regression tests for DB-empty fallback and skip_db transcript persistence

Closes #33563.

## Testing
- uv run --frozen pytest -o addopts= tests/gateway/test_session.py -k "LoadTranscriptFallback or RewriteTranscript"
- uv run --frozen pytest -o addopts= tests/run_agent/test_860_dedup.py -k "skip_db or default_writes_to_sqlite"
- uv run --frozen ruff check gateway/session.py tests/gateway/test_session.py tests/run_agent/test_860_dedup.py
- git diff --check

## Proof
- `.paperclip_artifacts/quality-gate/proof-71574eb3ceb2ffb505bb8f98ef96951c14904784.json`