### PR TITLE
fix(cli): prioritize plugin commands above skills in Telegram menu

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -550,10 +550,23 @@ need to survive the visible menu cap ahead of lower-priority built-ins.
 def _prioritize_telegram_menu_commands(
     commands: list[tuple[str, str]],
 ) -> list[tuple[str, str]]:
+    """Sort commands by priority: built-in > plugins > skills.
+
+    Built-in commands in _TELEGRAM_MENU_PRIORITY get highest priority (0).
+    Plugin commands get middle priority (1) — they should appear before skills.
+    All other commands (skills) get lowest priority (2).
+    """
     priority = {
         _sanitize_telegram_name(name): index
         for index, name in enumerate(_TELEGRAM_MENU_PRIORITY)
     }
+    # Collect plugin command names for middle-priority treatment
+    plugin_names: set[str] = set()
+    for name, _description, _args_hint in _iter_plugin_command_entries():
+        tg_name = _sanitize_telegram_name(name)
+        if tg_name:
+            plugin_names.add(tg_name)
+
     return [
         command
         for _index, command in sorted(
@@ -566,6 +579,11 @@ def _prioritize_telegram_menu_commands(
             if item[1][0] in priority
             else (
                 1,
+                item[0],
+            )
+            if item[1][0] in plugin_names
+            else (
+                2,
                 item[0],
             ),
         )


### PR DESCRIPTION
## Summary
Fixes #33480 — Plugin slash commands were invisible in Telegram's command menu due to being truncated by the 30-command cap alongside skill commands.

## Problem
- `_prioritize_telegram_menu_commands` gave plugin commands priority 1 (same as skills)
- With ~48 total commands and a 30-command cap, plugins were pushed beyond position 30
- User-installed plugins never appeared in Telegram's `/` autocomplete menu

## Fix
Modified `_prioritize_telegram_menu_commands` to give plugin commands middle priority:
- **Priority 0**: Core built-in commands (`/new`, `/help`, `/status`, etc.) — always visible
- **Priority 1**: Plugin commands — visible when slots remain after core commands
- **Priority 2**: Skill commands — fill remaining slots

## Testing
Before: Plugin commands truncated at cap, invisible in menu
After: Plugin commands survive cap, appear before skills in menu

```python
# Verify priority order
from hermes_cli.commands import telegram_menu_commands
menu, hidden = telegram_menu_commands(max_commands=30)
# Plugin commands now appear in first 30 slots (if < 12 core commands)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)