### PR TITLE
test(ci): harden two flaky tests (cron yaml-warning, browser supervisor teardown)

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1450,9 +1450,19 @@ class TestRunJobConfigLogging:
             "prompt": "hello",
         }
 
+        # Mock heavy post-yaml work so the test only exercises the warning
+        # path. Without these mocks, _run_job_impl continues into provider
+        # resolution and MCP discovery, both of which can spawn subprocesses
+        # / hit the network and have caused this test to time out on CI
+        # (>30s wall clock) under load. See PR #33661 follow-up.
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value={"provider": "openrouter", "api_key": "x",
+                                 "base_url": "https://example.invalid",
+                                 "api_mode": "chat_completions"}), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
@@ -1482,6 +1492,11 @@ class TestRunJobConfigLogging:
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value={"provider": "openrouter", "api_key": "x",
+                                 "base_url": "https://example.invalid",
+                                 "api_mode": "chat_completions"}), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -89,18 +89,45 @@ def chrome_cdp(request):
         except Exception:
             time.sleep(0.25)
     if ws_url is None:
-        proc.terminate()
-        proc.wait(timeout=5)
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except (subprocess.TimeoutExpired, AssertionError, Exception):
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=2)
+            except (AssertionError, Exception):
+                pass
         shutil.rmtree(profile, ignore_errors=True)
         pytest.skip("Chrome didn't expose CDP in time")
 
     yield ws_url, port
 
-    proc.terminate()
+    # Tear down Chrome. The stdlib `subprocess._wait()` POSIX implementation
+    # has a known race (https://bugs.python.org/issue38630): when SIGCHLD
+    # arrives concurrently with `proc.wait()`, `_try_wait(WNOHANG)` can
+    # return a foreign pid and the `assert pid == self.pid or pid == 0`
+    # fires. We saw this in CI on slice 1 after this fixture's teardown
+    # (PR #33661 follow-up). Swallow the stdlib race + force-kill if wait
+    # hangs, then always reap so we don't leak a zombie.
+    try:
+        proc.terminate()
+    except Exception:
+        pass
     try:
         proc.wait(timeout=3)
-    except Exception:
-        proc.kill()
+    except (subprocess.TimeoutExpired, AssertionError, Exception):
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=2)
+        except (AssertionError, Exception):
+            pass
     shutil.rmtree(profile, ignore_errors=True)
 
 


### PR DESCRIPTION
## Summary

Hardens two flaky tests that caused transient CI failures on PR #33661's initial run (both passed on rerun, but the underlying flakiness exists on main).

## Changes

**`tests/cron/test_scheduler.py::TestRunJobConfigLogging`** — add mocks for `resolve_runtime_provider()` and `discover_mcp_tools()`.

The two yaml-warning tests intend to verify only the warning log line, but `_run_job_impl` continues into provider resolution and MCP discovery AFTER the warning fires. Both code paths can spawn subprocesses (MCP stdio servers) or hit the network (provider auth), and pushed the test over the 30s pytest-timeout budget on GHA under load. Local: 0.57s. CI failure: >30s. Now mocked at the right boundary so the test does only what it claims to test.

**`tests/tools/test_browser_supervisor.py`** — harden Chrome teardown against the stdlib `subprocess._wait()` race ([bpo-38630](https://bugs.python.org/issue38630)).

The POSIX `_wait()` impl has a longstanding race: when SIGCHLD arrives during `proc.wait()`, `_try_wait(WNOHANG)` can return a foreign pid and the `assert pid == self.pid or pid == 0` fires. CI hit this on slice 1 during fixture teardown, killing the whole job with 0 actual test failures. Fixture now:
- catches `AssertionError` / `TimeoutExpired` on `proc.wait()`
- force-kills on failure
- always reaps with a second `wait()` so no zombie escapes

Same hardening applied to the early-skip branch (lines 91-94) which had the same pattern.

## Validation

- `py_compile` clean
- `pytest tests/cron/test_scheduler.py::TestRunJobConfigLogging --durations=0` → 0.67s, 2 passed
- `pytest tests/tools/test_browser_supervisor.py --collect-only` → 22 tests collected, no import errors (real Chrome teardown runs only in CI / on machines with google-chrome installed)

## Context

Follow-up to PR #33661. Both flakes pre-existed; they surfaced together on that run's CI. Filed as a separate PR per workflow ("one change per branch push").
