### PR TITLE
fix(config): preserve original .env file mode instead of unconditionally tightening to 0600

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5106,19 +5106,21 @@ def save_env_value(key: str, value: str):
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, env_path)
-        # Restore original permissions before _secure_file may tighten them.
+        # Preserve the original file mode (e.g. 0640 for Docker volume mounts)
+        # instead of letting _secure_file unconditionally tighten to 0600.
         if original_mode is not None:
             try:
                 os.chmod(env_path, original_mode)
             except OSError:
                 pass
+        else:
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
 
     os.environ[key] = value
     invalidate_env_cache()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -227,6 +227,25 @@ class TestSaveEnvValueSecure:
             env_mode = (tmp_path / ".env").stat().st_mode & 0o777
             assert env_mode == 0o600
 
+    def test_save_env_value_preserves_existing_file_mode_on_posix(self, tmp_path):
+        """Regression for #31518: pre-existing .env mode (e.g. 0640 for a
+        Docker bind-mount that the operator chose) survives subsequent
+        writes. Previously _secure_file ran unconditionally after the
+        mode-restore branch and re-tightened to 0600.
+        """
+        if os.name == "nt":
+            return
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("EXISTING=value\n")
+        os.chmod(env_path, 0o640)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("TENOR_API_KEY", "sk-test-secret")
+
+        env_mode = env_path.stat().st_mode & 0o777
+        assert env_mode == 0o640, f"expected 0o640, got {oct(env_mode)}"
+
 
 class TestRemoveEnvValue:
     def test_removes_key_from_env_file(self, tmp_path):


### PR DESCRIPTION
Salvages the focused config fix from #31518 by @blut-agent.

## What changed

`save_env_value()` captures the original `.env` file mode (e.g. `0640` for an operator-set permission on a Docker bind-mount) and restores it via `os.chmod` — but the next line unconditionally called `_secure_file(env_path)`, which re-tightens the mode to `0600` and defeats the entire preservation logic. The intent was already in the code (preserve when `original_mode` is captured, secure otherwise); it just got short-circuited.

Move `_secure_file()` into the `else` branch so it only runs when no original mode was captured. Fresh `.env` files written for the first time still get the `0600` hardening; operator-set modes on existing files survive subsequent writes.

## Why this is a salvage, not a merge of #31518 directly

@blut-agent's PR also bundled an unrelated lowercase-lookup normalization in `hermes_cli/commands.py` (`_build_command_lookup`, `GATEWAY_KNOWN_COMMANDS`, `is_gateway_known_command`). That change is reasonable on its own merits but it's a different bug class and shouldn't ride along with the file-mode fix. This salvage cherry-picks only the `config.py` commit (`d175c48cc`) and leaves the `commands.py` work for a separate PR.

## Tests

Added `test_save_env_value_preserves_existing_file_mode_on_posix` to `TestSaveEnvValueSecure` — pre-existing `.env` with mode `0640` survives `save_env_value()`.

**Empirical bug-reproduction check (per the stale-pr-triage skill):** ran the new test against `origin/main`'s `config.py` (with the salvage's config change reverted). Result: `AssertionError: expected 0o640, got 0o600` — confirms the test exercises the actual bug. With the salvage's `else`-branch fix applied, the test passes alongside the existing `test_save_env_value_hardens_file_permissions_on_posix` (fresh-file 0600 hardening preserved).

Full local suite for the touched files (`tests/hermes_cli/test_config.py` + `tests/cron/test_file_permissions.py`): 96 tests pass.

Closes #31518.

Co-authored-by: blut-agent <278569635+blut-agent@users.noreply.github.com>