### PR TITLE
fix(cli): print copyable skills search identifiers

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -312,6 +312,10 @@ def do_search(query: str, source: str = "all", limit: int = 10,
     c.print("[dim]Use: hermes skills inspect <identifier> to preview, "
             "hermes skills install <identifier> to install "
             "(--json for scripting)[/]\n")
+    c.print("[bold]Copyable identifiers:[/]")
+    for r in results:
+        c.print(f"  {r.identifier}", soft_wrap=True)
+    c.print()
 
 
 def do_browse(page: int = 1, page_size: int = 20, source: str = "all",

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_search, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -262,6 +262,28 @@ def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():
          patch("tools.skills_hub.create_source_router", return_value={}), \
          patch("tools.skills_hub.GitHubAuth"):
         handle_skills_slash("/skills search kubernetes", console=ChatConsole())
+
+
+def test_do_search_prints_copyable_full_identifiers_when_table_truncates():
+    long_identifier = "browse-sh/weather.gov/get-forecast-1uezib"
+    results = [type("R", (), {
+        "name": "get-forecast",
+        "description": "Weather forecast skill",
+        "source": "browse-sh",
+        "trust_level": "community",
+        "identifier": long_identifier,
+    })()]
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=True, color_system=None, width=50)
+
+    with patch("tools.skills_hub.unified_search", return_value=results), \
+         patch("tools.skills_hub.create_source_router", return_value={}), \
+         patch("tools.skills_hub.GitHubAuth"):
+        do_search("weather.gov", console=console)
+
+    output = sink.getvalue()
+    assert long_identifier in output
+    assert "Copyable identifiers" in output
 
 
 def test_do_install_scans_with_resolved_identifier(monkeypatch, tmp_path, hub_env):


### PR DESCRIPTION
## Summary
- Prints a copyable list of full skill identifiers after `hermes skills search` results
- Keeps the existing table for readability while avoiding Rich table truncation hiding browse.sh hash suffixes
- Adds a regression test for narrow-terminal output with a browse.sh-style identifier

## Test Plan
- [x] `PYTHONPATH="$PWD" /Users/clawuser/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_skills_hub.py::test_do_search_prints_copyable_full_identifiers_when_table_truncates -q`
- [x] `PYTHONPATH="$PWD" /Users/clawuser/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_skills_hub.py -q`
- [x] `PYTHONPATH="$PWD" /Users/clawuser/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py`

Closes #33674
