### PR TITLE
ci(docker): avoid gha cache on arm64 PR builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -196,10 +196,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
-      # Build once, load into the local daemon for smoke testing.  Cached
-      # to gha with a per-arch scope; the push step below reuses every
-      # layer from this build.
-      - name: Build image (arm64, smoke test)
+      # Build once, load into the local daemon for smoke testing. PR arm64
+      # builds deliberately avoid the gha cache: cold-cache arm64 builds can
+      # outlive GitHub's short-lived Azure cache SAS token, then fail while
+      # reading or writing cache blobs before the smoke test can run.
+      - name: Build image (arm64, smoke test, uncached PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          platforms: linux/arm64
+          tags: ${{ env.IMAGE_NAME }}:test
+          build-args: |
+            HERMES_GIT_SHA=${{ github.sha }}
+
+      # Main/release builds still use the per-arch gha cache so the digest
+      # push below can reuse layers from this smoke-test build.
+      - name: Build image (arm64, smoke test, cached publish)
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .


### PR DESCRIPTION
## Summary
- Splits the arm64 Docker smoke-test build into PR and publish paths.
- Closes #33688 by disabling the GHA cache only for pull-request arm64 builds, where cold-cache builds can outlive the cache SAS token.

## Why
- The arm64 PR build can take long enough on a cold cache for GitHub's Azure cache SAS token to expire before BuildKit finishes reading or writing `type=gha` cache blobs.
- Push/release builds still need the per-arch cache so the publish digest build can reuse the smoke-test layers.

## Changes
- `.github/workflows/docker-publish.yml`: adds an uncached PR-only arm64 smoke-test build step.
- `.github/workflows/docker-publish.yml`: keeps the existing cached arm64 smoke-test build for non-PR publish events.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` — parsed `docker-publish.yml` and asserted the PR arm64 step has no `cache-from`/`cache-to`, while the publish arm64 step keeps both cache settings.
- `actionlint .github/workflows/docker-publish.yml` was not available locally (`actionlint not installed; skipped`).

## Scope
- In scope: arm64 Docker PR build reliability for cold GHA cache runs.
- Out of scope: changing amd64 caching, publish/release cache behavior, or switching cache backends.
