### PR TITLE
fix(kanban): pass max_in_progress from CLI dispatch to dispatch_once

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -613,6 +613,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                         help=f"Auto-block a task after this many consecutive non-success attempts "
                              f"(spawn_failed, timed_out, or crashed; default: {kb.DEFAULT_SPAWN_FAILURE_LIMIT})")
     p_disp.add_argument("--json", action="store_true")
+    p_disp.add_argument("--max-in-progress", type=int, default=None,
+                        help="Cap number of simultaneously running tasks "
+                             "(overrides kanban.max_in_progress config)")
 
     # --- daemon (deprecated) ---
     p_daemon = sub.add_parser(
@@ -2092,6 +2095,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             conn,
             dry_run=args.dry_run,
             max_spawn=args.max,
+            max_in_progress=getattr(args, "max_in_progress", None),
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
         )
     if getattr(args, "json", False):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2800,6 +2800,78 @@ def test_dispatch_max_in_progress_none_is_unlimited(kanban_home, all_assignees_s
 
     assert len(spawns) == 4, f"expected 4 spawns (unlimited), got {len(spawns)}"
 
+
+def test_cli_dispatch_passes_max_in_progress(kanban_home, monkeypatch):
+    """hermes kanban dispatch --max-in-progress passes the value to dispatch_once.
+
+    Regression for #33488: the CLI _cmd_dispatch function did not forward
+    max_in_progress to kanban_db.dispatch_once, silently ignoring the cap.
+    """
+    from types import SimpleNamespace
+    from hermes_cli import kanban as kanban_mod
+
+    captured = {}
+
+    original_dispatch_once = kb.dispatch_once
+
+    def spy_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        return original_dispatch_once(conn, **kwargs)
+
+    monkeypatch.setattr(kb, "dispatch_once", spy_dispatch_once)
+
+    # Create some tasks so dispatch_once has something to work with
+    with kb.connect() as conn:
+        for title in ["a", "b", "c"]:
+            kb.create_task(conn, title=title, assignee="alice")
+
+    args = SimpleNamespace(
+        dry_run=True,
+        max=None,
+        max_in_progress=2,
+        failure_limit=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
+        json=False,
+    )
+    kanban_mod._cmd_dispatch(args)
+
+    assert captured.get("max_in_progress") == 2, (
+        f"max_in_progress not passed to dispatch_once; "
+        f"captured kwargs: {captured}"
+    )
+
+
+def test_cli_dispatch_max_in_progress_none_by_default(kanban_home, monkeypatch):
+    """hermes kanban dispatch without --max-in-progress passes None (unlimited)."""
+    from types import SimpleNamespace
+    from hermes_cli import kanban as kanban_mod
+
+    captured = {}
+
+    original_dispatch_once = kb.dispatch_once
+
+    def spy_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        return original_dispatch_once(conn, **kwargs)
+
+    monkeypatch.setattr(kb, "dispatch_once", spy_dispatch_once)
+
+    with kb.connect() as conn:
+        kb.create_task(conn, title="a", assignee="alice")
+
+    args = SimpleNamespace(
+        dry_run=True,
+        max=None,
+        max_in_progress=None,
+        failure_limit=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
+        json=False,
+    )
+    kanban_mod._cmd_dispatch(args)
+
+    assert captured.get("max_in_progress") is None, (
+        f"max_in_progress should be None by default; got {captured.get('max_in_progress')}"
+    )
+
+
 # Review column dispatch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The `hermes kanban dispatch` command accepted `--max-in-progress` as an argparse argument but never forwarded it to `kanban_db.dispatch_once()`, silently ignoring the concurrency cap.

## Root Cause

In `hermes_cli/kanban.py`:
- The `dispatch` subparser defined `--max-in-progress` arg (but it was missing)
- The `_cmd_dispatch` function called `dispatch_once()` without passing `max_in_progress`
- The gateway dispatcher already passed this correctly (`gateway/run.py:5383`)

## Fix

1. Add `--max-in-progress` argument to the `dispatch` subparser with help text noting it overrides `kanban.max_in_progress` config
2. Pass `max_in_progress=getattr(args, "max_in_progress", None)` in the `dispatch_once()` call

## Tests

Added 2 regression tests in `tests/hermes_cli/test_kanban_db.py`:
- `test_cli_dispatch_passes_max_in_progress`: Verifies the CLI arg is passed through
- `test_cli_dispatch_max_in_progress_none_by_default`: Verifies None (unlimited) by default

Both existing and new tests pass (5 total max_in_progress tests).

## Code Intelligence

- **Primary symbol**: `hermes_cli.kanban._cmd_dispatch` (CLI dispatch entry point)
- **Callers**: `hermes kanban dispatch` command (interactive use)
- **Blast radius**: LOW — only CLI dispatch command, gateway dispatcher unaffected
- **Related patterns**: `gateway/run.py:_tick_once_for_board` (gateway dispatch, already correct)
- **Test coverage**: 2 new regression tests, 3 existing max_in_progress tests all pass

Fixes #33488
