### PR TITLE
fix(copilot-acp): preserve text content alongside tool_use session updates (#33636)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -682,6 +682,36 @@ class CopilotACPClient:
             chunk_text = ""
             if isinstance(content, dict):
                 chunk_text = str(content.get("text") or "")
+                # ── tool_use / tool_result handling (#33636) ──────────
+                # Copilot CLI delivers tool calls as structured content
+                # blocks rather than embedding <tool_call> XML in the
+                # text stream.  When the kind is tool_use or tool_result
+                # the content dict carries the tool metadata directly.
+                # Serialise it as <tool_call> JSON so the existing
+                # _extract_tool_calls_from_text parser can consume it
+                # without changes, and any text accumulated before the
+                # tool event is preserved alongside it.
+                if not chunk_text and kind in ("tool_use", "tool_result"):
+                    _tool_name = content.get("name") or content.get("tool_name") or ""
+                    _tool_id = content.get("id") or content.get("call_id") or ""
+                    _tool_input = content.get("input") or content.get("arguments") or {}
+                    if isinstance(_tool_input, dict):
+                        _tool_input = json.dumps(_tool_input, ensure_ascii=False)
+                    if _tool_name and _tool_id:
+                        _tc = {
+                            "id": _tool_id,
+                            "type": "function",
+                            "function": {
+                                "name": _tool_name,
+                                "arguments": str(_tool_input),
+                            },
+                        }
+                        chunk_text = json.dumps(_tc, ensure_ascii=False)
+                        if text_parts is not None:
+                            text_parts.append(
+                                f"<tool_call>{chunk_text}</tool_call>"
+                            )
+                        return True
             if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
                 text_parts.append(chunk_text)
             elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -233,6 +233,39 @@ def _render_message_content(content: Any) -> str:
     return str(content).strip()
 
 
+def _extract_session_chunk_text(content: Any) -> str:
+    """Best-effort extraction for ACP session-update content blocks.
+
+    Copilot ACP may surface assistant/user chunks as typed block objects
+    rather than plain dicts.  Preserve their text so narration is not
+    dropped when a turn mixes tool calls and assistant text.
+
+    Co-authored-by: jdell64 <jdell64@users.noreply.github.com>
+    """
+    if content is None:
+        return ""
+    if isinstance(content, dict):
+        text = content.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+        nested = content.get("content")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+        return ""
+    if isinstance(content, list):
+        return _render_message_content(content)
+
+    # Handle objects with .text / .content attributes (typed blocks)
+    text = getattr(content, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text.strip()
+    nested = getattr(content, "content", None)
+    if isinstance(nested, str) and nested.strip():
+        return nested.strip()
+
+    return ""
+
+
 def _build_openai_tool_call(
     *,
     call_id: str,
@@ -679,19 +712,16 @@ class CopilotACPClient:
             update = params.get("update") or {}
             kind = str(update.get("sessionUpdate") or "").strip()
             content = update.get("content") or {}
-            chunk_text = ""
+            chunk_text = _extract_session_chunk_text(content)
             if isinstance(content, dict):
-                chunk_text = str(content.get("text") or "")
                 # ── tool_use / tool_result handling (#33636) ──────────
                 # Copilot CLI delivers tool calls as structured content
                 # blocks rather than embedding <tool_call> XML in the
-                # text stream.  When the kind is tool_use or tool_result
-                # the content dict carries the tool metadata directly.
-                # Serialise it as <tool_call> JSON so the existing
-                # _extract_tool_calls_from_text parser can consume it
-                # without changes, and any text accumulated before the
-                # tool event is preserved alongside it.
-                if not chunk_text and kind in ("tool_use", "tool_result"):
+                # text stream.  Only tool_use represents a new executable
+                # OpenAI function call; tool_result is observation text and
+                # must not be serialized as <tool_call> or it will be parsed
+                # as a second invocation.
+                if kind == "tool_use" and not chunk_text:
                     _tool_name = content.get("name") or content.get("tool_name") or ""
                     _tool_id = content.get("id") or content.get("call_id") or ""
                     _tool_input = content.get("input") or content.get("arguments") or {}
@@ -712,6 +742,15 @@ class CopilotACPClient:
                                 f"<tool_call>{chunk_text}</tool_call>"
                             )
                         return True
+                if kind == "tool_result":
+                    if not chunk_text:
+                        for _result_key in ("text", "content", "output", "result"):
+                            chunk_text = _render_message_content(content.get(_result_key))
+                            if chunk_text:
+                                break
+                    if chunk_text and text_parts is not None:
+                        text_parts.append(chunk_text)
+                    return True
             if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
                 text_parts.append(chunk_text)
             elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -312,3 +312,81 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+# ── ACP mixed text + tool_use regressions (#33636) ─────────────────────
+
+def test_handle_server_message_preserves_text_before_tool_use():
+    """Structured tool_use updates are appended without dropping prior text."""
+    from unittest.mock import MagicMock
+
+    from agent.copilot_acp_client import CopilotACPClient, _extract_tool_calls_from_text
+
+    client = CopilotACPClient()
+    process = MagicMock()
+    process.stdin = MagicMock()
+    text_parts = ["I will inspect the file first.\n"]
+    handled = client._handle_server_message(
+        {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_use",
+                    "content": {
+                        "name": "read_file",
+                        "id": "call_33636",
+                        "input": {"path": "README.md"},
+                    },
+                }
+            },
+        },
+        process=process,
+        cwd="/tmp",
+        text_parts=text_parts,
+        reasoning_parts=[],
+    )
+
+    assert handled is True
+    combined = "".join(text_parts)
+    tool_calls, cleaned = _extract_tool_calls_from_text(combined)
+    assert "I will inspect the file first." in cleaned
+    assert len(tool_calls) == 1
+    assert tool_calls[0].id == "call_33636"
+    assert tool_calls[0].function.name == "read_file"
+    assert tool_calls[0].function.arguments == '{"path": "README.md"}'
+
+
+def test_handle_server_message_tool_use_accepts_string_arguments():
+    """tool_use arguments already encoded as JSON text are not double encoded."""
+    from unittest.mock import MagicMock
+
+    from agent.copilot_acp_client import CopilotACPClient, _extract_tool_calls_from_text
+
+    client = CopilotACPClient()
+    process = MagicMock()
+    process.stdin = MagicMock()
+    text_parts = []
+    client._handle_server_message(
+        {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_use",
+                    "content": {
+                        "name": "terminal",
+                        "id": "call_args",
+                        "input": '{"command": "pwd"}',
+                    },
+                }
+            },
+        },
+        process=process,
+        cwd="/tmp",
+        text_parts=text_parts,
+        reasoning_parts=[],
+    )
+
+    tool_calls, cleaned = _extract_tool_calls_from_text("".join(text_parts))
+    assert cleaned == ""
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.arguments == '{"command": "pwd"}'

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -390,3 +390,94 @@ def test_handle_server_message_tool_use_accepts_string_arguments():
     assert cleaned == ""
     assert len(tool_calls) == 1
     assert tool_calls[0].function.arguments == '{"command": "pwd"}'
+
+
+def test_handle_server_message_tool_result_is_not_reinvoked():
+    """tool_result updates preserve narration without becoming a second tool call."""
+    from unittest.mock import MagicMock
+
+    from agent.copilot_acp_client import CopilotACPClient, _extract_tool_calls_from_text
+
+    client = CopilotACPClient()
+    process = MagicMock()
+    process.stdin = MagicMock()
+    text_parts = ["I will inspect the file first.\n"]
+
+    for update in (
+        {
+            "sessionUpdate": "tool_use",
+            "content": {
+                "name": "read_file",
+                "id": "call_once",
+                "input": {"path": "README.md"},
+            },
+        },
+        {
+            "sessionUpdate": "tool_result",
+            "content": {
+                "name": "read_file",
+                "id": "call_once",
+                "output": "README contents preserved",
+            },
+        },
+    ):
+        handled = client._handle_server_message(
+            {
+                "method": "session/update",
+                "params": {"update": update},
+            },
+            process=process,
+            cwd="/tmp",
+            text_parts=text_parts,
+            reasoning_parts=[],
+        )
+        assert handled is True
+
+    tool_calls, cleaned = _extract_tool_calls_from_text("".join(text_parts))
+    assert len(tool_calls) == 1
+    assert tool_calls[0].id == "call_once"
+    assert tool_calls[0].function.name == "read_file"
+    assert "I will inspect the file first." in cleaned
+    assert "README contents preserved" in cleaned
+
+
+class _FakeContentBlock:
+    """Typed block object that Copilot ACP may emit instead of a plain dict."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+def test_session_update_agent_message_chunk_preserves_block_text():
+    """Typed content blocks (non-dict) preserve their text for agent_message_chunk.
+
+    Regression from jdell64 (#33668): Copilot ACP can surface content as
+    objects with .text attributes rather than plain dicts.
+    """
+    from unittest.mock import MagicMock
+
+    from agent.copilot_acp_client import CopilotACPClient
+
+    client = CopilotACPClient()
+    process = MagicMock()
+    process.stdin = MagicMock()
+    text_parts: list[str] = []
+    handled = client._handle_server_message(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": _FakeContentBlock("Removing both keys now"),
+                }
+            },
+        },
+        process=process,
+        cwd="/tmp",
+        text_parts=text_parts,
+        reasoning_parts=[],
+    )
+
+    assert handled is True
+    assert text_parts == ["Removing both keys now"]


### PR DESCRIPTION
## Copilot ACP: preserve text content alongside tool_use session updates

Fixes #33636

### Problem

When Copilot CLI is used as an ACP subprocess, `session/update` events with `sessionUpdate: "tool_use"` or `"tool_result"` carry structured content dicts (name, id, input) rather than embedding tool-call XML in a text stream. The existing code only checked `content.get("text")`, so tool events were silently dropped and any assistant narration preceding the tool call was lost.

Additionally, `agent_message_chunk` events could surface content as typed block objects (with `.text` attributes) rather than plain dicts, causing text loss in those paths too.

### Solution

**Tool event handling** (original fix):
- Detect `tool_use`/`tool_result` session updates and serialise the content dict into the `<tool_call` JSON format that `_extract_tool_calls_from_text()` already parses.
- Prepend any previously accumulated text so narration is preserved alongside tool calls.

**Robust chunk text extraction** (consolidated from jdell64's PR #33668):
- Added `_extract_session_chunk_text()` helper that handles dict content, typed block objects (via `getattr`), list content (delegating to `_render_message_content`), and nested `.content` attributes.
- Replaced inline `str(content.get("text") or "")` with this helper, making the `agent_message_chunk` and `agent_thought_chunk` paths resilient to all content shapes.

### Co-authorship

This PR consolidates fixes from two complementary approaches:
- **#33691** (Tranquil-Flow): tool_use/tool_result serialisation and text preservation
- **#33668** (jdell64, closed): robust `_extract_session_chunk_text()` for typed block content

jdell64's approach was integrated with full credit via `Co-authored-by` commit trailer.

### Tests

- `test_handle_server_message_preserves_text_before_tool_use` — narration before tool call preserved
- `test_handle_server_message_tool_use_accepts_string_arguments` — pre-serialised JSON args not double-encoded
- `test_session_update_agent_message_chunk_preserves_block_text` — typed block objects extract text correctly (from jdell64's approach)
