### PR TITLE
fix(gateway): make Feishu groups visible and lane-scoped

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -118,7 +118,17 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "slack":           {**_TIER_MEDIUM, "tool_progress": "off"},
     "mattermost":      _TIER_MEDIUM,
     "matrix":          _TIER_MEDIUM,
-    "feishu":          _TIER_MEDIUM,
+    "feishu":          {
+        **_TIER_MEDIUM,
+        # Feishu/Lark workspace chats make permanent progress/status bubbles
+        # look noisy, especially in group lanes. Prefer a TUI-like single
+        # assistant bubble that is progressively edited, and keep tool detail
+        # in logs/sessions unless explicitly enabled by config.
+        "tool_progress": "off",
+        "interim_assistant_messages": False,
+        "busy_ack_detail": False,
+        "cleanup_progress": True,
+    },
 
     # Tier 3 — no edit support, progress messages are permanent
     "signal":          _TIER_LOW,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -84,6 +84,11 @@ def _reply_anchor_for_event(event) -> str | None:
     topic lanes prefer replying to the triggering user message so the answer
     stays attached to the active lane; synthetic/resumed sends fall back to
     ``direct_messages_topic_id`` metadata when no message id is available.
+
+    Feishu group chats hide ordinary ``message.reply`` responses behind the
+    triggering message's inline reply affordance, so a visible group response
+    should be a normal chat message unless the inbound event is already inside a
+    Feishu thread/topic.
     """
     source = getattr(event, "source", None)
     platform = _platform_name(getattr(source, "platform", None))
@@ -94,8 +99,11 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu":
+        if thread_id:
+            return getattr(event, "reply_to_message_id", None)
+        if getattr(source, "chat_type", None) in {"group", "supergroup", "channel", None, ""}:
+            return None
     return getattr(event, "message_id", None)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15723,14 +15723,21 @@ class GatewayRunner:
                         if source.platform == Platform.TELEGRAM
                         else 0.0
                     )
+                    _feishu_tui_like = (
+                        source.platform == Platform.FEISHU
+                        and (getattr(source, "chat_type", "") or "") in {"group", "supergroup", "channel", ""}
+                        and not (_thread_metadata or {}).get("thread_id")
+                    )
                     _consumer_cfg = StreamConsumerConfig(
-                        edit_interval=_scfg.edit_interval,
-                        buffer_threshold=_scfg.buffer_threshold,
+                        edit_interval=1.8 if _feishu_tui_like else _scfg.edit_interval,
+                        buffer_threshold=96 if _feishu_tui_like else _scfg.buffer_threshold,
                         cursor=_effective_cursor,
                         buffer_only=_buffer_only,
                         fresh_final_after_seconds=_fresh_final_secs,
                         transport=_scfg.transport or "edit",
                         chat_type=getattr(source, "chat_type", "") or "",
+                        preserve_message_across_segments=_feishu_tui_like,
+                        min_initial_preview_chars=24 if _feishu_tui_like else 4,
                     )
                     _stream_consumer = GatewayStreamConsumer(
                         adapter=_adapter,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -640,6 +640,11 @@ def build_session_key(
         return f"agent:main:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
+    feishu_plain_group_lane = (
+        source.platform == Platform.FEISHU
+        and source.chat_type in {"group", "supergroup", "channel"}
+        and not source.thread_id
+    )
     if participant_id and source.platform == Platform.WHATSAPP:
         # Same JID/LID-flip bug as the DM case: without canonicalisation, a
         # single group member gets two isolated per-user sessions when the
@@ -656,6 +661,11 @@ def build_session_key(
     # conversation).  Per-user isolation only applies when explicitly enabled
     # via thread_sessions_per_user, or when there is no thread (regular group).
     isolate_user = group_sessions_per_user
+    if feishu_plain_group_lane:
+        # Feishu/Lark workspace groups behave like project/lane rooms. Make
+        # the default UX match a long-lived TUI session for that lane instead
+        # of splitting the same group by sender.
+        isolate_user = False
     if source.thread_id and not thread_sessions_per_user:
         isolate_user = False
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -132,7 +132,7 @@ class GatewayStreamConsumer:
         # the content, not edit the old bubble above it.
         # Called with no arguments. Exceptions are swallowed.
         self._on_new_message = on_new_message
-        self._initial_reply_to_id = initial_reply_to_id
+        self._initial_reply_to_id = None if self._should_send_plain_first_message() else initial_reply_to_id
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -181,6 +181,19 @@ class GatewayStreamConsumer:
         # first failure we permanently disable drafts for the remainder of
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
+
+    def _should_send_plain_first_message(self) -> bool:
+        """Return True when the first streaming bubble must not be a reply.
+
+        Feishu renders message.reply output as an inline nested reply that is
+        easy to miss in ordinary group chats. Topic/thread chats still need the
+        reply anchor for routing, but plain group chats should create a normal
+        top-level bot message.
+        """
+        platform_name = getattr(getattr(self.adapter, "name", None), "value", None) or getattr(self.adapter, "name", "")
+        platform_name = str(platform_name or "").lower()
+        chat_type = str(getattr(self.cfg, "chat_type", "") or "").lower()
+        return platform_name == "feishu" and chat_type in {"group", "supergroup", "channel", ""} and not (self.metadata or {}).get("thread_id")
 
     @property
     def already_sent(self) -> bool:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -73,6 +73,15 @@ class StreamConsumerConfig:
     # "group", "supergroup", "forum").  Used to gate native draft streaming,
     # which is platform-specific (Telegram drafts are DM-only).
     chat_type: str = ""
+    # Keep one visible bubble across tool/commentary segment breaks instead of
+    # finalizing each segment and starting a fresh platform message. This is
+    # useful for workspace chat surfaces (notably Feishu/Lark groups) where a
+    # TUI-like single progressively edited message is less noisy than permanent
+    # per-tool bubbles.
+    preserve_message_across_segments: bool = False
+    # Minimum visible codepoints before creating the first streaming preview.
+    # Helps platforms with visible edits avoid tiny "O ▉" style first bubbles.
+    min_initial_preview_chars: int = 4
 
 
 class GatewayStreamConsumer:
@@ -462,6 +471,9 @@ class GatewayStreamConsumer:
                 # tag is not lost.
                 if got_done:
                     self._flush_think_buffer()
+
+                if got_segment_break and self.cfg.preserve_message_across_segments:
+                    got_segment_break = False
 
                 # Decide whether to flush an edit
                 now = time.monotonic()
@@ -1148,7 +1160,7 @@ class GatewayStreamConsumer:
         # This was reported on Telegram, Matrix, and other clients where the
         # ▉ block character renders as a visible white box ("tofu").
         # Existing messages (edits) are unaffected — only first sends gated.
-        _MIN_NEW_MSG_CHARS = 4
+        _MIN_NEW_MSG_CHARS = max(0, int(getattr(self.cfg, "min_initial_preview_chars", 4) or 0))
         if (self._message_id is None
                 and self.cfg.cursor
                 and self.cfg.cursor in text

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -189,11 +189,20 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "discord", "tool_progress") == "all"
 
     def test_medium_tier_platforms(self):
-        """Mattermost, Matrix, Feishu, WhatsApp default to 'new' tool progress."""
+        """Mattermost, Matrix, WhatsApp default to 'new' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("mattermost", "matrix", "feishu", "whatsapp"):
+        for plat in ("mattermost", "matrix", "whatsapp"):
             assert resolve_display_setting({}, plat, "tool_progress") == "new", plat
+
+    def test_feishu_defaults_to_tui_like_quiet_group_chat(self):
+        """Feishu/Lark defaults to quiet, edit-first workspace chat output."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "feishu", "tool_progress") == "off"
+        assert resolve_display_setting({}, "feishu", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "feishu", "busy_ack_detail") is False
+        assert resolve_display_setting({}, "feishu", "cleanup_progress") is True
 
     def test_slack_defaults_tool_progress_off(self):
         """Slack defaults to quiet tool progress (permanent chat noise otherwise)."""

--- a/tests/gateway/test_feishu_group_lane_session.py
+++ b/tests/gateway/test_feishu_group_lane_session.py
@@ -1,0 +1,60 @@
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def test_feishu_plain_group_session_key_is_lane_scoped_across_users():
+    alice = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_w3kits",
+        chat_name="W3Kits Dev",
+        chat_type="group",
+        user_id="ou_alice",
+        user_name="Alice",
+    )
+    bob = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_w3kits",
+        chat_name="W3Kits Dev",
+        chat_type="group",
+        user_id="ou_bob",
+        user_name="Bob",
+    )
+
+    assert build_session_key(alice) == "agent:main:feishu:group:oc_w3kits"
+    assert build_session_key(alice) == build_session_key(bob)
+
+
+def test_feishu_thread_session_key_still_separates_thread():
+    root = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_w3kits",
+        chat_type="group",
+        user_id="ou_alice",
+    )
+    thread = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_w3kits",
+        chat_type="group",
+        thread_id="omt_design",
+        user_id="ou_alice",
+    )
+
+    assert build_session_key(root) == "agent:main:feishu:group:oc_w3kits"
+    assert build_session_key(thread) == "agent:main:feishu:group:oc_w3kits:omt_design"
+
+
+def test_feishu_runner_uses_lane_session_even_when_config_is_per_user():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(group_sessions_per_user=True)
+    runner.session_store = None
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_w3kits",
+        chat_type="group",
+        user_id="ou_alice",
+    )
+
+    assert runner._session_key_for_source(source) == "agent:main:feishu:group:oc_w3kits"

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -27,6 +27,7 @@ def _make_adapter(send_result=None, edit_result=None, max_length=4096):
         return_value=edit_result or SimpleNamespace(success=True)
     )
     adapter.MAX_MESSAGE_LENGTH = max_length
+    adapter.name = "test"
     return adapter
 
 
@@ -227,3 +228,42 @@ class TestFeishuFallbackThreadRouting:
         )
 
         mock_client.im.v1.message.create.assert_called_once()
+
+
+
+class TestFeishuPlainGroupVisibility:
+    """Feishu plain group replies should be top-level visible messages."""
+
+    @pytest.mark.asyncio
+    async def test_plain_feishu_group_ignores_initial_reply_anchor(self):
+        adapter = _make_adapter()
+        adapter.name = "feishu"
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "oc_group",
+            config=StreamConsumerConfig(chat_type="group"),
+            metadata=None,
+            initial_reply_to_id="om_user_msg",
+        )
+
+        await consumer._send_or_edit("Visible answer")
+
+        call_kwargs = adapter.send.call_args[1]
+        assert call_kwargs["reply_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_feishu_topic_keeps_initial_reply_anchor(self):
+        adapter = _make_adapter()
+        adapter.name = "feishu"
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "oc_group",
+            config=StreamConsumerConfig(chat_type="group"),
+            metadata={"thread_id": "omt_topic"},
+            initial_reply_to_id="om_root_msg",
+        )
+
+        await consumer._send_or_edit("Threaded answer")
+
+        call_kwargs = adapter.send.call_args[1]
+        assert call_kwargs["reply_to"] == "om_root_msg"

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -1329,3 +1329,35 @@ async def test_send_retries_retry_after_errors():
     assert result.success is True
     assert result.message_id == "300"
     assert attempt[0] == 2
+
+
+
+def test_reply_anchor_for_feishu_plain_group_is_top_level():
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        message_id="om_user_msg",
+        source=SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="group",
+            thread_id=None,
+        ),
+    )
+
+    assert _reply_anchor_for_event(event) is None
+
+
+def test_reply_anchor_for_feishu_thread_preserves_parent_anchor():
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        message_id="om_reply_msg",
+        reply_to_message_id="om_root_msg",
+        source=SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="group",
+            thread_id="omt_topic",
+        ),
+    )
+
+    assert _reply_anchor_for_event(event) == "om_root_msg"


### PR DESCRIPTION
## Summary
- make Feishu/Lark plain group replies top-level messages instead of hidden inline `message.reply` replies
- make Feishu group delivery quieter and more TUI-like: no tool progress spam, low-frequency edit streaming, preserve one main message across segment boundaries
- make Feishu plain group sessions lane-scoped by chat ID while keeping threads/topics separate

## Test plan
- `uv run --no-project --with pytest --with pytest-asyncio --with pytest-timeout --with pyyaml --with aiohttp --with pydantic --with httpx --with python-dotenv python -m pytest -q tests/gateway/test_feishu_group_lane_session.py tests/gateway/test_display_config.py::TestPlatformDefaults::test_feishu_defaults_to_tui_like_quiet_group_chat tests/gateway/test_stream_consumer_thread_routing.py::TestFeishuPlainGroupVisibility tests/gateway/test_telegram_thread_fallback.py::test_reply_anchor_for_feishu_plain_group_is_top_level tests/gateway/test_telegram_thread_fallback.py::test_reply_anchor_for_feishu_thread_preserves_parent_anchor`
- `git diff --check`