### PR TITLE
feat(dashboard): surface plugin provider setup

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11,6 +11,7 @@ Usage:
 
 import asyncio
 import hmac
+import importlib
 import importlib.util
 import json
 import logging
@@ -45,6 +46,7 @@ from hermes_cli.config import (
     save_config,
     save_env_value,
     remove_env_value,
+    set_config_value,
     check_config_version,
     redact_key,
 )
@@ -4417,6 +4419,120 @@ def _strip_dashboard_manifest(p: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in p.items() if not k.startswith("_")}
 
 
+def _registry_provider_metadata(registry_module: str, label: str) -> Dict[str, Dict[str, Any]]:
+    """Return registered provider setup metadata for a plugin registry."""
+    providers: Dict[str, Dict[str, Any]] = {}
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+
+        get_plugin_manager().discover_and_load()
+        registry = importlib.import_module(registry_module)
+        for provider in registry.list_providers():
+            try:
+                schema = provider.get_setup_schema() or {}
+            except Exception:
+                schema = {}
+            try:
+                available = bool(provider.is_available())
+            except Exception:
+                available = False
+            name = str(getattr(provider, "name", "") or "").strip()
+            if not name:
+                continue
+            providers[name] = {
+                "name": name,
+                "display_name": getattr(provider, "display_name", name),
+                "available": available,
+                "setup_schema": schema,
+            }
+    except Exception as exc:
+        _log.debug("Could not load %s provider metadata: %s", label, exc)
+    return providers
+
+
+def _web_provider_metadata() -> Dict[str, Dict[str, Any]]:
+    """Return registered web-provider metadata for the plugins hub."""
+    providers: Dict[str, Dict[str, Any]] = {}
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+
+        get_plugin_manager().discover_and_load()
+        from agent.web_search_registry import list_providers
+
+        for provider in list_providers():
+            try:
+                schema = provider.get_setup_schema() or {}
+            except Exception:
+                schema = {}
+            try:
+                available = bool(provider.is_available())
+            except Exception:
+                available = False
+            providers[provider.name] = {
+                "name": provider.name,
+                "display_name": getattr(provider, "display_name", provider.name),
+                "available": available,
+                "supports_search": bool(provider.supports_search()),
+                "supports_extract": bool(provider.supports_extract()),
+                "supports_crawl": bool(provider.supports_crawl()),
+                "setup_schema": schema,
+            }
+    except Exception as exc:
+        _log.debug("Could not load web provider metadata: %s", exc)
+    return providers
+
+
+def _setup_env_fields(
+    env_specs: List[Any],
+    env_on_disk: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Build redacted env-entry prompts declared by plugin setup metadata."""
+    fields: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw_item in env_specs:
+        item = {"key": raw_item} if isinstance(raw_item, str) else raw_item
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("key") or "").strip()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        info = OPTIONAL_ENV_VARS.get(key, {})
+        value = env_on_disk.get(key)
+        fields.append({
+            "key": key,
+            "prompt": item.get("prompt") or info.get("prompt") or key,
+            "description": item.get("description") or info.get("description") or "",
+            "url": item.get("url") or info.get("url"),
+            "password": bool(item.get("password", info.get("password", True))),
+            "tools": info.get("tools", []),
+            "is_set": bool(value),
+            "redacted_value": redact_key(value) if value else None,
+        })
+    return fields
+
+
+def _provider_setup_env_specs(
+    provider_names: List[str],
+    provider_meta: Dict[str, Dict[str, Any]],
+) -> List[Any]:
+    """Return env-var specs declared by provider plugin setup schemas."""
+    specs: List[Any] = []
+    for provider_name in provider_names:
+        schema = (provider_meta.get(provider_name) or {}).get("setup_schema") or {}
+        specs.extend(schema.get("env_vars") or [])
+    return specs
+
+
+def _plugin_provider_names(manifest_data: Dict[str, Any], field: str) -> List[str]:
+    """Read provider names from a plugin manifest field."""
+    return [
+        str(p).strip()
+        for p in (manifest_data.get(field) or [])
+        if str(p).strip()
+    ]
+
+
 def _merged_plugins_hub() -> Dict[str, Any]:
     """Agent discovery + dashboard manifests + optional provider picker metadata."""
     from hermes_cli.plugins_cmd import (
@@ -4435,10 +4551,18 @@ def _merged_plugins_hub() -> Dict[str, Any]:
 
     disabled_set = _get_disabled_set()
     enabled_set = _get_enabled_set()
+    web_provider_meta = _web_provider_metadata()
+    browser_provider_meta = _registry_provider_metadata("agent.browser_registry", "browser")
+    image_provider_meta = _registry_provider_metadata("agent.image_gen_registry", "image_gen")
+    video_provider_meta = _registry_provider_metadata("agent.video_gen_registry", "video_gen")
+    tts_provider_meta = _registry_provider_metadata("agent.tts_registry", "tts")
+    stt_provider_meta = _registry_provider_metadata("agent.transcription_registry", "transcription")
+    env_on_disk = load_env()
 
     # Read user-hidden plugins from config for the user_hidden field.
     config = load_config()
     hidden_plugins: list = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
+    web_cfg = config.get("web") if isinstance(config.get("web"), dict) else {}
 
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
     rows: List[Dict[str, Any]] = []
@@ -4483,6 +4607,39 @@ def _merged_plugins_hub() -> Dict[str, Any]:
             except Exception:
                 pass
 
+        web_provider_names = _plugin_provider_names(manifest_data, "provides_web_providers")
+        browser_provider_names = _plugin_provider_names(manifest_data, "provides_browser_providers")
+        image_provider_names = _plugin_provider_names(manifest_data, "provides_image_gen_providers")
+        video_provider_names = _plugin_provider_names(manifest_data, "provides_video_gen_providers")
+        tts_provider_names = _plugin_provider_names(manifest_data, "provides_tts_providers")
+        stt_provider_names = _plugin_provider_names(manifest_data, "provides_transcription_providers")
+
+        # Bundled image/video plugin manifests predate explicit
+        # provides_*_providers fields; their discovery name is category/name.
+        if not image_provider_names and name.startswith("image_gen/"):
+            image_provider_names = [name.split("/", 1)[1]]
+        if not video_provider_names and name.startswith("video_gen/"):
+            video_provider_names = [name.split("/", 1)[1]]
+
+        web_providers = [
+            {k: v for k, v in (web_provider_meta.get(pname) or {"name": pname}).items() if k != "setup_schema"}
+            for pname in web_provider_names
+        ]
+
+        setup_env_specs: List[Any] = []
+        for provider_names, provider_meta in (
+            (web_provider_names, web_provider_meta),
+            (browser_provider_names, browser_provider_meta),
+            (image_provider_names, image_provider_meta),
+            (video_provider_names, video_provider_meta),
+            (tts_provider_names, tts_provider_meta),
+            (stt_provider_names, stt_provider_meta),
+        ):
+            setup_env_specs.extend(_provider_setup_env_specs(provider_names, provider_meta))
+        manifest_requires_env = manifest_data.get("requires_env") or []
+        if isinstance(manifest_requires_env, list):
+            setup_env_specs.extend(manifest_requires_env)
+
         rows.append({
             "name": name,
             "version": version or "",
@@ -4497,6 +4654,8 @@ def _merged_plugins_hub() -> Dict[str, Any]:
             "auth_required": auth_required,
             "auth_command": auth_command,
             "user_hidden": name in hidden_plugins,
+            "web_providers": web_providers,
+            "setup_env": _setup_env_fields(setup_env_specs, env_on_disk),
         })
 
     agent_names = {r["name"] for r in rows}
@@ -4528,6 +4687,13 @@ def _merged_plugins_hub() -> Dict[str, Any]:
             "memory_options": memory_providers,
             "context_engine": _get_current_context_engine(),
             "context_options": context_engines,
+            "web_search_backend": str(web_cfg.get("search_backend") or ""),
+            "web_extract_backend": str(web_cfg.get("extract_backend") or ""),
+            "web_backend": str(web_cfg.get("backend") or ""),
+            "web_options": [
+                {k: v for k, v in meta.items() if k != "setup_schema"}
+                for meta in sorted(web_provider_meta.values(), key=lambda item: str(item.get("display_name") or item.get("name")))
+            ],
         },
     }
 
@@ -4625,11 +4791,14 @@ async def delete_agent_plugin(request: Request, name: str):
 class _PluginProvidersPutBody(BaseModel):
     memory_provider: Optional[str] = None
     context_engine: Optional[str] = None
+    web_search_backend: Optional[str] = None
+    web_extract_backend: Optional[str] = None
+    web_backend: Optional[str] = None
 
 
 @app.put("/api/dashboard/plugin-providers")
 async def put_plugin_providers(request: Request, body: _PluginProvidersPutBody):
-    """Persist memory provider / context engine selection (writes config.yaml)."""
+    """Persist runtime provider selections (writes config.yaml)."""
     _require_token(request)
     from hermes_cli.plugins_cmd import (
         _save_context_engine,
@@ -4640,6 +4809,12 @@ async def put_plugin_providers(request: Request, body: _PluginProvidersPutBody):
         _save_memory_provider(body.memory_provider)
     if body.context_engine is not None:
         _save_context_engine(body.context_engine)
+    if body.web_search_backend is not None:
+        set_config_value("web.search_backend", body.web_search_backend)
+    if body.web_extract_backend is not None:
+        set_config_value("web.extract_backend", body.web_extract_backend)
+    if body.web_backend is not None:
+        set_config_value("web.backend", body.web_backend)
     return {"ok": True}
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -218,6 +218,62 @@ class TestWebServerEndpoints:
         # Should contain known env var names
         assert any(k.endswith("_API_KEY") or k.endswith("_TOKEN") for k in data.keys())
 
+    def test_setup_env_fields_redacts_values_and_deduplicates(self):
+        """Plugin setup metadata must never expose raw stored credentials."""
+        import hermes_cli.web_server as web_server
+
+        fields = web_server._setup_env_fields(
+            [
+                "FAL_KEY",
+                {
+                    "key": "BRAVE_SEARCH_API_KEY",
+                    "prompt": "Brave Search API key",
+                    "url": "https://brave.com/search/api/",
+                },
+                {"key": "BRAVE_SEARCH_API_KEY", "prompt": "Duplicate"},
+            ],
+            {
+                "BRAVE_SEARCH_API_KEY": "brv-secret-value-123456",
+                "FAL_KEY": "fal-secret-value-123456",
+            },
+        )
+
+        assert [field["key"] for field in fields] == ["FAL_KEY", "BRAVE_SEARCH_API_KEY"]
+        assert fields[0]["is_set"] is True
+        assert fields[0]["redacted_value"] != "fal-secret-value-123456"
+        assert fields[1]["is_set"] is True
+        assert fields[1]["redacted_value"] != "brv-secret-value-123456"
+        assert "secret-value" not in fields[1]["redacted_value"]
+        assert fields[1]["url"] == "https://brave.com/search/api/"
+
+    def test_plugin_providers_persists_web_backend_keys(self, monkeypatch):
+        """The dashboard provider endpoint writes only the fixed web config paths."""
+        import hermes_cli.web_server as web_server
+
+        calls = []
+        monkeypatch.setattr(
+            web_server,
+            "set_config_value",
+            lambda key, value: calls.append((key, value)),
+        )
+
+        resp = self.client.put(
+            "/api/dashboard/plugin-providers",
+            json={
+                "web_search_backend": "brave-free",
+                "web_extract_backend": "firecrawl",
+                "web_backend": "",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert calls == [
+            ("web.search_backend", "brave-free"),
+            ("web.extract_backend", "firecrawl"),
+            ("web.backend", ""),
+        ]
+
     def test_reveal_env_var(self, tmp_path):
         """POST /api/env/reveal should return the real unredacted value."""
         from hermes_cli.config import save_env_value

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -897,6 +897,26 @@ export interface PluginManifestResponse {
   source: string;
 }
 
+export interface PluginSetupEnvVar {
+  key: string;
+  prompt: string;
+  description: string;
+  url?: string | null;
+  password: boolean;
+  tools?: string[];
+  is_set: boolean;
+  redacted_value?: string | null;
+}
+
+export interface PluginWebProvider {
+  name: string;
+  display_name?: string;
+  available?: boolean;
+  supports_search?: boolean;
+  supports_extract?: boolean;
+  supports_crawl?: boolean;
+}
+
 export interface HubAgentPluginRow {
   name: string;
   version: string;
@@ -911,6 +931,8 @@ export interface HubAgentPluginRow {
   auth_required: boolean;
   auth_command: string;
   user_hidden: boolean;
+  setup_env?: PluginSetupEnvVar[];
+  web_providers?: PluginWebProvider[];
 }
 
 export interface PluginsHubProviders {
@@ -918,6 +940,10 @@ export interface PluginsHubProviders {
   memory_options: Array<{ name: string; description: string }>;
   context_engine: string;
   context_options: Array<{ name: string; description: string }>;
+  web_search_backend?: string;
+  web_extract_backend?: string;
+  web_backend?: string;
+  web_options?: PluginWebProvider[];
 }
 
 export interface PluginsHubResponse {
@@ -953,4 +979,7 @@ export interface AgentPluginUpdateResponse {
 export interface PluginProvidersPutRequest {
   memory_provider?: string;
   context_engine?: string;
+  web_search_backend?: string;
+  web_extract_backend?: string;
+  web_backend?: string;
 }

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -23,6 +23,7 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 
 /** Select value for built-in memory (`config` uses empty string). Never use `""` — UI Select maps empty value to an empty label. */
 const MEMORY_PROVIDER_BUILTIN = "__hermes_memory_builtin__";
+const WEB_PROVIDER_AUTO = "__hermes_web_auto__";
 
 export default function PluginsPage() {
   const [hub, setHub] = useState<PluginsHubResponse | null>(null);
@@ -34,6 +35,7 @@ export default function PluginsPage() {
   const [rescanBusy, setRescanBusy] = useState(false);
   const [memorySel, setMemorySel] = useState(MEMORY_PROVIDER_BUILTIN);
   const [contextSel, setContextSel] = useState("compressor");
+  const [webSearchSel, setWebSearchSel] = useState(WEB_PROVIDER_AUTO);
   const [providerBusy, setProviderBusy] = useState(false);
   const [rowBusy, setRowBusy] = useState<string | null>(null);
 
@@ -49,6 +51,7 @@ export default function PluginsPage() {
         const p = h.providers;
         setMemorySel(p.memory_provider ? p.memory_provider : MEMORY_PROVIDER_BUILTIN);
         setContextSel(p.context_engine || "compressor");
+        setWebSearchSel(p.web_search_backend || p.web_backend || WEB_PROVIDER_AUTO);
       })
       .catch(() => showToast(t.common.loading, "error"));
   }, [showToast, t.common.loading]);
@@ -123,6 +126,7 @@ export default function PluginsPage() {
         memory_provider:
           memorySel === MEMORY_PROVIDER_BUILTIN ? "" : memorySel,
         context_engine: contextSel,
+        web_search_backend: webSearchSel === WEB_PROVIDER_AUTO ? "" : webSearchSel,
       });
       showToast(t.pluginsPage.savedProviders, "success");
       await loadHub();
@@ -165,7 +169,7 @@ export default function PluginsPage() {
 
             <CardContent className="flex flex-col gap-6">
 
-              <div className="grid gap-6 sm:grid-cols-2 max-w-full">
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-full">
               <div className="grid gap-2 min-w-0">
                 <Label htmlFor="mem-provider">{t.pluginsPage.memoryProviderLabel}</Label>
 
@@ -203,6 +207,27 @@ export default function PluginsPage() {
                     .map((o) => (
                       <SelectOption key={o.name} value={o.name}>
                         {o.name}
+                      </SelectOption>
+                    ))}
+                </Select>
+              </div>
+
+              <div className="grid gap-2 min-w-0">
+                <Label htmlFor="web-search-provider">Web search provider</Label>
+
+                <Select
+                  id="web-search-provider"
+                  className="w-full"
+                  value={webSearchSel}
+                  onValueChange={setWebSearchSel}
+                >
+                  <SelectOption value={WEB_PROVIDER_AUTO}>Auto</SelectOption>
+
+                  {(providers.web_options ?? [])
+                    .filter((o) => o.supports_search)
+                    .map((o) => (
+                      <SelectOption key={o.name} value={o.name}>
+                        {o.display_name ?? o.name}
                       </SelectOption>
                     ))}
                 </Select>
@@ -395,6 +420,33 @@ function PluginRowCard(props: PluginRowCardProps) {
 
   const busy = rowBusy === row.name;
   const [confirmRemove, setConfirmRemove] = useState(false);
+  const [envValues, setEnvValues] = useState<Record<string, string>>({});
+  const setupEnv = row.setup_env ?? [];
+  const primaryWebProvider = row.web_providers?.[0];
+  const setupActionLabel = primaryWebProvider ? "Save & Use" : "Save Key";
+
+  const saveSetupEnv = (fieldKey: string) => {
+    const value = (envValues[fieldKey] ?? "").trim();
+    if (!value) {
+      showToast(`Enter ${fieldKey} first`, "error");
+      return;
+    }
+
+    void setRuntimeLoading(row.name, async () => {
+      await api.setEnvVar(fieldKey, value);
+      if (row.runtime_status !== "enabled") {
+        await api.enableAgentPlugin(row.name);
+      }
+      if (primaryWebProvider?.supports_search) {
+        await api.savePluginProviders({ web_search_backend: primaryWebProvider.name });
+      }
+      if (primaryWebProvider?.supports_extract) {
+        await api.savePluginProviders({ web_extract_backend: primaryWebProvider.name });
+      }
+      setEnvValues((current) => ({ ...current, [fieldKey]: "" }));
+      showToast(`${fieldKey} saved`, "success");
+    });
+  };
 
   const badgeTone =
     row.runtime_status === "enabled"
@@ -535,6 +587,61 @@ function PluginRowCard(props: PluginRowCardProps) {
           <p className="min-w-0 w-full text-xs tracking-[0.06em] text-text-secondary break-words">
             {row.description}
           </p>
+        ) : null}
+
+        {setupEnv.length ? (
+          <div className="grid gap-3 rounded border border-current/15 p-3">
+            {setupEnv.map((field) => {
+              const inputId = `${row.name}-${field.key}`.replace(/[^a-zA-Z0-9_-]/g, "-");
+              const hasValue = Boolean((envValues[field.key] ?? "").trim());
+              return (
+                <div key={field.key} className="grid gap-2 md:grid-cols-[minmax(12rem,1fr)_minmax(14rem,1.4fr)_auto] md:items-end">
+                  <div className="min-w-0">
+                    <Label htmlFor={inputId}>{field.prompt || field.key}</Label>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-text-tertiary">
+                      <span className="font-mono-ui">{field.key}</span>
+                      {field.is_set ? <Badge tone="success">{field.redacted_value ?? "set"}</Badge> : null}
+                      {field.url ? (
+                        <a
+                          className="inline-flex items-center gap-1 underline"
+                          href={field.url}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                          Source
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <Input
+                    id={inputId}
+                    type={field.password ? "password" : "text"}
+                    autoComplete="off"
+                    placeholder={field.is_set ? "Replace stored value" : "Paste key"}
+                    value={envValues[field.key] ?? ""}
+                    onChange={(e) =>
+                      setEnvValues((current) => ({
+                        ...current,
+                        [field.key]: e.target.value,
+                      }))
+                    }
+                  />
+
+                  <Button
+                    className="h-9 uppercase"
+                    disabled={busy || !hasValue}
+                    size="sm"
+                    onClick={() => saveSetupEnv(field.key)}
+                    prefix={busy ? <Spinner /> : undefined}
+                  >
+                    {setupActionLabel}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
         ) : null}
 
         {dm?.slots?.length ? (


### PR DESCRIPTION
## Summary
- surface plugin setup env fields in the dashboard plugin hub from provider `get_setup_schema()` and manifest `requires_env`
- add web search provider selection to the plugins page
- let key-requiring plugin cards save redacted env values from the dashboard; web providers can also become the active search/extract backend
- align setup action buttons with the key input height

## Validation
- `git diff --check`
- `python -m py_compile hermes_cli/web_server.py`
- `npm run build` in `web/`
- targeted dashboard tests: `2 passed`
- related provider/dashboard suite: `289 passed, 1 warning`
- repo wrapper on related files: `8 files, 289 tests passed`
- live dashboard smoke: `/plugins` serves the new bundle and `/api/dashboard/plugins/hub` returns 17 setup-key plugin sections
- live auth smoke: no token and wrong token both return `401`
- secret scan: configured GitHub token was not present in the worktree; setup payload did not expose raw secret values

## Notes
- Full non-integration `scripts/run_tests.sh` was attempted in the local Hermes environment and found unrelated existing failures outside this PR surface, mostly live-system guard/process cleanup and migration/config tests. The PR-focused and adjacent dashboard/provider coverage is green.