### PR TITLE
fix(skills): verify skill writes persist to disk

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -704,6 +704,121 @@ class TestSecurityScanGate:
 
 
 # ---------------------------------------------------------------------------
+# Post-write persistence verification (issue #31657)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceVerification:
+    """Regression: skill_manage must surface an error — not report success —
+    when the SKILL.md file silently fails to land on disk. Previously the
+    handler trusted ``_atomic_write_text`` and returned ``success: True`` even
+    when the file vanished, leading to skills "disappearing" across sessions.
+    """
+
+    def test_create_reports_failure_when_file_missing_after_write(self, tmp_path):
+        # Simulate a write path that returns without creating the file (e.g.
+        # a buggy atomic_replace, a filesystem that silently drops the rename,
+        # or any future regression in _atomic_write_text). The verifier must
+        # catch this and turn success: True into a structured error.
+        with _skill_dir(tmp_path):
+            with patch("tools.skill_manager_tool._atomic_write_text", return_value=None):
+                result = _create_skill("ghost-skill", VALID_SKILL_CONTENT)
+        assert result["success"] is False
+        assert "ghost-skill" in result["error"]
+        assert "persist" in result["error"].lower()
+        # And the (empty) skill dir must be rolled back so the in-memory
+        # index doesn't show a skill that has no SKILL.md.
+        assert not (tmp_path / "ghost-skill").exists()
+
+    def test_create_reports_failure_when_write_raises(self, tmp_path):
+        # Disk full / permission denied / EIO — the exception must be caught
+        # and converted into a structured error instead of bubbling up and
+        # getting swallowed by the tool dispatcher.
+        with _skill_dir(tmp_path):
+            with patch(
+                "tools.skill_manager_tool._atomic_write_text",
+                side_effect=OSError("disk full"),
+            ):
+                result = _create_skill("doomed-skill", VALID_SKILL_CONTENT)
+        assert result["success"] is False
+        assert "persist" in result["error"].lower()
+        assert "disk full" in result["error"] or "OSError" in result["error"]
+        assert not (tmp_path / "doomed-skill").exists()
+
+    def test_edit_preserves_original_when_persistence_fails(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("keep-me", VALID_SKILL_CONTENT)
+            with patch("tools.skill_manager_tool._atomic_write_text", return_value=None):
+                result = _edit_skill("keep-me", VALID_SKILL_CONTENT_2)
+        assert result["success"] is False
+        # The verification ran on the real write, so the patched no-op produced
+        # the "missing on disk" error. The original SKILL.md must still be on
+        # disk because we did not actually overwrite it.
+        on_disk = (tmp_path / "keep-me" / "SKILL.md").read_text()
+        assert "A test skill for unit testing." in on_disk
+
+    def test_dispatcher_surfaces_persistence_error_via_skill_manage(self, tmp_path):
+        # End-to-end: the JSON the agent sees must carry success=False so the
+        # agent can react (retry, alert the user) instead of building further
+        # work on a phantom skill.
+        with _skill_dir(tmp_path):
+            with patch("tools.skill_manager_tool._atomic_write_text", return_value=None):
+                payload = skill_manage(
+                    action="create",
+                    name="phantom-skill",
+                    content=VALID_SKILL_CONTENT,
+                )
+        decoded = json.loads(payload)
+        assert decoded["success"] is False
+        assert "phantom-skill" in decoded["error"]
+
+    def test_patch_via_dispatcher_reports_failed_persist_and_keeps_original(self, tmp_path):
+        # Same end-to-end guard for action=patch: a write helper that silently
+        # returns without changing disk must not become success=True, and the
+        # original SKILL.md body must remain the source of truth.
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="patch-persist", content=VALID_SKILL_CONTENT)
+            with patch("tools.skill_manager_tool._atomic_write_text", return_value=None):
+                payload = skill_manage(
+                    action="patch",
+                    name="patch-persist",
+                    old_string="Do the thing.",
+                    new_string="Do the new thing.",
+                )
+
+        decoded = json.loads(payload)
+        assert decoded["success"] is False
+        assert "patch-persist" in decoded["error"]
+        assert "persist" in decoded["error"].lower()
+        on_disk = (tmp_path / "patch-persist" / "SKILL.md").read_text()
+        assert "Do the thing." in on_disk
+        assert "Do the new thing." not in on_disk
+
+    def test_write_file_via_dispatcher_rolls_back_new_file_on_failed_persist(self, tmp_path):
+        # New supporting files create their parent directory before the atomic
+        # write. If the write never persists, rollback must remove both the
+        # phantom file and any empty directory it created so the skill tree
+        # matches its pre-write state.
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="write-persist", content=VALID_SKILL_CONTENT)
+            with patch("tools.skill_manager_tool._atomic_write_text", return_value=None):
+                payload = skill_manage(
+                    action="write_file",
+                    name="write-persist",
+                    file_path="references/api.md",
+                    file_content="# API\nEndpoint docs.",
+                )
+
+        decoded = json.loads(payload)
+        assert decoded["success"] is False
+        assert "write-persist" in decoded["error"]
+        assert "references/api.md" in decoded["error"]
+        assert "persist" in decoded["error"].lower()
+        assert not (tmp_path / "write-persist" / "references" / "api.md").exists()
+        assert not (tmp_path / "write-persist" / "references").exists()
+
+
+# ---------------------------------------------------------------------------
 # External skills directories (skills.external_dirs) — mutations in place
 # ---------------------------------------------------------------------------
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -446,6 +446,17 @@ def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Pat
     return target, None
 
 
+def _prune_empty_skill_subdirs(start_dir: Path, skill_dir: Path) -> None:
+    """Remove empty directories created below a skill root during rollback."""
+    current = start_dir
+    while current != skill_dir and current.exists():
+        try:
+            current.rmdir()
+        except OSError:
+            break
+        current = current.parent
+
+
 def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -> None:
     """
     Atomically write text content to a file.
@@ -476,6 +487,40 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
         except OSError:
             logger.error("Failed to remove temporary file %s during atomic write", temp_path, exc_info=True)
         raise
+
+
+def _atomic_write_and_verify(file_path: Path, content: str, encoding: str = "utf-8") -> Optional[str]:
+    """Write atomically, then verify on-disk persistence with one retry."""
+
+    def _attempt() -> Optional[str]:
+        try:
+            _atomic_write_text(file_path, content, encoding=encoding)
+        except Exception as exc:  # noqa: BLE001 - surface any I/O failure
+            return f"write to {file_path} raised {type(exc).__name__}: {exc}"
+        if not os.path.exists(file_path):
+            return f"file does not exist on disk after write: {file_path}"
+        try:
+            written = file_path.read_text(encoding=encoding)
+        except OSError as exc:
+            return f"could not read back {file_path} after write: {exc}"
+        if written != content:
+            return (
+                f"on-disk content of {file_path} does not match what was written "
+                f"(expected {len(content)} chars, got {len(written)})"
+            )
+        return None
+
+    err = _attempt()
+    if err is None:
+        return None
+    logger.warning("skill_manage write verification failed for %s: %s; retrying once", file_path, err)
+    err2 = _attempt()
+    if err2 is None:
+        return None
+    return (
+        f"Skill file was not persisted to disk after two attempts at {file_path}. "
+        f"Last error: {err2}"
+    )
 
 
 # =============================================================================
@@ -514,9 +559,12 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     skill_dir = _resolve_skill_dir(name, category)
     skill_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write SKILL.md atomically
+    # Write SKILL.md atomically and verify it landed on disk.
     skill_md = skill_dir / "SKILL.md"
-    _atomic_write_text(skill_md, content)
+    persist_err = _atomic_write_and_verify(skill_md, content)
+    if persist_err:
+        shutil.rmtree(skill_dir, ignore_errors=True)
+        return {"success": False, "error": f"Failed to persist skill '{name}': {persist_err}"}
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)
@@ -553,13 +601,21 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
 
-    skill_md = existing["path"] / "SKILL.md"
+    skill_dir = existing["path"]
+    skill_md = skill_dir / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
-    _atomic_write_text(skill_md, content)
+    persist_err = _atomic_write_and_verify(skill_md, content)
+    if persist_err:
+        if original_content is not None:
+            try:
+                _atomic_write_text(skill_md, original_content)
+            except Exception:
+                logger.warning("Rollback after persistence failure on %s also failed", skill_md, exc_info=True)
+        return {"success": False, "error": f"Failed to persist skill '{name}': {persist_err}"}
 
     # Security scan — roll back on block
-    scan_error = _security_scan_skill(existing["path"])
+    scan_error = _security_scan_skill(skill_dir)
     if scan_error:
         if original_content is not None:
             _atomic_write_text(skill_md, original_content)
@@ -652,7 +708,13 @@ def _patch_skill(
             }
 
     original_content = content  # for rollback
-    _atomic_write_text(target, new_content)
+    persist_err = _atomic_write_and_verify(target, new_content)
+    if persist_err:
+        try:
+            _atomic_write_text(target, original_content)
+        except Exception:
+            logger.warning("Rollback after persistence failure on %s also failed", target, exc_info=True)
+        return {"success": False, "error": f"Failed to persist patch to '{name}': {persist_err}"}
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)
@@ -751,13 +813,27 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name, " Create it first with action='create'.")}
 
-    target, err = _resolve_skill_target(existing["path"], file_path)
+    skill_dir = existing["path"]
+    target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
         return {"success": False, "error": err}
     target.parent.mkdir(parents=True, exist_ok=True)
     # Back up for rollback
     original_content = target.read_text(encoding="utf-8") if target.exists() else None
-    _atomic_write_text(target, file_content)
+    persist_err = _atomic_write_and_verify(target, file_content)
+    if persist_err:
+        if original_content is not None:
+            try:
+                _atomic_write_text(target, original_content)
+            except Exception:
+                logger.warning("Rollback after persistence failure on %s also failed", target, exc_info=True)
+        else:
+            try:
+                target.unlink(missing_ok=True)
+            except OSError:
+                pass
+            _prune_empty_skill_subdirs(target.parent, skill_dir)
+        return {"success": False, "error": f"Failed to persist file '{file_path}' to skill '{name}': {persist_err}"}
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(existing["path"])
@@ -766,6 +842,7 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
             _atomic_write_text(target, original_content)
         else:
             target.unlink(missing_ok=True)
+            _prune_empty_skill_subdirs(target.parent, skill_dir)
         return {"success": False, "error": scan_error}
 
     return {


### PR DESCRIPTION
## Problem

`skill_manage` could report `{ "success": true }` for `create`, `edit`, `patch`, and `write_file` even when the target `SKILL.md` or supporting file did not persist to disk. That let the in-memory skill index continue as if the write succeeded, while the skill disappeared after the next reload.

Closes #31657.

## Root Cause

`tools/skill_manager_tool.py` trusted `_atomic_write_text()` once it returned. There was no post-write existence/read-back check, so a dropped replace, swallowed filesystem issue, or other no-op write path could become a false success.

## Fix

- Added `_atomic_write_and_verify(...)`, which writes atomically, verifies the file exists, reads it back, compares exact content, and retries once before returning a structured persistence error.
- Applied that verified write path to `_create_skill`, `_edit_skill`, `_patch_skill`, and `_write_file`.
- Added rollback for failed persistence:
  - new skill dirs are removed on failed create,
  - edits and patches best-effort restore the original content,
  - failed new supporting-file writes remove the phantom file and prune empty skill subdirectories.
- Preserved the existing security-scan rollback behavior.

## Review State

- Rebased onto current `upstream/main` at `9c051f57c3b1e9962feef958710ee58fa8ca2444`.
- No PR comments or reviews were present when refreshed.
- The fork branch ref is now `ff02fd2debf13d2554ebae8fd7a76e3c0019641c`.

## Verification

RED on current main before the fix:

- `pytest tests\tools\test_skill_manager_tool.py::TestPersistenceVerification -q --timeout-method=thread` -> 6 failures, reproducing false success / unstructured failure behavior.

GREEN after the fix:

- `.venv\Scripts\python.exe -m pytest tests\tools\test_skill_manager_tool.py::TestPersistenceVerification -q --timeout-method=thread` -> 6 passed.
- `.venv\Scripts\python.exe -m pytest tests\tools\test_skill_manager_tool.py tests\tools\test_skill_size_limits.py tests\tools\test_skill_improvements.py -q --timeout-method=thread` -> 116 passed, 3 skipped.
- `.venv\Scripts\ruff.exe check tools\skill_manager_tool.py tests\tools\test_skill_manager_tool.py tests\tools\test_skill_size_limits.py tests\tools\test_skill_improvements.py` -> passed.
- `.venv\Scripts\python.exe -m py_compile tools\skill_manager_tool.py tests\tools\test_skill_manager_tool.py tests\tools\test_skill_size_limits.py tests\tools\test_skill_improvements.py` -> passed.
- `git diff --check` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> `a70339cd10ce069416007fd64063c4a2b734543a`.

## Risk

Adds one read-back per skill write, plus a single retry only on mismatch/missing file. The public `skill_manage` schema is unchanged; failed writes now surface accurately as `success: false` instead of false-positive success.