### PR TITLE
fix(gateway,codex): guard stalled sends and missing streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ docs/superpowers/*
 # also created in-repo when an agent operates in this checkout). Plans, audit
 # logs, and per-session caches are never artifacts of the codebase.
 .hermes/
+
+# Playwright CLI scratch snapshots/logs from browser debugging.
+.playwright-cli/

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -802,6 +802,11 @@ class _CodexCompletionsAdapter:
                 _check_cancelled()
 
             event_stream = self._client.responses.create(**stream_kwargs)
+            if event_stream is None:
+                logger.warning("Codex auxiliary Responses create(stream=True) returned no event stream; retrying once")
+                event_stream = self._client.responses.create(**stream_kwargs)
+            if event_stream is None:
+                raise RuntimeError("Codex auxiliary Responses create(stream=True) returned no event stream")
             try:
                 final = _consume_codex_event_stream(
                     event_stream,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -470,6 +470,19 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 continue
             raise
 
+        if event_stream is None:
+            message = "Codex Responses create(stream=True) returned no event stream"
+            if attempt < max_stream_retries:
+                logger.warning(
+                    "%s (attempt %s/%s); retrying. %s",
+                    message,
+                    attempt + 1,
+                    max_stream_retries + 1,
+                    agent._client_log_context(),
+                )
+                continue
+            raise RuntimeError(message)
+
         try:
             # Compatibility: some mocks/providers return a concrete response
             # instead of an iterable.  Pass it straight through.

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -21,9 +21,21 @@ import logging
 import os
 import time
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _persist_codex_app_server_turn(
+    agent,
+    messages: List[Dict[str, Any]],
+    conversation_history: Optional[List[Dict[str, Any]]],
+) -> None:
+    """Best-effort durable checkpoint for the codex app-server runtime."""
+    try:
+        agent._persist_session(messages, conversation_history)
+    except Exception:
+        logger.warning("codex app-server session persistence failed", exc_info=True)
 
 
 def run_codex_app_server_turn(
@@ -32,6 +44,7 @@ def run_codex_app_server_turn(
     user_message: str,
     original_user_message: Any,
     messages: List[Dict[str, Any]],
+    conversation_history: Optional[List[Dict[str, Any]]] = None,
     effective_task_id: str,
     should_review_memory: bool = False,
 ) -> Dict[str, Any]:
@@ -66,8 +79,17 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    def checkpoint_projected_messages(projected_messages: List[Dict[str, Any]]) -> None:
+        if not projected_messages:
+            return
+        snapshot = list(messages) + [dict(msg) for msg in projected_messages]
+        _persist_codex_app_server_turn(agent, snapshot, conversation_history)
+
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            projection_checkpoint=checkpoint_projected_messages,
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
@@ -77,6 +99,7 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
+        _persist_codex_app_server_turn(agent, messages, conversation_history)
         return {
             "final_response": (
                 f"Codex app-server turn failed: {exc}. "
@@ -86,6 +109,7 @@ def run_codex_app_server_turn(
             "api_calls": 0,
             "completed": False,
             "partial": True,
+            "interrupted": False,
             "error": str(exc),
         }
 
@@ -110,6 +134,7 @@ def run_codex_app_server_turn(
     # is exactly what curator.py / sessions DB expect.
     if turn.projected_messages:
         messages.extend(turn.projected_messages)
+        _persist_codex_app_server_turn(agent, messages, conversation_history)
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
@@ -162,12 +187,15 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
+    _persist_codex_app_server_turn(agent, messages, conversation_history)
+
     return {
         "final_response": turn.final_text,
         "messages": messages,
         "api_calls": 1,  # one app-server "turn" maps to one logical API call
         "completed": not turn.interrupted and turn.error is None,
         "partial": turn.interrupted or turn.error is not None,
+        "interrupted": turn.interrupted,
         "error": turn.error,
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -763,13 +763,24 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        # Durability checkpoint: the codex app-server runtime can run for a
+        # long time outside Hermes' normal tool loop, so persist the inbound
+        # user turn before handing control to the subprocess.
+        agent._persist_session(messages, conversation_history)
         return agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
+            conversation_history=conversation_history,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )
+
+    # Durability checkpoint for normal runtimes: persist the clean inbound
+    # user turn before the first long provider/API call. API-only memory and
+    # plugin context is injected into api_messages later without mutating
+    # messages, so this checkpoint stays replay-safe and non-ephemeral.
+    agent._persist_session(messages, conversation_history)
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
@@ -3633,6 +3644,7 @@ def run_conversation(
                             "tool_call_id": tc.id,
                             "content": content,
                         })
+                    agent._persist_session(messages, conversation_history)
                     continue
                 # Reset retry counter on successful tool call validation
                 agent._invalid_tool_retries = 0
@@ -3725,6 +3737,7 @@ def run_conversation(
                                 "tool_call_id": tc.id,
                                 "content": tool_result,
                             })
+                        agent._persist_session(messages, conversation_history)
                         continue
                 
                 # Reset retry counter on successful JSON validation
@@ -3809,6 +3822,9 @@ def run_conversation(
                         pass
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                # Persist after every completed tool batch so a crash or
+                # gateway restart preserves the current work trace.
+                agent._persist_session(messages, conversation_history)
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -365,6 +365,7 @@ class CodexAppServerSession:
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
+        projection_checkpoint: Optional[Callable[[list[dict]], None]] = None,
     ) -> TurnResult:
         """Send a user message and block until turn/completed, while
         forwarding server-initiated approval requests and projecting items
@@ -397,6 +398,20 @@ class CodexAppServerSession:
 
         self._interrupt_event.clear()
         projector = CodexEventProjector()
+
+        def _record_projected_messages(projected_messages: list[dict]) -> None:
+            if not projected_messages:
+                return
+            result.projected_messages.extend(projected_messages)
+            if projection_checkpoint is None:
+                return
+            try:
+                projection_checkpoint(list(result.projected_messages))
+            except Exception:
+                logger.warning(
+                    "codex app-server projection checkpoint failed",
+                    exc_info=True,
+                )
 
         user_input_text = _coerce_turn_input_text(user_input)
 
@@ -503,7 +518,7 @@ class CodexAppServerSession:
                     self._track_pending_file_change(pending)
                     proj = projector.project(pending)
                     if proj.messages:
-                        result.projected_messages.extend(proj.messages)
+                        _record_projected_messages(proj.messages)
                     if proj.is_tool_iteration:
                         result.tool_iterations += 1
                         last_tool_completion_at = time.monotonic()
@@ -544,7 +559,7 @@ class CodexAppServerSession:
             # Project into messages
             projection = projector.project(note)
             if projection.messages:
-                result.projected_messages.extend(projection.messages)
+                _record_projected_messages(projection.messages)
             if projection.is_tool_iteration:
                 result.tool_iterations += 1
                 # Arm/refresh the post-tool quiet watchdog whenever a

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -64,6 +64,7 @@ logger = logging.getLogger(__name__)
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
+AUTO_PORT_RANGE_END = 8699
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
@@ -77,6 +78,68 @@ def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _probe_host(host: str) -> str:
+    """Return a concrete loopback address for local bind probes."""
+    if host in {"", "0.0.0.0", "::", "::0"}:
+        return "127.0.0.1"
+    return host
+
+
+def _is_port_open(host: str, port: int) -> bool:
+    try:
+        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.25)
+            return sock.connect_ex((_probe_host(host), port)) == 0
+    except OSError:
+        return False
+
+
+def _read_env_file(path: Path) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return values
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        values[key.strip()] = value.strip().strip("\"'")
+    return values
+
+
+def _api_server_port_assignments() -> Dict[int, List[str]]:
+    """Map configured API server ports to enabled Hermes profile names."""
+    try:
+        from hermes_cli.profiles import list_profiles
+    except Exception:
+        return {}
+
+    assignments: Dict[int, List[str]] = {}
+    try:
+        profiles = list_profiles()
+    except Exception:
+        return assignments
+
+    for profile in profiles:
+        env = _read_env_file(Path(profile.path) / ".env")
+        enabled = str(env.get("API_SERVER_ENABLED", "")).strip().lower() in {"1", "true", "yes", "on"}
+        has_key = bool(env.get("API_SERVER_KEY", ""))
+        if not enabled and not has_key:
+            continue
+        port = _coerce_port(env.get("API_SERVER_PORT"), DEFAULT_PORT)
+        assignments.setdefault(port, []).append(profile.name)
+    return assignments
 
 
 _TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
@@ -700,6 +763,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            self._profile_name = get_active_profile_name()
+        except Exception:
+            self._profile_name = "custom"
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -718,6 +786,94 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+
+    def _find_auto_port(self, assignments: Dict[int, List[str]]) -> Optional[int]:
+        reserved = {
+            port
+            for port, owners in assignments.items()
+            if self._profile_name not in owners
+        }
+        start = max(DEFAULT_PORT, min(self._port + 1, AUTO_PORT_RANGE_END))
+        for candidate in range(start, AUTO_PORT_RANGE_END + 1):
+            if candidate in reserved:
+                continue
+            if not _is_port_open(self._host, candidate):
+                return candidate
+        for candidate in range(DEFAULT_PORT, start):
+            if candidate in reserved:
+                continue
+            if not _is_port_open(self._host, candidate):
+                return candidate
+        return None
+
+    def _persist_auto_port(self, port: int) -> None:
+        if not _env_flag("HERMES_API_SERVER_PERSIST_AUTO_PORT", True):
+            return
+        try:
+            from hermes_constants import get_hermes_home
+            env_path = get_hermes_home() / ".env"
+            try:
+                lines = env_path.read_text(encoding="utf-8").splitlines()
+            except OSError:
+                lines = []
+
+            replaced = False
+            next_lines: List[str] = []
+            for line in lines:
+                stripped = line.strip()
+                if stripped.startswith("API_SERVER_PORT="):
+                    next_lines.append(f"API_SERVER_PORT={port}")
+                    replaced = True
+                else:
+                    next_lines.append(line)
+            if not replaced:
+                next_lines.append(f"API_SERVER_PORT={port}")
+
+            env_path.parent.mkdir(parents=True, exist_ok=True)
+            env_path.write_text("\n".join(next_lines).rstrip() + "\n", encoding="utf-8")
+        except Exception as exc:
+            logger.warning(
+                "[%s] API server auto-selected port %d but could not persist it: %s",
+                self.name, port, exc,
+            )
+
+    def _maybe_reassign_busy_port(self) -> bool:
+        if not _is_port_open(self._host, self._port):
+            return True
+
+        assignments = _api_server_port_assignments()
+        owners = assignments.get(self._port, [])
+        collision_is_configured = len(owners) > 1 and self._profile_name in owners
+        auto_enabled = _env_flag("HERMES_API_SERVER_AUTO_PORT", True)
+        auto_always = _env_flag("HERMES_API_SERVER_AUTO_PORT_ALWAYS", False)
+
+        if auto_enabled and (collision_is_configured or auto_always):
+            replacement = self._find_auto_port(assignments)
+            if replacement is not None:
+                old_port = self._port
+                self._port = replacement
+                self._persist_auto_port(replacement)
+                logger.warning(
+                    "[%s] API server port %d is shared by enabled profiles %s; "
+                    "auto-selected http://%s:%d and persisted API_SERVER_PORT=%d.",
+                    self.name,
+                    old_port,
+                    ", ".join(sorted(owners)) or "(unknown)",
+                    self._host,
+                    replacement,
+                    replacement,
+                )
+                return True
+
+        owner_hint = f" configured by enabled profiles: {', '.join(sorted(owners))}" if owners else ""
+        logger.error(
+            "[%s] Port %d already in use%s. Set API_SERVER_PORT to a free value "
+            "or fix duplicate profile port assignments.",
+            self.name,
+            self._port,
+            owner_hint,
+        )
+        return False
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -4128,15 +4284,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 except ImportError:
                     pass
 
-            # Port conflict detection — fail fast if port is already in use
-            try:
-                with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
-                    _s.settimeout(1)
-                    _s.connect(('127.0.0.1', self._port))
-                logger.error('[%s] Port %d already in use. Set a different port in config.yaml: platforms.api_server.port', self.name, self._port)
+            # Port conflict detection. Duplicate enabled Hermes profiles are
+            # auto-reassigned into the reserved API range; unrelated listeners
+            # still fail loudly so a real conflict is not hidden.
+            if not self._maybe_reassign_busy_port():
                 return False
-            except (ConnectionRefusedError, OSError):
-                pass  # port is free
 
             self._runner = web.AppRunner(self._app)
             await self._runner.setup()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1404,6 +1404,7 @@ def merge_pending_message_event(
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
+            _notify_pending_messages_changed(pending_messages)
             return
 
         if existing_has_media or incoming_has_media:
@@ -1422,6 +1423,7 @@ def merge_pending_message_event(
                 and event.message_type != MessageType.TEXT
             ):
                 existing.message_type = event.message_type
+            _notify_pending_messages_changed(pending_messages)
             return
 
         if (
@@ -1431,6 +1433,7 @@ def merge_pending_message_event(
         ):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            _notify_pending_messages_changed(pending_messages)
             return
 
     pending_messages[session_key] = event
@@ -1460,6 +1463,57 @@ _RETRYABLE_ERROR_PATTERNS = (
 # reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
 # ``None`` when the response was already delivered (e.g. via streaming).
 MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+
+
+_MISSING = object()
+
+
+class PendingMessageStore(dict):
+    """dict that notifies GatewayRunner when queued follow-ups change."""
+
+    def __init__(self, *args, on_change: Optional[Callable[[], None]] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._on_change = on_change
+
+    def set_change_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        self._on_change = callback
+
+    def notify_changed(self) -> None:
+        if self._on_change is None:
+            return
+        try:
+            self._on_change()
+        except Exception:
+            logger.debug("pending message change callback failed", exc_info=True)
+
+    def __setitem__(self, key, value) -> None:
+        super().__setitem__(key, value)
+        self.notify_changed()
+
+    def __delitem__(self, key) -> None:
+        super().__delitem__(key)
+        self.notify_changed()
+
+    def pop(self, key, default=_MISSING):
+        value = super().pop(key, _MISSING)
+        if value is not _MISSING:
+            self.notify_changed()
+            return value
+        if default is _MISSING:
+            raise KeyError(key)
+        return default
+
+    def clear(self) -> None:
+        if not self:
+            return
+        super().clear()
+        self.notify_changed()
+
+
+def _notify_pending_messages_changed(pending_messages: Dict[str, MessageEvent]) -> None:
+    notify = getattr(pending_messages, "notify_changed", None)
+    if callable(notify):
+        notify()
 
 
 def resolve_channel_prompt(
@@ -1580,7 +1634,7 @@ class BasePlatformAdapter(ABC):
         # Without the owner-task map, an old task's finally block could delete
         # a newer task's guard, leaving stale busy state.
         self._active_sessions: Dict[str, asyncio.Event] = {}
-        self._pending_messages: Dict[str, MessageEvent] = {}
+        self._pending_messages: Dict[str, MessageEvent] = PendingMessageStore()
         self._session_tasks: Dict[str, asyncio.Task] = {}
         self._busy_text_mode: str = (
             os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue").strip().lower()
@@ -1858,6 +1912,15 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_pending_message_change_callback(
+        self,
+        callback: Optional[Callable[[], None]],
+    ) -> None:
+        """Set callback fired when queued follow-ups are added or drained."""
+        store = getattr(self, "_pending_messages", None)
+        if hasattr(store, "set_change_callback"):
+            store.set_change_callback(callback)
     
     def set_session_store(self, session_store: Any) -> None:
         """
@@ -3059,6 +3122,10 @@ class BasePlatformAdapter(ABC):
 
         delay = self._text_debounce_delay(session_key)
         state.task = asyncio.create_task(self._flush_text_debounce(session_key, delay))
+        # The debounce buffer is RAM-only, so force a durable pending snapshot
+        # while the short merge window is open. If the gateway dies in that
+        # window, startup restores this as a normal pending follow-up.
+        _notify_pending_messages_changed(self._pending_messages)
 
     async def _flush_text_debounce(self, session_key: str, delay: float) -> None:
         """Timer task that flushes the debounced text buffer."""
@@ -4123,7 +4190,10 @@ class BasePlatformAdapter(ABC):
         self._background_tasks.clear()
         self._expected_cancelled_tasks.clear()
         self._session_tasks.clear()
-        self._pending_messages.clear()
+        # Do not notify/persist a deletion here. During gateway shutdown or
+        # replacement, queued follow-ups should remain in the durable pending
+        # queue for the next process to restore.
+        dict.clear(self._pending_messages)
         self._active_sessions.clear()
         for state in list(self._text_debounce_store().values()):
             if state.task is not None and not state.task.done():

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5709,10 +5709,21 @@ class TelegramAdapter(BasePlatformAdapter):
         chat = message.chat
         user = message.from_user
         
-        # Determine chat type.  Normalize through ``str`` so tests/mocks and
-        # python-telegram-bot enum values both work (``ChatType.CHANNEL`` is
-        # string-like, but mocks often provide plain strings).
-        telegram_chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        # Determine chat type. Normalize through known ChatType constants first:
+        # some tests install MagicMock Telegram modules, whose string form looks
+        # like "<MagicMock name='...SUPERGROUP' ...>" and is not enum-like.
+        raw_chat_type = getattr(chat, "type", "")
+        telegram_chat_type = str(raw_chat_type).split(".")[-1].strip().lower()
+        for attr_name, normalized in (
+            ("GROUP", "group"),
+            ("SUPERGROUP", "supergroup"),
+            ("CHANNEL", "channel"),
+            ("PRIVATE", "private"),
+        ):
+            if raw_chat_type is getattr(ChatType, attr_name, None):
+                telegram_chat_type = normalized
+                break
+
         chat_type = "dm"
         if telegram_chat_type in {"group", "supergroup"}:
             chat_type = "group"

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -396,6 +396,40 @@ class TelegramAdapter(BasePlatformAdapter):
             value = min(value, max_value)
         return value
 
+    @classmethod
+    def _telegram_send_timeout_seconds(cls) -> float:
+        return cls._env_float_clamped(
+            "HERMES_TELEGRAM_SEND_TIMEOUT_SECONDS",
+            45.0,
+            min_value=5.0,
+            max_value=180.0,
+        )
+
+    @classmethod
+    def _telegram_typing_timeout_seconds(cls) -> float:
+        return cls._env_float_clamped(
+            "HERMES_TELEGRAM_TYPING_TIMEOUT_SECONDS",
+            2.0,
+            min_value=0.2,
+            max_value=10.0,
+        )
+
+    @classmethod
+    def _telegram_post_send_typing_timeout_seconds(cls) -> float:
+        return cls._env_float_clamped(
+            "HERMES_TELEGRAM_POST_SEND_TYPING_TIMEOUT_SECONDS",
+            2.0,
+            min_value=0.2,
+            max_value=10.0,
+        )
+
+    @staticmethod
+    async def _await_telegram_api(awaitable, *, timeout: float, operation: str):
+        try:
+            return await asyncio.wait_for(awaitable, timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(f"Telegram {operation} timed out after {timeout:.1f}s") from exc
+
     @property
     def message_len_fn(self):
         """Telegram measures message length in UTF-16 code units."""
@@ -1856,6 +1890,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except (ImportError, AttributeError):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
+            send_timeout = self._telegram_send_timeout_seconds()
             for i, chunk in enumerate(chunks):
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
@@ -1904,28 +1939,36 @@ class TelegramAdapter(BasePlatformAdapter):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
                         try:
-                            msg = await self._bot.send_message(
-                                chat_id=int(chat_id),
-                                text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
-                                reply_to_message_id=reply_to_id,
-                                **thread_kwargs,
-                                **self._link_preview_kwargs(),
-                                **self._notification_kwargs(metadata),
+                            msg = await self._await_telegram_api(
+                                self._bot.send_message(
+                                    chat_id=int(chat_id),
+                                    text=chunk,
+                                    parse_mode=ParseMode.MARKDOWN_V2,
+                                    reply_to_message_id=reply_to_id,
+                                    **thread_kwargs,
+                                    **self._link_preview_kwargs(),
+                                    **self._notification_kwargs(metadata),
+                                ),
+                                timeout=send_timeout,
+                                operation="send_message",
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
                             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
-                                msg = await self._bot.send_message(
-                                    chat_id=int(chat_id),
-                                    text=plain_chunk,
-                                    parse_mode=None,
-                                    reply_to_message_id=reply_to_id,
-                                    **thread_kwargs,
-                                    **self._link_preview_kwargs(),
-                                    **self._notification_kwargs(metadata),
+                                msg = await self._await_telegram_api(
+                                    self._bot.send_message(
+                                        chat_id=int(chat_id),
+                                        text=plain_chunk,
+                                        parse_mode=None,
+                                        reply_to_message_id=reply_to_id,
+                                        **thread_kwargs,
+                                        **self._link_preview_kwargs(),
+                                        **self._notification_kwargs(metadata),
+                                    ),
+                                    timeout=send_timeout,
+                                    operation="send_message",
                                 )
                             else:
                                 raise
@@ -2039,7 +2082,11 @@ class TelegramAdapter(BasePlatformAdapter):
             # (especially noticeable when the agent sends intermediate progress
             # messages like "Checking:" before running tools).
             try:
-                await self.send_typing(chat_id, metadata=metadata)
+                await self._await_telegram_api(
+                    self.send_typing(chat_id, metadata=metadata),
+                    timeout=self._telegram_post_send_typing_timeout_seconds(),
+                    operation="post-send typing",
+                )
             except Exception:
                 pass  # Typing failures are non-fatal
 
@@ -4136,10 +4183,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 _typing_thread = self._metadata_thread_id(metadata)
                 _is_dm_topic = bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
                 message_thread_id = self._message_thread_id_for_typing(_typing_thread)
-                await self._bot.send_chat_action(
-                    chat_id=int(chat_id),
-                    action="typing",
-                    message_thread_id=message_thread_id,
+                await self._await_telegram_api(
+                    self._bot.send_chat_action(
+                        chat_id=int(chat_id),
+                        action="typing",
+                        message_thread_id=message_thread_id,
+                    ),
+                    timeout=self._telegram_typing_timeout_seconds(),
+                    operation="send_chat_action",
                 )
             except Exception as e:
                 # For DM topic lanes, Telegram may reject message_thread_id.
@@ -4147,9 +4198,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 # indicator at least appears in the main DM view.
                 if _is_dm_topic and message_thread_id is not None:
                     try:
-                        await self._bot.send_chat_action(
-                            chat_id=int(chat_id),
-                            action="typing",
+                        await self._await_telegram_api(
+                            self._bot.send_chat_action(
+                                chat_id=int(chat_id),
+                                action="typing",
+                            ),
+                            timeout=self._telegram_typing_timeout_seconds(),
+                            operation="send_chat_action",
                         )
                         return
                     except Exception:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1678,7 +1678,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     webhook_url=webhook_url,
                     secret_token=webhook_secret,
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=False,
                 )
                 self._webhook_mode = True
                 logger.info(
@@ -1711,7 +1711,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=False,
                     error_callback=_polling_error_callback,
                 )
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1730,6 +1730,7 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._durable_pending_path = _hermes_home / "gateway_pending_messages.json"
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
         # "next-turn" follow-ups where repeated sends collapse into one
@@ -2637,6 +2638,237 @@ class GatewayRunner:
         if adapter is not None and session_key in getattr(adapter, "_pending_messages", {}):
             depth += 1
         return depth
+
+    def _message_event_to_dict(self, event: "MessageEvent") -> dict:
+        source = getattr(event, "source", None)
+        return {
+            "text": event.text or "",
+            "message_type": event.message_type.value,
+            "source": source.to_dict() if source else None,
+            "message_id": event.message_id,
+            "platform_update_id": event.platform_update_id,
+            "media_urls": list(event.media_urls or []),
+            "media_types": list(event.media_types or []),
+            "reply_to_message_id": event.reply_to_message_id,
+            "reply_to_text": event.reply_to_text,
+            "auto_skill": event.auto_skill,
+            "channel_prompt": event.channel_prompt,
+            "channel_context": event.channel_context,
+            "internal": bool(event.internal),
+            "timestamp": event.timestamp.isoformat() if event.timestamp else None,
+        }
+
+    def _message_event_from_dict(self, data: dict) -> Optional["MessageEvent"]:
+        try:
+            source_data = data.get("source")
+            if not isinstance(source_data, dict):
+                return None
+            timestamp_raw = data.get("timestamp")
+            timestamp = (
+                datetime.fromisoformat(timestamp_raw)
+                if isinstance(timestamp_raw, str) and timestamp_raw
+                else datetime.now()
+            )
+            return MessageEvent(
+                text=data.get("text") or "",
+                message_type=MessageType(data.get("message_type") or MessageType.TEXT.value),
+                source=SessionSource.from_dict(source_data),
+                message_id=data.get("message_id"),
+                platform_update_id=data.get("platform_update_id"),
+                media_urls=list(data.get("media_urls") or []),
+                media_types=list(data.get("media_types") or []),
+                reply_to_message_id=data.get("reply_to_message_id"),
+                reply_to_text=data.get("reply_to_text"),
+                auto_skill=data.get("auto_skill"),
+                channel_prompt=data.get("channel_prompt"),
+                channel_context=data.get("channel_context"),
+                internal=bool(data.get("internal")),
+                timestamp=timestamp,
+            )
+        except Exception:
+            logger.debug("Failed to restore durable pending message", exc_info=True)
+            return None
+
+    def _read_durable_pending_payload(self) -> dict:
+        path = getattr(self, "_durable_pending_path", None)
+        if path is None or not path.exists():
+            return {"pending": {}, "queued": {}}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Failed to read durable pending queue %s: %s", path, exc)
+            self._quarantine_durable_pending_payload(path)
+            return {"pending": {}, "queued": {}}
+        if not isinstance(data, dict):
+            logger.warning("Invalid durable pending queue shape in %s", path)
+            self._quarantine_durable_pending_payload(path)
+            return {"pending": {}, "queued": {}}
+        pending = data.get("pending") if isinstance(data.get("pending"), dict) else {}
+        queued = data.get("queued") if isinstance(data.get("queued"), dict) else {}
+        return {"pending": pending, "queued": queued}
+
+    def _quarantine_durable_pending_payload(self, path: Path) -> None:
+        try:
+            suffix = datetime.now().strftime("%Y%m%d%H%M%S%f")
+            quarantine = path.with_name(f"{path.name}.corrupt.{suffix}")
+            path.replace(quarantine)
+            logger.warning("Quarantined corrupt durable pending queue to %s", quarantine)
+        except Exception as exc:
+            logger.warning("Failed to quarantine durable pending queue %s: %s", path, exc)
+
+    def _save_durable_pending_messages(self) -> None:
+        path = getattr(self, "_durable_pending_path", None)
+        if path is None:
+            return
+
+        # Preserve entries for platforms that are not connected in this
+        # process yet, so reconnect/startup ordering cannot drop them.
+        existing = self._read_durable_pending_payload()
+        connected_platforms = {p.value for p in self.adapters.keys()}
+        pending_payload = {
+            key: value
+            for key, value in existing.get("pending", {}).items()
+            if isinstance(value, dict)
+            and (value.get("source") or {}).get("platform") not in connected_platforms
+        }
+        queued_payload = {
+            key: value
+            for key, value in existing.get("queued", {}).items()
+            if isinstance(value, list)
+            and (
+                not value
+                or ((value[0].get("source") or {}).get("platform") not in connected_platforms)
+            )
+        }
+
+        for adapter in self.adapters.values():
+            for session_key, event in (getattr(adapter, "_pending_messages", {}) or {}).items():
+                pending_payload[session_key] = self._message_event_to_dict(event)
+            for session_key, state in (getattr(adapter, "_text_debounce", {}) or {}).items():
+                event = getattr(state, "event", None)
+                if event is not None and session_key not in pending_payload:
+                    pending_payload[session_key] = self._message_event_to_dict(event)
+
+        for session_key, events in (getattr(self, "_queued_events", {}) or {}).items():
+            if events:
+                queued_payload[session_key] = [
+                    self._message_event_to_dict(event) for event in events
+                ]
+
+        try:
+            if not pending_payload and not queued_payload:
+                path.unlink(missing_ok=True)
+                return
+            payload = {
+                "updated_at": datetime.now().isoformat(),
+                "pending": pending_payload,
+                "queued": queued_payload,
+            }
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+            tmp.replace(path)
+        except Exception as exc:
+            logger.warning("Failed to save durable pending queue %s: %s", path, exc)
+
+    def _restore_durable_pending_messages_for_adapter(self, adapter: Any) -> int:
+        payload = self._read_durable_pending_payload()
+        restored = 0
+        platform = getattr(adapter, "platform", None)
+        platform_value = getattr(platform, "value", platform)
+
+        pending_store = getattr(adapter, "_pending_messages", None)
+        if pending_store is not None:
+            for session_key, event_data in payload.get("pending", {}).items():
+                event = self._message_event_from_dict(event_data)
+                if event is None:
+                    continue
+                if getattr(event.source.platform, "value", event.source.platform) != platform_value:
+                    continue
+                if session_key not in pending_store:
+                    dict.__setitem__(pending_store, session_key, event)
+                    restored += 1
+
+        for session_key, event_items in payload.get("queued", {}).items():
+            if not isinstance(event_items, list):
+                continue
+            events: list[MessageEvent] = []
+            for item in event_items:
+                event = self._message_event_from_dict(item)
+                if event is None:
+                    continue
+                if getattr(event.source.platform, "value", event.source.platform) != platform_value:
+                    continue
+                events.append(event)
+            if events and not self._queued_events.get(session_key):
+                self._queued_events[session_key] = events
+                restored += len(events)
+
+        return restored
+
+    def _is_session_resume_pending(self, session_key: str) -> bool:
+        try:
+            with self.session_store._lock:  # noqa: SLF001
+                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                entry = self.session_store._entries.get(session_key)  # noqa: SLF001
+                return bool(entry and entry.resume_pending and not entry.suspended)
+        except Exception:
+            return False
+
+    def _schedule_durable_pending_messages(self) -> int:
+        scheduled = 0
+        for adapter in list(self.adapters.values()):
+            pending_store = getattr(adapter, "_pending_messages", None)
+            if not pending_store:
+                continue
+            for session_key, event in list(pending_store.items()):
+                if session_key in self._running_agents:
+                    continue
+                # If the previous turn was interrupted, let auto-resume run
+                # first; the restored pending slot will be drained afterward.
+                if self._is_session_resume_pending(session_key):
+                    continue
+                # Claim the in-memory slot without notifying the durable
+                # snapshot writer. The on-disk queue remains protected until
+                # handle_message completes and durably owns the user turn.
+                dict.pop(pending_store, session_key, None)
+                task = asyncio.create_task(
+                    self._handle_durable_pending_message(adapter, session_key, event)
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+                scheduled += 1
+        if scheduled:
+            logger.info("Scheduled %d durable pending message(s)", scheduled)
+        return scheduled
+
+    def _requeue_durable_pending_message(
+        self,
+        adapter: Any,
+        session_key: str,
+        event: MessageEvent,
+    ) -> None:
+        pending_store = getattr(adapter, "_pending_messages", None)
+        if pending_store is not None and session_key not in pending_store:
+            dict.__setitem__(pending_store, session_key, event)
+        self._save_durable_pending_messages()
+
+    async def _handle_durable_pending_message(
+        self,
+        adapter: Any,
+        session_key: str,
+        event: MessageEvent,
+    ) -> None:
+        try:
+            await adapter.handle_message(event)
+        except asyncio.CancelledError:
+            self._requeue_durable_pending_message(adapter, session_key, event)
+            raise
+        except Exception:
+            logger.exception("Durable pending message failed; re-queued for retry")
+            self._requeue_durable_pending_message(adapter, session_key, event)
+        else:
+            self._save_durable_pending_messages()
 
     @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
@@ -3809,6 +4041,33 @@ class GatewayRunner:
         {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
     )
 
+    async def _heartbeat_active_session(
+        self,
+        session_key: str,
+        stop_event: asyncio.Event,
+        *,
+        interval_seconds: float = 30.0,
+    ) -> None:
+        """Keep SessionEntry.updated_at fresh while a long turn is running.
+
+        Crash recovery marks recently updated sessions as resume_pending on
+        next startup. Without a heartbeat, all-day jobs can look idle and be
+        skipped by that recovery window.
+        """
+        if not session_key:
+            return
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+            except asyncio.TimeoutError:
+                pass
+            if stop_event.is_set():
+                break
+            try:
+                self.session_store.update_session(session_key)
+            except Exception as exc:
+                logger.debug("session heartbeat failed for %s: %s", session_key, exc)
+
     def _schedule_resume_pending_sessions(self) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
@@ -4174,6 +4433,11 @@ class GatewayRunner:
                 success = await self._connect_adapter_with_timeout(adapter, platform)
                 if success:
                     self.adapters[platform] = adapter
+                    restored_pending = self._restore_durable_pending_messages_for_adapter(adapter)
+                    if hasattr(adapter, "set_pending_message_change_callback"):
+                        adapter.set_pending_message_change_callback(
+                            self._save_durable_pending_messages
+                        )
                     self._sync_voice_mode_state_to_adapter(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
@@ -4182,7 +4446,14 @@ class GatewayRunner:
                         error_code=None,
                         error_message=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
+                    if restored_pending:
+                        logger.info(
+                            "✓ %s connected; restored %d durable pending message(s)",
+                            platform.value,
+                            restored_pending,
+                        )
+                    else:
+                        logger.info("✓ %s connected", platform.value)
                 else:
                     logger.warning("✗ %s failed to connect", platform.value)
                     # Defensive cleanup: a failed connect() may have
@@ -4372,6 +4643,7 @@ class GatewayRunner:
         # by the normal successful-turn path, so a failed auto-resume remains
         # visible for manual recovery on the next user message.
         self._schedule_resume_pending_sessions()
+        self._schedule_durable_pending_messages()
 
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
@@ -5871,6 +6143,11 @@ class GatewayRunner:
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:
                         self.adapters[platform] = adapter
+                        restored_pending = self._restore_durable_pending_messages_for_adapter(adapter)
+                        if hasattr(adapter, "set_pending_message_change_callback"):
+                            adapter.set_pending_message_change_callback(
+                                self._save_durable_pending_messages
+                            )
                         self._sync_voice_mode_state_to_adapter(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
@@ -8840,17 +9117,33 @@ class GatewayRunner:
             await self.hooks.emit("agent:start", hook_ctx)
 
             # Run the agent
-            agent_result = await self._run_agent(
-                message=message_text,
-                context_prompt=context_prompt,
-                history=history,
-                source=source,
-                session_id=session_entry.session_id,
-                session_key=session_key,
-                run_generation=run_generation,
-                event_message_id=self._reply_anchor_for_event(event),
-                channel_prompt=event.channel_prompt,
+            _heartbeat_stop = asyncio.Event()
+            _heartbeat_task = asyncio.create_task(
+                self._heartbeat_active_session(session_key, _heartbeat_stop)
             )
+            _background_tasks = getattr(self, "_background_tasks", None)
+            if _background_tasks is not None:
+                _background_tasks.add(_heartbeat_task)
+                _heartbeat_task.add_done_callback(_background_tasks.discard)
+            try:
+                agent_result = await self._run_agent(
+                    message=message_text,
+                    context_prompt=context_prompt,
+                    history=history,
+                    source=source,
+                    session_id=session_entry.session_id,
+                    session_key=session_key,
+                    run_generation=run_generation,
+                    event_message_id=self._reply_anchor_for_event(event),
+                    channel_prompt=event.channel_prompt,
+                )
+            finally:
+                _heartbeat_stop.set()
+                _heartbeat_task.cancel()
+                try:
+                    await _heartbeat_task
+                except asyncio.CancelledError:
+                    pass
 
             # Stop persistent typing indicator now that the agent is done
             try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1888,14 +1888,12 @@ class SessionDB:
 
         Context compression ends the current session and forks a new child session
         (linked via ``parent_session_id``). The flush cursor is reset, so the
-        child is where new messages actually land — the parent ends up with
-        ``message_count = 0`` rows unless messages had already been flushed to
-        it before compression. See #15000.
+        child is where new messages actually land. See #15000.
 
-        This helper walks ``parent_session_id`` forward from ``session_id`` and
-        returns the first descendant in the chain that has at least one message
-        row. If the original session already has messages, or no descendant
-        has any, the original ``session_id`` is returned unchanged.
+        This helper first follows the explicit compression chain so resuming an
+        ended parent opens the live continuation even if the parent already has
+        messages. Older data can have empty compression parents, so we keep the
+        message-bearing descendant fallback for non-marked chains.
 
         The chain is always walked via the child whose ``started_at`` is
         latest; that matches the single-chain shape that compression creates.
@@ -1903,6 +1901,13 @@ class SessionDB:
         """
         if not session_id:
             return session_id
+
+        try:
+            tip = self.get_compression_tip(session_id)
+        except Exception:
+            tip = session_id
+        if tip and tip != session_id:
+            return tip
 
         with self._lock:
             # If this session already has messages, nothing to redirect.
@@ -3311,4 +3316,3 @@ class SessionDB:
                 (error[:500], session_id),
             )
         self._execute_write(_do)
-

--- a/run_agent.py
+++ b/run_agent.py
@@ -4390,12 +4390,13 @@ class AIAgent:
         user_message: str,
         original_user_message: Any,
         messages: List[Dict[str, Any]],
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
         effective_task_id: str,
         should_review_memory: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, conversation_history=conversation_history, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
 def main(
     query: str = None,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2644,6 +2644,40 @@ class TestCodexAuxiliaryAdapterTimeout:
 
         assert time.monotonic() - started < 0.14
 
+    def test_retries_once_when_create_returns_none(self):
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="summary recovered")],
+        )
+        events = [
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(
+                status="completed", id="r1", usage=None,
+            )),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        class FakeResponses:
+            def __init__(self):
+                self.calls = 0
+
+            def create(self, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return None
+                return _FakeCreateStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize this"}])
+
+        assert fake_client.responses.calls == 2
+        assert response.choices[0].message.content == "summary recovered"
+
 
 class TestCodexAuxiliaryAdapterNullOutputRecovery:
     def test_recovers_output_item_when_terminal_event_has_null_output(self):

--- a/tests/gateway/test_durable_pending_messages.py
+++ b/tests/gateway/test_durable_pending_messages.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, PendingMessageStore
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _Adapter:
+    platform = Platform.TELEGRAM
+
+    def __init__(self):
+        self._pending_messages = PendingMessageStore()
+        self._text_debounce = {}
+        self.handled: list[MessageEvent] = []
+
+    def set_pending_message_change_callback(self, callback):
+        self._pending_messages.set_change_callback(callback)
+
+    async def handle_message(self, event: MessageEvent):
+        self.handled.append(event)
+
+
+class _BlockingAdapter(_Adapter):
+    def __init__(self):
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def handle_message(self, event: MessageEvent):
+        self.started.set()
+        await self.release.wait()
+        await super().handle_message(event)
+
+
+class _FailingAdapter(_Adapter):
+    def __init__(self):
+        super().__init__()
+        self.started = asyncio.Event()
+
+    async def handle_message(self, event: MessageEvent):
+        self.started.set()
+        raise RuntimeError("boom")
+
+
+def _runner(tmp_path, adapter: _Adapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._queued_events = {}
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    runner._durable_pending_path = tmp_path / "gateway_pending_messages.json"
+    return runner
+
+
+def _event(text: str = "queued follow-up") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="u1",
+        ),
+        message_id="m1",
+    )
+
+
+def _payload_has_pending(runner: GatewayRunner, session_key: str) -> bool:
+    return session_key in runner._read_durable_pending_payload().get("pending", {})
+
+
+def test_pending_message_store_callback_persists_snapshot(tmp_path):
+    adapter = _Adapter()
+    runner = _runner(tmp_path, adapter)
+    adapter.set_pending_message_change_callback(runner._save_durable_pending_messages)
+
+    adapter._pending_messages["session-1"] = _event("do not lose this")
+
+    payload = runner._read_durable_pending_payload()
+    assert payload["pending"]["session-1"]["text"] == "do not lose this"
+    assert payload["pending"]["session-1"]["source"]["platform"] == "telegram"
+
+
+def test_restores_durable_pending_messages_for_adapter(tmp_path):
+    adapter = _Adapter()
+    runner = _runner(tmp_path, adapter)
+    adapter._pending_messages["session-1"] = _event("restore me")
+    runner._save_durable_pending_messages()
+
+    restored_adapter = _Adapter()
+    restored_runner = _runner(tmp_path, restored_adapter)
+
+    assert restored_runner._restore_durable_pending_messages_for_adapter(restored_adapter) == 1
+    assert restored_adapter._pending_messages["session-1"].text == "restore me"
+
+
+def test_saves_text_debounce_buffer_as_durable_pending(tmp_path):
+    adapter = _Adapter()
+    runner = _runner(tmp_path, adapter)
+    adapter._text_debounce["session-1"] = SimpleNamespace(event=_event("debounced"))
+
+    runner._save_durable_pending_messages()
+
+    payload = runner._read_durable_pending_payload()
+    assert payload["pending"]["session-1"]["text"] == "debounced"
+
+
+@pytest.mark.asyncio
+async def test_schedules_restored_pending_when_session_not_resuming(tmp_path):
+    adapter = _Adapter()
+    runner = _runner(tmp_path, adapter)
+    adapter._pending_messages["session-1"] = _event("run me")
+    runner._is_session_resume_pending = lambda session_key: False
+
+    assert runner._schedule_durable_pending_messages() == 1
+    await asyncio.wait_for(asyncio.gather(*list(runner._background_tasks)), timeout=1)
+
+    assert [event.text for event in adapter.handled] == ["run me"]
+    assert "session-1" not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_restored_pending_snapshot_survives_until_handle_completes(tmp_path):
+    adapter = _BlockingAdapter()
+    runner = _runner(tmp_path, adapter)
+    adapter.set_pending_message_change_callback(runner._save_durable_pending_messages)
+    adapter._pending_messages["session-1"] = _event("run me durably")
+    runner._is_session_resume_pending = lambda session_key: False
+
+    assert runner._schedule_durable_pending_messages() == 1
+    await asyncio.wait_for(adapter.started.wait(), timeout=1)
+
+    assert "session-1" not in adapter._pending_messages
+    assert _payload_has_pending(runner, "session-1")
+
+    adapter.release.set()
+    await asyncio.wait_for(asyncio.gather(*list(runner._background_tasks)), timeout=1)
+
+    assert [event.text for event in adapter.handled] == ["run me durably"]
+    assert not _payload_has_pending(runner, "session-1")
+
+
+@pytest.mark.asyncio
+async def test_restored_pending_reinserted_on_handle_failure(tmp_path):
+    adapter = _FailingAdapter()
+    runner = _runner(tmp_path, adapter)
+    adapter.set_pending_message_change_callback(runner._save_durable_pending_messages)
+    adapter._pending_messages["session-1"] = _event("retry me")
+    runner._is_session_resume_pending = lambda session_key: False
+
+    assert runner._schedule_durable_pending_messages() == 1
+    await asyncio.wait_for(adapter.started.wait(), timeout=1)
+    for _ in range(10):
+        if "session-1" in adapter._pending_messages:
+            break
+        await asyncio.sleep(0)
+
+    assert adapter._pending_messages["session-1"].text == "retry me"
+    assert _payload_has_pending(runner, "session-1")
+
+
+@pytest.mark.asyncio
+async def test_resume_pending_skip_keeps_snapshot_then_later_drains(tmp_path):
+    adapter = _Adapter()
+    runner = _runner(tmp_path, adapter)
+    adapter.set_pending_message_change_callback(runner._save_durable_pending_messages)
+    adapter._pending_messages["session-1"] = _event("after resume")
+
+    runner._is_session_resume_pending = lambda session_key: True
+    assert runner._schedule_durable_pending_messages() == 0
+    assert _payload_has_pending(runner, "session-1")
+    assert adapter.handled == []
+
+    runner._is_session_resume_pending = lambda session_key: False
+    assert runner._schedule_durable_pending_messages() == 1
+    await asyncio.wait_for(asyncio.gather(*list(runner._background_tasks)), timeout=1)
+
+    assert [event.text for event in adapter.handled] == ["after resume"]
+    assert not _payload_has_pending(runner, "session-1")
+
+
+def test_corrupt_durable_pending_snapshot_is_quarantined(tmp_path):
+    adapter = _Adapter()
+    runner = _runner(tmp_path, adapter)
+    runner._durable_pending_path.write_text("{not-json", encoding="utf-8")
+
+    assert runner._read_durable_pending_payload() == {"pending": {}, "queued": {}}
+
+    assert not runner._durable_pending_path.exists()
+    assert list(tmp_path.glob("gateway_pending_messages.json.corrupt.*"))

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -5,6 +5,7 @@ can enter a wedged state where ``bot.send_message()`` returns a valid Message
 but nothing reaches the recipient.  ``_send_path_degraded`` short-circuits
 ``send()`` so cron's live-adapter branch falls through to standalone HTTP.
 """
+import asyncio
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -63,6 +64,39 @@ async def test_send_short_circuits_when_path_degraded():
     assert result.error == "send_path_degraded"
     assert result.retryable is True
     adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_message_timeout_returns_without_hanging(monkeypatch):
+    adapter = _make_adapter()
+
+    async def slow_send_message(**kwargs):
+        await asyncio.sleep(10)
+
+    adapter._bot.send_message = AsyncMock(side_effect=slow_send_message)
+    monkeypatch.setattr(adapter, "_telegram_send_timeout_seconds", lambda: 0.01)
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert "timed out" in result.error.lower()
+    assert result.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_post_send_typing_timeout_does_not_block_delivery(monkeypatch):
+    adapter = _make_adapter()
+
+    async def slow_send_typing(chat_id, metadata=None):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(adapter, "send_typing", slow_send_typing)
+    monkeypatch.setattr(adapter, "_telegram_post_send_typing_timeout_seconds", lambda: 0.01)
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    adapter._bot.send_message.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -56,6 +56,24 @@ def test_returns_self_when_session_has_messages(db):
     assert db.resolve_resume_session_id("root") == "root"
 
 
+def test_compression_parent_with_messages_redirects_to_tip(db):
+    _make_chain(db, [("root", None), ("child", "root")])
+    db.append_message("root", role="user", content="old parent row")
+    db.append_message("child", role="assistant", content="live continuation")
+    base = int(time.time())
+    db._conn.execute(
+        "UPDATE sessions SET ended_at = ?, end_reason = 'compression' WHERE id = ?",
+        (base, "root"),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (base + 1, "child"),
+    )
+    db._conn.commit()
+
+    assert db.resolve_resume_session_id("root") == "child"
+
+
 def test_returns_self_when_no_descendant_has_messages(db):
     _make_chain(db, [("root", None), ("child1", "root"), ("child2", "child1")])
     assert db.resolve_resume_session_id("root") == "root"

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -215,7 +215,7 @@ class TestHTTP413Compression:
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(
                 agent, "_persist_session",
-                side_effect=lambda msgs, hist: persist_calls.append(hist),
+                side_effect=lambda msgs, hist: persist_calls.append((msgs, hist)),
             ),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
@@ -227,7 +227,13 @@ class TestHTTP413Compression:
             agent.run_conversation("hello", conversation_history=big_history)
 
         assert len(persist_calls) >= 1, "Expected at least one _persist_session call"
-        for hist in persist_calls:
+        compressed_persists = [
+            hist
+            for msgs, hist in persist_calls
+            if msgs and msgs[0].get("content") == "summary"
+        ]
+        assert compressed_persists, "Expected compressed session persist"
+        for hist in compressed_persists:
             assert hist is None, (
                 f"conversation_history should be None after mid-loop compression, "
                 f"got list with {len(hist)} items"
@@ -254,7 +260,7 @@ class TestHTTP413Compression:
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(
                 agent, "_persist_session",
-                side_effect=lambda msgs, hist: persist_calls.append(hist),
+                side_effect=lambda msgs, hist: persist_calls.append((msgs, hist)),
             ),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
@@ -266,7 +272,13 @@ class TestHTTP413Compression:
             agent.run_conversation("hello", conversation_history=big_history)
 
         assert len(persist_calls) >= 1
-        for hist in persist_calls:
+        compressed_persists = [
+            hist
+            for msgs, hist in persist_calls
+            if msgs and msgs[0].get("content") == "summary"
+        ]
+        assert compressed_persists, "Expected compressed session persist"
+        for hist in compressed_persists:
             assert hist is None, (
                 f"conversation_history should be None after context-overflow compression, "
                 f"got list with {len(hist)} items"

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -83,6 +83,91 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+        assert result["interrupted"] is False
+
+    def test_persists_user_message_before_codex_turn(self, fake_session):
+        """The current user message must hit durable persistence before
+        codex_app_server starts any long-running work."""
+        agent = _make_codex_agent()
+        snapshots = []
+
+        def capture(messages, conversation_history=None):
+            snapshots.append([dict(m) for m in messages])
+
+        with patch.object(agent, "_persist_session", side_effect=capture), patch.object(
+            agent, "_spawn_background_review", return_value=None
+        ):
+            agent.run_conversation("flight info is BA123")
+
+        assert snapshots, "expected at least one persistence checkpoint"
+        assert snapshots[0] == [{"role": "user", "content": "flight info is BA123"}]
+
+    def test_persists_projected_codex_messages(self, fake_session):
+        """The codex_app_server path must persist its projected assistant/tool
+        transcript because the gateway skips DB writes when an agent has DB
+        persistence available."""
+        agent = _make_codex_agent()
+        snapshots = []
+
+        def capture(messages, conversation_history=None):
+            snapshots.append([dict(m) for m in messages])
+
+        with patch.object(agent, "_persist_session", side_effect=capture), patch.object(
+            agent, "_spawn_background_review", return_value=None
+        ):
+            agent.run_conversation("hello")
+
+        assert any(
+            any(
+                msg.get("role") == "assistant"
+                and msg.get("content") == "echo: hello"
+                for msg in snapshot
+            )
+            for snapshot in snapshots
+        ), snapshots
+
+    def test_persists_projected_codex_messages_before_run_turn_returns(self, monkeypatch):
+        """Projected app-server messages must checkpoint during the blocking
+        run_turn() loop, not only after turn/completed returns."""
+        snapshots = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            checkpoint = kwargs.get("projection_checkpoint")
+            assert checkpoint is not None, "run_turn needs an incremental checkpoint callback"
+            checkpoint([{"role": "assistant", "content": "mid-turn work"}])
+            assert any(
+                any(msg.get("content") == "mid-turn work" for msg in snapshot)
+                for snapshot in snapshots
+            ), "projection was not persisted before run_turn returned"
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "mid-turn work"}],
+                tool_iterations=0,
+                turn_id="turn-stub-1",
+                thread_id="thread-stub-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-1"
+        )
+
+        agent = _make_codex_agent()
+
+        def capture(messages, conversation_history=None):
+            snapshots.append([dict(m) for m in messages])
+
+        with patch.object(agent, "_persist_session", side_effect=capture), patch.object(
+            agent, "_spawn_background_review", return_value=None
+        ):
+            result = agent.run_conversation("do codex work")
+
+        assert result["completed"] is True
+        assert sum(
+            1
+            for msg in result["messages"]
+            if msg.get("role") == "assistant" and msg.get("content") == "mid-turn work"
+        ) == 1
 
     def test_projected_messages_are_spliced(self, fake_session):
         agent = _make_codex_agent()
@@ -318,8 +403,32 @@ class TestErrorHandling:
             result = agent.run_conversation("hi")
         assert result["completed"] is False
         assert result["partial"] is True
+        assert result["interrupted"] is False
         assert "subprocess died" in result["error"]
         assert "codex-runtime auto" in result["final_response"]
+
+    def test_session_exception_still_persists_user_message(self, monkeypatch):
+        def boom_run_turn(self, user_input, **kwargs):
+            raise RuntimeError("subprocess died")
+
+        monkeypatch.setattr(CodexAppServerSession, "ensure_started",
+                            lambda self: "t1")
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", boom_run_turn)
+
+        agent = _make_codex_agent()
+        snapshots = []
+
+        def capture(messages, conversation_history=None):
+            snapshots.append([dict(m) for m in messages])
+
+        with patch.object(agent, "_persist_session", side_effect=capture), patch.object(
+            agent, "_spawn_background_review", return_value=None
+        ):
+            result = agent.run_conversation("do not lose this")
+
+        assert result["completed"] is False
+        assert snapshots
+        assert snapshots[0] == [{"role": "user", "content": "do not lose this"}]
 
     def test_interrupted_turn_marked_partial(self, monkeypatch):
         def interrupted_turn(self, user_input, **kwargs):
@@ -341,6 +450,7 @@ class TestErrorHandling:
             result = agent.run_conversation("hi")
         assert result["completed"] is False
         assert result["partial"] is True
+        assert result["interrupted"] is True
         assert result["error"] == "user interrupted"
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2783,6 +2783,37 @@ class TestRunConversation:
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c and "assistant_message" in c for c in post_request_calls)
 
+    def test_persists_clean_user_message_before_first_api_call(self, agent):
+        """A crash during the first provider call must not lose the inbound
+        user turn, and API-only injected context must stay ephemeral."""
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        snapshots = []
+
+        def capture(messages, conversation_history=None):
+            snapshots.append([dict(m) for m in messages])
+
+        def api_call(api_kwargs):
+            assert snapshots, "user message was not persisted before first API call"
+            assert snapshots[0] == [{"role": "user", "content": "plain user turn"}]
+            api_user = next(
+                msg for msg in api_kwargs["messages"] if msg.get("role") == "user"
+            )
+            assert "EPHEMERAL PLUGIN CONTEXT" in api_user.get("content", "")
+            assert "EPHEMERAL PLUGIN CONTEXT" not in snapshots[0][0]["content"]
+            return resp
+
+        with (
+            patch.object(agent, "_persist_session", side_effect=capture),
+            patch.object(agent, "_interruptible_api_call", side_effect=api_call),
+            patch("hermes_cli.plugins.invoke_hook", return_value=[{"context": "EPHEMERAL PLUGIN CONTEXT"}]),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("plain user turn")
+
+        assert result["completed"] is True
+
     def test_content_with_tool_calls_stays_silent_for_non_cli_quiet_mode(self, agent):
         self._setup_agent(agent)
         agent.platform = None

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -531,6 +531,36 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.usage.total_tokens == 11
 
 
+def test_run_codex_stream_retries_when_create_returns_none(monkeypatch):
+    """Regression: SDK/provider drift can return None instead of an iterable."""
+    agent = _build_agent(monkeypatch)
+    calls = {"create": 0}
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        assert kwargs.get("stream") is True
+        if calls["create"] == 1:
+            return None
+        return _FakeCreateStream(
+            [
+                SimpleNamespace(type="response.created"),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=_codex_message_response("retry recovered"),
+                ),
+            ]
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls["create"] == 2
+    assert response.status == "completed"
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary
- Retry once when Codex Responses streaming returns no event stream instead of an iterable.
- Add bounded Telegram send and typing waits so stalled bot API calls do not wedge gateway delivery.
- Add regressions for Codex stream recovery and Telegram send/typing timeout behavior.

## Verification
- venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_retries_when_create_returns_none tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_retries_once_when_create_returns_none tests/gateway/test_telegram_send_path_health.py::test_send_message_timeout_returns_without_hanging tests/gateway/test_telegram_send_path_health.py::test_post_send_typing_timeout_does_not_block_delivery
- ./scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py tests/gateway/test_telegram_send_path_health.py
- venv/bin/python -m ruff check agent/auxiliary_client.py agent/codex_runtime.py gateway/platforms/telegram.py tests/agent/test_auxiliary_client.py tests/run_agent/test_run_agent_codex_responses.py tests/gateway/test_telegram_send_path_health.py
- git diff --check