### PR TITLE
fix(tools): search_files(target='files') now returns directories too

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -558,6 +558,70 @@ class TestSearchFilesFallbackHiddenPaths:
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
+    def test_fallback_finds_directories_matching_pattern(self, tmp_path, monkeypatch):
+        """Fallback find should return directories whose name matches the pattern.
+
+        Regression: previously _search_files used ``-type f`` which silently
+        excluded directories, breaking the tool's documented role as a ``find/ls``
+        replacement. An agent asked "what's in folder X?" would get an empty
+        result and conclude the folder didn't exist.
+        """
+        root = tmp_path / "repo"
+        root.mkdir()
+        target_dir = root / "myproject"
+        target_dir.mkdir()
+        nested_target_dir = root / "src" / "myproject"
+        nested_target_dir.mkdir(parents=True)
+        regular_file = root / "myproject.txt"
+        regular_file.write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops._search_files("myproject", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert str(target_dir) in result.files
+        assert str(nested_target_dir) in result.files
+
+    def test_rg_path_finds_directories_via_parallel_find(self, tmp_path, monkeypatch):
+        """rg-backed search should also return matching directories.
+
+        rg --files is regular-files-only; the implementation runs a parallel
+        ``find -type d`` pass to capture directories. Both files and
+        directories matching the same pattern should appear in the result.
+        """
+        root = tmp_path / "repo"
+        root.mkdir()
+        target_dir = root / "components"
+        target_dir.mkdir()
+        regular_file_in_dir = target_dir / "components"
+        regular_file_in_dir.write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in {"rg", "find"})
+        result = ops._search_files("components", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert str(target_dir) in result.files
+        assert str(regular_file_in_dir) in result.files
+
+    def test_rg_path_excludes_hidden_directories(self, tmp_path, monkeypatch):
+        """The directory pass should skip hidden directories, matching rg's defaults."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        visible_dir = root / "visible_target"
+        visible_dir.mkdir()
+        hidden_parent_target = root / ".hidden" / "visible_target"
+        hidden_parent_target.mkdir(parents=True)
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command in {"rg", "find"})
+        result = ops._search_files("visible_target", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert str(visible_dir) in result.files
+        assert str(hidden_parent_target) not in result.files
+
 
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1698,14 +1698,16 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        # Match both regular files and directories so this tool delivers the
+        # find/ls replacement contract its description promises.
+        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} \\( -type f -o -type d \\) -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
 
         if not result.stdout.strip():
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} \\( -type f -o -type d \\) -name {self._escape_shell_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
 
@@ -1742,12 +1744,16 @@ class ShellFileOperations(FileOperations):
         )
 
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
-        """Search for files by name using ripgrep's --files mode.
+        """Search for files and directories by name using ripgrep + find.
 
         rg --files respects .gitignore and excludes hidden directories by
         default, and uses parallel directory traversal for ~200x speedup
         over find on wide trees.  Results are sorted by modification time
         (most recently edited first) when rg >= 13.0 supports --sortr.
+
+        rg --files is regular-files-only by design; a parallel ``find -type d``
+        pass captures matching directories so this tool delivers the find/ls
+        replacement contract its description promises.
         """
         # rg --files -g uses glob patterns; wrap bare names so they match
         # at any depth (equivalent to find -name).
@@ -1776,12 +1782,24 @@ class ShellFileOperations(FileOperations):
             result = self._exec(cmd_plain, timeout=60)
             all_files = [f for f in result.stdout.strip().split('\n') if f]
 
-        page = all_files[offset:offset + limit]
+        # Directories: rg --files is files-only, so use a parallel find pass.
+        # Exclude hidden directories to match rg's default behavior.
+        cmd_dirs = (
+            f"find {self._escape_shell_arg(path)} -type d -not -path '*/.*' "
+            f"-name {self._escape_shell_arg(glob_pattern)} 2>/dev/null "
+            f"| head -n {fetch_limit}"
+        )
+        result_dirs = self._exec(cmd_dirs, timeout=60)
+        all_dirs = [d for d in result_dirs.stdout.strip().split('\n') if d]
+
+        # Files (mtime-sorted) first, then directories; dedupe preserves order.
+        combined = list(dict.fromkeys(all_files + all_dirs))
+        page = combined[offset:offset + limit]
 
         return SearchResult(
             files=page,
-            total_count=len(all_files),
-            truncated=len(all_files) >= fetch_limit,
+            total_count=len(combined),
+            truncated=len(combined) >= fetch_limit,
         )
     
     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],


### PR DESCRIPTION
## Problem

`search_files(target='files')` is documented as a `find/ls` replacement:

> "Use this instead of grep/rg/find/ls in terminal." — `terminal_tool.py` description
> "Find files by glob pattern… Also use this instead of ls — results sorted by modification time." — `SEARCH_FILES_SCHEMA` description in `file_tools.py`

But the implementation uses `rg --files` (in `_search_files_rg`) and `find -type f` (in the `_search_files` fallback), both of which only return regular files. **Directories are never in the result set.**

This causes a confusing failure mode: an agent asked "what's in folder X?" or "find the foo directory" calls `search_files(target='files', pattern='X')`, gets `{\"total_count\": 0}`, and concludes the directory doesn't exist — even when it does. The model is following the documented contract; the tool is silently breaking it.

Worth noting: this affects both small and large models equally — it's a contract gap, not a reasoning failure.

## Fix

- **`_search_files_rg`**: keep `rg --files` for regular files (preserves the .gitignore-respecting, parallel-traversal speedup from #1464), but add a parallel `find -type d -not -path '*/.*' -name <glob>` pass to capture directories. Merge + dedupe; files-first ordering preserves the existing mtime sort. Hidden directories are still excluded, matching rg's default behavior.
- **`_search_files`** (find fallback when ripgrep isn't installed): change `-type f` to `\( -type f -o -type d \)` in both the `-printf` and BSD-fallback branches.

## Tests

Three new tests in `TestSearchFilesFallbackHiddenPaths`:
- `test_fallback_finds_directories_matching_pattern` — fallback path finds matching directories at root and nested.
- `test_rg_path_finds_directories_via_parallel_find` — rg path returns matching directories alongside matching files.
- `test_rg_path_excludes_hidden_directories` — directory pass still honors the hidden-dir exclusion.

All 124 tests in `tests/tools/test_file_operations*.py` and `test_search_hidden_dirs.py` pass.

## Notes

- **No tool description changes required.** The implementation now matches what the description has always promised, so the schema and the `terminal` tool's `Do NOT use ls — use search_files(target='files') instead` guidance both become accurate.
- **Hidden directories are still excluded** by the `-not -path '*/.*'` filter in the new `find -type d` pass, matching `rg --files`'s default behavior.
- **Performance**: the added `find -type d` traversal walks directory entries only (skips files), which is fast even on wide trees. Trade-off is acceptable given the size of the silent failure being fixed.
- **Referenced PR**: this is a direct follow-up to #1464, which made the perf improvement by switching to `rg --files` — that switch removed the directory results that the older `find` (without `-type f` filter on macOS BSD-find via the `-printf` fallback) sometimes returned. This PR restores directory results while keeping the perf benefit.