### PR TITLE
fix(discord): decouple thread history backfill from mention gating

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4787,10 +4787,9 @@ class DiscordAdapter(BasePlatformAdapter):
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
 
         # ── History backfill ─────────────────────────────────────────
-        # When require_mention is active, the bot only processes messages
-        # that @mention it.  Messages in the channel between bot turns are
-        # invisible to the session transcript.  To recover that context,
-        # fetch recent channel history and prepend it to the user message.
+        # Messages in the channel between bot turns are invisible to the
+        # session transcript.  To recover that context, fetch recent
+        # channel history and prepend it to the user message.
         #
         # The fetch window is: everything after the bot's last message in
         # the channel up to (but not including) the current trigger.  On
@@ -4812,13 +4811,8 @@ class DiscordAdapter(BasePlatformAdapter):
         _channel_context = None
         _is_dm = isinstance(message.channel, discord.DMChannel)
         if not _is_dm:
-            _needed_mention = (
-                require_mention
-                and not is_free_channel
-                and not in_bot_thread
-            )
             _backfill_enabled = self._discord_history_backfill()
-            if _needed_mention and _backfill_enabled:
+            if _backfill_enabled:
                 _backfill_text = await self._fetch_channel_context(
                     message.channel, before=message,
                 )

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -884,3 +884,34 @@ async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
         assert event.channel_context is None
 
 
+@pytest.mark.asyncio
+async def test_discord_thread_backfills_when_thread_require_mention_false(adapter, monkeypatch):
+    """Backfill must run for thread messages even when thread_require_mention is false.
+
+    Regression test for #33666: when thread_require_mention=false (default),
+    in_bot_thread evaluates to true, which previously gated backfill behind
+    _needed_mention — a condition that conflates mention-gating with context
+    recovery.  Threads where the bot participates freely still benefit from
+    backfilling recent thread history (e.g. messages during processing delays).
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+    adapter.config.extra["history_backfill"] = True
+
+    # Mark thread as a bot thread (bot has previously participated)
+    thread = FakeThread(channel_id=789, name="test-thread")
+    adapter._threads.mark("789")
+
+    adapter._fetch_channel_context = AsyncMock(
+        return_value="[Recent channel messages]\n[Alice] context",
+    )
+
+    message = make_message(channel=thread, content="hello in thread")
+    await adapter._handle_message(message)
+
+    # Backfill should run despite thread_require_mention=false
+    adapter._fetch_channel_context.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.channel_context == "[Recent channel messages]\n[Alice] context"
+
+


### PR DESCRIPTION
## What does this PR do?

Decouples history backfill from mention gating in the Discord adapter. When `thread_require_mention: false` (the default), backfill was silently disabled for all thread messages, leaving the bot without recent thread context.

Fixes #33666.

## Root Cause

`_needed_mention` was computed as:

```python
_needed_mention = (
    require_mention
    and not is_free_channel
    and not in_bot_thread
)
```

When `thread_require_mention=false`, `in_bot_thread=True` for any thread the bot has previously participated in, making `_needed_mention=False`. The backfill condition `if _needed_mention and _backfill_enabled:` then skipped backfill entirely.

This conflated two separate concerns:
1. **Mention gating**: should the bot respond to this message?
2. **Context recovery**: should the bot fetch recent channel history?

## Fix

Removed the `_needed_mention` gate from the backfill condition. Backfill now runs for all non-DM channels/threads when `history_backfill` is enabled, regardless of mention requirements. The `_fetch_channel_context()` function already has built-in limits (`history_backfill_limit`) and stops at the bot's last message, so running it more broadly is safe.

## Testing

- All 35 existing tests in `test_discord_free_response.py` pass (no regressions)
- Added `test_discord_thread_backfills_when_thread_require_mention_false` — regression test that verifies backfill runs for thread messages when `thread_require_mention=false`

## Code Intelligence

- Analyzed: `plugins/platforms/discord/adapter.py` — `_handle_message()` method, lines 4811-4826
- Callers: `_handle_message` is the main message handler, called on every incoming Discord message
- Blast radius: LOW — change is localized to the backfill gating condition; `_fetch_channel_context` behavior unchanged
- Related patterns: `_discord_history_backfill()` (line 3685), `_fetch_channel_context()` (line 3714), `_discord_thread_require_mention()` (line 3666)
