### PR TITLE
feat: allow Feishu group chat allowlist

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6456,8 +6456,8 @@ class GatewayRunner:
 
         user_id = source.user_id
 
-        # Telegram (and similar) authorize entire group/forum/channel chats
-        # by chat ID via TELEGRAM_GROUP_ALLOWED_CHATS / QQ_GROUP_ALLOWED_USERS.
+        # Telegram, Feishu, and similar platforms authorize entire
+        # group/forum/channel chats by chat ID via *_GROUP_ALLOWED_CHATS.
         # That allowlist is chat-scoped, so it must work even when
         # source.user_id is None — Telegram emits anonymous-admin posts,
         # sender_chat traffic, and channel broadcasts with no `from_user`,
@@ -6469,6 +6469,7 @@ class GatewayRunner:
         if source.chat_type in {"group", "forum", "channel"} and source.chat_id:
             chat_allowlist_env = {
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
+                Platform.FEISHU: "FEISHU_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
@@ -6509,6 +6510,7 @@ class GatewayRunner:
         }
         platform_group_chat_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
+            Platform.FEISHU: "FEISHU_GROUP_ALLOWED_CHATS",
             Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
         }
         platform_allow_all_map = {
@@ -6708,6 +6710,7 @@ class GatewayRunner:
                     "TELEGRAM_GROUP_ALLOWED_USERS",
                     "TELEGRAM_GROUP_ALLOWED_CHATS",
                 ),
+                Platform.FEISHU: ("FEISHU_GROUP_ALLOWED_CHATS",),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
             if os.getenv(platform_env_map.get(platform, ""), "").strip():

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -18,6 +18,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "SIGNAL_ALLOWED_USERS",
         "SIGNAL_GROUP_ALLOWED_USERS",
         "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "FEISHU_GROUP_ALLOWED_CHATS",
         "EMAIL_ALLOWED_USERS",
         "SMS_ALLOWED_USERS",
         "MATTERMOST_ALLOWED_USERS",
@@ -274,6 +275,81 @@ def test_telegram_group_chat_allowlist_authorizes_group_chat_without_user_allowl
     )
 
     assert runner._is_user_authorized(source) is True
+
+
+def test_feishu_group_chat_allowlist_authorizes_group_chat_without_user_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("FEISHU_ALLOW_ALL_USERS", "false")
+    monkeypatch.setenv("FEISHU_GROUP_ALLOWED_CHATS", "oc_allowed_chat")
+
+    runner, _adapter = _make_runner(
+        Platform.FEISHU,
+        GatewayConfig(platforms={Platform.FEISHU: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        user_id="ou_stranger",
+        chat_id="oc_allowed_chat",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_feishu_group_chat_allowlist_does_not_authorize_other_groups(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("FEISHU_ALLOW_ALL_USERS", "false")
+    monkeypatch.setenv("FEISHU_GROUP_ALLOWED_CHATS", "oc_allowed_chat")
+
+    runner, _adapter = _make_runner(
+        Platform.FEISHU,
+        GatewayConfig(platforms={Platform.FEISHU: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        user_id="ou_stranger",
+        chat_id="oc_other_chat",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is False
+
+
+def test_feishu_group_chat_allowlist_does_not_authorize_dms(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("FEISHU_ALLOW_ALL_USERS", "false")
+    monkeypatch.setenv("FEISHU_GROUP_ALLOWED_CHATS", "oc_allowed_chat")
+
+    runner, _adapter = _make_runner(
+        Platform.FEISHU,
+        GatewayConfig(platforms={Platform.FEISHU: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        user_id="ou_stranger",
+        chat_id="oc_allowed_chat",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is False
+
+
+def test_feishu_group_chat_allowlist_makes_unauthorized_dms_silent(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("FEISHU_GROUP_ALLOWED_CHATS", "oc_allowed_chat")
+
+    runner, _adapter = _make_runner(
+        Platform.FEISHU,
+        GatewayConfig(platforms={Platform.FEISHU: PlatformConfig(enabled=True)}),
+    )
+
+    assert runner._get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore"
 
 
 def test_telegram_group_chat_allowlist_authorizes_anonymous_sender(monkeypatch):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -332,6 +332,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `FEISHU_ENCRYPT_KEY` | Optional encryption key for webhook mode |
 | `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode |
 | `FEISHU_ALLOWED_USERS` | Comma-separated Feishu user IDs allowed to message the bot |
+| `FEISHU_GROUP_ALLOWED_CHATS` | Comma-separated Feishu group chat IDs allowed to message the bot |
 | `FEISHU_ALLOW_BOTS` | `none` (default) / `mentions` / `all` — accept inbound messages from other bots. See [bot-to-bot messaging](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
 | `FEISHU_REQUIRE_MENTION` | `true` (default) / `false` — whether group messages must @mention the bot. Override per-chat via `group_rules.<chat_id>.require_mention`. |
 | `FEISHU_HOME_CHANNEL` | Feishu chat ID for cron delivery and notifications |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -155,6 +155,14 @@ FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 
 If you leave the allowlist empty, anyone who can reach the bot may be able to use it. In group chats, the allowlist is checked against the sender's open_id before the message is processed.
 
+To allow a specific group chat without opening direct messages from unknown users, set a chat ID allowlist:
+
+```bash
+FEISHU_GROUP_ALLOWED_CHATS=oc_xxx,oc_yyy
+```
+
+This authorizes messages from the listed group chats while leaving direct-message access governed by `FEISHU_ALLOWED_USERS`, pairing, or `FEISHU_ALLOW_ALL_USERS`.
+
 ### Webhook Encryption Key
 
 When running in webhook mode, set an encryption key to enable signature verification of inbound webhook payloads:
@@ -488,6 +496,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `FEISHU_DOMAIN` | — | `feishu` | `feishu` (China) or `lark` (international) |
 | `FEISHU_CONNECTION_MODE` | — | `websocket` | `websocket` or `webhook` |
 | `FEISHU_ALLOWED_USERS` | — | _(empty)_ | Comma-separated open_id list for user allowlist |
+| `FEISHU_GROUP_ALLOWED_CHATS` | — | _(empty)_ | Comma-separated chat ID allowlist for Feishu group chats |
 | `FEISHU_ALLOW_BOTS` | — | `none` | Accept messages from other bots: `none`, `mentions`, or `all` |
 | `FEISHU_REQUIRE_MENTION` | — | `true` | Whether group messages must @mention the bot |
 | `FEISHU_HOME_CHANNEL` | — | — | Chat ID for cron/notification output |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -332,6 +332,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `FEISHU_ENCRYPT_KEY` | webhook 模式的可选加密密钥 |
 | `FEISHU_VERIFICATION_TOKEN` | webhook 模式的可选验证 token |
 | `FEISHU_ALLOWED_USERS` | 允许向 bot 发送消息的逗号分隔飞书用户 ID |
+| `FEISHU_GROUP_ALLOWED_CHATS` | 允许向 bot 发送消息的逗号分隔飞书群聊 ID |
 | `FEISHU_ALLOW_BOTS` | `none`（默认）/`mentions`/`all`——接受来自其他 bot 的入站消息。参见 [bot 间消息传递](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
 | `FEISHU_REQUIRE_MENTION` | `true`（默认）/`false`——群组消息是否必须 @mention bot。可通过 `group_rules.<chat_id>.require_mention` 按聊天覆盖。 |
 | `FEISHU_HOME_CHANNEL` | cron 投递和通知的飞书聊天 ID |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
@@ -155,6 +155,14 @@ FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 
 如果白名单为空，任何能访问机器人的人都可能使用它。在群聊中，消息处理前会根据发送者的 open_id 检查白名单。
 
+如需允许特定群聊，但不开放陌生用户私信，可设置群聊 ID 白名单：
+
+```bash
+FEISHU_GROUP_ALLOWED_CHATS=oc_xxx,oc_yyy
+```
+
+这会允许来自所列群聊的消息；私信访问仍由 `FEISHU_ALLOWED_USERS`、配对机制或 `FEISHU_ALLOW_ALL_USERS` 控制。
+
 ### Webhook 加密密钥
 
 在 webhook 模式下运行时，设置加密密钥以启用入站 webhook payload 的签名验证：
@@ -488,6 +496,7 @@ platforms:
 | `FEISHU_DOMAIN` | — | `feishu` | `feishu`（中国）或 `lark`（国际版） |
 | `FEISHU_CONNECTION_MODE` | — | `websocket` | `websocket` 或 `webhook` |
 | `FEISHU_ALLOWED_USERS` | — | _（空）_ | 用户白名单的逗号分隔 open_id 列表 |
+| `FEISHU_GROUP_ALLOWED_CHATS` | — | _（空）_ | 飞书群聊 ID 白名单，逗号分隔 |
 | `FEISHU_ALLOW_BOTS` | — | `none` | 接受其他机器人消息：`none`、`mentions` 或 `all` |
 | `FEISHU_REQUIRE_MENTION` | — | `true` | 群消息是否必须 @提及 机器人 |
 | `FEISHU_HOME_CHANNEL` | — | — | cron/通知输出的聊天 ID |


### PR DESCRIPTION
## Summary
- add `FEISHU_GROUP_ALLOWED_CHATS` as a Feishu group chat allowlist alongside existing per-user allowlists
- keep direct-message access governed by Feishu user allowlists, pairing, or allow-all settings
- document the new environment variable in English and zh-Hans docs

## Test Plan
- `python -m pytest tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_setup_feishu.py -q -o 'addopts='`
