### PR TITLE
fix(gateway): backfill Discord thread context

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4818,7 +4818,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not in_bot_thread
             )
             _backfill_enabled = self._discord_history_backfill()
-            if _needed_mention and _backfill_enabled:
+            if _backfill_enabled and (_needed_mention or is_thread):
                 _backfill_text = await self._fetch_channel_context(
                     message.channel, before=message,
                 )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -52,6 +52,7 @@ AUTHOR_MAP = {
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "3540493+kpadilha@users.noreply.github.com": "kpadilha",
     "40378218+chaconne67@users.noreply.github.com": "chaconne67",
+    "Pluviobyte@users.noreply.github.com": "Pluviobyte",
     "sanghyuk_seo@nexcubecorp.com": "sanghyuk-seo-nexcube",
     "subrtt@gmail.com": "Brixyy",
     "wangpuv@hotmail.com": "wangpuv",

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -852,6 +852,27 @@ async def test_discord_per_user_channel_backfills_too(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discord_participated_thread_backfills_without_mention(adapter, monkeypatch):
+    """Known threads still need recent thread context when mention gating is bypassed."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    adapter.config.extra["history_backfill"] = True
+    adapter._fetch_channel_context = AsyncMock(return_value="[Recent channel messages]\n[Alice] thread context")
+
+    thread = FakeThread(channel_id=456, name="follow-up")
+    adapter._threads.mark("456")
+
+    message = make_message(channel=thread, content="follow-up without mention")
+    await adapter._handle_message(message)
+
+    adapter._fetch_channel_context.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "follow-up without mention"
+    assert event.channel_context == "[Recent channel messages]\n[Alice] thread context"
+
+
+@pytest.mark.asyncio
 async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
     """DMs skip backfill — every DM triggers the bot, so there's no mention gap."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")


### PR DESCRIPTION
## What does this PR do?

Discord threads where the bot has already participated bypass mention gating by default, but the history backfill gate was still tied to whether an explicit mention was required. This meant follow-up thread messages could trigger a response without giving the session recent thread context.

This decouples those checks by allowing thread messages to backfill whenever Discord history backfill is enabled, while preserving the existing DM skip and channel mention backfill behavior.

## Related Issue

Fixes #33666

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `plugins/platforms/discord/adapter.py` so Discord thread messages run history backfill when backfill is enabled.
- Added a regression test covering a known thread follow-up that does not explicitly mention the bot but still needs recent thread context.
- Added this contributor email to `scripts/release.py` AUTHOR_MAP for the contributor attribution check.

## How to Test

1. Configure Discord with `require_mention: true`, default `thread_require_mention: false`, and `history_backfill: true`.
2. Send a follow-up message in a thread where the bot has already participated, without @mentioning the bot.
3. Confirm Hermes responds and includes recent thread context from history backfill.

Local verification run:

```bash
uv run --extra dev --extra messaging python -m pytest tests/gateway/test_discord_free_response.py -q
uv run --extra dev ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_free_response.py scripts/release.py
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.1 (Amazon Linux), Python 3.12 via uv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
35 passed in 0.85s
All checks passed!
```

Made with [Cursor](https://cursor.com)
