### PR TITLE
fix(codex): guard against None response.output in OpenAI SDK streaming

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1219,3 +1219,36 @@ def _normalize_codex_response(
     else:
         finish_reason = "stop"
     return assistant_message, finish_reason
+
+
+# ---------------------------------------------------------------------------
+# SDK compatibility patch: guard against None response.output (#20xxx)
+# ---------------------------------------------------------------------------
+# The ChatGPT Codex backend (chatgpt.com/backend-api/codex) may send
+# output: null in the response.completed streaming event.  The
+# OpenAI Python SDK (<= 2.32.0) iterates response.output without a
+# None guard in openai.lib._parsing._responses.parse_response,
+# raising TypeError: 'NoneType' object is not iterable.
+#
+# This monkey-patch survives pip upgrades of the SDK (re-applied on every
+# import) and is safe to remove once the upstream SDK fixes it.
+# ---------------------------------------------------------------------------
+def _patch_openai_parse_response_none_output() -> None:
+    try:
+        from openai.lib._parsing import _responses as _pr
+    except ImportError:
+        return
+
+    _original_parse_response = _pr.parse_response
+
+    def _patched_parse_response(**kwargs):
+        response = kwargs.get("response")
+        if response is not None and getattr(response, "output", None) is None:
+            response.output = []
+        return _original_parse_response(**kwargs)
+
+    if not getattr(_pr.parse_response, "_hermes_patched", False):
+        _patched_parse_response._hermes_patched = True  # type: ignore[attr-defined]
+        _pr.parse_response = _patched_parse_response
+
+_patch_openai_parse_response_none_output()

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2137,3 +2137,42 @@ def test_run_conversation_codex_invalid_encrypted_content_without_replay_state_d
     assert all(not any(item.get("type") == "reasoning" for item in payload["input"]) for payload in request_payloads)
     assert agent._codex_reasoning_replay_enabled is True
     assert result["messages"][0].get("codex_reasoning_items") is None
+
+
+def test_patch_openai_parse_response_none_output(monkeypatch):
+    """The ChatGPT Codex backend may send output=None in response.completed.
+    The monkey-patch in codex_responses_adapter must normalise it to [] so
+    the SDK's parse_response does not raise TypeError."""
+    from agent.codex_responses_adapter import _patch_openai_parse_response_none_output
+    from openai.lib._parsing import _responses as _pr
+
+    # Ensure the patch is applied
+    _patch_openai_parse_response_none_output()
+    assert getattr(_pr.parse_response, "_hermes_patched", False)
+
+    # Build a Response with output=None via construct to skip validation
+    from openai._models import construct_type_unchecked
+    from openai.types.responses import Response
+
+    response = construct_type_unchecked(
+        type_=Response,
+        value={
+            "id": "resp_test",
+            "created_at": 0,
+            "model": "gpt-5.5",
+            "object": "response",
+            "output": None,
+            "parallel_tool_calls": True,
+            "temperature": 1.0,
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": 1.0,
+            "truncation": "disabled",
+        },
+    )
+    assert response.output is None  # confirm None survived construction
+
+    # Without the patch this would raise TypeError: 'NoneType' object is not iterable
+    from openai._types import NOT_GIVEN
+    result = _pr.parse_response(text_format=NOT_GIVEN, input_tools=NOT_GIVEN, response=response)
+    assert result.output == []


### PR DESCRIPTION
The ChatGPT Codex backend (chatgpt.com/backend-api/codex) may send output: null in the response.completed streaming event. The OpenAI Python SDK (<= 2.32.0) iterates response.output without a None guard in parse_response(), raising TypeError: NoneType object is not iterable.

This adds a module-level monkey-patch in codex_responses_adapter that normalizes None output to an empty list before the SDK parse_response processes it. The patch is idempotent and survives SDK upgrades.

## What does this PR do?

The ChatGPT Codex backend (chatgpt.com/backend-api/codex) may send output:    
null in the response.completed streaming event. The OpenAI Python SDK (<=     
2.32.0) iterates response.output without a None guard in                      
openai.lib._parsing._responses.parse_response(), raising TypeError: 'NoneType'
 object is not iterable. This breaks all agent-based cron jobs and interactive
 sessions when using the openai-codex provider.            
                                                                              
This adds a module-level monkey-patch in codex_responses_adapter that
normalizes None output to an empty list before the SDK's parse_response     
processes it. The patch is idempotent and survives SDK upgrades.

## Related Issue

N/A — discovered in production when all agent-based cron jobs and interactive sessions started failing on May 26, 2026.

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- agent/codex_responses_adapter.py: Added   
_patch_openai_parse_response_none_output() monkey-patch applied at module
import time. Guards against response.output being None in the SDK's
parse_response().                                                             
- tests/run_agent/test_run_agent_codex_responses.py: Added
test_patch_openai_parse_response_none_output — constructs a Response with     
output=None and verifies parse_response returns output == [] instead of
raising TypeError. 

## How to Test

1. Configure Hermes with openai-codex provider (base_url:  
https://chatgpt.com/backend-api/codex)                                      
2. Send any message or trigger a cron job
3. Without the patch: TypeError: 'NoneType' object is not iterable on every   
request                                     
4. With the patch: streaming completes, output reconstructed from deltas by   
existing _run_codex_stream() backfill                      
5. Run: pytest tests/run_agent/test_run_agent_codex_responses.py::test_patch_o
penai_parse_response_none_output -xvs

## Checklist

- I've read the                             
https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md        
- My commit messages follow https://www.conventionalcommits.org/
- I searched for https://github.com/NousResearch/hermes-agent/pulls to make   
sure this isn't a duplicate                 
- My PR contains only changes related to this fix                             
- I've run pytest tests/ -q and all tests pass                                
- I've added tests for my changes                                             
- I've tested on my platform: Ubuntu 22.04 

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

  Before fix:                                                                   
  ERROR root: Non-retryable client error: 'NoneType' object is not iterable     
  Traceback: openai/lib/_parsing/_responses.py:61 → for output in               
  response.output: → TypeError                                                  
                                                                              
  After fix:                                                                  
  $ pytest tests/run_agent/test_run_agent_codex_responses.py::test_patch_openai_
  parse_response_none_output -xvs                                               
  PASSED                                                                        
                                                                                
  ---                                                                         
  Create the PR here: https://github.com/CorporalCleg/hermes-agent/pull/new/fix/
  openai-sdk-none-output-guard 

