### PR TITLE
fix: accept discord channel-prefixed send targets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1092,6 +1092,20 @@ class TestParseTargetRefDiscord:
         assert thread_id == "789"
         assert is_explicit is True
 
+    def test_discord_channel_prefix_without_thread(self):
+        """OpenClaw-style channel:<id> Discord targets are explicit."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("discord", "channel:1476302380520837355")
+        assert chat_id == "1476302380520837355"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_discord_channel_prefix_with_thread(self):
+        """OpenClaw-style channel:<id>:<thread> Discord targets preserve thread ID."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("discord", "channel:1476302380520837355:1476302380520837356")
+        assert chat_id == "1476302380520837355"
+        assert thread_id == "1476302380520837356"
+        assert is_explicit is True
+
 
 class TestParseTargetRefMatrix:
     """_parse_target_ref correctly handles Matrix room IDs and user MXIDs."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -34,6 +34,7 @@ _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Z
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
+_DISCORD_CHANNEL_TARGET_RE = re.compile(r"^\s*channel:(\d+)(?::(\d+))?\s*$")
 # Platforms that address recipients by phone number and accept E.164 format
 # (with a leading '+'). Without this, "+15551234567" fails the isdigit() check
 # below and falls through to channel-name resolution, which has no way to
@@ -351,6 +352,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             return match.group(1), match.group(2), True
     if platform_name == "discord":
+        match = _DISCORD_CHANNEL_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
         match = _NUMERIC_TOPIC_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True


### PR DESCRIPTION
## Summary
- Accept Discord targets in the form `discord:channel:<channel_id>`.
- Preserve optional Discord thread IDs with `discord:channel:<channel_id>:<thread_id>`.
- Add targeted parser regression coverage for OpenClaw-style channel refs.

## Test Plan
- `python -m pytest tests/tools/test_send_message_tool.py::TestParseTargetRefDiscord -q -o 'addopts='`