### PR TITLE
fix(vision): preserve fallback provider kwargs and model defaults

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3084,17 +3084,18 @@ def _try_configured_fallback_chain(
         label = f"fallback_chain[{i}]({fb_provider})"
 
         try:
-            fb_client = _resolve_single_provider(
+            fb_client, fb_resolved_model = _resolve_single_provider(
                 fb_provider, fb_model, fb_base_url, fb_api_key)
         except Exception:
-            fb_client = None
+            fb_client, fb_resolved_model = None, None
 
         if fb_client is not None:
+            effective_model = fb_model or fb_resolved_model
             logger.info(
                 "Auxiliary %s: %s on %s — configured fallback to %s (%s)",
-                task, reason, failed_provider, label, fb_model or "default",
+                task, reason, failed_provider, label, effective_model or "default",
             )
-            return fb_client, fb_model, label
+            return fb_client, effective_model, label
         tried.append(label)
 
     if tried:
@@ -3110,19 +3111,21 @@ def _resolve_single_provider(
     model: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
-) -> Optional[Any]:
+) -> Tuple[Optional[Any], Optional[str]]:
     """Resolve a single provider entry from fallback_chain to an OpenAI client.
 
     Uses the existing provider resolution infrastructure where possible.
+    Returns the resolved model so callers can preserve provider defaults when
+    the fallback_chain entry omits ``model``.
     """
     # Reuse resolve_provider_client which handles provider→client mapping
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
-    return client
+    return client, resolved_model
 
 def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Full auto-detection chain.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1737,6 +1737,73 @@ class TestTryMainAgentModelFallback:
         assert client is None
 
 
+class TestResolveSingleProviderKwargs:
+    """Regression for #27555: fallback_chain kwargs must match resolver API."""
+
+    def test_forwards_base_url_and_api_key_as_explicit_kwargs(self):
+        from agent.auxiliary_client import _resolve_single_provider
+
+        fake_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, "mimo-v2-omni"),
+        ) as rpc:
+            client, model = _resolve_single_provider(
+                "xiaomi-tp",
+                model="mimo-v2-omni",
+                base_url="https://xm.example/v1",
+                api_key="xm-test-key",
+            )
+
+        assert client is fake_client
+        assert model == "mimo-v2-omni"
+        rpc.assert_called_once_with(
+            provider="xiaomi-tp",
+            model="mimo-v2-omni",
+            explicit_base_url="https://xm.example/v1",
+            explicit_api_key="xm-test-key",
+        )
+
+    def test_real_resolve_provider_client_accepts_forwarded_kwargs(self):
+        from agent.auxiliary_client import _resolve_single_provider
+
+        client, model = _resolve_single_provider(
+            "custom",
+            model="some-model",
+            base_url="https://example.invalid/v1",
+            api_key="sk-test",
+        )
+
+        assert client is not None
+        assert model == "some-model"
+
+
+class TestConfiguredFallbackChainResolvedModel:
+    """fallback_chain entries without model use the provider default model."""
+
+    def test_uses_resolved_model_when_entry_omits_model(self, monkeypatch):
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": [{"provider": "openrouter"}]},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, "openrouter-default-model"),
+        ):
+            client, model, label = _try_configured_fallback_chain(
+                "compression",
+                "primary-provider",
+            )
+
+        assert client is fake_client
+        assert model == "openrouter-default-model"
+        assert label == "fallback_chain[0](openrouter)"
+
+
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Rebased the fix onto current `upstream/main` (`9c051f57`).
- `_resolve_single_provider()` now forwards fallback-chain overrides with the kwarg names `resolve_provider_client()` actually accepts: `explicit_base_url` and `explicit_api_key`.
- `_resolve_single_provider()` now returns the resolver's model along with the client, and `_try_configured_fallback_chain()` returns the configured model or the provider default when a fallback-chain entry omits `model`.
- This covers the reviewed #27555 failure mode where `TypeError` was swallowed and the vision fallback chain silently skipped entries such as Gemini -> Xiaomi-TP/MiMo -> Ollama. It also includes the default-model propagation surface noted in the related #27850 discussion; broader vision-fallback proposals remain separate.

## Test plan

- [x] RED: `pytest tests/agent/test_auxiliary_client.py::TestResolveSingleProviderKwargs tests/agent/test_auxiliary_client.py::TestConfiguredFallbackChainResolvedModel -q --timeout-method=thread` failed on pre-fix current main with the expected `base_url` kwarg / tuple return / missing default-model failures.
- [x] GREEN: same targeted command -> `3 passed`.
- [x] `pytest tests/agent/test_auxiliary_client.py -q --timeout-method=thread` -> `221 passed, 1 warning` (existing Discord `audioop` deprecation warning).
- [x] `ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` -> passed.
- [x] `python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` -> passed.
- [x] `git diff --check` -> passed.
- [x] `git merge-tree --write-tree upstream/main HEAD` -> `09a7018d3af9b174e99843bf5aa14f2e39908d06`.

Closes #27555