### PR TITLE
fix(config): quote .env values containing # to prevent truncation

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5501,6 +5501,29 @@ def save_config(config: Dict[str, Any]):
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 
+def _parse_env_value(raw_value: str) -> str:
+    """Parse the small .env value subset Hermes writes itself."""
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        quoted = value[1:-1]
+        parsed: list[str] = []
+        i = 0
+        while i < len(quoted):
+            ch = quoted[i]
+            if ch == "\\" and i + 1 < len(quoted):
+                next_ch = quoted[i + 1]
+                if next_ch in {'"', "\\"}:
+                    parsed.append(next_ch)
+                    i += 2
+                    continue
+            parsed.append(ch)
+            i += 1
+        return "".join(parsed)
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1]
+    return value
+
+
 def load_env() -> Dict[str, str]:
     """Load environment variables from ~/.hermes/.env.
 
@@ -5550,7 +5573,7 @@ def load_env() -> Dict[str, str]:
             line = line.strip()
             if line and not line.startswith('#') and '=' in line:
                 key, _, value = line.partition('=')
-                env_vars[key.strip()] = value.strip().strip('"\'')
+                env_vars[key.strip()] = _parse_env_value(value)
 
     if cache_key is not None:
         _env_cache = (cache_key, dict(env_vars))
@@ -5724,6 +5747,22 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
     return sanitized
 
 
+def _quote_env_value(value: str) -> str:
+    """Quote .env values containing characters with special dotenv meaning."""
+    if value == "":
+        return value
+    needs_quoting = (
+        "#" in value
+        or '"' in value
+        or "'" in value
+        or value != value.strip()
+    )
+    if not needs_quoting:
+        return value
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def save_env_value(key: str, value: str):
     """Save or update a value in ~/.hermes/.env."""
     if is_managed():
@@ -5750,11 +5789,13 @@ def save_env_value(key: str, value: str):
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
 
+    serialized_value = _quote_env_value(value)
+
     # Find and update or append
     found = False
     for i, line in enumerate(lines):
         if line.strip().startswith(f"{key}="):
-            lines[i] = f"{key}={value}\n"
+            lines[i] = f"{key}={serialized_value}\n"
             found = True
             break
 
@@ -5762,7 +5803,7 @@ def save_env_value(key: str, value: str):
         # Ensure there's a newline at the end of the file before appending
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
-        lines.append(f"{key}={value}\n")
+        lines.append(f"{key}={serialized_value}\n")
     
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -311,6 +311,55 @@ class TestSaveEnvValueSecure:
         env_mode = env_path.stat().st_mode & 0o777
         assert env_mode == 0o640, f"expected 0o640, got {oct(env_mode)}"
 
+    def test_save_env_value_quotes_values_containing_hash(self, tmp_path):
+        """Regression test for #30355."""
+        from dotenv import dotenv_values
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("ANTHROPIC_TOKEN", None)
+            token = "sk-ant-oat01-abc#xyz#more"
+            save_env_value("ANTHROPIC_TOKEN", token)
+
+            content = (tmp_path / ".env").read_text(encoding="utf-8")
+            assert f'ANTHROPIC_TOKEN="{token}"' in content
+
+            parsed = dotenv_values(str(tmp_path / ".env"))
+            assert parsed["ANTHROPIC_TOKEN"] == token
+            assert load_env()["ANTHROPIC_TOKEN"] == token
+
+    def test_save_env_value_hash_value_round_trips_quotes_and_backslashes(self, tmp_path):
+        from dotenv import dotenv_values
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("ANTHROPIC_TOKEN", None)
+            token = 'abc"def\\ghi#jkl'
+            save_env_value("ANTHROPIC_TOKEN", token)
+
+            content = (tmp_path / ".env").read_text(encoding="utf-8")
+            assert 'ANTHROPIC_TOKEN="abc\\"def\\\\ghi#jkl"' in content
+
+            parsed = dotenv_values(str(tmp_path / ".env"))
+            assert parsed["ANTHROPIC_TOKEN"] == token
+            assert load_env()["ANTHROPIC_TOKEN"] == token
+
+    def test_save_env_value_updates_hash_value_with_quotes(self, tmp_path):
+        from dotenv import dotenv_values
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("ANTHROPIC_TOKEN", None)
+            save_env_value("ANTHROPIC_TOKEN", "old-token")
+
+            token = 'abc"def\\ghi#jkl'
+            save_env_value("ANTHROPIC_TOKEN", token)
+
+            content = (tmp_path / ".env").read_text(encoding="utf-8")
+            assert content.count("ANTHROPIC_TOKEN=") == 1
+            assert 'ANTHROPIC_TOKEN="abc\\"def\\\\ghi#jkl"' in content
+
+            parsed = dotenv_values(str(tmp_path / ".env"))
+            assert parsed["ANTHROPIC_TOKEN"] == token
+            assert load_env()["ANTHROPIC_TOKEN"] == token
+
 
 class TestRemoveEnvValue:
     def test_removes_key_from_env_file(self, tmp_path):


### PR DESCRIPTION
## Root cause

`hermes_cli.config.save_env_value()` wrote `~/.hermes/.env` lines as raw `KEY=value`. Dotenv parsers treat an unquoted `#` as the start of an inline comment, so a token like:

```dotenv
ANTHROPIC_TOKEN=sk-ant-oat01-abc#xyz
```

round-trips back as `sk-ant-oat01-abc`, which breaks downstream authentication.

## Fix

- Add `_quote_env_value()` so values containing `#`, quotes, or leading/trailing whitespace are written as double-quoted dotenv values with `\` and `"` escaped.
- Add `_parse_env_value()` for the small quoted subset Hermes writes, so `load_env()` round-trips escaped quotes and backslashes correctly.
- Keep clean values diff-stable as `KEY=value`; permissions, atomic replace, cache invalidation, ASCII credential sanitization, and denylist behavior are unchanged.

## Review context

The prior comment called this a duplicate of #30357 and related to #30473/#30747. #30357 and #30473 are closed unmerged; #30747 is still open and competing. This PR is now rebased onto current `upstream/main` (`9c051f57`) and remains a narrow #30355 fix.

## Test plan

- [x] RED: `pytest tests/hermes_cli/test_config.py::TestSaveEnvValueSecure::test_save_env_value_quotes_values_containing_hash tests/hermes_cli/test_config.py::TestSaveEnvValueSecure::test_save_env_value_hash_value_round_trips_quotes_and_backslashes tests/hermes_cli/test_config.py::TestSaveEnvValueSecure::test_save_env_value_updates_hash_value_with_quotes -q --timeout-method=thread` failed on pre-fix current main with raw unquoted values.
- [x] GREEN: same targeted command -> `3 passed`.
- [x] `pytest tests/hermes_cli/test_config.py::TestSaveEnvValueSecure tests/hermes_cli/test_env_load_cache.py -q --timeout-method=thread` -> `14 passed`.
- [x] `ruff check hermes_cli/config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_env_load_cache.py tests/hermes_cli/test_anthropic_oauth_flow.py tests/hermes_cli/test_setup.py` -> passed.
- [x] `python -m py_compile hermes_cli/config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_env_load_cache.py tests/hermes_cli/test_anthropic_oauth_flow.py tests/hermes_cli/test_setup.py` -> passed.
- [x] `git diff --check` -> passed.
- [x] `git merge-tree --write-tree upstream/main HEAD` -> `30d62e56390a675ba42861c37a619305421fdcb8`.

Windows local note: `pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_env_load_cache.py -q --timeout-method=thread` still has 7 failures here, and the same 7 failures reproduce on a clean detached `upstream/main` worktree at `9c051f57` (default Windows config path plus GBK decoding of UTF-8 YAML). They are not introduced by this PR.

Closes #30355