### PR TITLE
Add Discord thread context isolation setting

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1446,6 +1446,7 @@ DEFAULT_CONFIG = {
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
+        "thread_context_isolation": False,  # If True, keep auto-created thread sessions from inheriting parent/sibling thread starter context
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3691,6 +3691,21 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_HISTORY_BACKFILL", "true").lower() in {"true", "1", "yes"}
 
+    def _discord_thread_context_isolation(self) -> bool:
+        """Return whether Discord thread starters are isolated from backfill.
+
+        When enabled, parent-channel backfill will not import starter messages
+        from sibling threads, and a newly auto-created thread starts with only
+        its triggering message instead of inheriting parent-channel scrollback.
+        Default is off for compatibility with existing deployments.
+        """
+        configured = self.config.extra.get("thread_context_isolation")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in {"false", "0", "no", "off"}
+            return bool(configured)
+        return os.getenv("DISCORD_THREAD_CONTEXT_ISOLATION", "false").lower() in {"true", "1", "yes", "on"}
+
     def _discord_history_backfill_limit(self) -> int:
         """Return the max number of messages to scan backwards for context.
 
@@ -3777,6 +3792,20 @@ class DiscordAdapter(BasePlatformAdapter):
 
                 # Skip system messages (pins, joins, thread renames, etc.)
                 if msg.type not in {discord.MessageType.default, discord.MessageType.reply}:
+                    continue
+
+                # Optional isolation for Discord thread-starter messages visible
+                # in the parent channel. Those messages are the first turn of a
+                # different thread, so including them in parent-channel backfill
+                # can leak sibling thread context into later tasks. Kept opt-in
+                # for compatibility with deployments that expect legacy channel
+                # backfill to include all parent-channel messages.
+                msg_thread = getattr(msg, "thread", None)
+                msg_flags = getattr(msg, "flags", None)
+                if (
+                    self._discord_thread_context_isolation()
+                    and (msg_thread is not None or bool(getattr(msg_flags, "has_thread", False)))
+                ):
                     continue
 
                 # Respect DISCORD_ALLOW_BOTS for other bots.
@@ -4478,6 +4507,9 @@ class DiscordAdapter(BasePlatformAdapter):
         raw_content = message.content.strip()
         normalized_content = raw_content
         mention_prefix = False
+        require_mention = False
+        is_free_channel = False
+        in_bot_thread = False
 
         snapshot_attachments = []
         if hasattr(message, "message_snapshots") and message.message_snapshots:
@@ -4778,11 +4810,19 @@ class DiscordAdapter(BasePlatformAdapter):
         _channel_context = None
         _is_dm = isinstance(message.channel, discord.DMChannel)
         if not _is_dm:
-            _needed_mention = (
-                require_mention
-                and not is_free_channel
-                and not in_bot_thread
-            )
+            # When thread context isolation is enabled and this mention just
+            # created a new auto-thread, the new thread's session starts with
+            # the trigger message only. Backfilling the parent channel here
+            # would leak sibling/parent conversation into the fresh thread even
+            # though responses are routed to ``effective_channel``.
+            if auto_threaded_channel is not None and self._discord_thread_context_isolation():
+                _needed_mention = False
+            else:
+                _needed_mention = (
+                    require_mention
+                    and not is_free_channel
+                    and not in_bot_thread
+                )
             _backfill_enabled = self._discord_history_backfill()
             if _needed_mention and _backfill_enabled:
                 _backfill_text = await self._fetch_channel_context(
@@ -6109,6 +6149,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     hbl = discord_cfg.get("history_backfill_limit")
     if hbl is not None and not os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT"):
         os.environ["DISCORD_HISTORY_BACKFILL_LIMIT"] = str(hbl)
+    if "thread_context_isolation" in discord_cfg and not os.getenv("DISCORD_THREAD_CONTEXT_ISOLATION"):
+        os.environ["DISCORD_THREAD_CONTEXT_ISOLATION"] = str(discord_cfg["thread_context_isolation"]).lower()
     # allow_mentions: granular control over what the bot can ping.
     # Safe defaults (no @everyone/roles) are applied in the adapter;
     # these YAML keys only override when set and let users opt back
@@ -6171,7 +6213,7 @@ def register(ctx) -> None:
         # ``discord:`` keys (require_mention, free_response_channels,
         # auto_thread, reactions, ignored_channels, allowed_channels,
         # no_thread_channels, allow_mentions.*, reply_to_mode,
-        # thread_require_mention) into ``DISCORD_*`` env vars that the
+        # thread_require_mention, thread_context_isolation) into ``DISCORD_*`` env vars that the
         # adapter reads via ``os.getenv()``.  Replaces the hardcoded block
         # that used to live in ``gateway/config.py``.  Hook contract: #24836.
         apply_yaml_config_fn=_apply_yaml_config,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -420,18 +420,21 @@ class TestLoadGatewayConfig:
         config_path.write_text(
             "discord:\n"
             "  history_backfill: true\n"
-            "  history_backfill_limit: 17\n",
+            "  history_backfill_limit: 17\n"
+            "  thread_context_isolation: true\n",
             encoding="utf-8",
         )
 
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.delenv("DISCORD_HISTORY_BACKFILL", raising=False)
         monkeypatch.delenv("DISCORD_HISTORY_BACKFILL_LIMIT", raising=False)
+        monkeypatch.delenv("DISCORD_THREAD_CONTEXT_ISOLATION", raising=False)
 
         load_gateway_config()
 
         assert os.getenv("DISCORD_HISTORY_BACKFILL") == "true"
         assert os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT") == "17"
+        assert os.getenv("DISCORD_THREAD_CONTEXT_ISOLATION") == "true"
 
     def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -113,6 +113,7 @@ def adapter(monkeypatch):
         "DISCORD_IGNORED_CHANNELS",
         "DISCORD_HISTORY_BACKFILL",
         "DISCORD_HISTORY_BACKFILL_LIMIT",
+        "DISCORD_THREAD_CONTEXT_ISOLATION",
         "DISCORD_ALLOW_BOTS",
     ):
         monkeypatch.delenv(_var, raising=False)
@@ -688,6 +689,62 @@ async def test_fetch_channel_context_skips_other_bots_when_allow_bots_none(adapt
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_skips_thread_starter_messages(adapter, monkeypatch):
+    """Parent-channel backfill must not import starter messages from sibling threads."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+    adapter.config.extra["thread_context_isolation"] = True
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    starter = make_history_message(
+        author=human,
+        content="opening message for another thread",
+        msg_id=2,
+    )
+    starter.thread = SimpleNamespace(id=999)
+
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="ordinary parent-channel note", msg_id=3),
+            starter,
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert result == "[Recent channel messages]\n[Alice] ordinary parent-channel note"
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_keeps_thread_starters_by_default(adapter, monkeypatch):
+    """Thread starter filtering is opt-in for compatibility."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    starter = make_history_message(
+        author=human,
+        content="opening message for another thread",
+        msg_id=2,
+    )
+    starter.thread = SimpleNamespace(id=999)
+
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="ordinary parent-channel note", msg_id=3),
+            starter,
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert "opening message for another thread" in result
+    assert "ordinary parent-channel note" in result
+
+
+@pytest.mark.asyncio
 async def test_fetch_channel_context_uses_cache_to_narrow_window(adapter, monkeypatch):
     """When _last_self_message_id is cached, the fetch passes after= to skip old messages."""
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
@@ -823,6 +880,73 @@ async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeyp
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "hello with mention"
     assert event.channel_context == "[Recent channel messages]\n[Alice] context"
+
+
+@pytest.mark.asyncio
+async def test_discord_auto_thread_does_not_backfill_parent_channel_into_new_thread(adapter, monkeypatch):
+    """A newly auto-created thread must not inherit parent-channel backfill.
+
+    The triggering message becomes the first turn in the new thread session;
+    messages from the parent channel belong to a different context and should
+    not be prepended to the thread.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    adapter.config.extra["history_backfill"] = True
+    adapter.config.extra["thread_context_isolation"] = True
+    adapter._fetch_channel_context = AsyncMock(return_value="[Recent channel messages]\n[Alice] parent context")
+
+    parent = FakeTextChannel(channel_id=321, name="agent-office")
+    new_thread = FakeThread(channel_id=654, name="isolated task", parent=parent)
+    adapter._auto_create_thread = AsyncMock(return_value=new_thread)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=parent,
+        content=f"<@{bot_user.id}> start isolated task",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter._fetch_channel_context.assert_not_awaited()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+    assert event.source.chat_id == "654"
+    assert event.channel_context is None
+    assert event.text == "start isolated task"
+
+
+@pytest.mark.asyncio
+async def test_discord_auto_thread_backfills_parent_channel_by_default(adapter, monkeypatch):
+    """New auto-thread isolation is opt-in for compatibility."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    adapter.config.extra["history_backfill"] = True
+    adapter._fetch_channel_context = AsyncMock(return_value="[Recent channel messages]\n[Alice] parent context")
+
+    parent = FakeTextChannel(channel_id=321, name="agent-office")
+    new_thread = FakeThread(channel_id=654, name="isolated task", parent=parent)
+    adapter._auto_create_thread = AsyncMock(return_value=new_thread)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=parent,
+        content=f"<@{bot_user.id}> start isolated task",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter._fetch_channel_context.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+    assert event.source.chat_id == "654"
+    assert event.channel_context == "[Recent channel messages]\n[Alice] parent context"
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -315,6 +315,7 @@ discord:
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
+  thread_context_isolation: false # Keep new threads from inheriting parent/sibling thread context (default: false)
   channel_prompts: {}             # Per-channel ephemeral system prompts
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
     everyone: false               # @everyone / @here pings (default: false)
@@ -482,6 +483,22 @@ Maximum number of messages to scan backwards when recovering channel context. In
 discord:
   history_backfill: true
   history_backfill_limit: 50
+```
+
+#### `discord.thread_context_isolation`
+
+**Type:** boolean — **Default:** `false`
+
+When enabled, Discord thread tasks stay isolated from parent-channel history backfill:
+
+- If `auto_thread` creates a new thread from a channel mention, that new thread starts with only the triggering message. Hermes does not prepend parent-channel scrollback to the new thread's first turn.
+- Parent-channel backfill skips Discord messages that have attached thread previews/starters, because those messages are the first turn of sibling threads rather than ordinary parent-channel context.
+
+The default is `false` for compatibility with existing deployments that expect legacy backfill to include all parent-channel messages.
+
+```yaml
+discord:
+  thread_context_isolation: true
 ```
 
 #### `group_sessions_per_user`


### PR DESCRIPTION
## Summary

This adds an opt-in Discord setting for deployments that use one thread per task and want strict thread isolation:

```yaml
discord:
  thread_context_isolation: true
```

When enabled:

- newly auto-created Discord threads start with only the triggering message, without parent-channel history backfill
- parent-channel history backfill skips Discord thread starter/preview messages from sibling threads
- the setting is documented and bridged from `config.yaml` into the Discord adapter

The default remains `false`, so existing deployments keep the current behavior unless they opt in.

## Test Plan

```bash
python -m pytest tests/gateway/test_discord_free_response.py tests/gateway/test_config.py -q -o 'addopts='
```
