### PR TITLE
fix(skills): populate repo field in official skills index

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1690,6 +1690,33 @@ class TestOptionalSkillSourceBinaryAssets:
         assert bundle.files["assets/neutts-cli/samples/jo.txt"] == b"hello\n"
         assert "assets/neutts-cli/src/neutts_cli/__pycache__/cli.cpython-312.pyc" not in bundle.files
 
+    def test_search_emits_upstream_repo_and_path(self, tmp_path):
+        """Regression test for #30482.
+
+        Every ``official/*`` entry in the published skills index must carry a
+        non-empty ``repo`` + ``path`` so ``HermesIndexSource.fetch`` can fall
+        back to a direct GitHub fetch.  Empty values made all 81 official
+        skills uninstallable via the ``official/<skill>`` identifier.
+        """
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "finance" / "3-statement-model"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: 3-statement-model\ndescription: model\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        results = src.search("3-statement-model", limit=10)
+
+        assert len(results) == 1
+        meta = results[0]
+        assert meta.identifier == "official/finance/3-statement-model"
+        assert meta.repo == "NousResearch/hermes-agent"
+        assert meta.path == "optional-skills/finance/3-statement-model"
+
 
 class TestQuarantineBundleBinaryAssets:
     def test_quarantine_bundle_writes_binary_files(self, tmp_path):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1,6 +1,7 @@
 """Tests for tools/skills_hub.py — source adapters, lock file, taps, dedup logic."""
 
 import json
+from pathlib import PureWindowsPath
 from unittest.mock import patch, MagicMock
 
 import httpx
@@ -1716,6 +1717,37 @@ class TestOptionalSkillSourceBinaryAssets:
         assert meta.identifier == "official/finance/3-statement-model"
         assert meta.repo == "NousResearch/hermes-agent"
         assert meta.path == "optional-skills/finance/3-statement-model"
+
+    def test_search_emits_posix_repo_metadata_path_on_windows(self, tmp_path):
+        """Published official index paths must use GitHub/POSIX separators."""
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "finance" / "3-statement-model"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: 3-statement-model\ndescription: model\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+        path_class = type(skill_dir)
+        original_relative_to = path_class.relative_to
+
+        def _windows_relative_to(self, *other):
+            rel = original_relative_to(self, *other)
+            if self == skill_dir and other == (optional_root,):
+                return PureWindowsPath(*rel.parts)
+            return rel
+
+        with patch.object(path_class, "relative_to", _windows_relative_to):
+            results = src.search("3-statement-model", limit=10)
+
+        assert len(results) == 1
+        meta = results[0]
+        assert meta.identifier == "official/finance/3-statement-model"
+        assert meta.path == "optional-skills/finance/3-statement-model"
+        assert "\\" not in meta.identifier
+        assert "\\" not in meta.path
 
 
 class TestQuarantineBundleBinaryAssets:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2940,7 +2940,7 @@ class OptionalSkillSource(SkillSource):
                 if isinstance(hermes_meta, dict):
                     tags = hermes_meta.get("tags", [])
 
-            rel_path = str(parent.relative_to(self._optional_dir))
+            rel_path = parent.relative_to(self._optional_dir).as_posix()
 
             results.append(SkillMeta(
                 name=name,

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2802,6 +2802,14 @@ class OptionalSkillSource(SkillSource):
     (search / install / inspect) and labelled "official" with "builtin" trust.
     """
 
+    # Canonical upstream location for the official optional skills.  Emitted
+    # on every ``SkillMeta`` so the published skills index has a usable
+    # ``repo`` + ``path`` pair that ``HermesIndexSource.fetch`` can resolve
+    # against GitHub when the local optional-skills tree isn't present
+    # (e.g. ``hermes skills install official/<skill>`` on a packaged install).
+    UPSTREAM_REPO = "NousResearch/hermes-agent"
+    UPSTREAM_PATH_PREFIX = "optional-skills"
+
     def __init__(self):
         from hermes_constants import get_optional_skills_dir
 
@@ -2940,7 +2948,15 @@ class OptionalSkillSource(SkillSource):
                 source="official",
                 identifier=f"official/{rel_path}",
                 trust_level="builtin",
-                path=rel_path,
+                # ``repo`` + ``path`` describe the upstream GitHub location so
+                # ``HermesIndexSource.fetch`` can fall back to a direct
+                # ``owner/repo/path`` GitHub fetch when the user doesn't have
+                # the optional-skills tree on disk.  Without these, the
+                # published skills index emits empty ``repo`` for all 81
+                # official skills and ``hermes skills install official/<x>``
+                # fails for everyone (#30482).
+                repo=self.UPSTREAM_REPO,
+                path=f"{self.UPSTREAM_PATH_PREFIX}/{rel_path}",
                 tags=tags if isinstance(tags, list) else [],
             ))
 


### PR DESCRIPTION
## Summary

`OptionalSkillSource._scan_all()` built `SkillMeta` objects without setting `repo`, so the daily-generated `skills-index.json` emitted `"repo": ""` and `"resolved_github_id": ""` for every one of the 81 `official/*` entries.  `HermesIndexSource.fetch()` requires either `resolved_github_id` or a non-empty `repo` + `path`, so `hermes skills install official/<anything>` returned `Could not fetch official/... from any source.` for every user on every Hermes version.

The fix populates each official entry with the upstream coordinates that already work as the documented manual workaround:

- `repo = "NousResearch/hermes-agent"`
- `path = "optional-skills/<rel_path>"` (e.g. `optional-skills/finance/3-statement-model`)

`HermesIndexSource.fetch()` then composes `f"{repo}/{path}"` and hands it to `GitHubSource.fetch()`, exactly like the workaround in the bug report.

The next scheduled `skills-index.yml` workflow run will regenerate `skills-index.json` with the populated fields — no committed data file to update.

## Test plan

- [x] New regression test `TestOptionalSkillSourceBinaryAssets::test_search_emits_upstream_repo_and_path` asserts that `search()` returns `repo="NousResearch/hermes-agent"` and `path="optional-skills/finance/3-statement-model"` for the exact skill called out in the issue.
- [x] `tests/tools/test_skills_hub.py` full suite: 127 passed.
- [ ] After the next `skills-index.yml` build, confirm the live index has non-empty `repo`/`path` and `hermes skills install official/finance/3-statement-model` succeeds.

Closes #30482