### PR TITLE
feat(weixin): add configurable per-sender input buffering

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1019,6 +1019,14 @@ def _message_type_from_media(media_types: List[str], text: str) -> MessageType:
     return MessageType.TEXT
 
 
+def _item_list_has_media(item_list: List[Dict[str, Any]]) -> bool:
+    """Return True if *item_list* contains any image/video/file/voice item."""
+    for item in item_list:
+        if item.get("type") in {ITEM_IMAGE, ITEM_VIDEO, ITEM_FILE, ITEM_VOICE}:
+            return True
+    return False
+
+
 def _sync_buf_path(hermes_home: str, account_id: str) -> Path:
     return _account_dir(hermes_home) / f"{account_id}.sync.json"
 
@@ -1226,6 +1234,17 @@ class WeixinAdapter(BasePlatformAdapter):
             default=False,
         )
 
+        # Input buffering: when a sender fires multiple messages in quick
+        # succession (e.g. splitting a thought across several short lines),
+        # wait ``input_buffer_seconds`` before dispatching so they can be
+        # coalesced into a single turn.  0 disables buffering (default).
+        self._input_buffer_seconds = float(
+            extra.get("input_buffer_seconds")
+            or os.getenv("WEIXIN_INPUT_BUFFER_SECONDS", "2.0")
+        )
+        # per-sender_id: {inbound queue of raw message dicts, asyncio.Task timer}
+        self._input_buffers: Dict[str, Dict[str, Any]] = {}
+
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
             if persisted:
@@ -1300,6 +1319,20 @@ class WeixinAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
         self._poll_task = None
+
+        # Cancel pending input-buffer timers and flush any queued text so
+        # no messages are lost on shutdown.
+        for sender_id in list(self._input_buffers.keys()):
+            entry = self._input_buffers[sender_id]
+            timer = entry.get("timer")
+            if timer is not None and not timer.done():
+                timer.cancel()
+            try:
+                await self._flush_input_buffer(sender_id)
+            except Exception:
+                pass
+        self._input_buffers.clear()
+
         if self._poll_session and not self._poll_session.closed:
             await self._poll_session.close()
         self._poll_session = None
@@ -1406,10 +1439,38 @@ class WeixinAdapter(BasePlatformAdapter):
         elif not self._is_dm_allowed(sender_id):
             return
 
+        # Input buffering: when enabled, queue text messages from the same
+        # sender and coalesce them after a configurable window.  Media
+        # messages are dispatched immediately (they can't be meaningfully
+        # merged) and also flush any pending buffer for the same sender.
+        has_media = _item_list_has_media(item_list)
+        use_buffer = self._input_buffer_seconds > 0 and not has_media
+
+        if use_buffer:
+            self._enqueue_input_buffer(sender_id, message)
+            return
+
+        # Media message arriving while a text buffer is pending for this
+        # sender: flush the buffer first so the media is processed after
+        # any queued text, preserving order.
+        if self._input_buffer_seconds > 0 and sender_id in self._input_buffers:
+            await self._flush_input_buffer(sender_id)
+
+        await self._dispatch_message(message)
+
+    async def _dispatch_message(self, message: Dict[str, Any]) -> None:
+        """Build a MessageEvent from a raw inbound dict and hand it to the gateway."""
+        sender_id = str(message.get("from_user_id") or "").strip()
+        item_list = message.get("item_list") or []
+        text = _extract_text(item_list)
+
+        message_id = str(message.get("message_id") or "").strip()
         context_token = str(message.get("context_token") or "").strip()
         if context_token:
             self._token_store.set(self._account_id, sender_id, context_token)
         asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
+
+        chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)
 
         media_paths: List[str] = []
         media_types: List[str] = []
@@ -1442,6 +1503,81 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
         await self.handle_message(event)
+
+    def _enqueue_input_buffer(self, sender_id: str, message: Dict[str, Any]) -> None:
+        """Queue a text message for the sender and reset the coalesce timer."""
+        entry = self._input_buffers.get(sender_id)
+        if entry is None:
+            entry = {"messages": [], "timer": None}
+            self._input_buffers[sender_id] = entry
+        entry["messages"].append(message)
+
+        # Cancel any existing timer — each new message resets the window.
+        old_timer = entry.get("timer")
+        if old_timer is not None and not old_timer.done():
+            old_timer.cancel()
+
+        entry["timer"] = asyncio.create_task(
+            self._flush_input_buffer_after(sender_id, self._input_buffer_seconds)
+        )
+
+    async def _flush_input_buffer_after(self, sender_id: str, delay: float) -> None:
+        """Sleep *delay* seconds, then drain the sender's buffer."""
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        await self._flush_input_buffer(sender_id)
+
+    async def _flush_input_buffer(self, sender_id: str) -> None:
+        """Merge all queued messages for *sender_id* into one and dispatch."""
+        entry = self._input_buffers.pop(sender_id, None)
+        if entry is None:
+            return
+        timer = entry.get("timer")
+        if timer is not None and not timer.done():
+            timer.cancel()
+
+        messages = entry.get("messages", [])
+        if not messages:
+            return
+
+        if len(messages) == 1:
+            await self._dispatch_message(messages[0])
+            return
+
+        # Merge: concatenate text from every message, use the last message
+        # as the metadata carrier (context_token, message_id, etc.).
+        merged_parts: List[str] = []
+        for msg in messages:
+            t = _extract_text(msg.get("item_list") or [])
+            if t:
+                merged_parts.append(t)
+
+        merged_text = "\n".join(merged_parts)
+        last_message = messages[-1]
+
+        # Build a synthetic message dict with the merged text.
+        merged_message = dict(last_message)
+        merged_item_list: List[Dict[str, Any]] = []
+        for item in (last_message.get("item_list") or []):
+            merged_item_list.append(dict(item))
+        # Replace text in the first text item, or add one.
+        replaced = False
+        for item in merged_item_list:
+            if item.get("type") == ITEM_TEXT:
+                item.setdefault("text_item", {})["text"] = merged_text
+                replaced = True
+                break
+        if not replaced:
+            merged_item_list.append({"type": ITEM_TEXT, "text_item": {"text": merged_text}})
+        merged_message["item_list"] = merged_item_list
+
+        logger.debug(
+            "[%s] Flushed input buffer for %s: %d messages coalesced (%d chars)",
+            self.name, _safe_id(sender_id), len(messages), len(merged_text),
+        )
+        await self._dispatch_message(merged_message)
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -883,3 +883,169 @@ class TestWeixinContentDedup:
         assert adapter.handle_message.await_count == 0
         # is_duplicate should only be called for message_id, never for content
         assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)
+
+
+def _make_text_message(from_user_id: str, text: str, message_id: str = "msg-1") -> dict:
+    """Helper: build a minimal text message dict for testing."""
+    return {
+        "from_user_id": from_user_id,
+        "message_id": message_id,
+        "item_list": [{"type": 1, "text_item": {"text": text}}],
+        "context_token": "",
+    }
+
+
+class TestWeixinInputBuffering:
+    """Tests for the per-sender input-buffer feature (``input_buffer_seconds``)."""
+
+    ASYNC_RUN = asyncio.run
+
+    def test_buffering_disabled_by_default_dispatches_immediately(self):
+        """With input_buffer_seconds=0 (default), messages fire immediately."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._input_buffer_seconds = 0.0
+
+        asyncio.run(adapter._process_message(
+            _make_text_message("wxid_a", "hello")))
+        assert adapter.handle_message.await_count == 1
+        assert adapter.handle_message.await_args[0][0].text == "hello"
+
+    def test_buffering_coalesces_two_messages(self):
+        """Two rapid text messages from the same sender are merged."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._input_buffer_seconds = 0.05  # 50 ms
+
+        async def _send():
+            await adapter._process_message(_make_text_message("wxid_a", "hello", "m1"))
+            await adapter._process_message(_make_text_message("wxid_a", "world", "m2"))
+            # Let the timer fire
+            await asyncio.sleep(0.15)
+
+        asyncio.run(_send())
+        assert adapter.handle_message.await_count == 1
+        event = adapter.handle_message.await_args[0][0]
+        assert "hello" in event.text
+        assert "world" in event.text
+
+    def test_buffering_resets_timer_on_each_message(self):
+        """Each new message resets the window — no premature flush."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._input_buffer_seconds = 0.2
+
+        async def _send():
+            await adapter._process_message(_make_text_message("wxid_a", "a", "m1"))
+            await asyncio.sleep(0.05)
+            await adapter._process_message(_make_text_message("wxid_a", "b", "m2"))
+            await asyncio.sleep(0.05)
+            await adapter._process_message(_make_text_message("wxid_a", "c", "m3"))
+            # Now wait for the final timer to expire
+            await asyncio.sleep(0.3)
+
+        asyncio.run(_send())
+        assert adapter.handle_message.await_count == 1
+        event = adapter.handle_message.await_args[0][0]
+        parts = event.text.split("\n")
+        assert parts == ["a", "b", "c"]
+
+    def test_different_senders_have_independent_buffers(self):
+        """Buffer is per-sender — messages from B don't interfere with A."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._input_buffer_seconds = 0.1
+
+        async def _send():
+            await adapter._process_message(_make_text_message("wxid_a", "a1", "m1"))
+            await adapter._process_message(_make_text_message("wxid_b", "b1", "m2"))
+            await asyncio.sleep(0.2)
+
+        asyncio.run(_send())
+        assert adapter.handle_message.await_count == 2
+        texts = {call.args[0].text for call in adapter.handle_message.await_args_list}
+        assert texts == {"a1", "b1"}
+
+    def test_single_message_after_timer_is_not_merged(self):
+        """Only one message in the window → dispatched as-is (no join)."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._input_buffer_seconds = 0.05
+
+        async def _send():
+            await adapter._process_message(_make_text_message("wxid_a", "solo"))
+            await asyncio.sleep(0.1)
+
+        asyncio.run(_send())
+        assert adapter.handle_message.await_count == 1
+        assert adapter.handle_message.await_args[0][0].text == "solo"
+
+    def test_media_message_bypasses_buffer(self):
+        """A media message is dispatched immediately, even when buffering is on.
+
+        We verify bypass by checking that no buffer entry is created and
+        _dispatch_message is called (not queued).  Because _collect_media
+        needs a real iLink session, we mock _dispatch_message directly
+        and assert it was invoked.
+        """
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter._dispatch_message = AsyncMock()
+        adapter._input_buffer_seconds = 2.0
+
+        media_msg = {
+            "from_user_id": "wxid_a",
+            "message_id": "m-img",
+            "item_list": [{"type": 2}],  # ITEM_IMAGE
+            "context_token": "",
+        }
+        asyncio.run(adapter._process_message(media_msg))
+        # Media messages bypass the buffer entirely
+        assert "wxid_a" not in adapter._input_buffers
+        adapter._dispatch_message.assert_awaited_once()
+
+    def test_media_flushes_pending_text_buffer(self):
+        """Media arriving while text buffer pending: flush text first, then media."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter._dispatch_message = AsyncMock()
+        adapter._input_buffer_seconds = 2.0
+
+        async def _send():
+            await adapter._process_message(_make_text_message("wxid_a", "before"))
+            # Text is buffered; media should flush it
+            media_msg = {
+                "from_user_id": "wxid_a",
+                "message_id": "m-img",
+                "item_list": [{"type": 2}],
+                "context_token": "",
+            }
+            await adapter._process_message(media_msg)
+
+        asyncio.run(_send())
+        # Both the flushed text and the media are dispatched
+        assert adapter._dispatch_message.await_count >= 2
+        # The buffer should be empty after flush
+        assert "wxid_a" not in adapter._input_buffers
+
+    def test_buffer_cleared_on_disconnect(self):
+        """On disconnect, pending buffers are flushed."""
+        adapter = _make_adapter()
+        adapter._poll_session = AsyncMock(closed=False)
+        adapter._send_session = AsyncMock(closed=False)
+        adapter.handle_message = AsyncMock()
+        adapter._input_buffer_seconds = 2.0
+
+        async def _send():
+            await adapter._process_message(_make_text_message("wxid_a", "queued"))
+            adapter._running = False
+            await adapter.disconnect()
+
+        asyncio.run(_send())
+        assert adapter.handle_message.await_count == 1
+        assert adapter.handle_message.await_args[0][0].text == "queued"


### PR DESCRIPTION
Add `input_buffer_seconds` option to the Weixin adapter that coalesces rapid text messages from the same sender into a single turn.

- Configurable via `platforms.weixin.extra.input_buffer_seconds` (default: 2.0). Set to 0 to disable.
- Also readable from `WEIXIN_INPUT_BUFFER_SECONDS` env var.
- Media messages bypass the buffer; media also flushes pending text.
- Pending buffers drained on disconnect.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

