### PR TITLE
fix(tools): unescape common sequences in new_string when escape_normalized matches

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -429,3 +429,75 @@ class TestFormatNoMatchHint:
         )
         assert result == ""
 
+
+class TestEscapeNormalizedNewString:
+    """Regression tests for unescaping common sequences in new_string
+    when the match succeeded via the escape_normalized strategy.
+
+    Issue #33733: LLMs overwhelmingly represent tabs as the two-character
+    sequence \\t (backslash + t) in JSON tool-call arguments. When the file
+    contains real tab bytes (0x09), the escape_normalized strategy matches
+    old_string by unescaping it — but new_string was written as-is, leaving
+    literal \\t characters in the file.
+    """
+
+    def test_tab_in_new_string_unescaped(self):
+        """File has real tab, model sends literal \\t in new_string."""
+        content = "def hello():\n\tprint(\"before\")\n"
+        old_string = "def hello():\n\\tprint(\"before\")\n"
+        new_string = "def hello():\n\\tprint(\"after\")\n"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        # Must contain a real tab, not literal \t
+        assert "\tprint(\"after\")" in new
+        assert "\\t" not in new
+
+    def test_newline_in_new_string_unescaped(self):
+        """File has real newlines, model sends literal \\n in new_string."""
+        content = "line1\nline2\nline3\n"
+        old_string = "line1\\nline2\\n"
+        new_string = "line1\\nreplaced\\n"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert "replaced" in new
+        assert "\\n" not in new
+
+    def test_carriage_return_in_new_string_unescaped(self):
+        """File has real CR, model sends literal \\r in new_string."""
+        content = "line1\r\nline2\r\n"
+        old_string = "line1\\r\\nline2\\r\\n"
+        new_string = "replaced\\r\\n"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert "replaced\r" in new
+
+    def test_mixed_escape_sequences_in_new_string(self):
+        """Model sends \\t and \\n together in new_string."""
+        content = "def foo():\n\tpass\n"
+        old_string = "def foo():\\n\\tpass\\n"
+        new_string = "def bar():\\n\\treturn 1\\n"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "escape_normalized"
+        assert "\treturn 1" in new
+        assert "\\t" not in new
+        assert "\\n" not in new
+
+    def test_exact_match_preserves_literal_escapes(self):
+        """When matching via exact strategy, literal \\t in new_string should
+        NOT be unescaped — the file genuinely contains backslash-t characters."""
+        content = "path = \"C:\\\\Users\\\"\n"
+        old_string = "path = \"C:\\\\Users\\\"\n"
+        new_string = "path = \"D:\\\\data\\\"\n"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None
+        assert strategy == "exact"
+        # Literal backslashes should be preserved
+        assert "\\\\" in new

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -113,8 +113,16 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             # old_string/new_string — e.g. LLM used 2-space indent but the
             # file is 4-space. Shift new_string by the indentation delta so
             # the replacement matches the file's actual indent pattern.
+            effective_new = new_string
+            if strategy_name == "escape_normalized":
+                # The escape_normalized strategy matched because old_string
+                # contained literal \t/\n/\r that were unescaped to match
+                # real control characters in the file. Apply the same
+                # unescaping to new_string so we don't write literal
+                # backslash sequences where the file has real tabs/newlines.
+                effective_new = _unescape_common_sequences(new_string)
             new_content = _apply_replacements(
-                content, matches, new_string,
+                content, matches, effective_new,
                 old_string=old_string if strategy_name != "exact" else None,
             )
             return new_content, len(matches), strategy_name, None
@@ -245,6 +253,19 @@ def _reindent_replacement(file_region: str, old_string: str, new_string: str) ->
             # the start of new_string. Anchor to the file's base.
             out_lines.append(file_indent + line.lstrip(" \t"))
     return "\n".join(out_lines)
+
+
+def _unescape_common_sequences(s: str) -> str:
+    """Unescape common C-style escape sequences that LLMs produce literally.
+
+    When the model sends ``\\t`` (two characters: backslash + t) instead of a
+    real tab byte (0x09), the patch tool would write the literal characters.
+    This helper converts common escape sequences to their actual byte values.
+
+    Only call this when the matching strategy confirmed that the file already
+    contains real control characters (i.e. ``escape_normalized`` matched).
+    """
+    return s.replace('\\t', '\t').replace('\\n', '\n').replace('\\r', '\r')
 
 
 def _apply_replacements(content: str, matches: List[Tuple[int, int]],


### PR DESCRIPTION
## Summary

When the patch tool's `escape_normalized` matching strategy succeeds, `old_string` contained literal `\\t`, `\\n`, `\\r` sequences that were unescaped to match real control characters in the file. However, `new_string` was written as-is, leaving literal backslash sequences (two characters: `\` + `t`) in the patched file instead of real tab/newline bytes.

**Root cause**: The `_strategy_escape_normalized` function unescapes `old_string` for matching but `new_string` passes through to `_apply_replacements` without the same treatment.

**Fix**: Add `_unescape_common_sequences()` helper and apply it to `new_string` only when the matching strategy is `escape_normalized`. Exact matches are unaffected — literal backslashes are preserved when the file genuinely contains them.

Fixes #33733

## Changes

- `tools/fuzzy_match.py`: Added `_unescape_common_sequences()` helper; modified replacement block to unescape `new_string` when `strategy_name == "escape_normalized"`
- `tests/tools/test_fuzzy_match.py`: Added `TestEscapeNormalizedNewString` class with 5 regression tests (tab, newline, CR, mixed sequences, exact-match preservation)

## Testing

```
45 passed in 0.81s
```

All existing tests continue to pass. 5 new regression tests verify:
- Tab (`\\t`) in `new_string` is unescaped to real tab byte
- Newline (`\\n`) in `new_string` is unescaped to real newline
- Carriage return (`\\r`) in `new_string` is unescaped
- Mixed escape sequences are all unescaped together
- Exact-match strategy preserves literal backslashes (no unescaping)

## Code Intelligence
- Analyzed: `tools/fuzzy_match.py:fuzzy_find_and_replace` (callers: `tools/patch_tool.py`, `tests/tools/test_fuzzy_match.py`)
- Blast radius: LOW — only affects `new_string` processing when `escape_normalized` strategy matches; exact matches and all other strategies are unaffected
- Related patterns: `_detect_escape_drift` (guards `\\'`/`\\"` drift), `_strategy_escape_normalized` (unescapes `old_string` for matching)
