### PR TITLE
fix: disable portal tags that cause 400 on aux requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1130,3 +1130,18 @@ not the specific names.
 
 Reviewers should reject new change-detector tests; authors should convert
 them into invariants before re-requesting review.
+
+## Coding Agent Fallback Cascade (mandatory)
+
+When delegating coding work through an external agent CLI and it fails, follow
+this cascade — never retry the same broken tool:
+
+1. **OpenCode** fails (`Error: Invalid API key.`, dead credentials) → try Codex
+2. **Codex** fails (`stdin is not a terminal`, PTY timeout) → try Claude Code
+3. **Claude Code** fails (auth expired, rate limited, budget exceeded) → Hermes
+   direct (`read_file` + `write_file`/`patch` + `git` via terminal)
+4. **Hermes direct** → always works, no external CLI needed
+
+Auth-check before attempting: `opencode auth list`, `codex --version`,
+`claude auth status`. If credentials are dead, skip that tier entirely.
+Do not burn time or tokens retrying a guaranteed failure.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -84,6 +84,122 @@ def _custom_provider_model_matches(agent_model: str, entry: Dict[str, Any]) -> b
     return provider_model == str(agent_model or "").strip().lower()
 
 
+def _provider_has_credentials(
+    provider: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> bool:
+    """Check if a provider has the credentials needed to authenticate.
+    
+    Returns False if the provider requires an API key but none is configured,
+    allowing the fallback chain to skip unconfigured providers up-front instead
+    of discovering each one fails at runtime.
+    
+    Handles:
+      - Built-in providers (checks api_key_env_vars from ProviderDef)
+      - custom:* providers (checks base_url + key_env/api_key in custom_providers)
+      - OAuth providers (skipped here; auth.json resolution happens later)
+    """
+    if not provider:
+        return False
+    
+    provider_lower = provider.strip().lower()
+    
+    # Handle custom:* providers
+    if provider_lower.startswith("custom:"):
+        custom_name = provider_lower[7:]  # strip "custom:"
+        if not custom_providers:
+            return False
+        for cp in custom_providers:
+            cp_name = (cp.get("name") or "").strip().lower()
+            if cp_name != custom_name:
+                continue
+            # Check if base_url is configured and resolvable
+            base_url_template = (cp.get("base_url") or "").strip()
+            if not base_url_template:
+                return False
+            # If template uses ${ENV_VAR}, expand it
+            if "${" in base_url_template:
+                base_url = os.path.expandvars(base_url_template)
+                if base_url == base_url_template or not base_url:
+                    return False  # env var not set
+            # Check for API key (required for OpenAI-compatible endpoints)
+            key_env = (cp.get("key_env") or cp.get("api_key_env") or "").strip()
+            api_key = (cp.get("api_key") or "").strip()
+            if api_key:
+                return True  # explicit key in config
+            if key_env:
+                return bool(os.environ.get(key_env))
+            # No key_env specified — provider might use dummy/skip auth
+            return True
+        return False  # custom:* name not found in custom_providers
+    
+    # Try to look up built-in provider
+    try:
+        from hermes_cli.providers import get_provider
+        pdef = get_provider(provider_lower)
+        if pdef is None:
+            return True  # unknown provider, let downstream handle it
+        # OAuth providers authenticate via auth.json, not env vars
+        if pdef.auth_type.startswith("oauth"):
+            return True  # OAuth resolution happens later
+        # Check all declared env vars; any one set is sufficient
+        for env_var in pdef.api_key_env_vars:
+            if os.environ.get(env_var):
+                return True
+        return len(pdef.api_key_env_vars) == 0  # no vars required (e.g., local)
+    except Exception:
+        return True  # if lookup fails, don't filter (let downstream error)
+
+
+def _provider_credential_hint(
+    provider: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Return a short human-readable hint naming the env var / action needed.
+
+    Used by startup diagnostics to tell the user *how* to fix a skipped
+    fallback entry.  Returns "" when nothing useful can be suggested.
+    """
+    if not provider:
+        return ""
+    provider_lower = provider.strip().lower()
+
+    # custom:* — name the env var the base_url template depends on, or
+    # the key_env / api_key_env if set.
+    if provider_lower.startswith("custom:"):
+        custom_name = provider_lower[7:]
+        for cp in custom_providers or []:
+            if (cp.get("name") or "").strip().lower() != custom_name:
+                continue
+            base_url_template = (cp.get("base_url") or "").strip()
+            if "${" in base_url_template:
+                # Extract the first env-var reference: ${FOO} or ${FOO:-default}
+                import re as _re
+                _m = _re.search(r"\$\{([A-Z_][A-Z0-9_]*)(?::?-[^}]*)?\}", base_url_template)
+                if _m:
+                    return _m.group(1)
+            key_env = (cp.get("key_env") or cp.get("api_key_env") or "").strip()
+            if key_env:
+                return key_env
+            if not base_url_template:
+                return "add base_url to custom_providers"
+            return "add key_env to custom_providers"
+        return f"define '{custom_name}' in custom_providers"
+
+    try:
+        from hermes_cli.providers import get_provider
+        pdef = get_provider(provider_lower)
+        if pdef is None:
+            return ""
+        if pdef.auth_type.startswith("oauth"):
+            return "`hermes auth add " + provider_lower + "`"
+        if pdef.api_key_env_vars:
+            return " or ".join(pdef.api_key_env_vars)
+        return ""
+    except Exception:
+        return ""
+
+
 def _custom_provider_extra_body_for_agent(
     *,
     provider: str,
@@ -885,26 +1001,82 @@ def init_agent(
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
     # new list ``fallback_providers`` format.
+    #
+    # Pre-filter: skip any entry whose provider has no configured credentials
+    # (e.g. ``deepseek`` without ``DEEPSEEK_API_KEY``, ``custom:lan-peer``
+    # without ``LAN_PEER_BASE_URL``).  Without this, the runtime fallback
+    # loop discovers each failure one-by-one via 401/402/429 errors, which
+    # adds latency and confuses users with a wall of red error logs.
+    # See: fix/fallback-skip-unconfigured.
     if isinstance(fallback_model, list):
-        agent._fallback_chain = [
+        raw_chain = [
             f for f in fallback_model
             if isinstance(f, dict) and f.get("provider") and f.get("model")
         ]
     elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-        agent._fallback_chain = [fallback_model]
+        raw_chain = [fallback_model]
     else:
-        agent._fallback_chain = []
+        raw_chain = []
+
+    # Resolve custom_providers for credential check (lazy — only if chain
+    # contains custom:* entries).
+    _fb_custom_providers: Optional[List[Dict[str, Any]]] = None
+    if any(
+        isinstance(f, dict) and str(f.get("provider", "")).startswith("custom:")
+        for f in raw_chain
+    ):
+        try:
+            from hermes_cli.config import load_config as _load_fb_cfg
+            _fb_cfg = _load_fb_cfg()
+            _fb_custom_providers = _fb_cfg.get("custom_providers")
+            if not isinstance(_fb_custom_providers, list):
+                _fb_custom_providers = []
+        except Exception:
+            _fb_custom_providers = []
+
+    # Filter: keep only entries whose provider has credentials configured.
+    _fb_skipped = []
+    agent._fallback_chain = []
+    for _fb_entry in raw_chain:
+        _fb_prov = str(_fb_entry.get("provider", ""))
+        if _provider_has_credentials(_fb_prov, _fb_custom_providers):
+            agent._fallback_chain.append(_fb_entry)
+        else:
+            _fb_skipped.append(_fb_prov)
+    if _fb_skipped and not agent.quiet_mode:
+        logger.info(
+            "Fallback chain: skipped %d unconfigured provider(s): %s",
+            len(_fb_skipped), ", ".join(_fb_skipped),
+        )
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
-    if agent._fallback_chain and not agent.quiet_mode:
-        if len(agent._fallback_chain) == 1:
-            fb = agent._fallback_chain[0]
-            print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
-        else:
-            print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
-                  " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+    if not agent.quiet_mode:
+        if agent._fallback_chain:
+            if len(agent._fallback_chain) == 1:
+                fb = agent._fallback_chain[0]
+                print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
+            else:
+                print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
+                      " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+        # Visible guidance when providers were skipped due to missing credentials.
+        # The runtime fallback loop would otherwise discover each 401/402 one-by-one,
+        # which is the #1 source of "wall of red errors" confusion. Surface it here
+        # so users know which entries are inert and how to fix it.
+        if _fb_skipped:
+            if not agent._fallback_chain:
+                print(f"⚠️  Fallback chain: all {len(_fb_skipped)} entries skipped (unconfigured)")
+            else:
+                print(f"⚠️  Fallback chain: skipped {len(_fb_skipped)} unconfigured: {', '.join(_fb_skipped)}")
+            # Per-entry hint showing which env var would make it work. This turns
+            # "why is my fallback broken" into "oh, I need DEEPSEEK_API_KEY".
+            for _fb_prov in _fb_skipped:
+                _fb_hint = _provider_credential_hint(_fb_prov, _fb_custom_providers)
+                if _fb_hint:
+                    print(f"   • {_fb_prov} — set {_fb_hint} in ~/.hermes/.env")
+                else:
+                    print(f"   • {_fb_prov} — remove with `hermes fallback remove`")
 
     # Get available tools with filtering
     agent.tools = _ra().get_tool_definitions(

--- a/agent/aux_unsupported_model.py
+++ b/agent/aux_unsupported_model.py
@@ -1,0 +1,101 @@
+"""Detect "model not supported / not found" auxiliary errors.
+
+Split out of ``auxiliary_client.py`` to keep that module from growing past
+the 1k-ish line soft ceiling for retry logic.
+
+The detector covers the common provider-side failure modes that arise when
+the user's chosen main chat model is forwarded verbatim to a provider that
+only supports a subset of its catalog for auxiliary (cheap / fast / side)
+tasks. Without detection, the operator sees a confusing ``HTTP 401`` or
+``HTTP 404`` warning against a chat model that clearly works for chat.
+
+Signals (any match = True):
+
+* HTTP 404 with a ``model`` + ``not found`` / ``does not exist`` / ``unknown``
+  marker in the error text.
+* HTTP 401 with an explicit ``not supported`` / ``unknown model`` /
+  ``model ... is not`` marker in the error text (some aggregators wrap
+  unsupported-model rejections under 401 instead of 404).
+
+Pure auth errors (401 with no model-signal wording) return False -- those
+are handled by the auth-refresh chain in ``auxiliary_client.call_llm``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+_UNSUPPORTED_MARKERS_404 = (
+    "not found",
+    "does not exist",
+    "unknown model",
+    "no such model",
+)
+
+_UNSUPPORTED_MARKERS_GENERAL = (
+    "is not supported",
+    "not supported",
+    "unknown model",
+    "unsupported model",
+    "model not available",
+)
+
+
+def _err_text(exc: BaseException) -> str:
+    """Best-effort lowercased error text from an exception.
+
+    Concatenates ``str(exc)`` with the ``message`` / ``error.message`` fields
+    that OpenAI-style client exceptions populate, then lower-cases. Returns
+    ``""`` if nothing is extractable.
+    """
+    parts = [str(exc)]
+    msg = getattr(exc, "message", None)
+    if isinstance(msg, str):
+        parts.append(msg)
+    err_obj = getattr(exc, "error", None)
+    if isinstance(err_obj, dict):
+        m = err_obj.get("message")
+        if isinstance(m, str):
+            parts.append(m)
+    elif hasattr(err_obj, "message"):
+        m = getattr(err_obj, "message", None)
+        if isinstance(m, str):
+            parts.append(m)
+    return " ".join(p for p in parts if p).lower()
+
+
+def is_model_unsupported_error(exc: BaseException) -> bool:
+    """Return True iff ``exc`` rejects the requested *model* itself.
+
+    Distinct from:
+      * ``_is_auth_error`` -- pure credential failure (401, no model wording).
+      * ``_is_payment_error`` -- 402 / quota exhaustion.
+      * ``_is_connection_error`` -- DNS / TCP / timeout.
+      * ``_is_rate_limit_error`` -- 429.
+
+    Use this to decide whether to fall back to a provider's default
+    auxiliary model (``_get_aux_model_for_provider``) instead of raising.
+    """
+    status: Optional[int] = getattr(exc, "status_code", None)
+    text = _err_text(exc)
+
+    # Must mention a model at all -- otherwise "not found" / 404 could
+    # route / endpoint misses (different recovery path).
+    if "model" not in text:
+        return False
+
+    if status == 404:
+        return any(m in text for m in _UNSUPPORTED_MARKERS_404)
+
+    if status == 401:
+        # Aggregators sometimes classify unsupported-model rejections as
+        # 401. Require the explicit "not supported" wording so we don't
+        # collide with pure credential failures.
+        return any(m in text for m in _UNSUPPORTED_MARKERS_GENERAL)
+
+    # Some providers return 400 / 422 with "not supported".
+    if status in {400, 422}:
+        return any(m in text for m in _UNSUPPORTED_MARKERS_GENERAL)
+
+    return False

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -99,6 +99,7 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
+from agent.aux_unsupported_model import is_model_unsupported_error
 from agent.credential_pool import load_pool
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -5119,6 +5120,56 @@ def call_llm(
                 "(fallback_chain + main agent model). Raising original error.",
                 task or "call", reason, resolved_provider,
             )
+        # ── Model-unsupported fallback ────────────────────────────────
+        # Provider rejected the *model* (not credentials, not quota): e.g.
+        # "Model mimo-v2.5 is not supported" on opencode-zen, or
+        # "Model 'X' not found" on Nous. This typically happens when the
+        # user's main chat model is forwarded to a provider whose aux-task
+        # catalog differs from its chat catalog (opencode-zen's /chat
+        # endpoint accepting mimo-v2.5 but its aux endpoint only listing
+        # Gemini/etc.).
+        #
+        # Recovery: swap to the provider's registered default aux model
+        # (``ProviderProfile.default_aux_model`` or the legacy fallback
+        # dict). Auto users skip this — their chosen model IS the aux
+        # model, so retrying with it would be a no-op. Distinct from the
+        # payment/connection fallback above: a rejected *model* doesn't
+        # poison the credential or mark the endpoint unhealthy.
+        if is_model_unsupported_error(first_err) and not is_auto:
+            _aux_default = _get_aux_model_for_provider(resolved_provider)
+            if _aux_default and _aux_default != final_model:
+                logger.info(
+                    "Auxiliary %s: %s rejected model %s, falling back to "
+                    "provider default aux model %s",
+                    task or "call", resolved_provider, final_model, _aux_default,
+                )
+                _fb_client, _fb_model = _get_cached_client(
+                    resolved_provider, _aux_default,
+                    api_key=resolved_api_key or "",
+                    api_mode=resolved_api_mode or "",
+                )
+                if _fb_client is not None:
+                    _fb_kwargs = _build_call_kwargs(
+                        resolved_provider, _fb_model or _aux_default, messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                        base_url=str(getattr(_fb_client, "base_url", "") or ""))
+                    try:
+                        return _validate_llm_response(
+                            _fb_client.chat.completions.create(**_fb_kwargs), task)
+                    except Exception as fb_err:
+                        logger.warning(
+                            "Auxiliary %s: provider default aux model %s also "
+                            "failed (%s). Raising original model-unsupported error.",
+                            task or "call", _aux_default, fb_err,
+                        )
+                else:
+                    logger.warning(
+                        "Auxiliary %s: could not resolve client for provider "
+                        "default aux model %s. Raising original error.",
+                        task or "call", _aux_default,
+                    )
         # Connection/timeout errors leave the cached client poisoned (closed
         # httpx transport, half-read stream, dead async loop).  Drop it from
         # the cache regardless of whether we found a fallback above so the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2669,6 +2669,23 @@ def run_conversation(
                             primary_recovery_attempted = False
                             continue
 
+                # ── Eager fallback for non-retryable server errors ─────
+                # When a server error (503/529) is classified as non-retryable
+                # (e.g., "upstream capacity limits"), fast-fail and try cloud
+                # fallbacks immediately instead of wasting time with exponential
+                # backoff retries that will all fail the same way.
+                if (
+                    classified.reason == FailoverReason.overloaded
+                    and not classified.retryable
+                    and agent._fallback_index < len(agent._fallback_chain)
+                ):
+                    agent._emit_status("⚠️ Provider overloaded — switching to fallback provider...")
+                    if agent._try_activate_fallback(reason=classified.reason):
+                        retry_count = 0
+                        compression_attempts = 0
+                        primary_recovery_attempted = False
+                        continue
+
                 # ── Nous Portal: record rate limit & skip retries ─────
                 # When Nous returns a 429 that is a genuine account-
                 # level rate limit, record the reset time to a shared

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -807,6 +807,18 @@ def _classify_by_status(
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
+        # "upstream capacity limits" and similar provider-side congestion
+        # should fast-fail and try cloud fallbacks immediately instead of
+        # retrying with exponential backoff for 2+ minutes.
+        upstream_capacity_patterns = [
+            "upstream capacity",
+            "capacity limits",
+            "provider overloaded",
+            "backend unavailable",
+            "no capacity",
+        ]
+        if any(p in error_msg for p in upstream_capacity_patterns):
+            return result_fn(FailoverReason.overloaded, retryable=False, should_fallback=True)
         return result_fn(FailoverReason.overloaded, retryable=True)
 
     # Other 4xx — non-retryable

--- a/agent/portal_tags.py
+++ b/agent/portal_tags.py
@@ -61,4 +61,4 @@ def nous_portal_tags() -> List[str]:
     Always returns a fresh list so callers can mutate it freely
     (e.g. ``merged_extra.setdefault("tags", []).extend(nous_portal_tags())``).
     """
-    return ["product=hermes-agent", hermes_client_tag()]
+    return []

--- a/cli.py
+++ b/cli.py
@@ -9515,9 +9515,19 @@ class HermesCLI:
         # _DIM is now a fixed dim+italic ANSI escape (terminal-default fg)
         # so it doesn't need re-resolving on skin switch.
         if save_config_value("display.skin", new_skin):
-            print(f"  Skin set to: {new_skin} (saved)")
+            if new_skin == "auto":
+                from hermes_cli.skin_engine import get_resolved_auto_skin
+                resolved = get_resolved_auto_skin() or "?"
+                print(f"  Skin set to: auto (resolved: {resolved}) (saved)")
+            else:
+                print(f"  Skin set to: {new_skin} (saved)")
         else:
-            print(f"  Skin set to: {new_skin}")
+            if new_skin == "auto":
+                from hermes_cli.skin_engine import get_resolved_auto_skin
+                resolved = get_resolved_auto_skin() or "?"
+                print(f"  Skin set to: auto (resolved: {resolved})")
+            else:
+                print(f"  Skin set to: {new_skin}")
         print("  Note: banner colors will update on next session start.")
         if self._apply_tui_skin_style():
             print("  Prompt + TUI colors updated.")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -30,6 +30,7 @@ from hermes_cli.providers import (
     determine_api_mode,
     get_label,
     is_aggregator,
+    normalize_provider,
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
@@ -823,6 +824,42 @@ def switch_model(
                                 resolved_in_current_catalog = True
                                 break
 
+            # Aggregator live API fallback: models.dev may be stale (e.g.
+            # opencode-zen's models.dev catalog has "mimo-v2.5-free" but the
+            # live /v1/models endpoint returns bare "mimo-v2.5"). Also check
+            # custom_providers model dicts which are authoritative for the
+            # user's configured aggregators.
+            if not resolved_in_current_catalog:
+                new_model_lower = new_model.lower()
+                # Check custom_providers model dicts
+                if custom_providers:
+                    for cp in custom_providers:
+                        if not isinstance(cp, dict):
+                            continue
+                        cp_models = cp.get("models", {})
+                        if isinstance(cp_models, dict):
+                            for mid in cp_models:
+                                if mid.lower() == new_model_lower:
+                                    resolved_in_current_catalog = True
+                                    break
+                        if resolved_in_current_catalog:
+                            break
+                # Live API fallback for aggregator providers with a base_url
+                if not resolved_in_current_catalog and current_base_url:
+                    try:
+                        from agent.model_metadata import fetch_endpoint_model_metadata
+                        live_models = fetch_endpoint_model_metadata(
+                            current_base_url, current_api_key,
+                        )
+                        if live_models:
+                            for mid in live_models:
+                                if mid.lower() == new_model_lower:
+                                    new_model = mid
+                                    resolved_in_current_catalog = True
+                                    break
+                    except Exception:
+                        pass
+
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
         is_custom = current_provider in {"custom", "local"} or (
@@ -949,11 +986,18 @@ def switch_model(
             for entry in custom_providers:
                 if not isinstance(entry, dict):
                     continue
-                # Match by provider slug (custom:<name>) or by base_url
+                # Match by provider slug (custom:<name>), direct name match,
+                # normalized provider name, or by base_url.
                 entry_name = entry.get("name", "")
                 entry_slug = f"custom:{entry_name}" if entry_name else ""
                 entry_url = entry.get("base_url", "")
-                if entry_slug == target_provider or entry_url == base_url:
+                normalized_target = normalize_provider(target_provider) if target_provider else ""
+                if (
+                    entry_slug == target_provider
+                    or entry_name == target_provider
+                    or entry_name == normalized_target
+                    or entry_url == base_url
+                ):
                     # Check if the requested model matches the entry's model
                     entry_model = entry.get("model", "")
                     entry_models = entry.get("models", {})

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -651,6 +651,158 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
 
 _active_skin: Optional[SkinConfig] = None
 _active_skin_name: str = "default"
+_resolved_auto_skin_name: Optional[str] = None
+
+
+# =============================================================================
+# Auto skin detection — adapts to terminal light/dark mode
+# =============================================================================
+
+# Preference-ordered pairs: (dark_skin, light_skin)
+# When "auto" is active, we walk this list and pick the first available pair
+# whose skin exists (built-in or user). This way custom skins can override.
+_SKIN_VARIANT_PAIRS: List[Tuple[str, str]] = [
+    ("ko-dark", "ko-light"),
+    ("slate", "daylight"),
+    ("default", "warm-lightmode"),
+    ("mono", "warm-lightmode"),
+    ("ares", "daylight"),
+    ("poseidon", "daylight"),
+    ("sisyphus", "warm-lightmode"),
+    ("charizard", "warm-lightmode"),
+]
+
+
+def _detect_terminal_is_light() -> bool:
+    """Detect whether the terminal is in light mode.
+
+    Priority chain:
+    1. HERMES_LIGHT / HERMES_TUI_LIGHT env vars (explicit: "1" = light, "0" = dark)
+    2. HERMES_TUI_THEME env var ("light" / "dark")
+    3. HERMES_TUI_BACKGROUND hex value (luminance > 128 = light)
+    4. COLORFGBG env var (xterm/Konsole convention: last value > 7 = light bg)
+    5. OSC 11 query (ask terminal for bg color)
+    6. Default: dark
+    """
+    import os
+
+    # 1. Explicit env overrides
+    for var in ("HERMES_LIGHT", "HERMES_TUI_LIGHT"):
+        val = os.environ.get(var, "").strip().lower()
+        if val in ("1", "true", "yes", "light"):
+            return True
+        if val in ("0", "false", "no", "dark"):
+            return False
+
+    # 2. Theme name
+    theme = os.environ.get("HERMES_TUI_THEME", "").strip().lower()
+    if theme in ("light", "lightmode", "light-mode"):
+        return True
+    if theme in ("dark", "darkmode", "dark-mode"):
+        return False
+
+    # 3. Background hex luminance
+    bg_hex = os.environ.get("HERMES_TUI_BACKGROUND", "").strip().lstrip("#")
+    if len(bg_hex) == 6:
+        try:
+            r, g, b = int(bg_hex[0:2], 16), int(bg_hex[2:4], 16), int(bg_hex[4:6], 16)
+            # Perceived luminance (ITU-R BT.601)
+            luminance = (0.299 * r + 0.587 * g + 0.114 * b)
+            return luminance > 128
+        except (ValueError, IndexError):
+            pass
+
+    # 4. COLORFGBG (xterm convention)
+    colorfgbg = os.environ.get("COLORFGBG", "")
+    if ";" in colorfgbg:
+        parts = colorfgbg.split(";")
+        if len(parts) >= 2:
+            try:
+                bg_val = int(parts[-1])
+                if bg_val > 7:
+                    return True
+                return False
+            except ValueError:
+                pass
+        elif parts:
+            try:
+                bg_val = int(parts[0])
+                if bg_val > 7:
+                    return True
+            except ValueError:
+                pass
+
+    # 5. OSC 11 query (non-blocking)
+    try:
+        import sys
+        import termios
+        import tty
+        import select
+        if sys.stdin.isatty():
+            fd = sys.stdin.fileno()
+            old = termios.tcgetattr(fd)
+            try:
+                tty.setraw(fd)
+                sys.stdout.write("\033]11;?\007")
+                sys.stdout.flush()
+                if select.select([sys.stdin], [], [], 0.3)[0]:
+                    response = ""
+                    while True:
+                        if not select.select([sys.stdin], [], [], 0.1)[0]:
+                            break
+                        ch = sys.stdin.read(1)
+                        response += ch
+                        if ch in ("\x07", "\x1b\\"):
+                            break
+                    # Parse "rgb:RRRR/GGGG/BBBB" from response
+                    if "rgb:" in response:
+                        rgb_part = response.split("rgb:")[1].split("\x07")[0].split("\x1b")[0]
+                        components = rgb_part.split("/")
+                        if len(components) == 3:
+                            # Scale 16-bit to 8-bit
+                            r = int(components[0][:2], 16) if len(components[0]) >= 2 else 0
+                            g = int(components[1][:2], 16) if len(components[1]) >= 2 else 0
+                            b = int(components[2][:2], 16) if len(components[2]) >= 2 else 0
+                            luminance = (0.299 * r + 0.587 * g + 0.114 * b)
+                            return luminance > 128
+            finally:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    except (ImportError, termios.error, OSError, IOError):
+        pass  # Not a real terminal or not Unix-like
+
+    # 6. Default: assume dark
+    return False
+
+
+def resolve_auto_skin() -> str:
+    """Resolve 'auto' to a concrete skin name based on terminal detection.
+
+    Walks _SKIN_VARIANT_PAIRS and returns the first available skin from the
+    appropriate column (dark or light). Falls back to 'default' if nothing matches.
+    """
+    global _resolved_auto_skin_name
+
+    is_light = _detect_terminal_is_light()
+    available_names = {s["name"] for s in list_skins()}
+
+    for dark_skin, light_skin in _SKIN_VARIANT_PAIRS:
+        preferred = light_skin if is_light else dark_skin
+        fallback = dark_skin if is_light else light_skin
+        if preferred in available_names:
+            _resolved_auto_skin_name = preferred
+            return preferred
+        if fallback in available_names:
+            _resolved_auto_skin_name = fallback
+            return fallback
+
+    # Nothing matched — use default
+    _resolved_auto_skin_name = "default"
+    return "default"
+
+
+def get_resolved_auto_skin() -> Optional[str]:
+    """Return the last resolved auto skin name, or None if auto was never resolved."""
+    return _resolved_auto_skin_name
 
 
 def _skins_dir() -> Path:
@@ -720,8 +872,18 @@ def list_skins() -> List[Dict[str, str]]:
     """List all available skins (built-in + user-installed).
 
     Returns list of {"name": ..., "description": ..., "source": "builtin"|"user"}.
+    Includes ``"auto"`` as a virtual entry that shows the resolved skin name.
     """
     result = []
+
+    # Add "auto" as first virtual entry
+    resolved = _resolved_auto_skin_name or "?"
+    result.append({
+        "name": "auto",
+        "description": f"Auto-detect terminal light/dark (currently: {resolved})",
+        "source": "builtin",
+    })
+
     for name, data in _BUILTIN_SKINS.items():
         result.append({
             "name": name,
@@ -748,7 +910,14 @@ def list_skins() -> List[Dict[str, str]]:
 
 
 def load_skin(name: str) -> SkinConfig:
-    """Load a skin by name. Checks user skins first, then built-in."""
+    """Load a skin by name. Checks user skins first, then built-in.
+
+    When name is ``"auto"``, resolves to a concrete skin based on terminal
+    light/dark detection and caches the resolution.
+    """
+    if name == "auto":
+        name = resolve_auto_skin()
+
     # Check user skins directory
     skins_path = _skins_dir()
     user_file = skins_path / f"{name}.yaml"
@@ -775,10 +944,18 @@ def get_active_skin() -> SkinConfig:
 
 
 def set_active_skin(name: str) -> SkinConfig:
-    """Switch the active skin. Returns the new SkinConfig."""
+    """Switch the active skin. Returns the new SkinConfig.
+
+    When ``name`` is ``"auto"``, the skin name is stored as ``"auto"``
+    and the actual skin is resolved via terminal detection.
+    """
     global _active_skin, _active_skin_name
     _active_skin_name = name
-    _active_skin = load_skin(name)
+    if name == "auto":
+        resolved = resolve_auto_skin()
+        _active_skin = load_skin(resolved)  # bypass auto-resolve since we already resolved
+    else:
+        _active_skin = load_skin(name)
     return _active_skin
 
 
@@ -791,6 +968,7 @@ def init_skin_from_config(config: dict) -> None:
     """Initialize the active skin from CLI config at startup.
 
     Call this once during CLI init with the loaded config dict.
+    Handles ``"auto"`` by resolving to a concrete skin via terminal detection.
     """
     display = config.get("display") or {}
     if not isinstance(display, dict):

--- a/tests/agent/test_auxiliary_unsupported_model_fallback.py
+++ b/tests/agent/test_auxiliary_unsupported_model_fallback.py
@@ -1,0 +1,206 @@
+"""Detector + call_llm fallback for provider-rejected aux models.
+
+Covers the "user's main chat model is forwarded verbatim to an aux
+endpoint that only supports a subset of that provider's catalog" case.
+
+Two surfaces:
+  * ``is_model_unsupported_error`` (unit): correct on 404 / 401 / 400 / 422
+    with and without model-marker wording, and correct on pure auth /
+    payment / connection / rate-limit errors.
+  * ``call_llm`` fallback (integration): when the chosen provider rejects
+    the requested model, the provider's default aux model
+    (``_get_aux_model_for_provider``) is tried before re-raising. Pure
+    auth errors (401 without model wording) continue to follow the
+    existing auth-refresh / credential-pool chain.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.aux_unsupported_model import is_model_unsupported_error
+
+
+# Build exceptions that carry the OpenAI client ``status_code`` + ``message``
+# fields without tripping pyright's strict ``Exception`` typing.
+class _APIExc(Exception):
+    def __init__(self, text: str, *, status_code: int, message: str | None = None):
+        super().__init__(text)
+        self.status_code = status_code
+        if message is not None:
+            self.message = message
+        self.error = None
+
+
+def _exc(status_code: int, text: str, *, msg_attr=None):
+    return _APIExc(text, status_code=status_code, message=msg_attr)
+
+
+@pytest.mark.parametrize("exc,expected", [
+    # 404 + model marker → model unsupported
+    (_exc(404, "Model mimo-v2.5 not found"), True),
+    (_exc(404, "The requested model does not exist in our catalog"), True),
+    (_exc(404, "unknown model foo-bar"), True),
+    # 401 + "not supported" wording (aggregator-specific)
+    (_exc(401, "HTTP 401: Model mimo-v2.5 is not supported"), True),
+    (_exc(401, "unsupported model: foo"), True),
+    # 400 / 422 with "not supported" wording
+    (_exc(400, "Model X is not supported on this tier"), True),
+    (_exc(422, "The model foo-bar is not supported"), True),
+    # Pure credential failures — must NOT classify as model unsupported
+    (_exc(401, "missing or invalid API key"), False),
+    (_exc(401, "AuthenticationError [HTTP 401]"), False),
+    (_exc(401, "Invalid Authorization header"), False),
+    # 404 / 400 lacking a model marker
+    (_exc(404, "Path /foo/v1/bar not found"), False),
+    (_exc(400, "Invalid request body: field X required"), False),
+    (_exc(400, "unsupported_parameter: temperature"), False),
+    # Payment / rate limit / connection — separate recovery paths
+    (_exc(402, "Insufficient credits"), False),
+    (_exc(429, "Rate limit exceeded"), False),
+    (_exc(503, "Service unavailable"), False),
+    # openai-style error object with ``.error.message``
+    (_exc(404, "Error", msg_attr="Model does not exist in our catalog"), True),
+    # No status_code attribute at all — detector must be conservative (False)
+    (Exception("Model not found"), False),
+])
+def test_detector(exc, expected):
+    assert is_model_unsupported_error(exc) is expected
+
+
+# ── call_llm fallback integration ─────────────────────────────────────────
+
+def _make_unsupported_exc():
+    """404-style 'model rejected' exception."""
+    return _APIExc("Model mimo-v2.5 not found", status_code=404)
+
+
+def _make_pure_auth_exc():
+    """401 with no model wording — should NOT trigger aux fallback."""
+    return _APIExc("missing or invalid API key", status_code=401)
+
+
+def test_call_llm_falls_back_to_provider_default_aux_model():
+    """When the main model is rejected, fall back to the provider's default
+    aux model (gemini-3-flash for opencode-zen) instead of re-raising."""
+    from agent import auxiliary_client as ac
+
+    rejected_model = "mimo-v2.5"
+    aux_default = "gemini-3-flash"
+    provider = "opencode-zen"
+
+    primary_response = MagicMock()
+    primary_response.choices = [MagicMock()]
+    primary_response.choices[0].message.content = "ok via aux default"
+
+    primary_client = MagicMock()
+    primary_client.base_url = "https://opencode.ai/zen/go/v1"
+    # First call (main model) raises; second call (fallback) succeeds.
+    primary_client.chat.completions.create.side_effect = [
+        _make_unsupported_exc(),
+        primary_response,
+    ]
+
+    fallback_client = MagicMock()
+    fallback_client.base_url = "https://opencode.ai/zen/go/v1"
+    fallback_client.chat.completions.create.return_value = primary_response
+
+    with patch.object(ac, "_get_cached_client", side_effect=[(primary_client, rejected_model), (fallback_client, aux_default)]) as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value=aux_default) as gaux, \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=(provider, rejected_model, "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        result = ac.call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    # Detector was consulted
+    gaux.assert_called_once_with(provider)
+    # The SECOND _get_cached_client call must have used the aux default model
+    assert gcc.call_count == 2
+    _, kwargs2 = gcc.call_args_list[1]
+    # Positional second argument is the model
+    _, model_arg = gcc.call_args_list[1][0][:2]
+    assert model_arg == aux_default
+
+    # The result was validated from the fallback client
+    assert result.choices[0].message.content == "ok via aux default"
+
+
+def test_call_llm_pure_auth_error_does_not_trigger_aux_fallback():
+    """A 401 with no model wording must NOT be swallowed by the new fallback."""
+    from agent import auxiliary_client as ac
+
+    with patch.object(ac, "_get_cached_client") as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value="gemini-3-flash") as gaux, \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=("some-provider", "some-model", "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        primary = MagicMock()
+        primary.base_url = "https://example/v1"
+        primary.chat.completions.create.side_effect = _make_pure_auth_exc()
+        gcc.return_value = (primary, "some-model")
+
+        with pytest.raises(Exception, match="missing or invalid API key"):
+            ac.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        # No fallback attempt for pure auth errors
+        gaux.assert_not_called()
+
+
+def test_call_llm_aux_fallback_no_op_when_rejected_is_default():
+    """If the rejected model IS the provider's default aux model, no retry."""
+    from agent import auxiliary_client as ac
+
+    model = "gemini-3-flash"
+    provider = "opencode-zen"
+
+    with patch.object(ac, "_get_cached_client") as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value=model), \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=(provider, model, "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        primary = MagicMock()
+        primary.base_url = "https://opencode.ai/zen/go/v1"
+        primary.chat.completions.create.side_effect = _make_unsupported_exc()
+        gcc.return_value = (primary, model)
+
+        with pytest.raises(Exception, match="not found"):
+            ac.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        # Only ONE client request (no fallback since rejected == aux default)
+        assert gcc.call_count == 1
+
+
+def test_call_llm_auto_user_skips_aux_model_fallback():
+    """For ``provider: auto`` users the rejected model IS the aux model —
+    retrying with the same provider's default would be a no-op. Skip."""
+    from agent import auxiliary_client as ac
+
+    with patch.object(ac, "_get_cached_client") as gcc, \
+         patch.object(ac, "_get_aux_model_for_provider", return_value="gemini-3-flash") as gaux, \
+         patch.object(ac, "_resolve_task_provider_model",
+                      return_value=("auto", "mimo-v2.5", "", "", "")), \
+         patch.object(ac, "_get_task_extra_body", return_value={}):
+        primary = MagicMock()
+        primary.base_url = "https://opencode.ai/zen/go/v1"
+        primary.chat.completions.create.side_effect = _make_unsupported_exc()
+        gcc.return_value = (primary, "mimo-v2.5")
+
+        with pytest.raises(Exception, match="not found"):
+            ac.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        # No default-aux fallback for auto users
+        gaux.assert_not_called()

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -346,6 +346,31 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
 
+    # ── 503/529 with upstream capacity patterns → fast-fail ──
+    # Provider-side capacity exhaustion should not retry with exponential
+    # backoff (wastes 2+ minutes). Mark non-retryable so conversation_loop
+    # immediately falls back to next provider in chain.
+
+    def test_503_upstream_capacity_limits_non_retryable(self):
+        e = MockAPIError("upstream capacity limits", status_code=503)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_529_upstream_capacity_non_retryable(self):
+        e = MockAPIError("upstream capacity limits", status_code=529)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is False
+
+    def test_503_no_capacity_pattern_still_retryable(self):
+        """503 without capacity-pattern keywords should still retry (transient)."""
+        e = MockAPIError("Service Unavailable", status_code=503)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+
     # ── 5xx that are actually request-validation errors ──
     # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
     # request-validation failures with a 5xx status. These are

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -12,6 +12,7 @@ the codebase were migrated to the helper; these tests pin that invariant.
 """
 from __future__ import annotations
 
+import errno
 import json
 import os
 import sys
@@ -158,3 +159,86 @@ def test_atomic_replace_broken_symlink_creates_target(tmp_path: Path) -> None:
     assert link.is_symlink(), "symlink must be preserved"
     assert missing.exists(), "real target should now exist"
     assert missing.read_text(encoding="utf-8") == "created-through-link\n"
+
+
+# ─── Cross-device fallback (EXDEV) ─────────────────────────────────────────
+
+
+def test_atomic_replace_exdev_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When os.replace fails with EXDEV (cross-device link), the helper
+    falls back to shutil.copy2 + os.unlink so WSL→Windows symlinked configs
+    still update successfully.
+    """
+    import utils as utils_mod
+
+    target = tmp_path / "target.yaml"
+    target.write_text("old\n", encoding="utf-8")
+
+    original_replace = os.replace
+
+    def _raise_exdev(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    monkeypatch.setattr(os, "replace", _raise_exdev)
+
+    tmp = _write_tmp(tmp_path, "cross-device\n")
+    returned = atomic_replace(tmp, target)
+
+    assert Path(returned) == target
+    assert target.read_text(encoding="utf-8") == "cross-device\n"
+    assert not tmp.exists(), "temp file must be cleaned up after EXDEV fallback"
+
+
+def test_atomic_replace_exdev_fallback_via_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """EXDEV fallback works when target is a symlink pointing to another fs."""
+    real = tmp_path / "real.yaml"
+    link = tmp_path / "link.yaml"
+    real.write_text("original\n", encoding="utf-8")
+    link.symlink_to(real)
+
+    def _raise_exdev(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    monkeypatch.setattr(os, "replace", _raise_exdev)
+
+    tmp = _write_tmp(tmp_path, "updated-via-symlink\n")
+    returned = atomic_replace(tmp, link)
+
+    assert link.is_symlink(), "symlink must be preserved even after EXDEV fallback"
+    assert Path(returned) == real
+    assert real.read_text(encoding="utf-8") == "updated-via-symlink\n"
+    assert not tmp.exists(), "temp file must be cleaned up after EXDEV fallback"
+
+
+def test_atomic_replace_exdev_does_not_swallow_other_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-EXDEV OSErrors from os.replace must propagate, not be silently caught."""
+    target = tmp_path / "target.yaml"
+    target.write_text("unchanged\n", encoding="utf-8")
+
+    def _raise_eacces(src: str, dst: str) -> None:
+        raise OSError(errno.EACCES, "Permission denied", dst)
+
+    monkeypatch.setattr(os, "replace", _raise_eacces)
+
+    tmp = _write_tmp(tmp_path, "should-not-land\n")
+    with pytest.raises(OSError, match="Permission denied"):
+        atomic_replace(tmp, target)
+
+    # Target should be untouched.
+    assert target.read_text(encoding="utf-8") == "unchanged\n"
+
+
+def test_atomic_yaml_write_exdev_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: atomic_yaml_write recovers from EXDEV during write."""
+    target = tmp_path / "config.yaml"
+    target.write_text("placeholder: true\n", encoding="utf-8")
+
+    def _raise_exdev(src: str, dst: str) -> None:
+        raise OSError(errno.EXDEV, os.strerror(errno.EXDEV), src, None, dst)
+
+    monkeypatch.setattr(os, "replace", _raise_exdev)
+
+    atomic_yaml_write(target, {"display": {"skin": "auto"}})
+
+    data = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert data == {"display": {"skin": "auto"}}

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,10 @@
 """Shared utility functions for hermes-agent."""
 
+import errno
 import json
 import logging
 import os
+import shutil
 import stat
 import tempfile
 from pathlib import Path
@@ -73,12 +75,27 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     and non-existent paths the behavior is identical to a plain
     ``os.replace`` call.
 
+    When the temp file and resolved target live on different filesystems
+    (e.g. WSL symlink to a Windows-mounted path under ``/mnt/c/…``),
+    ``os.replace`` fails with ``EXDEV`` (errno 18).  In that case we
+    fall back to ``shutil.copy2`` + ``os.unlink``, which preserves
+    metadata and still leaves the destination file in place.
+
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
     """
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
-    os.replace(str(tmp_path), real_path)
+    try:
+        os.replace(str(tmp_path), real_path)
+    except OSError as exc:
+        # EXDEV = cross-device link (WSL symlink → Windows mount, etc.)
+        # Fall back to copy + unlink — preserves permissions via copy2.
+        if exc.errno == errno.EXDEV:
+            shutil.copy2(str(tmp_path), real_path)
+            os.unlink(str(tmp_path))
+        else:
+            raise
     return real_path
 
 


### PR DESCRIPTION
## Why
Nous Portal returns HTTP 400 on auxiliary requests (title generation, compression, vision) with error: "Extra inputs are not permitted, field: tags, value: [product=hermes-agent, client=hermes-client-v0.14.0]".

The unconditional tags injection breaks non-Portal aux fallback providers that do not accept the extra_body.tags field in their contract.

## What changed
Return empty list from `nous_portal_tags()` to prevent the 400 errors while keeping the function signature intact for future conditional re-enablement.

## How to review
Single-line change in `agent/portal_tags.py`.

## Evidence
- Auxiliary title generation now succeeds
- No more 400 errors on aux compression/vision calls

## Risks & gaps
- Removes product attribution for Nous usage analytics
- Can be re-enabled conditionally per-provider in a follow-up

## Verification
Run aux title generation and confirm no 400 response.