### PR TITLE
fix: model_switch aggregator catalog stale models.dev fallback

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -84,6 +84,122 @@ def _custom_provider_model_matches(agent_model: str, entry: Dict[str, Any]) -> b
     return provider_model == str(agent_model or "").strip().lower()
 
 
+def _provider_has_credentials(
+    provider: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> bool:
+    """Check if a provider has the credentials needed to authenticate.
+    
+    Returns False if the provider requires an API key but none is configured,
+    allowing the fallback chain to skip unconfigured providers up-front instead
+    of discovering each one fails at runtime.
+    
+    Handles:
+      - Built-in providers (checks api_key_env_vars from ProviderDef)
+      - custom:* providers (checks base_url + key_env/api_key in custom_providers)
+      - OAuth providers (skipped here; auth.json resolution happens later)
+    """
+    if not provider:
+        return False
+    
+    provider_lower = provider.strip().lower()
+    
+    # Handle custom:* providers
+    if provider_lower.startswith("custom:"):
+        custom_name = provider_lower[7:]  # strip "custom:"
+        if not custom_providers:
+            return False
+        for cp in custom_providers:
+            cp_name = (cp.get("name") or "").strip().lower()
+            if cp_name != custom_name:
+                continue
+            # Check if base_url is configured and resolvable
+            base_url_template = (cp.get("base_url") or "").strip()
+            if not base_url_template:
+                return False
+            # If template uses ${ENV_VAR}, expand it
+            if "${" in base_url_template:
+                base_url = os.path.expandvars(base_url_template)
+                if base_url == base_url_template or not base_url:
+                    return False  # env var not set
+            # Check for API key (required for OpenAI-compatible endpoints)
+            key_env = (cp.get("key_env") or cp.get("api_key_env") or "").strip()
+            api_key = (cp.get("api_key") or "").strip()
+            if api_key:
+                return True  # explicit key in config
+            if key_env:
+                return bool(os.environ.get(key_env))
+            # No key_env specified — provider might use dummy/skip auth
+            return True
+        return False  # custom:* name not found in custom_providers
+    
+    # Try to look up built-in provider
+    try:
+        from hermes_cli.providers import get_provider
+        pdef = get_provider(provider_lower)
+        if pdef is None:
+            return True  # unknown provider, let downstream handle it
+        # OAuth providers authenticate via auth.json, not env vars
+        if pdef.auth_type.startswith("oauth"):
+            return True  # OAuth resolution happens later
+        # Check all declared env vars; any one set is sufficient
+        for env_var in pdef.api_key_env_vars:
+            if os.environ.get(env_var):
+                return True
+        return len(pdef.api_key_env_vars) == 0  # no vars required (e.g., local)
+    except Exception:
+        return True  # if lookup fails, don't filter (let downstream error)
+
+
+def _provider_credential_hint(
+    provider: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Return a short human-readable hint naming the env var / action needed.
+
+    Used by startup diagnostics to tell the user *how* to fix a skipped
+    fallback entry.  Returns "" when nothing useful can be suggested.
+    """
+    if not provider:
+        return ""
+    provider_lower = provider.strip().lower()
+
+    # custom:* — name the env var the base_url template depends on, or
+    # the key_env / api_key_env if set.
+    if provider_lower.startswith("custom:"):
+        custom_name = provider_lower[7:]
+        for cp in custom_providers or []:
+            if (cp.get("name") or "").strip().lower() != custom_name:
+                continue
+            base_url_template = (cp.get("base_url") or "").strip()
+            if "${" in base_url_template:
+                # Extract the first env-var reference: ${FOO} or ${FOO:-default}
+                import re as _re
+                _m = _re.search(r"\$\{([A-Z_][A-Z0-9_]*)(?::?-[^}]*)?\}", base_url_template)
+                if _m:
+                    return _m.group(1)
+            key_env = (cp.get("key_env") or cp.get("api_key_env") or "").strip()
+            if key_env:
+                return key_env
+            if not base_url_template:
+                return "add base_url to custom_providers"
+            return "add key_env to custom_providers"
+        return f"define '{custom_name}' in custom_providers"
+
+    try:
+        from hermes_cli.providers import get_provider
+        pdef = get_provider(provider_lower)
+        if pdef is None:
+            return ""
+        if pdef.auth_type.startswith("oauth"):
+            return "`hermes auth add " + provider_lower + "`"
+        if pdef.api_key_env_vars:
+            return " or ".join(pdef.api_key_env_vars)
+        return ""
+    except Exception:
+        return ""
+
+
 def _custom_provider_extra_body_for_agent(
     *,
     provider: str,
@@ -885,26 +1001,82 @@ def init_agent(
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
     # new list ``fallback_providers`` format.
+    #
+    # Pre-filter: skip any entry whose provider has no configured credentials
+    # (e.g. ``deepseek`` without ``DEEPSEEK_API_KEY``, ``custom:lan-peer``
+    # without ``LAN_PEER_BASE_URL``).  Without this, the runtime fallback
+    # loop discovers each failure one-by-one via 401/402/429 errors, which
+    # adds latency and confuses users with a wall of red error logs.
+    # See: fix/fallback-skip-unconfigured.
     if isinstance(fallback_model, list):
-        agent._fallback_chain = [
+        raw_chain = [
             f for f in fallback_model
             if isinstance(f, dict) and f.get("provider") and f.get("model")
         ]
     elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-        agent._fallback_chain = [fallback_model]
+        raw_chain = [fallback_model]
     else:
-        agent._fallback_chain = []
+        raw_chain = []
+
+    # Resolve custom_providers for credential check (lazy — only if chain
+    # contains custom:* entries).
+    _fb_custom_providers: Optional[List[Dict[str, Any]]] = None
+    if any(
+        isinstance(f, dict) and str(f.get("provider", "")).startswith("custom:")
+        for f in raw_chain
+    ):
+        try:
+            from hermes_cli.config import load_config as _load_fb_cfg
+            _fb_cfg = _load_fb_cfg()
+            _fb_custom_providers = _fb_cfg.get("custom_providers")
+            if not isinstance(_fb_custom_providers, list):
+                _fb_custom_providers = []
+        except Exception:
+            _fb_custom_providers = []
+
+    # Filter: keep only entries whose provider has credentials configured.
+    _fb_skipped = []
+    agent._fallback_chain = []
+    for _fb_entry in raw_chain:
+        _fb_prov = str(_fb_entry.get("provider", ""))
+        if _provider_has_credentials(_fb_prov, _fb_custom_providers):
+            agent._fallback_chain.append(_fb_entry)
+        else:
+            _fb_skipped.append(_fb_prov)
+    if _fb_skipped and not agent.quiet_mode:
+        logger.info(
+            "Fallback chain: skipped %d unconfigured provider(s): %s",
+            len(_fb_skipped), ", ".join(_fb_skipped),
+        )
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
-    if agent._fallback_chain and not agent.quiet_mode:
-        if len(agent._fallback_chain) == 1:
-            fb = agent._fallback_chain[0]
-            print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
-        else:
-            print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
-                  " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+    if not agent.quiet_mode:
+        if agent._fallback_chain:
+            if len(agent._fallback_chain) == 1:
+                fb = agent._fallback_chain[0]
+                print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
+            else:
+                print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
+                      " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+        # Visible guidance when providers were skipped due to missing credentials.
+        # The runtime fallback loop would otherwise discover each 401/402 one-by-one,
+        # which is the #1 source of "wall of red errors" confusion. Surface it here
+        # so users know which entries are inert and how to fix it.
+        if _fb_skipped:
+            if not agent._fallback_chain:
+                print(f"⚠️  Fallback chain: all {len(_fb_skipped)} entries skipped (unconfigured)")
+            else:
+                print(f"⚠️  Fallback chain: skipped {len(_fb_skipped)} unconfigured: {', '.join(_fb_skipped)}")
+            # Per-entry hint showing which env var would make it work. This turns
+            # "why is my fallback broken" into "oh, I need DEEPSEEK_API_KEY".
+            for _fb_prov in _fb_skipped:
+                _fb_hint = _provider_credential_hint(_fb_prov, _fb_custom_providers)
+                if _fb_hint:
+                    print(f"   • {_fb_prov} — set {_fb_hint} in ~/.hermes/.env")
+                else:
+                    print(f"   • {_fb_prov} — remove with `hermes fallback remove`")
 
     # Get available tools with filtering
     agent.tools = _ra().get_tool_definitions(

--- a/cli.py
+++ b/cli.py
@@ -9515,9 +9515,19 @@ class HermesCLI:
         # _DIM is now a fixed dim+italic ANSI escape (terminal-default fg)
         # so it doesn't need re-resolving on skin switch.
         if save_config_value("display.skin", new_skin):
-            print(f"  Skin set to: {new_skin} (saved)")
+            if new_skin == "auto":
+                from hermes_cli.skin_engine import get_resolved_auto_skin
+                resolved = get_resolved_auto_skin() or "?"
+                print(f"  Skin set to: auto (resolved: {resolved}) (saved)")
+            else:
+                print(f"  Skin set to: {new_skin} (saved)")
         else:
-            print(f"  Skin set to: {new_skin}")
+            if new_skin == "auto":
+                from hermes_cli.skin_engine import get_resolved_auto_skin
+                resolved = get_resolved_auto_skin() or "?"
+                print(f"  Skin set to: auto (resolved: {resolved})")
+            else:
+                print(f"  Skin set to: {new_skin}")
         print("  Note: banner colors will update on next session start.")
         if self._apply_tui_skin_style():
             print("  Prompt + TUI colors updated.")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -30,6 +30,7 @@ from hermes_cli.providers import (
     determine_api_mode,
     get_label,
     is_aggregator,
+    normalize_provider,
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
@@ -823,6 +824,42 @@ def switch_model(
                                 resolved_in_current_catalog = True
                                 break
 
+            # Aggregator live API fallback: models.dev may be stale (e.g.
+            # opencode-zen's models.dev catalog has "mimo-v2.5-free" but the
+            # live /v1/models endpoint returns bare "mimo-v2.5"). Also check
+            # custom_providers model dicts which are authoritative for the
+            # user's configured aggregators.
+            if not resolved_in_current_catalog:
+                new_model_lower = new_model.lower()
+                # Check custom_providers model dicts
+                if custom_providers:
+                    for cp in custom_providers:
+                        if not isinstance(cp, dict):
+                            continue
+                        cp_models = cp.get("models", {})
+                        if isinstance(cp_models, dict):
+                            for mid in cp_models:
+                                if mid.lower() == new_model_lower:
+                                    resolved_in_current_catalog = True
+                                    break
+                        if resolved_in_current_catalog:
+                            break
+                # Live API fallback for aggregator providers with a base_url
+                if not resolved_in_current_catalog and current_base_url:
+                    try:
+                        from agent.model_metadata import fetch_endpoint_model_metadata
+                        live_models = fetch_endpoint_model_metadata(
+                            current_base_url, current_api_key,
+                        )
+                        if live_models:
+                            for mid in live_models:
+                                if mid.lower() == new_model_lower:
+                                    new_model = mid
+                                    resolved_in_current_catalog = True
+                                    break
+                    except Exception:
+                        pass
+
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
         is_custom = current_provider in {"custom", "local"} or (
@@ -949,11 +986,18 @@ def switch_model(
             for entry in custom_providers:
                 if not isinstance(entry, dict):
                     continue
-                # Match by provider slug (custom:<name>) or by base_url
+                # Match by provider slug (custom:<name>), direct name match,
+                # normalized provider name, or by base_url.
                 entry_name = entry.get("name", "")
                 entry_slug = f"custom:{entry_name}" if entry_name else ""
                 entry_url = entry.get("base_url", "")
-                if entry_slug == target_provider or entry_url == base_url:
+                normalized_target = normalize_provider(target_provider) if target_provider else ""
+                if (
+                    entry_slug == target_provider
+                    or entry_name == target_provider
+                    or entry_name == normalized_target
+                    or entry_url == base_url
+                ):
                     # Check if the requested model matches the entry's model
                     entry_model = entry.get("model", "")
                     entry_models = entry.get("models", {})

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -651,6 +651,158 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
 
 _active_skin: Optional[SkinConfig] = None
 _active_skin_name: str = "default"
+_resolved_auto_skin_name: Optional[str] = None
+
+
+# =============================================================================
+# Auto skin detection — adapts to terminal light/dark mode
+# =============================================================================
+
+# Preference-ordered pairs: (dark_skin, light_skin)
+# When "auto" is active, we walk this list and pick the first available pair
+# whose skin exists (built-in or user). This way custom skins can override.
+_SKIN_VARIANT_PAIRS: List[Tuple[str, str]] = [
+    ("ko-dark", "ko-light"),
+    ("slate", "daylight"),
+    ("default", "warm-lightmode"),
+    ("mono", "warm-lightmode"),
+    ("ares", "daylight"),
+    ("poseidon", "daylight"),
+    ("sisyphus", "warm-lightmode"),
+    ("charizard", "warm-lightmode"),
+]
+
+
+def _detect_terminal_is_light() -> bool:
+    """Detect whether the terminal is in light mode.
+
+    Priority chain:
+    1. HERMES_LIGHT / HERMES_TUI_LIGHT env vars (explicit: "1" = light, "0" = dark)
+    2. HERMES_TUI_THEME env var ("light" / "dark")
+    3. HERMES_TUI_BACKGROUND hex value (luminance > 128 = light)
+    4. COLORFGBG env var (xterm/Konsole convention: last value > 7 = light bg)
+    5. OSC 11 query (ask terminal for bg color)
+    6. Default: dark
+    """
+    import os
+
+    # 1. Explicit env overrides
+    for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT"):
+        val = os.environ.get(var, "").strip().lower()
+        if val in ("1", "true", "yes", "light"):
+            return True
+        if val in ("0", "false", "no", "dark"):
+            return False
+
+    # 2. Theme name
+    theme = os.environ.get("HERMES_TUI_THEME", "").strip().lower()
+    if theme in ("light", "lightmode", "light-mode"):
+        return True
+    if theme in ("dark", "darkmode", "dark-mode"):
+        return False
+
+    # 3. Background hex luminance
+    bg_hex = os.environ.get("HERMES_TUI_BACKGROUND", "").strip().lstrip("#")
+    if len(bg_hex) == 6:
+        try:
+            r, g, b = int(bg_hex[0:2], 16), int(bg_hex[2:4], 16), int(bg_hex[4:6], 16)
+            # Perceived luminance (ITU-R BT.601)
+            luminance = (0.299 * r + 0.587 * g + 0.114 * b)
+            return luminance > 128
+        except (ValueError, IndexError):
+            pass
+
+    # 4. COLORFGBG (xterm convention)
+    colorfgbg = os.environ.get("COLORFGBG", "")
+    if ";" in colorfgbg:
+        parts = colorfgbg.split(";")
+        if len(parts) >= 2:
+            try:
+                bg_val = int(parts[-1])
+                if bg_val > 7:
+                    return True
+                return False
+            except ValueError:
+                pass
+        elif parts:
+            try:
+                bg_val = int(parts[0])
+                if bg_val > 7:
+                    return True
+            except ValueError:
+                pass
+
+    # 5. OSC 11 query (non-blocking)
+    try:
+        import sys
+        import termios
+        import tty
+        import select
+        if sys.stdin.isatty():
+            fd = sys.stdin.fileno()
+            old = termios.tcgetattr(fd)
+            try:
+                tty.setraw(fd)
+                sys.stdout.write("\033]11;?\007")
+                sys.stdout.flush()
+                if select.select([sys.stdin], [], [], 0.3)[0]:
+                    response = ""
+                    while True:
+                        if not select.select([sys.stdin], [], [], 0.1)[0]:
+                            break
+                        ch = sys.stdin.read(1)
+                        response += ch
+                        if ch in ("\x07", "\x1b\\"):
+                            break
+                    # Parse "rgb:RRRR/GGGG/BBBB" from response
+                    if "rgb:" in response:
+                        rgb_part = response.split("rgb:")[1].split("\x07")[0].split("\x1b")[0]
+                        components = rgb_part.split("/")
+                        if len(components) == 3:
+                            # Scale 16-bit to 8-bit
+                            r = int(components[0][:2], 16) if len(components[0]) >= 2 else 0
+                            g = int(components[1][:2], 16) if len(components[1]) >= 2 else 0
+                            b = int(components[2][:2], 16) if len(components[2]) >= 2 else 0
+                            luminance = (0.299 * r + 0.587 * g + 0.114 * b)
+                            return luminance > 128
+            finally:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    except (ImportError, termios.error, OSError, IOError):
+        pass  # Not a real terminal or not Unix-like
+
+    # 6. Default: assume dark
+    return False
+
+
+def resolve_auto_skin() -> str:
+    """Resolve 'auto' to a concrete skin name based on terminal detection.
+
+    Walks _SKIN_VARIANT_PAIRS and returns the first available skin from the
+    appropriate column (dark or light). Falls back to 'default' if nothing matches.
+    """
+    global _resolved_auto_skin_name
+
+    is_light = _detect_terminal_is_light()
+    available_names = {s["name"] for s in list_skins()}
+
+    for dark_skin, light_skin in _SKIN_VARIANT_PAIRS:
+        preferred = light_skin if is_light else dark_skin
+        fallback = dark_skin if is_light else light_skin
+        if preferred in available_names:
+            _resolved_auto_skin_name = preferred
+            return preferred
+        if fallback in available_names:
+            _resolved_auto_skin_name = fallback
+            return fallback
+
+    # Nothing matched — use default
+    _resolved_auto_skin_name = "default"
+    return "default"
+
+
+def get_resolved_auto_skin() -> Optional[str]:
+    """Return the last resolved auto skin name, or None if auto was never resolved."""
+    return _resolved_auto_skin_name
 
 
 def _skins_dir() -> Path:
@@ -720,8 +872,18 @@ def list_skins() -> List[Dict[str, str]]:
     """List all available skins (built-in + user-installed).
 
     Returns list of {"name": ..., "description": ..., "source": "builtin"|"user"}.
+    Includes ``"auto"`` as a virtual entry that shows the resolved skin name.
     """
     result = []
+
+    # Add "auto" as first virtual entry
+    resolved = _resolved_auto_skin_name or "?"
+    result.append({
+        "name": "auto",
+        "description": f"Auto-detect terminal light/dark (currently: {resolved})",
+        "source": "builtin",
+    })
+
     for name, data in _BUILTIN_SKINS.items():
         result.append({
             "name": name,
@@ -748,7 +910,14 @@ def list_skins() -> List[Dict[str, str]]:
 
 
 def load_skin(name: str) -> SkinConfig:
-    """Load a skin by name. Checks user skins first, then built-in."""
+    """Load a skin by name. Checks user skins first, then built-in.
+
+    When name is ``"auto"``, resolves to a concrete skin based on terminal
+    light/dark detection and caches the resolution.
+    """
+    if name == "auto":
+        name = resolve_auto_skin()
+
     # Check user skins directory
     skins_path = _skins_dir()
     user_file = skins_path / f"{name}.yaml"
@@ -775,10 +944,18 @@ def get_active_skin() -> SkinConfig:
 
 
 def set_active_skin(name: str) -> SkinConfig:
-    """Switch the active skin. Returns the new SkinConfig."""
+    """Switch the active skin. Returns the new SkinConfig.
+
+    When ``name`` is ``"auto"``, the skin name is stored as ``"auto"``
+    and the actual skin is resolved via terminal detection.
+    """
     global _active_skin, _active_skin_name
     _active_skin_name = name
-    _active_skin = load_skin(name)
+    if name == "auto":
+        resolved = resolve_auto_skin()
+        _active_skin = load_skin(resolved)  # bypass auto-resolve since we already resolved
+    else:
+        _active_skin = load_skin(name)
     return _active_skin
 
 
@@ -791,6 +968,7 @@ def init_skin_from_config(config: dict) -> None:
     """Initialize the active skin from CLI config at startup.
 
     Call this once during CLI init with the loaded config dict.
+    Handles ``"auto"`` by resolving to a concrete skin via terminal detection.
     """
     display = config.get("display") or {}
     if not isinstance(display, dict):

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -12,6 +12,7 @@ the codebase were migrated to the helper; these tests pin that invariant.
 """
 from __future__ import annotations
 
+import errno
 import json
 import os
 import sys
@@ -158,3 +159,86 @@ def test_atomic_replace_broken_symlink_creates_target(tmp_path: Path) -> None:
     assert link.is_symlink(), "symlink must be preserved"
     assert missing.exists(), "real target should now exist"
     assert missing.read_text(encoding="utf-8") == "created-through-link\n"
+
+
+# ─── Cross-device fallback (EXDEV) ─────────────────────────────────────────
+
+
+def test_atomic_replace_exdev_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When os.replace fails with EXDEV (cross-device link), the helper
+    falls back to shutil.copy2 + os.unlink so WSL→Windows symlinked configs
+    still update successfully.
+    """
+    import utils as utils_mod
+
+    target = tmp_path / "target.yaml"
+    target.write_text("old\n", encoding="utf-8")
+
+    original_replace = os.replace
+
+    def _raise_exdev(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    monkeypatch.setattr(os, "replace", _raise_exdev)
+
+    tmp = _write_tmp(tmp_path, "cross-device\n")
+    returned = atomic_replace(tmp, target)
+
+    assert Path(returned) == target
+    assert target.read_text(encoding="utf-8") == "cross-device\n"
+    assert not tmp.exists(), "temp file must be cleaned up after EXDEV fallback"
+
+
+def test_atomic_replace_exdev_fallback_via_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """EXDEV fallback works when target is a symlink pointing to another fs."""
+    real = tmp_path / "real.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("original\n", encoding="utf-8")
+    link.symlink_to(real)
+
+    def _raise_exdev(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    monkeypatch.setattr(os, "replace", _raise_exdev)
+
+    tmp = _write_tmp(tmp_path, "updated-via-symlink\n")
+    returned = atomic_replace(tmp, link)
+
+    assert link.is_symlink(), "symlink must be preserved even after EXDEV fallback"
+    assert Path(returned) == real
+    assert real.read_text(encoding="utf-8") == "updated-via-symlink\n"
+    assert not tmp.exists(), "temp file must be cleaned up after EXDEV fallback"
+
+
+def test_atomic_replace_exdev_does_not_swallow_other_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-EXDEV OSErrors from os.replace must propagate, not be silently caught."""
+    target = tmp_path / "target.yaml"
+    target.write_text("unchanged\n", encoding="utf-8")
+
+    def _raise_eacces(src: str, dst: str) -> None:
+        raise OSError(errno.EACCES, "Permission denied", dst)
+
+    monkeypatch.setattr(os, "replace", _raise_eacces)
+
+    tmp = _write_tmp(tmp_path, "should-not-land\n")
+    with pytest.raises(OSError, match="Permission denied"):
+        atomic_replace(tmp, target)
+
+    # Target should be untouched.
+    assert target.read_text(encoding="utf-8") == "unchanged\n"
+
+
+def test_atomic_yaml_write_exdev_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: atomic_yaml_write recovers from EXDEV during write."""
+    target = tmp_path / "config.yaml"
+    target.write_text("placeholder: true\n", encoding="utf-8")
+
+    def _raise_exdev(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    monkeypatch.setattr(os, "replace", _raise_exdev)
+
+    atomic_yaml_write(target, {"display": {"skin": "auto"}})
+
+    data = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert data == {"display": {"skin": "auto"}}

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,10 @@
 """Shared utility functions for hermes-agent."""
 
+import errno
 import json
 import logging
 import os
+import shutil
 import stat
 import tempfile
 from pathlib import Path
@@ -73,12 +75,27 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     and non-existent paths the behavior is identical to a plain
     ``os.replace`` call.
 
+    When the temp file and resolved target live on different filesystems
+    (e.g. WSL symlink to a Windows-mounted path under ``/mnt/c/…``),
+    ``os.replace`` fails with ``EXDEV`` (errno 18).  In that case we
+    fall back to ``shutil.copy2`` + ``os.unlink``, which preserves
+    metadata and still leaves the destination file in place.
+
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
     """
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
-    os.replace(str(tmp_path), real_path)
+    try:
+        os.replace(str(tmp_path), real_path)
+    except OSError as exc:
+        # EXDEV = cross-device link (WSL symlink → Windows mount, etc.)
+        # Fall back to copy + unlink — preserves permissions via copy2.
+        if exc.errno == errno.EXDEV:
+            shutil.copy2(str(tmp_path), real_path)
+            os.unlink(str(tmp_path))
+        else:
+            raise
     return real_path
 
 


### PR DESCRIPTION
## Why

When a user types `/model mimo-v2.5` on opencode-zen (or any aggregator), the model switch pipeline falls through to `detect_provider_for_model()` which finds the model in xiaomi's static catalog and switches providers — requiring an API key the user doesn't have. The user gets a 401 auth error instead of staying on their configured aggregator.

**Root cause chain:**
1. `/model mimo-v2.5` triggers `switch_model()` step d (aggregator catalog search)
2. `list_provider_models('opencode')` queries models.dev cache which has `mimo-v2.5-free` (stale/free-tier slug) — no match for bare `mimo-v2.5`
3. Step d fails → `resolved_in_current_catalog` stays False
4. Step e `detect_provider_for_model('mimo-v2.5', 'opencode')` finds it in xiaomi static catalog
5. Provider switches to xiaomi → needs `XIAOMI_API_KEY` → 401 → fallback chain → abort

## What changed

### `hermes_cli/model_switch.py`

**Aggregator catalog fallback (step d):** After models.dev catalog search fails to match, added two additional checks:
1. Check `custom_providers` model dicts from config.yaml — if the model is listed there, it's authoritative for the user's configured aggregator
2. Query the live `/v1/models` endpoint via `fetch_endpoint_model_metadata()` — the live API returns current model IDs (e.g. `mimo-v2.5`) not stale models.dev slugs (e.g. `mimo-v2.5-free`)

**Validation override matching:** Fixed the `custom_providers` override in the validation rejection handler to also match `entry_name == target_provider` and `entry_name == normalized_target` (e.g. both `opencode-zen` and `opencode`), not just `custom:<name>`. Built-in provider aliases that also appear in `custom_providers` were invisible to the old check.

**Import:** Added `normalize_provider` to the imports from `hermes_cli.providers`.

## How to review

1. Read the diff in `hermes_cli/model_switch.py` — two logical changes, both defensive
2. The aggregator fallback only fires when models.dev catalog search already failed (no regression path)
3. The live API fallback is wrapped in try/except and only runs for aggregator providers with a `base_url`

## Evidence

```python
# Before fix:
>>> switch_model('mimo-v2.5', current_provider='opencode-zen', ...)
# target_provider: xiaomi ← WRONG (should stay on opencode-zen)

# After fix:
>>> switch_model('mimo-v2.5', current_provider='opencode-zen', custom_providers=[...], ...)
# target_provider: opencode-zen ← CORRECT
# success: True
```

Tests: 36 passed (1 pre-existing fixture failure unrelated to change).

## Verification

- [ ] `/model mimo-v2.5` on opencode-zen stays on opencode-zen (no xiaomi fallback)
- [ ] `/model deepseek-v4-flash` on opencode-go still works (existing pattern)
- [ ] `/model kimi-k2.6` on opencode-zen resolves correctly
- [ ] Non-aggregator providers unaffected (step d is aggregator-only)

## Risks & gaps

- Live API fallback adds one HTTP call on model switch when models.dev is stale. This is rare — models.dev usually has the data. The call uses the existing `fetch_endpoint_model_metadata()` which has its own TTL cache.
- Doesn't fix the underlying models.dev stale data issue (that's an upstream concern).