### PR TITLE
feat(tts): add Volcengine Doubao provider

### DIFF
--- a/tests/tools/test_tts_volcengine.py
+++ b/tests/tools/test_tts_volcengine.py
@@ -1,0 +1,206 @@
+"""Tests for the Volcengine / Doubao TTS provider in tools/tts_tool.py."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("VOLCENGINE_TTS_API_KEY", "VOLC_ACCESS_KEY", "VOLC_APP_ID", "VOLCENGINE_TTS_APP_ID", "HERMES_SESSION_PLATFORM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+class _MockStreamResponse:
+    def __init__(self, lines):
+        self._lines = lines
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self, decode_unicode=False):
+        for line in self._lines:
+            yield line
+
+
+class _MockJsonResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class TestGenerateVolcengineTts:
+    def test_missing_api_key_raises_value_error(self, tmp_path):
+        from tools.tts_tool import _generate_volcengine_tts
+
+        with pytest.raises(ValueError, match="VOLCENGINE_TTS_API_KEY / VOLC_ACCESS_KEY"):
+            _generate_volcengine_tts("Hello", str(tmp_path / "test.mp3"), {})
+
+    def test_missing_app_id_raises_value_error(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_volcengine_tts
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        with pytest.raises(ValueError, match="VOLCENGINE_TTS_APP_ID"):
+            _generate_volcengine_tts("Hello", str(tmp_path / "test.mp3"), {})
+
+    def test_successful_generation_writes_audio(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_volcengine_tts
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        monkeypatch.setenv("VOLC_APP_ID", "app-123")
+        response = _MockJsonResponse({
+            "code": 3000,
+            "message": "Success",
+            "data": base64.b64encode(b"hello-world").decode(),
+        })
+
+        with patch("requests.post", return_value=response) as mock_post:
+            output_path = str(tmp_path / "test.mp3")
+            result = _generate_volcengine_tts("Hello world", output_path, {})
+
+        assert result == output_path
+        assert (tmp_path / "test.mp3").read_bytes() == b"hello-world"
+
+        kwargs = mock_post.call_args[1]
+        assert kwargs["headers"]["Authorization"] == "Bearer;test-key"
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+        assert kwargs["json"]["app"]["appid"] == "app-123"
+        assert kwargs["json"]["app"]["cluster"] == "volcano_tts"
+        assert kwargs["json"]["audio"]["voice_type"] == "zh_female_vv_uranus_bigtts"
+        assert kwargs["json"]["audio"]["encoding"] == "mp3"
+        assert kwargs["json"]["request"]["text"] == "Hello world"
+        assert kwargs["json"]["request"]["operation"] == "query"
+        assert kwargs["timeout"] == 60
+
+    def test_ogg_extension_uses_ogg_opus_format(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_volcengine_tts
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        monkeypatch.setenv("VOLC_APP_ID", "app-123")
+        response = _MockJsonResponse({
+            "code": 3000,
+            "message": "Success",
+            "data": base64.b64encode(b"audio").decode(),
+        })
+
+        with patch("requests.post", return_value=response) as mock_post:
+            _generate_volcengine_tts("Hello", str(tmp_path / "test.ogg"), {})
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["audio"]["encoding"] == "ogg_opus"
+        assert payload["audio"]["compression_rate"] == 1
+
+    def test_global_speed_maps_to_speed_ratio(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_volcengine_tts
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        monkeypatch.setenv("VOLC_APP_ID", "app-123")
+        response = _MockJsonResponse({
+            "code": 3000,
+            "message": "Success",
+            "data": base64.b64encode(b"audio").decode(),
+        })
+
+        with patch("requests.post", return_value=response) as mock_post:
+            _generate_volcengine_tts("Hello", str(tmp_path / "test.mp3"), {"speed": 1.5})
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["audio"]["encoding"] == "mp3"
+        assert payload["audio"]["speed_ratio"] == 1.5
+        assert payload["audio"]["volume_ratio"] == 1.0
+        assert payload["audio"]["pitch_ratio"] == 1.0
+
+    def test_provider_speed_overrides_global_speed(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_volcengine_tts
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        monkeypatch.setenv("VOLC_APP_ID", "app-123")
+        response = _MockJsonResponse({
+            "code": 3000,
+            "message": "Success",
+            "data": base64.b64encode(b"audio").decode(),
+        })
+
+        with patch("requests.post", return_value=response) as mock_post:
+            _generate_volcengine_tts(
+                "Hello",
+                str(tmp_path / "test.mp3"),
+                {"speed": 1.5, "volcengine": {"speed": 0.8}},
+            )
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["audio"]["speed_ratio"] == 0.8
+
+    def test_api_error_code_raises_runtime_error(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_volcengine_tts
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        monkeypatch.setenv("VOLC_APP_ID", "app-123")
+        response = _MockJsonResponse({"code": 3031, "message": "bad request", "data": None})
+
+        with patch("requests.post", return_value=response):
+            with pytest.raises(RuntimeError, match="bad request"):
+                _generate_volcengine_tts("Hello", str(tmp_path / "test.mp3"), {})
+
+
+class TestTtsDispatcherVolcengine:
+    def test_dispatcher_routes_to_volcengine(self, tmp_path, monkeypatch):
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        monkeypatch.setenv("VOLC_APP_ID", "app-123")
+        response = _MockJsonResponse({
+            "code": 3000,
+            "message": "Success",
+            "data": base64.b64encode(b"audio").decode(),
+        })
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "volcengine"}), \
+             patch("requests.post", return_value=response):
+            result = json.loads(text_to_speech_tool("Hello", output_path=str(tmp_path / "out.mp3")))
+
+        assert result["success"] is True
+        assert result["provider"] == "volcengine"
+
+
+class TestCheckTtsRequirementsVolcengine:
+    def test_volcengine_key_and_app_id_return_true(self, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        monkeypatch.setenv("VOLC_APP_ID", "app-123")
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._import_mistral_client", side_effect=ImportError), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False):
+            assert check_tts_requirements() is True
+
+    def test_volcengine_key_without_app_id_returns_false(self, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        monkeypatch.setenv("VOLCENGINE_TTS_API_KEY", "test-key")
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._import_mistral_client", side_effect=ImportError), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False):
+            assert check_tts_requirements() is False
+
+    def test_volcengine_key_missing_returns_false(self):
+        from tools.tts_tool import check_tts_requirements
+
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._import_mistral_client", side_effect=ImportError), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False):
+            assert check_tts_requirements() is False

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -10,6 +10,7 @@ Built-in TTS providers:
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
 - xAI TTS: Grok voices, uses xAI Grok OAuth credentials or XAI_API_KEY
+- Volcengine / Doubao TTS: Chinese TTS, needs VOLCENGINE_TTS_API_KEY/VOLC_ACCESS_KEY and VOLC_APP_ID
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
 - Piper (local, free, no API key): OHF-Voice/piper1-gpl neural VITS, 44 languages
@@ -172,6 +173,11 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_VOLCENGINE_TTS_BASE_URL = "https://openspeech.bytedance.com/api/v1/tts"
+DEFAULT_VOLCENGINE_TTS_CLUSTER = "volcano_tts"
+DEFAULT_VOLCENGINE_TTS_VOICE = "zh_female_vv_uranus_bigtts"
+DEFAULT_VOLCENGINE_TTS_RESOURCE_ID = "seed-tts-2.0"
+DEFAULT_VOLCENGINE_TTS_SAMPLE_RATE = 24000
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -197,6 +203,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
     "gemini": 5000,       # Gemini TTS caps at ~8k input tokens / ~655s audio
+    "volcengine": 5000,   # conservative sync HTTP v1 cap for Doubao TTS
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
@@ -344,6 +351,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "xai",
     "mistral",
     "gemini",
+    "volcengine",
     "neutts",
     "kittentts",
     "piper",
@@ -1336,6 +1344,115 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
 
 
 # ===========================================================================
+# Provider: Volcengine / Doubao TTS
+# ===========================================================================
+def _generate_volcengine_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Volcengine / Doubao TTS HTTP v1 API."""
+    import requests
+
+    api_key = (
+        get_env_value("VOLC_ACCESS_KEY")
+        or get_env_value("VOLCENGINE_TTS_API_KEY")
+        or ""
+    ).strip()
+    if not api_key:
+        raise ValueError(
+            "VOLCENGINE_TTS_API_KEY / VOLC_ACCESS_KEY not set. Configure one in ~/.hermes/.env or the environment."
+        )
+
+    vc_config = tts_config.get("volcengine", {})
+    app_id = str(
+        vc_config.get("app_id")
+        or get_env_value("VOLCENGINE_TTS_APP_ID")
+        or get_env_value("VOLC_APP_ID")
+        or ""
+    ).strip()
+    if not app_id:
+        raise ValueError(
+            "VOLCENGINE_TTS_APP_ID (or VOLC_APP_ID) not set. Volcengine HTTP v1 requires an appid."
+        )
+
+    voice = str(vc_config.get("voice", DEFAULT_VOLCENGINE_TTS_VOICE)).strip() or DEFAULT_VOLCENGINE_TTS_VOICE
+    cluster = str(vc_config.get("cluster", DEFAULT_VOLCENGINE_TTS_CLUSTER)).strip() or DEFAULT_VOLCENGINE_TTS_CLUSTER
+    sample_rate = int(vc_config.get("sample_rate", DEFAULT_VOLCENGINE_TTS_SAMPLE_RATE))
+    base_url = str(vc_config.get("base_url", DEFAULT_VOLCENGINE_TTS_BASE_URL)).strip() or DEFAULT_VOLCENGINE_TTS_BASE_URL
+
+    speed = vc_config.get("speed", tts_config.get("speed", 1.0))
+    try:
+        speed_ratio = max(0.2, min(3.0, float(speed)))
+    except (TypeError, ValueError):
+        speed_ratio = 1.0
+
+    if output_path.endswith(".ogg"):
+        audio_format = "ogg_opus"
+    elif output_path.endswith(".wav"):
+        audio_format = "wav"
+    elif output_path.endswith(".pcm"):
+        audio_format = "pcm"
+    else:
+        audio_format = "mp3"
+
+    audio_payload: Dict[str, Any] = {
+        "voice_type": voice,
+        "encoding": audio_format,
+        "rate": sample_rate,
+        "speed_ratio": speed_ratio,
+        "volume_ratio": 1.0,
+        "pitch_ratio": 1.0,
+    }
+    if audio_format == "ogg_opus":
+        audio_payload["compression_rate"] = int(vc_config.get("compression_rate", 1))
+
+    payload = {
+        "app": {
+            "appid": app_id,
+            "token": str(vc_config.get("token", "hermes")).strip() or "hermes",
+            "cluster": cluster,
+        },
+        "user": {"uid": "hermes"},
+        "audio": audio_payload,
+        "request": {
+            "reqid": str(uuid.uuid4()),
+            "text": text,
+            "text_type": "plain",
+            "operation": "query",
+            "silence_duration": str(vc_config.get("silence_duration", 800)),
+            "pure_english_opt": "1",
+            "extra_param": json.dumps({"disable_emoji_filter": True}),
+        },
+    }
+
+    response = requests.post(
+        base_url,
+        headers={
+            "Authorization": f"Bearer;{api_key}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise RuntimeError(f"Volcengine TTS returned invalid JSON: {response.text[:300]}") from exc
+
+    code = data.get("code")
+    if code not in (3000, 0, None):
+        raise RuntimeError(data.get("message") or f"Volcengine TTS API error (code {code})")
+
+    audio_b64 = data.get("data")
+    if not audio_b64:
+        raise RuntimeError("Volcengine TTS returned no audio data")
+
+    with open(output_path, "wb") as f:
+        f.write(base64.b64decode(audio_b64))
+
+    return output_path
+
+
+# ===========================================================================
 # Provider: Google Gemini TTS
 # ===========================================================================
 def _wrap_pcm_as_wav(
@@ -1885,7 +2002,7 @@ def text_to_speech_tool(
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "volcengine"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -1969,6 +2086,10 @@ def text_to_speech_tool(
         elif provider == "gemini":
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
+
+        elif provider == "volcengine":
+            logger.info("Generating speech with Volcengine / Doubao TTS...")
+            _generate_volcengine_tts(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -2078,7 +2199,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
+        elif provider in {"elevenlabs", "openai", "mistral", "gemini", "volcengine"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)
@@ -2158,6 +2279,10 @@ def check_tts_requirements() -> bool:
     except Exception:
         pass
     if get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY"):
+        return True
+    volcengine_api_key = get_env_value("VOLCENGINE_TTS_API_KEY") or get_env_value("VOLC_ACCESS_KEY")
+    volcengine_app_id = get_env_value("VOLCENGINE_TTS_APP_ID") or get_env_value("VOLC_APP_ID")
+    if volcengine_api_key and volcengine_app_id:
         return True
     try:
         _import_mistral_client()


### PR DESCRIPTION
## Summary
- add a built-in `volcengine` / Doubao TTS provider using the HTTP v1 API
- support native OGG/Opus output for Telegram voice delivery
- validate both API key and app id availability via Hermes env resolution
- add regression coverage for generation, dispatch, output format, speed mapping, API errors, and requirements detection

## Test plan
- `python -m pytest tests/tools/test_tts_volcengine.py tests/tools/test_tts_opus_routing.py tests/tools/test_tts_dotenv_fallback.py tests/tools/test_tts_plugin_dispatch.py tests/tools/test_tts_speed.py -q -o 'addopts='` — 75 passed
- manual live smoke test generated OGG/Opus audio with provider=volcengine and voice_compatible=true

## Notes
- Credentials are read from existing Hermes env resolution helpers; no secrets are committed.
