### PR TITLE
fix: avoid compound rewrite on env-based spawn_via_env

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -888,6 +888,9 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
 def _media_delivery_allowed_roots() -> List[Path]:
     """Return roots from which model-emitted local media may be delivered."""
     roots = [Path(root) for root in MEDIA_DELIVERY_SAFE_ROOTS]
+    docker_workspace = _docker_workspace_host_root()
+    if docker_workspace is not None:
+        roots.append(docker_workspace)
     extra_roots = os.environ.get(MEDIA_DELIVERY_ALLOW_DIRS_ENV, "")
     for chunk in extra_roots.split(os.pathsep):
         for raw_root in chunk.split(","):
@@ -969,6 +972,64 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
+def _docker_workspace_container_path(candidate: Path) -> bool:
+    """Return True for absolute container paths rooted at ``/workspace``."""
+    if not candidate.is_absolute():
+        return False
+    try:
+        candidate.relative_to("/workspace")
+        return True
+    except ValueError:
+        return False
+
+
+def _docker_workspace_host_root() -> Optional[Path]:
+    """Return the host path backing Docker's default persistent ``/workspace``."""
+    if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+        return None
+    if os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower() not in {"1", "true", "yes", "on"}:
+        return None
+    if os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").strip().lower() in {"1", "true", "yes", "on"}:
+        return None
+
+    raw_volumes = os.getenv("TERMINAL_DOCKER_VOLUMES", "").strip()
+    if raw_volumes:
+        try:
+            import json as _json
+            parsed = _json.loads(raw_volumes)
+        except Exception:
+            parsed = []
+        if isinstance(parsed, list):
+            for spec in parsed:
+                if isinstance(spec, str) and ":/workspace" in spec:
+                    return None
+
+    try:
+        from tools.environments.base import get_sandbox_dir
+
+        root = (get_sandbox_dir() / "docker" / "default" / "workspace").resolve(strict=True)
+    except (ImportError, OSError, RuntimeError, ValueError):
+        return None
+    return root if root.is_dir() else None
+
+
+def _translate_docker_workspace_media_path(candidate: Path) -> Optional[Path]:
+    """Translate ``/workspace/...`` from a Docker container to its host path."""
+    if not _docker_workspace_container_path(candidate):
+        return None
+    host_workspace = _docker_workspace_host_root()
+    if host_workspace is None:
+        return None
+    try:
+        relative = candidate.relative_to("/workspace")
+        translated = (host_workspace / relative).resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if translated != host_workspace and not _path_is_within(translated, host_workspace):
+        return None
+    return translated
+
+
 def validate_media_delivery_path(path: str) -> Optional[str]:
     """Return a safe absolute file path for native media delivery, else None.
 
@@ -991,10 +1052,16 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not expanded.is_absolute():
         return None
 
-    try:
-        resolved = expanded.resolve(strict=True)
-    except (OSError, RuntimeError, ValueError):
+    translated = _translate_docker_workspace_media_path(expanded)
+    if translated is not None:
+        resolved = translated
+    elif _docker_workspace_container_path(expanded) and os.getenv("TERMINAL_ENV", "").strip().lower() == "docker":
         return None
+    else:
+        try:
+            resolved = expanded.resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            return None
 
     if not resolved.is_file():
         return None

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -26,6 +26,13 @@ Endpoint override:
   ``openai.OpenAI(base_url=...)`` when set, so image generation can target a
   provider-specific OpenAI-compatible endpoint without relying on the global
   ``OPENAI_BASE_URL`` environment variable.
+
+Credential override:
+
+- ``image_gen.openai.key_env`` names the environment variable containing the
+  API key for this image backend. ``api_key_env`` is accepted as an alias.
+  When neither resolves to a set value, the provider falls back to
+  ``OPENAI_API_KEY``.
 """
 
 from __future__ import annotations
@@ -139,6 +146,26 @@ def _resolve_base_url() -> Optional[str]:
     return cleaned or None
 
 
+def _resolve_api_key() -> Optional[str]:
+    """Return the configured OpenAI image API key, if available."""
+    cfg = _load_openai_config()
+    openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
+    if isinstance(openai_cfg, dict):
+        for field in ("key_env", "api_key_env"):
+            env_name = openai_cfg.get(field)
+            if not isinstance(env_name, str):
+                continue
+            env_name = env_name.strip()
+            if not env_name:
+                continue
+            value = os.environ.get(env_name, "").strip()
+            if value:
+                return value
+
+    value = os.environ.get("OPENAI_API_KEY", "").strip()
+    return value or None
+
+
 # ---------------------------------------------------------------------------
 # Provider
 # ---------------------------------------------------------------------------
@@ -156,7 +183,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         return "OpenAI"
 
     def is_available(self) -> bool:
-        if not os.environ.get("OPENAI_API_KEY"):
+        if not _resolve_api_key():
             return False
         try:
             import openai  # noqa: F401
@@ -210,12 +237,12 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        if not os.environ.get("OPENAI_API_KEY"):
+        api_key = _resolve_api_key()
+        if not api_key:
             return error_response(
                 error=(
-                    "OPENAI_API_KEY not set. Run `hermes tools` → Image "
-                    "Generation → OpenAI to configure, or `hermes setup` "
-                    "to add the key."
+                    "OpenAI image API key not set. Configure "
+                    "`image_gen.openai.key_env` or set OPENAI_API_KEY."
                 ),
                 error_type="auth_required",
                 provider="openai",
@@ -247,10 +274,10 @@ class OpenAIImageGenProvider(ImageGenProvider):
 
         try:
             base_url = _resolve_base_url()
+            client_kwargs: Dict[str, Any] = {"api_key": api_key}
             if base_url is not None:
-                client = openai.OpenAI(base_url=base_url)
-            else:
-                client = openai.OpenAI()
+                client_kwargs["base_url"] = base_url
+            client = openai.OpenAI(**client_kwargs)
             response = client.images.generate(**payload)
         except Exception as exc:
             logger.debug("OpenAI image generation failed", exc_info=True)

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -19,6 +19,13 @@ Selection precedence (first hit wins):
 2. ``image_gen.openai.model`` in ``config.yaml``
 3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
 4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
+
+Endpoint override:
+
+- ``image_gen.openai.base_url`` in ``config.yaml`` is passed explicitly to
+  ``openai.OpenAI(base_url=...)`` when set, so image generation can target a
+  provider-specific OpenAI-compatible endpoint without relying on the global
+  ``OPENAI_BASE_URL`` environment variable.
 """
 
 from __future__ import annotations
@@ -115,6 +122,21 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
         return candidate, _MODELS[candidate]
 
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_base_url() -> Optional[str]:
+    """Return a normalized explicit base URL for the OpenAI image client."""
+    cfg = _load_openai_config()
+    openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
+    if not isinstance(openai_cfg, dict):
+        return None
+
+    value = openai_cfg.get("base_url")
+    if not isinstance(value, str):
+        return None
+
+    cleaned = value.strip().rstrip("/")
+    return cleaned or None
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +246,11 @@ class OpenAIImageGenProvider(ImageGenProvider):
         }
 
         try:
-            client = openai.OpenAI()
+            base_url = _resolve_base_url()
+            if base_url is not None:
+                client = openai.OpenAI(base_url=base_url)
+            else:
+                client = openai.OpenAI()
             response = client.images.generate(**payload)
         except Exception as exc:
             logger.debug("OpenAI image generation failed", exc_info=True)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
@@ -373,6 +374,10 @@ class TestMediaDeliveryPathValidation:
         # specifically cover recency trust re-enable it themselves.
         monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
 
+    def _set_hermes_home(self, monkeypatch, hermes_home):
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return set_hermes_home_override(hermes_home)
+
     def test_allows_existing_file_inside_safe_root(self, tmp_path, monkeypatch):
         root = tmp_path / "media-cache"
         media_file = root / "voice.ogg"
@@ -534,6 +539,95 @@ class TestMediaDeliveryPathValidation:
 
         out = BasePlatformAdapter.filter_local_delivery_paths([str(fresh)])
         assert out == [str(fresh.resolve())]
+
+    def test_docker_workspace_media_path_translates_to_host_workspace(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        image = workspace / "foo.png"
+        image.parent.mkdir(parents=True)
+        image.write_bytes(b"fake image")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/foo.png") == str(image.resolve())
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_docker_root_media_path_is_not_translated_or_allowed(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        docker_home = hermes_home / "sandboxes" / "docker" / "default" / "home"
+        secret = docker_home / "foo.png"
+        secret.parent.mkdir(parents=True)
+        secret.write_bytes(b"do not send")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/root/foo.png") is None
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_docker_workspace_media_path_cannot_escape_workspace_via_dotdot(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        docker_home = hermes_home / "sandboxes" / "docker" / "default" / "home"
+        secret = docker_home / "secret.png"
+        workspace.mkdir(parents=True)
+        secret.parent.mkdir(parents=True)
+        secret.write_bytes(b"secret")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/../home/secret.png") is None
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_docker_workspace_media_path_cannot_escape_workspace_via_symlink(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        docker_home = hermes_home / "sandboxes" / "docker" / "default" / "home"
+        secret = docker_home / "secret.png"
+        workspace.mkdir(parents=True)
+        secret.parent.mkdir(parents=True)
+        secret.write_bytes(b"secret")
+        link = workspace / "escape"
+        try:
+            link.symlink_to(docker_home, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation is unavailable")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/escape/secret.png") is None
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_workspace_media_path_not_translated_for_non_docker_backend(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        workspace = hermes_home / "sandboxes" / "docker" / "default" / "workspace"
+        image = workspace / "foo.png"
+        image.parent.mkdir(parents=True)
+        image.write_bytes(b"fake image")
+        self._patch_roots(monkeypatch)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "1")
+        token = self._set_hermes_home(monkeypatch, hermes_home)
+
+        try:
+            assert BasePlatformAdapter.validate_media_delivery_path("/workspace/foo.png") is None
+        finally:
+            reset_hermes_home_override(token)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -164,6 +164,43 @@ class TestGenerate:
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
 
+    def test_config_base_url_is_passed_to_openai_client(self, provider, tmp_path):
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"base_url": "https://images.example.test/v1/"}}})
+        )
+
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://images.example.test/v1"
+
+    def test_config_base_url_overrides_openai_base_url_env(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://env.example.test/v1")
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"base_url": "https://config.example.test/v1/"}}})
+        )
+
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://config.example.test/v1"
+
     @pytest.mark.parametrize("tier,expected_quality", [
         ("gpt-image-2-low", "low"),
         ("gpt-image-2-medium", "medium"),

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -80,6 +80,28 @@ class TestAvailability:
         monkeypatch.setenv("OPENAI_API_KEY", "test")
         assert openai_plugin.OpenAIImageGenProvider().is_available() is True
 
+    def test_key_env_config_makes_provider_available(self, monkeypatch, tmp_path):
+        import yaml
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("CUSTOM_IMAGE_KEY", "custom-key")
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"key_env": "CUSTOM_IMAGE_KEY"}}})
+        )
+
+        assert openai_plugin.OpenAIImageGenProvider().is_available() is True
+
+    def test_unset_key_env_falls_back_to_openai_api_key(self, monkeypatch, tmp_path):
+        import yaml
+
+        monkeypatch.setenv("OPENAI_API_KEY", "fallback-key")
+        monkeypatch.delenv("CUSTOM_IMAGE_KEY", raising=False)
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"key_env": "CUSTOM_IMAGE_KEY"}}})
+        )
+
+        assert openai_plugin.OpenAIImageGenProvider().is_available() is True
+
 
 # ── Model resolution ────────────────────────────────────────────────────────
 
@@ -200,6 +222,66 @@ class TestGenerate:
 
         assert result["success"] is True
         assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://config.example.test/v1"
+
+    def test_config_key_env_is_passed_to_openai_client(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("CUSTOM_IMAGE_KEY", "custom-image-key")
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"key_env": "CUSTOM_IMAGE_KEY"}}})
+        )
+
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["api_key"] == "custom-image-key"
+
+    def test_config_api_key_env_alias_is_passed_to_openai_client(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("CUSTOM_IMAGE_ALIAS_KEY", "alias-image-key")
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"api_key_env": "CUSTOM_IMAGE_ALIAS_KEY"}}})
+        )
+
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["api_key"] == "alias-image-key"
+
+    def test_key_env_takes_priority_over_openai_api_key(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        monkeypatch.setenv("OPENAI_API_KEY", "global-key")
+        monkeypatch.setenv("CUSTOM_IMAGE_KEY", "custom-image-key")
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"key_env": "CUSTOM_IMAGE_KEY"}}})
+        )
+
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["api_key"] == "custom-image-key"
 
     @pytest.mark.parametrize("tier,expected_quality", [
         ("gpt-image-2-low", "low"),

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -483,8 +483,8 @@ class TestSpawnEnvSanitization:
             def get_temp_dir(self):
                 return "/data/data/com.termux/files/usr/tmp"
 
-            def execute(self, command, timeout=None):
-                self.commands.append((command, timeout))
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
                 return {"output": "4321\n"}
 
         env = FakeEnv()
@@ -503,6 +503,50 @@ class TestSpawnEnvSanitization:
         assert "cat /tmp/hermes_bg_" not in bg_command
         fake_thread.start.assert_called_once()
 
+    def test_spawn_via_env_checks_returncode_when_wrapper_fails(self, registry):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                return {"output": "syntax error", "returncode": 2}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(env, "echo hello")
+
+        assert session.exited is True
+        assert session.exit_code == 2
+        assert session.pid is None
+        assert session.output_buffer == "syntax error"
+        fake_thread.start.assert_not_called()
+
+    def test_spawn_via_env_disables_rewrite_for_bg_wrapper(self, registry):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def get_temp_dir(self):
+                return "/tmp"
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                return {"output": "4321\n", "returncode": 0}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_via_env(env, "echo hello")
+
+        args, kwargs = env.commands[0]
+        assert kwargs.get("rewrite_compound_background") is False
+
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")
         session.exited = False
@@ -516,8 +560,8 @@ class TestSpawnEnvSanitization:
                     {"output": "0\n"},
                 ])
 
-            def execute(self, command, timeout=None):
-                self.commands.append((command, timeout))
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
                 return next(self._responses)
 
         env = FakeEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -791,18 +791,18 @@ class BaseEnvironment(ABC):
         *,
         timeout: int | None = None,
         stdin_data: str | None = None,
+        rewrite_compound_background: bool = True,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}."""
         self._before_execute()
 
         exec_command, sudo_stdin = self._prepare_command(command)
-        # Guard against the `A && B &` subshell-wait trap: bash forks a
-        # subshell for the compound that then waits for an infinite B (a
-        # server, `yes > /dev/null`, etc.), leaking the subshell forever.
-        # Rewriting to `A && { B & }` runs B as a plain background in the
-        # current shell — no subshell wait.
-        from tools.terminal_tool import _rewrite_compound_background
-        exec_command = _rewrite_compound_background(exec_command)
+        # Guard against the `A && B &` subshell-wait trap by default.
+        # Some callers (spawn_via_env) already produce shell-safe wrappers and
+        # pass rewrite_compound_background=False.
+        if rewrite_compound_background:
+            from tools.terminal_tool import _rewrite_compound_background
+            exec_command = _rewrite_compound_background(exec_command)
         effective_timeout = timeout or self.timeout
         effective_cwd = cwd or self.cwd
 
@@ -851,4 +851,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-

--- a/tools/environments/modal_utils.py
+++ b/tools/environments/modal_utils.py
@@ -79,7 +79,12 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
         *,
         timeout: int | None = None,
         stdin_data: str | None = None,
+        rewrite_compound_background: bool = True,
     ) -> dict:
+        # Managed/remote modal transports execute commands via explicit transport
+        # and do not rely on shell background rewriters. Keep parameter for
+        # compatibility with BaseEnvironment callers.
+        _ = rewrite_compound_background
         self._before_execute()
         prepared = self._prepare_modal_exec(
             command,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -697,7 +697,11 @@ class ProcessRegistry:
         )
 
         try:
-            result = env.execute(bg_command, timeout=timeout)
+            result = env.execute(
+                bg_command,
+                timeout=timeout,
+                rewrite_compound_background=False,
+            )
             output = result.get("output", "").strip()
             # Try to extract the PID from the output
             for line in output.splitlines():
@@ -705,6 +709,16 @@ class ProcessRegistry:
                 if line.isdigit():
                     session.pid = int(line)
                     break
+            # If the wrapper couldn't produce a PID (for example, syntax
+            # error or broken redirect), treat it as a failed launch instead
+            # of exposing a fake running session.
+            if session.pid is None:
+                session.exited = True
+                session.exit_code = int(result.get("returncode", -1))
+                if session.exit_code == 0:
+                    session.exit_code = -1
+                session.exited = True
+                session.output_buffer = result.get("output", "").strip()
         except Exception as e:
             session.exited = True
             session.exit_code = -1
@@ -723,9 +737,12 @@ class ProcessRegistry:
 
         with self._lock:
             self._prune_if_needed()
-            self._running[session.id] = session
+            if not session.exited:
+                self._running[session.id] = session
 
-        self._write_checkpoint()
+        if not session.exited:
+            self._write_checkpoint()
+
         return session
 
     # ----- Reader / Poller Threads -----


### PR DESCRIPTION
## Summary
- Prevent `BaseEnvironment.execute()` from reapplying compound background rewrite for `spawn_via_env` wrapper commands.
- Pass `rewrite_compound_background=False` in `ProcessRegistry.spawn_via_env`.
- Mark spawn as failed when PID is not produced instead of exposing a fake running background session.
- Add registry-level regression tests for both launch-failure and rewrite-bypass behaviors.

## Testing
- `./.venv/bin/python -m pytest tests/tools/test_process_registry.py tests/tools/test_terminal_compound_background.py -q`

## Result
- `100 passed`
