### PR TITLE
fix(security): route shell-like MCP tool calls through approval gate

### DIFF
--- a/tests/tools/test_mcp_approval_gate.py
+++ b/tests/tools/test_mcp_approval_gate.py
@@ -1,0 +1,335 @@
+"""Regression tests for the MCP shell-like tool approval gate (#32877).
+
+Before this gate existed, ``tools/approval.py`` was only wired into
+``tools/terminal_tool.py``.  Any destructive command issued through a
+shell-wrapping MCP server (``ssh``, ``docker``, the official
+``@modelcontextprotocol/server-shell``, etc.) bypassed the dangerous-
+command + Smart-mode + hardline pipeline entirely — no regex check, no
+approval prompt, no audit trail.
+
+The fix in ``tools/mcp_tool.py`` adds a transport-layer gate:
+
+* If the MCP tool's name matches a known shell/exec fragment
+  (``shell``, ``bash``, ``exec``, ``run_command``, ``execute``, …),
+* AND the arguments expose a command-shaped field (``command``, ``cmd``,
+  ``args``, ``script``, …),
+* the candidate command is routed through ``check_all_command_guards``
+  with ``env_type="local"`` BEFORE ``server.session.call_tool`` is
+  invoked.
+
+These tests lock in that behavior end-to-end via the existing tool
+handler factory, mirroring the patterns used in ``test_mcp_tool.py``
+and ``test_mcp_circuit_breaker.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrored from tests/tools/test_mcp_tool.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_call_result(text: str = "ok", is_error: bool = False):
+    block = SimpleNamespace(text=text)
+    return SimpleNamespace(content=[block], isError=is_error, structuredContent=None)
+
+
+def _install_stub_server(mcp_tool, name: str, call_tool: AsyncMock):
+    from tools.mcp_tool import MCPServerTask
+
+    server = MCPServerTask(name)
+    session = MagicMock()
+    session.call_tool = call_tool
+    server.session = session
+    mcp_tool._servers[name] = server
+    mcp_tool._server_error_counts.pop(name, None)
+    if hasattr(mcp_tool, "_server_breaker_opened_at"):
+        mcp_tool._server_breaker_opened_at.pop(name, None)
+    return server
+
+
+def _patch_mcp_loop():
+    def fake_run(coro_or_factory, timeout=30):
+        coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+        return asyncio.run(coro)
+
+    return patch("tools.mcp_tool._run_on_mcp_loop", side_effect=fake_run)
+
+
+@pytest.fixture(autouse=True)
+def _reset_approval_state():
+    """Approval state is process-global; reset around every test."""
+    from tools import approval
+
+    saved = {
+        k: os.environ.get(k)
+        for k in (
+            "HERMES_INTERACTIVE",
+            "HERMES_GATEWAY_SESSION",
+            "HERMES_YOLO_MODE",
+            "HERMES_CRON_SESSION",
+            "HERMES_SESSION_KEY",
+        )
+    }
+    for k in list(saved):
+        os.environ.pop(k, None)
+    approval._session_approved.clear()
+    approval._session_yolo.clear()
+    approval._permanent_approved.clear()
+    approval._pending.clear()
+    approval._gateway_queues.clear()
+    approval._gateway_notify_cbs.clear()
+    yield
+    approval._session_approved.clear()
+    approval._session_yolo.clear()
+    approval._permanent_approved.clear()
+    approval._pending.clear()
+    approval._gateway_queues.clear()
+    approval._gateway_notify_cbs.clear()
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper coverage
+# ---------------------------------------------------------------------------
+
+
+class TestShellLikeDetection:
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "shell",
+            "bash",
+            "exec",
+            "execute",
+            "execute_command",
+            "run_command",
+            "runShell",
+            "docker_exec",
+            "ssh_exec",
+            "subprocess_run",
+            "spawn_process",
+        ],
+    )
+    def test_shell_like_names_detected(self, tool_name):
+        from tools.mcp_tool import _is_shell_like_mcp_tool
+
+        assert _is_shell_like_mcp_tool(tool_name) is True
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["read_file", "search_web", "list_resources", "get_weather", "", "fetch_url"],
+    )
+    def test_safe_names_not_detected(self, tool_name):
+        from tools.mcp_tool import _is_shell_like_mcp_tool
+
+        assert _is_shell_like_mcp_tool(tool_name) is False
+
+
+class TestCommandExtraction:
+    def test_command_key(self):
+        from tools.mcp_tool import _extract_mcp_command_payload
+
+        assert _extract_mcp_command_payload({"command": "ls -la"}) == "ls -la"
+
+    def test_cmd_key(self):
+        from tools.mcp_tool import _extract_mcp_command_payload
+
+        assert _extract_mcp_command_payload({"cmd": "whoami"}) == "whoami"
+
+    def test_argv_list_is_joined(self):
+        from tools.mcp_tool import _extract_mcp_command_payload
+
+        payload = _extract_mcp_command_payload({"argv": ["rm", "-rf", "/tmp/x"]})
+        assert payload == "rm -rf /tmp/x"
+
+    def test_returns_none_when_no_command_key(self):
+        from tools.mcp_tool import _extract_mcp_command_payload
+
+        assert _extract_mcp_command_payload({"path": "/tmp/foo"}) is None
+
+    def test_returns_none_for_non_dict(self):
+        from tools.mcp_tool import _extract_mcp_command_payload
+
+        assert _extract_mcp_command_payload(None) is None
+        assert _extract_mcp_command_payload("ls") is None
+        assert _extract_mcp_command_payload([1, 2, 3]) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end handler behavior — the actual #32877 regression
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerApprovalGate:
+    def test_hardline_command_blocks_before_mcp_call(self):
+        """``rm -rf /`` through a shell-MCP must NEVER reach the server."""
+        from tools import mcp_tool
+
+        call_tool = AsyncMock()
+        _install_stub_server(mcp_tool, "ssh", call_tool)
+
+        try:
+            handler = mcp_tool._make_tool_handler("ssh", "execute_command", 30)
+            with _patch_mcp_loop():
+                raw = handler({"command": "rm -rf /"})
+            parsed = json.loads(raw)
+            assert "error" in parsed
+            assert "BLOCKED" in parsed["error"]
+            assert "hardline" in parsed["error"].lower()
+            # Critical: the MCP session was never invoked.
+            call_tool.assert_not_called()
+        finally:
+            mcp_tool._servers.pop("ssh", None)
+
+    def test_dangerous_command_blocked_in_gateway_when_user_denies(self):
+        """Smart/manual mode in a gateway session must gate dangerous MCP calls."""
+        from tools import approval, mcp_tool
+
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = "test-session-32877"
+
+        # Register a notify callback that immediately denies — simulates
+        # the user clicking "Deny" on the gateway approval prompt.
+        def deny(_data):
+            approval.resolve_gateway_approval("test-session-32877", "deny")
+
+        approval.register_gateway_notify("test-session-32877", deny)
+
+        # Pin gateway timeout short so a regression that fails to wire
+        # the gate doesn't hang the test suite.
+        with patch.object(
+            approval,
+            "_get_approval_config",
+            return_value={"mode": "manual", "gateway_timeout": 5, "timeout": 5},
+        ):
+            call_tool = AsyncMock()
+            _install_stub_server(mcp_tool, "docker", call_tool)
+            try:
+                handler = mcp_tool._make_tool_handler("docker", "exec_in_container", 30)
+                with _patch_mcp_loop():
+                    raw = handler({"command": "rm -rf /home/user"})
+                parsed = json.loads(raw)
+                assert "error" in parsed
+                assert "BLOCKED" in parsed["error"]
+                # Critical: the MCP session was never invoked.
+                call_tool.assert_not_called()
+            finally:
+                mcp_tool._servers.pop("docker", None)
+                approval.unregister_gateway_notify("test-session-32877")
+
+    def test_safe_mcp_tool_call_passes_through_unchanged(self):
+        """Non-shell-like MCP tools must NOT be gated."""
+        from tools import mcp_tool
+
+        call_tool = AsyncMock(return_value=_make_call_result("file body", is_error=False))
+        _install_stub_server(mcp_tool, "fs", call_tool)
+
+        try:
+            handler = mcp_tool._make_tool_handler("fs", "read_file", 30)
+            with _patch_mcp_loop():
+                raw = handler({"path": "/tmp/safe.txt"})
+            parsed = json.loads(raw)
+            assert parsed["result"] == "file body"
+            call_tool.assert_called_once_with("read_file", arguments={"path": "/tmp/safe.txt"})
+        finally:
+            mcp_tool._servers.pop("fs", None)
+
+    def test_shell_tool_with_safe_command_passes_through(self):
+        """``ls -la`` through a shell-MCP is fine — only dangerous patterns block."""
+        from tools import mcp_tool
+
+        call_tool = AsyncMock(return_value=_make_call_result("listing", is_error=False))
+        _install_stub_server(mcp_tool, "ssh", call_tool)
+
+        try:
+            handler = mcp_tool._make_tool_handler("ssh", "execute_command", 30)
+            with _patch_mcp_loop():
+                raw = handler({"command": "ls -la /tmp"})
+            parsed = json.loads(raw)
+            assert parsed["result"] == "listing"
+            call_tool.assert_called_once()
+        finally:
+            mcp_tool._servers.pop("ssh", None)
+
+    def test_shell_tool_without_command_field_passes_through(self):
+        """A shell-named tool with no recognizable command arg isn't gated.
+
+        Some MCPs expose ``run_*``-named tools that don't actually take a
+        shell command (e.g. a ``run_query`` tool taking SQL).  Without a
+        command-shaped argument we can't scan, so we let the call through
+        rather than firing a false-positive block.
+        """
+        from tools import mcp_tool
+
+        call_tool = AsyncMock(return_value=_make_call_result("rows", is_error=False))
+        _install_stub_server(mcp_tool, "db", call_tool)
+
+        try:
+            handler = mcp_tool._make_tool_handler("db", "run_query", 30)
+            with _patch_mcp_loop():
+                raw = handler({"sql": "SELECT 1"})
+            parsed = json.loads(raw)
+            assert parsed["result"] == "rows"
+            call_tool.assert_called_once()
+        finally:
+            mcp_tool._servers.pop("db", None)
+
+    def test_yolo_mode_bypasses_gate(self):
+        """YOLO must propagate to the MCP gate, not just terminal_tool."""
+        from tools import approval, mcp_tool
+
+        os.environ["HERMES_SESSION_KEY"] = "yolo-session"
+        approval.enable_session_yolo("yolo-session")
+
+        call_tool = AsyncMock(return_value=_make_call_result("done", is_error=False))
+        _install_stub_server(mcp_tool, "ssh", call_tool)
+
+        try:
+            handler = mcp_tool._make_tool_handler("ssh", "execute_command", 30)
+            with _patch_mcp_loop():
+                raw = handler({"command": "rm -rf /tmp/scratch"})
+            parsed = json.loads(raw)
+            # YOLO lets the regular dangerous pattern through, but NOT
+            # the hardline list (rm -rf /). /tmp/scratch is dangerous-
+            # but-recoverable, so YOLO should let it pass.
+            assert parsed.get("result") == "done"
+            call_tool.assert_called_once()
+        finally:
+            mcp_tool._servers.pop("ssh", None)
+            approval.disable_session_yolo("yolo-session")
+
+    def test_yolo_does_not_bypass_hardline(self):
+        """Hardline floor (rm -rf /) must hold even with YOLO."""
+        from tools import approval, mcp_tool
+
+        os.environ["HERMES_SESSION_KEY"] = "yolo-session-2"
+        approval.enable_session_yolo("yolo-session-2")
+
+        call_tool = AsyncMock()
+        _install_stub_server(mcp_tool, "ssh", call_tool)
+
+        try:
+            handler = mcp_tool._make_tool_handler("ssh", "execute_command", 30)
+            with _patch_mcp_loop():
+                raw = handler({"command": "rm -rf /"})
+            parsed = json.loads(raw)
+            assert "error" in parsed
+            assert "hardline" in parsed["error"].lower()
+            call_tool.assert_not_called()
+        finally:
+            mcp_tool._servers.pop("ssh", None)
+            approval.disable_session_yolo("yolo-session-2")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2400,6 +2400,146 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
 
 
 # ---------------------------------------------------------------------------
+# Shell-like MCP tool detection + approval gate
+# ---------------------------------------------------------------------------
+#
+# ``tools/approval.py`` (dangerous-command + Smart-mode + hardline floor)
+# is only wired into ``tools/terminal_tool.py``.  MCP wrappers like
+# ``ssh``, ``docker``, the official ``@modelcontextprotocol/server-shell``,
+# and similar exec-style servers spawn subprocesses on their own — without
+# this guard, the agent can route ``rm -rf /``, ``shutdown``, etc. through
+# an MCP tool and bypass the entire approval system (no regex check, no
+# Smart-mode prompt, no audit entry).  See NousResearch/hermes-agent#32877.
+#
+# We can't blanket-gate every MCP call because MCP tools have arbitrary
+# semantics (reading a file, fetching a URL, querying a DB).  Instead we
+# fire the gate only when (a) the tool's name matches a known shell/exec
+# pattern AND (b) the arguments expose a command-shaped field we can scan.
+# That keeps the false-positive surface tiny while closing the most
+# obvious bypass paths reported in the issue.
+
+# Tool-name fragments that indicate shell/exec semantics. Matched as a
+# case-insensitive substring against the underlying MCP tool name (NOT the
+# ``mcp_<server>_<tool>`` registry alias) so e.g. ``run_command``,
+# ``execute_shell``, ``bash_exec``, and ``docker_exec`` all light up.
+_MCP_SHELL_TOOL_NAME_FRAGMENTS = (
+    "shell",
+    "bash",
+    "exec",
+    "run_command",
+    "runcommand",
+    "run_shell",
+    "runshell",
+    "run_script",
+    "runscript",
+    "command_line",
+    "commandline",
+    "subprocess",
+    "system_call",
+    "syscall",
+    "spawn",
+)
+
+# Argument keys (case-insensitive) that an exec-style MCP tool typically
+# uses to carry the actual command string.  When a tool name matches a
+# shell-like fragment we look for these keys and concatenate their values
+# into a single payload for ``check_all_command_guards``.
+_MCP_COMMAND_ARG_KEYS = (
+    "command",
+    "cmd",
+    "commandline",
+    "command_line",
+    "shell_command",
+    "script",
+    "bash",
+    "code",
+    "args",
+    "argv",
+    "arguments",
+)
+
+
+def _is_shell_like_mcp_tool(tool_name: str) -> bool:
+    """True if the MCP tool name suggests shell/exec semantics."""
+    if not tool_name:
+        return False
+    lowered = tool_name.lower()
+    return any(frag in lowered for frag in _MCP_SHELL_TOOL_NAME_FRAGMENTS)
+
+
+def _extract_mcp_command_payload(args: Any) -> Optional[str]:
+    """Pull a command-shaped string out of MCP tool arguments.
+
+    Returns the concatenated payload if one of ``_MCP_COMMAND_ARG_KEYS``
+    is present, otherwise ``None``.  Accepts list/tuple values (joined
+    with spaces) so ``argv``-style inputs are also scanned.
+    """
+    if not isinstance(args, dict):
+        return None
+    parts: List[str] = []
+    for key, value in args.items():
+        if not isinstance(key, str):
+            continue
+        if key.lower() not in _MCP_COMMAND_ARG_KEYS:
+            continue
+        if isinstance(value, str):
+            if value.strip():
+                parts.append(value)
+        elif isinstance(value, (list, tuple)):
+            joined = " ".join(str(v) for v in value if v is not None)
+            if joined.strip():
+                parts.append(joined)
+    if not parts:
+        return None
+    return " ".join(parts)
+
+
+def _check_mcp_command_guard(
+    server_name: str, tool_name: str, args: Any
+) -> Optional[str]:
+    """Run the dangerous-command guard on shell-like MCP tool calls.
+
+    Returns ``None`` when the call is approved (or the tool is not
+    shell-like / has no command-shaped argument).  Returns a JSON error
+    string when the call is blocked — the handler should short-circuit
+    and return that string instead of invoking the MCP server.
+    """
+    if not _is_shell_like_mcp_tool(tool_name):
+        return None
+    command = _extract_mcp_command_payload(args)
+    if not command:
+        return None
+    try:
+        from tools.approval import check_all_command_guards
+    except Exception as exc:  # pragma: no cover — approval is always available
+        logger.debug("MCP approval gate unavailable: %s", exc)
+        return None
+    try:
+        # ``env_type="local"`` — MCP-routed commands can affect the host
+        # (ssh, docker exec, filesystem MCP), so we want the full guard
+        # set rather than the container-bypass branch used by sandboxed
+        # terminal backends.
+        decision = check_all_command_guards(command, env_type="local")
+    except Exception as exc:
+        logger.warning(
+            "MCP approval gate raised for %s/%s: %s",
+            server_name, tool_name, exc,
+        )
+        return None
+    if decision.get("approved"):
+        return None
+    message = decision.get("message") or (
+        f"BLOCKED: MCP tool '{tool_name}' on server '{server_name}' "
+        "was denied by the dangerous-command approval gate."
+    )
+    logger.warning(
+        "MCP approval gate blocked %s/%s: %s",
+        server_name, tool_name, message,
+    )
+    return json.dumps({"error": message}, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
 # Handler / check-fn factories
 # ---------------------------------------------------------------------------
 
@@ -2444,6 +2584,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
             }, ensure_ascii=False)
+
+        # Dangerous-command approval gate for shell-like MCP tools.
+        # Routes ssh/docker/exec-style MCP calls through the same
+        # hardline + Smart-mode + manual-approval pipeline that
+        # ``tools/terminal_tool.py`` uses, so the agent can't bypass
+        # the gate by going through an MCP wrapper.  See #32877.
+        guard_block = _check_mcp_command_guard(server_name, tool_name, args)
+        if guard_block is not None:
+            return guard_block
 
         async def _call():
             async with server._rpc_lock:


### PR DESCRIPTION
## Summary

Fixes #32877. ``tools/approval.py`` was only consulted from
``tools/terminal_tool.py`` — MCP wrappers such as ``ssh``, ``docker``,
and the official ``@modelcontextprotocol/server-shell`` spawned
subprocesses directly with no gate, letting the agent route ``rm -rf /``,
``shutdown``, etc. through an MCP and bypass the entire dangerous-command
pipeline (no regex check, no Smart-mode prompt, no hardline floor, no
audit entry).

This adds a minimal transport-layer gate in
``tools/mcp_tool._make_tool_handler``:

- Only fires when the MCP tool name matches a known shell/exec fragment
  (``shell``, ``bash``, ``exec``, ``run_command``, ``subprocess``,
  ``spawn``, …) **and** the call arguments expose a command-shaped field
  (``command``, ``cmd``, ``script``, ``argv``, …). This keeps the
  false-positive surface tiny so safe MCPs (``read_file``,
  ``search_web``, ``run_query``) keep working unchanged.
- Forwards the extracted command to ``check_all_command_guards`` with
  ``env_type=\"local\"`` **before** ``session.call_tool`` is invoked, so
  MCP-routed commands inherit the same hardline floor + dangerous-pattern
  detector + Smart-mode auxiliary LLM + gateway/CLI approval prompt that
  ``terminal_tool`` already uses.
- On a block, returns the standard ``{\"error\": \"BLOCKED: …\"}`` JSON
  the MCP handler already speaks, so the agent sees a clear refusal
  instead of an opaque transport failure.

This is option (A) from the issue description (transport-layer gate),
chosen over option (B) (cross-process IPC endpoint) because it keeps the
fix in-process, requires no new gateway surface, and preserves the
existing Smart-mode + manual-approval UX for free.

## Test plan

- [x] New ``tests/tools/test_mcp_approval_gate.py`` (29 tests):
  - shell-like name detection: positive (``shell``, ``bash``, ``exec``,
    ``docker_exec``, ``ssh_exec``, ``subprocess_run``, ``spawn_process``,
    …) and negative (``read_file``, ``search_web``, ``run_query``, …)
  - command-payload extraction: ``command`` / ``cmd`` / ``argv`` list
    joining / safe fallthrough on non-dict input
  - end-to-end through ``_make_tool_handler``:
    - hardline ``rm -rf /`` via shell-MCP → BLOCKED, ``session.call_tool``
      never invoked
    - dangerous command in a gateway session with user deny → BLOCKED,
      ``session.call_tool`` never invoked
    - safe non-shell MCP tool → passes through unchanged
    - shell-tool with safe command (``ls -la``) → passes through
    - shell-named tool with no command-shaped argument (``run_query``
      taking SQL) → passes through (false-positive guard)
    - YOLO bypasses the regular pattern gate, but the hardline floor
      still holds for ``rm -rf /`` (parity with ``terminal_tool``)
- [x] Full existing ``tests/tools/test_mcp_tool.py`` +
  ``test_mcp_circuit_breaker.py`` + ``test_approval.py`` (387 tests)
  still pass — no regressions.