### PR TITLE
fix(deps): bump openai pin from ==2.24.0 to >=2.35.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   # extra and gets lazy-installed via `tools/lazy_deps.py` when the
   # user picks that backend. Smaller `dependencies` = smaller blast
   # radius for the next supply-chain attack.
-  "openai==2.24.0",
+  "openai>=2.35.0",
   "python-dotenv==1.2.2",
   "fire==0.7.1",
   "httpx[socks]==0.28.1",


### PR DESCRIPTION
## Problem

openai SDK `2.24.0` (the current pinned version) has a bug in
`openai/lib/_parsing/_responses.py` — `get_final_response()` iterates
`response.output` without a `None` guard:

```python
# SDK 2.24.0 – buggy
for output in response.output:   # TypeError when output is None
```

When the ChatGPT Codex API returns a `response.completed` SSE event
with `output: null`, this raises:

```
TypeError: 'NoneType' object is not iterable
```

The error propagates through `codex_runtime.py` → `conversation_loop.py`,
which classifies it as a non-retryable local validation error
(`is_local_validation_error` path, `status_code=None`) and surfaces to
users as:

```
Non-retryable error (HTTP None)
```

Observed in production logs on 2026-05-27 across multiple consecutive
hours (17:00, 17:15, 18:15, 19:15 UTC+8), affecting Hermes instances
running SDK 2.24.0 against ChatGPT Plus OAuth / Codex backend.

## Fix

openai [PR #3240](https://github.com/openai/openai-python/pull/3240)
(merged 2026-05-15) adds the None guard; the fix ships in SDK **≥ 2.35.0**:

```python
# SDK >=2.35.0 – fixed
for output in (response.output or []):
```

This PR relaxes the pin from `==2.24.0` to `>=2.35.0`.

## Relationship to Hermes PR #33042

Commit `cb38ce28c` rewrote `codex_runtime.py` to never read
`response.output` from the terminal event, which architecturally
removes the crash path inside Hermes itself.  However, pinning to a
pre-fix SDK version still exposes other SDK call-sites and any
downstream consumers that import from `openai.lib._parsing`.
Bumping the pin is complementary and ensures the fixed SDK is always
installed.

## Affected versions

| Component | Affected | Fixed |
|-----------|----------|-------|
| openai SDK | < 2.35.0 | ≥ 2.35.0 (PR #3240, 2026-05-15) |
| Hermes (codex path) | before commit `43a3f119f` | `43a3f119f` (partial), `cb38ce28c` (architectural) |

Users running Hermes `main` after `cb38ce28c` with the old SDK pin
(`==2.24.0`) are safe inside Hermes' own codex path, but a fresh
`pip install` will still pull the buggy SDK.

## Test plan

- [ ] `pip install -e .` in a clean venv resolves `openai>=2.35.0`
- [ ] Codex stream with `output: null` terminal event completes without TypeError
- [ ] Existing Hermes test suite passes