### PR TITLE
fix(cron): resolve BSM secrets in scheduler run_job (#33465)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1467,11 +1467,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     try:
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
-        from dotenv import load_dotenv
-        try:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
-        except UnicodeDecodeError:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv(hermes_home=_get_hermes_home())
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/tests/cron/test_cron_bsm_resolution.py
+++ b/tests/cron/test_cron_bsm_resolution.py
@@ -1,0 +1,47 @@
+"""Test that cron.scheduler.run_job calls load_hermes_dotenv (which resolve BSM)."""
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron.scheduler import run_job
+
+
+def test_run_job_uses_load_hermes_dotenv(tmp_path, monkeypatch):
+    """run_job must call load_hermes_dotenv so BSM-managed secrets are resolved."""
+    job = {
+        "name": "test-bsm",
+        "prompt": "hi",
+        "schedule": "0 0 * * *",
+        "model": "gpt-4",
+    }
+    fake_db = MagicMock()
+    captured = {}
+
+    def _fake_load_hermes_dotenv(*, hermes_home):
+        captured["called"] = True
+        captured["hermes_home"] = hermes_home
+
+    monkeypatch.setattr("cron.scheduler.load_hermes_dotenv", _fake_load_hermes_dotenv)
+    monkeypatch.setattr("cron.scheduler._resolve_origin", lambda jid: None)
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch("cron.scheduler._resolve_delivery_target", return_value=None), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             },
+         ), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+        run_job(job, job_id="j123")
+
+    assert captured.get("called") is True
+    assert isinstance(captured.get("hermes_home"), (Path, str))

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -229,7 +229,7 @@ class TestRunJobProfileContext:
             observed.setdefault("dotenv_paths", []).append(str(path))
             return True
 
-        monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+        monkeypatch.setattr("cron.scheduler", "load_hermes_dotenv", lambda **_: None)
 
     def test_run_job_sets_and_restores_profile_home(
         self, isolated_cron_profile_home, monkeypatch
@@ -280,7 +280,7 @@ class TestRunJobProfileContext:
             os.environ["HERMES_CRON_TIMEOUT"] = "123"
             return True
 
-        monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+        monkeypatch.setattr("cron.scheduler", "load_hermes_dotenv", lambda **_: None)
 
         job = {
             "id": "env-profile",

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -308,7 +308,7 @@ class TestRunJobTerminalCwd:
         # happily clobber TERMINAL_CWD out from under us if the real user .env
         # has TERMINAL_CWD set (common on dev boxes).  Stub it out.
         import dotenv
-        monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_kw: True)
+        monkeypatch.setattr("cron.scheduler", "load_hermes_dotenv", lambda **_: None)
 
     def test_workdir_sets_and_restores_terminal_cwd(
         self, tmp_path, monkeypatch

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -878,7 +878,7 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -925,7 +925,7 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -962,7 +962,7 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -990,7 +990,7 @@ class TestRunJobSessionPersistence:
         return fake_db, [
             patch("cron.scheduler._hermes_home", tmp_path),
             patch("cron.scheduler._resolve_origin", return_value=None),
-            patch("dotenv.load_dotenv"),
+            patch("cron.scheduler.load_hermes_dotenv"),
             patch("hermes_state.SessionDB", return_value=fake_db),
             patch(
                 "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1129,7 +1129,7 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1205,7 +1205,7 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1244,7 +1244,7 @@ class TestRunJobSessionPersistence:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1452,7 +1452,7 @@ class TestRunJobConfigLogging:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
@@ -1481,7 +1481,7 @@ class TestRunJobConfigLogging:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
@@ -1514,7 +1514,7 @@ class TestRunJobConfigEnvVarExpansion:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch("hermes_cli.runtime_provider.resolve_runtime_provider",
                    return_value=self._RUNTIME), \
@@ -1546,7 +1546,7 @@ class TestRunJobConfigEnvVarExpansion:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch("hermes_cli.runtime_provider.resolve_runtime_provider",
                    return_value=self._RUNTIME), \
@@ -1575,7 +1575,7 @@ class TestRunJobConfigEnvVarExpansion:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch("hermes_cli.runtime_provider.resolve_runtime_provider",
                    return_value=self._RUNTIME), \
@@ -1617,7 +1617,7 @@ class TestRunJobSkillBacked:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1677,7 +1677,7 @@ class TestRunJobSkillBacked:
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("tools.credential_files._resolve_hermes_home", return_value=tmp_path), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1715,7 +1715,7 @@ class TestRunJobSkillBacked:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1761,7 +1761,7 @@ class TestRunJobSkillBacked:
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("dotenv.load_dotenv"), \
+             patch("cron.scheduler.load_hermes_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",


### PR DESCRIPTION
Replaces bare `dotenv.load_dotenv()` with `load_hermes_dotenv()` from `hermes_cli.env_loader` in `cron/scheduler.py` so Bitwarden Secrets Manager (BSM) credentials are resolved for cron jobs.

**Root cause:** `run_job` loaded env via plain python-dotenv, skipping the `_apply_external_secret_sources` path entirely. Any cron job needing a BSM-managed key failed with HTTP 401.

**What changed:**
- `cron/scheduler.py`: 5-line bare dotenv block → single `load_hermes_dotenv(hermes_home=_get_hermes_home())` call
- Tests: updated all 19 `dotenv.load_dotenv` mocks across `test_scheduler.py`, `test_cron_profile.py", `test_cron_workdir.py` to mock `cron.scheduler.load_hermes_dotenv` instead
- Added `test_cron_bsm_resolution.py` regression test verifying the scheduler calls `load_hermes_dotenv` during `run_job`

**Deduplication:** `_apply_external_secret_sources` already guards by `_APPLIED_HOMES` (per commit de76f4d), so redundant BSM pulls on subsequent ticks are avoided.

Closes #33465