### PR TITLE
fix(codex): recover stream output after SDK null output

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -329,6 +329,42 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 )
                 return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             raise
+        except TypeError as exc:
+            err_text = str(exc)
+            sdk_output_none = "'NoneType' object is not iterable" in err_text
+            if sdk_output_none and (collected_output_items or agent._codex_streamed_text_parts):
+                # OpenAI SDK 2.24 can crash while parsing the terminal
+                # response.completed event from chatgpt.com/backend-api/codex
+                # when that event has response.output=null. The same stream
+                # has already delivered valid response.output_item.done events,
+                # so recover from those instead of failing the turn.
+                if collected_output_items:
+                    logger.debug(
+                        "Codex stream: recovered %d output items after SDK output=None parse error",
+                        len(collected_output_items),
+                    )
+                    return SimpleNamespace(
+                        output=list(collected_output_items),
+                        status="completed",
+                        model=api_kwargs.get("model"),
+                    )
+                if not has_tool_calls:
+                    assembled = "".join(agent._codex_streamed_text_parts)
+                    logger.debug(
+                        "Codex stream: recovered from SDK output=None parse error using %d text deltas (%d chars)",
+                        len(agent._codex_streamed_text_parts), len(assembled),
+                    )
+                    return SimpleNamespace(
+                        output=[SimpleNamespace(
+                            type="message",
+                            role="assistant",
+                            status="completed",
+                            content=[SimpleNamespace(type="output_text", text=assembled)],
+                        )],
+                        status="completed",
+                        model=api_kwargs.get("model"),
+                    )
+            raise
 
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -176,6 +176,25 @@ class _FakeResponsesStream:
         return self._final_response
 
 
+class _FakeResponsesStreamEventsThenTypeError:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+        raise TypeError("'NoneType' object is not iterable")
+
+    def get_final_response(self):
+        raise AssertionError("SDK TypeError should be recovered before get_final_response")
+
+
 class _FakeCreateStream:
     def __init__(self, events):
         self._events = list(events)
@@ -420,6 +439,30 @@ def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):
     response = agent._run_codex_stream(_codex_request_kwargs())
     assert calls["stream"] == 2
     assert response.output[0].content[0].text == "stream ok"
+
+
+def test_run_codex_stream_recovers_sdk_output_none_after_done_item(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    done_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="stream recovered")],
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStreamEventsThenTypeError([
+                SimpleNamespace(type="response.created"),
+                SimpleNamespace(type="response.output_text.delta", delta="stream recovered"),
+                SimpleNamespace(type="response.output_item.done", item=done_item),
+            ]),
+            create=lambda **kwargs: _codex_message_response("fallback should not run"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "stream recovered"
 
 
 def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(monkeypatch):


### PR DESCRIPTION
## Summary
- recover Codex Responses streams when the OpenAI SDK crashes on `response.completed.output = null`
- reuse already-collected `response.output_item.done` items or streamed text deltas instead of failing the turn
- add a regression test for the SDK TypeError path

## Root Cause
The ChatGPT Codex backend can stream valid output items and then emit a terminal `response.completed` event whose `response.output` is `null`. OpenAI SDK 2.24 raises `TypeError("'NoneType' object is not iterable")` while parsing that terminal event, before Hermes reaches the existing empty-output recovery path.

## Test
- `venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`
