### PR TITLE
Add model cascade and tool lifecycle tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ privvy*
 images/
 __pycache__/
 hermes_agent.egg-info/
+build/
 wandb/
 testlogs
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1049,6 +1049,11 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+    _model_cascade_cfg = _agent_cfg.get("model_cascade", {})
+    agent._model_cascade_config = (
+        _model_cascade_cfg if isinstance(_model_cascade_cfg, dict) else {}
+    )
+    agent._model_cascade_last_decision = None
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1624,6 +1624,14 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             choices=function_args.get("choices"),
             callback=agent.clarify_callback,
         )
+    elif function_name == "switch_model":
+        from tools.switch_model_tool import switch_model_for_agent as _switch_model_for_agent
+        return _switch_model_for_agent(
+            agent,
+            function_args.get("new_model", ""),
+            reason=function_args.get("reason"),
+            provider=function_args.get("provider"),
+        )
     elif function_name == "delegate_task":
         return agent._dispatch_delegate_task(function_args)
     else:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,134 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _codex_item_tool_event(item: dict) -> tuple[str, str, dict, bool]:
+    """Map a codex app-server item to Hermes tool trace fields."""
+    item_type = str(item.get("type") or "")
+    item_id = str(item.get("id") or "")
+    try:
+        from agent.transports.codex_event_projector import _deterministic_call_id
+    except Exception:
+        def _deterministic_call_id(kind: str, ident: str) -> str:  # type: ignore[no-redef]
+            return f"codex_{kind}_{ident or 'unknown'}"
+
+    if item_type == "commandExecution":
+        call_id = _deterministic_call_id("exec", item_id)
+        args = {
+            "command": item.get("command") or "",
+            "cwd": item.get("cwd") or "",
+        }
+        exit_code = item.get("exitCode")
+        return call_id, "exec_command", args, exit_code not in (None, 0)
+
+    if item_type == "fileChange":
+        call_id = _deterministic_call_id("apply_patch", item_id)
+        changes = []
+        for change in item.get("changes") or []:
+            if not isinstance(change, dict):
+                continue
+            kind = (change.get("kind") or {}).get("type") or "update"
+            path = change.get("path") or ""
+            changes.append({"kind": kind, "path": path})
+        first_path = next((c.get("path") for c in changes if c.get("path")), "")
+        return call_id, "apply_patch", {"path": first_path, "changes": changes}, False
+
+    if item_type == "mcpToolCall":
+        server = item.get("server") or "mcp"
+        tool = item.get("tool") or "unknown"
+        call_id = _deterministic_call_id(f"mcp_{server}_{tool}", item_id)
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        return call_id, f"mcp.{server}.{tool}", args, bool(item.get("error"))
+
+    if item_type == "dynamicToolCall":
+        tool = item.get("tool") or "unknown"
+        call_id = _deterministic_call_id(f"dyn_{tool}", item_id)
+        args = item.get("arguments") or {}
+        if not isinstance(args, dict):
+            args = {"arguments": args}
+        return call_id, str(tool), args, item.get("success") is False
+
+    return "", "", {}, False
+
+
+def _make_codex_tool_trace_event_callback(agent):
+    """Project codex app-server item events into Hermes tool callbacks."""
+    started: set[str] = set()
+    started_at: dict[str, float] = {}
+
+    def _emit_start(call_id: str, tool_name: str, args: dict) -> None:
+        if not call_id or not tool_name or call_id in started:
+            return
+        started.add(call_id)
+        started_at[call_id] = time.time()
+        if getattr(agent, "tool_start_callback", None):
+            try:
+                agent.tool_start_callback(call_id, tool_name, args)
+            except Exception:
+                logger.debug("codex tool_start_callback raised", exc_info=True)
+        elif getattr(agent, "tool_progress_callback", None):
+            try:
+                agent.tool_progress_callback(
+                    "tool.started",
+                    tool_name,
+                    "",
+                    args,
+                    tool_call_id=call_id,
+                )
+            except Exception:
+                logger.debug("codex tool_progress_callback raised", exc_info=True)
+
+    def _emit_complete(call_id: str, tool_name: str, args: dict, is_error: bool) -> None:
+        if not call_id or not tool_name:
+            return
+        if call_id not in started:
+            _emit_start(call_id, tool_name, args)
+        duration = None
+        if call_id in started_at:
+            duration = max(0.0, time.time() - started_at.pop(call_id, time.time()))
+        started.discard(call_id)
+        if getattr(agent, "tool_complete_callback", None):
+            try:
+                agent.tool_complete_callback(call_id, tool_name, args, {"error": is_error})
+            except Exception:
+                logger.debug("codex tool_complete_callback raised", exc_info=True)
+        elif getattr(agent, "tool_progress_callback", None):
+            try:
+                agent.tool_progress_callback(
+                    "tool.completed",
+                    tool_name,
+                    "",
+                    args,
+                    tool_call_id=call_id,
+                    duration=duration,
+                    is_error=is_error,
+                )
+            except Exception:
+                logger.debug("codex tool_progress_callback raised", exc_info=True)
+
+    def _on_event(notification: dict) -> None:
+        method = str(notification.get("method") or "")
+        params = notification.get("params") or {}
+        item = params.get("item") or {}
+        if not isinstance(item, dict):
+            return
+        if item.get("type") not in {
+            "commandExecution",
+            "fileChange",
+            "mcpToolCall",
+            "dynamicToolCall",
+        }:
+            return
+        call_id, tool_name, args, is_error = _codex_item_tool_event(item)
+        if method == "item/started":
+            _emit_start(call_id, tool_name, args)
+        elif method == "item/completed":
+            _emit_complete(call_id, tool_name, args, is_error)
+
+    return _on_event
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -47,6 +175,7 @@ def run_codex_app_server_turn(
     # Lazy session: one CodexAppServerSession per AIAgent instance.
     # Spawned on first turn, reused across turns, closed at AIAgent
     # shutdown (see _cleanup hook).
+    codex_tool_trace_callback = _make_codex_tool_trace_event_callback(agent)
     if not hasattr(agent, "_codex_session") or agent._codex_session is None:
         cwd = getattr(agent, "session_cwd", None) or os.getcwd()
         # Approval callback: defer to Hermes' standard prompt flow if a
@@ -60,7 +189,13 @@ def run_codex_app_server_turn(
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            on_event=codex_tool_trace_callback,
         )
+    else:
+        try:
+            agent._codex_session._on_event = codex_tool_trace_callback
+        except Exception:
+            logger.debug("failed to refresh codex app-server event callback", exc_info=True)
 
     # NOTE: the user message is ALREADY appended to messages by the
     # standard run_conversation() flow (line ~11823) before the early

--- a/agent/complexity_classifier.py
+++ b/agent/complexity_classifier.py
@@ -1,0 +1,278 @@
+"""Complexity classifier for Model Cascade routing.
+
+Classifies an incoming user message into one of four coarse levels:
+  'nano'     - greetings, acknowledgements, yes/no, tiny Q&A
+  'mini'     - small commands, short explanations, code under 10 lines
+  'full'     - debugging, analysis, architecture, planning, code over 10 lines
+  'frontier' - multi-file work, critical issues, large refactors
+"""
+
+import re
+from typing import List, Pattern, Set
+
+
+# Markers that elevate a prompt to 'frontier'.
+FRONTIER_MARKERS: Set[str] = {
+    "refactor",
+    "рефакторинг",
+    "multi-file",
+    "мультифайл",
+    "critical",
+    "критич",
+    "refactoring",
+    "migration",
+    "миграция",
+    "full rewrite",
+    "major refactor",
+    "redesign",
+    "редизайн",
+    "complete rewrite",
+    "global change",
+}
+
+# Short high-priority markers.
+FRONTIER_SHORT_MARKERS: Set[str] = {
+    "!важно",
+    "!critical",
+    "!срочно",
+    "!критично",
+    "!urgent",
+}
+
+# Markers that elevate a prompt to 'full'.
+FULL_MARKERS: Set[str] = {
+    "почему",
+    "как работает",
+    "how does",
+    "why does",
+    "explain",
+    "объясни",
+    "проанализируй",
+    "проанализировать",
+    "analyze",
+    "analyse",
+    "анализ",
+    "анализируй",
+    "plan",
+    "план",
+    "планирование",
+    "debug",
+    "дебаг",
+    "architecture",
+    "архитектура",
+    "спроектируй",
+    "design",
+    "compare",
+    "сравни",
+    "оптимизируй",
+    "optimize",
+    "rewrite",
+    "переписать",
+    "перепиши",
+}
+
+# Greetings and tiny acknowledgements for 'nano'.
+NANO_GREETINGS: Set[str] = {
+    "привет",
+    "hello",
+    "hi",
+    "hey",
+    "здравствуй",
+    "good morning",
+    "good evening",
+    "добрый день",
+    "доброе утро",
+    "добрый вечер",
+    "ok",
+    "okay",
+    "yes",
+    "да",
+    "no",
+    "нет",
+    "thanks",
+    "thank you",
+    "спасибо",
+    "bye",
+    "пока",
+    "до свидания",
+    "goodbye",
+}
+
+NANO_PATTERNS: List[Pattern] = [
+    re.compile(r"^\s*(?:ok|okay|yes|no|да|нет|thanks|спс|спасибо)\s*[.!]*\s*$", re.IGNORECASE),
+    re.compile(r"^\s*[+👍✅👎❌]\s*$"),
+]
+
+# Commands are at least 'mini' even when short.
+MINI_COMMAND_PREFIXES: List[str] = [
+    "напиши", "напишите", "сделай", "сделайте", "создай", "создайте",
+    "написать", "сделать", "создать",
+    "write", "create", "make", "build", "implement",
+    "run", "выполни", "запусти",
+    "install", "установи",
+    "открой", "open",
+    "найди", "find", "search",
+    "переведи", "translate",
+    "исправь", "fix",
+    "добавь", "add",
+    "удали", "remove", "delete",
+]
+
+# Question words are at least 'mini'.
+QUESTION_WORDS: List[str] = [
+    "что", "как", "зачем", "где", "когда", "кто", "сколько", "какой",
+    "what", "how", "why", "where", "when", "who", "which", "whose",
+]
+
+
+class ComplexityClassifier:
+    """Classify user messages for Model Cascade routing."""
+
+    # Word-count thresholds.
+    NANO_MAX_WORDS: int = 20
+    MINI_MAX_WORDS: int = 100
+    FULL_MAX_WORDS: int = 300
+
+    # Fenced-code line-count thresholds.
+    MINI_MAX_CODE_LINES: int = 10
+    FULL_MAX_CODE_LINES: int = 50
+
+    @classmethod
+    def classify(cls, message: str) -> str:
+        """Return the coarse complexity level for ``message``.
+
+        Args:
+            message: Incoming user prompt.
+
+        Returns:
+            One of: 'nano', 'mini', 'full', 'frontier'.
+        """
+        if not message or not message.strip():
+            return 'nano'
+
+        text = message.strip()
+
+        if cls._has_frontier_markers(text):
+            return 'frontier'
+
+        # Full markers outrank the short-message nano heuristic.
+        has_full_markers = cls._has_full_markers(text)
+        if has_full_markers and len(text.split()) >= 3:
+            return 'full'
+
+        is_nano = cls._is_nano(text)
+        if is_nano:
+            return 'nano'
+
+        code_blocks = cls._extract_code_blocks(text)
+        total_code_lines = sum(len(block.splitlines()) for block in code_blocks)
+        has_code = len(code_blocks) > 0
+
+        word_count = len(text.split())
+
+        if total_code_lines > cls.FULL_MAX_CODE_LINES:
+            return 'frontier'
+
+        if total_code_lines > cls.MINI_MAX_CODE_LINES:
+            return 'full'
+
+        if has_full_markers and word_count > cls.NANO_MAX_WORDS:
+            return 'full'
+
+        if has_full_markers:
+            return 'full'
+
+        if word_count > cls.FULL_MAX_WORDS:
+            return 'full'
+
+        if has_code and total_code_lines <= cls.MINI_MAX_CODE_LINES:
+            if word_count <= cls.NANO_MAX_WORDS:
+                return 'mini'
+            return 'mini'
+
+        if word_count > cls.MINI_MAX_WORDS:
+            return 'full'
+
+        if word_count > cls.NANO_MAX_WORDS:
+            return 'mini'
+
+        # A short non-nano message still needs at least a mini model.
+        if not is_nano:
+            return 'mini'
+
+        return 'nano'
+
+    @classmethod
+    def _has_frontier_markers(cls, text: str) -> bool:
+        """Return True when text contains a frontier marker."""
+        lower = text.lower()
+
+        for marker in FRONTIER_SHORT_MARKERS:
+            if text.startswith(marker) or text.startswith(marker.upper()):
+                return True
+
+        for marker in FRONTIER_MARKERS:
+            if marker in lower:
+                # For short markers, require a whole word match.
+                if len(marker) <= 6:
+                    if re.search(r'\b' + re.escape(marker) + r'\b', lower):
+                        return True
+                else:
+                    return True
+
+        return False
+
+    @classmethod
+    def _is_nano(cls, text: str) -> bool:
+        """Return True when text is suitable for the nano tier."""
+        lower_stripped = text.strip().lower().rstrip('.!?')
+        if lower_stripped in NANO_GREETINGS:
+            return True
+
+        for pattern in NANO_PATTERNS:
+            if pattern.match(text):
+                return True
+
+        # Short plain-text messages can stay nano unless they ask for work.
+        word_count = len(text.split())
+        if word_count <= cls.NANO_MAX_WORDS:
+            if '```' not in text and '`' not in text:
+                simple_chars = re.sub(r'[\w\s.,!?;:\'\"()\-@#]+', '', text)
+                if not simple_chars:
+                    lower = text.lower().strip()
+                    for prefix in MINI_COMMAND_PREFIXES:
+                        if lower.startswith(prefix):
+                            return False
+                    first_word = lower.split()[0] if lower.split() else ""
+                    if first_word in QUESTION_WORDS:
+                        return False
+                    return True
+
+        return False
+
+    @classmethod
+    def _has_full_markers(cls, text: str) -> bool:
+        """Return True when text contains a full-tier marker."""
+        lower = text.lower()
+        for marker in FULL_MARKERS:
+            if marker in lower:
+                return True
+        return False
+
+    @classmethod
+    def _extract_code_blocks(cls, text: str) -> List[str]:
+        """Extract fenced code blocks."""
+        blocks: List[str] = re.findall(r'```(?:\w+)?\n(.*?)```', text, re.DOTALL)
+        return blocks
+
+
+def cascade_router_classify(message: str) -> str:
+    """Convenience wrapper for external callers.
+
+    Args:
+        message: Incoming user prompt.
+
+    Returns:
+        One of: 'nano', 'mini', 'full', 'frontier'.
+    """
+    return ComplexityClassifier.classify(message)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -335,6 +335,36 @@ def run_conversation(
     if isinstance(persist_user_message, str):
         persist_user_message = _sanitize_surrogates(persist_user_message)
 
+    # Optional model cascade: classify this turn and switch through the
+    # normal session-local model resolver before any model-specific preflight
+    # work (context compression, runtime-main routing, API call logging).
+    try:
+        from agent.model_cascade import maybe_apply_model_cascade
+
+        _cascade_message = (
+            persist_user_message
+            if isinstance(persist_user_message, str)
+            else user_message
+        )
+        _cascade_decision = maybe_apply_model_cascade(agent, _cascade_message)
+        if _cascade_decision and _cascade_decision.get("applied"):
+            logger.info(
+                "model cascade switched session=%s tier=%s model=%s provider=%s",
+                agent.session_id or "none",
+                _cascade_decision.get("tier"),
+                _cascade_decision.get("resolved_model") or _cascade_decision.get("model"),
+                _cascade_decision.get("resolved_provider") or _cascade_decision.get("provider"),
+            )
+            try:
+                set_runtime_main(
+                    getattr(agent, "provider", "") or "",
+                    getattr(agent, "model", "") or "",
+                )
+            except Exception:
+                pass
+    except Exception as _cascade_err:
+        logger.warning("model cascade pre-turn routing failed: %s", _cascade_err)
+
     # Store stream callback for _interruptible_api_call to pick up
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None

--- a/agent/model_cascade.py
+++ b/agent/model_cascade.py
@@ -1,0 +1,110 @@
+"""Config-gated model cascade routing for the main agent."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from agent.complexity_classifier import ComplexityClassifier
+
+logger = logging.getLogger(__name__)
+
+
+_TRUE_VALUES = {"1", "true", "yes", "on", "enabled"}
+
+
+def _is_enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUE_VALUES
+    return False
+
+
+def _tier_value(mapping: Any, tier: str) -> str:
+    if not isinstance(mapping, dict):
+        return ""
+    value = mapping.get(tier) or ""
+    return str(value).strip() if value is not None else ""
+
+
+def classify_for_model_cascade(message: str) -> str:
+    """Return the cascade tier for a user message."""
+    return ComplexityClassifier.classify(message)
+
+
+def resolve_model_cascade_target(config: Dict[str, Any], message: str) -> Dict[str, str]:
+    """Resolve the configured cascade target for ``message``.
+
+    The config shape is intentionally small and stable:
+
+    model_cascade:
+      enabled: true
+      models:
+        nano: gpt-4.1-nano
+        mini: gpt-5.4-mini
+        full: gpt-5.4
+        frontier: gpt-5.5
+      providers:
+        frontier: openrouter
+    """
+    tier = classify_for_model_cascade(message)
+    if not isinstance(config, dict) or not _is_enabled(config.get("enabled", False)):
+        return {"tier": tier, "model": "", "provider": ""}
+
+    return {
+        "tier": tier,
+        "model": _tier_value(config.get("models"), tier),
+        "provider": _tier_value(config.get("providers"), tier),
+    }
+
+
+def maybe_apply_model_cascade(agent: Any, message: str) -> Optional[Dict[str, Any]]:
+    """Apply a configured per-turn model cascade switch.
+
+    Returns a decision dict for observability, or None when disabled or no
+    target model is configured for the classified tier.
+    """
+    config = getattr(agent, "_model_cascade_config", {}) or {}
+    decision = resolve_model_cascade_target(config, message or "")
+    target_model = decision.get("model") or ""
+    if not target_model:
+        setattr(agent, "_model_cascade_last_decision", decision)
+        return None
+
+    current_model = str(getattr(agent, "model", "") or "").strip()
+    explicit_provider = decision.get("provider") or ""
+    if target_model == current_model and not explicit_provider:
+        decision["applied"] = False
+        decision["reason"] = "already_on_target_model"
+        setattr(agent, "_model_cascade_last_decision", decision)
+        return decision
+
+    try:
+        from tools.switch_model_tool import switch_model_for_agent
+
+        raw = switch_model_for_agent(
+            agent,
+            target_model,
+            reason=f"model_cascade:{decision['tier']}",
+            provider=explicit_provider or None,
+        )
+        result = json.loads(raw) if isinstance(raw, str) else {}
+    except Exception as exc:
+        logger.warning("model cascade switch failed: %s", exc)
+        decision.update({"applied": False, "error": str(exc)})
+        setattr(agent, "_model_cascade_last_decision", decision)
+        return decision
+
+    decision["applied"] = bool(result.get("success"))
+    if result.get("error"):
+        decision["error"] = str(result.get("error"))
+    if result.get("new_model"):
+        decision["resolved_model"] = str(result.get("new_model"))
+    if result.get("provider"):
+        decision["resolved_provider"] = str(result.get("provider"))
+    setattr(agent, "_model_cascade_last_decision", decision)
+    return decision

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -158,21 +158,21 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     for tc, name, args, block_result, blocked_by_guardrail in parsed_calls:
         if block_result is not None:
             continue
+        if agent.tool_start_callback:
+            try:
+                agent.tool_start_callback(tc.id, name, args)
+            except Exception as cb_err:
+                logging.debug(f"Tool start callback error: {cb_err}")
+
+    for tc, name, args, block_result, blocked_by_guardrail in parsed_calls:
+        if block_result is not None:
+            continue
         if agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(name, args)
                 agent.tool_progress_callback("tool.started", name, preview, args)
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
-
-    for tc, name, args, block_result, blocked_by_guardrail in parsed_calls:
-        if block_result is not None:
-            continue
-        if agent.tool_start_callback:
-            try:
-                agent.tool_start_callback(tc.id, name, args)
-            except Exception as cb_err:
-                logging.debug(f"Tool start callback error: {cb_err}")
 
     # ── Concurrent execution ─────────────────────────────────────────
     # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag)
@@ -548,18 +548,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception:
                 pass
 
+        if not _execution_blocked and agent.tool_start_callback:
+            try:
+                agent.tool_start_callback(tool_call.id, function_name, function_args)
+            except Exception as cb_err:
+                logging.debug(f"Tool start callback error: {cb_err}")
+
         if not _execution_blocked and agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(function_name, function_args)
                 agent.tool_progress_callback("tool.started", function_name, preview, function_args)
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
-
-        if not _execution_blocked and agent.tool_start_callback:
-            try:
-                agent.tool_start_callback(tool_call.id, function_name, function_args)
-            except Exception as cb_err:
-                logging.debug(f"Tool start callback error: {cb_err}")
 
         # Checkpoint: snapshot working dir before file-mutating tools
         if not _execution_blocked and function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
@@ -664,6 +664,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+        elif function_name == "switch_model":
+            from tools.switch_model_tool import switch_model_for_agent as _switch_model_for_agent
+            function_result = _switch_model_for_agent(
+                agent,
+                function_args.get("new_model", ""),
+                reason=function_args.get("reason"),
+                provider=function_args.get("provider"),
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('switch_model', function_args, tool_duration, result=function_result)}")
         elif function_name == "delegate_task":
             tasks_arg = function_args.get("tasks")
             if tasks_arg and isinstance(tasks_arg, list):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -692,6 +692,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        self._run_tool_started_at: Dict[str, Dict[str, float]] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
@@ -2903,42 +2904,34 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
+    def _push_run_event(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        event: Dict[str, Any],
+    ) -> None:
+        """Push one structured event to a run's SSE queue from any thread."""
+        self._set_run_status(
+            run_id,
+            self._run_statuses.get(run_id, {}).get("status", "running"),
+            last_event=event.get("event"),
+        )
+        q = self._run_streams.get(run_id)
+        if q is None:
+            return
+        try:
+            loop.call_soon_threadsafe(q.put_nowait, event)
+        except Exception:
+            pass
+
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
-        """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+        """Return a progress callback for non-tool structured run events."""
         def _push(event: Dict[str, Any]) -> None:
-            self._set_run_status(
-                run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
-                last_event=event.get("event"),
-            )
-            q = self._run_streams.get(run_id)
-            if q is None:
-                return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
-            except Exception:
-                pass
+            self._push_run_event(run_id, loop, event)
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
-            if event_type == "tool.started":
-                _push({
-                    "event": "tool.started",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "tool": tool_name,
-                    "preview": preview,
-                })
-            elif event_type == "tool.completed":
-                _push({
-                    "event": "tool.completed",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "tool": tool_name,
-                    "duration": round(kwargs.get("duration", 0), 3),
-                    "error": kwargs.get("is_error", False),
-                })
-            elif event_type == "reasoning.available":
+            if event_type == "reasoning.available":
                 _push({
                     "event": "reasoning.available",
                     "run_id": run_id,
@@ -2946,6 +2939,64 @@ class APIServerAdapter(BasePlatformAdapter):
                     "text": preview or "",
                 })
             # _thinking and subagent_progress are intentionally not forwarded
+
+        return _callback
+
+    def _make_run_tool_start_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+        """Return the system tool-start event callback for /v1/runs SSE."""
+        def _callback(tool_call_id: str, tool_name: str, args: dict | None = None):
+            if tool_call_id:
+                self._run_tool_started_at.setdefault(run_id, {})[tool_call_id] = time.time()
+            try:
+                from agent.display import build_tool_preview
+
+                preview = build_tool_preview(tool_name, args or {}) or ""
+            except Exception:
+                preview = ""
+            self._push_run_event(
+                run_id,
+                loop,
+                {
+                    "event": "tool.started",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "tool_call_id": tool_call_id,
+                    "tool": tool_name,
+                    "preview": preview,
+                    "status": "running",
+                },
+            )
+
+        return _callback
+
+    def _make_run_tool_complete_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
+        """Return the system tool-complete event callback for /v1/runs SSE."""
+        def _callback(tool_call_id: str, tool_name: str, args: dict | None = None, result: Any = None):
+            started_at = None
+            if tool_call_id:
+                started_at = self._run_tool_started_at.setdefault(run_id, {}).pop(tool_call_id, None)
+            event = {
+                "event": "tool.completed",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "tool_call_id": tool_call_id,
+                "tool": tool_name,
+                "status": "completed",
+            }
+            if started_at is not None:
+                event["duration"] = round(max(0.0, time.time() - started_at), 3)
+            try:
+                from agent.display import _detect_tool_failure
+
+                is_error, _ = _detect_tool_failure(tool_name, result)
+                event["error"] = is_error
+            except Exception:
+                pass
+            self._push_run_event(
+                run_id,
+                loop,
+                event,
+            )
 
         return _callback
 
@@ -3039,6 +3090,8 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_approval_sessions[run_id] = approval_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
+        tool_start_cb = self._make_run_tool_start_callback(run_id, loop)
+        tool_complete_cb = self._make_run_tool_complete_callback(run_id, loop)
 
         # Also wire stream_delta_callback so message.delta events flow through.
         def _text_cb(delta: Optional[str]) -> None:
@@ -3070,6 +3123,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    tool_start_callback=tool_start_cb,
+                    tool_complete_callback=tool_complete_cb,
                     gateway_session_key=gateway_session_key,
                 )
                 self._active_run_agents[run_id] = agent
@@ -3226,6 +3281,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_tool_started_at.pop(run_id, None)
 
         task = asyncio.create_task(_run_and_close())
         self._active_run_tasks[run_id] = task
@@ -3306,6 +3362,7 @@ class APIServerAdapter(BasePlatformAdapter):
         finally:
             self._run_streams.pop(run_id, None)
             self._run_streams_created.pop(run_id, None)
+            self._run_tool_started_at.pop(run_id, None)
 
         return response
 
@@ -3463,6 +3520,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_tool_started_at.pop(run_id, None)
 
             stale_statuses = [
                 run_id

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -38,10 +38,10 @@ import tempfile
 import threading
 import time
 import sqlite3
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
@@ -131,6 +131,10 @@ _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
     re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
     re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
+)
+_GATEWAY_SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|token|secret|password|authorization|credential)",
+    re.IGNORECASE,
 )
 
 
@@ -226,6 +230,24 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     return redacted
 
 
+def _gateway_visible_arg_keys(args: dict | None) -> list[str]:
+    """Return non-sensitive argument keys safe to show in chat progress."""
+    if not isinstance(args, dict):
+        return []
+    return [str(key) for key in args.keys() if not _GATEWAY_SECRET_KEY_RE.search(str(key))]
+
+
+def _gateway_redacted_args_for_display(args: dict | None) -> dict:
+    """Return a shallow copy of args with secret-looking keys removed."""
+    if not isinstance(args, dict):
+        return {}
+    return {
+        key: value
+        for key, value in args.items()
+        if not _GATEWAY_SECRET_KEY_RE.search(str(key))
+    }
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -316,6 +338,222 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
     return text
+
+
+def _format_gateway_tool_complete_message(
+    tool_name: str,
+    *,
+    is_error: bool = False,
+    duration: float | int | None = None,
+) -> str:
+    """Return a compact user-facing tool completion trace line."""
+    from agent.display import get_tool_emoji
+
+    emoji = get_tool_emoji(tool_name, default="⚙️")
+    suffix = ""
+    try:
+        if duration is not None:
+            duration_f = float(duration)
+            suffix = f" ({duration_f:.1f}s)" if duration_f < 10 else f" ({round(duration_f)}s)"
+    except Exception:
+        suffix = ""
+    status = "error" if is_error else "completed"
+    marker = "❌" if is_error else "✅"
+    return f"{marker} {emoji} {tool_name} {status}{suffix}"
+
+
+def _format_gateway_tool_start_message(
+    tool_name: str,
+    args: dict | None = None,
+    *,
+    progress_mode: str = "all",
+) -> str:
+    """Return a compact, redacted user-facing tool start trace line."""
+    from agent.display import (
+        build_tool_preview,
+        get_tool_emoji,
+        get_tool_preview_max_len,
+    )
+
+    emoji = get_tool_emoji(tool_name, default="⚙️")
+    args = args or {}
+    if progress_mode == "verbose" and args:
+        args_str = json.dumps(
+            _gateway_redacted_args_for_display(args),
+            ensure_ascii=False,
+            default=str,
+        )
+        args_str = _redact_gateway_user_facing_secrets(args_str)
+        preview_len = get_tool_preview_max_len()
+        if preview_len > 0 and len(args_str) > preview_len:
+            args_str = args_str[: preview_len - 3] + "..."
+        return f"{emoji} {tool_name} started({_gateway_visible_arg_keys(args)})\n{args_str}"
+
+    preview = build_tool_preview(tool_name, args) or ""
+    preview = _redact_gateway_user_facing_secrets(str(preview))
+    if preview:
+        preview_len = get_tool_preview_max_len()
+        cap = preview_len if preview_len > 0 else 80
+        if len(preview) > cap:
+            preview = preview[: cap - 3] + "..."
+        return f"{emoji} {tool_name} started: \"{preview}\""
+    return f"{emoji} {tool_name} started"
+
+
+_TELEGRAM_FORCED_TOOL_TRACE_LABELS: tuple[tuple[tuple[str, ...], tuple[str, str]], ...] = (
+    (("terminal", "shell", "bash", "command", "exec_command"), ("💻", "terminal")),
+    (("read_file", "file_read", "read"), ("📖", "read_file")),
+    (("write_file", "file_write", "write"), ("✍️", "write_file")),
+    (("apply_patch", "patch"), ("🔧", "patch")),
+    (("search_files", "grep", "find", "rg", "search"), ("🔎", "search_files")),
+    (("skill_view", "view_skill"), ("📚", "skill_view")),
+    (("todo", "planning", "update_plan"), ("📋", "todo")),
+    (("python", "execute_code", "code_interpreter"), ("🐍", "execute_code")),
+    (("browser", "web", "web_extract", "browser_navigate"), ("🌐", "browser")),
+)
+
+
+def _telegram_forced_tool_trace_label(tool_name: str | None) -> tuple[str, str]:
+    name = str(tool_name or "").lower()
+    for needles, label in _TELEGRAM_FORCED_TOOL_TRACE_LABELS:
+        if any(needle in name for needle in needles):
+            return label
+    return "🛠", "tool"
+
+
+def _telegram_forced_tool_trace_payload(tool_name: str | None, args: dict | None) -> str:
+    """Return a compact, redacted action payload for forced Telegram trace."""
+    if not isinstance(args, dict) or not args:
+        return ""
+    name = str(tool_name or "").lower()
+    preferred_keys: tuple[str, ...]
+    if any(s in name for s in ("terminal", "shell", "bash", "command", "exec_command")):
+        preferred_keys = ("command", "cmd", "query")
+    elif "read" in name:
+        preferred_keys = ("path", "file_path", "filename", "target")
+    elif any(s in name for s in ("write", "patch")):
+        preferred_keys = ("path", "file_path", "filename", "target")
+    elif any(s in name for s in ("search", "grep", "find", "rg")):
+        preferred_keys = ("pattern", "query", "path", "target")
+    elif "skill" in name:
+        preferred_keys = ("skill", "name", "path", "query")
+    elif any(s in name for s in ("todo", "planning", "update_plan")):
+        preferred_keys = ("step", "title", "task", "status")
+    elif any(s in name for s in ("python", "execute_code", "code")):
+        preferred_keys = ("code", "script", "command")
+    elif any(s in name for s in ("browser", "web")):
+        preferred_keys = ("url", "query", "path")
+    else:
+        preferred_keys = ("path", "file_path", "command", "query", "pattern", "url", "name")
+
+    value: Any = None
+    for key in preferred_keys:
+        if key in args and args.get(key) not in (None, ""):
+            value = args.get(key)
+            break
+    if value is None:
+        visible_keys = [
+            str(key) for key in args.keys()
+            if not _GATEWAY_SECRET_KEY_RE.search(str(key))
+        ]
+        value = ", ".join(visible_keys[:4])
+    if isinstance(value, (dict, list, tuple)):
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    else:
+        text = str(value)
+    text = _redact_gateway_user_facing_secrets(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > 160:
+        text = text[:157] + "..."
+    return text
+
+
+def _format_telegram_forced_tool_trace_message(
+    event_type: str,
+    tool_name: str | None,
+    args: dict | None = None,
+    *,
+    duration: float | int | None = None,
+    is_error: bool = False,
+) -> str:
+    """Format a one-line Telegram tool trace message sent as its own bubble."""
+    emoji, label = _telegram_forced_tool_trace_label(tool_name)
+    event = str(event_type or "")
+    if event == "tool.completed":
+        suffix = ""
+        try:
+            if duration is not None:
+                duration_f = float(duration)
+                suffix = f" ({duration_f:.1f}s)" if duration_f < 10 else f" ({round(duration_f)}s)"
+        except Exception:
+            suffix = ""
+        state = "error" if is_error else "done"
+        marker = "❌" if is_error else "✅"
+        return f"{marker} {emoji} {label}: {state}{suffix}"
+
+    payload = _telegram_forced_tool_trace_payload(tool_name, args)
+    if payload:
+        return f"{emoji} {label}: \"{payload}\""
+    return f"{emoji} {label}"
+
+
+def _telegram_tool_trace_spy_enabled() -> bool:
+    return is_truthy_value(os.getenv("HERMES_TELEGRAM_TOOL_TRACE_SPY"), default=False)
+
+
+def _telegram_tool_trace_spy_path() -> Path:
+    override = os.getenv("HERMES_TELEGRAM_TOOL_TRACE_SPY_PATH")
+    if override:
+        return Path(override).expanduser()
+    return _hermes_home / "logs" / "telegram-tool-trace-spy.log"
+
+
+def _truncate_telegram_trace_preview(value: Any, *, limit: int = 180) -> str:
+    if isinstance(value, (dict, list, tuple)):
+        try:
+            text = json.dumps(value, ensure_ascii=False, default=str)
+        except Exception:
+            text = repr(value)
+    else:
+        text = str(value or "")
+    text = _redact_gateway_user_facing_secrets(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > limit:
+        text = text[: limit - 3] + "..."
+    return text
+
+
+def _write_telegram_tool_trace_spy(
+    source_name: str,
+    event_type: str,
+    tool_name: str | None,
+    preview: Any = "",
+    *,
+    chat_id_present: bool = False,
+    sent_to_telegram: bool = False,
+) -> None:
+    """Append one redacted Telegram tool-trace diagnostic line when enabled."""
+    if not _telegram_tool_trace_spy_enabled():
+        return
+    try:
+        spy_path = _telegram_tool_trace_spy_path()
+        spy_path.parent.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+        line = " | ".join(
+            [
+                timestamp,
+                _truncate_telegram_trace_preview(source_name, limit=80),
+                _truncate_telegram_trace_preview(event_type, limit=80),
+                _truncate_telegram_trace_preview(tool_name or "", limit=80),
+                _truncate_telegram_trace_preview(preview, limit=180),
+                f"chat_id_present={'yes' if chat_id_present else 'no'}",
+                f"sent_to_telegram={'yes' if sent_to_telegram else 'no'}",
+            ]
+        )
+        with spy_path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except Exception:
+        logger.debug("Telegram tool trace spy write failed", exc_info=True)
 
 
 async def _send_or_update_status_coro(adapter, chat_id, status_key, content, metadata):
@@ -15824,6 +16062,10 @@ class GatewayRunner:
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
         tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        force_telegram_tool_trace = (
+            source.platform == Platform.TELEGRAM
+            and is_truthy_value(os.getenv("HERMES_TELEGRAM_FORCE_TOOL_TRACE"), default=False)
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -15840,6 +16082,11 @@ class GatewayRunner:
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
+        visible_tool_lifecycle = deque()  # FIFO names for starts rendered to chat
+        use_system_tool_events = source.platform == Platform.TELEGRAM
+        visible_system_tool_calls: Dict[str, Dict[str, Any]] = {}
+        forced_tool_trace_queue = queue.Queue() if force_telegram_tool_trace else None
+        forced_tool_trace_seen: set[tuple[str, str, str, str]] = set()
 
         # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
         # that implements ``delete_message``). When enabled via
@@ -15863,8 +16110,79 @@ class GatewayRunner:
         long_tool_hint_fired = [False]
         _LONG_TOOL_THRESHOLD_S = 30.0
 
+        def _enqueue_forced_tool_trace(
+            event_type: str,
+            tool_name: str | None,
+            args: dict | None = None,
+            *,
+            tool_call_id: str | None = None,
+            duration: float | int | None = None,
+            is_error: bool = False,
+            source_name: str = "gateway.tool_callback",
+        ) -> None:
+            preview = _telegram_forced_tool_trace_payload(tool_name, args)
+            _write_telegram_tool_trace_spy(
+                source_name,
+                event_type,
+                tool_name,
+                preview,
+                chat_id_present=bool(source.chat_id),
+                sent_to_telegram=False,
+            )
+            if not forced_tool_trace_queue or not _run_still_current():
+                return
+            if str(tool_name or "").startswith("_"):
+                return
+            run_id = f"{session_key or source.chat_id or 'gateway'}:{run_generation or 0}"
+            call_id = str(tool_call_id or "")
+            if not call_id:
+                call_id = f"legacy:{str(tool_name or '')}:{preview}"
+            dedup_key = (run_id, call_id, str(event_type or ""), str(tool_name or ""))
+            if dedup_key in forced_tool_trace_seen:
+                return
+            forced_tool_trace_seen.add(dedup_key)
+            msg = _format_telegram_forced_tool_trace_message(
+                event_type,
+                tool_name,
+                args if isinstance(args, dict) else {},
+                duration=duration,
+                is_error=is_error,
+            )
+            forced_tool_trace_queue.put(
+                {
+                    "message": msg,
+                    "event_type": str(event_type or ""),
+                    "tool_name": str(tool_name or ""),
+                    "preview": preview,
+                    "dedup_key": dedup_key,
+                    "source": source_name,
+                }
+            )
+
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
+            _write_telegram_tool_trace_spy(
+                "gateway.progress_callback",
+                event_type,
+                tool_name,
+                preview or args or "",
+                chat_id_present=bool(source.chat_id),
+                sent_to_telegram=False,
+            )
+            if (
+                force_telegram_tool_trace
+                and event_type in {"tool.started", "tool.completed"}
+                and not use_system_tool_events
+            ):
+                _enqueue_forced_tool_trace(
+                    event_type,
+                    tool_name,
+                    args,
+                    tool_call_id=kwargs.get("tool_call_id"),
+                    duration=kwargs.get("duration"),
+                    is_error=bool(kwargs.get("is_error")),
+                    source_name="gateway.progress_callback",
+                )
             if not progress_queue or not _run_still_current():
                 return
 
@@ -15895,12 +16213,53 @@ class GatewayRunner:
                             mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
                 except Exception as _hint_err:
                     logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
+
+            if event_type == "tool.completed":
+                if use_system_tool_events:
+                    return
+                # Only render completions for starts that were actually shown.
+                # This avoids duplicate-looking lifecycle lines in "new" mode,
+                # where repeated same-tool starts are intentionally suppressed.
+                matched_tool = False
+                try:
+                    for _idx, _visible_name in enumerate(visible_tool_lifecycle):
+                        if _visible_name == tool_name:
+                            del visible_tool_lifecycle[_idx]
+                            matched_tool = True
+                            break
+                except Exception:
+                    matched_tool = False
+                if not matched_tool:
+                    return
+
+                progress_queue.put(
+                    _format_gateway_tool_complete_message(
+                        tool_name,
+                        is_error=bool(kwargs.get("is_error")),
+                        duration=kwargs.get("duration"),
+                    )
+                )
                 return
 
-
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
+            # Only act on tool.started events (ignore reasoning.available, etc.)
             if event_type not in {"tool.started",}:
                 return
+            if str(tool_name or "").startswith("_"):
+                return
+            if use_system_tool_events:
+                # Real AIAgent instances emit structured tool_start_callback
+                # events with call IDs. Keep legacy progress events as a
+                # fallback for older/custom integrations that only call
+                # tool_progress_callback, but do not render duplicate starts
+                # once the system lifecycle stream has seen this tool.
+                try:
+                    if any(
+                        str(call.get("name") or "") == str(tool_name or "")
+                        for call in visible_system_tool_calls.values()
+                    ):
+                        return
+                except Exception:
+                    pass
 
             # Suppress tool-progress bubbles once the user has sent `stop`.
             # When the LLM response carries N parallel tool calls, the agent
@@ -15922,6 +16281,7 @@ class GatewayRunner:
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
+            visible_tool_lifecycle.append(tool_name)
             
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
@@ -15932,17 +16292,22 @@ class GatewayRunner:
                 if args:
                     from agent.display import get_tool_preview_max_len
                     _pl = get_tool_preview_max_len()
-                    args_str = json.dumps(args, ensure_ascii=False, default=str)
+                    args_str = json.dumps(
+                        _gateway_redacted_args_for_display(args),
+                        ensure_ascii=False,
+                        default=str,
+                    )
+                    args_str = _redact_gateway_user_facing_secrets(args_str)
                     # When tool_preview_length is 0 (default), don't truncate
                     # in verbose mode — the user explicitly asked for full
                     # detail.  Platform message-length limits handle the rest.
                     if _pl > 0 and len(args_str) > _pl:
                         args_str = args_str[:_pl - 3] + "..."
-                    msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+                    msg = f"{emoji} {tool_name} started({_gateway_visible_arg_keys(args)})\n{args_str}"
                 elif preview:
-                    msg = f"{emoji} {tool_name}: \"{preview}\""
+                    msg = f"{emoji} {tool_name} started: \"{preview}\""
                 else:
-                    msg = f"{emoji} {tool_name}..."
+                    msg = f"{emoji} {tool_name} started"
                 progress_queue.put(msg)
                 return
             
@@ -15955,9 +16320,9 @@ class GatewayRunner:
                 _cap = _pl if _pl > 0 else 40
                 if len(preview) > _cap:
                     preview = preview[:_cap - 3] + "..."
-                msg = f"{emoji} {tool_name}: \"{preview}\""
+                msg = f"{emoji} {tool_name} started: \"{preview}\""
             else:
-                msg = f"{emoji} {tool_name}..."
+                msg = f"{emoji} {tool_name} started"
             
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same
@@ -15972,6 +16337,83 @@ class GatewayRunner:
             repeat_count[0] = 0
             
             progress_queue.put(msg)
+
+        def tool_start_callback(tool_call_id: str, tool_name: str, args: dict = None):
+            """System lifecycle callback for visible Telegram tool starts."""
+            if not _run_still_current():
+                return
+            if not use_system_tool_events:
+                return
+            if str(tool_name or "").startswith("_"):
+                return
+            try:
+                _agent_for_interrupt = agent_holder[0] if agent_holder else None
+                if _agent_for_interrupt is not None and getattr(
+                    _agent_for_interrupt, "is_interrupted", False
+                ):
+                    return
+            except Exception:
+                pass
+            visible_system_tool_calls[str(tool_call_id)] = {
+                "name": str(tool_name),
+                "started_at": time.time(),
+            }
+            _enqueue_forced_tool_trace(
+                "tool.started",
+                tool_name,
+                args,
+                tool_call_id=str(tool_call_id or ""),
+                source_name="gateway.tool_start_callback",
+            )
+            if not progress_queue:
+                return
+            msg = _format_gateway_tool_start_message(
+                str(tool_name),
+                args if isinstance(args, dict) else {},
+                progress_mode=str(progress_mode or "all"),
+            )
+            progress_queue.put(msg)
+
+        def tool_complete_callback(tool_call_id: str, tool_name: str, args: dict = None, result=None):
+            """System lifecycle callback for visible Telegram tool completion."""
+            if not _run_still_current():
+                return
+            if not use_system_tool_events:
+                return
+            call_id = str(tool_call_id)
+            visible = visible_system_tool_calls.pop(call_id, None)
+            if not visible:
+                return
+            visible_name = str(visible.get("name") or tool_name or "tool")
+            duration = None
+            try:
+                duration = max(0.0, time.time() - float(visible.get("started_at")))
+            except Exception:
+                duration = None
+            try:
+                from agent.display import _detect_tool_failure
+
+                is_error, _ = _detect_tool_failure(str(tool_name or visible_name), result)
+            except Exception:
+                is_error = False
+            _enqueue_forced_tool_trace(
+                "tool.completed",
+                str(tool_name or visible_name),
+                args if isinstance(args, dict) else {},
+                tool_call_id=call_id,
+                duration=duration,
+                is_error=is_error,
+                source_name="gateway.tool_complete_callback",
+            )
+            if not progress_queue:
+                return
+            progress_queue.put(
+                _format_gateway_tool_complete_message(
+                    str(tool_name or visible_name),
+                    is_error=is_error,
+                    duration=duration,
+                )
+            )
         
         # Background task to send progress messages
         # Accumulates tool lines into a single message that gets edited.
@@ -16326,6 +16768,87 @@ class GatewayRunner:
                 except Exception as e:
                     logger.error("Progress message error: %s", e)
                     await asyncio.sleep(1)
+
+        async def send_forced_tool_trace_messages():
+            if not forced_tool_trace_queue:
+                return
+            adapter = self.adapters.get(source.platform)
+            if not adapter:
+                return
+            while True:
+                try:
+                    if not _run_still_current():
+                        while not forced_tool_trace_queue.empty():
+                            try:
+                                forced_tool_trace_queue.get_nowait()
+                            except Exception:
+                                break
+                        return
+                    event = forced_tool_trace_queue.get_nowait()
+                    if isinstance(event, dict):
+                        msg = str(event.get("message") or "")
+                        event_type = str(event.get("event_type") or "")
+                        tool_name = str(event.get("tool_name") or "")
+                        preview = event.get("preview") or msg
+                    else:
+                        msg = str(event)
+                        event_type = "tool.trace"
+                        tool_name = ""
+                        preview = msg
+                    result = await adapter.send(
+                        chat_id=source.chat_id,
+                        content=msg,
+                        reply_to=_progress_reply_to,
+                        metadata=_progress_metadata,
+                    )
+                    _write_telegram_tool_trace_spy(
+                        "gateway.forced_broadcaster",
+                        event_type,
+                        tool_name,
+                        preview,
+                        chat_id_present=bool(source.chat_id),
+                        sent_to_telegram=bool(getattr(result, "success", False)),
+                    )
+                    await asyncio.sleep(0.15)
+                except queue.Empty:
+                    await asyncio.sleep(0.2)
+                except asyncio.CancelledError:
+                    while not forced_tool_trace_queue.empty():
+                        try:
+                            event = forced_tool_trace_queue.get_nowait()
+                        except Exception:
+                            break
+                        try:
+                            if isinstance(event, dict):
+                                msg = str(event.get("message") or "")
+                                event_type = str(event.get("event_type") or "")
+                                tool_name = str(event.get("tool_name") or "")
+                                preview = event.get("preview") or msg
+                            else:
+                                msg = str(event)
+                                event_type = "tool.trace"
+                                tool_name = ""
+                                preview = msg
+                            result = await adapter.send(
+                                chat_id=source.chat_id,
+                                content=msg,
+                                reply_to=_progress_reply_to,
+                                metadata=_progress_metadata,
+                            )
+                            _write_telegram_tool_trace_spy(
+                                "gateway.forced_broadcaster.cancel_flush",
+                                event_type,
+                                tool_name,
+                                preview,
+                                chat_id_present=bool(source.chat_id),
+                                sent_to_telegram=bool(getattr(result, "success", False)),
+                            )
+                        except Exception:
+                            break
+                    return
+                except Exception as e:
+                    logger.error("Forced Telegram tool trace error: %s", e)
+                    await asyncio.sleep(1)
         
         # We need to share the agent instance for interrupt support
         agent_holder = [None]  # Mutable container for the agent instance
@@ -16647,7 +17170,9 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            agent.tool_progress_callback = progress_callback if (tool_progress_enabled or force_telegram_tool_trace) else None
+            agent.tool_start_callback = tool_start_callback if ((tool_progress_enabled or force_telegram_tool_trace) and use_system_tool_events) else None
+            agent.tool_complete_callback = tool_complete_callback if ((tool_progress_enabled or force_telegram_tool_trace) and use_system_tool_events) else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
@@ -17271,6 +17796,9 @@ class GatewayRunner:
         progress_task = None
         if tool_progress_enabled:
             progress_task = asyncio.create_task(send_progress_messages())
+        forced_tool_trace_task = None
+        if force_telegram_tool_trace:
+            forced_tool_trace_task = asyncio.create_task(send_forced_tool_trace_messages())
 
         # Start stream consumer task — polls for consumer creation since it
         # happens inside run_sync (thread pool) after the agent is constructed.
@@ -17823,6 +18351,8 @@ class GatewayRunner:
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
                 progress_task.cancel()
+            if forced_tool_trace_task:
+                forced_tool_trace_task.cancel()
             interrupt_monitor.cancel()
             _notify_task.cancel()
 
@@ -17869,7 +18399,7 @@ class GatewayRunner:
                 self._update_runtime_status("draining")
             
             # Wait for cancelled tasks
-            for task in [progress_task, interrupt_monitor, tracking_task, _notify_task]:
+            for task in [progress_task, forced_tool_trace_task, interrupt_monitor, tracking_task, _notify_task]:
                 if task:
                     try:
                         await task

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -922,6 +922,27 @@ DEFAULT_CONFIG = {
         "min_coding_score": 0.65,
     },
 
+    # Optional per-turn model cascade. Disabled by default because changing
+    # the active model affects cost, latency, and provider credentials. When
+    # enabled, the user message is classified as nano/mini/full/frontier and
+    # the corresponding configured model is applied through the same resolver
+    # used by `/model`.
+    "model_cascade": {
+        "enabled": False,
+        "models": {
+            "nano": "",
+            "mini": "",
+            "full": "",
+            "frontier": "",
+        },
+        "providers": {
+            "nano": "",
+            "mini": "",
+            "full": "",
+            "frontier": "",
+        },
+    },
+
     # AWS Bedrock provider configuration.
     # Only used when model.provider is "bedrock".
     "bedrock": {

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -66,6 +66,7 @@ CONFIGURABLE_TOOLSETS = [
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
+    ("model_control",   "🔄 Model Control",             "switch_model (session-local)"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
@@ -94,7 +95,7 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "model_control"}
 
 
 def _xai_credentials_present() -> bool:

--- a/model_tools.py
+++ b/model_tools.py
@@ -492,7 +492,7 @@ def _compute_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "switch_model"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/tests/agent/test_complexity_classifier.py
+++ b/tests/agent/test_complexity_classifier.py
@@ -1,0 +1,36 @@
+from agent.complexity_classifier import ComplexityClassifier, cascade_router_classify
+
+
+def test_classifies_greetings_as_nano():
+    assert ComplexityClassifier.classify("hello") == "nano"
+    assert ComplexityClassifier.classify("спасибо") == "nano"
+
+
+def test_short_commands_are_mini_not_nano():
+    assert ComplexityClassifier.classify("write a small script") == "mini"
+    assert ComplexityClassifier.classify("сделай файл") == "mini"
+
+
+def test_debug_and_architecture_are_full_not_frontier():
+    assert ComplexityClassifier.classify("debug this failing pytest case") == "full"
+    assert ComplexityClassifier.classify("explain the architecture here") == "full"
+    assert ComplexityClassifier.classify("дебаг почему тест падает") == "full"
+
+
+def test_urgent_or_major_refactor_markers_are_frontier():
+    assert ComplexityClassifier.classify("!urgent fix production now") == "frontier"
+    assert ComplexityClassifier.classify("complete rewrite of the gateway") == "frontier"
+
+
+def test_code_block_size_changes_complexity():
+    small_code = "```python\nprint('hello')\n```"
+    medium_code = "```python\n" + "\n".join(f"print({i})" for i in range(12)) + "\n```"
+    large_code = "```python\n" + "\n".join(f"print({i})" for i in range(55)) + "\n```"
+
+    assert ComplexityClassifier.classify(small_code) == "mini"
+    assert ComplexityClassifier.classify(medium_code) == "full"
+    assert ComplexityClassifier.classify(large_code) == "frontier"
+
+
+def test_cascade_router_classify_delegates_to_classifier():
+    assert cascade_router_classify("why does this happen?") == "full"

--- a/tests/agent/test_model_cascade.py
+++ b/tests/agent/test_model_cascade.py
@@ -1,0 +1,112 @@
+import json
+from types import SimpleNamespace
+
+from agent.model_cascade import (
+    classify_for_model_cascade,
+    maybe_apply_model_cascade,
+    resolve_model_cascade_target,
+)
+
+
+def test_resolve_model_cascade_target_disabled_keeps_classification_only():
+    decision = resolve_model_cascade_target(
+        {
+            "enabled": False,
+            "models": {"full": "gpt-5.4"},
+        },
+        "debug this failing test",
+    )
+
+    assert decision == {"tier": "full", "model": "", "provider": ""}
+
+
+def test_resolve_model_cascade_target_uses_tier_model_and_provider():
+    decision = resolve_model_cascade_target(
+        {
+            "enabled": True,
+            "models": {
+                "nano": "gpt-4.1-nano",
+                "mini": "gpt-5.4-mini",
+                "full": "gpt-5.4",
+                "frontier": "gpt-5.5",
+            },
+            "providers": {"frontier": "openrouter"},
+        },
+        "!urgent complete rewrite of the gateway",
+    )
+
+    assert decision == {
+        "tier": "frontier",
+        "model": "gpt-5.5",
+        "provider": "openrouter",
+    }
+
+
+def test_maybe_apply_model_cascade_calls_switch_model_for_configured_tier(monkeypatch):
+    calls = []
+
+    def fake_switch(agent, model, *, reason=None, provider=None):
+        calls.append((agent, model, reason, provider))
+        agent.model = "resolved/gpt-5.4"
+        agent.provider = "openrouter"
+        return json.dumps(
+            {
+                "success": True,
+                "new_model": "resolved/gpt-5.4",
+                "provider": "openrouter",
+            }
+        )
+
+    monkeypatch.setattr("tools.switch_model_tool.switch_model_for_agent", fake_switch)
+    agent = SimpleNamespace(
+        model="gpt-4.1-nano",
+        provider="openai",
+        _model_cascade_config={
+            "enabled": True,
+            "models": {"full": "gpt-5.4"},
+            "providers": {"full": "openrouter"},
+        },
+    )
+
+    decision = maybe_apply_model_cascade(agent, "explain the architecture here")
+
+    assert calls == [
+        (agent, "gpt-5.4", "model_cascade:full", "openrouter")
+    ]
+    assert decision["applied"] is True
+    assert decision["tier"] == "full"
+    assert decision["resolved_model"] == "resolved/gpt-5.4"
+    assert decision["resolved_provider"] == "openrouter"
+    assert agent._model_cascade_last_decision == decision
+
+
+def test_maybe_apply_model_cascade_skips_unconfigured_tier(monkeypatch):
+    monkeypatch.setattr(
+        "tools.switch_model_tool.switch_model_for_agent",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("should not switch")),
+    )
+    agent = SimpleNamespace(
+        model="gpt-5.4",
+        provider="openai",
+        _model_cascade_config={"enabled": True, "models": {"frontier": "gpt-5.5"}},
+    )
+
+    assert maybe_apply_model_cascade(agent, "hello") is None
+    assert agent._model_cascade_last_decision == {
+        "tier": "nano",
+        "model": "",
+        "provider": "",
+    }
+
+
+def test_classify_for_model_cascade_delegates_to_complexity_classifier():
+    assert classify_for_model_cascade("write a small script") == "mini"
+
+
+def test_default_config_contains_disabled_model_cascade_shape():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG["model_cascade"]
+    assert cfg["enabled"] is False
+    assert set(cfg["models"]) == {"nano", "mini", "full", "frontier"}
+    assert set(cfg["providers"]) == {"nano", "mini", "full", "frontier"}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -306,6 +306,50 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    def test_run_tool_events_use_system_lifecycle_callbacks(self, adapter):
+        """Run SSE callbacks should emit real tool lifecycle events with call ids."""
+        import queue
+
+        class _ImmediateLoop:
+            def call_soon_threadsafe(self, fn, *args):
+                fn(*args)
+
+        run_id = "run_tool_events"
+        event_q = queue.Queue()
+        adapter._run_streams[run_id] = event_q
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+
+        loop = _ImmediateLoop()
+        progress_cb = adapter._make_run_event_callback(run_id, loop)
+        start_cb = adapter._make_run_tool_start_callback(run_id, loop)
+        complete_cb = adapter._make_run_tool_complete_callback(run_id, loop)
+
+        start_cb("call_terminal_1", "terminal", {"command": "pwd"})
+        progress_cb("tool.started", "terminal", "legacy duplicate", {"command": "pwd"})
+        complete_cb("call_terminal_1", "terminal", {"command": "pwd"}, "ok")
+        progress_cb(
+            "tool.completed",
+            "terminal",
+            None,
+            None,
+            duration=0.1,
+            is_error=False,
+        )
+
+        tool_events = []
+        while not event_q.empty():
+            event = event_q.get_nowait()
+            if event.get("event", "").startswith("tool."):
+                tool_events.append(event)
+
+        assert [e["event"] for e in tool_events] == ["tool.started", "tool.completed"]
+        assert tool_events[0]["tool_call_id"] == "call_terminal_1"
+        assert tool_events[0]["status"] == "running"
+        assert tool_events[1]["tool_call_id"] == "call_terminal_1"
+        assert tool_events[1]["status"] == "completed"
+        assert tool_events[1]["error"] is False
+        assert isinstance(tool_events[1]["duration"], float)
+
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -144,6 +144,35 @@ class FakeAgent:
         }
 
 
+class ToolLifecycleAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tool_start_callback = kwargs.get("tool_start_callback")
+        self.tool_complete_callback = kwargs.get("tool_complete_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        start_cb = self.tool_start_callback
+        complete_cb = self.tool_complete_callback
+        progress_cb = self.tool_progress_callback
+        if start_cb is not None:
+            if progress_cb is not None:
+                progress_cb("tool.started", "search_files", "legacy duplicate", {"pattern": "gateway progress"})
+            start_cb("call_search_1", "search_files", {"pattern": "gateway progress"})
+            time.sleep(0.35)
+            if progress_cb is not None:
+                progress_cb("tool.completed", "search_files", None, None, duration=0.42, is_error=False)
+            complete_cb("call_search_1", "search_files", {"pattern": "gateway progress"}, '{"success": true}')
+            start_cb("call_terminal_1", "terminal", {"command": "false"})
+            time.sleep(0.35)
+            complete_cb("call_terminal_1", "terminal", {"command": "false"}, '{"exit_code": 1, "error": "failed"}')
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -245,6 +274,100 @@ def _make_runner(adapter):
     return runner
 
 
+def test_format_gateway_tool_complete_message_compact():
+    gateway_run = importlib.import_module("gateway.run")
+
+    line = gateway_run._format_gateway_tool_complete_message(
+        "search_files",
+        is_error=False,
+        duration=0.42,
+    )
+
+    assert "search_files completed" in line
+    assert "0.4s" in line
+    assert "pattern" not in line
+    assert "\n" not in line
+
+
+def test_format_gateway_tool_complete_message_error_compact():
+    gateway_run = importlib.import_module("gateway.run")
+
+    line = gateway_run._format_gateway_tool_complete_message(
+        "terminal",
+        is_error=True,
+        duration=12.3,
+    )
+
+    assert "terminal error" in line
+    assert "12s" in line
+    assert "command" not in line
+    assert "\n" not in line
+
+
+def test_format_gateway_tool_start_message_compact_redacted():
+    gateway_run = importlib.import_module("gateway.run")
+
+    line = gateway_run._format_gateway_tool_start_message(
+        "terminal",
+        {"command": "echo hello", "api_key": "sk-secret"},
+        progress_mode="all",
+    )
+
+    assert "terminal started" in line
+    assert "echo hello" in line
+    assert "api_key" not in line
+    assert "sk-secret" not in line
+    assert "\n" not in line
+
+
+def test_format_gateway_tool_start_message_verbose_redacted():
+    gateway_run = importlib.import_module("gateway.run")
+
+    line = gateway_run._format_gateway_tool_start_message(
+        "search_files",
+        {"pattern": "tool trace", "token": "sk-secret1234567890"},
+        progress_mode="verbose",
+    )
+
+    assert "search_files started" in line
+    assert "pattern" in line
+    assert "tool trace" in line
+    assert "token" not in line
+    assert "sk-secret1234567890" not in line
+
+
+def test_format_telegram_forced_tool_trace_message_redacted():
+    gateway_run = importlib.import_module("gateway.run")
+
+    line = gateway_run._format_telegram_forced_tool_trace_message(
+        "tool.started",
+        "terminal",
+        {"command": "echo hello", "api_key": "sk-secret"},
+    )
+
+    assert line == '💻 terminal: "echo hello"'
+    assert "api_key" not in line
+    assert "sk-secret" not in line
+
+
+def test_telegram_tool_trace_spy_path_defaults_to_hermes_logs(monkeypatch, tmp_path):
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.delenv("HERMES_TELEGRAM_TOOL_TRACE_SPY_PATH", raising=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    assert gateway_run._telegram_tool_trace_spy_path() == (
+        tmp_path / "logs" / "telegram-tool-trace-spy.log"
+    )
+
+
+def test_telegram_tool_trace_spy_path_honors_override(monkeypatch, tmp_path):
+    gateway_run = importlib.import_module("gateway.run")
+    override = tmp_path / "trace.log"
+    monkeypatch.setenv("HERMES_TELEGRAM_TOOL_TRACE_SPY_PATH", str(override))
+
+    assert gateway_run._telegram_tool_trace_spy_path() == override
+
+
 @pytest.mark.asyncio
 async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
@@ -283,7 +406,7 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
     assert adapter.sent == [
         {
             "chat_id": "-1001",
-            "content": '💻 terminal: "pwd"',
+            "content": '💻 terminal started: "pwd"',
             "reply_to": None,
             "metadata": {"thread_id": "17585"},
         }
@@ -464,6 +587,103 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
     assert adapter.sent[0]["metadata"] == {"thread_id": "topic_17585"}
     assert adapter.edits
     assert adapter.edits[0]["message_id"] == "progress-1"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_telegram_progress_renders_tool_lifecycle(monkeypatch, tmp_path):
+    """Telegram progress should show compact started/completed/error lifecycle."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolLifecycleAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-tool-lifecycle",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_progress_text = "\n".join(
+        [call["content"] for call in adapter.sent]
+        + [call["content"] for call in adapter.edits]
+    )
+    assert "search_files started" in all_progress_text
+    assert "search_files completed" in all_progress_text
+    assert "terminal started" in all_progress_text
+    assert "terminal error" in all_progress_text
+    assert "gateway progress" in all_progress_text
+    assert "pattern" not in all_progress_text
+    assert "command" not in all_progress_text
+
+
+def test_run_agent_telegram_forced_tool_trace_sends_separate_messages(monkeypatch, tmp_path):
+    """Forced Telegram trace bypasses editable progress bubbles when enabled."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setenv("HERMES_TELEGRAM_FORCE_TOOL_TRACE", "1")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolLifecycleAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    async def _run():
+        return await runner._run_agent(
+            message="hello",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-forced-tool-trace",
+            session_key="agent:main:telegram:dm:12345",
+        )
+
+    result = asyncio.run(_run())
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert not adapter.edits
+    all_trace_text = "\n".join(call["content"] for call in adapter.sent)
+    assert '🔎 search_files: "gateway progress"' in all_trace_text
+    assert "✅ 🔎 search_files: done" in all_trace_text
+    assert '💻 terminal: "false"' in all_trace_text
+    assert "❌ 💻 terminal: error" in all_trace_text
+    assert "pattern" not in all_trace_text
+    assert "command" not in all_trace_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -265,6 +265,7 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
     returned as a single picker row with all their models merged."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_k: [])
 
     providers = list_authenticated_providers(
         current_provider="custom",
@@ -351,6 +352,7 @@ def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypat
     even if some display names happen to be similar."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_k: [])
 
     providers = list_authenticated_providers(
         user_providers={},
@@ -408,6 +410,7 @@ def test_list_authenticated_providers_total_models_reflects_grouped_count(monkey
     the full count, and every grouped model appears in the list."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_k: [])
 
     entries = [
         {"name": f"Ollama \u2014 Model {i}", "base_url": "http://localhost:11434/v1",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1033,11 +1033,13 @@ def test_discord_toolsets_in_configurable_toolsets():
     keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     assert "discord" in keys
     assert "discord_admin" in keys
+    assert "model_control" in keys
 
 
 def test_discord_toolsets_in_default_off():
     assert "discord" in _DEFAULT_OFF_TOOLSETS
     assert "discord_admin" in _DEFAULT_OFF_TOOLSETS
+    assert "model_control" in _DEFAULT_OFF_TOOLSETS
 
 
 def test_discord_toolsets_not_available_on_other_platforms():

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -12,11 +12,13 @@ Verifies that:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 import run_agent
+from agent.codex_runtime import _make_codex_tool_trace_event_callback
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
@@ -68,6 +70,81 @@ class TestApiModeAccepted:
     def test_api_mode_is_codex_app_server(self):
         agent = _make_codex_agent()
         assert agent.api_mode == "codex_app_server"
+
+
+class TestCodexToolTraceProjection:
+    def test_codex_item_events_emit_tool_lifecycle_callbacks(self):
+        starts = []
+        completes = []
+        agent = SimpleNamespace(
+            tool_start_callback=lambda call_id, name, args: starts.append((call_id, name, args)),
+            tool_complete_callback=lambda call_id, name, args, result: completes.append(
+                (call_id, name, args, result)
+            ),
+        )
+        on_event = _make_codex_tool_trace_event_callback(agent)
+
+        item = {
+            "type": "commandExecution",
+            "id": "exec-1",
+            "command": "pwd",
+            "cwd": "/tmp/project",
+            "exitCode": 0,
+        }
+        on_event({"method": "item/started", "params": {"item": item}})
+        on_event({"method": "item/completed", "params": {"item": item}})
+
+        assert starts == [
+            (
+                "codex_exec_exec-1",
+                "exec_command",
+                {"command": "pwd", "cwd": "/tmp/project"},
+            )
+        ]
+        assert completes == [
+            (
+                "codex_exec_exec-1",
+                "exec_command",
+                {"command": "pwd", "cwd": "/tmp/project"},
+                {"error": False},
+            )
+        ]
+
+    def test_codex_completed_event_starts_unseen_tool_before_completion(self):
+        starts = []
+        completes = []
+        agent = SimpleNamespace(
+            tool_start_callback=lambda call_id, name, args: starts.append((call_id, name, args)),
+            tool_complete_callback=lambda call_id, name, args, result: completes.append(
+                (call_id, name, args, result)
+            ),
+        )
+        on_event = _make_codex_tool_trace_event_callback(agent)
+
+        on_event({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "dynamicToolCall",
+                    "id": "tool-1",
+                    "tool": "web_search",
+                    "arguments": {"query": "hermes"},
+                    "success": False,
+                }
+            },
+        })
+
+        assert starts == [
+            ("codex_dyn_web_search_tool-1", "web_search", {"query": "hermes"})
+        ]
+        assert completes == [
+            (
+                "codex_dyn_web_search_tool-1",
+                "web_search",
+                {"query": "hermes"},
+                {"error": True},
+            )
+        ]
 
 
 class TestRunConversationCodexPath:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2706,6 +2706,49 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_model_cascade_applies_before_api_call(self, agent, monkeypatch):
+        self._setup_agent(agent)
+        agent.model = "gpt-4.1-nano"
+        agent.provider = "openai"
+        agent._model_cascade_config = {
+            "enabled": True,
+            "models": {"full": "gpt-5.4"},
+            "providers": {"full": "openrouter"},
+        }
+
+        def fake_switch(agent_obj, model, *, reason=None, provider=None):
+            assert model == "gpt-5.4"
+            assert reason == "model_cascade:full"
+            assert provider == "openrouter"
+            agent_obj.model = "openrouter/gpt-5.4"
+            agent_obj.provider = "openrouter"
+            return json.dumps(
+                {
+                    "success": True,
+                    "new_model": "openrouter/gpt-5.4",
+                    "provider": "openrouter",
+                }
+            )
+
+        monkeypatch.setattr("tools.switch_model_tool.switch_model_for_agent", fake_switch)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("explain the architecture here")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Final answer"
+        assert agent.model == "openrouter/gpt-5.4"
+        assert agent._model_cascade_last_decision["applied"] is True
+        assert agent.client.chat.completions.create.call_args.kwargs["model"] == "openrouter/gpt-5.4"
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -212,6 +212,9 @@ class TestToolsetConsistency:
             for inc in ts["includes"]:
                 assert inc in TOOLSETS, f"{name} includes unknown toolset '{inc}'"
 
+    def test_model_control_toolset_exposes_switch_model(self):
+        assert TOOLSETS["model_control"]["tools"] == ["switch_model"]
+
     def test_hermes_platforms_share_core_tools(self):
         """All hermes-* platform toolsets share the same core tools.
 

--- a/tests/tools/test_switch_model_tool.py
+++ b/tests/tools/test_switch_model_tool.py
@@ -1,0 +1,118 @@
+import json
+from types import SimpleNamespace
+
+from hermes_cli.model_switch import ModelSwitchResult
+from model_tools import handle_function_call
+from tools.switch_model_tool import switch_model_for_agent, switch_model_tool
+
+
+def test_switch_model_tool_requires_agent_loop():
+    result = json.loads(switch_model_tool("gpt-5.4"))
+
+    assert result["success"] is False
+    assert "agent loop" in result["error"]
+
+
+def test_handle_function_call_does_not_dispatch_switch_model_directly():
+    result = json.loads(handle_function_call("switch_model", {"new_model": "gpt-5.4"}))
+
+    assert "error" in result
+    assert "must be handled by the agent loop" in result["error"]
+
+
+def test_switch_model_for_agent_resolves_and_applies_session_switch(monkeypatch):
+    calls = {}
+
+    def fake_load_config():
+        return {"providers": {"custom": {"base_url": "https://example.invalid"}}}
+
+    def fake_get_compatible_custom_providers(cfg):
+        calls["custom_cfg"] = cfg
+        return [{"id": "custom"}]
+
+    def fake_switch_model(**kwargs):
+        calls["switch_model"] = kwargs
+        return ModelSwitchResult(
+            success=True,
+            new_model="provider/gpt-5.4",
+            target_provider="openrouter",
+            api_key="sk-new",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+        )
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_compatible_custom_providers",
+        fake_get_compatible_custom_providers,
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
+
+    applied = {}
+
+    def apply_switch(**kwargs):
+        applied.update(kwargs)
+
+    agent = SimpleNamespace(
+        model="old-model",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-old",
+        switch_model=apply_switch,
+    )
+
+    result = json.loads(
+        switch_model_for_agent(
+            agent,
+            "gpt-5.4",
+            reason="need stronger reasoning",
+            provider="openrouter",
+        )
+    )
+
+    assert result == {
+        "success": True,
+        "old_model": "old-model",
+        "new_model": "provider/gpt-5.4",
+        "provider": "openrouter",
+        "provider_label": "OpenRouter",
+        "reason": "need stronger reasoning",
+        "warning": "",
+    }
+    assert calls["switch_model"]["raw_input"] == "gpt-5.4"
+    assert calls["switch_model"]["current_model"] == "old-model"
+    assert calls["switch_model"]["current_api_key"] == "sk-old"
+    assert calls["switch_model"]["explicit_provider"] == "openrouter"
+    assert calls["switch_model"]["user_providers"] == {
+        "custom": {"base_url": "https://example.invalid"}
+    }
+    assert calls["switch_model"]["custom_providers"] == [{"id": "custom"}]
+    assert applied == {
+        "new_model": "provider/gpt-5.4",
+        "new_provider": "openrouter",
+        "api_key": "sk-new",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+    }
+
+
+def test_switch_model_for_agent_returns_resolution_error(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.get_compatible_custom_providers", lambda _cfg: [])
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_kwargs: ModelSwitchResult(success=False, error_message="no such model"),
+    )
+
+    agent = SimpleNamespace(
+        model="old-model",
+        provider="openrouter",
+        base_url="",
+        api_key="sk-old",
+        switch_model=lambda **_kwargs: None,
+    )
+
+    result = json.loads(switch_model_for_agent(agent, "missing-model"))
+
+    assert result == {"success": False, "error": "no such model"}

--- a/tools/switch_model_tool.py
+++ b/tools/switch_model_tool.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Agent-level tool for switching the active model mid-session."""
+
+import json
+from typing import Optional
+
+SWITCH_MODEL_SCHEMA = {
+    "name": "switch_model",
+    "description": (
+        "Change the active model for the remainder of this conversation. "
+        "Useful when you need a different model's capabilities "
+        "(stronger reasoning, faster response, vision, larger context).\n\n"
+        "After switching, all subsequent messages use the new model. "
+        "The change persists for the current session only.\n\n"
+        "Available models:\n"
+        "- gpt-4.1-nano — cheapest, fast, cache works. Use: greetings, status, confirmations, simple Q&A\n"
+        "- gpt-5.4-mini — balanced. Use: code review, analysis, medium complexity\n"
+        "- gpt-5.4 — strong reasoning, large context. Use: complex debug, planning, architecture\n"
+        "- gpt-5.5 — strongest model. Use: frontier research, multi-file refactoring, critical issues\n\n"
+        "Format: just the model name (e.g. \"gpt-5.4\"). Provider auto-detected."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "new_model": {
+                "type": "string",
+                "description": "Model name to switch to (e.g. gpt-4.1-nano, gpt-5.4, gpt-5.5)",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional explanation of why the switch is needed",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Optional provider slug, equivalent to /model <model> --provider <provider>",
+            },
+        },
+        "required": ["new_model"],
+    },
+}
+
+
+def switch_model_tool(
+    new_model: str,
+    reason: Optional[str] = None,
+    provider: Optional[str] = None,
+    agent=None,
+) -> str:
+    """Switch the agent's active model at runtime."""
+    if agent is None:
+        return json.dumps({
+            "success": False,
+            "error": "switch_model must be handled by the agent loop",
+        }, ensure_ascii=False)
+
+    return switch_model_for_agent(agent, new_model, reason=reason, provider=provider)
+
+
+def switch_model_for_agent(
+    agent,
+    new_model: str,
+    *,
+    reason: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> str:
+    """Resolve and apply a session-local model switch for an AIAgent."""
+    if not new_model or not new_model.strip():
+        return json.dumps({
+            "success": False,
+            "error": "new_model is required",
+        }, ensure_ascii=False)
+
+    new_model = new_model.strip()
+    old_model = getattr(agent, "model", "") or ""
+    current_api_key = getattr(agent, "api_key", "") or ""
+    if not isinstance(current_api_key, str):
+        current_api_key = ""
+
+    user_providers = None
+    custom_providers = None
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+
+        cfg = load_config()
+        if isinstance(cfg, dict):
+            providers_cfg = cfg.get("providers")
+            if isinstance(providers_cfg, dict):
+                user_providers = providers_cfg
+            custom_providers = get_compatible_custom_providers(cfg)
+    except Exception:
+        user_providers = None
+        custom_providers = None
+
+    try:
+        from hermes_cli.model_switch import switch_model
+
+        result = switch_model(
+            raw_input=new_model,
+            current_provider=getattr(agent, "provider", "") or "",
+            current_model=old_model,
+            current_base_url=getattr(agent, "base_url", "") or "",
+            current_api_key=current_api_key,
+            is_global=False,
+            explicit_provider=(provider or "").strip(),
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+        )
+    except Exception as exc:
+        return json.dumps({
+            "success": False,
+            "error": f"Failed to resolve model switch: {exc}",
+        }, ensure_ascii=False)
+
+    if not result.success:
+        return json.dumps({
+            "success": False,
+            "error": result.error_message or "model switch failed",
+        }, ensure_ascii=False)
+
+    try:
+        agent.switch_model(
+            new_model=result.new_model,
+            new_provider=result.target_provider,
+            api_key=result.api_key,
+            base_url=result.base_url,
+            api_mode=result.api_mode,
+        )
+    except Exception as exc:
+        return json.dumps({
+            "success": False,
+            "error": f"Failed to switch model: {exc}",
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "success": True,
+        "old_model": old_model,
+        "new_model": result.new_model,
+        "provider": result.target_provider,
+        "provider_label": result.provider_label or result.target_provider,
+        "reason": reason or "",
+        "warning": result.warning_message or "",
+    }, ensure_ascii=False)
+
+
+def check_switch_model_requirements() -> bool:
+    """No external requirements — always available."""
+    return True
+
+
+# =============================================================================
+# Registry — auto-discovered by model_tools.py
+# =============================================================================
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="switch_model",
+    toolset="model_control",
+    schema=SWITCH_MODEL_SCHEMA,
+    handler=lambda args, **kw: switch_model_tool(
+        new_model=args.get("new_model", ""),
+        reason=args.get("reason"),
+        provider=args.get("provider"),
+        agent=kw.get("agent")),
+    check_fn=check_switch_model_requirements,
+    emoji="🔄",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -209,6 +209,12 @@ TOOLSETS = {
         "tools": ["todo"],
         "includes": []
     },
+
+    "model_control": {
+        "description": "Session-local model switching tool",
+        "tools": ["switch_model"],
+        "includes": []
+    },
     
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",


### PR DESCRIPTION
## Summary
- add model cascade complexity classification and switch-model tooling
- add tool lifecycle/progress tracing through agent and gateway paths
- cover model cascade, switch_model tool, gateway progress topics, and integration behavior with tests

## Tests
- Not run in this handoff; local branch was pushed from existing committed state.