### PR TITLE
fix(kanban): salvage cross-process init flock + busy_timeout (from #32759)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -982,6 +982,68 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
+DEFAULT_BUSY_TIMEOUT_MS = 120_000
+
+
+def _resolve_busy_timeout_ms() -> int:
+    """Return the SQLite busy timeout for Kanban connections.
+
+    Kanban is the shared cross-profile dispatch bus, so worker stampedes are
+    expected.  A long busy timeout lets SQLite serialize writers via WAL rather
+    than surfacing transient ``database is locked`` failures during bursts.
+    """
+    raw = os.environ.get("HERMES_KANBAN_BUSY_TIMEOUT_MS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = 0
+        if parsed > 0:
+            return parsed
+    return DEFAULT_BUSY_TIMEOUT_MS
+
+
+def _sqlite_connect(path: Path) -> sqlite3.Connection:
+    """Open a Kanban SQLite connection with consistent lock waiting."""
+    busy_timeout_ms = _resolve_busy_timeout_ms()
+    conn = sqlite3.connect(
+        str(path),
+        isolation_level=None,
+        timeout=busy_timeout_ms / 1000.0,
+    )
+    # ``sqlite3.connect(timeout=...)`` normally maps to busy_timeout, but set
+    # the PRAGMA explicitly so it is observable and survives future wrapper
+    # changes. Parameter binding is not supported for PRAGMA assignments.
+    conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+    return conn
+
+
+@contextlib.contextmanager
+def _cross_process_init_lock(path: Path):
+    """Serialize first-connect WAL/schema/integrity setup across processes.
+
+    ``_INIT_LOCK`` only protects threads inside one Python process. During a
+    dispatcher burst, many worker processes can all hit a fresh/legacy board at
+    once and each process has an empty ``_INITIALIZED_PATHS`` cache. This file
+    lock keeps header validation, integrity probing, WAL activation, and
+    additive migrations single-file/single-writer across the whole host while
+    leaving normal post-init DB usage concurrent under SQLite WAL.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".init.lock")
+    handle = lock_path.open("a+b")
+    try:
+        if not _IS_WINDOWS:
+            import fcntl
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if not _IS_WINDOWS:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
 
 
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
@@ -1142,7 +1204,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         return
     reason: Optional[str] = None
     try:
-        probe = sqlite3.connect(str(resolved), timeout=5, isolation_level=None)
+        probe = _sqlite_connect(resolved)
         try:
             row = probe.execute("PRAGMA integrity_check").fetchone()
         finally:
@@ -1188,51 +1250,52 @@ def connect(
     else:
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
-    # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
-    # and other invalid-header cases without opening a sqlite connection.
-    _validate_sqlite_header(path)
-    # Full integrity probe — catches corruption past the header (malformed
-    # pages, broken internal metadata). Cached per-path after first success
-    # via _INITIALIZED_PATHS so it only runs once per process per path.
-    _guard_existing_db_is_healthy(path)
-    resolved = str(path.resolve())
-    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
-    try:
-        conn.row_factory = sqlite3.Row
-        with _INIT_LOCK:
-            # WAL activation can take an exclusive lock while SQLite creates the
-            # sidecar files for a fresh database. Keep it in the same process-local
-            # critical section as schema initialization so concurrent gateway
-            # startup threads do not race before _INITIALIZED_PATHS is populated.
-            # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-            # falls back to DELETE with one WARNING so kanban stays usable there.
-            # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-            from hermes_state import apply_wal_with_fallback
-            apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-            # FULL (was NORMAL): fsync before each checkpoint to narrow the
-            # crash window that can leave a b-tree page header torn.
-            conn.execute("PRAGMA synchronous=FULL")
-            conn.execute("PRAGMA wal_autocheckpoint=100")
-            conn.execute("PRAGMA foreign_keys=ON")
-            # Zero freed pages so a later torn write cannot expose stale
-            # cell content; persisted in the DB header for new DBs.
-            conn.execute("PRAGMA secure_delete=ON")
-            # Surface corrupt cells as read errors instead of silent
-            # wrong-data returns.
-            conn.execute("PRAGMA cell_size_check=ON")
-            needs_init = resolved not in _INITIALIZED_PATHS
-            if needs_init:
-                # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
-                # migrations. Cached so subsequent connect() calls in the same
-                # process are cheap. The lock prevents same-process dispatcher
-                # threads from racing through the additive ALTER TABLE pass with
-                # stale PRAGMA snapshots during gateway startup.
-                conn.executescript(SCHEMA_SQL)
-                _migrate_add_optional_columns(conn)
-                _INITIALIZED_PATHS.add(resolved)
-    except Exception:
-        conn.close()
-        raise
+    with _cross_process_init_lock(path):
+        # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
+        # and other invalid-header cases without opening a sqlite connection.
+        _validate_sqlite_header(path)
+        # Full integrity probe — catches corruption past the header (malformed
+        # pages, broken internal metadata). Cached per-path after first success
+        # via _INITIALIZED_PATHS so it only runs once per process per path.
+        _guard_existing_db_is_healthy(path)
+        resolved = str(path.resolve())
+        conn = _sqlite_connect(path)
+        try:
+            conn.row_factory = sqlite3.Row
+            with _INIT_LOCK:
+                # WAL activation can take an exclusive lock while SQLite creates the
+                # sidecar files for a fresh database. Keep it in the same process-local
+                # critical section as schema initialization so concurrent gateway
+                # startup threads do not race before _INITIALIZED_PATHS is populated.
+                # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
+                # falls back to DELETE with one WARNING so kanban stays usable there.
+                # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
+                from hermes_state import apply_wal_with_fallback
+                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                # FULL (was NORMAL): fsync before each checkpoint to narrow the
+                # crash window that can leave a b-tree page header torn.
+                conn.execute("PRAGMA synchronous=FULL")
+                conn.execute("PRAGMA wal_autocheckpoint=100")
+                conn.execute("PRAGMA foreign_keys=ON")
+                # Zero freed pages so a later torn write cannot expose stale
+                # cell content; persisted in the DB header for new DBs.
+                conn.execute("PRAGMA secure_delete=ON")
+                # Surface corrupt cells as read errors instead of silent
+                # wrong-data returns.
+                conn.execute("PRAGMA cell_size_check=ON")
+                needs_init = resolved not in _INITIALIZED_PATHS
+                if needs_init:
+                    # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
+                    # migrations. Cached so subsequent connect() calls in the same
+                    # process are cheap. The lock prevents same-process dispatcher
+                    # threads from racing through the additive ALTER TABLE pass with
+                    # stale PRAGMA snapshots during gateway startup.
+                    conn.executescript(SCHEMA_SQL)
+                    _migrate_add_optional_columns(conn)
+                    _INITIALIZED_PATHS.add(resolved)
+        except Exception:
+            conn.close()
+            raise
     return conn
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1033,14 +1033,35 @@ def _cross_process_init_lock(path: Path):
     lock_path = path.with_name(path.name + ".init.lock")
     handle = lock_path.open("a+b")
     try:
-        if not _IS_WINDOWS:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            # Lock a single byte in the sidecar file. ``msvcrt.locking`` starts
+            # at the current file position, so seek explicitly before both
+            # lock and unlock.  The file is opened in append/read binary mode so
+            # it always exists but the byte-range lock is the synchronization
+            # primitive; no payload needs to be written.
+            handle.seek(0)
+            locking = getattr(msvcrt, "locking")
+            lock_mode = getattr(msvcrt, "LK_LOCK")
+            locking(handle.fileno(), lock_mode, 1)
+        else:
             import fcntl
+
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         yield
     finally:
         try:
-            if not _IS_WINDOWS:
+            if _IS_WINDOWS:
+                import msvcrt
+
+                handle.seek(0)
+                locking = getattr(msvcrt, "locking")
+                unlock_mode = getattr(msvcrt, "LK_UNLCK")
+                locking(handle.fileno(), unlock_mode, 1)
+            else:
                 import fcntl
+
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         finally:
             handle.close()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -73,6 +73,7 @@ AUTHOR_MAP = {
     "anadi.jaggia@gmail.com": "Jaggia",
     "steve@steveonjava.com": "steveonjava",
     "steveonjava@gmail.com": "steveonjava",
+    "squiddy@2rook.ai": "MoonRay305",
     "32201324+simpolism@users.noreply.github.com": "simpolism",
     "simpolism@gmail.com": "simpolism",
     "jake@nousresearch.com": "simpolism",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import sqlite3
+import sys
 import time
+import types
 import unittest.mock
 from pathlib import Path
 
@@ -63,6 +65,27 @@ def test_connect_honors_kanban_busy_timeout_env(kanban_home, monkeypatch):
         row = conn.execute("PRAGMA busy_timeout").fetchone()
 
     assert row[0] == 123456
+
+
+def test_cross_process_init_lock_uses_windows_byte_range_lock(tmp_path, monkeypatch):
+    """Windows must use a real process lock, not a no-op sidecar open."""
+    calls: list[tuple[int, int, int]] = []
+    fake_msvcrt = types.SimpleNamespace(
+        LK_LOCK=1,
+        LK_UNLCK=2,
+        locking=lambda fd, mode, nbytes: calls.append((fd, mode, nbytes)),
+    )
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+    db_path = tmp_path / "kanban.db"
+    with kb._cross_process_init_lock(db_path):
+        assert calls == [(calls[0][0], fake_msvcrt.LK_LOCK, 1)]
+
+    assert [call[1:] for call in calls] == [
+        (fake_msvcrt.LK_LOCK, 1),
+        (fake_msvcrt.LK_UNLCK, 1),
+    ]
 
 
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -49,6 +49,22 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
+def test_connect_honors_kanban_busy_timeout_env(kanban_home, monkeypatch):
+    """All kanban connections should use the explicit busy-timeout knob.
+
+    A worker stampede should wait for SQLite's writer lock instead of failing
+    immediately with ``database is locked`` during first-connect/WAL/schema
+    setup.  The timeout must be queryable via PRAGMA so CLI, gateway, and tool
+    connections behave the same way.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_BUSY_TIMEOUT_MS", "123456")
+
+    with kb.connect() as conn:
+        row = conn.execute("PRAGMA busy_timeout").fetchone()
+
+    assert row[0] == 123456
+
+
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     """Kanban should classify TLS-looking page-0 clobbers before WAL setup."""
     home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary

Salvages PR #32759 (@MoonRay305 / Squiddy of 2rook.ai) onto current `main` with a manual conflict resolution that preserves the SQLite pragma hardening from #33482 (just landed) alongside this PR's new cross-process flock + busy_timeout knob. Authorship preserved on both contributor commits via cherry-pick.

Closes #32759. Closes #32461 (alternative inter-process flock by @WenhuaXia, weaker design — `fcntl` import at module level breaks Windows; uses `id(conn)` as dict key with potential leaks). Closes #31965 (@steveonjava's flock-on-every-write_txn variant — see "Why this PR over the alternatives" below). Refs #31158.

## What this PR adds (defense-in-depth on top of #33482)

`hermes_cli/kanban_db.py`:

1. **`_cross_process_init_lock(path)`** — context manager using `fcntl.flock(LOCK_EX)` (Unix) and `msvcrt.locking(LK_LOCK)` (Windows, added in commit 2). Wraps the first-connect setup phase (header validation + integrity probe + WAL pragma + schema init + additive migrations) in a process-level exclusive lock via a `<db>.init.lock` sidecar file. Process-local `_INIT_LOCK` (the existing `threading.RLock`) stays nested inside — they're complementary: threading lock for in-process races, file lock for cross-process races.
2. **`_resolve_busy_timeout_ms()` + `DEFAULT_BUSY_TIMEOUT_MS=120_000`** — replaces the previously-hardcoded `timeout=30` and `timeout=5` with an explicit 2-minute busy timeout. Configurable via `HERMES_KANBAN_BUSY_TIMEOUT_MS` env var, following the established `HERMES_KANBAN_*` env-var convention (CLAIM_TTL_SECONDS, CRASH_GRACE_SECONDS, etc.). Lets concurrent writers serialize via WAL rather than failing with `database is locked` during bursts.
3. **`_sqlite_connect(path)`** — centralized `sqlite3.connect` wrapper that applies the busy timeout consistently across `connect()` and `_guard_existing_db_is_healthy()` probes (was inconsistent before: 5s vs 30s).

## Manual conflict resolution (what changed from the original PR)

The PR was authored against pre-#33482 code and a verbatim cherry-pick would have **reverted** the just-landed SQLite hardening pragmas. Specifically, the PR's `connect()` re-write hardcoded `synchronous=NORMAL` (the old baseline), missing all four pragmas we just added:

```diff
-                conn.execute("PRAGMA synchronous=NORMAL")
+                conn.execute("PRAGMA synchronous=FULL")
+                conn.execute("PRAGMA wal_autocheckpoint=100")
                 conn.execute("PRAGMA foreign_keys=ON")
+                conn.execute("PRAGMA secure_delete=ON")
+                conn.execute("PRAGMA cell_size_check=ON")
```

The merge resolution keeps **both contributions**: the PR's new `_cross_process_init_lock` + `_sqlite_connect` + busy_timeout infrastructure AND #33482's pragma block (FULL, secure_delete, cell_size_check, wal_autocheckpoint). Verified via E2E test (see below).

## Why this PR over the alternatives

Three different open PRs proposed inter-process locking for the same problem class:

| PR | Author | Scope | Cost | Windows | Issues |
|---|---|---|---|---|---|
| **#32759 (THIS)** | @MoonRay305 / Squiddy | First-connect only | One-time | ✅ msvcrt | Clean, minimal |
| #32461 | @WenhuaXia | First-connect, but `fcntl` import at module level | One-time | ❌ breaks on Windows immediately | Uses `id(conn)` dict key, leaks unless tracked |
| #31965 | @steveonjava | First-connect AND every `write_txn` (flock per-transaction) | Per-write | ❌ skipped (no-op) | Overkill — SQLite serializes via WAL once busy_timeout is set |

#32759 is the cleanest design. The WAL-init race is the actual scenario; once both processes are on WAL with `synchronous=FULL` + `wal_autocheckpoint=100`, `BEGIN IMMEDIATE` should not deadlock — SQLite serializes via WAL with the new busy_timeout knob. #31965's per-write flock would tax every kanban write without addressing the root cause that #33482 commit 8 (`skip redundant WAL pragma on already-WAL connections`) already fixed at the source.

#33482 commit 8 closes the redundant-WAL-pragma path on already-WAL connections. #32759 covers the remaining gap: the **first** connection from each process still hits the WAL-init path, and two processes racing on a *fresh* DB can produce the mixed-journal-mode corruption pattern. #32759's flock serializes that first-open across processes.

## Tests + E2E verification

```
.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -o addopts= --tb=line -q
# 196 passed
```

Broader sweep (kanban + state + dispatcher functionality):
```
.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/test_hermes_state.py \
  tests/test_hermes_state_wal_fallback.py tests/hermes_cli/test_kanban_core_functionality.py \
  tests/hermes_cli/test_kanban_db_init.py -o addopts= --tb=line -q
# 599 passed, 1 skipped, 3 failed (3 pre-existing on origin/main — live_system_guard
# rejects os.kill(99999, …) on macOS sandboxes; CI is fine)
```

E2E (4 concurrent subprocesses against a fresh DB):
- ✅ `_cross_process_init_lock` fires (`<db>.init.lock` sidecar created)
- ✅ `journal_mode=wal`
- ✅ `synchronous=2` (FULL — #33482's pragma preserved)
- ✅ `secure_delete=1` (ON — #33482's pragma preserved)
- ✅ `cell_size_check=1` (ON — #33482's pragma preserved)
- ✅ `wal_autocheckpoint=100` (#33482's pragma preserved)
- ✅ `foreign_keys=1` (ON)
- ✅ `busy_timeout=60000` (this PR's `HERMES_KANBAN_BUSY_TIMEOUT_MS` env var honored)

`ruff check` on all changed files: clean.

## Credit

Both substantive commits authored by **@MoonRay305 (Squiddy of 2rook.ai)** — `squiddy@2rook.ai` identity, preserved per-commit. Cherry-picked with `git cherry-pick` (which preserves author); manual merge resolution applied to the pragma block. Follow-up `chore(release)` commit (AUTHOR_MAP entry) attributed to the salvager.
