### PR TITLE
fix(website): pin serialize-javascript and uuid via npm overrides (salvage of #30036)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12564,19 +12564,6 @@
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -16895,15 +16882,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17921,12 +17899,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -19405,12 +19383,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,10 @@
     "@docusaurus/types": "3.9.2",
     "typescript": "~5.6.2"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^14.0.0"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## Summary

Salvages the website half of @stephenschoettler's PR #30036 — pins two vulnerable transitive deps in `website/` via npm `overrides`, resolving two open Dependabot alerts.

## Vulns resolved

| Package | Before | After | Advisory |
|---------|--------|-------|----------|
| `serialize-javascript` | 6.0.2 | 7.0.5 | high RCE via `RegExp.flags`+`Date.prototype.to*`, medium DoS |
| `uuid` | 8.3.2 | 14.0.0 | medium buffer-bounds miss in v3/v5/v6 when `buf` is provided |

## Changes

- `website/package.json` — adds an `overrides` block pinning the two packages
- `website/package-lock.json` — regenerated fresh against current `main` (not the stale 7-day-old lockfile from #30036; several Dependabot bumps have landed since)

## Validation

- `npm install --package-lock-only` clean — `serialize-javascript` resolves to `7.0.5`, `uuid` to `14.0.0`
- `npm audit --package-lock-only --json` — both target packages no longer appear in the vulnerability map
- `npm ci` + `npm run build` — build exits 0; only pre-existing Docusaurus broken-link warnings, no new errors

## Why salvaged this way

PR #30036 also fixed the TUI `--expose-gc` test expectation. That half is already on main (test at `tests/hermes_cli/test_tui_npm_install.py:171` already asserts the new contract, passes), so this PR is web-only. The lockfile was regenerated rather than cherry-picked because the original lockfile diff was 7 days behind several Dependabot bumps that landed on main since.

## Attribution

@stephenschoettler authored the original `overrides` block (PR #30036). Original PR will be closed with credit after merge.
