### PR TITLE
feat(cron): persist content to failed-deliveries/ when all targets fail

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -673,6 +673,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+    delivery_successes = 0
 
     for target in targets:
         platform_name = target["platform"]
@@ -771,6 +772,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
+                    delivery_successes += 1
             except Exception as e:
                 logger.warning(
                     "Job '%s': live adapter delivery to %s:%s failed (%s), falling back to standalone",
@@ -804,6 +806,38 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            delivery_successes += 1
+
+    # Fail-loud fallback: if every configured target failed, persist the content
+    # to a dedicated failed-deliveries dir AND escalate to ERROR-level logging.
+    # The user can recover the message there even if Telegram/Discord/etc. drop it.
+    if targets and delivery_successes == 0 and delivery_errors:
+        try:
+            from hermes_constants import get_hermes_home
+            from datetime import datetime
+            failed_dir = get_hermes_home() / "cron" / "failed-deliveries"
+            failed_dir.mkdir(parents=True, exist_ok=True)
+            stamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in str(job.get("name", job["id"])))[:60]
+            failed_path = failed_dir / f"{stamp}_{job['id']}_{safe_name}.md"
+            failed_path.write_text(
+                f"# Failed delivery — {job.get('name', job['id'])}\n\n"
+                f"**Job ID:** {job['id']}\n"
+                f"**Time:** {stamp}\n"
+                f"**Targets attempted:** {len(targets)}\n"
+                f"**Errors:** {'; '.join(delivery_errors)}\n\n"
+                f"---\n\n{delivery_content}\n",
+                encoding="utf-8",
+            )
+            logger.error(
+                "Job '%s': ALL %d delivery targets failed — content saved to %s",
+                job["id"], len(targets), failed_path,
+            )
+        except Exception as save_err:
+            logger.error(
+                "Job '%s': all deliveries failed AND failed-delivery save also failed: %s",
+                job["id"], save_err,
+            )
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -866,6 +866,85 @@ class TestDeliverResultErrorReturns:
         assert result is not None
         assert "no delivery target" in result
 
+    def test_all_targets_failing_persists_to_failed_deliveries_dir(self, tmp_path, monkeypatch, caplog):
+        """When every configured target fails, content is saved under
+        <hermes_home>/cron/failed-deliveries/ and ERROR is logged, so the user
+        can recover the message even if Telegram/Discord/etc. drop it."""
+        import logging
+        from gateway.config import Platform
+
+        # Redirect hermes_home so the test writes into tmp_path
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"error": "telegram api: 400 chat not found"})), \
+             caplog.at_level(logging.ERROR, logger="cron.scheduler"):
+            job = {
+                "id": "test-failed",
+                "name": "morning-briefing",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            result = _deliver_result(job, "Content that must not be lost.")
+
+        # Error string is still returned (preserves caller contract)
+        assert result is not None
+        assert "delivery error" in result
+
+        # File is persisted with content + metadata
+        failed_dir = tmp_path / "cron" / "failed-deliveries"
+        assert failed_dir.is_dir(), "failed-deliveries directory should be created"
+        files = list(failed_dir.glob("*_test-failed_morning-briefing.md"))
+        assert len(files) == 1, f"expected one failed-delivery file, got {files}"
+        body = files[0].read_text(encoding="utf-8")
+        assert "Content that must not be lost." in body
+        assert "test-failed" in body
+        assert "morning-briefing" in body
+        assert "telegram api: 400 chat not found" in body
+
+        # ERROR is logged so operators see the failure even without checking the dir
+        assert any(
+            "ALL" in rec.message and "delivery targets failed" in rec.message
+            for rec in caplog.records
+        ), f"expected ERROR log about failed targets, got {[r.message for r in caplog.records]}"
+
+    def test_partial_success_does_not_persist_to_failed_deliveries_dir(self, tmp_path, monkeypatch):
+        """If at least one target succeeds, no failed-delivery file is written
+        (fan-out absorbs the partial failure)."""
+        from gateway.config import Platform
+
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        # First call fails, second succeeds — simulates fan-out where one chat is broken
+        send_mock = AsyncMock(side_effect=[
+            {"error": "telegram api: 400 chat not found"},
+            {"success": True},
+        ])
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock):
+            job = {
+                "id": "partial",
+                "name": "fanout-job",
+                "deliver": "telegram:111,telegram:222",
+            }
+            _deliver_result(job, "Important content.")
+
+        failed_dir = tmp_path / "cron" / "failed-deliveries"
+        assert not failed_dir.exists() or not any(failed_dir.iterdir()), \
+            "no file should be written when at least one delivery succeeded"
+
 
 class TestRunJobSessionPersistence:
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):


### PR DESCRIPTION
## What & Why

When **every** configured delivery target for a cron job fails (Telegram API 400, disabled platform, network blip, expired token, etc.) the produced content was logged at WARN/ERROR and then **lost**. For low-frequency jobs — a morning briefing that runs once a day, a weekly summary, an alert that fires twice a month — this is painful: the work the agent did is gone, and the operator often only notices the next time the job runs (or never).

This PR adds a small **fail-loud fallback** inside `_deliver_result`:

- Tracks per-target successes alongside the existing per-target errors.
- When `targets` is non-empty **AND** zero successes were recorded **AND** at least one error occurred, the full delivery content (with metadata: job id, timestamp, attempted target count, error summary) is written to:
  ```
  <hermes_home>/cron/failed-deliveries/<stamp>_<job_id>_<safe_name>.md
  ```
- Escalates to `logger.error` with the saved path so it shows up in standard log monitoring even if the user never checks the directory.
- **Partial successes** (fan-out where 1-of-N targets fail) do *not* trigger the fallback — the message reached at least one destination, so the existing error-string return path is enough.

The caller contract is unchanged: `_deliver_result` still returns the joined error string on any failure, `None` on full success.

## How to test

1. Configure a cron job with `deliver: telegram:99999` (a chat the bot can't access).
2. Run the job: `hermes cron run <job_id>`.
3. Verify the content shows up at `~/.hermes/cron/failed-deliveries/<stamp>_<job_id>_<name>.md` and an `ERROR` line appears in the gateway log.

Unit tests added:

- `test_all_targets_failing_persists_to_failed_deliveries_dir` — happy fallback path
- `test_partial_success_does_not_persist_to_failed_deliveries_dir` — fan-out absorbs partial failure

```
$ python -m pytest tests/cron/test_scheduler.py
130 passed, 1 warning in 16.10s
```

## Platforms tested

- Linux (Raspberry Pi OS, Python 3.11)

## Background

Real-world trigger: a daily morning-briefing job silently dropped its output for several days because the configured Telegram chat id had drifted; the agent had no way to recover the content and the user had no idea anything was wrong until they asked "waar is de ochtend briefing gebleven?".

No related issue.
