### PR TITLE
fix(memory/honcho): align shutdown join timeout with Honcho HTTP timeout

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1399,9 +1399,21 @@ class HonchoMemoryProvider(MemoryProvider):
             return tool_error(f"Honcho {tool_name} failed: {e}")
 
     def shutdown(self) -> None:
+        # Honcho dialectic / prefetch HTTP calls can block for the
+        # configured client timeout (default 30s). Joining for less than
+        # that leaves the daemon thread mid-call when CPython starts
+        # finalization, which intermittently aborts the interpreter
+        # (issue #33485). Align join window with the HTTP timeout while
+        # keeping a 5s floor so very-short configured timeouts still get
+        # a reasonable shutdown grace period.
+        try:
+            from plugins.memory.honcho.client import resolve_http_timeout
+            join_timeout = max(5.0, resolve_http_timeout(self._config))
+        except Exception:
+            join_timeout = 5.0
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
-                t.join(timeout=5.0)
+                t.join(timeout=join_timeout)
         # Flush any remaining messages
         if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
             try:

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -215,6 +215,32 @@ def _parse_dialectic_depth_levels(host_val, root_val, depth: int) -> list[str] |
 _DEFAULT_HTTP_TIMEOUT = 30.0
 
 
+def resolve_http_timeout(config: HonchoClientConfig | None) -> float:
+    """Resolve the effective HTTP timeout (seconds) for Honcho SDK calls.
+
+    Mirrors the resolution chain inside :func:`get_honcho_client` so that
+    other code paths (e.g. provider shutdown, which must outlast a
+    pending dialectic call to avoid CPython finalization aborts) can
+    reason about the same upper bound the SDK is using.
+    """
+    resolved = config.timeout if config is not None else None
+    if resolved is None:
+        try:
+            from hermes_cli.config import load_config
+            hermes_cfg = load_config()
+            honcho_cfg = hermes_cfg.get("honcho", {})
+            if isinstance(honcho_cfg, dict):
+                resolved = _resolve_optional_float(
+                    honcho_cfg.get("timeout"),
+                    honcho_cfg.get("request_timeout"),
+                )
+        except Exception:
+            pass
+    if resolved is None:
+        resolved = _DEFAULT_HTTP_TIMEOUT
+    return resolved
+
+
 def _resolve_optional_float(*values: Any) -> float | None:
     """Return the first non-empty value coerced to a positive float."""
     for value in values:
@@ -801,27 +827,19 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         # mapping, enabling remote self-hosted Honcho deployments without
         # requiring the server to live on localhost.
         resolved_base_url = config.base_url
-        resolved_timeout = config.timeout
-        if not resolved_base_url or resolved_timeout is None:
+        if not resolved_base_url:
             try:
                 from hermes_cli.config import load_config
                 hermes_cfg = load_config()
                 honcho_cfg = hermes_cfg.get("honcho", {})
                 if isinstance(honcho_cfg, dict):
-                    if not resolved_base_url:
-                        resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
-                    if resolved_timeout is None:
-                        resolved_timeout = _resolve_optional_float(
-                            honcho_cfg.get("timeout"),
-                            honcho_cfg.get("request_timeout"),
-                        )
+                    resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
             except Exception:
                 pass
 
         # Fall back to the default so an unconfigured install cannot hang
         # indefinitely on a stalled Honcho request.
-        if resolved_timeout is None:
-            resolved_timeout = _DEFAULT_HTTP_TIMEOUT
+        resolved_timeout = resolve_http_timeout(config)
 
         if resolved_base_url:
             logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)

--- a/tests/honcho_plugin/test_shutdown_join_timeout.py
+++ b/tests/honcho_plugin/test_shutdown_join_timeout.py
@@ -1,0 +1,137 @@
+"""Regression tests for HonchoMemoryProvider.shutdown join-timeout alignment.
+
+Issue #33485: ``HonchoMemoryProvider.shutdown`` joined the dialectic /
+prefetch threads with a fixed ``timeout=5.0``, but Honcho HTTP calls
+default to a 30s client timeout.  When the join expired before the
+HTTP call returned, the daemon thread was still alive when CPython
+started ``Py_FinalizeEx`` — intermittently aborting the interpreter
+with SIGABRT during clean shutdown.
+
+These tests pin the new contract: shutdown must wait at least as long
+as the configured Honcho HTTP timeout (with a 5s floor) before
+declaring the worker abandoned, and ``resolve_http_timeout`` must
+agree with the resolution chain inside ``get_honcho_client``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import (
+    _DEFAULT_HTTP_TIMEOUT,
+    HonchoClientConfig,
+    resolve_http_timeout,
+)
+
+
+def _shutdown_with_threads(provider: HonchoMemoryProvider) -> tuple[float, float]:
+    """Run shutdown with mocked alive threads and return the join timeouts."""
+    prefetch = MagicMock(name="prefetch_thread")
+    prefetch.is_alive.return_value = True
+    sync = MagicMock(name="sync_thread")
+    sync.is_alive.return_value = True
+
+    provider._prefetch_thread = prefetch
+    provider._sync_thread = sync
+    provider._manager = None  # skip flush_all
+
+    provider.shutdown()
+
+    return (
+        prefetch.join.call_args.kwargs["timeout"],
+        sync.join.call_args.kwargs["timeout"],
+    )
+
+
+class TestShutdownJoinTimeout:
+    """Provider shutdown must outlive a pending Honcho HTTP call."""
+
+    def test_uses_explicit_config_timeout(self):
+        """When honcho.json sets timeout=60, shutdown joins for 60s."""
+        provider = HonchoMemoryProvider()
+        provider._config = HonchoClientConfig(api_key="k", timeout=60.0)
+
+        prefetch_to, sync_to = _shutdown_with_threads(provider)
+
+        assert prefetch_to == 60.0
+        assert sync_to == 60.0
+
+    def test_falls_back_to_default_http_timeout(self):
+        """With no explicit timeout, shutdown waits the SDK default (30s)."""
+        provider = HonchoMemoryProvider()
+        provider._config = HonchoClientConfig(api_key="k", timeout=None)
+
+        # Patch out hermes_cli.config so the helper doesn't pick up a
+        # real on-disk override and skew the assertion.
+        with patch("hermes_cli.config.load_config", return_value={}):
+            prefetch_to, sync_to = _shutdown_with_threads(provider)
+
+        assert prefetch_to == _DEFAULT_HTTP_TIMEOUT
+        assert sync_to == _DEFAULT_HTTP_TIMEOUT
+
+    def test_keeps_five_second_floor_for_short_timeouts(self):
+        """A user-configured 2s HTTP timeout must not shrink the join window
+        below the original 5s grace period.
+        """
+        provider = HonchoMemoryProvider()
+        provider._config = HonchoClientConfig(api_key="k", timeout=2.0)
+
+        prefetch_to, sync_to = _shutdown_with_threads(provider)
+
+        assert prefetch_to == 5.0
+        assert sync_to == 5.0
+
+    def test_handles_missing_config_gracefully(self):
+        """Shutdown before initialize() must not crash; falls back to the
+        SDK default timeout because ``resolve_http_timeout(None)`` returns
+        ``_DEFAULT_HTTP_TIMEOUT``.
+        """
+        provider = HonchoMemoryProvider()
+        # _config is None straight from __init__
+
+        with patch("hermes_cli.config.load_config", return_value={}):
+            prefetch_to, sync_to = _shutdown_with_threads(provider)
+
+        assert prefetch_to == _DEFAULT_HTTP_TIMEOUT
+        assert sync_to == _DEFAULT_HTTP_TIMEOUT
+
+
+class TestResolveHttpTimeout:
+    """``resolve_http_timeout`` must agree with ``get_honcho_client``'s chain."""
+
+    def test_prefers_config_timeout_over_hermes_cli(self):
+        cfg = HonchoClientConfig(timeout=11.0)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"honcho": {"timeout": 99}},
+        ):
+            assert resolve_http_timeout(cfg) == 11.0
+
+    def test_falls_back_to_hermes_cli_timeout(self):
+        cfg = HonchoClientConfig(timeout=None)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"honcho": {"timeout": 77}},
+        ):
+            assert resolve_http_timeout(cfg) == 77.0
+
+    def test_request_timeout_alias_is_honored(self):
+        cfg = HonchoClientConfig(timeout=None)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"honcho": {"request_timeout": "55.5"}},
+        ):
+            assert resolve_http_timeout(cfg) == 55.5
+
+    def test_defaults_to_thirty_seconds(self):
+        cfg = HonchoClientConfig(timeout=None)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert resolve_http_timeout(cfg) == _DEFAULT_HTTP_TIMEOUT
+
+    def test_handles_none_config(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert resolve_http_timeout(None) == _DEFAULT_HTTP_TIMEOUT
+
+    def test_swallows_load_config_failure(self):
+        cfg = HonchoClientConfig(timeout=None)
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            assert resolve_http_timeout(cfg) == _DEFAULT_HTTP_TIMEOUT


### PR DESCRIPTION
## What does this PR do?

`HonchoMemoryProvider.shutdown` joined the dialectic / prefetch daemon threads with a fixed `timeout=5.0`, but the Honcho SDK HTTP client defaults to a 30s timeout (configurable via `HonchoClientConfig.timeout`, `honcho.timeout` / `requestTimeout`, or `HONCHO_TIMEOUT`). When the join expired before a pending HTTP call returned, the daemon thread was still mid-call once CPython entered `Py_FinalizeEx`, intermittently aborting the interpreter with SIGABRT during otherwise-clean shutdown. Issue #33485 isolated this to `recallMode: hybrid` where the dialectic background worker is the most reliable trigger; the reporter confirmed extending the join window to 30s or shrinking the HTTP timeout to 3s eliminates the abort, which matches the timing analysis.

This PR aligns the shutdown grace period with whatever timeout the Honcho client is actually using, while preserving a 5s floor:

- Extracts the existing timeout-resolution chain inside `get_honcho_client` into a reusable `resolve_http_timeout(config)` helper so shutdown and the SDK kwargs read from the same source.
- Switches `HonchoMemoryProvider.shutdown` to `t.join(timeout=max(5.0, resolve_http_timeout(self._config)))` for both `_prefetch_thread` and `_sync_thread`. The 5s floor preserves the original grace period when a user configures a very short HTTP timeout — the HTTP call cannot outlive that floor anyway, so the join is still bounded.
- The helper guards `import` failures and missing config so shutdown stays exception-free.

## Related Issue

Fixes #33485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/client.py` — added `resolve_http_timeout(config)` and routed `get_honcho_client` through it so SDK and shutdown agree on the effective HTTP timeout.
- `plugins/memory/honcho/__init__.py` — `HonchoMemoryProvider.shutdown` now waits `max(5.0, resolve_http_timeout(self._config))` before abandoning the dialectic / prefetch threads.
- `tests/honcho_plugin/test_shutdown_join_timeout.py` — new file with 10 regression tests covering explicit config timeout, hermes-cli fallback, default 30s, 5s floor, missing config, and `resolve_http_timeout` chain semantics.
- `scripts/release.py` — added this contributor email to `AUTHOR_MAP` so the contributor-attribution check has a GitHub username for the noreply address.

## How to Test

1. Configure Honcho with `recallMode: hybrid` (the default) so the dialectic worker is exercised.
2. Trigger shutdown while a dialectic HTTP call is in flight (e.g. point Honcho at an unreachable backend so the call sits idle until its 30s timeout, then exit the CLI). Before this PR the daemon thread was orphaned after 5s and CPython occasionally aborted with SIGABRT during `Py_FinalizeEx`. After this PR the join waits the full 30s, the worker exits cleanly, and the interpreter shuts down without abort.
3. Run the focused regression suite plus surrounding Honcho tests:

```bash
uv run --extra dev python -m pytest tests/honcho_plugin/test_shutdown_join_timeout.py -q
uv run --extra dev python -m pytest tests/honcho_plugin/ tests/test_honcho_session_context.py tests/test_honcho_client_config.py tests/agent/test_memory_user_id.py -q
uv run --extra dev ruff check plugins/memory/honcho/__init__.py plugins/memory/honcho/client.py tests/honcho_plugin/test_shutdown_join_timeout.py scripts/release.py
git diff --check
```

Regression-coverage check: temporarily reverting the `__init__.py` change makes 3 of the 4 `TestShutdownJoinTimeout` tests fail (the one that already expects 5s still passes), confirming the new tests pin the bug rather than the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.1 (Amazon Linux), Python 3.12 via uv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ uv run --extra dev python -m pytest tests/honcho_plugin/test_shutdown_join_timeout.py -q
..........                                                               [100%]
10 passed in 0.37s

$ uv run --extra dev python -m pytest tests/honcho_plugin/ tests/test_honcho_session_context.py tests/test_honcho_client_config.py tests/agent/test_memory_user_id.py -q
346 passed, 4 skipped in 10.33s

$ uv run --extra dev ruff check plugins/memory/honcho/__init__.py plugins/memory/honcho/client.py tests/honcho_plugin/test_shutdown_join_timeout.py scripts/release.py
All checks passed!
```

Note on overlap: PRs #7627 (close httpx pool), #31664 (route oneshot through `HonchoSessionManager.shutdown`), and #33543 (`os._exit` from oneshot to skip finalizers entirely) target the same SIGABRT class from different layers and are independent of this change. None of them adjusts the 5s join timeout, so this PR is complementary regardless of which lands first.

Made with [Cursor](https://cursor.com)