### PR TITLE
test(anthropic): cover Responses kwarg sanitization

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3938,8 +3938,8 @@ class AIAgent:
         if self.api_mode == "anthropic_messages":
             self._try_refresh_anthropic_client_credentials()
         # Defensive: strip Responses-only kwargs that can leak in under an
-        # api_mode-flip race (the Anthropic SDK raises a non-retryable
-        # TypeError on them). See #31673.
+        # api_mode-flip race. The Anthropic SDK raises a non-retryable
+        # TypeError on them. See #31673 / sanitize_anthropic_kwargs().
         from agent.anthropic_adapter import sanitize_anthropic_kwargs
         sanitize_anthropic_kwargs(
             api_kwargs, log_prefix=getattr(self, "log_prefix", "")

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1419,6 +1419,93 @@ class TestBuildAnthropicKwargs:
 
 
 # ---------------------------------------------------------------------------
+# Foreign-kwarg sanitization (regression for #31673)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeAnthropicKwargs:
+    """sanitize_anthropic_kwargs strips Responses-only kwargs before SDK use."""
+
+    def test_drops_instructions_kwarg(self):
+        from agent.anthropic_adapter import sanitize_anthropic_kwargs
+
+        kwargs = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 4096,
+            "instructions": "You are a helpful assistant.",
+        }
+        sanitize_anthropic_kwargs(kwargs, log_prefix="[test] ")
+        assert "instructions" not in kwargs
+        assert kwargs["model"] == "claude-sonnet-4-6"
+        assert kwargs["max_tokens"] == 4096
+
+    def test_drops_input_kwarg(self):
+        from agent.anthropic_adapter import sanitize_anthropic_kwargs
+
+        kwargs = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "input": [{"role": "user", "content": "leaked"}],
+        }
+        sanitize_anthropic_kwargs(kwargs)
+        assert "input" not in kwargs
+        assert kwargs["messages"] == [{"role": "user", "content": "Hi"}]
+
+    def test_drops_other_responses_only_kwargs(self):
+        from agent.anthropic_adapter import sanitize_anthropic_kwargs
+
+        kwargs = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "store": False,
+            "parallel_tool_calls": True,
+        }
+        sanitize_anthropic_kwargs(kwargs)
+        assert "store" not in kwargs
+        assert "parallel_tool_calls" not in kwargs
+        assert kwargs["messages"] == [{"role": "user", "content": "Hi"}]
+
+    def test_noop_when_clean(self):
+        from agent.anthropic_adapter import sanitize_anthropic_kwargs
+
+        kwargs = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 4096,
+            "system": "Be helpful.",
+        }
+        before = dict(kwargs)
+        sanitize_anthropic_kwargs(kwargs)
+        assert kwargs == before
+
+    def test_returns_kwargs_for_chaining(self):
+        from agent.anthropic_adapter import sanitize_anthropic_kwargs
+
+        kwargs = {"model": "claude-sonnet-4-6", "messages": []}
+        assert sanitize_anthropic_kwargs(kwargs) is kwargs
+
+    def test_wire_sanitizer_strips_leaked_instructions_after_build(self):
+        from agent.anthropic_adapter import (
+            build_anthropic_kwargs,
+            sanitize_anthropic_kwargs,
+        )
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+        )
+        assert "instructions" not in kwargs
+
+        kwargs["instructions"] = "leaked from auxiliary path"
+        sanitize_anthropic_kwargs(kwargs)
+        assert "instructions" not in kwargs
+
+
+# ---------------------------------------------------------------------------
 # Model output limit lookup
 # ---------------------------------------------------------------------------
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5754,6 +5754,43 @@ class TestAnthropicCredentialRefresh:
         agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
         assert result is response
 
+    def test_anthropic_messages_create_strips_leaked_instructions(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="sk-ant-api03-test",
+                base_url="https://api.anthropic.com",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        response = SimpleNamespace(content=[])
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.create.return_value = response
+
+        contaminated_kwargs = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 4096,
+            "instructions": "You are a helpful assistant.",
+            "input": [{"role": "user", "content": "leaked"}],
+        }
+
+        with patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=True):
+            agent._anthropic_messages_create(contaminated_kwargs)
+
+        call_kwargs = agent._anthropic_client.messages.create.call_args.kwargs
+        assert "instructions" not in call_kwargs
+        assert "input" not in call_kwargs
+        assert call_kwargs["model"] == "claude-sonnet-4-6"
+        assert call_kwargs["max_tokens"] == 4096
+        assert call_kwargs["messages"] == [{"role": "user", "content": "Hi"}]
+
 
 # ===================================================================
 # _streaming_api_call tests

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -986,6 +986,54 @@ class TestAnthropicStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == len(events)
 
+    def test_anthropic_stream_strips_leaked_openai_kwargs_before_sdk(self):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.anthropic.com",
+            model="claude-sonnet-4-6",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+
+        final_message = SimpleNamespace(
+            content=[],
+            stop_reason="end_turn",
+        )
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.__iter__ = MagicMock(return_value=iter([]))
+        mock_stream.get_final_message.return_value = final_message
+
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = mock_stream
+
+        contaminated_kwargs = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 4096,
+            "instructions": "Leaked from an OpenAI Responses request",
+            "input": [{"role": "user", "content": "OpenAI Responses shape"}],
+            "parallel_tool_calls": True,
+        }
+
+        with patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=False):
+            response = agent._interruptible_streaming_api_call(contaminated_kwargs)
+
+        assert response is final_message
+        call_kwargs = agent._anthropic_client.messages.stream.call_args.kwargs
+        assert "instructions" not in call_kwargs
+        assert "input" not in call_kwargs
+        assert "parallel_tool_calls" not in call_kwargs
+        assert call_kwargs["model"] == "claude-sonnet-4-6"
+        assert call_kwargs["messages"] == [{"role": "user", "content": "Hi"}]
+        assert call_kwargs["max_tokens"] == 4096
+
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     def test_anthropic_stream_parser_valueerror_retries_before_delivery(
         self, mock_replace, monkeypatch,


### PR DESCRIPTION
## Problem

Issue #31673 reported an Anthropic Messages SDK crash when OpenAI Responses-shaped kwargs leaked into an Anthropic Messages call:

```text
Messages.stream() got an unexpected keyword argument 'instructions'
```

Current `upstream/main` already contains the production sanitizer boundary, so this refresh keeps the PR focused on regression coverage and a small clarifying comment.

Refs #31673.

## Current Production Boundary

`upstream/main` already has:

- `agent.anthropic_adapter.sanitize_anthropic_kwargs(api_kwargs, *, log_prefix="")`
- the streaming boundary in `agent/chat_completion_helpers.py`
- the non-streaming boundary in `run_agent.py::_anthropic_messages_create`

## What Changed

- Added `tests/agent/test_anthropic_adapter.py::TestSanitizeAnthropicKwargs` coverage for stripping `instructions`, `input`, `store`, and `parallel_tool_calls`, preserving clean payloads, and returning the same kwargs dict for chaining.
- Added non-streaming `_anthropic_messages_create` coverage proving leaked `instructions` / `input` are stripped before `messages.create`.
- Added streaming `Messages.stream` coverage proving leaked `instructions`, `input`, and `parallel_tool_calls` are stripped before SDK dispatch.
- Clarified the defensive comment in `run_agent.py` to reference `sanitize_anthropic_kwargs()`.
- Preserved newer current-main tests; the stale branch diff would have removed current Bedrock streaming fallback tests, so this refresh replayed only additive coverage.

## Review State

- Rebased onto current `upstream/main` at `9c051f57c3b1e9962feef958710ee58fa8ca2444`.
- No PR comments or reviews were present when refreshed.
- The fork branch ref is now `78fddd68a3dbecc7363f9d872368e4b605c9f58e`.

## Verification

- `.venv\Scripts\python.exe -m pytest tests\agent\test_anthropic_adapter.py tests\run_agent\test_run_agent.py::TestAnthropicCredentialRefresh tests\run_agent\test_streaming.py::TestAnthropicStreamCallbacks -q --timeout-method=thread` -> 172 passed, 1 skipped, 1 warning (`discord.player` imports deprecated `audioop`).
- `.venv\Scripts\ruff.exe check run_agent.py tests\agent\test_anthropic_adapter.py tests\run_agent\test_run_agent.py tests\run_agent\test_streaming.py` -> passed.
- `.venv\Scripts\python.exe -m py_compile run_agent.py tests\agent\test_anthropic_adapter.py tests\run_agent\test_run_agent.py tests\run_agent\test_streaming.py` -> passed.
- `git diff --check` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> `c1e5eb30c69f9a52ddff7c6ab6433354391acafa`.

## Risk

Low. This is coverage plus a comment refresh; production behavior is unchanged beyond the existing sanitizer already on `upstream/main`.