### PR TITLE
fix: honor configured base URL for manual auth

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -96,8 +96,30 @@ def _provider_base_url(provider: str) -> str:
         if cp_config:
             return str(cp_config.get("base_url") or "").strip()
         return ""
+
     pconfig = PROVIDER_REGISTRY.get(provider)
-    return pconfig.inference_base_url if pconfig else ""
+    registry_base_url = pconfig.inference_base_url if pconfig else ""
+
+    # Manual credentials should follow the active model endpoint.  Some
+    # providers expose multiple OpenAI-compatible hosts for the same API-key
+    # shape (for example Xiaomi MiMo's standard API endpoint vs Token Plan
+    # endpoint).  If `hermes auth add <provider>` persists the registry default
+    # into the credential pool, runtime resolution can override a deliberate
+    # `model.base_url` setting and send a valid key to the wrong host.
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        model_cfg = config.get("model") if isinstance(config, dict) else None
+        if isinstance(model_cfg, dict):
+            configured_provider = _normalize_provider(str(model_cfg.get("provider") or ""))
+            configured_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+            if configured_provider == provider and configured_base_url:
+                return configured_base_url
+    except Exception:
+        pass
+
+    return registry_base_url
 
 
 def _oauth_default_label(provider: str, count: int) -> str:

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -104,6 +104,52 @@ def test_auth_add_api_key_uses_config_base_url_for_active_provider(tmp_path, mon
     assert entry["base_url"] == token_plan_url
 
 
+def test_auth_add_api_key_ignores_config_base_url_for_other_provider(tmp_path, monkeypatch):
+    """A manual key for a provider that is NOT the active one must not inherit
+    the configured ``model.base_url``.
+
+    This locks in the negative branch of the fix: with Xiaomi's Token Plan URL
+    configured as the active endpoint, adding an Anthropic key must fall back to
+    Anthropic's registry endpoint — never Xiaomi's host. Without this guard the
+    "narrow fix" guarantee (only the same-provider case follows the config)
+    would be untested, since the existing OpenRouter test configures no foreign
+    ``model.base_url`` and so never exercises ``configured_provider != provider``.
+    """
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("XIAOMI_API_KEY", raising=False)
+    monkeypatch.delenv("XIAOMI_BASE_URL", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token_plan_url = "https://token-plan-ams.xiaomimimo.com/v1"
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "xiaomi",
+                    "name": "mimo-v2.5-pro",
+                    "base_url": token_plan_url,
+                }
+            }
+        )
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "api-key"
+        api_key = "sk-ant-manual"
+        label = "anthropic-manual"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    entries = payload["credential_pool"]["anthropic"]
+    entry = next(item for item in entries if item["source"] == "manual")
+    # Anthropic must NOT inherit Xiaomi's configured Token Plan endpoint.
+    assert entry["base_url"] != token_plan_url
+
+
 def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -62,6 +62,48 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_auth_add_api_key_uses_config_base_url_for_active_provider(tmp_path, monkeypatch):
+    """Manual API keys should inherit model.base_url for the active provider.
+
+    Xiaomi MiMo Token Plan users configure ``model.base_url`` to the Token Plan
+    endpoint.  If ``hermes auth add xiaomi`` stores the provider registry
+    default instead, credential-pool runtime resolution silently sends the key
+    to the wrong endpoint and marks an otherwise-valid key as 401/exhausted.
+    """
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("XIAOMI_API_KEY", raising=False)
+    monkeypatch.delenv("XIAOMI_BASE_URL", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token_plan_url = "https://token-plan-ams.xiaomimimo.com/v1"
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "xiaomi",
+                    "name": "mimo-v2.5-pro",
+                    "base_url": token_plan_url,
+                }
+            }
+        )
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "xiaomi"
+        auth_type = "api-key"
+        api_key = "sk-xiaomi-token-plan"
+        label = "token-plan"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    entries = payload["credential_pool"]["xiaomi"]
+    entry = next(item for item in entries if item["source"] == "manual")
+    assert entry["base_url"] == token_plan_url
+
+
 def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)


### PR DESCRIPTION
## Summary

Fixes manual API-key auth so `hermes auth add <provider>` honors the active `model.base_url` when the credential is for the same configured provider.

This matters for providers with multiple OpenAI-compatible endpoints behind the same provider/key shape. Xiaomi MiMo is the real-world case here: a valid Token Plan key must be used against `https://token-plan-ams.xiaomimimo.com/v1`, but manual auth could persist the registry default endpoint instead. After restart/subagent use, Hermes could treat the same valid Xiaomi key as missing/failed because runtime credential resolution was pointed at the wrong host.

## What changed

- `hermes_cli/auth_commands.py`
  - `_provider_base_url()` now checks the active `model.provider` and `model.base_url`.
  - If the provider being added matches the configured model provider and a configured base URL exists, the manual credential stores that configured endpoint.
  - Falls back to the provider registry default for all other cases.
- `tests/hermes_cli/test_auth_commands.py`
  - Adds regression coverage proving manual Xiaomi auth stores the configured Token Plan base URL.
  - Adds fallback coverage proving unrelated/default provider behavior is unchanged.

## Real-world incident evidence

The excerpts below are copied from the reporter's chat transcript (`mimotoken`). One literal API key appeared in the raw transcript; it is intentionally redacted here.

### 1) Xiaomi auth failed mid-session

```text
09:36 PM
let me give you an example: the message I just sent and the reply with tool calls used up 260m credits and 1% of my monthly allowance.
09:36 PM
H
Hermes

Error: Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with hermes model.
Provider details

09:36 PM

Error: Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with hermes model.
Provider details

09:37 PM
test
09:38 PM
H
Hermes

Error: Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with hermes model.
Provider details

09:38 PM

Error: Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with hermes model.
Provider details

09:38 PM

Error: Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with hermes model.
Provider details
```

Note: after this Xiaomi failure, the reporter switched the session to GPT-5.5 / OpenAI Codex to continue debugging and preserve the Xiaomi/OpenAI privacy boundary.

### 2) Investigation showed a stored credential existed, but Hermes treated it as failed

```text
09:52 PM
H
Hermes

I found something better than the env file: Hermes still has a Xiaomi credential in its auth store, but it’s marked as a failed 401 credential. That means the key didn’t vanish — Hermes has effectively quarantined it.
09:52 PM

I’m going to try the low-risk fix first: clear Xiaomi’s failed state and re-check status. If it works, we’ve got a workaround; if not, we’ve at least confirmed the bug isn’t just a stuck cache.
09:52 PM

I’ve cleared the failed state. I’m verifying whether Hermes still remembers Xiaomi as a valid credential or whether it’s now just a dead entry.
09:52 PM

Yeah — that does look like a bug.
What I found

    The update did restart Hermes.
    Your Xiaomi auth was not gone; it lives in Hermes’s auth store (~/.hermes/auth.json), not just .env.
    But after the update/restart, Hermes had marked the Xiaomi credential as failed 401 / re-auth may be required.
    I ran:

bash

hermes auth reset xiaomi

and that cleared the failed state.

After that, hermes auth list shows Xiaomi again as a normal credential:

    before: manual auth failed (401)
    after: manual

So the likely bug
Not “your key vanished,” but:

the update/restart left Xiaomi’s credential in a bad failed state and Hermes treated it as dead until reset.

That’s bogus behavior if it was still working before the update.
```

### 3) Re-auth restored Xiaomi, proving the key/provider worked

```text
09:53 PM
can we reauth xiaomi
09:53 PM
H
Hermes

I’m checking the Xiaomi auth command shape first so I don’t guess and trash the credential pool.
09:53 PM

I need to see whether Xiaomi is still recoverable from Hermes’s stored credential or whether it needs a fresh key from you.
09:53 PM

Yes — but it’s already showing as logged in right now, so the only thing we can really do is replace/re-enter the Xiaomi API key.

I don’t have the key, so I need you to paste it if you want me to reauth it.
If you want, I can do the clean swap flow:

    logout the current Xiaomi credential
    add a fresh one
    verify it works

Paste the Xiaomi API key and I’ll handle the rest.
09:53 PM
[REDACTED_XIAOMI_API_KEY]
09:54 PM
H
Hermes

I’m re-adding Xiaomi with the new key and then I’ll verify it’s actually accepted.
09:54 PM

I’m checking the credential list so we know whether the new key landed cleanly and where Hermes will draw from next.
09:54 PM

Done.

Xiaomi now has a fresh pooled credential:

    api-key-2
    api-key-3 ← the new one you just gave me

hermes auth list xiaomi now shows both as manual and hermes auth status xiaomi says logged in.
```

### 4) Manual Xiaomi calls succeeded after re-auth

```text
09:56 PM
ive switched models to mimo
09:56 PM
H
Hermes

Confirmed.

    Xiaomi auth: logged in
    Provider: Xiaomi MiMo
    Model: mimo-v2.5-pro

So the switchover is clean now. If Xiaomi still acts weird on the next turn, that’ll be easier to spot as a real runtime bug instead of a stale credential problem.
09:56 PM
lets test xiaomi. Can you do a large input token call? like 50000 tokens. I dont know how many tokens your current calls take but i image 20k or so
09:59 PM
H
Hermes

Xiaomi is alive and kicking. Here's the result:
Test Results
Metric	Value
Status	✅ Success
Model	mimo-v2.5-pro
Prompt tokens	264,045
Completion tokens	200
Total tokens	264,245
Latency	21.4 seconds

The new key works fine. We hit it with 264K input tokens — way more than the 50K target (the filler was token-denser than I estimated).
```

### 5) The failure reproduced in a child/subagent path

```text
10:21 PM
yes look it up
10:23 PM
H
Hermes

The subagent hit the same Xiaomi auth issue — the new key isn't propagating to child processes yet. Let me search directly.
...
10:23 PM
Want me to install it and set it up for Hermes?
10:23 PM
yes
10:24 PM
H
Hermes

Error: Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with hermes model.
Provider details
...
happened again
10:26 PM
H
Hermes

Error: Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with hermes model.
Provider details

Provider 'xiaomi' is set in config.yaml but no API key was found. Set the XIAOMI_API_KEY environment variable, or switch to a different provider with `hermes model`.
```

## Patch verification

### Code-level regression test

```text
$ uv run --python /Users/jimdawdy/.local/bin/python3.11 python -m pytest tests/hermes_cli/test_auth_commands.py -q -o 'addopts='
...............................................                          [100%]
47 passed in 1.37s
```

## Why this fix is narrow

The change only prefers `model.base_url` when all of these are true:

1. the credential being added is for a known non-custom provider;
2. the active `model.provider` normalizes to that same provider; and
3. `model.base_url` is non-empty.

Otherwise the existing registry base URL behavior is preserved.

## Test plan

- [x] `uv run --python /Users/jimdawdy/.local/bin/python3.11 python -m pytest tests/hermes_cli/test_auth_commands.py -q -o 'addopts='`
