### PR TITLE
fix(cron): prevent timezone-migration double fires

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -338,6 +338,65 @@ def _recoverable_oneshot_run_at(
     return None
 
 
+def _is_tz_migration_phantom(
+    stored_next_run: str,
+    schedule: Dict[str, Any],
+    now: datetime,
+) -> bool:
+    """Return True when a cron next_run_at is due only because of a TZ migration.
+
+    A cron job persists ``next_run_at`` with the offset that was active when
+    the previous run computed it. If the Hermes/system timezone later moves to
+    a different offset, the same absolute instant maps to an *earlier* local
+    wall-clock time than the cron expression intended. ``_ensure_aware()`` then
+    converts the stored instant into the current zone and ``next_run_dt <= now``
+    fires the job early — and the post-run ``compute_next_run()`` then schedules
+    the same logical occurrence again at the correct wall-clock time, producing
+    a double-fire. See issue #28934.
+
+    We treat the next_run as a TZ-migration phantom when:
+
+    - the schedule is a cron expression (only cron carries wall-clock intent;
+      interval / once jobs are absolute and should not be "repaired"),
+    - the stored UTC offset differs from the current Hermes timezone offset,
+    - the stored *wall-clock time* (the naive part, reinterpreted in the
+      current Hermes zone) is still in the future relative to ``now``.
+
+    When the stored wall-clock time has already passed in the current zone,
+    the existing stale-run fast-forward branch handles it correctly, so this
+    helper returns False and the job stays on the normal due path.
+    """
+    if schedule.get("kind") != "cron":
+        return False
+
+    try:
+        stored_dt = datetime.fromisoformat(stored_next_run)
+    except (TypeError, ValueError):
+        return False
+    if stored_dt.tzinfo is None:
+        # Naive timestamps don't carry a migration signal; _ensure_aware()
+        # already interprets them in the configured zone.
+        return False
+
+    target_tz = now.tzinfo
+    if target_tz is None:
+        return False
+
+    stored_offset = stored_dt.utcoffset()
+    current_offset = now.utcoffset()
+    if stored_offset is None or current_offset is None:
+        return False
+    if stored_offset == current_offset:
+        return False
+
+    # Reinterpret the stored wall-clock time in the *current* Hermes timezone.
+    # If that wall-clock instant is still in the future, the cron expression's
+    # intended occurrence has not arrived yet — firing now would be the early
+    # half of a double-fire pair.
+    wall_in_current_tz = stored_dt.replace(tzinfo=target_tz)
+    return wall_in_current_tz > now
+
+
 def _compute_grace_seconds(schedule: dict) -> int:
     """Compute how late a job can be and still catch up instead of fast-forwarding.
 
@@ -1033,6 +1092,31 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         if next_run_dt <= now:
             schedule = job.get("schedule", {})
             kind = schedule.get("kind")
+
+            # Detect cron jobs whose persisted next_run_at carries an old
+            # UTC offset from before a Hermes/system timezone migration.
+            # In that case the same absolute instant maps to an earlier
+            # wall-clock time in the new zone, so the job appears due
+            # before its cron expression intended.  Recompute next_run_at
+            # from the current zone and skip dispatch this tick — see
+            # issue #28934.
+            if _is_tz_migration_phantom(next_run, schedule, now):
+                new_next = compute_next_run(schedule, now.isoformat())
+                if new_next:
+                    logger.info(
+                        "Job '%s' next_run_at %s carries a pre-migration "
+                        "UTC offset; rescheduling to %s in current Hermes "
+                        "timezone instead of firing early.",
+                        job.get("name", job["id"]),
+                        next_run,
+                        new_next,
+                    )
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            rj["next_run_at"] = new_next
+                            needs_save = True
+                            break
+                    continue  # Skip this run
 
             # For recurring jobs, check if the scheduled time is stale
             # (gateway was down and missed the window). Fast-forward to

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -359,6 +359,8 @@ def _is_tz_migration_phantom(
     - the schedule is a cron expression (only cron carries wall-clock intent;
       interval / once jobs are absolute and should not be "repaired"),
     - the stored UTC offset differs from the current Hermes timezone offset,
+      or the legacy stored timestamp is naive and was interpreted as due via
+      the old system-local timezone,
     - the stored *wall-clock time* (the naive part, reinterpreted in the
       current Hermes zone) is still in the future relative to ``now``.
 
@@ -373,14 +375,18 @@ def _is_tz_migration_phantom(
         stored_dt = datetime.fromisoformat(stored_next_run)
     except (TypeError, ValueError):
         return False
-    if stored_dt.tzinfo is None:
-        # Naive timestamps don't carry a migration signal; _ensure_aware()
-        # already interprets them in the configured zone.
-        return False
-
     target_tz = now.tzinfo
     if target_tz is None:
         return False
+
+    if stored_dt.tzinfo is None:
+        # Legacy naive values have no explicit offset, but _ensure_aware()
+        # still interprets them as old system-local wall time. On the due path,
+        # a naive cron wall-clock that is still future in the current Hermes
+        # zone is the same early-fire phantom as an aware timestamp carrying an
+        # old offset.
+        wall_in_current_tz = stored_dt.replace(tzinfo=target_tz)
+        return wall_in_current_tz > now
 
     stored_offset = stored_dt.utcoffset()
     current_offset = now.utcoffset()

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -849,6 +849,155 @@ class TestGetDueJobs:
         assert recovered_dt > now
 
 
+class TestCronTimezoneMigrationDoubleFire:
+    """Regression tests for issue #28934.
+
+    A recurring cron job persisted with the old UTC offset (e.g.
+    ``2026-05-19T21:00:00+10:00``) must NOT fire when ``_hermes_now()``
+    moves to a different offset (e.g. ``+02:00``) and converts that stored
+    instant into an earlier wall-clock time (``13:00+02``).  The scheduler
+    should detect the pre-migration offset, recompute next_run_at in the
+    current Hermes timezone, and skip dispatch for that tick — otherwise
+    the same logical occurrence fires once at 13:02 and again at 21:00.
+    """
+
+    def test_cron_with_stale_offset_does_not_fire_early(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        # Hermes timezone is now +02:00; we are 2 minutes past when the
+        # stored instant converts to local time.
+        target_tz = timezone(timedelta(hours=2))
+        now = datetime(2026, 5, 19, 13, 2, 0, tzinfo=target_tz)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        # Job was persisted under the previous +10:00 zone: 21:00+10
+        # converts to 13:00+02 in current time, which is <= now.
+        stored_next = "2026-05-19T21:00:00+10:00"
+        save_jobs(
+            [{
+                "id": "cron-tz-migrated",
+                "name": "Weekly digest",
+                "prompt": "Send digest",
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 21 * * 2",
+                    "display": "0 21 * * 2",
+                },
+                "schedule_display": "0 21 * * 2",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-12T21:00:00+10:00",
+                "next_run_at": stored_next,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        # The job MUST NOT be returned as due at 13:02 in the new zone.
+        assert get_due_jobs() == []
+
+        # next_run_at should have been recomputed into the current Hermes
+        # zone (+02:00) and pushed into the future, so the next tick won't
+        # double-fire either.
+        rescheduled = get_job("cron-tz-migrated")["next_run_at"]
+        assert rescheduled is not None
+        assert rescheduled != stored_next
+        rescheduled_dt = datetime.fromisoformat(rescheduled)
+        assert rescheduled_dt.tzinfo is not None
+        assert rescheduled_dt.utcoffset() == timedelta(hours=2)
+        assert rescheduled_dt > now
+
+    def test_cron_with_matching_offset_still_fires_when_due(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """Sanity check: same offset stored as Hermes now → normal due path."""
+        target_tz = timezone(timedelta(hours=2))
+        now = datetime(2026, 5, 19, 21, 0, 30, tzinfo=target_tz)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        stored_next = "2026-05-19T21:00:00+02:00"
+        save_jobs(
+            [{
+                "id": "cron-no-migration",
+                "name": "Weekly digest",
+                "prompt": "Send digest",
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 21 * * 2",
+                    "display": "0 21 * * 2",
+                },
+                "schedule_display": "0 21 * * 2",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-12T21:00:00+02:00",
+                "next_run_at": stored_next,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        due = get_due_jobs()
+        assert [j["id"] for j in due] == ["cron-no-migration"]
+
+    def test_cron_with_stale_offset_past_wall_clock_still_fast_forwards(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """If the stored wall-clock time has already passed in the new
+        zone (i.e. the gateway was actually down across the cron tick),
+        the existing stale-run fast-forward must still kick in instead of
+        firing a stale run. The TZ-migration guard only applies when the
+        wall-clock intent is still in the future.
+        """
+        target_tz = timezone(timedelta(hours=2))
+        # 23:30 in +02 is well past 21:00 wall-clock — old fast-forward path.
+        now = datetime(2026, 5, 19, 23, 30, 0, tzinfo=target_tz)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        stored_next = "2026-05-19T21:00:00+10:00"
+        save_jobs(
+            [{
+                "id": "cron-tz-stale-past",
+                "name": "Weekly digest",
+                "prompt": "Send digest",
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 21 * * 2",
+                    "display": "0 21 * * 2",
+                },
+                "schedule_display": "0 21 * * 2",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-12T21:00:00+10:00",
+                "next_run_at": stored_next,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        assert get_due_jobs() == []
+        rescheduled = get_job("cron-tz-stale-past")["next_run_at"]
+        rescheduled_dt = datetime.fromisoformat(rescheduled)
+        assert rescheduled_dt > now
+
+
 class TestEnabledToolsets:
     def test_enabled_toolsets_stored(self, tmp_cron_dir):
         job = create_job(prompt="monitor", schedule="every 1h", enabled_toolsets=["web", "terminal"])

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -3,6 +3,7 @@
 import threading
 import pytest
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from cron.jobs import (
     parse_duration,
@@ -913,6 +914,73 @@ class TestCronTimezoneMigrationDoubleFire:
         assert rescheduled_dt.utcoffset() == timedelta(hours=2)
         assert rescheduled_dt > now
 
+    def test_cron_with_naive_legacy_timestamp_does_not_fire_early(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        # Legacy jobs may have persisted next_run_at without an offset. If
+        # that naive timestamp came from the old system-local timezone, the
+        # absolute instant can look due before the cron wall clock arrives in
+        # the newly configured Hermes timezone.
+        target_tz = timezone(timedelta(hours=2))
+        old_system_tz = timezone(timedelta(hours=10))
+        now = datetime(2026, 5, 19, 13, 2, 0, tzinfo=target_tz)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        class _FakeSystemDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                old_local_now = datetime(
+                    2026, 5, 19, 21, 2, 0, tzinfo=old_system_tz
+                )
+                if tz is not None:
+                    return old_local_now.astimezone(tz)
+
+                class _FakeLocalNow:
+                    def astimezone(self, tz=None):
+                        if tz is not None:
+                            return old_local_now.astimezone(tz)
+                        return old_local_now
+
+                return _FakeLocalNow()
+
+        monkeypatch.setattr("cron.jobs.datetime", _FakeSystemDateTime)
+
+        stored_next = "2026-05-19T21:00:00"
+        save_jobs(
+            [{
+                "id": "cron-tz-naive-migrated",
+                "name": "Weekly digest",
+                "prompt": "Send digest",
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 21 * * 2",
+                    "display": "0 21 * * 2",
+                },
+                "schedule_display": "0 21 * * 2",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-05-12T21:00:00",
+                "next_run_at": stored_next,
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        assert get_due_jobs() == []
+        rescheduled = get_job("cron-tz-naive-migrated")["next_run_at"]
+        assert rescheduled is not None
+        assert rescheduled != stored_next
+        rescheduled_dt = datetime.fromisoformat(rescheduled)
+        assert rescheduled_dt.tzinfo is not None
+        assert rescheduled_dt.utcoffset() == timedelta(hours=2)
+        assert rescheduled_dt > now
+
     def test_cron_with_matching_offset_still_fires_when_due(
         self, tmp_cron_dir, monkeypatch
     ):
@@ -950,6 +1018,45 @@ class TestCronTimezoneMigrationDoubleFire:
 
         due = get_due_jobs()
         assert [j["id"] for j in due] == ["cron-no-migration"]
+
+    def test_cron_with_dst_offset_change_still_fires_when_due(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        # During the New York fall-back transition, the stored occurrence can
+        # carry -04:00 while the current local time carries -05:00. That offset
+        # difference is normal DST behavior, not a timezone migration phantom.
+        ny_tz = ZoneInfo("America/New_York")
+        now = datetime(2026, 11, 1, 1, 31, 0, tzinfo=ny_tz, fold=1)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "cron-dst-fallback",
+                "name": "DST digest",
+                "prompt": "Send digest",
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "30 1 * * *",
+                    "display": "30 1 * * *",
+                },
+                "schedule_display": "30 1 * * *",
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-10-31T01:30:00-04:00",
+                "next_run_at": "2026-11-01T01:30:00-04:00",
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        due = get_due_jobs()
+        assert [j["id"] for j in due] == ["cron-dst-fallback"]
 
     def test_cron_with_stale_offset_past_wall_clock_still_fast_forwards(
         self, tmp_cron_dir, monkeypatch


### PR DESCRIPTION
## Problem

Recurring cron jobs can double-fire across a timezone migration. A cron job persists `next_run_at` with the UTC offset that was active when it was last computed, for example `2026-05-19T21:00:00+10:00`. If Hermes/system timezone later moves to another offset, for example `+02:00`, `_ensure_aware()` converts that stored absolute instant into an earlier local wall-clock time, such as `13:00+02`.

The job then appears due, runs early, and the post-run `compute_next_run()` schedules the same logical occurrence again at the correct wall-clock time, producing a double fire.

## Root cause

`_get_due_jobs_locked()` treated any `next_run_at <= now` as due. It did not distinguish a genuinely due occurrence from a stored cron wall-clock timestamp whose persisted UTC offset predates a timezone change. Only cron schedules carry wall-clock intent; interval and one-shot jobs remain absolute.

## Fix

- Add `_is_tz_migration_phantom(stored_next_run, schedule, now)` for cron schedules whose stored offset differs from the current Hermes timezone and whose intended wall-clock time is still in the future.
- Recompute `next_run_at` in the current timezone and skip dispatch for that tick when the guard detects an early-fire phantom.
- Handle legacy naive cron timestamps that can be interpreted as old system-local wall time.
- Preserve the existing stale-run fast-forward behavior when the wall-clock time has already passed in the new timezone.
- Cover the DST fallback case so ordinary timezone offset changes inside the same zone still run when due.

Closes #28934

## Verification

- `.venv\\Scripts\\python.exe -m pytest tests\\cron\\test_jobs.py tests\\test_timezone.py -q --timeout-method=thread` -> 110 passed, 2 skipped
- `.venv\\Scripts\\python.exe -m py_compile cron\\jobs.py tests\\cron\\test_jobs.py tests\\test_timezone.py` -> passed
- `.venv\\Scripts\\ruff.exe check cron\\jobs.py tests\\cron\\test_jobs.py tests\\test_timezone.py` -> passed
- `git diff --check upstream/main...HEAD` -> passed
- `git merge-tree --write-tree upstream/main HEAD` -> clean tree `23fee22a0fc9b9904c9ce9c4a3e4f347434bb6e3`