### PR TITLE
fix(gateway): add periodic heartbeat to gateway_state.json

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4404,6 +4404,11 @@ class GatewayRunner:
         # turn so the agent kicks off the new chat.
         asyncio.create_task(self._handoff_watcher())
 
+        # Start background heartbeat watcher — periodically touches
+        # gateway_state.json so external liveness monitors (e.g. WebUI)
+        # can confirm the process is alive even when idle.
+        asyncio.create_task(self._heartbeat_watcher())
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -4457,6 +4462,26 @@ class GatewayRunner:
             except Exception as exc:
                 logger.debug("Handoff watcher tick error: %s", exc, exc_info=True)
             await asyncio.sleep(interval)
+
+    async def _heartbeat_watcher(self, interval: int = 60) -> None:
+        """Background task that periodically writes ``gateway_state.json``.
+
+        Without this, the file is only updated on state transitions (start,
+        stop, platform connect/disconnect).  External liveness monitors such
+        as hermes-webui rely on the ``updated_at`` field to decide whether
+        the gateway is alive; a gateway that is healthy but idle for more
+        than ~2 minutes looks dead to them.
+        """
+        # Short initial delay — let the gateway finish startup before the
+        # first heartbeat so the file already contains the "running" state.
+        await asyncio.sleep(10)
+        while self._running:
+            try:
+                self._update_runtime_status()
+            except Exception:
+                pass
+            await asyncio.sleep(interval)
+
 
     async def _process_handoff(self, row: Dict[str, Any]) -> None:
         """Execute one handoff row. Raises on failure (caller marks failed)."""

--- a/tests/gateway/test_heartbeat_watcher.py
+++ b/tests/gateway/test_heartbeat_watcher.py
@@ -1,0 +1,94 @@
+"""Tests for the gateway heartbeat watcher (issue #32887)."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_watcher_updates_runtime_status_periodically():
+    """The heartbeat watcher must call _update_runtime_status at least twice
+    within a short window, proving it ticks independently of state changes.
+    """
+    runner, _adapter = make_restart_runner()
+    call_count = 0
+
+    def _track_update(*, gateway_state=None, exit_reason=None):
+        nonlocal call_count
+        call_count += 1
+
+    runner._update_runtime_status = _track_update
+
+    # Run the watcher with a short interval. The initial delay is 10s in
+    # production; we patch asyncio.sleep's first call to skip it.
+    sleep_calls = 0
+    real_sleep = asyncio.sleep
+
+    async def _fast_first_sleep(delay, *args, **kwargs):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1 and delay >= 10:
+            return  # skip initial 10s delay
+        await real_sleep(delay, *args, **kwargs)
+
+    import gateway.run as _gw_run
+    original_sleep = _gw_run.asyncio.sleep
+    _gw_run.asyncio.sleep = _fast_first_sleep
+    try:
+        async def _run_and_stop():
+            task = asyncio.create_task(runner._heartbeat_watcher(interval=1))
+            # Wait long enough for at least 2 ticks (interval=1s each)
+            await real_sleep(2.5)
+            runner._running = False
+            await task
+
+        await _run_and_stop()
+        assert call_count >= 2, f"Expected >= 2 heartbeat ticks, got {call_count}"
+    finally:
+        _gw_run.asyncio.sleep = original_sleep
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_watcher_stops_when_gateway_stops():
+    """The heartbeat watcher must exit when _running is set to False."""
+    runner, _adapter = make_restart_runner()
+    runner._running = False  # Already stopped
+
+    # Should return immediately without error
+    await runner._heartbeat_watcher(interval=1)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_watcher_survives_update_failure():
+    """The heartbeat watcher must not crash if _update_runtime_status raises."""
+    runner, _adapter = make_restart_runner()
+    runner._update_runtime_status = MagicMock(side_effect=OSError("disk full"))
+
+    sleep_calls = 0
+    real_sleep = asyncio.sleep
+
+    async def _fast_first_sleep(delay, *args, **kwargs):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1 and delay >= 10:
+            return
+        await real_sleep(delay, *args, **kwargs)
+
+    import gateway.run as _gw_run
+    original_sleep = _gw_run.asyncio.sleep
+    _gw_run.asyncio.sleep = _fast_first_sleep
+    try:
+        async def _run_briefly():
+            task = asyncio.create_task(runner._heartbeat_watcher(interval=1))
+            await real_sleep(0.2)
+            runner._running = False
+            await task
+
+        # Should not raise despite OSError in _update_runtime_status
+        await _run_briefly()
+        assert runner._update_runtime_status.call_count >= 1
+    finally:
+        _gw_run.asyncio.sleep = original_sleep


### PR DESCRIPTION
## What does this PR do?

`gateway_state.json` is only written on state transitions (start, stop, platform connect/disconnect). External liveness monitors like [hermes-webui](https://github.com/nesquena/hermes-webui) rely on the `updated_at` field to determine if the gateway is alive. After ~2 minutes of idle time with no state changes, the gateway appears dead despite being fully responsive and serving traffic.

**Reproduction:**
1. Run `hermes-agent gateway` with stable platforms (no disconnects)
2. Run hermes-webui sharing `~/.hermes` volume
3. Wait 3 minutes after last state transition
4. WebUI shows "Hermes agent is not responding. Gateway heartbeat failed."
5. Gateway process is fully responsive

## Related Issue

Fixes #32887

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `GatewayRunner._update_runtime_status` (7 call sites in run.py), `write_runtime_status` (1 definition in status.py)
- Blast radius: LOW — additive change (new background task), no existing call sites modified
- Related patterns: follows the same `asyncio.create_task` + `while self._running` pattern as `_session_expiry_watcher`, `_kanban_notifier_watcher`, `_handoff_watcher`

Fixes #32887