### PR TITLE
fix(cli): prevent Identifier column truncation in skills search; add --json flag (#33674)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12573,6 +12573,12 @@ Examples:
         ],
     )
     skills_search.add_argument("--limit", type=int, default=10, help="Max results")
+    skills_search.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Output results as JSON (full identifiers, machine-readable)",
+    )
 
     skills_install = skills_subparsers.add_parser("install", help="Install a skill")
     skills_install.add_argument(

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -244,8 +244,9 @@ def _prompt_for_category(c: Console, existing: List[str]) -> str:
 
 
 def do_search(query: str, source: str = "all", limit: int = 10,
-              console: Optional[Console] = None) -> None:
-    """Search registries and display results as a Rich table."""
+              console: Optional[Console] = None,
+              json_output: bool = False) -> None:
+    """Search registries and display results as a Rich table or JSON."""
     from tools.skills_hub import GitHubAuth, create_source_router, unified_search
 
     c = console or _console
@@ -265,7 +266,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
     table.add_column("Description", max_width=60)
     table.add_column("Source", style="dim")
     table.add_column("Trust", style="dim")
-    table.add_column("Identifier", style="dim")
+    table.add_column("Identifier", style="dim", no_wrap=True)
 
     for r in results:
         trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(r.trust_level, "dim")
@@ -277,6 +278,21 @@ def do_search(query: str, source: str = "all", limit: int = 10,
             f"[{trust_style}]{trust_label}[/]",
             r.identifier,
         )
+
+    if json_output:
+        import json as _json
+        out = [
+            {
+                "name": r.name,
+                "description": r.description,
+                "source": r.source,
+                "trust_level": r.trust_level,
+                "identifier": r.identifier,
+            }
+            for r in results
+        ]
+        c.print(_json.dumps(out, indent=2))
+        return
 
     c.print(table)
     c.print("[dim]Use: hermes skills inspect <identifier> to preview, "
@@ -1390,7 +1406,8 @@ def skills_command(args) -> None:
     if action == "browse":
         do_browse(page=args.page, page_size=args.size, source=args.source)
     elif action == "search":
-        do_search(args.query, source=args.source, limit=args.limit)
+        do_search(args.query, source=args.source, limit=args.limit,
+                  json_output=getattr(args, "json", False))
     elif action == "install":
         do_install(args.identifier, category=args.category, force=args.force,
                    skip_confirm=getattr(args, "yes", False),

--- a/tests/hermes_cli/test_skills_hub_search_identifier.py
+++ b/tests/hermes_cli/test_skills_hub_search_identifier.py
@@ -1,0 +1,161 @@
+"""Regression tests for #33674: skills search identifier truncation.
+
+``hermes skills search`` rendered a Rich table where the Identifier column
+was truncated (Rich default), cutting off the hash suffix like ``-1uezib``
+from browse-sh skill slugs.  Users copied the truncated identifier and
+``hermes skills install`` failed.
+
+Two fixes were applied:
+  1. ``no_wrap=True`` on the Identifier column so Rich never truncates it.
+  2. ``--json`` flag that outputs full machine-readable JSON including
+     full identifiers, so scripting workflows can reliably capture slugs.
+"""
+
+import json
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from hermes_cli.skills_hub import do_search
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_result(identifier, name="weather-forecast"):
+    """Build a fake search result object with a browse-sh-style identifier."""
+    return SimpleNamespace(
+        name=name,
+        description="Get NOAA weather forecasts for a location",
+        source="browse-sh",
+        trust_level="community",
+        identifier=identifier,
+    )
+
+
+def _run_do_search(identifiers, *, json_output=False, console_width=200):
+    """Run do_search with mocked dependencies and return captured output."""
+    results = [_make_result(ident) for ident in identifiers]
+    buf = StringIO()
+    console = Console(file=buf, width=console_width, highlight=False, no_color=True)
+
+    with (
+        patch("tools.skills_hub.unified_search", return_value=results),
+        patch("tools.skills_hub.create_source_router", return_value={}),
+        patch("tools.skills_hub.GitHubAuth"),
+    ):
+        do_search("weather", source="all", limit=10, console=console,
+                  json_output=json_output)
+
+    return buf.getvalue()
+
+
+def _extract_json(output: str):
+    """Extract the first JSON array from Rich console output."""
+    start = output.find("[")
+    if start == -1:
+        raise ValueError(f"No JSON array found in output: {output!r}")
+    return json.loads(output[start:].strip())
+
+
+# ── tests: no_wrap on Identifier column ──────────────────────────────────
+
+
+class TestIdentifierColumnNoWrap:
+    """Identifier column must not be truncated in the table output."""
+
+    def test_short_identifier_fully_shown(self):
+        """Plain short identifiers are unaffected."""
+        output = _run_do_search(["openai/weather/forecast"])
+        assert "openai/weather/forecast" in output, (
+            "Short identifier should appear verbatim in table output"
+        )
+
+    def test_long_browse_sh_identifier_not_truncated(self):
+        """browse-sh slugs with hash suffix must never be truncated."""
+        long_id = "browse-sh/weather.gov/get-forecast-1uezib"
+        output = _run_do_search([long_id])
+
+        assert long_id in output, (
+            f"Full identifier {long_id!r} not found in table output.\n"
+            "This means no_wrap=True is not set on the Identifier column. "
+            "Users cannot install skills with truncated identifiers (#33674)."
+        )
+        assert "…" not in output, (
+            "Identifier column is truncating with '…' — set no_wrap=True on the column"
+        )
+
+    def test_multiple_long_identifiers_all_shown(self):
+        """All rows must show their full identifier."""
+        identifiers = [
+            "browse-sh/weather.gov/get-forecast-1uezib",
+            "browse-sh/weather.gov/get-hourly-abc123",
+            "browse-sh/weather.gov/get-alerts-xyz789",
+        ]
+        output = _run_do_search(identifiers)
+        for ident in identifiers:
+            assert ident in output, (
+                f"Identifier {ident!r} was truncated in table output (#33674)"
+            )
+
+
+# ── tests: --json output ──────────────────────────────────────────────────
+
+
+class TestJsonOutput:
+    """--json flag must emit machine-readable JSON with full identifiers."""
+
+    def test_json_output_is_valid_json(self):
+        """JSON mode must produce parseable JSON."""
+        output = _run_do_search(
+            ["browse-sh/weather.gov/get-forecast-1uezib"],
+            json_output=True,
+        )
+        parsed = _extract_json(output)
+        assert isinstance(parsed, list), "JSON output must be a list"
+
+    def test_json_output_contains_full_identifier(self):
+        """JSON output must include the full, untruncated identifier field."""
+        full_id = "browse-sh/weather.gov/get-forecast-1uezib"
+        output = _run_do_search([full_id], json_output=True)
+        parsed = _extract_json(output)
+        assert len(parsed) == 1
+        assert parsed[0]["identifier"] == full_id, (
+            f"Expected full identifier {full_id!r} in JSON output, "
+            f"got {parsed[0].get('identifier')!r} (#33674)"
+        )
+
+    def test_json_output_has_expected_fields(self):
+        """JSON rows must include name, description, source, trust_level, identifier."""
+        output = _run_do_search(
+            ["browse-sh/test-skill/action-hash99"],
+            json_output=True,
+        )
+        parsed = _extract_json(output)
+        row = parsed[0]
+        for field in ("name", "description", "source", "trust_level", "identifier"):
+            assert field in row, f"JSON output missing field '{field}' (#33674)"
+
+    def test_json_mode_omits_table_header(self):
+        """When --json is active, no Rich table header text should appear."""
+        output = _run_do_search(["openai/skills/pptx"], json_output=True)
+        assert "Skills Hub" not in output, (
+            "Table header 'Skills Hub' should not appear in JSON mode"
+        )
+
+    def test_json_multiple_results_all_present(self):
+        """All results must appear in JSON output."""
+        identifiers = [
+            "browse-sh/weather.gov/get-forecast-1uezib",
+            "browse-sh/weather.gov/get-hourly-abc123",
+        ]
+        output = _run_do_search(identifiers, json_output=True)
+        parsed = _extract_json(output)
+        assert len(parsed) == 2
+        returned_ids = {r["identifier"] for r in parsed}
+        assert returned_ids == set(identifiers), (
+            f"Expected {identifiers!r} in JSON, got {returned_ids!r}"
+        )


### PR DESCRIPTION
## Summary

Fixes #33674 — `hermes skills search` truncates the Identifier column, making browse-sh skills impossible to install.

## Problem

### Truncation
The Identifier column in the search results table used Rich's default text-wrapping behaviour, which truncated long browse-sh skill slugs:

```
┃ Identifier              ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ browse-sh/weather.gov/… │   ← -1uezib hash invisible!
```

Users copied the truncated value and `hermes skills install` failed with a 404 because the hash suffix (`-1uezib`) is mandatory.

### No machine-readable output
Without a `--json` flag, there was no reliable way to script `search → install` pipelines.

## Fix

### 1. `no_wrap=True` on Identifier column
In `hermes_cli/skills_hub.py` `do_search()`:
```diff
-    table.add_column("Identifier", style="dim")
+    table.add_column("Identifier", style="dim", no_wrap=True)
```
This tells Rich to expand the column rather than truncate it.

### 2. `--json` flag
```bash
# Get full identifiers for scripting:
hermes skills search "weather.gov" --json | jq '.[].identifier'
# browse-sh/weather.gov/get-forecast-1uezib
# browse-sh/weather.gov/get-hourly-abc123
```

JSON output schema per result:
```json
{
  "name": "weather-forecast",
  "description": "Get NOAA weather forecasts...",
  "source": "browse-sh",
  "trust_level": "community",
  "identifier": "browse-sh/weather.gov/get-forecast-1uezib"
}
```

## Files Changed

| File | Change |
|---|---|
| `hermes_cli/skills_hub.py` | `no_wrap=True` on column; `json_output` param; JSON render path |
| `hermes_cli/main.py` | `--json` arg added to `skills search` subparser |
| `tests/hermes_cli/test_skills_hub_search_identifier.py` | 8 new regression tests |

## Tests

```
8 passed in 0.17s
```

- **no_wrap**: short identifier shown, long browse-sh slug not truncated, multiple rows all shown
- **JSON**: valid JSON output, full identifier present, required fields, no table pollution, multiple results