### PR TITLE
fix(gateway): include asyncio context message in transient error warning log

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -263,8 +263,9 @@ def _gateway_loop_exception_handler(
             except Exception:
                 task_name = repr(task)
         logger.warning(
-            "Gateway swallowed transient network error from %s: %s: %s",
+            "Gateway swallowed transient network error from %s: %s: %s: %s",
             task_name or "<unknown task>",
+            message,
             type(exc).__name__,
             exc,
             exc_info=(type(exc), exc, exc.__traceback__),


### PR DESCRIPTION
## Summary

The `_gateway_loop_exception_handler` in `gateway/run.py` extracts the `message` field from the asyncio loop context dict (line 202) but never includes it in the `logger.warning()` call (line 210). This means useful diagnostic context like `"Task exception was never retrieved"` is silently dropped from transient error logs.

## Fix

Include the `message` variable in the log format string so the full asyncio context is captured in the warning output.

**Before:**
```
Gateway swallowed transient network error from <task>: TimedOut: Timed out
```

**After:**
```
Gateway swallowed transient network error from <task>: Task exception was never retrieved: TimedOut: Timed out
```

## Testing

- `python3 -m py_compile gateway/run.py` passes
- All 14 existing tests in `tests/gateway/test_loop_exception_handler.py` pass

## Files Changed

- `gateway/run.py` — Added `message` to the warning log format string (1 line format string + 1 line argument)