### PR TITLE
feat: Claude Code Bridge + /interrupt slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7819,6 +7819,30 @@ class HermesCLI:
         except Exception:
             return False
 
+    def _should_handle_interrupt_command_inline(self, text: str, has_images: bool = False) -> bool:
+        """Return True when /interrupt should be dispatched immediately on the UI thread.
+
+        /interrupt MUST bypass the normal _pending_input → process_loop path when
+        the agent is active, because process_loop is blocked inside self.chat()
+        for the duration of the run.  By the time the queued command is pulled
+        from _pending_input, _agent_running has already flipped back to False,
+        and process_command() takes the idle fallback — delivering the message
+        as a next-turn message instead of interrupting mid-run.  Dispatching
+        inline on the UI thread calls agent.interrupt() directly, which is
+        thread-safe (uses _interrupt_requested flag + thread-local signals).
+        """
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        if not getattr(self, "_agent_running", False):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            return bool(cmd and cmd.name == "interrupt")
+        except Exception:
+            return False
+
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
         if getattr(self, "_app", None):
@@ -8631,6 +8655,26 @@ class HermesCLI:
                         _cprint("  Steer rejected (empty payload).")
             else:
                 # No active run — treat as a normal next-turn message.
+                self._pending_input.put(payload)
+                _cprint(f"  No agent running; queued as next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
+        elif canonical == "interrupt":
+            # Kill in-flight tool executions and inject a new message immediately.
+            # If the agent is actively running, call agent.interrupt() which is
+            # thread-safe (uses _interrupt_requested flag + per-thread interrupt
+            # signals).  If no agent is running, fall back to queue semantics.
+            parts = cmd_original.split(None, 1)
+            payload = parts[1].strip() if len(parts) > 1 else ""
+            if not payload:
+                _cprint("  Usage: /interrupt <message>")
+                _cprint("  Aliases: /i <message>")
+            elif self._agent_running and self.agent is not None and hasattr(self.agent, "interrupt"):
+                try:
+                    self.agent.interrupt(payload)
+                except Exception as exc:
+                    _cprint(f"  Interrupt failed: {exc}")
+                else:
+                    _cprint(f"  ⚡ Interrupting with: {payload[:80]}{'...' if len(payload) > 80 else ''}")
+            else:
                 self._pending_input.put(payload)
                 _cprint(f"  No agent running; queued as next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "goal":
@@ -12700,6 +12744,16 @@ class HermesCLI:
                 # post-run next-turn message — defeating mid-run injection.
                 # agent.steer() is thread-safe (holds _pending_steer_lock).
                 if self._should_handle_steer_command_inline(text, has_images=has_images):
+                    self.process_command(text)
+                    event.app.current_buffer.reset(append_to_history=True)
+                    return
+
+                # Handle /interrupt while the agent is running immediately on the
+                # UI thread.  Same reasoning as /steer — queuing through
+                # _pending_input would deadlock the interrupt until after the
+                # agent loop finishes.  agent.interrupt() is thread-safe
+                # (uses _interrupt_requested flag + per-thread interrupt signals).
+                if self._should_handle_interrupt_command_inline(text, has_images=has_images):
                     self.process_command(text)
                     event.app.current_buffer.reset(append_to_history=True)
                     return

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -104,6 +104,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("q",), args_hint="<prompt>"),
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
                args_hint="<prompt>"),
+    CommandDef("interrupt", "Interrupt the agent mid-task and inject a new message", "Session",
+               aliases=("i",), args_hint="<message>"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | pause | resume | clear | status]"),
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1151,7 +1151,7 @@ DEFAULT_CONFIG = {
         # when an exchange was tool-heavy. Set False to restore the legacy
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
-        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        "busy_input_mode": "steer",  # interrupt | queue | steer
         # When true, `hermes --tui` auto-resumes the most recent human-
         # facing session on launch instead of forging a fresh one.
         # Mirrors `hermes -c` muscle memory.  Default off so existing

--- a/scripts/claude-bridge.py
+++ b/scripts/claude-bridge.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Claude Code Bridge — Wraps `claude -p` as an OpenAI-compatible API endpoint.
+
+Routes Hermes agent API calls through the Claude Code CLI using your existing
+Claude Pro/Max subscription — zero API credits burned.
+
+Architecture:
+  Hermes profile (config.yaml: custom_provider → localhost:8800)
+      ↓ HTTP POST /v1/chat/completions
+  claude-bridge.py (this script)
+      ↓ subprocess: claude -p --output-format json --model opus
+  Claude Code CLI (authenticated via OAuth, subscription billing)
+
+Usage:
+  CLAUDE_BIN=/path/to/claude CLAUDE_HOME=/home/user PORT=8800 python3 claude-bridge.py
+
+  All config is via environment variables:
+    CLAUDE_BIN      — path to the `claude` CLI binary (default: finds in PATH)
+    CLAUDE_HOME     — directory containing .claude/.credentials.json (required)
+    PORT            — listen port (default: 8800)
+    HOST            — bind address (default: 127.0.0.1)
+    CLAUDE_MODEL    — model name for Claude Code (default: sonnet)
+    TIMEOUT_SECONDS — subprocess timeout in seconds (default: 300)
+"""
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+import subprocess
+import os
+import uuid
+import time
+import sys
+import shutil
+
+
+def _find_claude_bin() -> str:
+    """Find the Claude Code CLI binary, preferring env var over PATH search."""
+    bin_path = os.environ.get("CLAUDE_BIN", "")
+    if bin_path and os.path.isfile(bin_path):
+        return bin_path
+    found = shutil.which("claude")
+    if found:
+        return found
+    return "claude"  # will fail with a clear FileNotFoundError later
+
+
+CLAUDE_BIN = _find_claude_bin()
+CLAUDE_HOME = os.environ.get("CLAUDE_HOME", os.path.expanduser("~"))
+PORT = int(os.environ.get("PORT", "8800"))
+HOST = os.environ.get("HOST", "127.0.0.1")
+CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL", "sonnet")
+
+# Claude Code flags — print mode, non-interactive, structured JSON output
+CLAUDE_FLAGS = [
+    "--print",
+    "--output-format", "json",
+    "--model", CLAUDE_MODEL,
+    "--no-session-persistence",
+    "--dangerously-skip-permissions",
+]
+
+TIMEOUT_SECONDS = int(os.environ.get("TIMEOUT_SECONDS", "300"))
+
+
+def build_prompt(messages: list) -> str:
+    """Convert OpenAI-format messages into a single prompt for Claude Code."""
+    parts = []
+
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+
+        # Handle array content (multimodal / tool results)
+        if isinstance(content, list):
+            text_parts = []
+            for c in content:
+                t = c.get("type", "")
+                if t == "text":
+                    text_parts.append(c.get("text", ""))
+                elif t == "tool_result":
+                    text_parts.append(
+                        f"[Tool Result: {c.get('tool_use_id', '')}]\n"
+                        f"{c.get('content', '')}"
+                    )
+                elif t == "tool_use":
+                    text_parts.append(
+                        f"[Tool Call: {c.get('name', '')}]\n"
+                        f"{json.dumps(c.get('input', {}), indent=2)}"
+                    )
+                elif t == "image_url":
+                    text_parts.append(
+                        f"[Image: {c.get('image_url', {}).get('url', '')}]"
+                    )
+            content = "\n".join(text_parts)
+
+        content = content.strip()
+        if not content:
+            continue
+
+        if role == "system":
+            parts.append(content)
+        elif role == "user":
+            parts.append(f"User: {content}")
+        elif role == "assistant":
+            parts.append(f"Assistant: {content}")
+
+    prompt = "\n\n".join(parts)
+
+    # Prevent Claude Code from attempting tool use in -p mode
+    prompt += (
+        "\n\n---\n"
+        "Respond directly to the user. Do not attempt to use any tools or "
+        "filesystem operations — just provide your analysis and answer as text."
+    )
+
+    return prompt
+
+
+class BridgeHandler(BaseHTTPRequestHandler):
+    """OpenAI-compatible /v1/chat/completions endpoint."""
+
+    def do_POST(self):
+        if self.path not in ("/v1/chat/completions", "/chat/completions"):
+            self._json_error(404, "Not found")
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            self._json_error(400, "Invalid JSON")
+            return
+
+        messages = data.get("messages", [])
+        model = data.get("model", f"claude-{CLAUDE_MODEL}")
+        stream = data.get("stream", False)
+
+        if stream:
+            self._json_error(501, "Streaming not supported — use non-streaming")
+            return
+
+        prompt = build_prompt(messages)
+        cmd = [CLAUDE_BIN] + CLAUDE_FLAGS + [prompt]
+
+        env = os.environ.copy()
+        env["HOME"] = CLAUDE_HOME  # point Claude Code at OAuth credentials
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=TIMEOUT_SECONDS,
+                env=env,
+                cwd="/tmp",  # neutral cwd — avoids picking up project CLAUDE.md
+            )
+
+            stdout = result.stdout.strip()
+            stderr = result.stderr.strip()
+
+            if not stdout and stderr:
+                self._json_error(500, f"Claude Code error: {stderr[:500]}")
+                return
+
+            try:
+                cc_output = json.loads(stdout)
+            except json.JSONDecodeError:
+                cc_output = {"result": stdout, "is_error": False}
+
+            if cc_output.get("is_error", False):
+                error_text = cc_output.get("result", stdout)[:500]
+                self._json_error(500, error_text)
+                return
+
+            response_text = cc_output.get("result", stdout)
+            usage = cc_output.get("usage", {})
+            cost_usd = cc_output.get("total_cost_usd", 0)
+
+            # Build OpenAI-format response
+            response = {
+                "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": response_text,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": usage.get("input_tokens", 0),
+                    "completion_tokens": usage.get("output_tokens", 0),
+                    "total_tokens": (
+                        usage.get("input_tokens", 0)
+                        + usage.get("output_tokens", 0)
+                    ),
+                },
+            }
+
+            self._json_response(200, response)
+            print(
+                f"[{time.strftime('%H:%M:%S')}] ✓ {len(response_text)} chars, "
+                f"${cost_usd:.4f} USD",
+                flush=True,
+            )
+
+        except subprocess.TimeoutExpired:
+            self._json_error(504, "Claude Code timed out")
+        except FileNotFoundError:
+            self._json_error(
+                500,
+                f"Claude binary not found at {CLAUDE_BIN}. "
+                "Set CLAUDE_BIN or install with: npm install -g @anthropic-ai/claude-code",
+            )
+        except Exception as e:
+            self._json_error(500, str(e))
+
+    def do_GET(self):
+        if self.path in ("/health", "/v1/health", "/"):
+            self._json_response(
+                200,
+                {
+                    "status": "ok",
+                    "claude_bin": CLAUDE_BIN,
+                    "claude_home": CLAUDE_HOME,
+                    "model": CLAUDE_MODEL,
+                },
+            )
+        else:
+            self._json_error(404, "Not found")
+
+    def _json_response(self, code, data):
+        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json_error(self, code, message):
+        self._json_response(
+            code,
+            {
+                "error": {
+                    "message": message,
+                    "type": "bridge_error",
+                    "code": code,
+                }
+            },
+        )
+
+    def log_message(self, format, *args):
+        """Suppress default HTTP logging to stdout."""
+        pass
+
+
+def main():
+    print(f"🧠 Claude Code Bridge")
+    print(f"   Listening: http://{HOST}:{PORT}/v1/chat/completions")
+    print(f"   Claude:    {CLAUDE_BIN}")
+    print(f"   Model:     {CLAUDE_MODEL} (subscription)")
+    print(f"   Timeout:   {TIMEOUT_SECONDS}s")
+    print()
+
+    server = HTTPServer((HOST, PORT), BridgeHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n👋 Shutting down...")
+        server.server_close()
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-bridge.service
+++ b/scripts/claude-bridge.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Claude Code Bridge — wraps claude -p as an OpenAI-compatible API
+Documentation=https://github.com/NousResearch/hermes-agent/blob/main/scripts/claude-bridge.py
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Replace <USER> with the user who owns the Claude OAuth credentials
+User=<USER>
+WorkingDirectory=<HERMES_HOME>/scripts
+ExecStart=/usr/bin/python3 <HERMES_HOME>/scripts/claude-bridge.py
+
+# Environment variables — adjust these to match your setup:
+Environment=HOME=<USER_HOME>/.hermes/profiles/main/home
+Environment=CLAUDE_BIN=<NPM_GLOBAL_PREFIX>/bin/claude
+Environment=CLAUDE_MODEL=sonnet
+# Optional: set to opus for max capability, haiku for speed/cost
+# Environment=CLAUDE_MODEL=opus
+Environment=PORT=8800
+Environment=TIMEOUT_SECONDS=300
+
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Three features from the Stella crew setup at ByteCode:

### 1. Claude Code Bridge (subscription-based Claude access)
Adds a Python HTTP bridge that wraps `claude -p` as an OpenAI-compatible API endpoint. Hermes profiles connect to localhost:8800 as a custom_provider, routing through the Claude Code CLI authenticated via OAuth — zero API credits burned.

- scripts/claude-bridge.py: HTTP server with /v1/chat/completions + /health
- scripts/claude-bridge.service: systemd unit template
- All paths configurable via env vars (CLAUDE_BIN, CLAUDE_HOME, CLAUDE_MODEL, PORT, TIMEOUT_SECONDS)

Use case: Give a Hermes profile (planner, architect, reviewer) access to Claude Opus/Sonnet without per-token API billing.

### 2. /interrupt slash command
Adds /interrupt (alias /i) — interrupts a running agent mid-task and injects a new message. Unlike /steer which waits for the next tool call, /interrupt immediately signals the agent loop to stop tool execution via agent.interrupt().

- hermes_cli/commands.py: register /interrupt with alias /i in COMMAND_REGISTRY
- cli.py: _should_handle_interrupt_command_inline() dispatches on the UI thread so interruption is immediate, bypassing the _pending_input queue

### 3. Default busy_input_mode changed to "steer"
Changes the default behavior when pressing Enter during an active agent run from "interrupt" (kill tool execution immediately) to "steer" (inject message after the next tool call completes).

Steer is less disruptive — it lets the current tool finish before processing new input. Users can override via /busy interrupt or /busy queue.

Config: display.busy_input_mode default: "interrupt" -> "steer"

## Testing
All features battle-tested in production:
- Claude Code Bridge: serving Shikamaru planner profile since May 23, 5d+ uptime
- /interrupt: used daily for mid-task course correction
- Default steer: preferred busy-mode across all profiles