### PR TITLE
fix(cli): run -z oneshot when stdout is non-TTY (SSH/cron/pipe)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,29 +174,62 @@ def run_oneshot(
     # Redirect stderr AND stdout to devnull for the entire call tree.
     # We'll print the final response to the real stdout at the end.
     real_stdout = sys.stdout
+    real_stderr = sys.stderr
     devnull = open(os.devnull, "w", encoding="utf-8")
 
+    response: str | None = None
+    failure: BaseException | None = None
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
-            response = _run_agent(
-                prompt,
-                model=model,
-                provider=provider,
-                toolsets=explicit_toolsets,
-                use_config_toolsets=use_config_toolsets,
-            )
+            try:
+                response = _run_agent(
+                    prompt,
+                    model=model,
+                    provider=provider,
+                    toolsets=explicit_toolsets,
+                    use_config_toolsets=use_config_toolsets,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                # Capture *anything* that escapes the agent (including
+                # OSError from prompt_toolkit/Vt100 when stdout is a non-TTY
+                # pipe, KeyboardInterrupt, SystemExit, etc.) so we can
+                # surface it on the real stderr instead of exiting 0
+                # silently — a silent success in a cron / SSH / subprocess
+                # context is the worst-case failure mode for the caller.
+                # See #30623.
+                failure = exc
     finally:
         try:
             devnull.close()
         except Exception:
             pass
 
+    if failure is not None:
+        # Re-raise control-flow exceptions so the parent handles them as
+        # usual (Ctrl-C / explicit sys.exit() inside the agent).
+        if isinstance(failure, (KeyboardInterrupt, SystemExit)):
+            raise failure
+        real_stderr.write(f"hermes -z: agent failed: {failure}\n")
+        real_stderr.flush()
+        return 1
+
     if response:
         real_stdout.write(response)
         if not response.endswith("\n"):
             real_stdout.write("\n")
         real_stdout.flush()
-    return 0
+        return 0
+
+    # No exception, but also no content from the agent.  Without this guard
+    # the process would exit 0 with empty stdout, indistinguishable from
+    # success — see #30623 (SSH/cron callers had no way to detect failure).
+    real_stderr.write(
+        "hermes -z: agent returned no content (no API response). "
+        "Run `hermes chat` in a terminal to diagnose, or check "
+        "~/.hermes/logs/errors.log for details.\n"
+    )
+    real_stderr.flush()
+    return 1
 
 
 def _create_session_db_for_oneshot():


### PR DESCRIPTION
## Summary

- `hermes -z PROMPT` previously exited 0 with no stdout when the agent path raised before producing content (e.g. prompt_toolkit's `Vt100_Output.flush()` raising `OSError: [Errno 5]` from a non-TTY pipe under SSH `ForceCommand` / cron / subprocess).
- The agent call was wrapped in `redirect_stdout(devnull), redirect_stderr(devnull)` with no `try/except` and no empty-response guard, so any failure inside the redirect was either swallowed (when something downstream caught it and returned `""`) or printed to the now-detached devnull stderr.
- Catch every escaping exception inside the redirect and re-emit it to the *real* stderr; also exit `1` (with a diagnostic message) when the agent returns no content. `KeyboardInterrupt` / `SystemExit` are still re-raised so Ctrl-C and explicit exits behave normally.

This preserves the interactive `-z` behavior (TTY path is unchanged: same redirect, same final stdout write) and is a minimal diff scoped to `hermes_cli/oneshot.py`.

Closes #30623

## Test plan

- [ ] `hermes -z 'Reply with exactly OK and nothing else.' | cat` → produces nonempty stdout, exit 0
- [ ] Force a failure (e.g. invalid `--provider foo --model bar`) under a pipe → nonzero exit with stderr message instead of silent exit 0
- [ ] `hermes -z 'test' > out.txt` (non-TTY stdout) → either real response or loud failure on stderr; never silent success with empty `out.txt`
- [ ] Ctrl-C during `-z` still raises `KeyboardInterrupt` (exit 130), not the new `return 1` path