### PR TITLE
fix(memory): normalize multimodal content and filter framework artifacts before provider sync

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -25,9 +25,10 @@ Usage in run_agent.py:
 
 from __future__ import annotations
 
+import inspect
+import json
 import logging
 import re
-import inspect
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -57,6 +58,88 @@ def sanitize_context(text: str) -> str:
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
     return text
+
+
+_TEXT_BLOCK_TYPES = {"text", "input_text"}
+_IMAGE_BLOCK_TYPES = {"image_url", "input_image"}
+_AUDIO_BLOCK_TYPES = {"audio", "input_audio"}
+_VIDEO_BLOCK_TYPES = {"video", "input_video"}
+_MEDIA_BLOCK_MARKERS = {
+    "image": "[image attached]",
+    "audio": "[audio attached]",
+    "video": "[video attached]",
+}
+
+
+def normalize_memory_turn_content(content: Any) -> str:
+    """Convert turn content to plain text before provider sync.
+
+    Some gateway/model paths represent multimodal messages as OpenAI-style
+    content block lists. Memory providers expect text; passing raw lists can
+    crash providers, and serializing the blocks verbatim may persist base64
+    media payloads. Keep human text and replace media blocks with short
+    markers.
+    """
+    normalized = _flatten_rich_content(content)
+    return sanitize_context(normalized).strip()
+
+
+def _flatten_rich_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        parsed = _parse_serialized_content_blocks(content)
+        if parsed is not None:
+            return _flatten_content_blocks(parsed)
+        return content
+    if isinstance(content, list):
+        return _flatten_content_blocks(content)
+    if isinstance(content, dict):
+        block = _flatten_content_block(content)
+        return block if block is not None else json.dumps(content, ensure_ascii=False)
+    return str(content)
+
+
+def _parse_serialized_content_blocks(content: str) -> Optional[list[Any]]:
+    stripped = content.strip()
+    if not stripped.startswith("["):
+        return None
+    try:
+        parsed = json.loads(stripped)
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, list) else None
+
+
+def _flatten_content_blocks(blocks: list[Any]) -> str:
+    parts: list[str] = []
+    saw_known_block = False
+    for block in blocks:
+        flattened = _flatten_content_block(block)
+        if flattened is None:
+            continue
+        saw_known_block = True
+        if flattened:
+            parts.append(flattened)
+    if saw_known_block:
+        return "\n\n".join(parts)
+    return json.dumps(blocks, ensure_ascii=False)
+
+
+def _flatten_content_block(block: Any) -> Optional[str]:
+    if not isinstance(block, dict):
+        return None
+    block_type = block.get("type")
+    if block_type in _TEXT_BLOCK_TYPES:
+        text = block.get("text")
+        return text.strip() if isinstance(text, str) else ""
+    if block_type in _IMAGE_BLOCK_TYPES:
+        return _MEDIA_BLOCK_MARKERS["image"]
+    if block_type in _AUDIO_BLOCK_TYPES:
+        return _MEDIA_BLOCK_MARKERS["audio"]
+    if block_type in _VIDEO_BLOCK_TYPES:
+        return _MEDIA_BLOCK_MARKERS["video"]
+    return None
 
 
 class StreamingContextScrubber:
@@ -368,11 +451,13 @@ class MemoryManager:
 
     # -- Sync ----------------------------------------------------------------
 
-    def sync_all(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_all(self, user_content: Any, assistant_content: Any, *, session_id: str = "") -> None:
         """Sync a completed turn to all providers."""
+        user_text = normalize_memory_turn_content(user_content)
+        assistant_text = normalize_memory_turn_content(assistant_content)
         for provider in self._providers:
             try:
-                provider.sync_turn(user_content, assistant_content, session_id=session_id)
+                provider.sync_turn(user_text, assistant_text, session_id=session_id)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' sync_turn failed: %s",

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -69,6 +69,31 @@ _MEDIA_BLOCK_MARKERS = {
     "audio": "[audio attached]",
     "video": "[video attached]",
 }
+_MAX_MEMORY_SYNC_CHARS = 8000
+_MEMORY_SYNC_BOILERPLATE_PREFIXES = (
+    "[IMPORTANT: The user has invoked",
+    "[CONTEXT COMPACTION",
+    "[System note:",
+    "Knowledge cutoff:",
+    "# Tools",
+    "# Instructions",
+)
+_MEMORY_SYNC_BOILERPLATE_MARKERS = (
+    "<memory-context>",
+    "<available_skills>",
+    "## Skills (mandatory)",
+    "Tool definitions",
+    "namespace functions",
+    "full skill content is loaded below",
+    "AGENTS.md",
+    "════════════════════════════════",
+)
+_MEMORY_SYNC_BINARY_PAYLOAD_MARKERS = (
+    "data:image/",
+    "data:video/",
+    "data:audio/",
+    ";base64,",
+)
 
 
 def normalize_memory_turn_content(content: Any) -> str:
@@ -80,8 +105,23 @@ def normalize_memory_turn_content(content: Any) -> str:
     media payloads. Keep human text and replace media blocks with short
     markers.
     """
-    normalized = _flatten_rich_content(content)
-    return sanitize_context(normalized).strip()
+    normalized = sanitize_context(_flatten_rich_content(content)).strip()
+    if not _should_store_memory_turn_content(normalized):
+        return ""
+    return normalized[:_MAX_MEMORY_SYNC_CHARS].rstrip()
+
+
+def _should_store_memory_turn_content(content: str) -> bool:
+    stripped = content.lstrip()
+    if not stripped:
+        return False
+    if any(stripped.startswith(prefix) for prefix in _MEMORY_SYNC_BOILERPLATE_PREFIXES):
+        return False
+    if any(marker in content for marker in _MEMORY_SYNC_BOILERPLATE_MARKERS):
+        return False
+    if any(marker in content for marker in _MEMORY_SYNC_BINARY_PAYLOAD_MARKERS):
+        return False
+    return True
 
 
 def _flatten_rich_content(content: Any) -> str:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -268,6 +268,39 @@ class TestMemoryManager:
 
         assert provider.synced_turns == [("Describe this\n\n[image attached]", "ok")]
 
+    def test_sync_all_drops_framework_boilerplate_per_side(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            '[IMPORTANT: The user has invoked the "hermes-agent" skill. Full skill content follows.]',
+            "Normal assistant response",
+        )
+
+        assert provider.synced_turns == [("", "Normal assistant response")]
+
+    def test_sync_all_drops_raw_base64_payloads_but_keeps_media_markers(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            "Here is an inline payload: data:image/png;base64,AAAA",
+            [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}],
+        )
+
+        assert provider.synced_turns == [("", "[image attached]")]
+
+    def test_sync_all_caps_excessive_turn_content(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all("x" * 9000, "ok")
+
+        assert provider.synced_turns == [("x" * 8000, "ok")]
+
     def test_sync_failure_doesnt_block_others(self):
         """If one provider's sync fails, others still run."""
         mgr = MemoryManager()

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -236,6 +236,38 @@ class TestMemoryManager:
         assert p1.synced_turns == [("user msg", "assistant msg")]
         assert p2.synced_turns == [("user msg", "assistant msg")]
 
+    def test_sync_all_normalizes_python_multimodal_blocks(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            [
+                {"type": "text", "text": "What is in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAA"},
+                },
+            ],
+            [{"type": "text", "text": "A red square."}],
+        )
+
+        assert provider.synced_turns == [
+            ("What is in this image?\n\n[image attached]", "A red square.")
+        ]
+
+    def test_sync_all_normalizes_serialized_multimodal_blocks(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            '[{"type":"input_text","text":"Describe this"},{"type":"input_image","image_url":"data:image/png;base64,AAAA"}]',
+            "ok",
+        )
+
+        assert provider.synced_turns == [("Describe this\n\n[image attached]", "ok")]
+
     def test_sync_failure_doesnt_block_others(self):
         """If one provider's sync fails, others still run."""
         mgr = MemoryManager()


### PR DESCRIPTION
## Summary

Adds normalization plus filter pass to `MemoryManager.sync_all()` so memory providers never receive raw multimodal content blocks, base64 media payloads, or framework boilerplate.

Two sequential commits:

1. **`fix(memory): normalize multimodal sync content`** flattens OpenAI-style `[{type: text, ...}, {type: image_url, ...}]` blocks into plain text with `[image attached]` / `[audio attached]` / `[video attached]` markers before calling `provider.sync_turn()`. Without this, multimodal turns either crash providers (passing list/dict to a method that expects str) or persist base64 payloads verbatim.
2. **`fix(memory): filter framework artifacts before sync`** drops turn content that is obviously framework noise: skill loadout (`<available_skills>`), tool definitions, system notes, context-compaction markers, raw base64 data URIs. Also caps each side at 8000 chars. Partial defense in depth against #32858 and similar future leaks.

## Why

Production deployment running Honcho hits this on every Discord turn with an image attachment, and on every turn that carries standard framework boilerplate. Two visible symptoms:

- Honcho session-query timeouts as the backing store accumulates large, low-signal records.
- Memory recall surfaces tool definitions and skill instructions as relevant past context.

Honcho already sanitizes on the *output* path (strips `<memory-context>` from injected user messages). These changes add the symmetric *input* sanitization at the orchestrator boundary so all 8 registered memory providers benefit, not just Honcho.

## Architecture

Filters live in `agent/memory_manager.py` (cross-provider), not in any single plugin, because:

- Multimodal flattening is provider-agnostic; every provider needs it.
- Framework boilerplate detection is provider-agnostic too; what makes a turn framework noise is about the *content*, not the *storage*.

Consistent with the principle in #33381 that core should not import plugin-specific knowledge; here the inverse also holds: pre-sync content normalization should not be duplicated across plugin implementations.

## Related

- Partial fix for #32858 (`background_review.py` self-attribution leak): the source-side fix proposed in that issue is complementary; this PR catches the symptom at the sync boundary even when other sources leak through.
- Does not address #33436 (configurable observation pruning), but creates the natural hook point for it: extend `_should_store_memory_turn_content()` with config-driven predicates.

## Test plan

- 5 new tests in `tests/agent/test_memory_provider.py`: Python multimodal blocks, JSON-serialized multimodal blocks, framework boilerplate per side, raw base64 payloads with media markers, excessive turn length cap.
- All 79 tests in `tests/agent/test_memory_provider.py` pass on the cherry-picked branch.
- Smoke-tested in production on a Hostinger KVM running Hermes 0.14.0 with Honcho plus Discord gateway. No regressions observed.

## Notes for reviewers

- Filter constants (`_MEMORY_SYNC_BOILERPLATE_PREFIXES`, etc.) are intentionally hardcoded to keep the diff minimal. Happy to move to `config.yaml` in a follow-up if preferred.
- The 8000-char cap matches typical Honcho observation size. Configurable per provider is also a reasonable follow-up.
- Commits rebased on current `main`; chain is normalize (required) then filter (builds on normalize). Splittable into two PRs if maintainers prefer.