### PR TITLE
fix(model-switch): write the target provider's own endpoint instead of blanking model.base_url

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -783,6 +783,40 @@ def resolve_custom_provider(
     return None
 
 
+def configured_provider_endpoint(
+    name: str,
+    user_providers: Optional[Dict[str, Any]] = None,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Endpoint ``name`` declares in the user's OWN config, or ``""``.
+
+    Built-in providers return ``""``: their endpoint lives in the resolver
+    registry, so config must not pin one (a pinned URL is what goes stale on a
+    provider switch).  User-declared providers — ``providers:`` blocks and
+    legacy ``custom_providers:`` entries — return their configured ``base_url``,
+    because for those the user-supplied URL *is* the provider's own default and
+    nothing else knows it.
+
+    Accepts every spelling a caller may hold: the canonical slug
+    (``custom:<name>``, what :func:`switch_model` reports), the raw display
+    name, and bare ``custom`` (which self-heals to the first valid entry, same
+    as :func:`resolve_custom_provider`).
+
+    Config-writing paths use this to answer "does the provider I'm switching TO
+    supply its own endpoint?" instead of unconditionally blanking
+    ``model.base_url`` — blanking strands any provider with no registry entry.
+    """
+    requested = (name or "").strip().lower()
+    if not requested:
+        return ""
+    pdef = resolve_user_provider(requested, user_providers or {}) or resolve_custom_provider(
+        requested, custom_providers
+    )
+    if pdef is None:
+        return ""
+    return (pdef.base_url or "").strip()
+
+
 def resolve_provider_full(
     name: str,
     user_providers: Optional[Dict[str, Any]] = None,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1497,6 +1497,27 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     return prov_in, model_in
 
 
+def _configured_endpoint_for(provider: str) -> str:
+    """``base_url`` ``provider`` declares in the active profile's config, or "".
+
+    Thin wrapper so the assignment helpers below stay readable; see
+    :func:`hermes_cli.providers.configured_provider_endpoint`. Reads the config
+    lazily (it is mtime-cached) and never raises — a lookup failure degrades to
+    the historical clear-on-switch behaviour rather than blocking the write.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.providers import configured_provider_endpoint
+
+        cfg = load_config() or {}
+        return configured_provider_endpoint(
+            provider, cfg.get("providers"), cfg.get("custom_providers")
+        )
+    except Exception:
+        _log.debug("configured-endpoint lookup failed for %r", provider, exc_info=True)
+        return ""
+
+
 def _apply_main_model_assignment(
     model_cfg: "Any", provider: str, model: str, base_url: str = "", api_key: str = ""
 ) -> dict:
@@ -1507,8 +1528,11 @@ def _apply_main_model_assignment(
     - An explicitly supplied ``base_url`` is always persisted (covers
       ``custom``/local endpoints and any provider whose key is bound to a
       non-default host).
-    - Otherwise, a stale ``base_url`` is cleared ONLY when switching to a
-      *different* provider — that URL belonged to the old provider. When the
+    - Otherwise, a stale ``base_url`` is replaced ONLY when switching to a
+      *different* provider — that URL belonged to the old provider. It is
+      replaced by whatever endpoint the new provider declares in the user's own
+      config (``providers:`` / ``custom_providers:``), which is empty for
+      built-ins, so they keep resolving through the registry as before. When the
       provider is unchanged and no new URL is supplied, the existing
       ``base_url`` is preserved. This keeps a user's custom endpoint (e.g. a
       Xiaomi MiMo Token Plan host, ``https://token-plan-*.xiaomimimo.com/v1``)
@@ -1534,10 +1558,19 @@ def _apply_main_model_assignment(
     if base_url.strip():
         model_cfg["base_url"] = base_url.strip()
     elif model_cfg.get("base_url") and new_provider != prev_provider:
-        # Switching providers: the old URL belonged to the old provider, drop
-        # it so the new provider's default endpoint is used. Same-provider
-        # re-assignment keeps the user's configured base_url intact.
-        model_cfg["base_url"] = ""
+        # Switching providers: the old URL belonged to the old provider, so it
+        # cannot stay. Replace it with the endpoint the NEW provider declares in
+        # the user's own config; built-ins declare none, so this still resolves
+        # to "" for them (unchanged behaviour — the registry supplies the URL).
+        #
+        # Clearing unconditionally stranded providers with no registry entry:
+        # the picker sends provider+model only (apps/desktop/src/hermes.ts
+        # ``setGlobalModel``), so switching to bare ``custom`` left
+        # ``model.base_url`` empty with nothing else pointing at the endpoint,
+        # the resolver fell through to OpenRouter's default host with no key,
+        # and the next agent call returned
+        # ``HTTP 401: Missing Authentication header``.
+        model_cfg["base_url"] = _configured_endpoint_for(provider)
     # The endpoint key follows the same lifecycle as base_url: an explicit key
     # is always persisted; an existing key is dropped only when switching to a
     # different provider (it belonged to the old endpoint), and preserved on a

--- a/tests/hermes_cli/test_web_server_picker_base_url.py
+++ b/tests/hermes_cli/test_web_server_picker_base_url.py
@@ -1,0 +1,170 @@
+"""Dashboard model picker (``POST /api/model/set``) × ``custom_providers``.
+
+The picker sends provider + model only — no ``base_url``
+(``apps/desktop/src/hermes.ts`` ``setGlobalModel``) — so
+``_apply_main_model_assignment`` alone decides what happens to
+``model.base_url`` on a provider switch.
+
+It used to blank the URL on every provider change, on the assumption that the
+resolver would supply "the new provider's own default". That holds for built-ins
+(their endpoint lives in the resolver registry) but not for providers the user
+declared themselves: for those the user-supplied URL *is* the default. A bare
+``custom`` target has no registry entry and no name to look up, so a blanked
+``model.base_url`` left the resolver falling through to OpenRouter's default host
+with no key, and the next agent call returned
+``HTTP 401: Missing Authentication header``.
+
+These tests pin the contract:
+  * switching to a user-declared provider writes THAT provider's endpoint
+    (canonical ``custom:<name>`` slug, raw display name, and bare ``custom``);
+  * switching to a built-in still clears ``base_url``;
+  * a same-provider re-pick still preserves it;
+  * and the resolver really does route to the user's gateway afterwards.
+"""
+
+import pytest
+import yaml
+
+web_server = pytest.importorskip(
+    "hermes_cli.web_server", reason="fastapi/starlette not installed"
+)
+_apply_main_model_assignment = web_server._apply_main_model_assignment
+
+LITELLM_URL = "http://192.168.1.10:4000"
+VLLM_URL = "http://192.168.1.11:8000"
+
+CONFIG = f"""\
+custom_providers:
+- name: my-litellm
+  base_url: {LITELLM_URL}
+  api_key: sk-test-litellm
+  api_format: openai
+- name: my-vllm
+  base_url: {VLLM_URL}
+  api_key: sk-test-vllm
+  api_format: openai
+
+model:
+  default: gpt-4o-mini
+  provider: {{provider}}
+  base_url: {{base_url}}
+  api_key: sk-test-endpoint
+"""
+
+
+@pytest.fixture
+def config_home(tmp_path, monkeypatch):
+    """HERMES_HOME holding a two-custom-provider config; returns a writer."""
+    home = tmp_path / "picker_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def _write(provider: str, base_url: str) -> dict:
+        (home / "config.yaml").write_text(
+            CONFIG.format(provider=provider, base_url=base_url or "''")
+        )
+        return yaml.safe_load((home / "config.yaml").read_text())
+
+    _write("anthropic", "https://api.anthropic.com")
+    return _write
+
+
+def _pick(cfg: dict, provider: str, model: str = "model-b") -> dict:
+    """Apply a picker assignment the way ``POST /api/model/set`` does."""
+    return _apply_main_model_assignment(cfg.get("model") or {}, provider, model)
+
+
+class TestSwitchingToUserDeclaredProvider:
+    """The target's OWN endpoint is written, whatever spelling arrives."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            "custom:my-litellm",  # canonical slug — what the picker rows use
+            "my-litellm",  # raw display name
+            "custom",  # bare: self-heals to the first valid entry
+        ],
+    )
+    def test_switch_writes_target_endpoint(self, config_home, provider):
+        cfg = config_home("anthropic", "https://api.anthropic.com")
+
+        model_cfg = _pick(cfg, provider)
+
+        assert model_cfg["provider"] == provider
+        assert model_cfg["default"] == "model-b"
+        assert model_cfg.get("base_url") == LITELLM_URL, (
+            f"picker left base_url={model_cfg.get('base_url')!r} for {provider!r}; "
+            "an empty URL makes the resolver fall through to OpenRouter and the "
+            "next agent call 401s"
+        )
+
+    def test_switch_between_custom_providers_uses_the_new_one(self, config_home):
+        """custom-A → custom-B must not leave A's host behind.
+
+        Preserving the old URL would point B's model at A's gateway — the
+        opposite failure from clearing it.
+        """
+        cfg = config_home("custom:my-litellm", LITELLM_URL)
+
+        model_cfg = _pick(cfg, "custom:my-vllm")
+
+        assert model_cfg.get("base_url") == VLLM_URL
+
+    def test_explicit_base_url_still_wins(self, config_home):
+        cfg = config_home("custom:my-litellm", LITELLM_URL)
+
+        model_cfg = _apply_main_model_assignment(
+            cfg["model"], "custom:my-litellm", "model-b", "http://127.0.0.1:9999"
+        )
+
+        assert model_cfg.get("base_url") == "http://127.0.0.1:9999"
+
+
+class TestBuiltInAndSameProviderBehaviourUnchanged:
+    """Pre-existing rules this fix must not disturb."""
+
+    def test_switch_to_built_in_clears_stale_base_url(self, config_home):
+        cfg = config_home("custom:my-litellm", LITELLM_URL)
+
+        model_cfg = _pick(cfg, "anthropic", "claude-haiku-4-5")
+
+        assert model_cfg["provider"] == "anthropic"
+        assert not model_cfg.get("base_url"), (
+            "a built-in provider carries its endpoint in the resolver registry; "
+            "a pinned URL from the previous provider must not survive"
+        )
+
+    def test_same_provider_repick_preserves_base_url(self, config_home):
+        cfg = config_home("custom:my-litellm", LITELLM_URL)
+
+        model_cfg = _pick(cfg, "custom:my-litellm")
+
+        assert model_cfg.get("base_url") == LITELLM_URL
+
+    def test_empty_base_url_stays_empty_for_built_ins(self, config_home):
+        cfg = config_home("openai", "")
+
+        model_cfg = _pick(cfg, "anthropic", "claude-haiku-4-5")
+
+        assert not model_cfg.get("base_url")
+
+
+def test_resolution_after_bare_custom_switch_reaches_the_users_gateway(config_home):
+    """End-to-end: the picker write must leave routing intact.
+
+    This is the assertion that actually encodes the bug report — before the fix
+    the resolved endpoint was ``https://openrouter.ai/api/v1`` with no key.
+    """
+    from hermes_cli.config import get_config_path
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    cfg = config_home("anthropic", "https://api.anthropic.com")
+    cfg["model"] = _pick(cfg, "custom")
+    get_config_path().write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+    runtime = resolve_runtime_provider(
+        requested=cfg["model"]["provider"], target_model="model-b"
+    )
+
+    assert runtime.get("base_url") == LITELLM_URL
+    assert "openrouter.ai" not in (runtime.get("base_url") or "")

--- a/tests/test_tui_gateway_model_switch_base_url.py
+++ b/tests/test_tui_gateway_model_switch_base_url.py
@@ -1,0 +1,123 @@
+"""``tui_gateway.server._persist_model_switch`` × ``custom_providers``.
+
+Companion to ``tests/hermes_cli/test_web_server_picker_base_url.py`` — the
+dashboard picker and the chat TUI's ``/model`` slash command both persist
+``model.base_url`` and share one bug class: blanking the URL when switching to a
+provider whose endpoint only exists in the user's config strands routing.
+
+The important detail here is the SPELLING of the target. ``switch_model()``
+reports custom providers by canonical slug — ``custom:<normalized-name>``, see
+``hermes_cli.providers.custom_provider_slug`` — never by the raw
+``custom_providers[].name``, no matter which form the caller passed in. Any fix
+that compares ``result.target_provider`` against raw names therefore never fires
+on a real switch, so every case below uses the slug the resolver actually emits.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+LITELLM_URL = "http://192.168.1.10:4000"
+VLLM_URL = "http://192.168.1.11:8000"
+
+CONFIG = f"""\
+custom_providers:
+- name: my-litellm
+  base_url: {LITELLM_URL}
+  api_key: sk-test-litellm
+  api_format: openai
+- name: my-vllm
+  base_url: {VLLM_URL}
+  api_key: sk-test-vllm
+  api_format: openai
+
+model:
+  default: model-a
+  provider: custom:my-litellm
+  base_url: {LITELLM_URL}
+  api_key: sk-test-litellm
+"""
+
+
+@pytest.fixture
+def config_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME holding the two-custom-provider config."""
+    home = tmp_path / "tui_home"
+    home.mkdir()
+    (home / ".env").write_text("")
+    (home / "config.yaml").write_text(CONFIG)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _persist(target_provider, base_url=None, new_model="model-b"):
+    """Run the real persist path with a switch result shaped like switch_model's."""
+    from tui_gateway.server import _persist_model_switch
+
+    _persist_model_switch(
+        SimpleNamespace(
+            new_model=new_model,
+            target_provider=target_provider,
+            base_url=base_url,
+        )
+    )
+
+
+def _model(home) -> dict:
+    cfg = yaml.safe_load((home / "config.yaml").read_text()) or {}
+    model = cfg.get("model")
+    return model if isinstance(model, dict) else {}
+
+
+class TestPersistUserDeclaredProvider:
+    """A target that declares its own endpoint keeps routing."""
+
+    @pytest.mark.parametrize(
+        "target_provider",
+        [
+            "custom:my-litellm",  # what switch_model() actually emits
+            "my-litellm",  # display-name spelling, for callers that pass it
+            "custom",  # bare: self-heals to the first valid entry
+        ],
+    )
+    def test_endpoint_is_written_when_result_has_none(self, config_home, target_provider):
+        """switch_model resolved no URL — take it from the target's own config."""
+        _persist(target_provider)
+
+        model = _model(config_home)
+        assert model.get("default") == "model-b"
+        assert model.get("provider") == target_provider
+        assert model.get("base_url") == LITELLM_URL, (
+            f"/model cleared base_url for {target_provider!r}; the resolver then "
+            "falls back to OpenRouter and the next turn 401s"
+        )
+
+    def test_switch_between_custom_providers_uses_the_new_one(self, config_home):
+        _persist("custom:my-vllm")
+
+        assert _model(config_home).get("base_url") == VLLM_URL
+
+    def test_explicit_result_base_url_always_wins(self, config_home):
+        _persist("custom:my-litellm", base_url="http://192.168.1.10:4001")
+
+        assert _model(config_home).get("base_url") == "http://192.168.1.10:4001"
+
+
+class TestPersistBuiltInProvider:
+    """Built-ins keep the historical clear — the registry supplies the URL."""
+
+    def test_switch_to_built_in_clears_stale_base_url(self, config_home):
+        _persist("anthropic", new_model="claude-haiku-4-5")
+
+        model = _model(config_home)
+        assert model.get("provider") == "anthropic"
+        assert model.get("base_url") in ("", None), (
+            f"stale custom URL survived a built-in switch: {model.get('base_url')!r}"
+        )
+
+    def test_unknown_provider_clears_rather_than_guessing(self, config_home):
+        """An unrecognised name declares no endpoint, so don't keep the old one."""
+        _persist("not-a-configured-provider")
+
+        assert _model(config_home).get("base_url") in ("", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3989,12 +3989,36 @@ def _persist_model_switch(result) -> None:
     if result.base_url:
         save_config_value("model.base_url", result.base_url)
     else:
-        # Clear any stale base_url when switching to a provider that doesn't use
-        # one (e.g. custom endpoint -> native provider). Reads coalesce null to
-        # absent (`model_cfg.get("base_url") or ""`), so a null is equivalent to
-        # removal without needing a key-delete. Leaving the old value would
-        # route the new model at the previous custom host (#48305).
-        save_config_value("model.base_url", None)
+        # No resolved URL for the target. Write whatever endpoint the target
+        # declares in the user's own config, and clear only when it declares
+        # none — that is the case the original clear was for (custom endpoint ->
+        # native provider), where leaving the old value would route the new model
+        # at the previous custom host (#48305). Reads coalesce null to absent
+        # (`model_cfg.get("base_url") or ""`), so a null is equivalent to removal
+        # without needing a key-delete.
+        #
+        # Match through the resolver, NOT against raw ``custom_providers[].name``
+        # values: switch_model() reports custom providers by canonical slug
+        # (``custom:<name>`` — see providers.custom_provider_slug), so a raw-name
+        # comparison never matches a real switch and silently clears the URL.
+        # configured_provider_endpoint() accepts the slug, the display name and
+        # bare ``custom`` alike. Mirrors hermes_cli/web_server.py's
+        # _apply_main_model_assignment.
+        from hermes_cli.config import load_config
+        from hermes_cli.providers import configured_provider_endpoint
+
+        try:
+            cfg = load_config() or {}
+            target_base_url = configured_provider_endpoint(
+                result.target_provider, cfg.get("providers"), cfg.get("custom_providers")
+            )
+        except Exception:
+            logger.debug(
+                "configured-endpoint lookup failed for %r", result.target_provider,
+                exc_info=True,
+            )
+            target_base_url = ""
+        save_config_value("model.base_url", target_base_url or None)
 
 
 def _snapshot_agent_model_runtime(agent) -> dict:


### PR DESCRIPTION
## Summary

A model switch that changes provider blanks `model.base_url`, on the assumption that the resolver will supply "the new provider's own default endpoint". That holds for built-in providers, whose endpoints live in the resolver registry, but not for providers the user declares themselves — for those, the user-supplied URL *is* the default and nothing else knows it.

Both config-writing paths did this: the dashboard picker (`hermes_cli/web_server.py` `_apply_main_model_assignment`) and the chat TUI's `/model` command (`tui_gateway/server.py` `_persist_model_switch`).

Both now ask the provider being switched TO what endpoint it declares in the user's own config, and clear only when it declares none. Built-in behaviour is unchanged.

## What changed since the last review

This branch was re-cut from current `main` (was a conflicted merge) and is much smaller than before. @teknium1's review point was correct and is fixed; two of the original four files are gone because `main` already covers them:

- **Dropped the `cli.py` hunk.** `main` already resolves `HERMES_HOME` live in `save_config_value` (and no longer falls back to the project `cli-config.yaml`).
- **Dropped the inline `web_server.py` picker hunk** in favour of `main`'s `_apply_main_model_assignment`, which already preserves `base_url` on a same-provider re-pick.
- **Fixed the provider comparison.** The previous revision compared `result.target_provider` against raw `custom_providers[].name` values. `switch_model()` reports custom providers by canonical slug (`custom:<name>`, `providers.custom_provider_slug`) for *every* input spelling, so that comparison never matched a real switch — the fix was inert and its tests passed only because they fabricated a raw name the resolver never emits. Matching now goes through the resolver, which accepts the slug, the display name, and bare `custom` alike.

## What is actually still broken on `main`

Probing the resolver directly (picker payload = provider + model only, per `apps/desktop/src/hermes.ts` `setGlobalModel`):

| picker target | `model.base_url` after write | resolved runtime endpoint |
| --- | --- | --- |
| `custom:my-litellm` (slug) | cleared | ✅ the user's gateway — `_get_named_custom_provider` recovers it |
| `my-litellm` (display name) | cleared | ✅ the user's gateway |
| `custom` (bare) | cleared | ❌ `https://openrouter.ai/api/v1`, **no key** → `HTTP 401: Missing Authentication header` |
| same provider, new model | preserved | ✅ |

So the original report no longer reproduces for *named* custom providers — `main` self-heals those. What survives is any target with no registry entry and no name to look up: bare `custom` is stranded, because a blanked `model.base_url` was its only pointer to the endpoint. The mirror case is also wrong today: switching custom-A → custom-B leaves A's host in place and routes B's model at the previous gateway.

## Fix

New shared helper, `hermes_cli.providers.configured_provider_endpoint()`, resolving through `resolve_user_provider` / `resolve_custom_provider`:

- built-ins declare no endpoint → returns `""` → the URL is still cleared (unchanged behaviour, registry supplies it);
- user-declared providers return their configured `base_url`;
- accepts the canonical slug, the raw display name, and bare `custom` (self-heals to the first valid entry, as `resolve_custom_provider` already does).

Both call sites write that value instead of `""` / `None`. A stale URL from the previous provider is still never kept.

## Repro

```yaml
# ~/.hermes/config.yaml
custom_providers:
- name: my-litellm
  base_url: http://192.168.1.10:4000
  api_key: sk-...
  api_format: openai

model:
  provider: custom          # bare form
  base_url: http://192.168.1.10:4000
  api_key: sk-...
  default: gpt-4o-mini
```

1. Change the default model in the dashboard picker (or `/model` in a chat).
2. `grep -A2 '^model:' ~/.hermes/config.yaml` → `base_url` is empty.
3. Send any message → `provider=custom base_url=https://openrouter.ai/api/v1 ... HTTP 401: Missing Authentication header`.

## Test plan

Two test files, 16 tests, both green; with the source changes stashed, 9 of them fail — including an end-to-end one that reports `- http://192.168.1.10:4000` / `+ https://openrouter.ai/api/v1`, i.e. the 401 itself.

- `tests/hermes_cli/test_web_server_picker_base_url.py` — picker writes the target's endpoint for slug / display-name / bare-`custom` targets; custom-A → custom-B uses B's host; built-in switch still clears; same-provider re-pick still preserves; and `resolve_runtime_provider` really does route to the user's gateway after the write.
- `tests/test_tui_gateway_model_switch_base_url.py` — same contract for `_persist_model_switch`, using the `custom:<name>` slug that `switch_model()` actually emits; an explicit `result.base_url` still wins; an unrecognised provider clears rather than guessing.

Also run locally, no regressions: 609 passed / 4 skipped across `tests/hermes_cli/test_web_server.py`, `test_web_server_profile_unification.py` and `tests/test_tui_gateway_server.py`; 20 passed across the model-switch / base-url / api-mode files; 1419 passed across all 122 provider-related test files (9 further failures there are pre-existing in my local environment — missing `acp`, asyncio marks, `concurrent_log_handler` — and fail identically without this patch).

## Related

- Supersedes the earlier revision of this PR (raw-name comparison + the two now-redundant hunks). Previous head is archived at `Marinto-Richee:archive/pr-33732-pre-v2`.
- #48305 — sibling `model.*` keys must survive a switch; both paths still use targeted writes.
- #25107, #21703 — earlier `base_url` / stale-credential preservation gaps in the same area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
