### PR TITLE
feat(providers): add DigitalOcean Gradient AI as first-class provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -372,6 +372,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
     "api.gmi-serving.com": "gmi",
+    "inference.do-ai.run": "digitalocean",
     "api.novita.ai": "novita",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -177,6 +177,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "perplexity": "perplexity",
     "cohere": "cohere",
     "ollama-cloud": "ollama-cloud",
+    "digitalocean": "digitalocean",
 }
 
 # Reverse mapping: models.dev → Hermes (built lazily)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -304,6 +304,17 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GMI_API_KEY",),
         base_url_env_var="GMI_BASE_URL",
     ),
+    "digitalocean": ProviderConfig(
+        id="digitalocean",
+        name="DigitalOcean Gradient AI",
+        auth_type="api_key",
+        inference_base_url="https://inference.do-ai.run/v1",
+        # CUSTOM_API_KEY kept first for backward compat with users migrating from
+        # a generic `custom` provider pointed at DO; DIGITALOCEAN_ACCESS_TOKEN is
+        # the upstream convention (models.dev `env` field).
+        api_key_env_vars=("CUSTOM_API_KEY", "DIGITALOCEAN_ACCESS_TOKEN"),
+        base_url_env_var="DIGITALOCEAN_BASE_URL",
+    ),
     "minimax": ProviderConfig(
         id="minimax",
         name="MiniMax",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1955,6 +1955,11 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "zai",
     "gemini",
     "google",
+    # DigitalOcean Gradient AI does not implement /v1/models, so live
+    # discovery is intentionally skipped (see commit 24a6e1e5). The 76 DO
+    # model IDs + context_length live in the bundled models.dev catalog;
+    # this entry surfaces them in the picker via _merge_with_models_dev().
+    "digitalocean",
 })
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -202,6 +202,18 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://ollama.com/v1",
         base_url_env_var="OLLAMA_BASE_URL",
     ),
+    # DigitalOcean Gradient AI Platform — OpenAI-compatible inference at
+    # https://inference.do-ai.run/v1.  models.dev publishes the catalog
+    # (76+ models incl. Anthropic, OpenAI, Mistral, DeepSeek) so we don't
+    # need to ship a model list.  Two env vars accepted: the upstream
+    # convention (DIGITALOCEAN_ACCESS_TOKEN) and CUSTOM_API_KEY for users
+    # migrating from a generic `custom` provider config.
+    "digitalocean": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("CUSTOM_API_KEY",),
+        base_url_override="https://inference.do-ai.run/v1",
+        base_url_env_var="DIGITALOCEAN_BASE_URL",
+    ),
     # Azure Foundry: supports both OpenAI-style and Anthropic-style endpoints.
     # The transport is determined at runtime from config.yaml model.api_mode.
     "azure-foundry": HermesOverlay(


### PR DESCRIPTION
# feat(providers): add DigitalOcean Gradient AI as a first-class provider

## Summary

Adds `digitalocean` as a canonical provider so users of DigitalOcean's Gradient AI Platform (https://inference.do-ai.run/v1) don't need to fight upstream issue #33062 with `providers.custom` plumbing and a hardcoded `model.context_length`.

## Problem

The DigitalOcean Gradient AI inference endpoint is OpenAI-compatible at `/v1/chat/completions` but **does not implement `/v1/models`**. Configuring it via the generic `custom` provider:

1. Triggered live model-discovery failures (issue #33062).
2. Required hardcoding `model.context_length: 200000` and a `providers.custom` block.
3. **Broke whenever a user switched models via `hermes model`** — the TUI persistence path only writes `model.default` and `model.provider`, leaving stale `providers.custom` state behind and inconsistent context-length metadata.

Users hit this every time they wanted to switch between, say, Claude Opus and Claude Haiku via the model picker.

## Solution

Four small additions, modeled on the existing `gmi` provider entry. No new files, no refactors. **+25 lines, 0 deletions.**

| File | Change |
|---|---|
| `hermes_cli/auth.py` | Add `digitalocean` entry to `PROVIDER_REGISTRY`. Env vars: `DIGITALOCEAN_ACCESS_TOKEN` (canonical, matches models.dev `env` field) and `CUSTOM_API_KEY` (for users migrating from generic `custom` configs). |
| `hermes_cli/providers.py` | Add `digitalocean` entry to `HERMES_OVERLAYS` so the TUI provider picker surfaces it. |
| `agent/model_metadata.py` | Add `"inference.do-ai.run": "digitalocean"` to `_URL_TO_PROVIDER` for endpoint inference. |
| `agent/models_dev.py` | Add `"digitalocean": "digitalocean"` to `PROVIDER_TO_MODELS_DEV` so models.dev supplies `context_length` for all 76 DO models. |

## After this change

```yaml
# config.yaml — clean form, no providers.custom plumbing
model:
  provider: digitalocean
  default: anthropic-claude-opus-4.7
  api_mode: chat_completions
fallback_providers:
  - copilot
```

- `provider: digitalocean` resolves without `providers.custom` plumbing
- models.dev supplies `context_length` for all 76 DO models — no `/v1/models` HTTP probe, no `model.context_length` workaround
- TUI model switches round-trip cleanly: `DO → any provider → DO` preserves provider identity
- `fallback_providers` keeps working when `DIGITALOCEAN_ACCESS_TOKEN`/`CUSTOM_API_KEY` is absent

## Verification

Tested in a sandbox `HERMES_HOME` with both DO and a fallback (copilot) configured:

- [x] Chat works against DO inference endpoint
- [x] TUI round-trip: `DO/opus-4.7 → copilot/gpt-5-mini → DO/opus-4.7` — provider field persists as `digitalocean` after each switch
- [x] Fallback to copilot kicks in when DO credentials are removed
- [x] Zero `/v1/models` HTTP probes against the DO endpoint during import or chat
- [x] Context lengths resolve from models.dev: opus-4.7=1M, haiku-4.5=200K, gpt-5.5=1M, gpt-5-mini=400K
- [x] Unknown DO model falls back to the 256K conservative default
- [x] All 433 existing provider, auth, model_metadata and models_dev tests pass

## Backward compatibility

Users who currently have:

```yaml
model:
  provider: custom:custom
  context_length: 200000
providers:
  custom:
    base_url: https://inference.do-ai.run/v1
    api_key: ${CUSTOM_API_KEY}
```

…can simplify to `provider: digitalocean` and delete the `providers.custom` block and the `context_length` line. Their existing `.env` file works as-is: `CUSTOM_API_KEY` is the first env var in the new `ProviderConfig.api_key_env_vars` tuple specifically for this migration.

Closes: #33062 (workaround no longer required for DigitalOcean Gradient AI)



---

## Follow-up commit: `a5a8f08a9` — surface DigitalOcean models in the TUI picker

The original four-file patch above wired up chat-time resolution but the TUI model picker enumerates from a separate code path — `curated_models_for_provider()` in `hermes_cli/models.py`. That function only consults the models.dev catalog when the provider is listed in `_MODELS_DEV_PREFERRED`. `digitalocean` was missing from that frozenset, so the picker rendered **`DigitalOcean (0 models)`** even though chat itself worked correctly.

The fix is a single-set addition (+5 lines, 1 file):

```python
_MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
    ...,
    "google",
    # DigitalOcean Gradient AI does not implement /v1/models, so live
    # discovery is intentionally skipped (see commit 24a6e1e5). The 76 DO
    # model IDs + context_length live in the bundled models.dev catalog;
    # this entry surfaces them in the picker via _merge_with_models_dev().
    "digitalocean",
})
```

After this change, the picker calls `_merge_with_models_dev("digitalocean", [])` and returns the 59 agentic model IDs (76 catalog entries minus embeddings/rerankers filtered out by `list_agentic_models`).

No new HTTP probes — purely a static-catalog wiring fix.

## Note on Inference Router (out of scope)

DigitalOcean Gradient AI also exposes an [Inference Router](https://docs.digitalocean.com/products/inference/how-to/use-inference-router/) feature where model IDs take the form `router:<router-name>`. Routers are user-defined (or DO-preset slugs like `router:software-engineering`), so they cannot be hard-coded — they require a live fetch against `GET /v2/gen-ai/models/routers` and `GET /v2/gen-ai/models/routers/presets` on `api.digitalocean.com`, which uses a separate DO personal access token (distinct from the Model Access Key used for inference).

This is intentionally **out of scope for this PR** to keep the diff minimal. Router IDs already work end-to-end today if a user sets `model.default: router:<name>` in their config — DO accepts them as drop-in model IDs at the chat-completions endpoint. A future PR can add live enumeration of routers to the picker behind a new `DIGITALOCEAN_API_TOKEN` env var.
