### PR TITLE
fix(agent): preload jiter native parser

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -4,3 +4,5 @@ These modules contain pure utility functions and self-contained classes
 that were previously embedded in the 3,600-line run_agent.py. Extracting
 them makes run_agent.py focused on the AIAgent orchestrator class.
 """
+
+from . import jiter_preload as _jiter_preload  # noqa: F401

--- a/agent/jiter_preload.py
+++ b/agent/jiter_preload.py
@@ -1,0 +1,39 @@
+"""Best-effort early import for the OpenAI SDK's native streaming parser.
+
+The OpenAI SDK imports ``jiter`` while constructing streaming chat-completion
+responses.  On some Windows installs the native extension can be imported
+directly from the Hermes venv, but the first import fails when it happens later
+inside the threaded streaming request path.  Loading it once during agent
+package import avoids that import-order failure while preserving the normal
+SDK error path for genuinely missing or broken installs.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+_JITER_PRELOADED = False
+_JITER_PRELOAD_ERROR: Exception | None = None
+
+
+def preload_jiter_native_extension() -> bool:
+    """Import jiter's native extension early if it is available."""
+
+    global _JITER_PRELOADED, _JITER_PRELOAD_ERROR
+
+    if _JITER_PRELOADED:
+        return True
+
+    try:
+        importlib.import_module("jiter.jiter")
+        from jiter import from_json as _from_json  # noqa: F401
+    except Exception as exc:
+        _JITER_PRELOAD_ERROR = exc
+        return False
+
+    _JITER_PRELOADED = True
+    _JITER_PRELOAD_ERROR = None
+    return True
+
+
+preload_jiter_native_extension()

--- a/tests/agent/test_jiter_preload.py
+++ b/tests/agent/test_jiter_preload.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+from agent import jiter_preload
+
+
+def test_preload_jiter_native_extension_loads_sdk_parser_dependency():
+    assert jiter_preload.preload_jiter_native_extension() is True
+    assert "jiter.jiter" in sys.modules
+
+
+def test_preload_jiter_native_extension_is_best_effort(monkeypatch):
+    monkeypatch.setattr(jiter_preload, "_JITER_PRELOADED", False)
+
+    def _raise_missing(name: str):
+        assert name == "jiter.jiter"
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(importlib, "import_module", _raise_missing)
+
+    assert jiter_preload.preload_jiter_native_extension() is False
+    assert jiter_preload._JITER_PRELOADED is False
+    assert isinstance(jiter_preload._JITER_PRELOAD_ERROR, ModuleNotFoundError)


### PR DESCRIPTION
## What does this PR do?

Preloads the OpenAI SDK's native `jiter` streaming parser during agent package import.

A Windows support report showed `jiter.jiter` could be imported directly from the Hermes venv, and Hermes launched from that same venv, but the first DeepSeek/OpenAI-compatible streaming request still failed with `ModuleNotFoundError: No module named 'jiter.jiter'`. Launching Hermes with `jiter.jiter` preloaded made the same session work, which points to an import-order/module-state problem in the threaded streaming path rather than a missing dependency.

The preload is best-effort. If `jiter` is truly missing or damaged, startup continues and the normal SDK request path still surfaces the underlying dependency error.

## Related Issue

Support thread: API Call Failed - jiter.jiter

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/jiter_preload.py`: add an idempotent best-effort preload for `jiter.jiter` and `jiter.from_json`.
- `agent/__init__.py`: import the preload helper during agent package initialization so CLI, gateway, and other agent entry points get the same behavior.
- `tests/agent/test_jiter_preload.py`: cover successful preload and missing-extension fallback behavior.

## How to Test

1. Reproduce on the affected Windows install: direct `jiter.jiter` import succeeds from the Hermes venv, but a normal DeepSeek streaming request fails with `No module named 'jiter.jiter'`.
2. Launch Hermes after this change and send the same DeepSeek test message.
3. Confirm the request no longer fails before delivery with `No module named 'jiter.jiter'`.

Local verification run:

`./scripts/run_tests.sh -j 4 tests/agent/test_jiter_preload.py`

Result: 2 passed.

Additional local sanity check:

`./.venv/bin/python - <<'PY'`
`import agent`
`from agent import jiter_preload`
`print(jiter_preload._JITER_PRELOADED)`
`print(type(jiter_preload._JITER_PRELOAD_ERROR).__name__ if jiter_preload._JITER_PRELOAD_ERROR else 'None')`
`import jiter.jiter`
`print('jiter ok')`
`PY`

Result: `True`, `None`, `jiter ok`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux local focused test; Windows behavior inferred from support repro and confirmed user workaround

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Support report evidence:

- Direct venv import succeeded: `jiter ok` and `jiter.cp311-win_amd64.pyd` was present under the Hermes venv.
- Normal Hermes launch from `.\venv\Scripts\hermes.exe` still failed before delivery with `No module named 'jiter.jiter'`.
- Launching with `import jiter.jiter, runpy; runpy.run_module('hermes_cli.main', run_name='__main__')` worked.
