### PR TITLE
fix(agent): ignore non-positive auxiliary timeouts

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -115,6 +115,18 @@ def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
         return False
 
 
+def _normalize_timeout_value(timeout: Any) -> Any:
+    """Return a provider timeout only when it is a positive numeric value.
+
+    The auxiliary layer treats ``0`` and negative values as "no explicit
+    timeout override" so config can disable per-request timeout propagation
+    without accidentally sending an already-expired deadline to the SDK.
+    """
+    if isinstance(timeout, (int, float)) and timeout > 0:
+        return timeout
+    return None
+
+
 def _extract_url_query_params(url: str):
     """Extract query params from URL, return (clean_url, default_query dict or None)."""
     parsed = urlparse(url)
@@ -655,7 +667,7 @@ class _CodexCompletionsAdapter:
         # by auxiliary calls such as context compression; if the timeout is not
         # forwarded and enforced, a Codex Responses stream can sit behind a
         # dead-looking CLI until the user force-interrupts the whole session.
-        timeout = kwargs.get("timeout")
+        timeout = _normalize_timeout_value(kwargs.get("timeout"))
         if timeout is not None:
             resp_kwargs["timeout"] = timeout
 
@@ -731,7 +743,7 @@ class _CodexCompletionsAdapter:
         text_parts: List[str] = []
         tool_calls_raw: List[Any] = []
         usage = None
-        total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
+        total_timeout = _normalize_timeout_value(timeout)
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
         timed_out = threading.Event()
         timeout_timer: Optional[threading.Timer] = None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2382,6 +2382,28 @@ class TestCodexAdapterReasoningTranslation:
         assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
         assert captured.get("include") == ["reasoning.encrypted_content"]
 
+    @pytest.mark.parametrize("timeout_value", [0, 0.0, -1, -3.5])
+    def test_non_positive_timeout_is_not_forwarded(self, timeout_value):
+        """A zero or negative auxiliary timeout should behave like 'no override'.
+
+        That keeps config-driven timeout disabling from sending an already-
+        expired deadline into the SDK request kwargs.
+        """
+        adapter, captured = self._build_adapter()
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            timeout=timeout_value,
+        )
+        assert "timeout" not in captured
+
+    def test_positive_timeout_is_forwarded(self):
+        adapter, captured = self._build_adapter()
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            timeout=12.5,
+        )
+        assert captured.get("timeout") == 12.5
+
 
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on


### PR DESCRIPTION
## What does this PR do?

Prevents auxiliary provider requests from forwarding non-positive timeout values into the SDK. `timeout: 0` and negative values now behave like “no explicit timeout override,” which avoids sending an already-expired deadline into the Codex auxiliary path.

## Related Issue

Fixes #33227

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_normalize_timeout_value()` in `agent/auxiliary_client.py` and used it for both Codex request kwargs and auxiliary stream deadline tracking.
- Documented the zero/negative timeout behavior in the helper docstring.
- Added regression coverage in `tests/agent/test_auxiliary_client.py` for non-positive and positive timeout forwarding.

## How to Test

1. Run `python -m pytest -o addopts='' tests/agent/test_auxiliary_client.py -k TestCodexAdapterReasoningTranslation`
2. Confirm the selected adapter tests pass, including the new timeout regressions.
3. Run `python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 / Python 3.11.9

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m pytest -o addopts='' tests/agent/test_auxiliary_client.py -k TestCodexAdapterReasoningTranslation` → 17 passed, 166 deselected
- `python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` → success
