### PR TITLE
fix(agent): preload jiter native parser

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -4,3 +4,5 @@ These modules contain pure utility functions and self-contained classes
 that were previously embedded in the 3,600-line run_agent.py. Extracting
 them makes run_agent.py focused on the AIAgent orchestrator class.
 """
+
+from . import jiter_preload as _jiter_preload  # noqa: F401

--- a/agent/jiter_preload.py
+++ b/agent/jiter_preload.py
@@ -1,0 +1,39 @@
+"""Best-effort early import for the OpenAI SDK's native streaming parser.
+
+The OpenAI SDK imports ``jiter`` while constructing streaming chat-completion
+responses.  On some Windows installs the native extension can be imported
+directly from the Hermes venv, but the first import fails when it happens later
+inside the threaded streaming request path.  Loading it once during agent
+package import avoids that import-order failure while preserving the normal
+SDK error path for genuinely missing or broken installs.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+_JITER_PRELOADED = False
+_JITER_PRELOAD_ERROR: Exception | None = None
+
+
+def preload_jiter_native_extension() -> bool:
+    """Import jiter's native extension early if it is available."""
+
+    global _JITER_PRELOADED, _JITER_PRELOAD_ERROR
+
+    if _JITER_PRELOADED:
+        return True
+
+    try:
+        importlib.import_module("jiter.jiter")
+        from jiter import from_json as _from_json  # noqa: F401
+    except Exception as exc:
+        _JITER_PRELOAD_ERROR = exc
+        return False
+
+    _JITER_PRELOADED = True
+    _JITER_PRELOAD_ERROR = None
+    return True
+
+
+preload_jiter_native_extension()

--- a/tests/agent/test_jiter_preload.py
+++ b/tests/agent/test_jiter_preload.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+from agent import jiter_preload
+
+
+def test_preload_jiter_native_extension_loads_sdk_parser_dependency():
+    assert jiter_preload.preload_jiter_native_extension() is True
+    assert "jiter.jiter" in sys.modules
+
+
+def test_preload_jiter_native_extension_is_best_effort(monkeypatch):
+    monkeypatch.setattr(jiter_preload, "_JITER_PRELOADED", False)
+
+    def _raise_missing(name: str):
+        assert name == "jiter.jiter"
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(importlib, "import_module", _raise_missing)
+
+    assert jiter_preload.preload_jiter_native_extension() is False
+    assert jiter_preload._JITER_PRELOADED is False
+    assert isinstance(jiter_preload._JITER_PRELOAD_ERROR, ModuleNotFoundError)


### PR DESCRIPTION
Salvage of #33665 by @helix4u onto current main.

## Summary

Preloads the OpenAI SDK's native `jiter` streaming parser during `agent` package import, so the first DeepSeek/OpenAI-compatible streaming request on Windows doesn't hit `ModuleNotFoundError: No module named 'jiter.jiter'`.

## Root cause

OpenAI SDK lazy-imports `openai.lib.streaming.chat._completions` the first time a streaming response is consumed, from inside the SSE worker thread. That module does `from jiter import from_json`, which triggers `jiter/__init__.py` → `from .jiter import *` → load of the native `.pyd`. On some Windows installs this thread-load fails (likely an AV / file-lock / loader-state race), even though the same `import jiter.jiter` succeeds when run synchronously from the Hermes venv at a REPL.

Reproduced live by a Discord user (Lucien) on Windows + DeepSeek: direct `import jiter.jiter` printed `jiter ok`, but every streaming chat request failed with `ModuleNotFoundError: No module named 'jiter.jiter'`. Confirmed workaround:

```
.\venv\Scripts\python.exe -c "import jiter.jiter, runpy; runpy.run_module('hermes_cli.main', run_name='__main__')"
```

That preloads the native extension on the main thread before any Hermes code starts. The PR makes Hermes do the same automatically.

## Changes

- `agent/jiter_preload.py`: best-effort `importlib.import_module("jiter.jiter")` + `from jiter import from_json`, runs at module import. Swallows exceptions so a truly missing/broken install still surfaces via the normal SDK error path.
- `agent/__init__.py`: imports `jiter_preload` so the side effect runs on first `import agent.*` (which happens very early in CLI/gateway startup via `agent.portal_tags`, `agent.secret_sources`, etc.).
- `tests/agent/test_jiter_preload.py`: happy path + ModuleNotFoundError fallback.

## Validation

- `scripts/run_tests.sh tests/agent/test_jiter_preload.py` → 2/2 passed.
- Local `python3 -c "import agent; from agent import jiter_preload; print(jiter_preload._JITER_PRELOADED)"` → `True`, `jiter.jiter` in `sys.modules`.
- Author email already mapped in `scripts/release.py`.

Closes #33665. helix4u authorship preserved via rebase-merge.


## Infographic

![preload-jiter-native-parser](https://v3b.fal.media/files/b/0a9bfe16/fPt2UWF68cjefsANilNaA_kevVMghM.png)
