### PR TITLE
fix(gateway): create mirror sessions for cross-channel targets when none exist (#33530)

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -11,10 +11,14 @@ the full SessionStore machinery.
 
 import json
 import logging
+import os
+import tempfile
+import uuid
 from datetime import datetime
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +50,13 @@ def mirror_to_session(
             thread_id=thread_id,
             user_id=user_id,
         )
+        if not session_id:
+            session_id = _get_or_create_session_id(
+                platform,
+                str(chat_id),
+                thread_id=thread_id,
+                user_id=user_id,
+            )
         if not session_id:
             logger.debug(
                 "Mirror: no session found for %s:%s:%s:%s",
@@ -148,6 +159,125 @@ def _find_session_id(
     best_entry = max(candidates, key=lambda entry: entry.get("updated_at", ""))
     return best_entry.get("session_id")
 
+
+def _get_or_create_session_id(
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Optional[str]:
+    """Create a minimal session entry in sessions.json for mirroring.
+
+    When no existing session matches the target platform + chat_id,
+    this creates a placeholder entry so mirror messages are stored
+    and available when the recipient next interacts via the gateway.
+    The gateway will pick up this session entry naturally through
+    its existing session resolution.
+    """
+    try:
+        _SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+
+        session_id = uuid.uuid4().hex
+        now = datetime.now().isoformat()
+
+        # Build a session key compatible with gateway conventions.
+        key_parts = ["agent:main", platform.lower(), "group"]
+        if chat_id:
+            key_parts.append(str(chat_id))
+        if thread_id:
+            key_parts.append(str(thread_id))
+        session_key = ":".join(key_parts)
+
+        origin = {
+            "platform": platform.lower(),
+            "chat_id": str(chat_id),
+            "chat_name": None,
+            "chat_type": "group",
+            "user_id": str(user_id) if user_id else None,
+            "user_name": None,
+            "thread_id": str(thread_id) if thread_id else None,
+            "chat_topic": None,
+        }
+
+        entry = {
+            "session_key": session_key,
+            "session_id": session_id,
+            "created_at": now,
+            "updated_at": now,
+            "display_name": None,
+            "platform": platform.lower(),
+            "chat_type": "group",
+            "origin": origin,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "total_tokens": 0,
+            "estimated_cost_usd": 0.0,
+            "cost_status": "unknown",
+            "last_prompt_tokens": 0,
+        }
+
+        _write_session_entry(session_key, entry)
+        _create_sqlite_session(session_id, platform, user_id=user_id)
+
+        logger.debug(
+            "Mirror: created session %s for %s:%s:%s",
+            session_id, platform, chat_id, thread_id,
+        )
+        return session_id
+    except Exception as e:
+        logger.debug(
+            "Mirror: failed to create session for %s:%s: %s",
+            platform, chat_id, e,
+        )
+        return None
+
+
+def _write_session_entry(session_key: str, entry: dict) -> None:
+    """Atomically add or update a session entry in sessions.json."""
+    data: dict = {}
+    if _SESSIONS_INDEX.exists():
+        try:
+            with open(_SESSIONS_INDEX, encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            pass
+
+    data[session_key] = entry
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(_SESSIONS_DIR), suffix=".tmp", prefix=".sessions_mirror_"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, _SESSIONS_INDEX)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+
+def _create_sqlite_session(
+    session_id: str,
+    platform: str,
+    user_id: Optional[str] = None,
+) -> None:
+    """Create the SQLite session row needed before appending mirror messages."""
+    db = None
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        db.create_session(session_id=session_id, source=platform.lower(), user_id=user_id)
+    finally:
+        if db is not None:
+            db.close()
 
 
 def _append_to_sqlite(session_id: str, message: dict) -> None:

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -1,6 +1,8 @@
 """Tests for gateway/mirror.py — session mirroring."""
 
 import json
+import sqlite3
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import gateway.mirror as mirror_mod
@@ -230,20 +232,161 @@ class TestMirrorToSession:
         mock_sqlite.assert_called_once()
         assert mock_sqlite.call_args[0][0] == "sess_alice"
 
-    def test_no_matching_session(self, tmp_path):
+    def test_no_matching_session_creates_one(self, tmp_path):
+        """When no session exists, mirror_to_session creates a placeholder and succeeds."""
+        sessions_dir, index_file = _setup_sessions(tmp_path, {})
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_sqlite") as mock_sqlite:
+            result = mirror_to_session("telegram", "99999", "Hello!")
+
+        assert result is True
+        mock_sqlite.assert_called_once()
+        # Verify the session was persisted to sessions.json
+        with open(index_file) as f:
+            saved = json.load(f)
+        assert len(saved) == 1
+        entry = list(saved.values())[0]
+        assert entry["origin"]["platform"] == "telegram"
+        assert entry["origin"]["chat_id"] == "99999"
+        assert entry["platform"] == "telegram"
+
+    def test_creates_session_even_with_empty_sessions_file(self, tmp_path):
+        """When sessions.json exists but has no matching entries, still creates one."""
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "other": {
+                "session_id": "sess_other",
+                "origin": {"platform": "discord", "chat_id": "888"},
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_sqlite") as mock_sqlite:
+            result = mirror_to_session("telegram", "99999", "Hello new channel!")
+
+        assert result is True
+        mock_sqlite.assert_called_once()
+        with open(index_file) as f:
+            saved = json.load(f)
+        assert len(saved) == 2  # original + new
+
+    def test_no_matching_session_persists_mirror_message(self, tmp_path, monkeypatch):
+        """New placeholder sessions must be backed by SQLite so the mirror is stored."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import hermes_state
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
         sessions_dir, index_file = _setup_sessions(tmp_path, {})
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
              patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
-            result = mirror_to_session("telegram", "99999", "Hello!")
+            result = mirror_to_session("telegram", "99999", "Hello persisted!")
 
-        assert result is False
+        assert result is True
+        with sqlite3.connect(tmp_path / "state.db") as conn:
+            sessions = conn.execute("SELECT id, source FROM sessions").fetchall()
+            messages = conn.execute(
+                "SELECT session_id, role, content FROM messages"
+            ).fetchall()
+
+        assert len(sessions) == 1
+        assert sessions[0][1] == "telegram"
+        assert messages == [(sessions[0][0], "assistant", "Hello persisted!")]
 
     def test_error_returns_false(self, tmp_path):
         with patch("gateway.mirror._find_session_id", side_effect=Exception("boom")):
             result = mirror_to_session("telegram", "123", "msg")
 
         assert result is False
+
+
+class TestGetOrCreateSessionId:
+    def test_creates_session_when_none_exists(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        index_file = sessions_dir / "sessions.json"
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            from gateway.mirror import _get_or_create_session_id
+            session_id = _get_or_create_session_id("telegram", "12345")
+
+        assert session_id is not None
+        assert len(session_id) == 32  # uuid4 hex
+        assert index_file.exists()
+        with open(index_file) as f:
+            saved = json.load(f)
+        assert len(saved) == 1
+        entry = list(saved.values())[0]
+        assert entry["session_id"] == session_id
+        assert entry["origin"]["chat_id"] == "12345"
+
+    def test_creates_session_preserving_existing_entries(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "existing": {
+                "session_id": "sess_existing",
+                "origin": {"platform": "discord", "chat_id": "888"},
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            from gateway.mirror import _get_or_create_session_id
+            session_id = _get_or_create_session_id("telegram", "99999")
+
+        assert session_id is not None
+        with open(index_file) as f:
+            saved = json.load(f)
+        assert len(saved) == 2
+
+    def test_includes_thread_id_in_origin(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        index_file = sessions_dir / "sessions.json"
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            from gateway.mirror import _get_or_create_session_id
+            session_id = _get_or_create_session_id(
+                "telegram", "-1001", thread_id="42"
+            )
+
+        with open(index_file) as f:
+            saved = json.load(f)
+        entry = list(saved.values())[0]
+        assert entry["origin"]["thread_id"] == "42"
+
+    def test_includes_user_id_in_origin(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        index_file = sessions_dir / "sessions.json"
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            from gateway.mirror import _get_or_create_session_id
+            session_id = _get_or_create_session_id(
+                "telegram", "-1001", user_id="alice"
+            )
+
+        with open(index_file) as f:
+            saved = json.load(f)
+        entry = list(saved.values())[0]
+        assert entry["origin"]["user_id"] == "alice"
+
+    def test_first_mirror_when_no_sessions_dir(self, tmp_path):
+        """No sessions directory exists yet — mirror should create everything."""
+        sessions_dir = tmp_path / "sessions"
+        index_file = sessions_dir / "sessions.json"
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_sqlite") as mock_sqlite:
+            result = mirror_to_session("discord", "12345", "First mirror!")
+
+        assert result is True
+        assert sessions_dir.exists()
+        assert index_file.exists()
+        mock_sqlite.assert_called_once()
 
 
 class TestAppendToSqlite:


### PR DESCRIPTION
## What

When `send_message` delivers to a cross-channel target (e.g., Telegram → Discord) and no session already exists for that target, the gateway has nowhere to write the mirror entry. The outgoing message is silently lost from the recipient's perspective — when they reply, the agent has no memory of what was sent.

This PR adds `_get_or_create_session_id()` to `gateway/mirror.py`: when no existing session matches the target platform + chat_id, a minimal placeholder session entry is created in `sessions.json`. This ensures mirror messages are stored and available when the recipient next interacts via the gateway.

Fixes #33530

## Files changed

- `gateway/mirror.py` — added `_get_or_create_session_id()` + integration into `mirror_to_session()`
- `tests/gateway/test_mirror.py` — 2 new test cases covering creation path

## How to test

```bash
pytest tests/gateway/test_mirror.py -q
```

## Checklist

- [x] Single logical change
- [x] Regression tests included
- [x] ruff clean
- [x] Branch from upstream/main