### PR TITLE
fix: gateway drain waits for in-flight media uploads before --replace restart

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2165,6 +2165,10 @@ class BasePlatformAdapter(ABC):
         # construction (gateway/run.py). Default to "interrupt" so a stray
         # pre-sync read matches the single-knob default rather than silently
         # queueing.
+        # Count of in-flight media deliveries (chunked file uploads, etc.).
+        # GatewayRunner._drain_active_agents waits for this to reach zero so
+        # a --replace restart doesn't kill an ongoing upload mid-flight.
+        self._pending_media_deliveries: int = 0
         self._busy_text_mode: str = (
             os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "interrupt").strip().lower()
             or "interrupt"
@@ -4725,23 +4729,35 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(media_path).suffix.lower()
                         if should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
-                            media_result = await self.send_voice(
-                                chat_id=event.source.chat_id,
-                                audio_path=media_path,
-                                metadata=_final_thread_metadata,
-                            )
+                            self._pending_media_deliveries += 1
+                            try:
+                                media_result = await self.send_voice(
+                                    chat_id=event.source.chat_id,
+                                    audio_path=media_path,
+                                    metadata=_final_thread_metadata,
+                                )
+                            finally:
+                                self._pending_media_deliveries -= 1
                         elif ext in _VIDEO_EXTS:
-                            media_result = await self.send_video(
-                                chat_id=event.source.chat_id,
-                                video_path=media_path,
-                                metadata=_final_thread_metadata,
-                            )
+                            self._pending_media_deliveries += 1
+                            try:
+                                media_result = await self.send_video(
+                                    chat_id=event.source.chat_id,
+                                    video_path=media_path,
+                                    metadata=_final_thread_metadata,
+                                )
+                            finally:
+                                self._pending_media_deliveries -= 1
                         else:
-                            media_result = await self.send_document(
-                                chat_id=event.source.chat_id,
-                                file_path=media_path,
-                                metadata=_final_thread_metadata,
-                            )
+                            self._pending_media_deliveries += 1
+                            try:
+                                media_result = await self.send_document(
+                                    chat_id=event.source.chat_id,
+                                    file_path=media_path,
+                                    metadata=_final_thread_metadata,
+                                )
+                            finally:
+                                self._pending_media_deliveries -= 1
 
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
@@ -4755,17 +4771,25 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
-                            await self.send_video(
-                                chat_id=event.source.chat_id,
-                                video_path=file_path,
-                                metadata=_final_thread_metadata,
-                            )
+                            self._pending_media_deliveries += 1
+                            try:
+                                await self.send_video(
+                                    chat_id=event.source.chat_id,
+                                    video_path=file_path,
+                                    metadata=_final_thread_metadata,
+                                )
+                            finally:
+                                self._pending_media_deliveries -= 1
                         else:
-                            await self.send_document(
-                                chat_id=event.source.chat_id,
-                                file_path=file_path,
-                                metadata=_final_thread_metadata,
-                            )
+                            self._pending_media_deliveries += 1
+                            try:
+                                await self.send_document(
+                                    chat_id=event.source.chat_id,
+                                    file_path=file_path,
+                                    metadata=_final_thread_metadata,
+                                )
+                            finally:
+                                self._pending_media_deliveries -= 1
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2569,7 +2569,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        # Track active session leases for interrupt management
         self._active_session_leases: Dict[str, Any] = {}
+        # Count of in-flight media deliveries (file uploads) happening after the
+        # agent slot has been released.  _drain_active_agents waits for this to
+        # reach zero so a --replace restart doesn't kill an ongoing upload.
+        self._pending_media_count: int = 0
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Last successfully-resolved (non-empty) model, keyed by session. Used
         # as a fallback when a fresh config read transiently returns an empty
@@ -4499,12 +4504,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while (self._running_agents or self._pending_media_count > 0 or self._adapter_pending_media() > 0) and asyncio.get_running_loop().time() < deadline:
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+        timed_out = bool(self._running_agents or self._pending_media_count > 0 or self._adapter_pending_media() > 0)
         _maybe_update_status(force=True)
         return snapshot, timed_out
+
+    def _adapter_pending_media(self) -> int:
+        """Return total count of in-flight media deliveries across all adapters."""
+        total = 0
+        for adapter in self.adapters.values():
+            total += getattr(adapter, "_pending_media_deliveries", 0)
+        return total
 
     def _interrupt_running_agents(self, reason: str) -> None:
         for session_key, agent in list(self._running_agents.items()):
@@ -10096,9 +10108,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if response:
                     _media_adapter = self.adapters.get(source.platform)
                     if _media_adapter:
-                        await self._deliver_media_from_response(
-                            response, event, _media_adapter,
-                        )
+                        self._pending_media_count += 1
+                        try:
+                            await self._deliver_media_from_response(
+                                response, event, _media_adapter,
+                            )
+                        finally:
+                            self._pending_media_count -= 1
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.


### PR DESCRIPTION
## Problem

When the gateway receives a `--replace` signal (e.g. on restart), `_drain_active_agents()` only waits for `_running_agents` to be empty. However, `_release_running_agent_state()` is called as soon as the LLM agent finishes generating its response — **before** any media files (PDFs, ZIPs, etc.) are uploaded and sent to the user.

This means a `--replace` restart can kill an in-progress chunked file upload mid-flight, causing the file to never be delivered.

### Reproduction

1. Ask the agent to send a large file (e.g. a 17 MB PDF) via `MEDIA:/path/to/file.pdf`
2. While the chunked upload is in progress (after the text reply is sent), trigger a gateway restart
3. The upload is killed — the file never arrives

This was observed in production with QQBot chunked uploads (`upload_prepare` → PUT parts → `complete_upload`). The log showed:
```
INFO: All 2 parts uploaded, completing…
```
...then silence as the gateway restarted before `complete_upload` could finish.

## Fix

### `gateway/platforms/base.py`
- Add `_pending_media_deliveries: int = 0` counter to `BasePlatformAdapter.__init__`
- Wrap all `send_document()`, `send_video()`, and `send_voice()` calls in `_process_message_background` with `try/finally` blocks that increment/decrement the counter

### `gateway/run.py`
- Add `_pending_media_count: int = 0` counter to `GatewayRunner.__init__`
- Add `_adapter_pending_media()` helper that sums `_pending_media_deliveries` across all adapters
- Update `_drain_active_agents()` to also wait for both counters to reach zero before declaring drain complete
- Wrap the `_deliver_media_from_response()` call in the streaming path with the same `try/finally` pattern

## Result

The gateway now waits for all in-flight media uploads to complete before allowing a `--replace` restart to proceed. The drain timeout (`TimeoutStopSec=90` in the systemd service) still applies as a safety bound.