### PR TITLE
fix(tui): stabilize transcript row identity

### DIFF
--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -1,8 +1,10 @@
+import { PassThrough } from 'stream'
+
 import { renderSync } from '@hermes/ink'
 import React from 'react'
-import { PassThrough } from 'stream'
 import { describe, expect, it } from 'vitest'
 
+import { liveSessionInflightMessages } from '../app/useSessionLifecycle.js'
 import { MessageLine } from '../components/messageLine.js'
 import { toTranscriptMessages } from '../domain/messages.js'
 import { upsert } from '../lib/messages.js'
@@ -24,6 +26,25 @@ describe('toTranscriptMessages', () => {
       ['user', 'second prompt']
     ])
     expect(toTranscriptMessages(rows)[1]?.tools?.[0]).toContain('Search Files')
+  })
+
+  it('assigns stable ids to resumed transcript rows', () => {
+    const rows = [
+      { role: 'user', text: 'first prompt' },
+      { role: 'assistant', text: 'first answer' },
+      { role: 'user', text: 'second prompt' }
+    ]
+
+    const messages = toTranscriptMessages(rows)
+
+    expect(messages.every(msg => typeof msg.id === 'string' && msg.id.length > 0)).toBe(true)
+    expect(new Set(messages.map(msg => msg.id)).size).toBe(messages.length)
+  })
+})
+
+describe('liveSessionInflightMessages', () => {
+  it('assigns ids to inflight user rows', () => {
+    expect(liveSessionInflightMessages({ assistant: '', streaming: false, user: 'resume me' })[0]?.id).toMatch(/^msg-/)
   })
 })
 
@@ -77,11 +98,17 @@ describe('upsert', () => {
   })
 
   it('replaces when last role matches', () => {
-    expect(upsert([{ role: 'assistant', text: 'partial' }], 'assistant', 'full')[0]!.text).toBe('full')
+    const out = upsert([{ id: 'msg-keep', role: 'assistant', text: 'partial' }], 'assistant', 'full')
+
+    expect(out[0]!.text).toBe('full')
+    expect(out[0]!.id).toBe('msg-keep')
   })
 
   it('appends to empty', () => {
-    expect(upsert([], 'user', 'first')).toEqual([{ role: 'user', text: 'first' }])
+    const out = upsert([], 'user', 'first')
+
+    expect(out[0]).toMatchObject({ role: 'user', text: 'first' })
+    expect(out[0]!.id).toMatch(/^msg-/)
   })
 
   it('does not mutate', () => {

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -40,8 +40,10 @@ describe('live session activation in-flight state', () => {
 
   it('keeps the in-flight user prompt in history and hydrates partial assistant text', () => {
     const inflight = { assistant: 'partial answer', streaming: true, user: 'write a long answer' }
+    const messages = liveSessionInflightMessages(inflight)
 
-    expect(liveSessionInflightMessages(inflight)).toEqual([{ role: 'user', text: 'write a long answer' }])
+    expect(messages[0]).toMatchObject({ role: 'user', text: 'write a long answer' })
+    expect(messages[0]!.id).toMatch(/^msg-/)
 
     hydrateLiveSessionInflight(inflight)
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -20,7 +20,7 @@ import type {
 import { useGitBranch } from '../hooks/useGitBranch.js'
 import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
-import { appendTranscriptMessage } from '../lib/messages.js'
+import { appendTranscriptMessage, ensureMsgId } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
@@ -160,7 +160,7 @@ export function useMainApp(gw: GatewayClient) {
     }
   }, [stdout])
 
-  const [historyItems, setHistoryItems] = useState<Msg[]>(() => [{ kind: 'intro', role: 'system', text: '' }])
+  const [historyItems, setHistoryItems] = useState<Msg[]>(() => [ensureMsgId({ kind: 'intro', role: 'system', text: '' })])
   const [lastUserMsg, setLastUserMsg] = useState('')
   const [stickyPrompt, setStickyPrompt] = useState('')
   const [catalog, setCatalog] = useState<null | SlashCatalog>(null)
@@ -284,6 +284,10 @@ export function useMainApp(gw: GatewayClient) {
   }, [])
 
   const messageId = useCallback((msg: Msg) => {
+    if (msg.id) {
+      return msg.id
+    }
+
     const hit = msgIdsRef.current.get(msg)
 
     if (hit) {

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -17,6 +17,7 @@ import type {
   SessionTitleResponse,
   SetupStatusResponse
 } from '../gatewayTypes.js'
+import { ensureMsgId } from '../lib/messages.js'
 import { asRpcResult } from '../lib/rpc.js'
 import type { Msg, PanelSection, SessionInfo, Usage } from '../types.js'
 
@@ -55,7 +56,7 @@ export const writeActiveSessionFile = (sessionId: null | string, file = process.
 export const liveSessionInflightMessages = (inflight?: null | SessionInflightTurn): Msg[] => {
   const user = String(inflight?.user ?? '').trim()
 
-  return user ? [{ role: 'user', text: user }] : []
+  return user ? [ensureMsgId({ role: 'user', text: user })] : []
 }
 
 export const hydrateLiveSessionInflight = (inflight?: null | SessionInflightTurn) => {

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -1,8 +1,9 @@
 import { LONG_MSG } from '../config/limits.js'
+import { ensureMsgId } from '../lib/messages.js'
 import { buildToolTrailLine, fmtK } from '../lib/text.js'
 import type { Msg, SessionInfo } from '../types.js'
 
-export const introMsg = (info: SessionInfo): Msg => ({ info, kind: 'intro', role: 'system', text: '' })
+export const introMsg = (info: SessionInfo): Msg => ensureMsgId({ info, kind: 'intro', role: 'system', text: '' })
 
 export const imageTokenMeta = (info?: ImageMeta | null) => {
   const { width, height, token_estimate: t } = info ?? {}
@@ -57,10 +58,10 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
     }
 
     if (role === 'assistant') {
-      out.push({ role, text, ...(pending.length && { tools: pending }) })
+      out.push(ensureMsgId({ role, text, ...(pending.length && { tools: pending }) }))
       pending = []
     } else if (role === 'user' || role === 'system') {
-      out.push({ role, text })
+      out.push(ensureMsgId({ role, text }))
       pending = []
     }
   }

--- a/ui-tui/src/lib/messages.ts
+++ b/ui-tui/src/lib/messages.ts
@@ -2,7 +2,16 @@ import type { Msg, Role } from '../types.js'
 
 import { appendToolShelfMessage } from './liveProgress.js'
 
-export const appendTranscriptMessage = (prev: Msg[], msg: Msg): Msg[] => appendToolShelfMessage(prev, msg)
+let msgIdSeq = 0
+
+const nextMsgId = () => `msg-${++msgIdSeq}`
+
+export const ensureMsgId = <T extends Msg>(msg: T): T & { id: string } =>
+  msg.id ? (msg as T & { id: string }) : { ...msg, id: nextMsgId() }
+
+export const appendTranscriptMessage = (prev: Msg[], msg: Msg): Msg[] => appendToolShelfMessage(prev, ensureMsgId(msg))
 
 export const upsert = (prev: Msg[], role: Role, text: string): Msg[] =>
-  prev.at(-1)?.role === role ? [...prev.slice(0, -1), { role, text }] : [...prev, { role, text }]
+  prev.at(-1)?.role === role
+    ? [...prev.slice(0, -1), ensureMsgId({ ...prev.at(-1)!, role, text })]
+    : [...prev, ensureMsgId({ role, text })]

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -110,6 +110,7 @@ export interface ClarifyReq {
 }
 
 export interface Msg {
+  id?: string
   info?: SessionInfo
   kind?: 'diff' | 'intro' | 'panel' | 'slash' | 'trail'
   panelData?: PanelData


### PR DESCRIPTION
## Summary
- assign stable ids to transcript/inflight/resume TUI messages and preserve them through transcript updates
- prefer message ids over object identity for virtual transcript row keys so merged rows do not remount and jump
- add regression coverage for resumed transcript ids and inflight session rows

## Testing
- npm run build --prefix ui-tui/packages/hermes-ink
- npm test --prefix ui-tui -- --run src/__tests__/messages.test.ts src/__tests__/useSessionLifecycle.test.ts
- ./ui-tui/node_modules/.bin/eslint ui-tui/src/app/useMainApp.ts ui-tui/src/app/useSessionLifecycle.ts ui-tui/src/domain/messages.ts ui-tui/src/lib/messages.ts ui-tui/src/types.ts ui-tui/src/__tests__/messages.test.ts ui-tui/src/__tests__/useSessionLifecycle.test.ts
- git diff --check

Closes #33336