### PR TITLE
fix(agent): re-pad reasoning_content on cross-provider fallback to require-side providers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1994,6 +1994,36 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     api_msg.pop("reasoning_content", None)
 
 
+def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
+    """Re-pad assistant turns with reasoning_content for the active provider.
+
+    ``api_messages`` is built once, before the retry loop, while the *primary*
+    provider is active.  If a mid-conversation fallback then switches to a
+    require-side provider (DeepSeek / Kimi / MiMo thinking mode), assistant
+    turns that were built when the prior provider did NOT need the echo-back go
+    out without ``reasoning_content`` and the new provider rejects them with
+    HTTP 400 ("The reasoning_content in the thinking mode must be passed back").
+
+    Calling this immediately before building the request kwargs re-applies the
+    pad against the *current* provider.  It is idempotent and a no-op unless
+    ``_needs_thinking_reasoning_pad()`` is True for the active provider, so it
+    is safe to call every iteration and covers every fallback path.
+
+    Returns the number of assistant turns that gained reasoning_content.
+    """
+    if not agent._needs_thinking_reasoning_pad():
+        return 0
+    padded = 0
+    for api_msg in api_messages:
+        if api_msg.get("role") != "assistant":
+            continue
+        if api_msg.get("reasoning_content"):
+            continue
+        copy_reasoning_content_for_api(agent, api_msg, api_msg)
+        if api_msg.get("reasoning_content"):
+            padded += 1
+    return padded
+
 
 def _iter_pool_sockets(client: Any):
     """Yield raw sockets reachable from an OpenAI/httpx client pool.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1183,6 +1183,14 @@ def run_conversation(
 
             try:
                 agent._reset_stream_delivery_tracking()
+                # api_messages is built once, before this retry loop, while the
+                # primary provider is active.  A mid-conversation fallback can
+                # switch to a require-side provider (DeepSeek / Kimi / MiMo) that
+                # rejects assistant turns lacking reasoning_content.  Re-apply the
+                # echo-back pad for the *current* provider here (idempotent no-op
+                # unless the active provider needs it) so the fallback request
+                # isn't sent with stale, primary-shaped reasoning fields.
+                agent._reapply_reasoning_echo_for_provider(api_messages)
                 api_kwargs = agent._build_api_kwargs(api_messages)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4076,6 +4076,11 @@ class AIAgent:
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api
         return copy_reasoning_content_for_api(self, source_msg, api_msg)
 
+    def _reapply_reasoning_echo_for_provider(self, api_messages: list) -> int:
+        """Forwarder — see ``agent.agent_runtime_helpers.reapply_reasoning_echo_for_provider``."""
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+        return reapply_reasoning_echo_for_provider(self, api_messages)
+
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
         """Strip Codex Responses API fields from tool_calls for strict providers.

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -481,3 +481,85 @@ class TestNeedsKimiToolReasoning:
         )
         # model name contains 'moonshot' but host is openrouter — should be False
         assert agent._needs_kimi_tool_reasoning() is False
+
+
+class TestReapplyReasoningEchoForProviderSwitch:
+    """Mid-conversation fallover to a require-side provider must re-pad.
+
+    ``api_messages`` is built once, before the retry loop, while the *primary*
+    provider is active. When a fallback then switches to DeepSeek/Kimi/MiMo,
+    assistant turns that were built under a non-require primary (e.g. Codex,
+    which uses encrypted reasoning, not ``reasoning_content``) go out bare and
+    the new provider 400s with "reasoning_content must be passed back".
+
+    ``reapply_reasoning_echo_for_provider`` re-applies the pad against the
+    *current* provider right before the request is built. It is idempotent and
+    a no-op unless the active provider enforces echo-back.
+    """
+
+    @staticmethod
+    def _codex_built_history() -> list[dict]:
+        """Assistant turns as built under a Codex primary: some carry a
+        reasoning summary (stored as reasoning_content), some are bare."""
+        return [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "do the thing"},
+            {  # turn that emitted a reasoning summary
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "summary from codex",
+                "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {  # bare tool-call turn (Codex emitted no summary)
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "c2", "function": {"name": "terminal"}}],
+            },
+            {"role": "tool", "tool_call_id": "c2", "content": "ok"},
+        ]
+
+    def test_switch_to_deepseek_pads_bare_turns(self) -> None:
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msgs = self._codex_built_history()
+        padded = reapply_reasoning_echo_for_provider(agent, msgs)
+        assert padded == 1
+        bare = [m for m in msgs if m.get("role") == "assistant" and not m.get("reasoning_content")]
+        assert bare == []
+        # existing summary preserved verbatim, not clobbered with the pad
+        assert msgs[2]["reasoning_content"] == "summary from codex"
+        assert msgs[4]["reasoning_content"] == " "
+
+    def test_noop_under_non_require_provider(self) -> None:
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
+        agent = _make_agent(
+            provider="openai-codex",
+            model="gpt-5.5",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        msgs = self._codex_built_history()
+        padded = reapply_reasoning_echo_for_provider(agent, msgs)
+        assert padded == 0
+        # the bare turn stays bare — Codex doesn't want reasoning_content
+        assert "reasoning_content" not in msgs[4]
+
+    def test_idempotent(self) -> None:
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msgs = self._codex_built_history()
+        assert reapply_reasoning_echo_for_provider(agent, msgs) == 1
+        assert reapply_reasoning_echo_for_provider(agent, msgs) == 0
+
+    def test_non_assistant_messages_untouched(self) -> None:
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msgs = self._codex_built_history()
+        reapply_reasoning_echo_for_provider(agent, msgs)
+        assert "reasoning_content" not in msgs[0]  # system
+        assert "reasoning_content" not in msgs[1]  # user
+        assert "reasoning_content" not in msgs[3]  # tool


### PR DESCRIPTION
> **Note:** This PR was drafted by an AI assistant — Claude, Opus 4.7 — under human review, while fixing a real failure case on a personal Hermes deployment.

Closes #33783

## Problem

When the primary is `openai-codex` / `gpt-5.5` and a mid-conversation fallback switches to a **require-side** thinking provider (`deepseek` / `deepseek-v4-pro`, also Kimi / MiMo), the first request on the new provider 400s:

```
The `reasoning_content` in the thinking mode must be passed back to the API.
```

`api_messages` is built once, **before** the retry loop (`agent/conversation_loop.py:919`), while the primary (Codex) is active — so `_needs_thinking_reasoning_pad()` is `False` and bare assistant tool-call turns get no `reasoning_content`. `_try_activate_fallback()` (L1159/1395/1465) switches the provider but `continue`s without rebuilding, and `_build_api_kwargs(api_messages)` (L1186) re-sends the stale, primary-shaped history to DeepSeek, which requires the field on every assistant turn.

The pad logic in `_copy_reasoning_content_for_api` is correct — it just never re-runs after the switch.

## Fix

Add `reapply_reasoning_echo_for_provider(agent, api_messages)` and call it once, immediately before `_build_api_kwargs` in the retry loop. It re-applies the echo-back pad against the **current** provider. It is:

- **Idempotent** — only pads assistant turns that still lack `reasoning_content`; a second call is a no-op.
- **A no-op unless needed** — returns immediately unless `_needs_thinking_reasoning_pad()` is True for the active provider, so non-failover and reject-side paths are unaffected.
- **Fallback-path agnostic** — placed at the single kwargs-build site, so it covers all three current fallback `continue`s and any added later.

+43 lines across 3 files.

## Validation

End-to-end against the live DeepSeek API, replaying a captured real failing history (33 messages, 14 assistant tool-call turns, 5 bare):

| Build provider | Bare turns | DeepSeek result |
|---|---|---|
| codex (pre-fix failover) | 5 | **HTTP 400** reasoning_content |
| codex → fix applied on switch | 0 | **200** — `finish=tool_calls`, real continuation, full context preserved (42,182 prompt tokens, 42,112 cached) |

- No-op confirmed under the Codex primary (0 padded; bare turns stay bare).
- Idempotency confirmed (second call pads 0).
- Context integrity confirmed (message count, tool_calls, tool results unchanged).

## Tests

Adds `TestReapplyReasoningEchoForProviderSwitch` to `tests/run_agent/test_deepseek_reasoning_content_echo.py`:
- pads bare turns on switch to DeepSeek; preserves existing summaries verbatim
- no-op under a non-require provider (Codex)
- idempotent
- leaves non-assistant messages untouched

All 40 tests in the file pass.

## Scope

This fixes the **require-side** failover (DeepSeek / Kimi / MiMo). The **reject-side** failovers (Codex→Anthropic #29205, Codex→xAI #32617) need stripping/sanitizing instead and are out of scope for this PR.
