### PR TITLE
Fix dashboard WebSocket reconnects in Docker

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11,6 +11,7 @@ Usage:
 
 import asyncio
 import hmac
+import ipaddress
 import importlib.util
 import json
 import logging
@@ -82,10 +83,12 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 
 # ---------------------------------------------------------------------------
 # Session token for protecting sensitive endpoints (reveal).
-# Generated fresh on every server start — dies when the process exits.
-# Injected into the SPA HTML so only the legitimate web UI can use it.
+# By default this is generated fresh on every server start. Local container
+# deployments may set HERMES_DASHBOARD_SESSION_TOKEN so a browser tab can
+# reconnect after a supervised dashboard restart without receiving a stale
+# WebSocket token.
 # ---------------------------------------------------------------------------
-_SESSION_TOKEN = secrets.token_urlsafe(32)
+_SESSION_TOKEN = os.getenv("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``
@@ -3393,7 +3396,15 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return True
-    return client_host in _LOOPBACK_HOSTS
+    if client_host in _LOOPBACK_HOSTS:
+        return True
+    if env_var_enabled("HERMES_DASHBOARD_ALLOW_DOCKER_BRIDGE", False):
+        try:
+            client_ip = ipaddress.ip_address(client_host)
+        except ValueError:
+            return False
+        return client_ip.is_private or client_ip.is_loopback
+    return False
 
 
 def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     "9592417+adam91holt@users.noreply.github.com": "adam91holt",
     "45688690+fujinice@users.noreply.github.com": "fujinice",
+    "kdkcfp@gmail.com": "slowtokki0409",
     "276689385+carltonawong@users.noreply.github.com": "carltonawong",
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2142,6 +2142,17 @@ class TestPtyWebSocket:
                 pass
         assert exc.value.code == 4401
 
+    def test_docker_bridge_client_requires_opt_in(self, monkeypatch):
+        from types import SimpleNamespace
+
+        fake_ws = SimpleNamespace(client=SimpleNamespace(host="172.18.0.1"))
+
+        monkeypatch.delenv("HERMES_DASHBOARD_ALLOW_DOCKER_BRIDGE", raising=False)
+        assert self.ws_module._ws_client_is_allowed(fake_ws) is False
+
+        monkeypatch.setenv("HERMES_DASHBOARD_ALLOW_DOCKER_BRIDGE", "true")
+        assert self.ws_module._ws_client_is_allowed(fake_ws) is True
+
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(
             self.ws_module,
@@ -2443,4 +2454,3 @@ class TestDashboardPluginStaticAssetAllowlist:
         # 403 traversal-blocked OR 404 (depending on URL decode order)
         # — never 200.
         assert resp.status_code in (403, 404)
-


### PR DESCRIPTION
## Summary
- keep the dashboard session token stable when explicitly provided through the environment
- allow Docker bridge/private clients for dashboard PTY WebSocket connections only when the opt-in env flag is enabled
- add regression coverage for Docker bridge client handling

## Verification
- ./.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_docker_bridge_client_requires_opt_in tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_rejects_bad_token

## Notes
- Local Kevin-specific watchdog/LaunchAgent changes are intentionally not included in this upstream PR.
- This PR keeps existing token and Host/Origin guards in place.