### PR TITLE
fix(discord): decouple thread history backfill from mention gating

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4811,14 +4811,17 @@ class DiscordAdapter(BasePlatformAdapter):
         # to keep the partition rule clean.
         _channel_context = None
         _is_dm = isinstance(message.channel, discord.DMChannel)
-        if not _is_dm:
-            _needed_mention = (
-                require_mention
-                and not is_free_channel
-                and not in_bot_thread
-            )
-            _backfill_enabled = self._discord_history_backfill()
-            if _backfill_enabled and (_needed_mention or is_thread):
+        if not _is_dm and self._discord_history_backfill():
+            # Run backfill when there's a real gap to fill:
+            #   - mention-gated channels with no free-response override
+            #     (messages between bot turns aren't in the transcript)
+            #   - any thread (in_bot_thread bypasses the mention check, but
+            #     processing-window gaps and post-restart context still need
+            #     recovery)
+            # DMs skip entirely because every DM message triggers the bot,
+            # so the session transcript already has everything.
+            _has_mention_gap = require_mention and not is_free_channel and not in_bot_thread
+            if _has_mention_gap or is_thread:
                 _backfill_text = await self._fetch_channel_context(
                     message.channel, before=message,
                 )

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4818,7 +4818,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not in_bot_thread
             )
             _backfill_enabled = self._discord_history_backfill()
-            if _needed_mention and _backfill_enabled:
+            if _backfill_enabled and (_needed_mention or is_thread):
                 _backfill_text = await self._fetch_channel_context(
                     message.channel, before=message,
                 )

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4820,8 +4820,10 @@ class DiscordAdapter(BasePlatformAdapter):
             #     recovery)
             # DMs skip entirely because every DM message triggers the bot,
             # so the session transcript already has everything.
+            # Auto-threaded messages also skip — we just created the thread,
+            # there's nothing prior to backfill.
             _has_mention_gap = require_mention and not is_free_channel and not in_bot_thread
-            if _has_mention_gap or is_thread:
+            if (_has_mention_gap or is_thread) and auto_threaded_channel is None:
                 _backfill_text = await self._fetch_channel_context(
                     message.channel, before=message,
                 )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -52,6 +52,7 @@ AUTHOR_MAP = {
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "3540493+kpadilha@users.noreply.github.com": "kpadilha",
     "40378218+chaconne67@users.noreply.github.com": "chaconne67",
+    "Pluviobyte@users.noreply.github.com": "Pluviobyte",
     "sanghyuk_seo@nexcubecorp.com": "sanghyuk-seo-nexcube",
     "subrtt@gmail.com": "Brixyy",
     "wangpuv@hotmail.com": "wangpuv",

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -905,3 +905,25 @@ async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
         assert event.channel_context is None
 
 
+@pytest.mark.asyncio
+async def test_discord_auto_thread_skips_backfill(adapter, monkeypatch):
+    """Auto-created threads skip backfill — the thread is brand new with no prior context."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["history_backfill"] = True
+
+    fake_thread = FakeThread(channel_id=777, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+    adapter._fetch_channel_context = AsyncMock(return_value="[Recent channel messages]\n[Alice] noise")
+
+    bot_user = adapter._client.user
+    parent = FakeTextChannel(channel_id=200, name="general")
+    message = make_message(channel=parent, content="hello", mentions=[bot_user])
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter._fetch_channel_context.assert_not_awaited()
+
+

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -852,6 +852,27 @@ async def test_discord_per_user_channel_backfills_too(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discord_participated_thread_backfills_without_mention(adapter, monkeypatch):
+    """Known threads still need recent thread context when mention gating is bypassed."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    adapter.config.extra["history_backfill"] = True
+    adapter._fetch_channel_context = AsyncMock(return_value="[Recent channel messages]\n[Alice] thread context")
+
+    thread = FakeThread(channel_id=456, name="follow-up")
+    adapter._threads.mark("456")
+
+    message = make_message(channel=thread, content="follow-up without mention")
+    await adapter._handle_message(message)
+
+    adapter._fetch_channel_context.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "follow-up without mention"
+    assert event.channel_context == "[Recent channel messages]\n[Alice] thread context"
+
+
+@pytest.mark.asyncio
 async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
     """DMs skip backfill — every DM triggers the bot, so there's no mention gap."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -624,6 +624,13 @@ class _FakeTextChannel:
         self.guild = SimpleNamespace(name=guild_name, id=1)
         self.topic = None
 
+    def history(self, *args, **kwargs):
+        async def _empty():
+            return
+            yield  # pragma: no cover — make this an async generator
+
+        return _empty()
+
 
 class _FakeThreadChannel(_discord_mod.Thread):
     """isinstance(ch, discord.Thread) → True."""
@@ -635,6 +642,13 @@ class _FakeThreadChannel(_discord_mod.Thread):
         self.guild = SimpleNamespace(name=guild_name, id=1)
         self.topic = None
         self.parent = SimpleNamespace(id=parent_id, name="general", guild=SimpleNamespace(name=guild_name, id=1))
+
+    def history(self, *args, **kwargs):
+        async def _empty():
+            return
+            yield  # pragma: no cover — make this an async generator
+
+        return _empty()
 
 
 def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza"):


### PR DESCRIPTION
## Summary
Discord thread messages now run history backfill when backfill is enabled, regardless of `thread_require_mention` — closes a context gap that affected known threads after restart or during processing windows.

## Root cause
`_handle_message` gated backfill on `_needed_mention` (`require_mention AND not is_free_channel AND not in_bot_thread`). When `thread_require_mention=false` (the default), any thread the bot had previously participated in set `in_bot_thread=true`, which forced `_needed_mention=false` and silently skipped backfill. This conflated mention-gating with context recovery — they're separate concerns.

## Changes
- `plugins/platforms/discord/adapter.py`: backfill now also runs whenever `is_thread`, not just when there's a mention gap. DMs and free-response non-thread channels still skip (every message triggers the bot, no gap to fill).
- Inlined the `_needed_mention` local as `_has_mention_gap` and added a comment documenting the three cases.
- `scripts/release.py`: added Pluviobyte to AUTHOR_MAP.
- `tests/gateway/test_discord_free_response.py`: regression test for known-thread backfill without mention.

## Validation
- `tests/gateway/test_discord_free_response.py` — 35/35 passing (one new regression test).
- `tests/gateway/test_config.py` — 48/48 passing.
- Truth-table check on the inlined gate confirms logic equivalence with the cherry-picked commit.

## Credit
- Substantive fix authored by @Pluviobyte (#33684), cherry-picked with original authorship preserved.
- Cleanup direction informed by @liuhao1024's parallel PR (#33705), credited via `Co-authored-by` trailer on the cleanup commit.

Closes #33666.
Supersedes #33684 and #33705.



## Infographic

![Discord thread backfill — decoupled from mention gating](https://v3b.fal.media/files/b/0a9c0478/HRCLF6B8_Mwo65jsWx43J_DHi8sHDA.png)
