### PR TITLE
fix(gateway): subscribe chats for tool-created kanban cards

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8835,6 +8835,10 @@ class GatewayRunner:
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
+            try:
+                await self._auto_subscribe_kanban_create_tool_results(source, agent_messages)
+            except Exception as _kanban_sub_exc:
+                logger.debug("kanban_create tool auto-subscribe failed: %s", _kanban_sub_exc)
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
@@ -9606,6 +9610,126 @@ class GatewayRunner:
             f"Slash commands you can run: {runnable_str}"
         )
 
+
+    async def _auto_subscribe_kanban_create_tool_results(
+        self,
+        source: Any,
+        messages: list[dict],
+    ) -> list[str]:
+        """Subscribe the current gateway chat to cards created by the tool path.
+
+        The `/kanban create` slash command already auto-subscribes the
+        originating chat/thread. Normal assistant tool use bypasses that slash
+        handler: the model calls `kanban_create`, the worker eventually
+        completes, but `kanban_notify_subs` has no row, so the user never hears
+        back. This helper scans the completed agent turn for successful
+        `kanban_create` tool calls and adds the same notification subscription
+        using the original gateway source.
+        """
+        platform = getattr(source, "platform", None)
+        platform_value = getattr(platform, "value", None)
+        platform_str = (platform_value if platform_value is not None else str(platform or "")).lower()
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        if not platform_str or not chat_id:
+            return []
+        thread_id = str(getattr(source, "thread_id", "") or "")
+        user_id = str(getattr(source, "user_id", "") or "") or None
+        notifier_profile = (
+            getattr(self, "_kanban_notifier_profile", None)
+            or self._active_profile_name()
+        )
+
+        kanban_calls: dict[str, Optional[str]] = {}
+        for msg in messages or []:
+            if msg.get("role") != "assistant":
+                continue
+            for call in msg.get("tool_calls") or []:
+                fn = call.get("function") or {}
+                if fn.get("name") != "kanban_create":
+                    continue
+                call_id = call.get("id")
+                if not call_id:
+                    continue
+                board = None
+                raw_args = fn.get("arguments") or "{}"
+                if isinstance(raw_args, str):
+                    try:
+                        args = json.loads(raw_args)
+                    except Exception:
+                        args = {}
+                elif isinstance(raw_args, dict):
+                    args = raw_args
+                else:
+                    args = {}
+                if isinstance(args, dict) and args.get("board"):
+                    board = str(args.get("board"))
+                kanban_calls[call_id] = board
+
+        if not kanban_calls:
+            return []
+
+        subscriptions: list[tuple[str, Optional[str]]] = []
+        for msg in messages or []:
+            if msg.get("role") != "tool":
+                continue
+            call_id = msg.get("tool_call_id")
+            if call_id not in kanban_calls:
+                continue
+            content = msg.get("content")
+            try:
+                payload = json.loads(content) if isinstance(content, str) else (content or {})
+            except Exception:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            # `kanban_create` returns {"ok": true, "task_id": ...}; some
+            # older tool helpers use {"success": true}. Require an explicit
+            # success marker and ignore structured tool errors even if they
+            # happen to contain a task_id-like string.
+            if payload.get("error") or not (
+                payload.get("ok") is True or payload.get("success") is True
+            ):
+                continue
+            task_id = payload.get("task_id") or payload.get("id")
+            if not isinstance(task_id, str) or not task_id.startswith("t_"):
+                continue
+            result_board = payload.get("board")
+            board = str(result_board) if result_board else kanban_calls[call_id]
+            subscriptions.append((task_id, board))
+
+        if not subscriptions:
+            return []
+
+        deduped_subscriptions = list(dict.fromkeys(subscriptions))
+
+        def _subscribe_all() -> list[str]:
+            from hermes_cli import kanban_db as _kb
+
+            subscribed: list[str] = []
+            for task_id, board in deduped_subscriptions:
+                conn = _kb.connect(board=board)
+                try:
+                    _kb.add_notify_sub(
+                        conn,
+                        task_id=task_id,
+                        platform=platform_str,
+                        chat_id=chat_id,
+                        thread_id=thread_id or None,
+                        user_id=user_id,
+                        notifier_profile=notifier_profile,
+                    )
+                    subscribed.append(task_id)
+                finally:
+                    conn.close()
+            return subscribed
+
+        subscribed = await asyncio.to_thread(_subscribe_all)
+        if subscribed:
+            logger.info(
+                "kanban_create tool auto-subscribed %d task(s) for %s gateway chat",
+                len(subscribed), platform_str,
+            )
+        return subscribed
 
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,5 +1,7 @@
 import asyncio
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -234,3 +236,221 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_gateway_auto_subscribes_chat_for_kanban_create_tool_result(tmp_path, monkeypatch):
+    """Agent-created Kanban cards should notify the originating gateway chat.
+
+    `/kanban create` already auto-subscribes in the slash-command path. This
+    pins the normal agent-tool path: when the model calls `kanban_create` during
+    a Discord/Telegram turn, the gateway should subscribe the current source so
+    the user hears terminal events without manually polling the board.
+    """
+    db_path = tmp_path / "tool-create-autosub.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="tool-created", assignee="worker")
+    finally:
+        conn.close()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": json.dumps({"title": "tool-created", "assignee": "worker"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": json.dumps({"ok": True, "task_id": tid}),
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == [tid]
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "discord-chat"
+    assert subs[0]["thread_id"] == "discord-thread"
+    assert subs[0]["user_id"] == "user-1"
+    assert subs[0]["notifier_profile"] == "main"
+
+
+def test_gateway_does_not_subscribe_failed_kanban_create_tool_result(tmp_path, monkeypatch):
+    db_path = tmp_path / "tool-create-failed.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": json.dumps({"title": "bad", "assignee": "worker"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": json.dumps({"error": "kanban_create: bad board", "task_id": "t_deadbeef"}),
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn) == []
+    finally:
+        conn.close()
+
+
+def test_gateway_auto_subscribes_tool_result_board_field(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+
+    conn = kb.connect(board="custom-board")
+    try:
+        tid = kb.create_task(conn, title="tool-created", assignee="worker")
+    finally:
+        conn.close()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="telegram-chat",
+        thread_id="",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": json.dumps({"title": "tool-created", "assignee": "worker"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": json.dumps({"ok": True, "task_id": tid, "board": "custom-board"}),
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == [tid]
+    default_conn = kb.connect()
+    custom_conn = kb.connect(board="custom-board")
+    try:
+        assert kb.list_notify_subs(default_conn) == []
+        subs = kb.list_notify_subs(custom_conn, tid)
+    finally:
+        default_conn.close()
+        custom_conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "telegram-chat"
+    assert subs[0]["thread_id"] == ""
+
+
+def test_gateway_ignores_malformed_kanban_create_tool_content(tmp_path, monkeypatch):
+    db_path = tmp_path / "tool-create-malformed.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": "{not-json",
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "{not-json",
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn) == []
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -758,6 +758,7 @@ def test_create_happy_path(worker_env):
     assert d["ok"] is True
     assert d["task_id"]
     assert d["status"] == "todo"  # parent isn't done yet
+    assert "board" in d
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -710,6 +710,7 @@ def _handle_create(args: dict, **kw) -> str:
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                board=board,
             )
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

Fixes the gateway notification gap for Kanban cards created through normal assistant tool use.

The `/kanban create` slash-command path already subscribes the originating chat/thread so the user receives completion notifications. When the assistant calls `kanban_create` as a tool, that slash-command handler is bypassed, so no `kanban_notify_subs` row is created and the worker can complete silently.

This patch:

- scans the completed gateway agent turn for successful `kanban_create` tool calls
- correlates assistant tool calls with matching tool result messages by `tool_call_id`
- requires explicit successful tool output (`ok: true` or `success: true`) and ignores structured errors
- subscribes the originating gateway chat/thread using the existing Kanban notifier subscription path
- routes non-default boards using the `board` field returned by `kanban_create`
- deduplicates repeated subscription candidates before DB writes
- avoids logging chat/user/thread IDs

## Tests

- `git diff --check origin/main...HEAD`
- `venv/bin/python -m py_compile gateway/run.py tools/kanban_tools.py`
- `venv/bin/python -m pytest tests/gateway/test_kanban_notifier.py tests/tools/test_kanban_tools.py -q -o 'addopts='` → 91 passed
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_*.py tests/hermes_cli/test_pin_kanban_board_env.py tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier.py tests/plugins/test_kanban_dashboard_plugin.py tests/plugins/test_kanban_worker_runs.py -q -o 'addopts='` → 793 passed

## Review

Independent code-review gate: PASS.

Reviewer checked the current branch diff against `origin/main`, inspected integration with gateway/tool execution/Kanban DB subscription code, and reran the focused gateway/tools suite (91 passed). No blocker or concern-level issues found.
