### PR TITLE
fix(kimi): handle union type lists in Moonshot schema sanitizer

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -125,7 +125,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # empty, drop it entirely.
     if "enum" in repaired and isinstance(repaired["enum"], list):
         node_type = repaired.get("type")
-        if node_type in {"string", "integer", "number", "boolean"}:
+        if isinstance(node_type, str) and node_type in {"string", "integer", "number", "boolean"}:
             cleaned = [v for v in repaired["enum"]
                        if v is not None and v != ""]
             if cleaned:

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -393,3 +393,23 @@ class TestUnionTypeList:
         assert sort["type"] == "string"
         assert sort["enum"] == ["asc", "desc"]
         assert params["properties"]["sort"]["type"] == ["string", "null"]
+
+    def test_ref_union_type_list_with_enum_does_not_crash(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "choice": {
+                    "$ref": "#/$defs/Choice",
+                    "type": ["string", "null"],
+                    "enum": ["a", None],
+                },
+            },
+            "$defs": {"Choice": {"type": "string"}},
+        }
+
+        out = sanitize_moonshot_tool_parameters(params)
+
+        choice = out["properties"]["choice"]
+        assert choice["$ref"] == "#/$defs/Choice"
+        assert choice["type"] == ["string", "null"]
+        assert choice["enum"] == ["a", None]


### PR DESCRIPTION
## Summary
- Handles JSON Schema union type lists (`type: ["number", "string"]`) in Moonshot/Kimi schema sanitization.
- Treats list-valued `type` as an existing declaration in `_fill_missing_type` instead of using it in a set-membership check.
- Restricts enum cleanup to scalar string types so `$ref` schemas with list-valued `type` do not crash in `_repair_schema`.
- Rebased onto latest `upstream/main` (`b1af653bf`).

## Review notes
- Addresses #28291.
- Reviewed `alt-glitch`'s competing-fix note: the original branch only covered the enum-cleanup crash site; this update now covers both `_fill_missing_type` and `_repair_schema`, matching the completeness concern raised in comparison with #28422.

## TDD / verification
- RED: `.venv\Scripts\python.exe -m pytest tests\agent\test_moonshot_schema.py::TestUnionTypeList -q --timeout-method=thread` failed on current `upstream/main` with `TypeError: unhashable type: 'list'` in both `_fill_missing_type` and `_repair_schema` paths.
- GREEN: `.venv\Scripts\python.exe -m pytest tests\agent\test_moonshot_schema.py::TestUnionTypeList -q --timeout-method=thread` -> 4 passed.
- Full focused file: `.venv\Scripts\python.exe -m pytest tests\agent\test_moonshot_schema.py -q --timeout-method=thread` -> 38 passed.
- `.venv\Scripts\ruff.exe check agent\moonshot_schema.py tests\agent\test_moonshot_schema.py` -> passed.
- `.venv\Scripts\python.exe -m py_compile agent\moonshot_schema.py tests\agent\test_moonshot_schema.py` -> passed.
- `git diff --check` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> clean (`61dfe91430dee42379afafaecd1fbb2580959bcf`).