### PR TITLE
fix(cron): exclude jobs.json registry from disk-cleanup pattern

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -481,7 +481,14 @@ def guess_category(path: Path) -> Optional[str]:
         }:
             return None
         if top == "cron" or top == "cronjobs":
-            return "cron-output"
+            # Only files under the disposable ``output/`` subtree are
+            # cleanup candidates. Top-level cron control-plane state
+            # (e.g. ``jobs.json``, ``.tick.lock``) must never be
+            # auto-tracked — deleting it wipes the live scheduler
+            # registry. See issue #32164.
+            if len(rel.parts) >= 2 and rel.parts[1] == "output":
+                return "cron-output"
+            return None
         if top == "cache":
             return "temp"
     except ValueError:

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -129,11 +129,39 @@ class TestGuessCategory:
 
     def test_cron_subtree_categorised(self, _isolate_env):
         dg = _load_lib()
-        cron_dir = _isolate_env / "cron"
-        cron_dir.mkdir()
-        p = cron_dir / "job_output.md"
+        # Only files under ``cron/output/`` are disposable run artifacts.
+        output_dir = _isolate_env / "cron" / "output" / "job_123"
+        output_dir.mkdir(parents=True)
+        p = output_dir / "run.md"
         p.write_text("x")
         assert dg.guess_category(p) == "cron-output"
+
+    def test_cron_jobs_json_not_tracked(self, _isolate_env):
+        """Regression for #32164: the cron registry must never be tracked."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        p = cron_dir / "jobs.json"
+        p.write_text("[]")
+        assert dg.guess_category(p) is None
+
+    def test_cron_tick_lock_not_tracked(self, _isolate_env):
+        """Regression for #32164: cron tick-lock is control-plane state."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        p = cron_dir / ".tick.lock"
+        p.write_text("")
+        assert dg.guess_category(p) is None
+
+    def test_cronjobs_top_level_not_tracked(self, _isolate_env):
+        """The legacy ``cronjobs`` alias is also control-plane at the top."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cronjobs"
+        cron_dir.mkdir()
+        p = cron_dir / "jobs.json"
+        p.write_text("[]")
+        assert dg.guess_category(p) is None
 
     def test_ordinary_file_returns_none(self, _isolate_env):
         dg = _load_lib()


### PR DESCRIPTION
## Summary

- `plugins/disk-cleanup/disk_cleanup.py::guess_category()` classified every top-level path under `HERMES_HOME/cron/` (and the legacy `cronjobs/` alias) as `cron-output`, which made the durable scheduler registry (`~/.hermes/cron/jobs.json`, `.tick.lock`) eligible for automatic deletion.
- Restrict the `cron-output` label to `cron/output/**` only, matching the actual disposable-artifact subtree. Top-level cron control-plane files now return `None` and are never auto-tracked.
- Update the existing `test_cron_subtree_categorised` to use a real `cron/output/` path and add three regression tests covering `jobs.json`, `.tick.lock`, and the `cronjobs/` alias.

Closes #32164

## Test plan

- [x] `python3 -m pytest tests/plugins/test_disk_cleanup_plugin.py::TestGuessCategory` — 9/9 pass (3 new regression tests + adjusted cron-output test).
- [ ] Confirm no other call sites assumed the old `top == "cron"` blanket classification.