### PR TITLE
fix: accept responses as alias for codex_responses in api_mode config

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -257,6 +257,11 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     """Validate an api_mode value from config. Returns None if invalid."""
     if isinstance(raw, str):
         normalized = raw.strip().lower()
+        # Alias: "responses" is accepted as a shorthand for "codex_responses"
+        # so that api_mode: responses in config.yaml behaves identically to
+        # selecting option 3 in `hermes setup`.
+        if normalized == "responses":
+            return "codex_responses"
         if normalized in _VALID_API_MODES:
             return normalized
     return None


### PR DESCRIPTION
### Problem

When `api_mode: responses` is set in `config.yaml` for a custom provider, the value is silently ignored. Hermes always uses `/chat/completions` regardless of the setting.

The root cause is that `_parse_api_mode()` in `runtime_provider.py` only accepts values from `_VALID_API_MODES`, which does not include `"responses"`. The setup wizard (`hermes setup` option 3) correctly maps `"responses"` → `"codex_responses"`, but anyone who writes `api_mode: responses` directly in config.yaml hits this gap.

### Fix

Add a `"responses"` → `"codex_responses"` alias in `_parse_api_mode()` so the config file behaves identically to the setup wizard selection. This is a 1-line functional change (plus comments).

### Testing

- `python3 -m py_compile hermes_cli/runtime_provider.py` — passes
- Unit verification: `_parse_api_mode("responses")` now returns `"codex_responses"`
- Existing provider tests (5 selected) pass without modification

Closes #33600