### PR TITLE
fix(feishu): remove faulty table→text fallback in outbound payload

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -153,8 +153,10 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
+
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# No longer used in _build_outbound_payload (post md tags render tables fine),
+# but kept for potential future use.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -4284,12 +4286,6 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}


### PR DESCRIPTION
## Summary

The `_build_outbound_payload` function was downgrading messages containing markdown tables from `post` type (rich rendering) to `text` type (raw text). This caused all markdown formatting to appear as raw source when a table was present.

## Root Cause

The function checked for markdown tables first and forced the entire message to `text` msg_type. Feishu clients now render tables correctly in `post` type via the `md` element.

## Fix

Removed the table-detection fallback. Messages with markdown (including tables) now use `post` type. Plain text uses `text` type.

## Test Plan

- [x] Tested on Feishu 7.x (macOS): bold, italic, headings, code blocks, inline code, blockquotes, lists, and tables all render correctly