### PR TITLE
fix(setup): back up config.yaml before setup modifies it

### DIFF
--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -83,6 +83,23 @@ class TestNonInteractiveSetup:
         out = capsys.readouterr().out
         assert "hermes config set model.provider custom" in out
 
+    def test_non_interactive_setup_backs_up_existing_config(self, tmp_path, monkeypatch):
+        """Setup should back up config.yaml before it decides it cannot run interactively."""
+        from hermes_cli.setup import run_setup_wizard
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = load_config()
+        cfg["model"] = {"provider": "custom", "base_url": "http://localhost:8080/v1", "default": "llama3"}
+        save_config(cfg)
+
+        args = _make_setup_args(non_interactive=True)
+
+        run_setup_wizard(args)
+
+        backups = list(tmp_path.glob("config.yaml.bak.*"))
+        assert len(backups) == 1
+        assert "localhost:8080" in backups[0].read_text()
+
     def test_no_tty_skips_wizard(self, capsys):
         """When stdin has no TTY, the setup wizard should print guidance and return."""
         from hermes_cli.setup import run_setup_wizard


### PR DESCRIPTION
Salvage of #4150 by @SHL0MS — rebased onto current main

The original production patch is already present on current main, so this salvage preserves the behavior with focused regression coverage confirming setup backs up an existing config.yaml before it exits in non-interactive mode.

Validation:
- uv run --with pytest --with pytest-xdist pytest tests/hermes_cli/test_setup_noninteractive.py