### PR TITLE
fix: limit pre-update state snapshots to 1 (salvage of #20225)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -512,6 +512,7 @@ def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
 def create_quick_snapshot(
     label: Optional[str] = None,
     hermes_home: Optional[Path] = None,
+    keep: Optional[int] = None,
 ) -> Optional[str]:
     """Create a quick state snapshot of critical files.
 
@@ -585,8 +586,10 @@ def create_quick_snapshot(
     with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
 
-    # Auto-prune
-    _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP)
+    # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
+    # with known high-churn safety snapshots (for example pre-update) can pass a
+    # smaller keep value so large state.db copies do not accumulate indefinitely.
+    _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
 
     logger.info("State snapshot created: %s (%d files)", snap_id, len(manifest))
     return snap_id

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9052,7 +9052,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         try:
             from hermes_cli.backup import create_quick_snapshot
 
-            snap_id = create_quick_snapshot(label="pre-update")
+            snap_id = create_quick_snapshot(label="pre-update", keep=1)
             if snap_id:
                 print(f"  ✓ Pre-update snapshot: {snap_id}")
         except Exception as exc:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,7 @@ AUTHOR_MAP = {
     "omar@techdeveloper.site": "nycomar",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
+    "adityargadgil@gmail.com": "AdityaRajeshGadgil",
     "70629228+shaun0927@users.noreply.github.com": "shaun0927",
     "soju06@users.noreply.github.com": "Soju06",
     "34199905+Soju06@users.noreply.github.com": "Soju06",


### PR DESCRIPTION
Salvage of #20225 (@AdityaRajeshGadgil). `hermes update` was creating a full pre-update state snapshot (state.db + .env + auth.json + pairing dirs) on every run and keeping 20 of them in `~/.hermes/state-snapshots/`. On heavy users that's gigabytes piling up across updates.

## Changes

- `create_quick_snapshot()` gains an optional `keep` param; `None` preserves the existing `_QUICK_DEFAULT_KEEP=20` retention.
- `hermes update` now calls it with `keep=1` so only the most recent pre-update snapshot is retained.
- Manual `/snapshot` invocations and `hermes backup --quick` are unchanged (still keep 20).

## Validation

| | Before | After |
|---|---|---|
| Pre-update snapshots retained | 20 | 1 |
| Manual `/snapshot` retention | 20 | 20 (unchanged) |
| `tests/hermes_cli/test_backup.py` | passes | 99 passed |

E2E verified locally: 3 sequential `create_quick_snapshot(label="pre-update", keep=1)` calls → 1 snapshot on disk; 3 follow-up `keep=None` calls → 4 snapshots total (1 pre-update + 3 manual), confirming the split.

Closes #20225.


## Infographic

![pre-update snapshot retention](https://v3b.fal.media/files/b/0a9c017c/AfOjImkXsfROf8T-wk5hE_tDTOrl8Q.png)
