### PR TITLE
fix(agent): preserve ACP session chunk text

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -231,6 +231,38 @@ def _render_message_content(content: Any) -> str:
     return str(content).strip()
 
 
+def _extract_session_chunk_text(content: Any) -> str:
+    """Best-effort extraction for ACP session-update content blocks.
+
+    Copilot ACP may surface assistant/user chunks as typed block objects rather
+    than plain dicts. Preserve their text so narration is not dropped when a
+    turn mixes tool calls and assistant text.
+    """
+
+    if content is None:
+        return ""
+    if isinstance(content, dict):
+        text = content.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+        nested_content = content.get("content")
+        if isinstance(nested_content, str) and nested_content.strip():
+            return nested_content.strip()
+        return ""
+    if isinstance(content, list):
+        return _render_message_content(content)
+
+    text = getattr(content, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text.strip()
+
+    nested_content = getattr(content, "content", None)
+    if isinstance(nested_content, str) and nested_content.strip():
+        return nested_content.strip()
+
+    return ""
+
+
 def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:
     if not isinstance(text, str) or not text.strip():
         return [], ""
@@ -613,9 +645,7 @@ class CopilotACPClient:
             update = params.get("update") or {}
             kind = str(update.get("sessionUpdate") or "").strip()
             content = update.get("content") or {}
-            chunk_text = ""
-            if isinstance(content, dict):
-                chunk_text = str(content.get("text") or "")
+            chunk_text = _extract_session_chunk_text(content)
             if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
                 text_parts.append(chunk_text)
             elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -18,6 +18,11 @@ class _FakeProcess:
         self.stdin = io.StringIO()
 
 
+class _FakeContentBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
 class CopilotACPClientSafetyTests(unittest.TestCase):
     def setUp(self) -> None:
         self.client = CopilotACPClient(acp_cwd="/tmp")
@@ -144,6 +149,30 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
 
         self.assertIn("error", response)
         self.assertFalse(outside.exists())
+
+    def test_session_update_agent_message_chunk_preserves_block_text(self) -> None:
+        process = _FakeProcess()
+        text_parts: list[str] = []
+        handled = self.client._handle_server_message(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": _FakeContentBlock("Removing both keys now"),
+                    }
+                },
+            },
+            process=process,
+            cwd="/tmp",
+            text_parts=text_parts,
+            reasoning_parts=[],
+        )
+
+        self.assertTrue(handled)
+        self.assertEqual(text_parts, ["Removing both keys now"])
+        self.assertEqual(process.stdin.getvalue(), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

## Summary of Changes

- Added ACP session chunk text extraction that handles typed content blocks, not just plain dict payloads.
- Preserved assistant narration in `session/update` handling when Copilot ACP emits text blocks alongside tool calls.
- Added a regression test covering `agent_message_chunk` text preservation for block-style content.

## Optional Details

- This fixes the empty assistant-content path that caused mixed text + tool-call turns to lose narration before Hermes built the final assistant message.
- The change is intentionally narrow to the ACP transport adapter and its regression coverage.

## Related Issue

Fixes #33636

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/copilot_acp_client.py`: added `_extract_session_chunk_text()` and used it when handling `session/update` messages.
- `tests/agent/test_copilot_acp_client.py`: added a regression test for block-style `agent_message_chunk` text preservation.

## How to Test

1. Run `python -m pytest -o addopts='' tests/agent/test_copilot_acp_client.py`.
2. Confirm the new ACP regression test passes.
3. Reproduce a mixed text + tool-call ACP turn and verify the assistant narration is no longer dropped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Validation: `python -m pytest -o addopts='' tests/agent/test_copilot_acp_client.py` → 8 passed.
