### PR TITLE
fix(xai-proxy): handle 429 rate-limit responses in proxy retry path (#28932)

### DIFF
--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -79,7 +79,7 @@ class XAIGrokAdapter(UpstreamAdapter):
         failed_credential: UpstreamCredential,
         status_code: int,
     ) -> Optional[UpstreamCredential]:
-        if status_code != 401:
+        if status_code not in {401, 429}:
             return None
 
         with self._lock:
@@ -87,16 +87,25 @@ class XAIGrokAdapter(UpstreamAdapter):
             if pool is None:
                 return None
 
-            refreshed = pool.try_refresh_current()
-            if refreshed is None:
+            if status_code == 429:
+                # Mark the rate-limited key with its 1-hour cooldown and rotate
+                # to the next available credential. Returns None when the pool
+                # has no other key to offer — the 429 will flow back to the client.
                 refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
+            else:
+                refreshed = pool.try_refresh_current()
+                if refreshed is None:
+                    refreshed = pool.mark_exhausted_and_rotate(status_code=status_code)
             if refreshed is None:
                 return None
 
             retry_cred = self._credential_from_entry(refreshed)
             if retry_cred.bearer == failed_credential.bearer:
                 return None
-            logger.info("proxy: xAI upstream rejected bearer; retrying with refreshed pool credential")
+            logger.info(
+                "proxy: xAI upstream returned %s; retrying with rotated pool credential",
+                status_code,
+            )
             return retry_cred
 
     def _load_pool(self) -> Optional[CredentialPool]:

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -206,7 +206,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
             return session_or_response
         session = session_or_response
 
-        if upstream_resp.status == 401:
+        if upstream_resp.status in {401, 429}:
             try:
                 retry_cred = adapter.get_retry_credential(
                     failed_credential=cred,

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -450,6 +450,122 @@ def test_xai_adapter_retry_refreshes_current_pool_entry(tmp_path, monkeypatch):
     assert retry.bearer == "new-access-token"
 
 
+def test_xai_adapter_retry_rotates_pool_entry_on_429(tmp_path, monkeypatch):
+    """429 from xAI must rotate to the next pool entry, not attempt refresh.
+
+    Pre-fix (#28932) ``get_retry_credential`` only fired on 401, so a 429
+    rate-limit response flowed back to the client unchanged AND the
+    rate-limited bearer stayed active for the next request — defeating
+    the whole point of pool rotation.
+
+    Post-fix: 429 lands on ``mark_exhausted_and_rotate`` (no refresh —
+    that's irrelevant for rate limits), stamps the 1-hour cooldown
+    via ``EXHAUSTED_TTL_429_SECONDS`` on the offending key, and
+    returns the next available credential.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # Two pool entries so rotation has somewhere to go.
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "xai-oauth": [
+                {
+                    "id": "xai-first",
+                    "label": "xai-first",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:xai_pkce",
+                    "access_token": "first-access-token",
+                    "refresh_token": "first-refresh-token",
+                    "base_url": "https://api.x.ai/v1",
+                },
+                {
+                    "id": "xai-second",
+                    "label": "xai-second",
+                    "auth_type": "oauth",
+                    "priority": 1,
+                    "source": "manual:xai_pkce",
+                    "access_token": "second-access-token",
+                    "refresh_token": "second-refresh-token",
+                    "base_url": "https://api.x.ai/v1",
+                },
+            ]
+        },
+    }))
+
+    # Refresh must NOT be called on the 429 path — guard against
+    # the fix accidentally trying to refresh-on-rate-limit.
+    def _refresh_must_not_run(*args, **kwargs):
+        raise AssertionError("refresh_xai_oauth_pure must not run on 429")
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _refresh_must_not_run)
+
+    adapter = XAIGrokAdapter()
+    failed = adapter.get_credential()
+    assert failed.bearer == "first-access-token", "starting bearer should be the first entry"
+
+    retry = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=429,
+    )
+
+    assert retry is not None, "429 must rotate to next pool entry"
+    assert retry.bearer == "second-access-token", (
+        f"expected rotation to second entry, got {retry.bearer!r}"
+    )
+
+
+def test_xai_adapter_retry_returns_none_on_429_when_pool_exhausted(tmp_path, monkeypatch):
+    """Single-entry pool: 429 has nowhere to rotate to → return None
+    so the 429 flows back to the client unchanged (existing behavior
+    preserved)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_xai_pool_entry(tmp_path)  # single entry
+
+    def _refresh_must_not_run(*args, **kwargs):
+        raise AssertionError("refresh_xai_oauth_pure must not run on 429")
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _refresh_must_not_run)
+
+    adapter = XAIGrokAdapter()
+    failed = adapter.get_credential()
+    retry = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=429,
+    )
+
+    assert retry is None, (
+        "single-entry pool: 429 must return None so the response "
+        "flows back to the client unchanged"
+    )
+
+
+def test_xai_adapter_retry_returns_none_for_unrelated_status(tmp_path, monkeypatch):
+    """Non-{401, 429} statuses must NOT trigger any retry — pool
+    untouched, no refresh attempted, return None immediately."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_xai_pool_entry(tmp_path)
+
+    def _refresh_must_not_run(*args, **kwargs):
+        raise AssertionError("refresh_xai_oauth_pure must not run on non-retry status")
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _refresh_must_not_run)
+
+    adapter = XAIGrokAdapter()
+    failed = adapter.get_credential()
+    for status in (200, 400, 403, 500, 502, 503):
+        retry = adapter.get_retry_credential(
+            failed_credential=failed,
+            status_code=status,
+        )
+        assert retry is None, (
+            f"status {status} must not trigger retry, got {retry!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Server: path filtering + forwarding
 #


### PR DESCRIPTION
## Summary

`hermes proxy` now rotates the xAI credential pool when xAI returns HTTP 429, instead of silently letting the rate-limited bearer stay active. The pool's existing 1-hour cooldown on the offending key (`EXHAUSTED_TTL_429_SECONDS`) kicks in correctly so subsequent requests don't keep slamming the same exhausted credential.

Salvages PR #28932 (@sprmn24) + adds three regression tests.

## Root cause

`hermes_cli/proxy/adapters/xai.py:get_retry_credential` only fired on HTTP 401. A 429 from xAI:

1. Flowed back to the client unchanged (correct end-state for that request)
2. **But left the rate-limited bearer as the current pool entry** — so the very next request would pick the same key and 429 again.

The credential pool already had the right primitives (`mark_exhausted_and_rotate(status_code=429)` stamps `EXHAUSTED_TTL_429_SECONDS = 1 hour` cooldown). The proxy adapter just wasn't calling them.

## Changes

- **`hermes_cli/proxy/server.py`** — widen the retry gate from `status == 401` to `status in {401, 429}` so the adapter is consulted on rate-limit responses.
- **`hermes_cli/proxy/adapters/xai.py`** — on 429, skip the token-refresh branch (refresh is irrelevant for rate limits) and go straight to `mark_exhausted_and_rotate(status_code=429)`. Returns `None` when the pool has nothing else to offer so the 429 flows back to the client unchanged.

## Validation

```
scripts/run_tests.sh tests/hermes_cli/test_proxy.py
=== 39 tests passed, 0 failed in 0.7s ===
```

3 new tests:

| Test | Locks in |
|---|---|
| `rotates_pool_entry_on_429` | Two-entry pool: 429 on first → second entry returned AND refresh is NOT called |
| `returns_none_on_429_when_pool_exhausted` | Single-entry pool: 429 returns None, original response flows back unchanged |
| `returns_none_for_unrelated_status` | Non-{401, 429} (200, 400, 403, 500, 502, 503) all return None — no retry path |

Each test asserts `refresh_xai_oauth_pure` is never called on the 429 path — refresh is a 401-specific concern, and the new code path must not pollute it.

## Credit

@sprmn24 — clean salvage, no scope creep. The decision to skip refresh on 429 (rather than try-refresh-first-then-rotate like the 401 path) was the right call: refreshing a rate-limited bearer just produces a fresh-but-still-rate-limited bearer.
