### PR TITLE
docs(contributing): add fork, branch, and PR submission workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -862,27 +862,34 @@ After the [litellm supply chain compromise](https://github.com/BerriAI/litellm/i
 
 ### Fork & branch
 
-> **Note:** If you cloned the repo directly (and have write access), skip the fork step and push branches to `origin` instead.
+Most contributors should work from a fork so they can push branches without
+needing write access to `NousResearch/hermes-agent`:
 
-1. **Sync your fork** with upstream before starting:
+```bash
+# Fork the repository on GitHub, then clone your fork
+gh repo fork NousResearch/hermes-agent --clone
+cd hermes-agent
 
-   ```bash
-   git fetch upstream
-   git checkout main
-   git merge upstream/main
-   ```
+# Verify the remotes (origin = your fork, upstream = NousResearch)
+git remote -v
+```
 
-2. **Create a feature branch** from `main`:
+If you already cloned the repo directly and have write access, skip the fork step and push branches to `origin` instead.
 
-   ```bash
-   git checkout -b fix/my-description
-   ```
+Start from the latest upstream main and create a focused branch:
+
+```bash
+git fetch upstream
+git checkout main
+git merge --ff-only upstream/main
+git checkout -b fix/my-description
+```
 
 ### Make changes & commit
 
 ```bash
 # Make your changes, then:
-git add .
+git add <changed-files>
 git commit -m "fix(scope): description"
 ```
 
@@ -891,7 +898,7 @@ See [Commit messages](#commit-messages) below for the required format.
 ### Push & open a PR
 
 ```bash
-git push origin fix/my-description
+git push -u origin HEAD
 gh pr create --repo NousResearch/hermes-agent
 ```
 
@@ -908,7 +915,7 @@ After opening the PR, CI will run automatically. A maintainer will review and ma
 ```bash
 git fetch upstream
 git checkout main
-git merge upstream/main
+git merge --ff-only upstream/main
 git push origin main
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,10 +80,25 @@ This isn't a quality bar — it's a coupling-and-maintenance decision. Memory pr
 
 ### Clone and install
 
+**Internal contributors** (write access) can clone directly:
+
 ```bash
 git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
+```
 
+**External contributors** should fork first:
+
+1. Fork the repo on GitHub (click **Fork** on the repository page).
+2. Clone your fork:
+
+```bash
+git clone --recurse-submodules https://github.com/YOUR_USERNAME/hermes-agent.git
+cd hermes-agent
+git remote add upstream https://github.com/NousResearch/hermes-agent.git
+```
+
+```bash
 # Create venv with Python 3.11
 uv venv venv --python 3.11
 export VIRTUAL_ENV="$(pwd)/venv"
@@ -844,6 +859,67 @@ After the [litellm supply chain compromise](https://github.com/BerriAI/litellm/i
 ---
 
 ## Pull Request Process
+
+### Fork & branch
+
+> **Note:** If you cloned the repo directly (and have write access), skip the fork step and push branches to `origin` instead.
+
+1. **Sync your fork** with upstream before starting:
+
+   ```bash
+   git fetch upstream
+   git checkout main
+   git merge upstream/main
+   ```
+
+2. **Create a feature branch** from `main`:
+
+   ```bash
+   git checkout -b fix/my-description
+   ```
+
+### Make changes & commit
+
+```bash
+# Make your changes, then:
+git add .
+git commit -m "fix(scope): description"
+```
+
+See [Commit messages](#commit-messages) below for the required format.
+
+### Push & open a PR
+
+```bash
+git push origin fix/my-description
+gh pr create --repo NousResearch/hermes-agent
+```
+
+The PR template will be auto-populated. Fill in:
+- **What does this PR do** — explain the change and why
+- **Related Issue** — link with `Fixes #NNNN`
+- **Changes Made** — list specific files/changes
+- **How to Test** — reproduction steps or usage examples
+
+After opening the PR, CI will run automatically. A maintainer will review and may request changes — address feedback with additional commits (avoid force-pushing during review).
+
+### Keeping your fork up to date
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+Rebase your feature branch on the latest `main` before opening a PR to avoid merge conflicts:
+
+```bash
+git checkout fix/my-description
+git rebase main
+```
+
+> **Fine-grained PAT gotcha:** GitHub fine-grained personal access tokens cannot fork repositories you don't own (the API returns 403). If you hit this, use OAuth authentication instead: `gh auth login --web -p https`
 
 ### Branch naming
 


### PR DESCRIPTION
## What does this PR do?

Adds the missing **fork → branch → PR** workflow to `CONTRIBUTING.md`. The existing guide covers dev setup, architecture, and code style well but jumps straight from "clone and install" to "here's the project structure" without explaining how to actually submit code back.

## Related Issue

Fixes #33658

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- **`CONTRIBUTING.md` — "Clone and install" section**: Split into internal (direct clone) vs external (fork first) contributor paths, with fork instructions and `upstream` remote setup.
- **`CONTRIBUTING.md` — "Pull Request Process" section**: Added "Fork & branch", "Make changes & commit", "Push & open a PR", and "Keeping your fork up to date" subsections covering the full contribution workflow.
- **`CONTRIBUTING.md` — Fine-grained PAT gotcha**: Documented the GitHub limitation where fine-grained personal access tokens cannot fork repositories, with the `gh auth login --web -p https` workaround.

## How to Test

1. Read the updated `CONTRIBUTING.md` from a newcomer's perspective.
2. Verify the fork → clone → branch → commit → push → PR flow is clear and complete.
3. Verify the fine-grained PAT note is accurate (GitHub API returns 403 on fork attempts with fine-grained tokens).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (CONTRIBUTING.md)
- [x] I've considered cross-platform impact — or N/A (documentation only)
