### PR TITLE
fix(kanban): content-addressed corrupt-DB backup filename (refs #33529)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -1138,14 +1139,21 @@ class KanbanDbCorruptError(RuntimeError):
 
 
 def _backup_corrupt_db(path: Path) -> Optional[Path]:
-    """Copy a corrupt DB (and its WAL/SHM sidecars) to a timestamped backup.
+    """Copy a corrupt DB (and its WAL/SHM sidecars) to a content-addressed backup.
+
+    The backup filename is deterministic in the main DB's sha256, so repeated
+    quarantines of the same corrupt bytes (gateway restarts, dispatcher retries,
+    multi-profile fleets all hitting the same shared DB) reuse one backup
+    instead of amplifying disk usage by N. If the corrupt bytes actually
+    change between attempts — e.g. a partial repair or further damage — the
+    fingerprint changes and a separate backup is preserved.
 
     Returns the backup path of the main DB file, or ``None`` if the copy
     itself failed (the caller still raises loudly in that case).
 
-    Writes are confined to the original DB's parent directory. The
-    backup basename is derived purely from ``path.name``, never from
-    caller-supplied directory segments — no traversal is possible.
+    Writes are confined to the original DB's parent directory. The backup
+    basename is derived purely from ``path.name`` and a content hash, never
+    from caller-supplied directory segments — no traversal is possible.
     """
     # Resolve once and pin the parent so subsequent path operations cannot
     # escape it. ``Path.resolve()`` collapses any ``..`` segments and
@@ -1153,32 +1161,31 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     resolved = path.resolve()
     parent = resolved.parent
     base_name = resolved.name  # basename only
-    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    candidate = parent / f"{base_name}.corrupt.{stamp}.bak"
-    # Defensive: candidate must still be inside parent after construction.
-    # f-string interpolation of ``base_name`` cannot escape ``parent``
-    # because ``base_name`` is itself a resolved basename, but assert it
-    # anyway so static analyzers can see the containment guarantee.
-    if candidate.parent != parent:
-        return None
-    counter = 0
-    while candidate.exists():
-        counter += 1
-        candidate = parent / f"{base_name}.corrupt.{stamp}.{counter}.bak"
-        if candidate.parent != parent:
-            return None
+    digest = hashlib.sha256()
     try:
-        shutil.copy2(resolved, candidate)
+        with resolved.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
     except OSError:
         return None
+    token = digest.hexdigest()[:16]
+    candidate = parent / f"{base_name}.corrupt.{token}.bak"
+    # Defensive: candidate must still be inside parent after construction.
+    if candidate.parent != parent:
+        return None
+    if not candidate.exists():
+        try:
+            shutil.copy2(resolved, candidate)
+        except OSError:
+            return None
     for suffix in ("-wal", "-shm"):
         sidecar = parent / (base_name + suffix)
         if sidecar.parent != parent or not sidecar.exists():
             continue
+        sidecar_backup = parent / (candidate.name + suffix)
+        if sidecar_backup.parent != parent or sidecar_backup.exists():
+            continue
         try:
-            sidecar_backup = parent / (candidate.name + suffix)
-            if sidecar_backup.parent != parent:
-                continue
             shutil.copy2(sidecar, sidecar_backup)
         except OSError:
             pass

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3317,6 +3317,44 @@ def test_connect_refuses_corrupt_existing_file(tmp_path):
         kb.connect(db_path=db_path)
 
 
+def test_repeated_corrupt_open_reuses_single_backup(tmp_path):
+    """Repeated quarantines of the same corrupt bytes must not amplify disk usage.
+
+    Regression for the gateway dispatcher's 5-min retry loop on shared kanban
+    DBs across multi-profile fleets: each retry on an unchanged corrupt file
+    used to create a fresh ``.corrupt.<timestamp>.bak`` until disk filled. The
+    content-addressed backup name is deterministic in the DB's sha256, so
+    N retries of the same bytes share one backup.
+    """
+    db_path = tmp_path / "kanban.db"
+    original = _write_corrupt_db(db_path)
+
+    backups: set[Path] = set()
+    for _ in range(10):
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+        with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+            kb.connect(db_path=db_path)
+        assert excinfo.value.backup_path is not None
+        backups.add(excinfo.value.backup_path)
+
+    assert len(backups) == 1, f"expected 1 deterministic backup, got {len(backups)}"
+    (backup,) = backups
+    assert backup.exists()
+    assert backup.read_bytes() == original
+
+    # Mutate the corrupt bytes — fingerprint changes, separate backup preserved.
+    with db_path.open("r+b") as f:
+        f.seek(4096)
+        f.write(b"\xAB" * 64)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo2:
+        kb.connect(db_path=db_path)
+    second_backup = excinfo2.value.backup_path
+    assert second_backup is not None
+    assert second_backup != backup
+    assert second_backup.exists()
+
+
 def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
     """A transient lock during the probe must not produce a .corrupt backup
     and must not be reported as :class:`KanbanDbCorruptError`. Raw sqlite


### PR DESCRIPTION
Salvages the conceptual approach from PR #33529 (@hanzckernel) — content-addressed backup filename — at ~10% the LOC.

## Summary

`_backup_corrupt_db()` used a timestamp + collision counter for the backup filename. Each retry on an unchanged corrupt kanban.db produced a new `.corrupt.<timestamp>.bak` copy of the same bytes. After 10 retry cycles (gateway dispatcher's 5-minute quarantine timer, multi-profile fleets sharing one DB, manual reopen attempts) you had 11x the disk footprint of duplicate corrupt data.

This PR makes the backup filename deterministic in a sha256 of the main DB. Same bytes → same filename → `if not path.exists(): copy` skips the work on retries. Different bytes (partial repair, further damage) → different fingerprint → second backup preserved.

## Live verification

10 retries on the same corrupt DB (100KB):

| Metric | Before | After |
|---|---|---|
| Backup files | 11 | **1** |
| Disk usage | 1144 KB | **104 KB** |
| Amplification | 11x | **1x** |

Tests: 449/449 kanban tests pass (test_kanban_db.py + test_kanban_core_functionality.py + test_kanban_tools.py). New regression test `test_repeated_corrupt_open_reuses_single_backup` asserts the invariant directly + verifies mutated corrupt bytes still get a separate backup.

## Why simpler than #33529

@hanzckernel's PR weighed in at +670/-70 across 5 files. This is +66/-21 across 2 files. Dropped without losing the bug fix:

- **Persistent `.corrupt-quarantine.json` marker file.** Pure metadata. The deterministic backup file existing IS the marker — same property (idempotent retry), no separate state machine to maintain or clear.
- **Atomic temp + fsync + `os.replace` copy helper.** `shutil.copy2` is fine for a quarantine-only path. We're copying a known-broken DB; durability of the backup beats best-effort by no meaningful margin.
- **WAL+SHM sidecar fingerprinting at the backup layer.** The main DB hash is what changes between distinct corruption incidents; sidecar variations don't meaningfully define "is this the same incident." Sidecar backups still happen (inherit the same content-addressed name from the main DB).
- **Gateway-side `_pause_corrupt_board` / `_board_disabled_same_fingerprint` helper extraction.** DRY-only refactor in the original PR. Useful but orthogonal to the bug being fixed. Existing inline code paths in gateway/run.py already work.
- **Gateway-side WAL+SHM fingerprint extension.** The existing `(path, mtime, size)` tuple still gives the 5-minute retry semantics it needs.
- **Health-probe and auto-decompose skip-corrupt-boards paths.** Distinct concern (and a real latent issue) — not this bug. Defer.

The PR description for #33529 covers other issues (#30445, #31736) that the cluster sweep just closed via the WAL-init / connect_closing / quarantine-retry / torn-write defenses landed earlier this week. Those issues are resolved; the residual concern this PR addresses is purely the backup-file disk amplification on the retry path.

## Credit

- @hanzckernel — identified the bug, proposed the content-fingerprint approach, supplied the regression scenarios this PR's test is based on. Co-authored trailer on the commit.

## Infographic

![kanban-corrupt-backup-amplification](https://v3b.fal.media/files/b/0a9c025d/g2bYboKNKnxeqs66sNzIe_I8zDCVFN.png)
