### PR TITLE
fix: preserve Telegram command args after bot suffix

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4705,6 +4705,22 @@ class TelegramAdapter(BasePlatformAdapter):
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
         username = re.escape(self._bot.username)
+
+        # Telegram group command menus send addressed commands as
+        # ``/cmd@botname args``.  The generic mention cleaner below is for
+        # prose mentions; applying it here would remove ``@botname `` and
+        # collapse the argument onto the command (``/reasoningxhigh``), making
+        # valid commands look unknown.  Only strip the bot suffix from the
+        # first command token and preserve the argument separator.
+        if text.startswith("/"):
+            parts = text.split(maxsplit=1)
+            command_token = parts[0]
+            cleaned_command = re.sub(rf"(?i)@{username}\b[,:\-]*$", "", command_token)
+            if cleaned_command != command_token:
+                if len(parts) > 1 and parts[1].strip():
+                    return f"{cleaned_command} {parts[1].strip()}"
+                return cleaned_command or text
+
         cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
         return cleaned or text
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
-from gateway.platforms.base import MessageType
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
@@ -311,6 +311,17 @@ def test_observed_group_context_replays_normally_without_telegram_prompt():
 
     assert observed_context is None
     assert agent_history == [{"role": "user", "content": "[Alice|111]\nside chatter"}]
+
+
+def test_clean_bot_trigger_text_preserves_command_args_for_addressed_slash_commands():
+    adapter = _make_adapter(bot_username="Oliver_32gi7_bot")
+
+    cleaned = adapter._clean_bot_trigger_text("/reasoning@Oliver_32gi7_bot xhigh")
+
+    assert cleaned == "/reasoning xhigh"
+    event = MessageEvent(text=cleaned, message_type=MessageType.COMMAND)
+    assert event.get_command() == "reasoning"
+    assert event.get_command_args() == "xhigh"
 
 
 def test_observed_group_context_preserves_slash_command_text_for_dispatch():


### PR DESCRIPTION
## Summary
- Preserve the argument separator when cleaning Telegram addressed slash commands like `/reasoning@bot xhigh`
- Keep prose mention cleanup unchanged for normal group messages
- Add a regression test covering `/reasoning@Oliver_32gi7_bot xhigh`

## Test plan
- `python -m pytest tests/gateway/test_telegram_group_gating.py -q -o 'addopts='`
- `python -m pytest tests/gateway/test_reasoning_command.py -q -o 'addopts=' -k 'not resume'`
