### PR TITLE
fix(skills): relax mandatory loading prompt policy

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1190,17 +1190,13 @@ def build_skills_system_prompt(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
+            "## Skills\n"
+            "Use the skills below as a compact capability index. Load a skill with "
+            "skill_view(name) before acting when it is clearly relevant to the user's "
+            "current task, especially for specialized workflows, coding standards, "
+            "provider/tool-specific commands, or user-established procedures. For simple "
+            "greetings, meta questions about this chat, or requests that do not need a "
+            "domain workflow, do not load a skill.\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
@@ -1213,9 +1209,7 @@ def build_skills_system_prompt(
             "\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "</available_skills>"
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -266,6 +266,30 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_skill_policy_does_not_force_load_on_simple_chat(self, monkeypatch, tmp_path):
+        """The skills index should not make greetings/meta chat load arbitrary skills.
+
+        Regression for startup-context bloat: the old wording said every partially
+        relevant skill MUST be loaded before replying, which caused simple chats to
+        load large skills (for example kanban-worker) just because their category
+        appeared related to injected guidance.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "dev" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "skill_view" in result
+        assert "hermes-agent" in result
+        assert "MUST load" not in result
+        assert "Err on the side of loading" not in result
+        assert "simple greetings" in result
+        assert "do not load a skill" in result
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"


### PR DESCRIPTION
## Summary

Relaxes the skills system-prompt policy so ordinary greetings, meta questions, and requests that do not need a domain workflow are not instructed to load arbitrary skills before replying.

The old prompt said any skill that is "even partially relevant" MUST be loaded and told the agent to "Err on the side of loading". In practice, that can turn a trivial message into unnecessary `skill_view()` calls, loading large skill bodies into context.

This keeps the important Hermes-specific requirement: if the user asks to configure, set up, install, enable, disable, modify, or troubleshoot Hermes Agent itself, the agent should still load `hermes-agent` first.

## Why

This is a small behavioral mitigation for skill-related context bloat. It does not try to solve the full skill-index-size problem; it complements the broader work already tracked in:

- #22620
- #10164

It is also intentionally narrower than open architectural PRs such as #10172, #12015, #11223, and #32349.

Observed failure mode motivating this patch:

- User sends a trivial/meta message such as `hi` or `which model are you?`
- Prompt wording pressures the model to load skills if anything seems partially relevant
- A large skill can be loaded unnecessarily, immediately increasing context usage

## Changes

- Rename the prompt section from `## Skills (mandatory)` to `## Skills`
- Replace mandatory/over-broad language with mode-aware guidance:
  - load a skill when it is clearly relevant before acting
  - do not load a skill for simple greetings/meta chat/no-domain-workflow requests
  - still load `hermes-agent` for Hermes setup/config/troubleshooting
- Add a regression test that ensures the skills prompt no longer contains the old forced-loading language and explicitly includes the simple-chat exemption

## Validation

```text
/Users/peterhao/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_prompt_builder.py tests/tools/test_kanban_tools.py::test_kanban_guidance_not_in_normal_prompt tests/tools/test_kanban_tools.py::test_kanban_guidance_in_worker_prompt -q -o 'addopts='

126 passed, 1 skipped, 1 warning in 2.31s
```

## Notes

This patch is intentionally small and low-risk. It does not change skill discovery, skill indexing, or `skill_view()` behavior. It only changes the model-facing policy text so the agent is not pushed toward unnecessary skill loads on trivial turns.
