### PR TITLE
docs: drop stale Kimi/DeepSeek vision example

### DIFF
--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -54,7 +54,7 @@ Every auxiliary task defaults to `auto` — meaning Hermes uses your main model 
 | Task | When to override |
 |---|---|
 | **Title Gen** | Almost always. A $0.10/M flash model writes session titles as well as Opus. Default config sets this to `google/gemini-3-flash-preview` on OpenRouter. |
-| **Vision** | When your main model is a coding model without vision (e.g. Kimi, DeepSeek). Point it at `google/gemini-2.5-flash` or `gpt-4o-mini`. |
+| **Vision** | When your main model lacks vision support. Point it at `google/gemini-2.5-flash` or `gpt-4o-mini`. |
 | **Compression** | When you're burning reasoning tokens on Opus/M2.7 just to summarize context. A fast chat model does the job at 1/50th the cost. |
 | **Approval** | For `approval_mode: smart` — a fast/cheap model (haiku, flash, gpt-5-mini) decides whether to auto-approve low-risk commands. Expensive models here are waste. |
 | **Web Extract** | When you use `web_extract` heavily. Same logic as compression — summarization doesn't need reasoning. |


### PR DESCRIPTION
## Summary
Kimi K2.6 is natively multimodal — the auxiliary-task table was telling users to override Vision because their Kimi main model has none. Flagged by Shengyuan from the Kimi growth team; YouTube creators have been citing the docs claim.

## Changes
- `website/docs/user-guide/configuring-models.md`: replace the named-vendor example ("e.g. Kimi, DeepSeek") on the Vision auxiliary row with a model-agnostic phrasing so the row doesn't go stale again.

## Validation
Only occurrence across `website/` — confirmed with grep.
