### PR TITLE
feat(messaging): allow custom model entry in session picker

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7374,7 +7374,15 @@ class HermesCLI:
         lines.append(('class:approval-border', '╰' + ('─' * box_width) + '╯\n'))
         return lines
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(
+        self,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        user_provs=None,
+        custom_provs=None,
+        persist_global: bool = False,
+    ) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
@@ -7386,6 +7394,7 @@ class HermesCLI:
             "current_provider": current_provider,
             "user_provs": user_provs,
             "custom_provs": custom_provs,
+            "persist_global": persist_global,
         }
         self._invalidate(min_interval=0.0)
 
@@ -7506,10 +7515,12 @@ class HermesCLI:
         else:
             _cprint("    (session only — add --global to persist)")
 
-    def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
+    def _handle_model_picker_selection(self, persist_global: bool | None = None) -> None:
         state = self._model_picker_state
         if not state:
             return
+        if persist_global is None:
+            persist_global = bool(state.get("persist_global"))
         selected = state.get("selected", 0)
         stage = state.get("stage")
         if stage == "provider":
@@ -7540,8 +7551,20 @@ class HermesCLI:
         if stage == "model":
             provider_data = state.get("provider_data") or {}
             model_list = state.get("model_list") or []
-            back_idx = len(model_list)
-            cancel_idx = len(model_list) + 1
+            custom_idx = len(model_list)
+            back_idx = len(model_list) + 1
+            cancel_idx = len(model_list) + 2
+            if selected == custom_idx:
+                state["stage"] = "custom_model"
+                state["selected"] = 0
+                state["custom_error"] = ""
+                try:
+                    if getattr(self, "_app", None):
+                        self._app.current_buffer.reset()
+                except Exception:
+                    pass
+                self._invalidate(min_interval=0.0)
+                return
             if selected == back_idx:
                 state["stage"] = "provider"
                 state["selected"] = next((i for i, p in enumerate(state.get("providers") or []) if p.get("slug") == provider_data.get("slug")), 0)
@@ -7568,6 +7591,33 @@ class HermesCLI:
                 self._apply_model_switch_result(result, persist_global)
                 return
             self._close_model_picker()
+            return
+        if stage == "custom_model":
+            provider_data = state.get("provider_data") or {}
+            try:
+                raw_model = self._app.current_buffer.text.strip() if getattr(self, "_app", None) else ""
+            except Exception:
+                raw_model = ""
+            if not raw_model:
+                state["custom_error"] = "Enter a model name, or press Esc to cancel."
+                self._invalidate(min_interval=0.0)
+                return
+
+            from hermes_cli.model_switch import switch_model
+            result = switch_model(
+                raw_input=raw_model,
+                current_provider=self.provider or "",
+                current_model=self.model or "",
+                current_base_url=self.base_url or "",
+                current_api_key=self.api_key or "",
+                is_global=persist_global,
+                explicit_provider=provider_data.get("slug"),
+                user_providers=state.get("user_provs"),
+                custom_providers=state.get("custom_provs"),
+            )
+            self._close_model_picker()
+            self._apply_model_switch_result(result, persist_global)
+            return
 
     def _handle_model_switch(self, cmd_original: str):
         """Handle /model command — switch model for this session.
@@ -7634,6 +7684,7 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                persist_global=persist_global,
             )
             return
 
@@ -12929,8 +12980,10 @@ class HermesCLI:
                 return
             if state.get("stage") == "provider":
                 max_idx = len(state.get("providers") or [])
+            elif state.get("stage") == "model":
+                max_idx = len(state.get("model_list") or []) + 2
             else:
-                max_idx = len(state.get("model_list") or []) + 1
+                max_idx = 0
             state["selected"] = min(max_idx, state.get("selected", 0) + 1)
             event.app.invalidate()
 
@@ -14014,12 +14067,22 @@ class HermesCLI:
             else:
                 provider_data = state.get("provider_data") or {}
                 model_list = state.get("model_list") or []
-                title = f"⚙ Model Picker — {provider_data.get('name', provider_data.get('slug', 'Provider'))}"
-                choices = list(model_list) + ["← Back", "Cancel"]
-                if model_list:
-                    hint = f"Select a model ({len(model_list)} available)"
+                provider_name = provider_data.get('name', provider_data.get('slug', 'Provider'))
+                title = f"⚙ Model Picker — {provider_name}"
+                if stage == "custom_model":
+                    typed = ""
+                    try:
+                        typed = cli_ref._app.current_buffer.text.strip() if getattr(cli_ref, "_app", None) else ""
+                    except Exception:
+                        typed = ""
+                    choices = [f"Model: {typed or '<type below>'}", "Esc cancels"]
+                    hint = state.get("custom_error") or f"Enter a custom model name for {provider_name}, then press Enter."
                 else:
-                    hint = "No models listed for this provider. Use Back or Cancel."
+                    choices = list(model_list) + ["Enter custom model name", "← Back", "Cancel"]
+                    if model_list:
+                        hint = f"Select a model ({len(model_list)} available), or enter a custom model name."
+                    else:
+                        hint = "No models listed for this provider. Enter a custom model name, go Back, or Cancel."
 
             box_width = _panel_box_width(title, [hint] + choices, min_width=46, max_width=84)
             inner_text_width = max(8, box_width - 6)

--- a/tests/hermes_cli/test_cli_model_picker_custom.py
+++ b/tests/hermes_cli/test_cli_model_picker_custom.py
@@ -1,0 +1,95 @@
+"""Tests for prompt_toolkit /model picker custom model entry."""
+
+from types import SimpleNamespace
+
+from cli import HermesCLI
+
+
+class _Buffer:
+    def __init__(self, text=""):
+        self.text = text
+        self.cursor_position = len(text)
+        self.reset_count = 0
+
+    def reset(self):
+        self.text = ""
+        self.cursor_position = 0
+        self.reset_count += 1
+
+
+def _cli_with_picker_state(state, *, typed=""):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._model_picker_state = state
+    cli._app = SimpleNamespace(current_buffer=_Buffer(typed))
+    cli.model = "old-model"
+    cli.provider = "openrouter"
+    cli.base_url = "https://openrouter.ai/api/v1"
+    cli.api_key = "key"
+    cli._invalidate = lambda min_interval=0.0: None
+    return cli
+
+
+def test_model_picker_model_stage_can_enter_custom_model():
+    state = {
+        "stage": "model",
+        "selected": 2,
+        "provider_data": {"slug": "openrouter", "name": "OpenRouter"},
+        "model_list": ["anthropic/claude-sonnet-4", "openai/gpt-5"],
+    }
+    cli = _cli_with_picker_state(state, typed="stale")
+
+    cli._handle_model_picker_selection()
+
+    assert state["stage"] == "custom_model"
+    assert state["selected"] == 0
+    assert state["custom_error"] == ""
+    assert cli._app.current_buffer.text == ""
+    assert cli._app.current_buffer.reset_count == 1
+
+
+def test_model_picker_custom_stage_switches_session_model(monkeypatch):
+    state = {
+        "stage": "custom_model",
+        "selected": 0,
+        "persist_global": False,
+        "provider_data": {"slug": "openrouter", "name": "OpenRouter"},
+        "user_provs": {"openrouter": {}},
+        "custom_provs": [],
+    }
+    cli = _cli_with_picker_state(state, typed="acme/new-model")
+    applied = {}
+    result = SimpleNamespace(success=True, new_model="acme/new-model")
+
+    def fake_switch_model(**kwargs):
+        applied["switch_kwargs"] = kwargs
+        return result
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
+    cli._close_model_picker = lambda: applied.setdefault("closed", True)
+    cli._apply_model_switch_result = lambda res, persist: applied.update(
+        result=res,
+        persist_global=persist,
+    )
+
+    cli._handle_model_picker_selection()
+
+    assert applied["closed"] is True
+    assert applied["result"] is result
+    assert applied["persist_global"] is False
+    assert applied["switch_kwargs"]["raw_input"] == "acme/new-model"
+    assert applied["switch_kwargs"]["explicit_provider"] == "openrouter"
+    assert applied["switch_kwargs"]["is_global"] is False
+
+
+def test_model_picker_custom_stage_requires_model_name():
+    state = {
+        "stage": "custom_model",
+        "selected": 0,
+        "provider_data": {"slug": "openrouter", "name": "OpenRouter"},
+    }
+    cli = _cli_with_picker_state(state, typed="  ")
+
+    cli._handle_model_picker_selection()
+
+    assert state["stage"] == "custom_model"
+    assert "Enter a model name" in state["custom_error"]


### PR DESCRIPTION
## What does this PR do?

Adds an `Enter custom model name` option to the in-session `/model` picker.

The interactive /model picker only allows selecting from the listed models. This PR makes the picker support the same session-scoped custom model flow without requiring users to leave the picker or run hermes model.

## Related Issue

Fixes #33653

## Type of Change

New feature (non-breaking change that adds functionality)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adds an Enter custom model name option to the /model picker’s model-selection stage.
- Adds a custom-model entry stage after selecting that option.
- Routes the entered model name through the existing switch_model(...) path.
- Uses the selected provider when switching to the custom model.
- Keeps the default behavior session-scoped unless --global was explicitly used.

## How to Test

1. Start Hermes CLI.
2. Run /model.
3. Select a provider.
4. Select Enter custom model name.
5. Type a valid model slug for that provider.
6. Press Enter.
7. Confirm Hermes switches to that model for the current session.

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
<img width="801" height="466" alt="bild" src="https://github.com/user-attachments/assets/a3ec25fe-071d-4608-8fbf-f3110e25d7f1" />

<img width="938" height="470" alt="bild" src="https://github.com/user-attachments/assets/d62272b7-bcab-4f00-b705-649e333a1006" />

<img width="901" height="236" alt="bild" src="https://github.com/user-attachments/assets/12dfddc0-9b42-4a2a-8f54-e6219ce656c2" />





