### PR TITLE
fix(cli): skills search identifier truncation + add --json output

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12467,6 +12467,9 @@ Examples:
         ],
     )
     skills_search.add_argument("--limit", type=int, default=10, help="Max results")
+    skills_search.add_argument(
+        "--json", action="store_true", help="Output results as JSON (full identifiers)"
+    )
 
     skills_install = skills_subparsers.add_parser("install", help="Install a skill")
     skills_install.add_argument(

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -244,12 +244,11 @@ def _prompt_for_category(c: Console, existing: List[str]) -> str:
 
 
 def do_search(query: str, source: str = "all", limit: int = 10,
-              console: Optional[Console] = None) -> None:
-    """Search registries and display results as a Rich table."""
+              json_output: bool = False, console: Optional[Console] = None) -> None:
+    """Search registries and display results as a Rich table or JSON."""
     from tools.skills_hub import GitHubAuth, create_source_router, unified_search
 
     c = console or _console
-    c.print(f"\n[bold]Searching for:[/] {query}")
 
     auth = GitHubAuth()
     sources = create_source_router(auth)
@@ -257,15 +256,35 @@ def do_search(query: str, source: str = "all", limit: int = 10,
         results = unified_search(query, sources, source_filter=source, limit=limit)
 
     if not results:
-        c.print("[dim]No skills found matching your query.[/]\n")
+        if json_output:
+            print("[]")
+        else:
+            c.print("[dim]No skills found matching your query.[/]\n")
         return
 
+    if json_output:
+        import json
+        data = [
+            {
+                "name": r.name,
+                "description": r.description,
+                "source": r.source,
+                "trust_level": r.trust_level,
+                "identifier": r.identifier,
+            }
+            for r in results
+        ]
+        print(json.dumps(data, indent=2))
+        return
+
+    c.print(f"\n[bold]Searching for:[/] {query}")
+
     table = Table(title=f"Skills Hub — {len(results)} result(s)")
-    table.add_column("Name", style="bold cyan")
-    table.add_column("Description", max_width=60)
-    table.add_column("Source", style="dim")
-    table.add_column("Trust", style="dim")
-    table.add_column("Identifier", style="dim")
+    table.add_column("Name", style="bold cyan", max_width=20)
+    table.add_column("Description", max_width=40)
+    table.add_column("Source", style="dim", width=10)
+    table.add_column("Trust", width=8)
+    table.add_column("Identifier", style="dim", no_wrap=True)
 
     for r in results:
         trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(r.trust_level, "dim")
@@ -1346,7 +1365,8 @@ def skills_command(args) -> None:
     if action == "browse":
         do_browse(page=args.page, page_size=args.size, source=args.source)
     elif action == "search":
-        do_search(args.query, source=args.source, limit=args.limit)
+        do_search(args.query, source=args.source, limit=args.limit,
+                  json_output=getattr(args, "json", False))
     elif action == "install":
         do_install(args.identifier, category=args.category, force=args.force,
                    skip_confirm=getattr(args, "yes", False),


### PR DESCRIPTION
## Summary
Fixes #33674 — The Identifier column in `hermes skills search` was truncated by Rich's automatic column width handling, cutting off the hash suffix needed for installation.

## Problem
Browse.sh skill identifiers like `browse-sh/weather.gov/get-forecast-1uezib` were displayed as `browse-sh/weathe…`, making the necessary hash invisible. Users copying the truncated identifier would get install failures.

## Fix
- Add `no_wrap=True` to Identifier column so full slug is visible
- Adjust other column widths (Name: 20, Description: 40, Source: 10, Trust: 8) to balance table layout
- Add `--json` flag for machine-readable output with full identifiers

## Testing
- `hermes skills search "weather.gov"` — Identifier column now shows full slug
- `hermes skills search --json "weather.gov"` — Returns JSON array with full identifiers

## Example output
```
┃ Name ┃ Description ┃ Source ┃ Trust ┃ Identifier ┃
┡━━━━━━┩━━━━━━━━━━━━┩━━━━━━━━┩━━━━━━┩━━━━━━━━━━━━┩
│ …    │ …           │ …      │ …     │ browse-sh/weather.gov/get-forecast-1uezib │  ← full!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)