### PR TITLE
fix: expose context engine tools with saved toolsets (salvage of #31194)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -67,6 +67,7 @@ CONFIGURABLE_TOOLSETS = [
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
+    ("context_engine",  "🧩 Context Engine",            "runtime tools from the active context engine"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
@@ -1293,6 +1294,24 @@ def _get_platform_tools(
                 # New plugin not yet seen by hermes tools — default enabled
                 enabled_toolsets.add(pts)
             # else: known but not in config = user disabled it
+
+    # Context-engine tools are runtime-provided by the active engine, so they
+    # are not part of any static platform composite. When a non-default engine
+    # is selected, keep its recovery/status tools available even after a user
+    # saves an explicit platform toolset list. Preserve the explicit empty-list
+    # contract: selecting no configurable tools means no context-engine tools
+    # either unless the user adds ``context_engine`` manually later.
+    context_cfg = config.get("context") or {}
+    if not isinstance(context_cfg, dict):
+        context_cfg = {}
+    context_engine_name = str(context_cfg.get("engine") or "compressor").strip().lower()
+    explicit_empty_selection = (
+        platform in platform_toolsets
+        and isinstance(platform_toolsets.get(platform), list)
+        and not toolset_names
+    )
+    if context_engine_name and context_engine_name != "compressor" and not explicit_empty_selection:
+        enabled_toolsets.add("context_engine")
 
     # Preserve any explicit non-configurable toolset entries (for example,
     # custom toolsets or MCP server names saved in platform_toolsets).

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -79,6 +79,46 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
+
+def test_configurable_toolsets_include_context_engine():
+    assert any(ts_key == "context_engine" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+
+def test_get_platform_tools_active_context_engine_is_enabled_for_explicit_config():
+    config = {
+        "context": {"engine": "lcm"},
+        "platform_toolsets": {"cli": ["web", "terminal"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "context_engine" in enabled
+    assert "web" in enabled
+    assert "terminal" in enabled
+
+
+def test_get_platform_tools_context_engine_not_added_for_default_compressor():
+    config = {
+        "context": {"engine": "compressor"},
+        "platform_toolsets": {"cli": ["web", "terminal"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "context_engine" not in enabled
+
+
+def test_get_platform_tools_context_engine_respects_explicit_empty_selection():
+    config = {
+        "context": {"engine": "lcm"},
+        "platform_toolsets": {"cli": []},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "context_engine" not in enabled
+
+
 def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")
 

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -26,6 +26,17 @@ class _StubEngine(ContextEngine):
         return messages
 
 
+class _ToolEngine(_StubEngine):
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "stub_recover",
+                "description": "Recover context from the stub engine.",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+
 def test_plugin_engine_gets_context_length_on_init():
     """Plugin context engine should have context_length set during AIAgent init."""
     engine = _StubEngine()
@@ -54,6 +65,46 @@ def test_plugin_engine_gets_context_length_on_init():
     assert agent.context_compressor is engine
     assert engine.context_length == 204_800
     assert engine.threshold_tokens == int(204_800 * engine.threshold_percent)
+
+
+def test_active_context_engine_tools_survive_explicit_platform_toolsets():
+    """LCM-style recovery tools must survive saved `hermes tools` lists."""
+    engine = _ToolEngine()
+    cfg = {
+        "context": {"engine": "stub"},
+        "platform_toolsets": {"cli": ["web", "terminal"]},
+        "agent": {},
+    }
+
+    from hermes_cli.tools_config import _get_platform_tools
+
+    enabled_toolsets = _get_platform_tools(cfg, "cli", include_default_mcp_servers=False)
+    assert "context_engine" in enabled_toolsets
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            enabled_toolsets=sorted(enabled_toolsets),
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert "stub_recover" in getattr(agent, "valid_tool_names", set())
+    assert "stub_recover" in {
+        tool.get("function", {}).get("name")
+        for tool in getattr(agent, "tools", [])
+    }
 
 
 def test_plugin_engine_update_model_args():

--- a/toolsets.py
+++ b/toolsets.py
@@ -215,6 +215,12 @@ TOOLSETS = {
         "tools": ["memory"],
         "includes": []
     },
+
+    "context_engine": {
+        "description": "Runtime tools exposed by the active context engine",
+        "tools": [],
+        "includes": []
+    },
     
     "session_search": {
         "description": "Search and recall past conversations with summarization",


### PR DESCRIPTION
## Summary

Plugin context engines like hermes-lcm expose runtime tools through `get_tool_schemas()`. `AIAgent` only injects those schemas when the `context_engine` toolset is enabled (`agent/agent_init.py:1497`). But:

- `context_engine` wasn't a registered toolset in `toolsets.py`
- saved platform toolset lists from `hermes tools` (`web`, `terminal`, etc.) never included it

So an active LCM session running with `context.engine: lcm` would never see the `lcm_*` tools — the schemas existed but the toolset gate filtered them out.

This adds a first-class `context_engine` toolset and auto-enables it when a non-default `context.engine` is configured, while preserving the explicit empty-selection contract (a user who deliberately deselects everything still gets nothing).

## Changes

- `toolsets.py` — adds a static `context_engine` toolset entry (empty tool list; engines populate at runtime via `get_tool_schemas()`)
- `hermes_cli/tools_config.py` — adds `context_engine` to `CONFIGURABLE_TOOLSETS`; `_get_platform_tools()` auto-enables it when `context.engine` is set to anything other than the default `compressor`, unless the user has explicitly saved an empty selection
- `tests/hermes_cli/test_tools_config.py` — 40 lines of regressions for visibility with explicit platform toolsets, default compressor behavior, and the empty-selection contract
- `tests/run_agent/test_plugin_context_engine_init.py` — end-to-end regression proving a plugin context engine's tool schema reaches `AIAgent.valid_tool_names` after platform tool resolution

## Validation

```
pytest tests/hermes_cli/test_tools_config.py tests/test_toolsets.py \
       tests/run_agent/test_plugin_context_engine_init.py -q
112 passed
```

## Salvage notes

Salvage of PR #31194 by @stephenschoettler — original commit `6bd2b5b43` cherry-picked onto current main with authorship preserved (455 commits behind when picked, conflict-free auto-merge). Original PR will be closed with credit after merge.

Related: stephenschoettler/hermes-lcm#200.
