### PR TITLE
fix(cli): resolve aggregator models via custom_providers and live /v1/models when models.dev is stale

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -31,6 +31,7 @@ from hermes_cli.providers import (
     determine_api_mode,
     get_label,
     is_aggregator,
+    normalize_provider,
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
@@ -1070,6 +1071,42 @@ def switch_model(
                                 resolved_in_current_catalog = True
                                 break
 
+            # Aggregator live API fallback: models.dev may be stale (e.g.
+            # opencode-zen's models.dev catalog has "mimo-v2.5-free" but the
+            # live /v1/models endpoint returns bare "mimo-v2.5"). Also check
+            # custom_providers model dicts which are authoritative for the
+            # user's configured aggregators.
+            if not resolved_in_current_catalog:
+                new_model_lower = new_model.lower()
+                # Check custom_providers model dicts
+                if custom_providers:
+                    for cp in custom_providers:
+                        if not isinstance(cp, dict):
+                            continue
+                        cp_models = cp.get("models", {})
+                        if isinstance(cp_models, dict):
+                            for mid in cp_models:
+                                if mid.lower() == new_model_lower:
+                                    resolved_in_current_catalog = True
+                                    break
+                        if resolved_in_current_catalog:
+                            break
+                # Live API fallback for aggregator providers with a base_url
+                if not resolved_in_current_catalog and current_base_url:
+                    try:
+                        from agent.model_metadata import fetch_endpoint_model_metadata
+                        live_models = fetch_endpoint_model_metadata(
+                            current_base_url, current_api_key,
+                        )
+                        if live_models:
+                            for mid in live_models:
+                                if mid.lower() == new_model_lower:
+                                    new_model = mid
+                                    resolved_in_current_catalog = True
+                                    break
+                    except Exception:
+                        pass
+
         # --- Step d.5: configured-provider exact-match detection (#45006) ---
         # If the typed model is declared in user/custom provider config, route
         # to that provider BEFORE detect_provider_for_model() guesses from
@@ -1287,11 +1324,23 @@ def switch_model(
             for entry in custom_providers:
                 if not isinstance(entry, dict):
                     continue
-                # Match by provider slug (custom:<name>) or by base_url
+                # Match by provider slug (custom:<name>), direct name match,
+                # normalized provider name, or by base_url.
                 entry_name = entry.get("name", "")
                 entry_slug = f"custom:{entry_name}" if entry_name else ""
                 entry_url = entry.get("base_url", "")
-                if entry_slug == target_provider or entry_url == base_url:
+                normalized_target = normalize_provider(target_provider) if target_provider else ""
+                # Strip "custom:" prefix for suffix comparison — normalise
+                # always lowercases so "Custom:OpenRouter" becomes
+                # "custom:openrouter" while entry_name is just "openrouter".
+                target_suffix = target_provider.split(":", 1)[-1].lower() if target_provider else ""
+                if (
+                    entry_slug == target_provider
+                    or entry_name == target_provider
+                    or entry_name == normalized_target
+                    or entry_name.lower() == target_suffix
+                    or entry_url == base_url
+                ):
                     # Check if the requested model matches the entry's model
                     entry_model = entry.get("model", "")
                     entry_models = entry.get("models", {})

--- a/tests/hermes_cli/test_model_switch_aggregator_fallback.py
+++ b/tests/hermes_cli/test_model_switch_aggregator_fallback.py
@@ -1,0 +1,250 @@
+"""Regression tests for aggregator live-API fallback and custom: prefix matching.
+
+PR #33716 review feedback (liuhao1024):
+1. No tests for the aggregator fallback code paths (custom_providers model
+   dict iteration + live fetch_endpoint_model_metadata fallback).
+2. normalize_provider match misses custom:-prefixed targets — e.g.
+   "Custom:OpenRouter" should still match entry_name = "OpenRouter".
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from unittest.mock import patch
+
+import hermes_cli.providers as providers_mod
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Aggregator live-API fallback
+# ---------------------------------------------------------------------------
+
+@patch("hermes_cli.model_switch.get_model_info", return_value=None)
+@patch("hermes_cli.model_switch.get_model_capabilities", return_value=None)
+@patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION)
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+    "api_key": "test-key",
+    "base_url": "https://example.com/v1",
+    "api_mode": "chat_completions",
+})
+def test_aggregator_custom_providers_models_dict_resolves_missing_from_catalog(
+    _resolve, _validate, _caps, _info, monkeypatch,
+):
+    """Model present in custom_providers[models] dict but NOT in the live
+    models.dev catalog should still be accepted (resolved_in_current_catalog
+    flips True via the custom_providers iteration path)."""
+    # Empty models.dev catalog for the aggregator — model is NOT listed there
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    # Patch detect_provider_for_model so step-e doesn't hijack
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda *a, **k: None,
+    )
+
+    result = switch_model(
+        raw_input="mimo-v2.5",
+        current_provider="opencode-zen",
+        current_model="claude-sonnet-4",
+        current_base_url="https://opencode-zen.example.com/v1",
+        current_api_key="fake-key",
+        custom_providers=[
+            {
+                "name": "opencode-zen",
+                "base_url": "https://opencode-zen.example.com/v1",
+                "model": "mimo-v2.5-free",
+                "models": {
+                    "mimo-v2.5": {"context_length": 131072},
+                    "mimo-v2.5-free": {"context_length": 131072},
+                },
+            }
+        ],
+    )
+
+    assert result.success is True, (
+        f"Expected success but got error: {result.error_message}"
+    )
+
+
+@patch("hermes_cli.model_switch.get_model_info", return_value=None)
+@patch("hermes_cli.model_switch.get_model_capabilities", return_value=None)
+@patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION)
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+    "api_key": "test-key",
+    "base_url": "https://example.com/v1",
+    "api_mode": "chat_completions",
+})
+def test_aggregator_live_api_fallback_resolves_missing_model(
+    _resolve, _validate, _caps, _info, monkeypatch,
+):
+    """When models.dev AND custom_providers don't list the model, the live
+    fetch_endpoint_model_metadata fallback should resolve it and preserve the
+    canonical casing returned by the API."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda *a, **k: None,
+    )
+
+    # Live API returns the model (with different casing — the fix should
+    # preserve the canonical casing from the live endpoint).
+    monkeypatch.setattr(
+        "agent.model_metadata.fetch_endpoint_model_metadata",
+        lambda base_url, api_key: ["mimo-v2.5", "claude-sonnet-4"],
+    )
+
+    result = switch_model(
+        raw_input="mimo-v2.5",
+        current_provider="opencode-zen",
+        current_model="claude-sonnet-4",
+        current_base_url="https://opencode-zen.example.com/v1",
+        current_api_key="fake-key",
+        custom_providers=[],
+    )
+
+    assert result.success is True, (
+        f"Expected live-API fallback to succeed but got: {result.error_message}"
+    )
+    # The canonical model name from the live endpoint should be preserved
+    assert result.new_model == "mimo-v2.5"
+
+
+@patch("hermes_cli.model_switch.get_model_info", return_value=None)
+@patch("hermes_cli.model_switch.get_model_capabilities", return_value=None)
+@patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION)
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+    "api_key": "test-key",
+    "base_url": "https://example.com/v1",
+    "api_mode": "chat_completions",
+})
+def test_aggregator_live_api_fallback_swallows_exceptions(
+    _resolve, _validate, _caps, _info, monkeypatch,
+):
+    """If fetch_endpoint_model_metadata raises, the except Exception: pass
+    should not crash the pipeline — the function must continue to step e."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda *a, **k: None,
+    )
+
+    # Make the live API call raise — the broad except must swallow this.
+    def _broken_fetch(*a, **k):
+        raise ConnectionError("endpoint unreachable")
+    monkeypatch.setattr(
+        "agent.model_metadata.fetch_endpoint_model_metadata",
+        _broken_fetch,
+    )
+
+    # Validation accepts the model (simulate detect_provider_for_model
+    # finding it in a downstream provider catalog).
+    result = switch_model(
+        raw_input="some-unknown-model",
+        current_provider="opencode-zen",
+        current_model="claude-sonnet-4",
+        current_base_url="https://opencode-zen.example.com/v1",
+        current_api_key="fake-key",
+        custom_providers=[],
+    )
+
+    # We don't care whether this specific model succeeds — we care that
+    # the ConnectionError didn't propagate. The pipeline should reach
+    # validation, not die in the fallback block.
+    # If the exception leaked, we'd get an unhandled ConnectionError
+    # instead of a normal ModelSwitchResult.
+    assert hasattr(result, "success"), (
+        "Expected a ModelSwitchResult, not an unhandled exception"
+    )
+
+
+# ---------------------------------------------------------------------------
+# custom: prefix slug matching (case-insensitive)
+# ---------------------------------------------------------------------------
+
+@patch("hermes_cli.model_switch.get_model_info", return_value=None)
+@patch("hermes_cli.model_switch.get_model_capabilities", return_value=None)
+@patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION)
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+    "api_key": "test-key",
+    "base_url": "https://api.openrouter.ai/v1",
+    "api_mode": "chat_completions",
+})
+def test_custom_prefix_case_insensitive_match(
+    _resolve, _validate, _caps, _info, monkeypatch,
+):
+    """target_provider='Custom:OpenRouter' (non-canonical casing) should
+    still match entry_name='OpenRouter' via the split(':',1)[-1].lower()
+    fallback added in PR #33716."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    result = switch_model(
+        raw_input="anthropic/claude-sonnet-4",
+        current_provider="opencode-zen",
+        current_model="claude-sonnet-4",
+        current_base_url="https://opencode-zen.example.com/v1",
+        current_api_key="fake-key",
+        explicit_provider="Custom:OpenRouter",
+        custom_providers=[
+            {
+                "name": "OpenRouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "model": "anthropic/claude-sonnet-4",
+            }
+        ],
+    )
+
+    assert result.success is True, (
+        f"Custom:OpenRouter (mixed case) should match entry_name 'OpenRouter'. "
+        f"Got error: {result.error_message}"
+    )
+
+
+@patch("hermes_cli.model_switch.get_model_info", return_value=None)
+@patch("hermes_cli.model_switch.get_model_capabilities", return_value=None)
+@patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION)
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+    "api_key": "test-key",
+    "base_url": "https://api.deepseek.com",
+    "api_mode": "chat_completions",
+})
+def test_custom_prefix_lowercase_match(
+    _resolve, _validate, _caps, _info, monkeypatch,
+):
+    """target_provider='custom:deepseek' (lowercase custom: prefix) should
+    match entry_name='DeepSeek' via the suffix comparison."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    result = switch_model(
+        raw_input="deepseek-chat",
+        current_provider="opencode-zen",
+        current_model="claude-sonnet-4",
+        current_base_url="https://opencode-zen.example.com/v1",
+        current_api_key="fake-key",
+        explicit_provider="custom:deepseek",
+        custom_providers=[
+            {
+                "name": "DeepSeek",
+                "base_url": "https://api.deepseek.com",
+                "model": "deepseek-chat",
+            }
+        ],
+    )
+
+    assert result.success is True, (
+        f"custom:deepseek should match entry_name 'DeepSeek'. "
+        f"Got error: {result.error_message}"
+    )


### PR DESCRIPTION
## Why

When a user types `/model mimo-v2.5` on opencode-zen (or any aggregator), the model switch pipeline falls through to `detect_provider_for_model()` which finds the model in xiaomi's static catalog and switches providers — requiring an API key the user doesn't have. The user gets a 401 auth error instead of staying on their configured aggregator.

**Root cause chain:**
1. `/model mimo-v2.5` triggers `switch_model()` step d (aggregator catalog search)
2. `list_provider_models('opencode')` queries models.dev cache which has `mimo-v2.5-free` (stale/free-tier slug) — no match for bare `mimo-v2.5`
3. Step d fails → `resolved_in_current_catalog` stays False
4. Step e `detect_provider_for_model('mimo-v2.5', 'opencode')` finds it in xiaomi static catalog
5. Provider switches to xiaomi → needs `XIAOMI_API_KEY` → 401 → fallback chain → abort

## What changed

### `hermes_cli/model_switch.py`

**Aggregator catalog fallback (step d):** After models.dev catalog search fails to match, added two additional checks:
1. Check `custom_providers` model dicts from config.yaml — if the model is listed there, it's authoritative for the user's configured aggregator
2. Query the live `/v1/models` endpoint via `fetch_endpoint_model_metadata()` — the live API returns current model IDs (e.g. `mimo-v2.5`) not stale models.dev slugs (e.g. `mimo-v2.5-free`)

**Validation override matching:** Fixed the `custom_providers` override in the validation rejection handler to also match `entry_name == target_provider` and `entry_name == normalized_target` (e.g. both `opencode-zen` and `opencode`), not just `custom:<name>`. Built-in provider aliases that also appear in `custom_providers` were invisible to the old check.

**Import:** Added `normalize_provider` to the imports from `hermes_cli.providers`.

## How to review

1. Read the diff in `hermes_cli/model_switch.py` — two logical changes, both defensive
2. The aggregator fallback only fires when models.dev catalog search already failed (no regression path)
3. The live API fallback is wrapped in try/except and only runs for aggregator providers with a `base_url`

## Evidence

```python
# Before fix:
>>> switch_model('mimo-v2.5', current_provider='opencode-zen', ...)
# target_provider: xiaomi ← WRONG (should stay on opencode-zen)

# After fix:
>>> switch_model('mimo-v2.5', current_provider='opencode-zen', custom_providers=[...], ...)
# target_provider: opencode-zen ← CORRECT
# success: True
```

Tests: 36 passed (1 pre-existing fixture failure unrelated to change).

## Verification

- [ ] `/model mimo-v2.5` on opencode-zen stays on opencode-zen (no xiaomi fallback)
- [ ] `/model deepseek-v4-flash` on opencode-go still works (existing pattern)
- [ ] `/model kimi-k2.6` on opencode-zen resolves correctly
- [ ] Non-aggregator providers unaffected (step d is aggregator-only)

## Risks & gaps

- Live API fallback adds one HTTP call on model switch when models.dev is stale. This is rare — models.dev usually has the data. The call uses the existing `fetch_endpoint_model_metadata()` which has its own TTL cache.
- Doesn't fix the underlying models.dev stale data issue (that's an upstream concern).

## Note for reviewers

This is a resubmission of #33695 with only the focused model_switch.py fix (per reviewer feedback to split bundled changes). The unrelated changes (skin_engine.py, utils.py, test_atomic_replace_symlinks.py, agent_init.py) have been removed and will be submitted as separate PRs.