### PR TITLE
fix(kanban): sync allowlisted forced skills before blocking

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6077,6 +6077,9 @@ def dispatch_once(
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+        except MissingForcedSkillsError as exc:
+            if block_task(conn, claimed.id, reason=str(exc)):
+                result.auto_blocked.append(claimed.id)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -6152,6 +6155,9 @@ def dispatch_once(
                 _set_worker_pid(conn, claimed.id, int(pid))
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+        except MissingForcedSkillsError as exc:
+            if block_task(conn, claimed.id, reason=str(exc)):
+                result.auto_blocked.append(claimed.id)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -6397,13 +6403,331 @@ def _skill_available_for_home(skill_name: str, hermes_home: Optional[str]) -> bo
     return False
 
 
-def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
-    """Back-compat shim: ``--skills kanban-worker`` resolvability check.
 
-    Retained as a named entry point because the bundled-worker case is
-    referenced in inline comments below; delegates to the generic helper.
+class MissingForcedSkillsError(RuntimeError):
+    """Raised before worker spawn when task-level --skills would crash startup."""
+
+    def __init__(self, profile: str, hermes_home: Optional[str], missing: list[str]):
+        self.profile = profile
+        self.hermes_home = hermes_home
+        self.missing = missing
+        super().__init__(
+            "missing forced skill(s) for profile "
+            f"{profile!r}: {', '.join(missing)}. "
+            "Run the profile skill sync/check workflow or install/sync the skill "
+            "into the target profile before unblocking this task."
+        )
+
+
+def _frontmatter_skill_name(text: str) -> Optional[str]:
+    """Best-effort SKILL.md frontmatter name parser without importing YAML."""
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end < 0:
+        return None
+    frontmatter = text[3:end]
+    for line in frontmatter.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("name:"):
+            continue
+        raw = stripped.split(":", 1)[1].strip()
+        return raw.strip('"\'') or None
+    return None
+
+
+def _skill_available(hermes_home: Optional[str], skill_name: str) -> bool:
+    """True if ``skill_name`` resolves in the worker's active skill roots.
+
+    Forced skills are passed to the worker as ``--skills <name>``. If a skill is
+    absent from the worker profile's active local skills root or runtime overlay
+    roots, Hermes raises ``ValueError: Unknown skill(s): ...`` before the agent
+    loop can block or explain itself. This resolver mirrors the practical cases
+    we use in Kanban: directory name, relative path, plugin-qualified name, or
+    frontmatter ``name``.
     """
-    return _skill_available_for_home("kanban-worker", hermes_home)
+    from pathlib import Path as _Path
+
+    name = (skill_name or "").strip()
+    if not name:
+        return True
+
+    # Plugin-qualified skills are resolved by plugin machinery, not the local
+    # profile skill directory. Do not false-block them here.
+    if ":" in name and not name.startswith((".", "/", "~")):
+        return True
+
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    roots: list[_Path] = [base / "skills"]
+
+    # Mirror worker runtime overlays without mutating global HERMES_HOME. The
+    # shared skill_utils helper reads the active process config, while this
+    # preflight often needs to check a *different* worker profile home before
+    # spawning it.
+    env_dirs = os.environ.get("HERMES_SKILLS_EXTERNAL_DIRS", "").strip()
+    if env_dirs:
+        for raw in re.split(r"[:;,]", env_dirs):
+            raw = raw.strip()
+            if not raw:
+                continue
+            expanded = os.path.expanduser(os.path.expandvars(raw))
+            candidate = _Path(expanded)
+            if not candidate.is_absolute():
+                candidate = base / candidate
+            roots.append(candidate)
+
+    config_path = base / "config.yaml"
+    if config_path.is_file():
+        try:
+            from agent.skill_utils import yaml_load
+
+            config_data = yaml_load(config_path.read_text(encoding="utf-8"))
+        except Exception:
+            config_data = {}
+        skills_cfg = config_data.get("skills") if isinstance(config_data, dict) else None
+        raw_dirs = skills_cfg.get("external_dirs") if isinstance(skills_cfg, dict) else None
+        if isinstance(raw_dirs, str):
+            raw_dirs = [raw_dirs]
+        if isinstance(raw_dirs, list):
+            for raw in raw_dirs:
+                raw = str(raw or "").strip()
+                if not raw:
+                    continue
+                expanded = os.path.expanduser(os.path.expandvars(raw))
+                candidate = _Path(expanded)
+                if not candidate.is_absolute():
+                    candidate = base / candidate
+                roots.append(candidate)
+
+    seen_roots: set[_Path] = set()
+    rel = _Path(name)
+    for skills_root in roots:
+        try:
+            resolved_root = skills_root.resolve()
+        except OSError:
+            resolved_root = skills_root
+        if resolved_root in seen_roots or not skills_root.is_dir():
+            continue
+        seen_roots.add(resolved_root)
+
+        # Exact relative path: e.g. software-development/foo or foo.
+        if not rel.is_absolute() and (skills_root / rel / "SKILL.md").is_file():
+            return True
+
+        # Common category/name placement, then broad scan for arbitrary categories.
+        try:
+            for skill_md in skills_root.rglob("SKILL.md"):
+                try:
+                    rel_parent = skill_md.parent.relative_to(skills_root)
+                except ValueError:
+                    rel_parent = skill_md.parent
+                if skill_md.parent.name == name or str(rel_parent) == name:
+                    return True
+                try:
+                    fm_name = _frontmatter_skill_name(
+                        skill_md.read_text(encoding="utf-8", errors="ignore")
+                    )
+                except OSError:
+                    fm_name = None
+                if fm_name == name:
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def _skill_available_for_home(skill_name: str, hermes_home: Optional[str]) -> bool:
+    """Back-compat wrapper using the old argument order."""
+    return _skill_available(hermes_home, skill_name)
+
+
+def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
+    """Back-compat shim: ``--skills kanban-worker`` resolvability check."""
+    return _skill_available(hermes_home, "kanban-worker")
+
+
+def _missing_forced_skills(hermes_home: Optional[str], skills: Optional[list]) -> list[str]:
+    """Return task-level forced skills that would be unknown for the worker."""
+    missing: list[str] = []
+    seen: set[str] = set()
+    for raw in skills or []:
+        skill = str(raw or "").strip()
+        if not skill or skill == "kanban-worker" or skill in seen:
+            continue
+        seen.add(skill)
+        if not _skill_available(hermes_home, skill):
+            missing.append(skill)
+    return missing
+
+
+def _profile_skill_sync_policy_path(hermes_home: Optional[str]) -> Optional[Path]:
+    """Return the local profile-skill sync policy path when this install has one.
+
+    This is deliberately optional and local-policy driven. Upstream Hermes should
+    not blindly mutate profile skill directories; Hoang's Hermes OS policy file is
+    the explicit allowlist for profiles/skills that may be auto-synced before a
+    Kanban worker spawn.
+    """
+    override = os.environ.get("HERMES_PROFILE_SKILL_SYNC_POLICY", "").strip()
+    if override:
+        return Path(os.path.expandvars(os.path.expanduser(override))).resolve()
+    if not hermes_home:
+        return None
+    home = Path(hermes_home).expanduser().resolve()
+    # Profile homes are normally <root>/profiles/<name>; the policy lives under
+    # <root>/local/hermes-os/.
+    if home.parent.name == "profiles":
+        root = home.parent.parent
+    else:
+        root = home
+    return root / "local" / "hermes-os" / "profile-skill-sync-policy.yaml"
+
+
+def _profile_skill_sync_script_path(hermes_home: Optional[str]) -> Optional[Path]:
+    override = os.environ.get("HERMES_PROFILE_SKILL_SYNC_SCRIPT", "").strip()
+    if override:
+        return Path(os.path.expandvars(os.path.expanduser(override))).resolve()
+    policy = _profile_skill_sync_policy_path(hermes_home)
+    if policy is None:
+        return None
+    # <root>/local/hermes-os/profile-skill-sync-policy.yaml ->
+    # <root>/local/scripts/profile_skill_sync.py
+    root = policy.parent.parent.parent
+    return root / "local" / "scripts" / "profile_skill_sync.py"
+
+
+def _yaml_load_file(path: Path) -> dict:
+    try:
+        from agent.skill_utils import yaml_load
+
+        data = yaml_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        try:
+            import yaml  # type: ignore
+
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _maybe_sync_missing_forced_skills(
+    profile: str,
+    hermes_home: Optional[str],
+    missing: list[str],
+) -> list[str]:
+    """Try one allowlisted profile-skill sync, then return still-missing skills.
+
+    Missing task-level forced skills are a dispatcher-startup problem, not a
+    domain-task failure. If this install has the Hermes OS profile-skill sync
+    policy and the profile/skills are explicitly allowlisted, run the sync once
+    before blocking. If the policy/script is absent or the requested skill is not
+    allowlisted, fail closed and let the caller block with the original reason.
+    """
+    if not missing:
+        return []
+    policy_path = _profile_skill_sync_policy_path(hermes_home)
+    script_path = _profile_skill_sync_script_path(hermes_home)
+    if not policy_path or not script_path or not policy_path.is_file() or not script_path.is_file():
+        return missing
+
+    policy = _yaml_load_file(policy_path)
+    sync_profiles = {str(p) for p in policy.get("sync_profiles") or []}
+    sync_skills = {str(s) for s in policy.get("sync_skills") or []}
+    create_missing = bool(policy.get("create_missing_skill_dirs", False))
+    if profile not in sync_profiles or not create_missing:
+        return missing
+    if any(skill not in sync_skills for skill in missing):
+        return missing
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(script_path), "--apply", "--policy", str(policy_path)],
+            cwd=str(policy_path.parent),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except Exception:
+        return missing
+    if proc.returncode != 0:
+        return missing
+    return _missing_forced_skills(hermes_home, missing)
+
+
+def default_skill_catalog_path() -> Path:
+    """Return the local Kanban skill catalog path, if the user keeps one."""
+    override = os.environ.get("HERMES_KANBAN_SKILL_CATALOG", "").strip()
+    if override:
+        return Path(os.path.expandvars(os.path.expanduser(override))).resolve()
+    return kanban_home() / "local" / "hermes-os" / "kanban-skill-catalog.yaml"
+
+
+def _phrase_hits(text: str, phrases) -> list[str]:
+    hits: list[str] = []
+    if not phrases:
+        return hits
+    for raw in phrases:
+        phrase = str(raw or "").strip().lower()
+        if phrase and phrase in text:
+            hits.append(phrase)
+    return hits
+
+
+def suggest_task_skills_from_catalog(
+    *,
+    title: str,
+    body: Optional[str] = None,
+    assignee: Optional[str] = None,
+    catalog_path: Optional[str | Path] = None,
+    limit: Optional[int] = None,
+) -> list[dict[str, object]]:
+    """Return small metadata-only skill suggestions for a Kanban task.
+
+    This is intentionally conservative. It is a PM/orchestrator helper for
+    selecting likely task-level skills without loading every skill body.
+    """
+    path = Path(catalog_path) if catalog_path is not None else default_skill_catalog_path()
+    if not path.is_file():
+        return []
+    data = _yaml_load_file(path)
+    skills = data.get("skills") if isinstance(data, dict) else None
+    if not isinstance(skills, dict):
+        return []
+    policy = data.get("selection_policy") if isinstance(data.get("selection_policy"), dict) else {}
+    max_required = int(policy.get("max_required_skills_per_task") or 5)
+    if limit is None:
+        limit = max_required
+    text = " ".join(str(part or "") for part in (title, body, assignee)).lower()
+    suggestions: list[dict[str, object]] = []
+    for skill_name, meta in skills.items():
+        if not isinstance(meta, dict):
+            continue
+        allowed = meta.get("allowed_profiles") or []
+        if assignee and allowed and assignee not in allowed:
+            continue
+        selection = meta.get("selection") if isinstance(meta.get("selection"), dict) else {}
+        strong = _phrase_hits(text, selection.get("strong_triggers") or [])
+        weak = _phrase_hits(text, selection.get("weak_triggers") or [])
+        negative = _phrase_hits(text, selection.get("negative_triggers") or [])
+        score = len(strong) * 3 + len(weak) - len(negative) * 3
+        if score < 3:
+            continue
+        suggestions.append(
+            {
+                "skill": str(skill_name),
+                "score": score,
+                "reason": {
+                    "strong_triggers": strong,
+                    "weak_triggers": weak,
+                    "negative_triggers": negative,
+                },
+            }
+        )
+    suggestions.sort(key=lambda item: (-int(item["score"]), str(item["skill"])))
+    return suggestions[: max(0, int(limit or 0))]
 
 
 def _worker_terminal_timeout_env(
@@ -6556,6 +6880,18 @@ def _default_spawn(
     # contract still ships via KANBAN_GUIDANCE.
     if _kanban_worker_skill_available(env.get("HERMES_HOME")):
         cmd.extend(["--skills", "kanban-worker"])
+
+
+    missing_forced_skills = _missing_forced_skills(env.get("HERMES_HOME"), task.skills)
+    if missing_forced_skills:
+        missing_forced_skills = _maybe_sync_missing_forced_skills(
+            profile_arg,
+            env.get("HERMES_HOME"),
+            missing_forced_skills,
+        )
+    if missing_forced_skills:
+        raise MissingForcedSkillsError(profile_arg, env.get("HERMES_HOME"), missing_forced_skills)
+
     # Per-task force-loaded skills. Each name goes in its own
     # `--skills X` pair rather than a single comma-joined arg: the CLI
     # accepts both forms (action='append' + comma-split), but

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6360,39 +6360,50 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
-def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
-    """True if the bundled ``kanban-worker`` skill resolves for the home the
-    spawned worker will run under.
+def _skill_available_for_home(skill_name: str, hermes_home: Optional[str]) -> bool:
+    """True if ``skill_name`` resolves under the worker's ``HERMES_HOME``.
 
-    The dispatcher injects ``--skills kanban-worker`` into every worker. When
-    the worker activates a profile (``hermes -p <name>``), its ``SKILLS_DIR``
-    becomes ``<profile_home>/skills`` — which on many profiles does NOT contain
-    the bundled skill (it ships in the *default* root home, not every
-    profile-scoped skills dir). Preloading a missing skill is fatal at CLI
-    startup (``ValueError: Unknown skill(s): kanban-worker``), aborting the
-    worker before the agent loop runs. Gate the flag on actual resolvability;
-    the kanban lifecycle contract is still injected via ``KANBAN_GUIDANCE``, so
-    omitting the flag only drops the supplementary pattern library.
+    Preloading a missing skill via ``--skills <name>`` is fatal at CLI startup
+    (``ValueError: Unknown skill(s): <name>``), aborting the worker before the
+    agent loop runs. When a worker activates a profile (``hermes -p <name>``)
+    its ``SKILLS_DIR`` becomes ``<profile_home>/skills`` — which may not
+    contain skills that exist in the *default* root home. Gate every
+    ``--skills`` injection on actual resolvability instead of trusting the
+    caller; dropping a missing flag is safer than crash-looping the worker
+    until the watchdog auto-blocks it.
+
+    Used for both the bundled ``kanban-worker`` skill (always injected) and
+    per-task ``task.skills`` overrides.
     """
     from pathlib import Path as _Path
 
+    if not skill_name:
+        return False
     # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
+    # home (``~/.hermes``), which ships the bundled skill set.
     base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
     skills_root = base / "skills"
     if not skills_root.is_dir():
         return False
-    # Canonical bundled location first (cheap), then a bounded scan for
-    # profiles that have it nested elsewhere.
-    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
-        return True
+    # Bounded rglob covers nested categories (devops/, mlops/, etc.) without
+    # caller needing to know the category layout. Cheap on typical skill
+    # trees (a few dozen entries); short-circuits on first match.
     try:
-        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
+        for skill_md in skills_root.rglob(f"{skill_name}/SKILL.md"):
             if skill_md.is_file():
                 return True
     except OSError:
         pass
     return False
+
+
+def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
+    """Back-compat shim: ``--skills kanban-worker`` resolvability check.
+
+    Retained as a named entry point because the bundled-worker case is
+    referenced in inline comments below; delegates to the generic helper.
+    """
+    return _skill_available_for_home("kanban-worker", hermes_home)
 
 
 def _worker_terminal_timeout_env(
@@ -6552,10 +6563,30 @@ def _default_spawn(
     # quoting ambiguity if a skill name ever contains unusual chars.
     # Dedupe against the built-in so we don't double-load kanban-worker
     # if a task author asks for it explicitly.
+    #
+    # Gate each name on resolvability under the worker's HERMES_HOME
+    # for the same reason kanban-worker is gated above: preloading a
+    # missing skill is fatal at CLI startup. Without this filter, a
+    # ``task.skills`` entry that exists in the root home but not in
+    # the profile-scoped skills dir crash-loops the worker (often
+    # 100+ respawns before the watchdog auto-blocks) instead of just
+    # running without the supplementary context. A skipped skill is
+    # logged to stderr so operators see why the worker did not get
+    # the requested skill loaded; the task still proceeds.
     if task.skills:
+        worker_home = env.get("HERMES_HOME")
         for sk in task.skills:
-            if sk and sk != "kanban-worker":
+            if not sk or sk == "kanban-worker":
+                continue
+            if _skill_available_for_home(sk, worker_home):
                 cmd.extend(["--skills", sk])
+            else:
+                sys.stderr.write(
+                    f"kanban: task {task.id} requested skill "
+                    f"{sk!r} but it does not resolve under "
+                    f"{worker_home or '~/.hermes'}/skills — "
+                    f"dropping flag, worker will start without it\n"
+                )
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     cmd.extend([

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6527,8 +6527,8 @@ def _profile_skill_sync_policy_path(hermes_home: Optional[str]) -> Optional[Path
     """Return the local profile-skill sync policy path when this install has one.
 
     This is deliberately optional and local-policy driven. Upstream Hermes should
-    not blindly mutate profile skill directories; Hoang's Hermes OS policy file is
-    the explicit allowlist for profiles/skills that may be auto-synced before a
+    not blindly mutate profile skill directories; a local policy file is the
+    explicit allowlist for profiles/skills that may be auto-synced before a
     Kanban worker spawn.
     """
     override = os.environ.get("HERMES_PROFILE_SKILL_SYNC_POLICY", "").strip()
@@ -6618,79 +6618,6 @@ def _maybe_sync_missing_forced_skills(
     if proc.returncode != 0:
         return missing
     return _missing_forced_skills(hermes_home, missing)
-
-
-def default_skill_catalog_path() -> Path:
-    """Return the local Kanban skill catalog path, if the user keeps one."""
-    override = os.environ.get("HERMES_KANBAN_SKILL_CATALOG", "").strip()
-    if override:
-        return Path(os.path.expandvars(os.path.expanduser(override))).resolve()
-    return kanban_home() / "local" / "hermes-os" / "kanban-skill-catalog.yaml"
-
-
-def _phrase_hits(text: str, phrases) -> list[str]:
-    hits: list[str] = []
-    if not phrases:
-        return hits
-    for raw in phrases:
-        phrase = str(raw or "").strip().lower()
-        if phrase and phrase in text:
-            hits.append(phrase)
-    return hits
-
-
-def suggest_task_skills_from_catalog(
-    *,
-    title: str,
-    body: Optional[str] = None,
-    assignee: Optional[str] = None,
-    catalog_path: Optional[str | Path] = None,
-    limit: Optional[int] = None,
-) -> list[dict[str, object]]:
-    """Return small metadata-only skill suggestions for a Kanban task.
-
-    This is intentionally conservative. It is a PM/orchestrator helper for
-    selecting likely task-level skills without loading every skill body.
-    """
-    path = Path(catalog_path) if catalog_path is not None else default_skill_catalog_path()
-    if not path.is_file():
-        return []
-    data = _yaml_load_file(path)
-    skills = data.get("skills") if isinstance(data, dict) else None
-    if not isinstance(skills, dict):
-        return []
-    policy = data.get("selection_policy") if isinstance(data.get("selection_policy"), dict) else {}
-    max_required = int(policy.get("max_required_skills_per_task") or 5)
-    if limit is None:
-        limit = max_required
-    text = " ".join(str(part or "") for part in (title, body, assignee)).lower()
-    suggestions: list[dict[str, object]] = []
-    for skill_name, meta in skills.items():
-        if not isinstance(meta, dict):
-            continue
-        allowed = meta.get("allowed_profiles") or []
-        if assignee and allowed and assignee not in allowed:
-            continue
-        selection = meta.get("selection") if isinstance(meta.get("selection"), dict) else {}
-        strong = _phrase_hits(text, selection.get("strong_triggers") or [])
-        weak = _phrase_hits(text, selection.get("weak_triggers") or [])
-        negative = _phrase_hits(text, selection.get("negative_triggers") or [])
-        score = len(strong) * 3 + len(weak) - len(negative) * 3
-        if score < 3:
-            continue
-        suggestions.append(
-            {
-                "skill": str(skill_name),
-                "score": score,
-                "reason": {
-                    "strong_triggers": strong,
-                    "weak_triggers": weak,
-                    "negative_triggers": negative,
-                },
-            }
-        )
-    suggestions.sort(key=lambda item: (-int(item["score"]), str(item["skill"])))
-    return suggestions[: max(0, int(limit or 0))]
 
 
 def _worker_terminal_timeout_env(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6366,43 +6366,6 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
-def _skill_available_for_home(skill_name: str, hermes_home: Optional[str]) -> bool:
-    """True if ``skill_name`` resolves under the worker's ``HERMES_HOME``.
-
-    Preloading a missing skill via ``--skills <name>`` is fatal at CLI startup
-    (``ValueError: Unknown skill(s): <name>``), aborting the worker before the
-    agent loop runs. When a worker activates a profile (``hermes -p <name>``)
-    its ``SKILLS_DIR`` becomes ``<profile_home>/skills`` — which may not
-    contain skills that exist in the *default* root home. Gate every
-    ``--skills`` injection on actual resolvability instead of trusting the
-    caller; dropping a missing flag is safer than crash-looping the worker
-    until the watchdog auto-blocks it.
-
-    Used for both the bundled ``kanban-worker`` skill (always injected) and
-    per-task ``task.skills`` overrides.
-    """
-    from pathlib import Path as _Path
-
-    if not skill_name:
-        return False
-    # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill set.
-    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
-    skills_root = base / "skills"
-    if not skills_root.is_dir():
-        return False
-    # Bounded rglob covers nested categories (devops/, mlops/, etc.) without
-    # caller needing to know the category layout. Cheap on typical skill
-    # trees (a few dozen entries); short-circuits on first match.
-    try:
-        for skill_md in skills_root.rglob(f"{skill_name}/SKILL.md"):
-            if skill_md.is_file():
-                return True
-    except OSError:
-        pass
-    return False
-
-
 
 class MissingForcedSkillsError(RuntimeError):
     """Raised before worker spawn when task-level --skills would crash startup."""
@@ -6900,15 +6863,9 @@ def _default_spawn(
     # Dedupe against the built-in so we don't double-load kanban-worker
     # if a task author asks for it explicitly.
     #
-    # Gate each name on resolvability under the worker's HERMES_HOME
-    # for the same reason kanban-worker is gated above: preloading a
-    # missing skill is fatal at CLI startup. Without this filter, a
-    # ``task.skills`` entry that exists in the root home but not in
-    # the profile-scoped skills dir crash-loops the worker (often
-    # 100+ respawns before the watchdog auto-blocks) instead of just
-    # running without the supplementary context. A skipped skill is
-    # logged to stderr so operators see why the worker did not get
-    # the requested skill loaded; the task still proceeds.
+    # Validate every task-level forced skill before spawning. Missing required
+    # skills first get one allowlisted sync attempt; if they still don't
+    # resolve, block before Popen so the worker cannot crash at CLI startup.
     if task.skills:
         worker_home = env.get("HERMES_HOME")
         for sk in task.skills:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2987,6 +2987,9 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
     in addition to the built-in kanban-worker."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    # Per-task skills are also resolvability-gated now; stub the helper so
+    # synthetic skill names ("translation", "github-code-review") pass.
+    monkeypatch.setattr(kb, "_skill_available_for_home", lambda _n, _h: True)
     captured = {}
 
     class FakeProc:
@@ -3037,6 +3040,7 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
 def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monkeypatch):
     """If a task explicitly lists 'kanban-worker', we don't double-pass it."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    monkeypatch.setattr(kb, "_skill_available_for_home", lambda _n, _h: True)
     captured = {}
 
     class FakeProc:
@@ -3068,6 +3072,66 @@ def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monke
     assert len(worker_pairs) == 1, (
         f"kanban-worker appeared {len(worker_pairs)} times in argv: {cmd}"
     )
+
+
+def test_default_spawn_drops_unresolvable_task_skills(
+    kanban_home, monkeypatch, capfd, tmp_path
+):
+    """Per-task skill names that don't resolve under the worker's
+    HERMES_HOME must be dropped from argv (with a stderr warning) instead
+    of being passed through to crash the CLI at startup.
+
+    Regression: a task with ``skills=["some-skill"]`` whose name only
+    exists in the global skills root — not the profile-scoped one the
+    worker actually loads — would crash-loop the worker with
+    ``ValueError: Unknown skill(s): some-skill`` until the watchdog
+    auto-blocked the task (often 100+ respawns).
+    """
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    # Only "good-skill" resolves; "missing-skill" does not.
+    monkeypatch.setattr(
+        kb,
+        "_skill_available_for_home",
+        lambda name, _h: name == "good-skill",
+    )
+    captured = {}
+
+    class FakeProc:
+        pid = 7
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="mixed resolvability",
+            assignee="x",
+            skills=["good-skill", "missing-skill"],
+        )
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    skill_names = [
+        cmd[i + 1] for i, tok in enumerate(cmd)
+        if tok == "--skills" and i + 1 < len(cmd)
+    ]
+    assert "good-skill" in skill_names, skill_names
+    assert "missing-skill" not in skill_names, (
+        f"unresolvable skill leaked into argv: {skill_names}"
+    )
+
+    err = capfd.readouterr().err
+    assert "missing-skill" in err, err
+    assert tid in err, err  # Task id surfaced for operators triaging logs.
 
 
 def test_cli_create_skill_flag_repeatable(kanban_home):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2987,8 +2987,10 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
     in addition to the built-in kanban-worker."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
-    # Per-task skills are also resolvability-gated now; stub the helper so
-    # synthetic skill names ("translation", "github-code-review") pass.
+    # Per-task skills are also resolvability-gated now; stub the resolver so
+    # synthetic skill names ("translation", "github-code-review") pass both
+    # the pre-spawn required-skill check and final argv construction.
+    monkeypatch.setattr(kb, "_skill_available", lambda _h, _n: True)
     monkeypatch.setattr(kb, "_skill_available_for_home", lambda _n, _h: True)
     captured = {}
 
@@ -3040,6 +3042,7 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
 def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monkeypatch):
     """If a task explicitly lists 'kanban-worker', we don't double-pass it."""
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    monkeypatch.setattr(kb, "_skill_available", lambda _h, _n: True)
     monkeypatch.setattr(kb, "_skill_available_for_home", lambda _n, _h: True)
     captured = {}
 
@@ -3074,34 +3077,29 @@ def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monke
     )
 
 
-def test_default_spawn_drops_unresolvable_task_skills(
-    kanban_home, monkeypatch, capfd, tmp_path
+def test_default_spawn_blocks_unresolvable_task_skills_before_popen(
+    kanban_home, monkeypatch
 ):
-    """Per-task skill names that don't resolve under the worker's
-    HERMES_HOME must be dropped from argv (with a stderr warning) instead
-    of being passed through to crash the CLI at startup.
+    """Required per-task skills that don't resolve under the worker's
+    HERMES_HOME block before spawn instead of being passed through to crash
+    the CLI at startup.
 
-    Regression: a task with ``skills=["some-skill"]`` whose name only
-    exists in the global skills root — not the profile-scoped one the
-    worker actually loads — would crash-loop the worker with
-    ``ValueError: Unknown skill(s): some-skill`` until the watchdog
-    auto-blocked the task (often 100+ respawns).
+    Regression: a task with ``skills=["some-skill"]`` whose name only exists
+    in the global skills root — not the profile-scoped one the worker actually
+    loads — would crash-loop with ``ValueError: Unknown skill(s): some-skill``
+    until the watchdog auto-blocked it. Current ``task.skills`` are required,
+    so missing entries fail closed before ``Popen``.
     """
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
-    # Only "good-skill" resolves; "missing-skill" does not.
-    monkeypatch.setattr(
-        kb,
-        "_skill_available_for_home",
-        lambda name, _h: name == "good-skill",
-    )
+    # Only "good-skill" resolves; "missing-skill" does not. Patch both the
+    # pre-spawn required-skill check and final argv construction helper.
+    monkeypatch.setattr(kb, "_skill_available", lambda _h, name: name == "good-skill")
+    monkeypatch.setattr(kb, "_skill_available_for_home", lambda name, _h: name == "good-skill")
     captured = {}
-
-    class FakeProc:
-        pid = 7
 
     def fake_popen(cmd, **kwargs):
         captured["cmd"] = cmd
-        return FakeProc()
+        raise AssertionError("missing forced skills must block before Popen")
 
     monkeypatch.setattr("subprocess.Popen", fake_popen)
 
@@ -3114,24 +3112,18 @@ def test_default_spawn_drops_unresolvable_task_skills(
             skills=["good-skill", "missing-skill"],
         )
         task = kb.get_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
-        kb._default_spawn(task, str(workspace))
+        with pytest.raises(kb.MissingForcedSkillsError) as exc_info:
+            kb._default_spawn(task, str(workspace))
     finally:
         conn.close()
 
-    cmd = captured["cmd"]
-    skill_names = [
-        cmd[i + 1] for i, tok in enumerate(cmd)
-        if tok == "--skills" and i + 1 < len(cmd)
-    ]
-    assert "good-skill" in skill_names, skill_names
-    assert "missing-skill" not in skill_names, (
-        f"unresolvable skill leaked into argv: {skill_names}"
-    )
-
-    err = capfd.readouterr().err
-    assert "missing-skill" in err, err
-    assert tid in err, err  # Task id surfaced for operators triaging logs.
+    assert "cmd" not in captured
+    msg = str(exc_info.value)
+    assert "missing-skill" in msg
+    assert "good-skill" not in msg
+    assert "profile 'x'" in msg
 
 
 def test_cli_create_skill_flag_repeatable(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1358,6 +1358,227 @@ def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawna
         assert kb.get_task(conn, t).claim_lock is None
 
 
+def test_dispatch_blocks_missing_forced_skill_before_worker_spawn(kanban_home, all_assignees_spawnable):
+    profile_home = kanban_home / "profiles" / "alice"
+    (profile_home / "skills").mkdir(parents=True)
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="needs missing skill",
+            assignee="alice",
+            skills=["missing-specialist-skill"],
+        )
+        res = kb.dispatch_once(conn)
+        task = kb.get_task(conn, t)
+        assert task is not None
+        events = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+            (t,),
+        ).fetchall()
+
+    assert not res.spawned
+    assert t in res.auto_blocked
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+    assert any(e["kind"] == "blocked" and "missing-specialist-skill" in e["payload"] for e in events)
+
+
+def test_missing_forced_skill_auto_syncs_when_policy_allows(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "code-reviewer"
+    (profile_home / "skills").mkdir(parents=True)
+    canonical_skill = root / "skills" / "github" / "github-code-review"
+    canonical_skill.mkdir(parents=True)
+    (canonical_skill / "SKILL.md").write_text(
+        "---\nname: github-code-review\ndescription: review\n---\n\n# Review\n",
+        encoding="utf-8",
+    )
+    policy = root / "local" / "hermes-os" / "profile-skill-sync-policy.yaml"
+    policy.parent.mkdir(parents=True)
+    policy.write_text(
+        f"""
+canonical_skill_root: {root / 'skills'}
+profile_root: {root / 'profiles'}
+backup_root: {root / 'local' / 'backups' / 'profile-skill-sync'}
+sync_profiles:
+  - code-reviewer
+sync_skills:
+  - github-code-review
+create_missing_skill_dirs: true
+""".strip(),
+        encoding="utf-8",
+    )
+    script = root / "local" / "scripts" / "profile_skill_sync.py"
+    script.parent.mkdir(parents=True)
+    # Test repos do not contain Hoang's local script, so write the tiny behavior
+    # the dispatcher requires: create the missing allowlisted profile skill.
+    script.write_text(
+        """
+import pathlib, shutil, sys
+policy = pathlib.Path(sys.argv[-1])
+root = policy.parents[2]
+src = root / 'skills' / 'github' / 'github-code-review'
+dst = root / 'profiles' / 'code-reviewer' / 'skills' / 'github' / 'github-code-review'
+dst.parent.mkdir(parents=True, exist_ok=True)
+if dst.exists():
+    shutil.rmtree(dst)
+shutil.copytree(src, dst)
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE_SKILL_SYNC_POLICY", str(policy))
+    monkeypatch.setenv("HERMES_PROFILE_SKILL_SYNC_SCRIPT", str(script))
+
+    assert kb._missing_forced_skills(str(profile_home), ["github-code-review"]) == ["github-code-review"]
+    remaining = kb._maybe_sync_missing_forced_skills(
+        "code-reviewer",
+        str(profile_home),
+        ["github-code-review"],
+    )
+
+    assert remaining == []
+    assert kb._skill_available(str(profile_home), "github-code-review") is True
+
+
+def test_missing_forced_skill_auto_sync_fails_closed_when_not_allowlisted(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "code-reviewer"
+    (profile_home / "skills").mkdir(parents=True)
+    policy = root / "local" / "hermes-os" / "profile-skill-sync-policy.yaml"
+    policy.parent.mkdir(parents=True)
+    policy.write_text(
+        """
+sync_profiles:
+  - code-reviewer
+sync_skills:
+  - some-other-skill
+create_missing_skill_dirs: true
+""".strip(),
+        encoding="utf-8",
+    )
+    script = root / "local" / "scripts" / "profile_skill_sync.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("raise SystemExit(99)\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE_SKILL_SYNC_POLICY", str(policy))
+    monkeypatch.setenv("HERMES_PROFILE_SKILL_SYNC_SCRIPT", str(script))
+
+    remaining = kb._maybe_sync_missing_forced_skills(
+        "code-reviewer",
+        str(profile_home),
+        ["github-code-review"],
+    )
+
+    assert remaining == ["github-code-review"]
+
+
+def test_forced_skill_resolves_by_frontmatter_name(tmp_path):
+    home = tmp_path / "profile-home"
+    skill_dir = home / "skills" / "custom-category" / "directory-name"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: frontmatter-skill\ndescription: demo\n---\n\n# Skill\n",
+        encoding="utf-8",
+    )
+
+    assert kb._skill_available(str(home), "frontmatter-skill") is True
+    assert kb._missing_forced_skills(str(home), ["frontmatter-skill", "absent"]) == ["absent"]
+
+
+def test_forced_skill_resolves_from_runtime_overlay_root(tmp_path, monkeypatch):
+    """Preflight should accept skills available through worker-scoped overlay roots."""
+    home = tmp_path / "profile-home"
+    (home / "skills").mkdir(parents=True)
+    overlay_root = tmp_path / "overlay-skills"
+    skill_dir = overlay_root / "task-category" / "overlay-only-dir"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: overlay-only-skill\ndescription: demo\n---\n\n# Overlay Skill\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_SKILLS_EXTERNAL_DIRS", str(overlay_root))
+
+    assert kb._skill_available(str(home), "overlay-only-skill") is True
+    assert kb._missing_forced_skills(str(home), ["overlay-only-skill", "absent"]) == ["absent"]
+
+
+def test_forced_skill_resolves_from_worker_profile_external_dirs(tmp_path, monkeypatch):
+    """Preflight should mirror the worker profile's skills.external_dirs config."""
+    home = tmp_path / "profile-home"
+    (home / "skills").mkdir(parents=True)
+    external_root = home / "relative-external-skills"
+    skill_dir = external_root / "custom-category" / "configured-dir"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: configured-external-skill\ndescription: demo\n---\n\n# Configured\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "skills:\n  external_dirs:\n    - relative-external-skills\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("HERMES_SKILLS_EXTERNAL_DIRS", raising=False)
+
+    assert kb._skill_available(str(home), "configured-external-skill") is True
+    assert kb._missing_forced_skills(str(home), ["configured-external-skill"]) == []
+
+
+def test_suggest_task_skills_from_catalog_is_conservative(tmp_path):
+    catalog = tmp_path / "catalog.yaml"
+    catalog.write_text(
+        """
+selection_policy:
+  task_skills_default_mode: required
+  max_required_skills_per_task: 5
+skills:
+  systematic-debugging:
+    description: Debug failures.
+    default_mode: required
+    allowed_profiles: [backend-worker]
+    selection:
+      intent_tags: [debugging, root_cause]
+      strong_triggers: [failing tests, traceback]
+      weak_triggers: [bug, issue]
+      negative_triggers: [visual polish]
+  dogfood:
+    description: QA web apps.
+    default_mode: required
+    allowed_profiles: [frontend-worker]
+    selection:
+      strong_triggers: [exploratory qa]
+      weak_triggers: [browser]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    generic = kb.suggest_task_skills_from_catalog(
+        title="Update task summary",
+        body="This is a generic status issue.",
+        assignee="backend-worker",
+        catalog_path=catalog,
+    )
+    assert generic == []
+
+    selected = kb.suggest_task_skills_from_catalog(
+        title="Fix failing tests and find root cause",
+        body="Pytest traceback in backend-worker run.",
+        assignee="backend-worker",
+        catalog_path=catalog,
+    )
+    assert [item["skill"] for item in selected] == ["systematic-debugging"]
+    assert selected[0]["score"] >= 3
+
+    negative = kb.suggest_task_skills_from_catalog(
+        title="visual polish bug",
+        body="style critique only",
+        assignee="backend-worker",
+        catalog_path=catalog,
+    )
+    assert negative == []
+
+
 def test_dispatch_max_spawn_counts_existing_running_tasks(
     kanban_home, all_assignees_spawnable
 ):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1525,60 +1525,6 @@ def test_forced_skill_resolves_from_worker_profile_external_dirs(tmp_path, monke
     assert kb._missing_forced_skills(str(home), ["configured-external-skill"]) == []
 
 
-def test_suggest_task_skills_from_catalog_is_conservative(tmp_path):
-    catalog = tmp_path / "catalog.yaml"
-    catalog.write_text(
-        """
-selection_policy:
-  task_skills_default_mode: required
-  max_required_skills_per_task: 5
-skills:
-  systematic-debugging:
-    description: Debug failures.
-    default_mode: required
-    allowed_profiles: [backend-worker]
-    selection:
-      intent_tags: [debugging, root_cause]
-      strong_triggers: [failing tests, traceback]
-      weak_triggers: [bug, issue]
-      negative_triggers: [visual polish]
-  dogfood:
-    description: QA web apps.
-    default_mode: required
-    allowed_profiles: [frontend-worker]
-    selection:
-      strong_triggers: [exploratory qa]
-      weak_triggers: [browser]
-""".strip(),
-        encoding="utf-8",
-    )
-
-    generic = kb.suggest_task_skills_from_catalog(
-        title="Update task summary",
-        body="This is a generic status issue.",
-        assignee="backend-worker",
-        catalog_path=catalog,
-    )
-    assert generic == []
-
-    selected = kb.suggest_task_skills_from_catalog(
-        title="Fix failing tests and find root cause",
-        body="Pytest traceback in backend-worker run.",
-        assignee="backend-worker",
-        catalog_path=catalog,
-    )
-    assert [item["skill"] for item in selected] == ["systematic-debugging"]
-    assert selected[0]["score"] >= 3
-
-    negative = kb.suggest_task_skills_from_catalog(
-        title="visual polish bug",
-        body="style critique only",
-        assignee="backend-worker",
-        catalog_path=catalog,
-    )
-    assert negative == []
-
-
 def test_dispatch_max_spawn_counts_existing_running_tasks(
     kanban_home, all_assignees_spawnable
 ):


### PR DESCRIPTION
## Summary

- Extends Kanban forced-skill preflight from “detect missing skill and block” to “try one explicit allowlisted profile-skill sync, then block if still missing.”
- Keeps failure closed by default: no policy file, no sync script, non-allowlisted profile, non-allowlisted skill, or failed sync all leave the task blocked before worker spawn.
- Preserves worker crash-loop protection by raising a deterministic `MissingForcedSkillsError` before `Popen` rather than letting `hermes -p ... --skills missing` fail at CLI startup.
- Improves skill resolvability checks to cover directory names, relative paths, frontmatter `name`, plugin-qualified skills, env overlay roots, and profile `skills.external_dirs`.
- Adds conservative catalog-based skill suggestions for Kanban PM/orchestrator task-skill selection.

## Why

Kanban tasks can force-load skills through `task.skills`. If a profile-scoped worker lacks one of those skills, the worker dies before the agent loop can explain/block the task. PR #30025 fixed the first half by gating forced skills on resolvability. This branch adds the operational follow-up: if a local install has an explicit allowlisted profile-skill sync policy, attempt sync once before blocking.

This prevents repeated “missing forced skill” document/task crashes when the fix is safe and mechanical, while still avoiding broad implicit mutation of profile skill directories.

## Related

- Related upstream PR: #30025 — `fix(kanban): gate task.skills on resolvability to prevent worker crash loops`
- Related Kanban DB hardening batch: #32857
- Included in that batch / historical corruption hardening: #32300

## Test plan

- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py`
  - Result: 166 passed, 0 failed
