### PR TITLE
fix(auth): preserve custom:<subname> in credential pool lookup

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -651,7 +651,18 @@ def _resolve_named_custom_runtime(
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        #
+        # Preserve the sub-name from `custom:<subname>` for name-based pool
+        # selection — without this, multiple custom_providers sharing the same
+        # base_url silently collapse to the first url match (#29872).
+        _pool_provider_name: Optional[str] = None
+        if requested_provider and ":" in requested_provider:
+            _sub = requested_provider.split(":", 1)[1].strip()
+            if _sub:
+                _pool_provider_name = _sub
+        pool_result = _try_resolve_from_custom_pool(
+            base_url, "custom", None, provider_name=_pool_provider_name
+        )
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -52,6 +52,7 @@ AUTHOR_MAP = {
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "3540493+kpadilha@users.noreply.github.com": "kpadilha",
     "40378218+chaconne67@users.noreply.github.com": "chaconne67",
+    "Pluviobyte@users.noreply.github.com": "Pluviobyte",
     "sanghyuk_seo@nexcubecorp.com": "sanghyuk-seo-nexcube",
     "subrtt@gmail.com": "Brixyy",
     "wangpuv@hotmail.com": "wangpuv",

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2657,3 +2657,126 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+# ---------------------------------------------------------------------------
+# #29872 — direct-alias path must preserve `custom:<subname>` for pool lookup
+#
+# When a `model_aliases:` entry resolves to a provider that alias-maps to
+# bare "custom" (the direct-alias bare-custom branch in
+# `_resolve_named_custom_runtime`), the credential-pool lookup previously
+# dropped the sub-name and matched on base_url alone. With multiple
+# `custom_providers` sharing a base_url, the wrong API key would be picked.
+#
+# The fix splits `custom:<subname>` off `requested_provider` and threads it
+# through as the `provider_name` kwarg so name-based pool selection wins
+# over the url-only fallback.
+# ---------------------------------------------------------------------------
+
+def test_direct_alias_custom_subname_passed_to_pool_lookup(monkeypatch):
+    """`custom:<subname>` requested via direct alias must reach the pool
+    lookup as `provider_name=<subname>` so name-based selection wins over
+    base_url-only matching when multiple custom providers share a host."""
+    import hermes_cli.auth as auth_mod
+
+    captured: dict = {}
+
+    def _spy(base_url, provider_label, api_mode_override=None, provider_name=None):
+        captured["base_url"] = base_url
+        captured["provider_label"] = provider_label
+        captured["api_mode_override"] = api_mode_override
+        captured["provider_name"] = provider_name
+        return None
+
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", _spy)
+    monkeypatch.setattr(auth_mod, "resolve_provider", lambda *a, **k: "custom")
+
+    rp._resolve_named_custom_runtime(
+        requested_provider="custom:bobapi-deepseek",
+        explicit_base_url="https://bobdong.cn",
+    )
+
+    assert captured["base_url"] == "https://bobdong.cn"
+    assert captured["provider_label"] == "custom"
+    assert captured["provider_name"] == "bobapi-deepseek", (
+        "sub-name must be threaded into pool lookup so multiple custom_providers "
+        "sharing one base_url resolve to distinct credentials (#29872)"
+    )
+
+
+def test_direct_alias_bare_custom_keeps_provider_name_none(monkeypatch):
+    """Regression guard: bare `provider: custom` (no sub-name) must still
+    pass `provider_name=None` so the url-only pool match continues to work."""
+    import hermes_cli.auth as auth_mod
+
+    captured: dict = {}
+
+    def _spy(base_url, provider_label, api_mode_override=None, provider_name=None):
+        captured["provider_name"] = provider_name
+        return None
+
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", _spy)
+    monkeypatch.setattr(auth_mod, "resolve_provider", lambda *a, **k: "custom")
+
+    rp._resolve_named_custom_runtime(
+        requested_provider="custom",
+        explicit_base_url="http://localhost:11434/v1",
+    )
+
+    assert captured["provider_name"] is None
+
+
+def test_direct_alias_subname_resolves_correct_pool_when_url_shared(monkeypatch):
+    """End-to-end check: with two custom_providers behind one base_url, the
+    fix must select the pool keyed by the alias's sub-name, not whichever
+    entry happens to appear first in iteration order."""
+    import agent.credential_pool as cp
+    import hermes_cli.auth as auth_mod
+
+    cfg = {
+        "custom_providers": [
+            # NB: claude entry comes first so the url-only fallback would
+            # incorrectly pick it. The fix must win via name match.
+            {
+                "name": "bobapi-claude",
+                "base_url": "https://bobdong.cn",
+                "key_env": "BOBAPI_CLAUDE_KEY",
+            },
+            {
+                "name": "bobapi-deepseek",
+                "base_url": "https://bobdong.cn",
+                "key_env": "BOBAPI_DEEPSEEK_KEY",
+            },
+        ]
+    }
+
+    class _Entry:
+        def __init__(self, token):
+            self.access_token = token
+            self.runtime_api_key = None
+
+    class _Pool:
+        def __init__(self, pool_key):
+            self.pool_key = pool_key
+
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry(f"key-for-{self.pool_key}")
+
+    monkeypatch.setattr(rp, "load_config", lambda: cfg)
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: cfg)
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool(provider))
+    monkeypatch.setattr(auth_mod, "resolve_provider", lambda *a, **k: "custom")
+
+    result = rp._resolve_named_custom_runtime(
+        requested_provider="custom:bobapi-deepseek",
+        explicit_base_url="https://bobdong.cn",
+    )
+
+    assert result is not None
+    assert result["source"] == "direct-alias"
+    assert result["api_key"] == "key-for-custom:bobapi-deepseek", (
+        "alias sub-name must select the deepseek pool, not the first url match"
+    )


### PR DESCRIPTION
## What does this PR do?

When a `model_aliases:` entry resolves through the **direct-alias bare-custom branch** in `hermes_cli/runtime_provider.py::_resolve_named_custom_runtime` (i.e. `requested_provider` like `custom:bobapi-deepseek` gets normalised to `requested_norm == \"custom\"` via an alias that maps to `\"custom\"`), the credential-pool lookup was called with `provider_name=None` and silently fell back to base_url-only matching.

When two or more `custom_providers` share a single `base_url` (a common shape for Chinese aggregator APIs where each key is bound to a different group on the same domain — the exact case from #29872), the url-only fallback always picked whichever entry happened to appear first in iteration order, sending the request with the wrong API key. The upstream then returns a 503 / 404 that looks like a model-availability problem but is actually a credential-misroute.

The fix splits the sub-name off `requested_provider` and threads it through `_try_resolve_from_custom_pool(..., provider_name=<subname>)` so name-based pool selection wins over the url-only fallback. The kwarg form mirrors the sibling pool-lookup site in the same function (the named-custom-provider path) that already passes the name correctly via `custom_provider.get(\"name\")`.

This PR **salvages the auth-only subset of #29893** ([credit @vanhci](https://github.com/NousResearch/hermes-agent/pull/29893)). The original PR was closed with CHANGES_REQUESTED because it mixed in unrelated WhatsApp / `uv pip --system` / i18n flag changes; per reviewer feedback (\"split it into individual PRs\"), this PR ships **only** the `hermes_cli/runtime_provider.py` fix plus its regression tests. Two small refinements over the original diff: the sub-name is passed as a keyword argument (`provider_name=`) instead of as the third positional (which would have aliased to `api_mode_override`), and `.strip()` is applied so trailing whitespace in the alias name does not break pool selection.

## Related Issue

Fixes #29872

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/runtime_provider.py` — in `_resolve_named_custom_runtime`, extract `<subname>` from `requested_provider` (e.g. `bobapi-deepseek` from `custom:bobapi-deepseek`) and thread it through `_try_resolve_from_custom_pool(..., provider_name=_pool_provider_name)` for the direct-alias bare-custom branch.
- `tests/hermes_cli/test_runtime_provider_resolution.py` — added three regression tests:
  - `test_direct_alias_custom_subname_passed_to_pool_lookup` — asserts the sub-name reaches the pool lookup as the `provider_name=` kwarg.
  - `test_direct_alias_bare_custom_keeps_provider_name_none` — baseline guard so bare `provider: custom` (no sub-name) still passes `None`.
  - `test_direct_alias_subname_resolves_correct_pool_when_url_shared` — end-to-end check: two `custom_providers` behind one `base_url`, the deepseek alias must select the deepseek pool, not whichever entry iterates first.

## How to Test

1. Configure two or more `custom_providers` sharing the same `base_url`, each with a distinct `key_env`, plus a `model_aliases:` entry that references one by sub-name (the exact reproduction recipe is in #29872).
2. Run `hermes chat -m <alias>` (without the `--provider` workaround) and confirm the request fires with the alias's intended key instead of whichever `custom_providers` entry appears first.
3. Local verification run:

```bash
uv run --extra dev python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q
uv run --extra dev ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py
git diff main --check
```

Regression-verified the new tests by temporarily reverting the prod change (`git stash push hermes_cli/runtime_provider.py`) — two of the three new tests fail with the unfixed code (third stays green because it covers the bare-custom baseline). With the fix restored, all three pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.1 (Amazon Linux), Python 3.12 via uv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted-suite output:

\`\`\`text
\$ uv run --extra dev python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q
........................................................................ [ 55%]
.........................................................                [100%]
129 passed in 3.10s

\$ uv run --extra dev ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py
All checks passed!

\$ git diff main --check
(no whitespace issues)
\`\`\`

Regression check (prod fix temporarily reverted) — confirms the new tests catch the bug:

\`\`\`text
\$ git stash push hermes_cli/runtime_provider.py
\$ pytest -k \"direct_alias_custom_subname or direct_alias_subname_resolves\" -q
FAILED ...::test_direct_alias_custom_subname_passed_to_pool_lookup
FAILED ...::test_direct_alias_subname_resolves_correct_pool_when_url_shared
  AssertionError: alias sub-name must select the deepseek pool, not the first url match
  - key-for-custom:bobapi-deepseek
  + key-for-custom:bobapi-claude
2 failed, 1 passed
\`\`\`

Made with [Cursor](https://cursor.com)