### PR TITLE
fix(provider): custom provider respects api_mode and works in cron/bg tasks (#33600, #33333)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2932,10 +2932,22 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None
-        if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
+        if main_provider == "custom" or main_provider.startswith("custom:"):
             resolved_provider = "custom"
-            explicit_base_url = runtime_base_url
-            explicit_api_key = runtime_api_key or None
+            if runtime_base_url:
+                # Live session — use the runtime override.
+                explicit_base_url = runtime_base_url
+                explicit_api_key = runtime_api_key or None
+            else:
+                # Cron / background task — no live runtime.  Fall back to
+                # config.yaml model.base_url + model.api_key via the same
+                # resolver that _try_custom_endpoint uses (GitHub #33333).
+                _cr = _resolve_custom_runtime()
+                if _cr and _cr[0]:
+                    explicit_base_url = _cr[0]
+                    explicit_api_key = _cr[1] or None
+                    if not runtime_api_mode:
+                        runtime_api_mode = _cr[2] or ""
         # Skip Step-1 if the main provider was recently 402'd. The unhealthy
         # cache TTL bounds how long we bypass it, so a topped-up account
         # recovers automatically. If we tried Step-1 anyway, every aux call

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -240,6 +240,7 @@ def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
 _VALID_API_MODES = {
     "chat_completions",
     "codex_responses",
+    "responses",            # alias for codex_responses (GitHub #33600)
     "anthropic_messages",
     "bedrock_converse",
     # Optional opt-in: hand the entire turn to a `codex app-server` subprocess
@@ -252,10 +253,17 @@ _VALID_API_MODES = {
 
 
 def _parse_api_mode(raw: Any) -> Optional[str]:
-    """Validate an api_mode value from config. Returns None if invalid."""
+    """Validate an api_mode value from config. Returns None if invalid.
+
+    ``"responses"`` is normalised to ``"codex_responses"`` so downstream
+    code only needs to check for ``"codex_responses"``.
+    """
     if isinstance(raw, str):
         normalized = raw.strip().lower()
         if normalized in _VALID_API_MODES:
+            # Normalise the alias (GitHub #33600).
+            if normalized == "responses":
+                return "codex_responses"
             return normalized
     return None
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2991,3 +2991,52 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+class TestResolveAutoCustomNoRuntime:
+    """_resolve_auto should use config.yaml credentials for custom provider
+    even when main_runtime is None (cron / background tasks).
+    GitHub #33333."""
+
+    def test_custom_provider_no_runtime_uses_config(self, monkeypatch):
+        """When main_provider is 'custom' but no runtime override exists,
+        _resolve_auto should fall back to _resolve_custom_runtime() to
+        read base_url/api_key from config.yaml."""
+        from agent.auxiliary_client import _resolve_auto
+        from unittest.mock import patch, MagicMock
+
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+        with patch("agent.auxiliary_client._read_main_provider", return_value="custom"),              patch("agent.auxiliary_client._read_main_model", return_value="deepseek-v4-pro"),              patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("https://proxy.example.com/v1", "sk-test-key", None)),              patch("agent.auxiliary_client.resolve_provider_client") as mock_rpc:
+
+            mock_rpc.return_value = (MagicMock(), "deepseek-v4-pro")
+            client, model = _resolve_auto(main_runtime=None)
+
+        # resolve_provider_client should have been called with the config credentials
+        mock_rpc.assert_called_once()
+        call_kwargs = mock_rpc.call_args
+        assert call_kwargs[1]["explicit_base_url"] == "https://proxy.example.com/v1"
+        assert call_kwargs[1]["explicit_api_key"] == "sk-test-key"
+
+    def test_custom_provider_with_runtime_uses_runtime(self, monkeypatch):
+        """When main_provider is 'custom' AND a runtime override exists,
+        _resolve_auto should prefer the runtime base_url (live session)."""
+        from agent.auxiliary_client import _resolve_auto
+        from unittest.mock import patch, MagicMock
+
+        with patch("agent.auxiliary_client._read_main_provider", return_value="custom"),              patch("agent.auxiliary_client._read_main_model", return_value="deepseek-v4-pro"),              patch("agent.auxiliary_client.resolve_provider_client") as mock_rpc:
+
+            mock_rpc.return_value = (MagicMock(), "deepseek-v4-pro")
+            client, model = _resolve_auto(main_runtime={
+                "provider": "custom",
+                "model": "deepseek-v4-pro",
+                "base_url": "https://runtime.example.com/v1",
+                "api_key": "sk-runtime-key",
+            })
+
+        call_kwargs = mock_rpc.call_args
+        assert call_kwargs[1]["explicit_base_url"] == "https://runtime.example.com/v1"
+        assert call_kwargs[1]["explicit_api_key"] == "sk-runtime-key"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2626,3 +2626,17 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+def test_responses_alias_normalised_to_codex_responses():
+    """"responses" is a valid api_mode and should normalise to "codex_responses" (GitHub #33600)."""
+    assert rp._parse_api_mode("responses") == "codex_responses"
+    assert rp._parse_api_mode("Responses") == "codex_responses"
+    assert rp._parse_api_mode("RESPONSES") == "codex_responses"
+
+
+def test_parse_api_mode_invalid_still_returns_none():
+    """Unknown api_mode values still return None."""
+    assert rp._parse_api_mode("streaming") is None
+    assert rp._parse_api_mode("") is None
+    assert rp._parse_api_mode(None) is None


### PR DESCRIPTION
## Summary

Fixes two related bugs in custom provider handling that share the same code area in `agent/auxiliary_client.py`.

### Bug 1: custom provider ignores `api_mode`, always hits `/chat/completions`
**Closes [#33600](https://github.com/NousResearch/hermes-agent/issues/33600)**

When `provider: custom` with `api_mode: responses`, Hermes always sends requests to `{base_url}/chat/completions` instead of `{base_url}/responses`. The value `"responses"` was not in `_VALID_API_MODES`, causing `_parse_api_mode()` to return `None` → defaulting to `chat_completions`.

**Fix:**
- Add `"responses"` as a valid alias in `_VALID_API_MODES`
- Normalize `"responses"` → `"codex_responses"` in `_parse_api_mode()` so downstream code only checks for `"codex_responses"`
- This ensures the `CodexAuxiliaryClient` wrapper is applied, routing requests through the `/responses` endpoint

### Bug 2: `_resolve_auto()` drops credentials for custom provider in cron/background tasks
**Closes [#33333](https://github.com/NousResearch/hermes-agent/issues/33333)**

When `model.provider: custom` and `main_runtime=None` (cron jobs, gateway background tasks), `_resolve_auto()` Step 1 guarded on `runtime_base_url` being non-empty before passing `base_url`/`api_key` to `resolve_provider_client()`. With no live session, `runtime_base_url=""`, so the guard fails and credentials from `config.yaml` are silently dropped.

**Fix:**
- Remove the `runtime_base_url` prerequisite from the custom-provider check
- When `main_provider == "custom"` but `runtime_base_url` is empty, fall back to `_resolve_custom_runtime()` which reads `model.base_url`/`model.api_key` from `config.yaml`
- Also propagate `api_mode` from the custom runtime resolution

## Files Changed

| File | Change |
|------|--------|
| `hermes_cli/runtime_provider.py` | Add `"responses"` alias to `_VALID_API_MODES`; normalize in `_parse_api_mode()` |
| `agent/auxiliary_client.py` | `_resolve_auto()`: fallback to `_resolve_custom_runtime()` when no runtime override |
| `tests/hermes_cli/test_runtime_provider_resolution.py` | 2 tests: alias normalization + invalid mode |
| `tests/agent/test_auxiliary_client.py` | 2 tests: no-runtime fallback + runtime preference |

## Testing

- **4 new tests** — all passing
- **174/174** existing `test_auxiliary_client.py` tests passing (0 regressions)
- **299/301** `test_runtime_provider_resolution.py` tests passing (2 pre-existing qwen-oauth failures unrelated to this PR)
