### PR TITLE
fix(security): route memory-setup .env writer through save_env_value gate

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -362,9 +362,13 @@ def _write_env_vars(env_writes: dict) -> None:
     is therefore caught here too, not just at the dashboard
     ``PUT /api/env`` boundary that #32277 hardened.
 
-    Failures are surfaced and skipped rather than aborting the wizard
-    so a single denylisted/malformed key from one schema field doesn't
-    take down the rest of the batch.
+    Validation failures (``ValueError`` from ``save_env_value`` — i.e.
+    a denylisted name, an identifier rejected by ``_ENV_VAR_NAME_RE``)
+    are surfaced and skipped rather than aborting the wizard, so a
+    single bad key from one schema field doesn't take down the rest of
+    the batch. Non-validation errors (filesystem failures, permission
+    errors) are intentionally NOT caught — those indicate the wizard
+    cannot safely persist any subsequent key either and should propagate.
     """
     from hermes_cli.config import save_env_value
 

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -264,7 +264,6 @@ def cmd_setup(args) -> None:
     if not isinstance(provider_config, dict):
         provider_config = {}
 
-    env_path = get_hermes_home() / ".env"
     env_writes = {}
 
     if schema:
@@ -340,7 +339,7 @@ def cmd_setup(args) -> None:
 
     # Write secrets to .env
     if env_writes:
-        _write_env_vars(env_path, env_writes)
+        _write_env_vars(env_writes)
 
     print(f"\n  Memory provider: {name}")
     print(f"  Activation saved to config.yaml")
@@ -351,35 +350,29 @@ def cmd_setup(args) -> None:
     print(f"\n  Start a new session to activate.\n")
 
 
-def _write_env_vars(env_path: Path, env_writes: dict) -> None:
-    """Append or update env vars in .env file."""
-    env_path.parent.mkdir(parents=True, exist_ok=True)
+def _write_env_vars(env_writes: dict) -> None:
+    """Persist memory-provider env vars through the canonical ``.env`` writer.
 
-    existing_lines = []
-    if env_path.exists():
-        existing_lines = env_path.read_text(encoding="utf-8").splitlines()
+    Delegates to ``hermes_cli.config.save_env_value`` so every key flows
+    through the same input-validation gate as the rest of Hermes: the
+    ``_ENV_VAR_NAME_RE`` regex (no malformed identifiers), the
+    ``_ENV_VAR_NAME_DENYLIST`` (no ``LD_PRELOAD`` / ``PYTHONPATH`` /
+    ``HERMES_HOME`` / etc.), and CR/LF stripping on the value. A
+    misconfigured provider plugin schema (``env_var: "LD_PRELOAD"``)
+    is therefore caught here too, not just at the dashboard
+    ``PUT /api/env`` boundary that #32277 hardened.
 
-    updated_keys = set()
-    new_lines = []
-    for line in existing_lines:
-        key_match = line.split("=", 1)[0].strip() if "=" in line else ""
-        if key_match in env_writes:
-            new_lines.append(f"{key_match}={env_writes[key_match]}")
-            updated_keys.add(key_match)
-        else:
-            new_lines.append(line)
+    Failures are surfaced and skipped rather than aborting the wizard
+    so a single denylisted/malformed key from one schema field doesn't
+    take down the rest of the batch.
+    """
+    from hermes_cli.config import save_env_value
 
     for key, val in env_writes.items():
-        if key not in updated_keys:
-            new_lines.append(f"{key}={val}")
-
-    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    # Restrict permissions — .env holds API keys and tokens.
-    try:
-        import stat
-        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
-    except OSError:
-        pass  # Windows or read-only FS
+        try:
+            save_env_value(key, val)
+        except ValueError as exc:
+            print(f"  Skipping {key}: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_memory_setup_env_denylist.py
+++ b/tests/hermes_cli/test_memory_setup_env_denylist.py
@@ -16,14 +16,29 @@ code before ``main()``.
 The fix routes through ``save_env_value`` so the same gate fires.
 """
 
-import os
-from pathlib import Path
-from unittest.mock import patch
-
 import pytest
 
-from hermes_cli.config import ensure_hermes_home, load_env
+from hermes_cli.config import ensure_hermes_home, get_env_path, load_env
 from hermes_cli.memory_setup import _write_env_vars
+
+
+def _env_file_keys() -> set[str]:
+    """Parse ``~/.hermes/.env`` directly and return the set of keys present.
+
+    Used by tests that want to verify a key was NOT written to disk without
+    going through ``load_env()`` (whose sanitization/caching could mask the
+    underlying file state).
+    """
+    env_path = get_env_path()
+    if not env_path.exists():
+        return set()
+    keys: set[str] = set()
+    for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, _, _ = line.partition("=")
+            keys.add(key.strip())
+    return keys
 
 
 @pytest.fixture(autouse=True)
@@ -57,8 +72,11 @@ def test_denylisted_key_is_skipped(denied_key, capsys):
     provider schema. The wizard prints a warning and continues."""
     _write_env_vars({denied_key: "/tmp/evil.so"})
 
-    env = load_env()
-    assert denied_key not in env
+    # Assert directly against ``.env`` file contents so the test isn't
+    # coupled to ``load_env()``'s sanitization or any future merge with
+    # ``os.environ`` (where common names like ``PATH``/``EDITOR`` would
+    # always appear and trivially satisfy a ``not in env`` check).
+    assert denied_key not in _env_file_keys()
 
     captured = capsys.readouterr()
     assert denied_key in captured.out
@@ -75,8 +93,8 @@ def test_denylisted_key_does_not_block_other_writes(capsys):
         "OPENROUTER_API_KEY": "sk-or-test-456",
     })
 
+    assert "LD_PRELOAD" not in _env_file_keys()
     env = load_env()
-    assert "LD_PRELOAD" not in env
     assert env["HERMES_LANGFUSE_PUBLIC_KEY"] == "pk-test-123"
     assert env["OPENROUTER_API_KEY"] == "sk-or-test-456"
 
@@ -105,9 +123,9 @@ def test_malformed_key_name_is_skipped(capsys):
     verbatim, producing a malformed ``.env`` line."""
     _write_env_vars({"FOO BAR": "value"})
 
-    env = load_env()
-    assert "FOO BAR" not in env
-    assert "FOO" not in env  # not silently truncated either
+    keys = _env_file_keys()
+    assert "FOO BAR" not in keys
+    assert "FOO" not in keys  # not silently truncated either
 
     captured = capsys.readouterr()
     assert "Skipping" in captured.out or "FOO BAR" in captured.out
@@ -132,5 +150,6 @@ def test_value_with_embedded_newline_is_stripped():
     env = load_env()
     # CR/LF stripped, value still lands intact (minus the newlines)
     assert env["MEM0_API_KEY"] == "key1EVIL=injected"
-    # And no smuggled key landed
-    assert "EVIL" not in env
+    # And no smuggled key landed — assert against the file too so the test
+    # holds even if ``load_env()`` ever starts merging ``os.environ``.
+    assert "EVIL" not in _env_file_keys()

--- a/tests/hermes_cli/test_memory_setup_env_denylist.py
+++ b/tests/hermes_cli/test_memory_setup_env_denylist.py
@@ -1,0 +1,136 @@
+"""Tests for the env-write denylist on the memory-setup ``.env`` writer.
+
+``hermes_cli.memory_setup._write_env_vars`` persists provider plugin
+credentials to ``~/.hermes/.env``. Until this fix it called
+``Path.write_text`` directly, bypassing the
+``_ENV_VAR_NAME_DENYLIST`` gate that ``save_env_value`` enforces (added
+in #32277 by teknium1 for the dashboard ``PUT /api/env`` surface).
+
+A memory provider plugin schema declaring ``env_var: "LD_PRELOAD"``
+(or any other subprocess-influencing or Hermes-runtime-location name)
+could otherwise plant a value into ``.env`` via the interactive
+memory-setup wizard. The next Hermes process would load it through the
+``env_loader.py`` ``.env → os.environ`` chain and execute attacker
+code before ``main()``.
+
+The fix routes through ``save_env_value`` so the same gate fires.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import ensure_hermes_home, load_env
+from hermes_cli.memory_setup import _write_env_vars
+
+
+@pytest.fixture(autouse=True)
+def _hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ensure_hermes_home()
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "denied_key",
+    [
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "DYLD_INSERT_LIBRARIES",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "NODE_OPTIONS",
+        "PATH",
+        "EDITOR",
+        "GIT_SSH_COMMAND",
+        "HERMES_HOME",
+        "HERMES_PROFILE",
+        "HERMES_CONFIG",
+        "HERMES_ENV",
+    ],
+)
+def test_denylisted_key_is_skipped(denied_key, capsys):
+    """Each denylisted name must not land in .env even though the
+    memory-setup wizard accepted it from a (hypothetically malicious)
+    provider schema. The wizard prints a warning and continues."""
+    _write_env_vars({denied_key: "/tmp/evil.so"})
+
+    env = load_env()
+    assert denied_key not in env
+
+    captured = capsys.readouterr()
+    assert denied_key in captured.out
+    assert "denylist" in captured.out.lower() or "Skipping" in captured.out
+
+
+def test_denylisted_key_does_not_block_other_writes(capsys):
+    """If a single batch contains one denylisted key plus legitimate
+    integration credentials, the denylisted one is skipped but the
+    legitimate ones still land. The wizard must not abort mid-batch."""
+    _write_env_vars({
+        "LD_PRELOAD": "/tmp/evil.so",
+        "HERMES_LANGFUSE_PUBLIC_KEY": "pk-test-123",
+        "OPENROUTER_API_KEY": "sk-or-test-456",
+    })
+
+    env = load_env()
+    assert "LD_PRELOAD" not in env
+    assert env["HERMES_LANGFUSE_PUBLIC_KEY"] == "pk-test-123"
+    assert env["OPENROUTER_API_KEY"] == "sk-or-test-456"
+
+
+def test_legitimate_hermes_integration_key_still_writable():
+    """``HERMES_*`` overall is NOT blocked — only the four runtime
+    location names (HOME/PROFILE/CONFIG/ENV). Integration credentials
+    following the ``HERMES_*`` convention (HERMES_LANGFUSE_*,
+    HERMES_SPOTIFY_*, HERMES_QWEN_BASE_URL, ...) must keep working or
+    the memory-setup wizard regresses for every plugin that follows
+    the convention."""
+    _write_env_vars({
+        "HERMES_LANGFUSE_PUBLIC_KEY": "pk-lf-789",
+        "HERMES_QWEN_BASE_URL": "https://example.com/v1",
+    })
+
+    env = load_env()
+    assert env["HERMES_LANGFUSE_PUBLIC_KEY"] == "pk-lf-789"
+    assert env["HERMES_QWEN_BASE_URL"] == "https://example.com/v1"
+
+
+def test_malformed_key_name_is_skipped(capsys):
+    """The canonical writer also enforces ``_ENV_VAR_NAME_RE`` —
+    identifiers must match ``[A-Za-z_][A-Za-z0-9_]*``. A plugin schema
+    declaring ``env_var: "FOO BAR"`` (space) was previously persisted
+    verbatim, producing a malformed ``.env`` line."""
+    _write_env_vars({"FOO BAR": "value"})
+
+    env = load_env()
+    assert "FOO BAR" not in env
+    assert "FOO" not in env  # not silently truncated either
+
+    captured = capsys.readouterr()
+    assert "Skipping" in captured.out or "FOO BAR" in captured.out
+
+
+def test_legitimate_value_writes_round_trip():
+    """Negative control — the gate must not regress on a normal write."""
+    _write_env_vars({"MEM0_API_KEY": "m0-test-key-abc"})
+
+    env = load_env()
+    assert env["MEM0_API_KEY"] == "m0-test-key-abc"
+
+
+def test_value_with_embedded_newline_is_stripped():
+    """``save_env_value`` strips CR/LF from the value to prevent
+    .env-file structure injection (a value containing ``\\n`` would
+    otherwise split the line and inject an arbitrary follow-on key).
+    Routing through it gives the memory-setup wizard the same
+    protection."""
+    _write_env_vars({"MEM0_API_KEY": "key1\nEVIL=injected\n"})
+
+    env = load_env()
+    # CR/LF stripped, value still lands intact (minus the newlines)
+    assert env["MEM0_API_KEY"] == "key1EVIL=injected"
+    # And no smuggled key landed
+    assert "EVIL" not in env


### PR DESCRIPTION
## This is a sibling follow-up to #32277 (commit `30928f945`)

- #32277 covered: the dashboard `PUT /api/env` writer (`save_env_value`) — added `_ENV_VAR_NAME_DENYLIST`, `_ENV_VAR_NAME_RE`, and CR/LF strip.
- #32277 did NOT touch: `hermes_cli/memory_setup.py::_write_env_vars`, which writes to the same `~/.hermes/.env` via a parallel `Path.write_text` path and therefore bypasses all three gates.
- This PR routes `_write_env_vars` through `save_env_value` so the memory-setup wizard inherits the same boundary checks as the dashboard.

## What does this PR do?

`hermes_cli/memory_setup.py::_write_env_vars` persisted memory-provider plugin credentials to `~/.hermes/.env` via `Path.write_text` directly, skipping `save_env_value` entirely. That meant three input-validation vectors lived at the same code site:

1. **`_ENV_VAR_NAME_DENYLIST` was not enforced.** A provider plugin schema declaring `env_var: \"LD_PRELOAD\"` (or `LD_LIBRARY_PATH` / `PYTHONPATH` / `NODE_OPTIONS` / `GIT_SSH_COMMAND` / `EDITOR` / `HERMES_HOME` / ...) would land in `.env` and load via the `env_loader.py` `.env → os.environ` chain on the next Hermes startup — RCE before `main()`. This is the same threat model #32277 hardened against, just on the memory-setup wizard surface instead of the dashboard surface.
2. **`_ENV_VAR_NAME_RE` was not enforced.** A schema declaring `env_var: \"FOO BAR\"` (space) was persisted verbatim, producing a malformed `.env` line.
3. **CR/LF in values was not stripped.** A value containing `\\n` could split the line and inject an arbitrary follow-on `key=value` pair.

All three are closed by routing through `save_env_value`, which is the canonical `.env` writer and already gates all of them. Failures are logged and skipped (per-key) so a single denylisted/malformed schema field doesn't abort the whole batch.

Mirrors `save_env_value` gates: `_ENV_VAR_NAME_RE` → `_reject_denylisted_env_var` → CR/LF strip → atomic write + `_secure_file`.

## Related Issue

_No issue — this is a defense-in-depth follow-up to #32277, identified by mapping the existing denylist gate to other `.env` writers in the codebase._

## Type of Change

- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/memory_setup.py` — `_write_env_vars` now delegates to `hermes_cli.config.save_env_value` for each key, logging and skipping any value that fails the gate. The `env_path` parameter is dropped (single caller, no other consumers). Removes 27 lines of duplicated `.env` read/merge/write/chmod logic (those concerns now live in one place — the canonical writer).
- `tests/hermes_cli/test_memory_setup_env_denylist.py` — 18 new tests: 13 parametrized denylisted-name rejections, partial-batch rejection (denylisted skipped while legitimate keys still land), `HERMES_*` integration credentials still writable, malformed-key skip, legitimate-value round-trip, value newline stripping.

## How to Test

```bash
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \\
    tests/hermes_cli/test_memory_setup_env_denylist.py \\
    tests/hermes_cli/test_config.py::TestEnvWriteDenylist \\
    tests/plugins/memory/test_hindsight_provider.py \\
    tests/agent/test_memory_provider.py -v
```

Expected: 18 new pass, 31 existing `TestEnvWriteDenylist` pass, 170 memory-provider tests pass. Total 219 cases green; no regressions in adjacent suites.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — N/A; behavior is wholly internal and the new docstring on `_write_env_vars` explains the gate-inheritance.
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — \`save_env_value\` already handles the Windows-locale `.env` decode quirk (encoding=utf-8-sig) and the chmod-on-non-POSIX no-op, so delegating to it is strictly more portable than the previous direct \`Path.write_text\` / \`chmod\` calls.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Strict superset of input-validation behavior at this code site: denylist + regex + CR/LF strip + atomic write + `_secure_file` permissions + `os.environ` sync + cache invalidation — every gate `save_env_value` already provides.
- @annguyenNous's #30281 (open, idle 6d) addresses one related concern (atomic write of `.env` in `_write_env_vars`). This PR is orthogonal — `save_env_value` already does atomic write internally via `tempfile.mkstemp` + `atomic_replace`, so the route-through-canonical-writer approach incidentally subsumes the atomic-write fix as a side effect, but the primary motivation here is the denylist parity with #32277. Happy to coordinate either way.

## Salvage-with-widening hint

> Audited siblings: `save_env_value` and `save_env_value_secure` are already gated. The remaining writes to `~/.hermes/.env` in the repo are all guarded by tests under `TestEnvWriteDenylist` and the new `test_memory_setup_env_denylist`. Other `.env`-adjacent writers (`hermes_cli/auth.py`, `hermes_cli/plugins_cmd.py`, `hermes_cli/gateway.py`, `hermes_cli/mcp_catalog.py`, `hermes_cli/callbacks.py`) all already call `save_env_value` directly. No further sibling widening identified.