### PR TITLE
fix(windows): write planned_stop_marker on stop() to match Unix behavior (#33778)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1019,6 +1019,18 @@ def stop() -> None:
     _assert_windows()
     from hermes_cli.gateway import kill_gateway_processes
 
+    # Write the planned-stop marker so the gateway knows this is a deliberate
+    # restart (not a crash). On Unix, stop() does this before SIGTERM; Windows
+    # needs the same so the gateway's shutdown handler skips resume_pending.
+    try:
+        from gateway.status import get_running_pid, write_planned_stop_marker
+
+        pid = get_running_pid()
+        if pid is not None:
+            write_planned_stop_marker(pid)
+    except Exception:
+        pass  # Best-effort; non-zero exit is sufficient signal on platforms without markers
+
     stopped_any = False
     if is_task_registered():
         code, _out, err = _exec_schtasks(["/End", "/TN", get_task_name()])

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -482,3 +482,63 @@ def test_uninstall_access_denied_declined_keeps_task_and_cleans_files(monkeypatc
     assert "Skipped elevation" in out
     assert "UAC is Windows' admin approval prompt" in out
     assert "Scheduled Task still registered" in out
+
+
+def test_stop_writes_planned_stop_marker(monkeypatch):
+    """stop() writes the planned-stop marker before sending SIGTERM so the gateway
+    knows this is a deliberate restart (not a crash)."""
+    written_pids = []
+
+    def mock_get_running_pid(*args, **kwargs):
+        return 12345
+
+    def mock_write_marker(pid):
+        written_pids.append(pid)
+
+    def mock_kill_gateway_processes(*args, **kwargs):
+        return 0  # no stragglers
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gateway, "kill_gateway_processes", mock_kill_gateway_processes)
+
+    # Inject a fake gateway.status module so stop() finds our mocks
+    import sys
+    from types import ModuleType
+
+    fake_status = ModuleType("gateway.status")
+    fake_status.get_running_pid = mock_get_running_pid
+    fake_status.write_planned_stop_marker = mock_write_marker
+    monkeypatch.setitem(sys.modules, "gateway.status", fake_status)
+
+    gateway_windows.stop()
+
+    assert written_pids == [12345], f"Expected [12345], got {written_pids}"
+
+
+def test_stop_continues_when_marker_write_fails(monkeypatch):
+    """If writing the marker fails (e.g., permissions), stop() still terminates processes."""
+    calls = []
+
+    def mock_kill_gateway_processes(all_profiles=False):
+        calls.append("kill_called")
+        return 1
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gateway, "kill_gateway_processes", mock_kill_gateway_processes)
+
+    import sys
+    from types import ModuleType
+
+    fake_status = ModuleType("gateway.status")
+
+    def mock_get_running_pid_raises(*args, **kwargs):
+        raise OSError("simulated permission denied")
+
+    fake_status.get_running_pid = mock_get_running_pid_raises
+    monkeypatch.setitem(sys.modules, "gateway.status", fake_status)
+
+    gateway_windows.stop()
+
+    assert "kill_called" in calls, "kill_gateway_processes should still be called even if marker write fails"


### PR DESCRIPTION
## Fix Summary

**Issue**: [Issue #33778](https://github.com/NousResearch/hermes-agent/issues/33778) — Windows restart does not write `planned_stop_marker`

When the gateway is stopped via `schtasks /End` on Windows, no `planned_stop_marker` is written. This causes the gateway to detect the stop as an unexpected crash and refuse to restart automatically.

**Root Cause**: `stop()` in `hermes_cli/gateway_windows.py` calls `schtasks /End` to terminate the gateway task but never writes the `planned_stop_marker` file. The Unix implementation in `gateway.py` does write this marker.

**Fix**: Call `write_planned_stop_marker(pid)` at the start of `stop()` before sending SIGTERM, with a try/except so that transient failures (permissions, disk full) do not prevent process termination.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/gateway_windows.py` | +12 lines: `write_planned_stop_marker(pid)` call in `stop()` |
| `tests/hermes_cli/test_gateway_windows.py` | +62 lines: 2 new tests |

## Testing

```
tests/hermes_cli/test_gateway_windows.py::test_stop_writes_planned_stop_marker PASSED
tests/hermes_cli/test_gateway_windows.py::test_stop_continues_when_marker_write_fails PASSED
# full suite: 23/23 passed (1.01s)
```

## Verification

1. **Build**: `ruff check hermes_cli/gateway_windows.py` — pass
2. **Tests**: `pytest tests/hermes_cli/test_gateway_windows.py -o "addopts=" -q` — 23/23 passed
3. **Manual** (Windows): `hermes gateway stop` followed by `hermes gateway start` — restart should succeed without "crash detected" warning

Closes #33778
