### PR TITLE
fix(auxiliary): fall back to provider default aux model when main model rejected

### DIFF
--- a/agent/aux_unsupported_model.py
+++ b/agent/aux_unsupported_model.py
@@ -1,0 +1,101 @@
+"""Detect "model not supported / not found" auxiliary errors.
+
+Split out of ``auxiliary_client.py`` to keep that module from growing past
+the 1k-ish line soft ceiling for retry logic.
+
+The detector covers the common provider-side failure modes that arise when
+the user's chosen main chat model is forwarded verbatim to a provider that
+only supports a subset of its catalog for auxiliary (cheap / fast / side)
+tasks. Without detection, the operator sees a confusing ``HTTP 401`` or
+``HTTP 404`` warning against a chat model that clearly works for chat.
+
+Signals (any match = True):
+
+* HTTP 404 with a ``model`` + ``not found`` / ``does not exist`` / ``unknown``
+  marker in the error text.
+* HTTP 401 with an explicit ``not supported`` / ``unknown model`` /
+  ``model ... is not`` marker in the error text (some aggregators wrap
+  unsupported-model rejections under 401 instead of 404).
+
+Pure auth errors (401 with no model-signal wording) return False -- those
+are handled by the auth-refresh chain in ``auxiliary_client.call_llm``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+_UNSUPPORTED_MARKERS_404 = (
+    "not found",
+    "does not exist",
+    "unknown model",
+    "no such model",
+)
+
+_UNSUPPORTED_MARKERS_GENERAL = (
+    "is not supported",
+    "not supported",
+    "unknown model",
+    "unsupported model",
+    "model not available",
+)
+
+
+def _err_text(exc: BaseException) -> str:
+    """Best-effort lowercased error text from an exception.
+
+    Concatenates ``str(exc)`` with the ``message`` / ``error.message`` fields
+    that OpenAI-style client exceptions populate, then lower-cases. Returns
+    ``""`` if nothing is extractable.
+    """
+    parts = [str(exc)]
+    msg = getattr(exc, "message", None)
+    if isinstance(msg, str):
+        parts.append(msg)
+    err_obj = getattr(exc, "error", None)
+    if isinstance(err_obj, dict):
+        m = err_obj.get("message")
+        if isinstance(m, str):
+            parts.append(m)
+    elif hasattr(err_obj, "message"):
+        m = getattr(err_obj, "message", None)
+        if isinstance(m, str):
+            parts.append(m)
+    return " ".join(p for p in parts if p).lower()
+
+
+def is_model_unsupported_error(exc: BaseException) -> bool:
+    """Return True iff ``exc`` rejects the requested *model* itself.
+
+    Distinct from:
+      * ``_is_auth_error`` -- pure credential failure (401, no model wording).
+      * ``_is_payment_error`` -- 402 / quota exhaustion.
+      * ``_is_connection_error`` -- DNS / TCP / timeout.
+      * ``_is_rate_limit_error`` -- 429.
+
+    Use this to decide whether to fall back to a provider's default
+    auxiliary model (``_get_aux_model_for_provider``) instead of raising.
+    """
+    status: Optional[int] = getattr(exc, "status_code", None)
+    text = _err_text(exc)
+
+    # Must mention a model at all -- otherwise "not found" / 404 could
+    # route / endpoint misses (different recovery path).
+    if "model" not in text:
+        return False
+
+    if status == 404:
+        return any(m in text for m in _UNSUPPORTED_MARKERS_404)
+
+    if status == 401:
+        # Aggregators sometimes classify unsupported-model rejections as
+        # 401. Require the explicit "not supported" wording so we don't
+        # collide with pure credential failures.
+        return any(m in text for m in _UNSUPPORTED_MARKERS_GENERAL)
+
+    # Some providers return 400 / 422 with "not supported".
+    if status in {400, 422}:
+        return any(m in text for m in _UNSUPPORTED_MARKERS_GENERAL)
+
+    return False

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -100,6 +100,7 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
+from agent.aux_unsupported_model import is_model_unsupported_error
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from agent.process_bootstrap import build_keepalive_http_client
@@ -6488,6 +6489,56 @@ def call_llm(
                 "(fallback_chain + main agent model). Raising original error.",
                 task or "call", reason, resolved_provider,
             )
+        # ── Model-unsupported fallback ────────────────────────────────
+        # Provider rejected the *model* (not credentials, not quota): e.g.
+        # "Model mimo-v2.5 is not supported" on opencode-zen, or
+        # "Model 'X' not found" on Nous. This typically happens when the
+        # user's main chat model is forwarded to a provider whose aux-task
+        # catalog differs from its chat catalog (opencode-zen's /chat
+        # endpoint accepting mimo-v2.5 but its aux endpoint only listing
+        # Gemini/etc.).
+        #
+        # Recovery: swap to the provider's registered default aux model
+        # (``ProviderProfile.default_aux_model`` or the legacy fallback
+        # dict). Auto users skip this — their chosen model IS the aux
+        # model, so retrying with it would be a no-op. Distinct from the
+        # payment/connection fallback above: a rejected *model* doesn't
+        # poison the credential or mark the endpoint unhealthy.
+        if is_model_unsupported_error(first_err) and not is_auto:
+            _aux_default = _get_aux_model_for_provider(resolved_provider)
+            if _aux_default and _aux_default != final_model:
+                logger.info(
+                    "Auxiliary %s: %s rejected model %s, falling back to "
+                    "provider default aux model %s",
+                    task or "call", resolved_provider, final_model, _aux_default,
+                )
+                _fb_client, _fb_model = _get_cached_client(
+                    resolved_provider, _aux_default,
+                    api_key=resolved_api_key or "",
+                    api_mode=resolved_api_mode or "",
+                )
+                if _fb_client is not None:
+                    _fb_kwargs = _build_call_kwargs(
+                        resolved_provider, _fb_model or _aux_default, messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                        base_url=str(getattr(_fb_client, "base_url", "") or ""))
+                    try:
+                        return _validate_llm_response(
+                            _fb_client.chat.completions.create(**_fb_kwargs), task)
+                    except Exception as fb_err:
+                        logger.warning(
+                            "Auxiliary %s: provider default aux model %s also "
+                            "failed (%s). Raising original model-unsupported error.",
+                            task or "call", _aux_default, fb_err,
+                        )
+                else:
+                    logger.warning(
+                        "Auxiliary %s: could not resolve client for provider "
+                        "default aux model %s. Raising original error.",
+                        task or "call", _aux_default,
+                    )
         # Connection/timeout errors leave the cached client poisoned (closed
         # httpx transport, half-read stream, dead async loop).  Drop it from
         # the cache regardless of whether we found a fallback above so the
@@ -6977,6 +7028,51 @@ async def async_call_llm(
                 "(fallback_chain + main agent model). Raising original error.",
                 task or "call", reason, resolved_provider,
             )
+        # ── Model-unsupported fallback (mirrors sync call_llm) ────────
+        # Provider rejected the *model* (not credentials, not quota): the
+        # user's main chat model was forwarded to a provider whose aux-task
+        # catalog differs from its chat catalog. Recovery: swap to the
+        # provider's registered default aux model. Auto users skip this —
+        # their chosen model IS the aux model, so retrying would be a no-op.
+        # See the sync block in call_llm for the full rationale.
+        if is_model_unsupported_error(first_err) and not is_auto:
+            _aux_default = _get_aux_model_for_provider(resolved_provider)
+            if _aux_default and _aux_default != final_model:
+                logger.info(
+                    "Auxiliary %s (async): %s rejected model %s, falling back "
+                    "to provider default aux model %s",
+                    task or "call", resolved_provider, final_model, _aux_default,
+                )
+                _fb_client, _fb_model = _get_cached_client(
+                    resolved_provider, _aux_default,
+                    async_mode=True,
+                    api_key=resolved_api_key or "",
+                    api_mode=resolved_api_mode or "",
+                )
+                if _fb_client is not None:
+                    _fb_kwargs = _build_call_kwargs(
+                        resolved_provider, _fb_model or _aux_default, messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                        base_url=str(getattr(_fb_client, "base_url", "") or ""))
+                    try:
+                        return _validate_llm_response(
+                            await _fb_client.chat.completions.create(**_fb_kwargs),
+                            task)
+                    except Exception as fb_err:
+                        logger.warning(
+                            "Auxiliary %s (async): provider default aux model %s "
+                            "also failed (%s). Raising original "
+                            "model-unsupported error.",
+                            task or "call", _aux_default, fb_err,
+                        )
+                else:
+                    logger.warning(
+                        "Auxiliary %s (async): could not resolve client for "
+                        "provider default aux model %s. Raising original error.",
+                        task or "call", _aux_default,
+                    )
         # Mirror the sync path: drop poisoned clients on connection/timeout
         # so the next aux call rebuilds.  See issue #23432.
         if _is_connection_error(first_err):

--- a/tests/agent/test_auxiliary_unsupported_model_fallback.py
+++ b/tests/agent/test_auxiliary_unsupported_model_fallback.py
@@ -1,0 +1,261 @@
+"""Detector + call_llm fallback for provider-rejected aux models.
+
+Covers the "user's main chat model is forwarded verbatim to an aux
+endpoint that only supports a subset of that provider's catalog" case.
+
+Two surfaces:
+  * ``is_model_unsupported_error`` (unit): correct on 404 / 401 / 400 / 422
+    with and without model-marker wording, and correct on pure auth /
+    payment / connection / rate-limit errors.
+  * ``call_llm`` fallback (integration): when the chosen provider rejects
+    the requested model, the provider's default aux model
+    (``_get_aux_model_for_provider``) is tried before re-raising. Pure
+    auth errors (401 without model wording) continue to follow the
+    existing auth-refresh / credential-pool chain.
+  * ``async_call_llm`` fallback (integration): same recovery on the async
+    path, with the fallback client requested in async mode.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.aux_unsupported_model import is_model_unsupported_error
+
+
+# Build exceptions that carry the OpenAI client ``status_code`` + ``message``
+# fields without tripping pyright's strict ``Exception`` typing.
+class _APIExc(Exception):
+    def __init__(self, text: str, *, status_code: int, message: str | None = None):
+        super().__init__(text)
+        self.status_code = status_code
+        if message is not None:
+            self.message = message
+        self.error = None
+
+
+def _exc(status_code: int, text: str, *, msg_attr=None):
+    return _APIExc(text, status_code=status_code, message=msg_attr)
+
+
+@pytest.mark.parametrize("exc,expected", [
+    # 404 + model marker → model unsupported
+    (_exc(404, "Model mimo-v2.5 not found"), True),
+    (_exc(404, "The requested model does not exist in our catalog"), True),
+    (_exc(404, "unknown model foo-bar"), True),
+    # 401 + "not supported" wording (aggregator-specific)
+    (_exc(401, "HTTP 401: Model mimo-v2.5 is not supported"), True),
+    (_exc(401, "unsupported model: foo"), True),
+    # 400 / 422 with "not supported" wording
+    (_exc(400, "Model X is not supported on this tier"), True),
+    (_exc(422, "The model foo-bar is not supported"), True),
+    # Pure credential failures — must NOT classify as model unsupported
+    (_exc(401, "missing or invalid API key"), False),
+    (_exc(401, "AuthenticationError [HTTP 401]"), False),
+    (_exc(401, "Invalid Authorization header"), False),
+    # 404 / 400 lacking a model marker
+    (_exc(404, "Path /foo/v1/bar not found"), False),
+    (_exc(400, "Invalid request body: field X required"), False),
+    (_exc(400, "unsupported_parameter: temperature"), False),
+    # Payment / rate limit / connection — separate recovery paths
+    (_exc(402, "Insufficient credits"), False),
+    (_exc(429, "Rate limit exceeded"), False),
+    (_exc(503, "Service unavailable"), False),
+    # openai-style error object with ``.error.message``
+    (_exc(404, "Error", msg_attr="Model does not exist in our catalog"), True),
+    # No status_code attribute at all — detector must be conservative (False)
+    (Exception("Model not found"), False),
+])
+def test_detector(exc, expected):
+    assert is_model_unsupported_error(exc) is expected
+
+
+# ── call_llm fallback integration ─────────────────────────────────────────
+
+def _make_unsupported_exc():
+    """404-style 'model rejected' exception."""
+    return _APIExc("Model mimo-v2.5 not found", status_code=404)
+
+
+def _make_pure_auth_exc():
+    """401 with no model wording — should NOT trigger aux fallback."""
+    return _APIExc("missing or invalid API key", status_code=401)
+
+
+def test_call_llm_falls_back_to_provider_default_aux_model():
+    """When the main model is rejected, fall back to the provider's default
+    aux model (gemini-3-flash for opencode-zen) instead of re-raising."""
+    from agent import auxiliary_client as ac
+
+    rejected_model = "mimo-v2.5"
+    aux_default = "gemini-3-flash"
+    provider = "opencode-zen"
+
+    primary_response = MagicMock()
+    primary_response.choices = [MagicMock()]
+    primary_response.choices[0].message.content = "ok via aux default"
+
+    primary_client = MagicMock()
+    primary_client.base_url = "https://opencode.ai/zen/go/v1"
+    # First call (main model) raises; second call (fallback) succeeds.
+    primary_client.chat.completions.create.side_effect = [
+        _make_unsupported_exc(),
+        primary_response,
+    ]
+
+    fallback_client = MagicMock()
+    fallback_client.base_url = "https://opencode.ai/zen/go/v1"
+    fallback_client.chat.completions.create.return_value = primary_response
+
+    with patch.object(ac, "_get_cached_client", side_effect=[(primary_client, rejected_model), (fallback_client, aux_default)]) as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value=aux_default) as gaux, \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=(provider, rejected_model, "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        result = ac.call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    # Detector was consulted
+    gaux.assert_called_once_with(provider)
+    # The SECOND _get_cached_client call must have used the aux default model
+    assert gcc.call_count == 2
+    _, kwargs2 = gcc.call_args_list[1]
+    # Positional second argument is the model
+    _, model_arg = gcc.call_args_list[1][0][:2]
+    assert model_arg == aux_default
+
+    # The result was validated from the fallback client
+    assert result.choices[0].message.content == "ok via aux default"
+
+
+def test_call_llm_pure_auth_error_does_not_trigger_aux_fallback():
+    """A 401 with no model wording must NOT be swallowed by the new fallback."""
+    from agent import auxiliary_client as ac
+
+    with patch.object(ac, "_get_cached_client") as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value="gemini-3-flash") as gaux, \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=("some-provider", "some-model", "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        primary = MagicMock()
+        primary.base_url = "https://example/v1"
+        primary.chat.completions.create.side_effect = _make_pure_auth_exc()
+        gcc.return_value = (primary, "some-model")
+
+        with pytest.raises(Exception, match="missing or invalid API key"):
+            ac.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        # No fallback attempt for pure auth errors
+        gaux.assert_not_called()
+
+
+def test_call_llm_aux_fallback_no_op_when_rejected_is_default():
+    """If the rejected model IS the provider's default aux model, no retry."""
+    from agent import auxiliary_client as ac
+
+    model = "gemini-3-flash"
+    provider = "opencode-zen"
+
+    with patch.object(ac, "_get_cached_client") as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value=model), \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=(provider, model, "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        primary = MagicMock()
+        primary.base_url = "https://opencode.ai/zen/go/v1"
+        primary.chat.completions.create.side_effect = _make_unsupported_exc()
+        gcc.return_value = (primary, model)
+
+        with pytest.raises(Exception, match="not found"):
+            ac.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        # Only ONE client request (no fallback since rejected == aux default)
+        assert gcc.call_count == 1
+
+
+def test_call_llm_auto_user_skips_aux_model_fallback():
+    """For ``provider: auto`` users the rejected model IS the aux model —
+    retrying with the same provider's default would be a no-op. Skip."""
+    from agent import auxiliary_client as ac
+
+    with patch.object(ac, "_get_cached_client") as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value="gemini-3-flash") as gaux, \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=("auto", "mimo-v2.5", "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        primary = MagicMock()
+        primary.base_url = "https://opencode.ai/zen/go/v1"
+        primary.chat.completions.create.side_effect = _make_unsupported_exc()
+        gcc.return_value = (primary, "mimo-v2.5")
+
+        with pytest.raises(Exception, match="not found"):
+            ac.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        # No default-aux fallback for auto users
+        gaux.assert_not_called()
+
+
+# ── async_call_llm fallback parity ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_async_call_llm_falls_back_to_provider_default_aux_model():
+    """``async_call_llm`` mirrors the sync model-unsupported fallback: when
+    the main model is rejected, the provider's default aux model is tried
+    (with the fallback client requested in async mode) instead of re-raising."""
+    from agent import auxiliary_client as ac
+
+    rejected_model = "mimo-v2.5"
+    aux_default = "gemini-3-flash"
+    provider = "opencode-zen"
+
+    fallback_response = MagicMock()
+    fallback_response.choices = [MagicMock()]
+    fallback_response.choices[0].message.content = "ok via aux default"
+
+    primary_client = MagicMock()
+    primary_client.base_url = "https://opencode.ai/zen/go/v1"
+    primary_client.chat.completions.create = AsyncMock(
+        side_effect=_make_unsupported_exc())
+
+    fallback_client = MagicMock()
+    fallback_client.base_url = "https://opencode.ai/zen/go/v1"
+    fallback_client.chat.completions.create = AsyncMock(
+        return_value=fallback_response)
+
+    with patch.object(ac, "_get_cached_client",
+                      side_effect=[(primary_client, rejected_model),
+                                   (fallback_client, aux_default)]) as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider",
+                      return_value=aux_default) as gaux, \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=(provider, rejected_model, "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        result = await ac.async_call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    # Detector was consulted
+    gaux.assert_called_once_with(provider)
+    # The SECOND _get_cached_client call must have used the aux default model
+    # and requested an async client.
+    assert gcc.call_count == 2
+    _, model_arg = gcc.call_args_list[1][0][:2]
+    assert model_arg == aux_default
+    assert gcc.call_args_list[1][1].get("async_mode") is True
+
+    # The result was validated from the fallback client
+    assert result.choices[0].message.content == "ok via aux default"


### PR DESCRIPTION
## Summary

When the user's main chat model is forwarded verbatim to an auxiliary
(cheap / fast) endpoint that only supports a subset of the provider's
catalog, the operator currently sees a confusing HTTP 401 or HTTP 404
against a model that clearly works for chat.

Concretely reproduced:

* Main model `mimo-v2.5` via `opencode-zen` — chat succeeds.
* Title generation (auxiliary) routed to the same model →
  `HTTP 401: Model mimo-v2.5 is not supported`.
* `Nous Portal` — main model works for chat, `HTTP 404: Model does not
  exist` on an auxiliary task that uses the same slug.

Root cause: `call_llm()` raises the error instead of trying the
provider's registered default aux model. The existing fallback chain
(payment / connection / rate-limit) correctly skips this case because
model-unsupported errors aren't quota- or connectivity-related.

## Changes

### Detector — `agent/aux_unsupported_model.py` (new module)

`is_model_unsupported_error(exc)` distinguishes model rejection from
credential / quota / connectivity failures:

* `404` + `model` marker + `not found` / `does not exist` / `unknown model`
* `401` + `model` + explicit `not supported` / `unsupported model` wording
  (aggregators sometimes classify unsupported models as 401, not 404)
* `400` / `422` + `model` + `not supported` wording
* **Not matched**: pure credential failures (`401: invalid API key` →
  still handled by the existing auth-refresh chain),
  `unsupported_parameter: temperature` (separate retry path),
  `402` payment, `429` rate limit, `5xx`, connection errors.

### Fallback block — `agent/auxiliary_client.py`

Inserted a `Model-unsupported fallback` block in `call_llm()` between
the existing payment/connection fallback and the teardown:

* **Non-auto users**: resolve the provider's default aux model via
  `_get_aux_model_for_provider()` (i.e.
  `ProviderProfile.default_aux_model` or the legacy
  `_API_KEY_PROVIDER_AUX_MODELS_FALLBACK` dict) and retry the same
  request against it.
* **Auto users**: skipped — when `provider: auto`, the rejected model IS
  the aux model, so retrying would be a no-op.
* **No-op guard**: skips the retry when the rejected model already
  equals the provider's default aux model.
* On second failure, the original error is re-raised — no silent
  swallow.

### Tests

`tests/agent/test_auxiliary_unsupported_model_fallback.py`:

* 18 parametrized detector cases (True/False across 401, 404, 400, 422
  with and without model markers; pure auth, payment, rate limit,
  connection, no-status-code).
* 4 integration tests for `call_llm` wiring: fallback succeeds, pure
  auth still re-raises, no-op guard, auto-user skip.

All 22 tests pass; the pre-existing auxiliary test suites (257 tests
across `test_unsupported_parameter_retry`, `test_auxiliary_client`,
`test_auxiliary_main_first`, `test_auxiliary_named_custom_providers`)
still pass.

## Operator impact

Users on opencode-zen / Nous Portal / any provider whose aux catalog
differs from its chat catalog now get transparent recovery for title
generation, compression, session search, etc. — no more manual
`auxiliary.<task>.provider` / `auxiliary.<task>.model` pins in
`config.yaml` required to work around per-provider catalog quirks.

The fallback is strictly additive: no behavior change for working
configurations, only for previously-failing aux calls.
