### PR TITLE
fix(agent): prefer API-reported tokens over estimate to prevent over-compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -577,6 +577,15 @@ class ContextCompressor(ContextEngine):
 
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
+        # True when the last `last_prompt_tokens` write came from a rough
+        # estimate (post-compression bookkeeping) rather than an API-reported
+        # `usage.prompt_tokens`. `should_compress()` uses this to defer
+        # re-firing compression until a real API count is observed — without
+        # this guard the post-compression estimate (which can over-count by
+        # 5-30% vs the provider's tokenizer when tool schemas, system prompt,
+        # or thinking blocks are heavy) can keep the session above threshold
+        # and trigger compression every turn (#27566).
+        self._last_prompt_tokens_is_estimate = False
 
         self.summary_model = summary_model_override or ""
 
@@ -607,9 +616,15 @@ class ContextCompressor(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
-        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        _prompt = usage.get("prompt_tokens", 0) or 0
+        self.last_prompt_tokens = _prompt
         self.last_completion_tokens = usage.get("completion_tokens", 0)
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
+        # A real API-reported prompt count supersedes any post-compression
+        # estimate.  Clear the "estimate pending confirmation" flag so the
+        # next `should_compress()` honours the (precise) API value.
+        if _prompt > 0:
+            self._last_prompt_tokens_is_estimate = False
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Check if context exceeds the compression threshold.
@@ -617,6 +632,13 @@ class ContextCompressor(ContextEngine):
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
+
+        If the only token signal we have post-compression is the rough
+        estimate (no API response has confirmed `prompt_tokens` since the
+        last compress), defer firing until the next API turn — the
+        estimate can over-count by 5-30% vs the provider's tokenizer when
+        tool schemas / system prompt are heavy, which used to cause a
+        compression-every-turn loop (#27566).
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens < self.threshold_tokens:
@@ -629,6 +651,27 @@ class ContextCompressor(ContextEngine):
                     "Consider /new to start a fresh session, or /compress <topic> "
                     "for focused compression.",
                     self._ineffective_compression_count,
+                )
+            return False
+        # Defer one cycle when the only signal is a post-compression
+        # estimate that has not yet been confirmed by an API response.
+        # The next API call will overwrite `last_prompt_tokens` with the
+        # provider's precise count (see `update_from_response`), and we
+        # can make a real decision then.  We only defer once and only at
+        # most by `threshold * 1.10` worth of headroom — if the estimate
+        # is *truly* far above threshold (e.g. >10% over) we still fire
+        # to keep an unbounded session from running away.
+        if (
+            self.compression_count > 0
+            and self._last_prompt_tokens_is_estimate
+            and tokens < int(self.threshold_tokens * 1.10)
+        ):
+            if not self.quiet_mode:
+                logger.info(
+                    "Compression deferred — post-compression estimate "
+                    "(~%d tokens) is within 10%% of threshold (%d); "
+                    "waiting for next API response to confirm.",
+                    tokens, self.threshold_tokens,
                 )
             return False
         return True

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -465,6 +465,12 @@ def compress_context(
     )
     agent.context_compressor.last_prompt_tokens = _compressed_est
     agent.context_compressor.last_completion_tokens = 0
+    # Mark the value as a rough estimate (not an API-reported count) so
+    # `should_compress()` can defer one cycle if the estimate is only
+    # marginally above threshold — the rough estimator can over-count by
+    # 5-30% for tool-heavy sessions, and using it as a hard trigger causes
+    # compression to re-fire every turn after the first compaction (#27566).
+    agent.context_compressor._last_prompt_tokens_is_estimate = True
 
     # Clear the file-read dedup cache.  After compression the original
     # read content is summarised away — if the model re-reads the same

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -38,6 +38,76 @@ class TestShouldCompress:
         assert compressor.should_compress(prompt_tokens=50000) is False
 
 
+class TestPostCompressionEstimateDefer:
+    """Regression for #27566.
+
+    After a compression runs, the bookkeeping code in
+    ``conversation_compression.py`` writes a rough estimate into
+    ``last_prompt_tokens`` so pressure calculations use the post-compression
+    count, not the stale pre-compression count.  That estimate can over-count
+    real tokens by 5-30% (tool schemas, system prompt, thinking blocks), and
+    used to keep ``should_compress()`` returning True on every subsequent
+    call, firing compression every 1-2 turns even when no real API response
+    had yet confirmed the new size.
+
+    The fix: when the only token signal is a post-compression estimate
+    (no API ``usage.prompt_tokens`` since the last compress) AND the value
+    sits within 10% of threshold, defer until the next API turn supplies a
+    precise count.  If the estimate is materially above threshold (>10%
+    over) we still fire so unbounded sessions can't slip past the gate.
+    """
+
+    def test_estimate_just_over_threshold_defers(self, compressor):
+        # Simulate "we just compressed once" + post-compress estimate write.
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 86000  # 1.2% over 85k threshold
+        compressor._last_prompt_tokens_is_estimate = True
+        assert compressor.should_compress() is False, (
+            "post-compression estimate within 10% of threshold should defer "
+            "until next API response confirms the count (#27566)"
+        )
+
+    def test_api_confirmation_clears_defer(self, compressor):
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 86000
+        compressor._last_prompt_tokens_is_estimate = True
+        # Real API response arrives — precise count happens to be 86k too.
+        compressor.update_from_response({
+            "prompt_tokens": 86000,
+            "completion_tokens": 0,
+            "total_tokens": 86000,
+        })
+        assert compressor._last_prompt_tokens_is_estimate is False
+        assert compressor.should_compress() is True, (
+            "after the API confirms the count, the deferral must lift"
+        )
+
+    def test_estimate_far_over_threshold_still_fires(self, compressor):
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 95000  # ~12% over 85k threshold
+        compressor._last_prompt_tokens_is_estimate = True
+        assert compressor.should_compress() is True, (
+            "estimate >10% over threshold should still fire — we don't want "
+            "unbounded growth even on the estimate path"
+        )
+
+    def test_no_defer_before_first_compression(self, compressor):
+        # First compression cycle ever: there is no prior estimate write, so
+        # the estimate-defer guard must NOT block the very first compress.
+        assert compressor.compression_count == 0
+        compressor.last_prompt_tokens = 86000
+        compressor._last_prompt_tokens_is_estimate = True
+        assert compressor.should_compress() is True
+
+    def test_api_response_with_zero_does_not_clear_flag(self, compressor):
+        # Stale "no usage" API response (provider returned no usage dict)
+        # must not silently clear the estimate flag.
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 86000
+        compressor._last_prompt_tokens_is_estimate = True
+        compressor.update_from_response({})
+        assert compressor._last_prompt_tokens_is_estimate is True
+
 
 class TestUpdateFromResponse:
     def test_updates_fields(self, compressor):


### PR DESCRIPTION
## Problem

After the first compression, context compression re-fires every 1-2 turns even though compression just ran, so a session never stabilizes. In user logs the loop looks like `141K -> compress -> 60K -> compression #2 -> compression #3 -> ...`. It is most visible on tool-heavy sessions (50+ tool schemas, large system prompt, thinking blocks).

## Root cause

When a compression finishes, `compress_context()` in `agent/conversation_compression.py` writes a rough post-compression estimate (`_compressed_est`) into `context_compressor.last_prompt_tokens` so pressure math uses the post-compression size instead of the stale pre-compression value. That estimate over-counts the provider tokenizer's real prompt count by roughly 5-30% on tool-heavy sessions.

`should_compress()` in `agent/context_compressor.py` then treats this inflated estimate as a hard trigger. When the estimate lands just above `threshold_tokens`, the very next `should_compress()` call returns `True` and compression re-fires before any real API response has had a chance to overwrite `last_prompt_tokens` with the precise provider count. The existing anti-thrashing guard (skip when the last two compressions each saved less than 10%) does not catch this because the loop is driven by the unconfirmed estimate, not by ineffective compressions.

## Fix

The post-compression write is intentional and kept, but it is now tagged as advisory until the API confirms it:

- `ContextCompressor.__init__` adds `self._last_prompt_tokens_is_estimate = False` (`agent/context_compressor.py`).
- `compress_context()` sets `_last_prompt_tokens_is_estimate = True` right after writing the rough post-compression estimate (`agent/conversation_compression.py`).
- `update_from_response()` reads `prompt_tokens` defensively (`usage.get("prompt_tokens", 0) or 0`) and clears `_last_prompt_tokens_is_estimate` only when a real `prompt_tokens > 0` arrives, so an empty/usage-less response does not silently clear the flag.
- `should_compress()` defers one cycle (returns `False`) when all of: `compression_count > 0`, `_last_prompt_tokens_is_estimate` is set, and `tokens < int(threshold_tokens * 1.10)`. The next API turn overwrites `last_prompt_tokens` with the precise count, clears the flag, and a real decision is made then.

Bounding choices, all present in the diff:
- The deferral only applies when `compression_count > 0`, so the very first compression is never blocked.
- Estimates 10% or more over threshold still fire, so an unbounded session cannot slip past the gate on the estimate path.
- The deferral is logged (gated on `not self.quiet_mode`).

## Testing

New test class `TestPostCompressionEstimateDefer` in `tests/agent/test_context_compressor.py` covers:
- estimate within 10% of threshold defers (`test_estimate_just_over_threshold_defers`)
- a real API count clears the deferral and `should_compress()` then fires (`test_api_confirmation_clears_defer`)
- an estimate >10% over threshold still fires (`test_estimate_far_over_threshold_still_fires`)
- the guard does not block the first-ever compression while `compression_count == 0` (`test_no_defer_before_first_compression`)
- `update_from_response({})` with no usage dict does not clear the flag (`test_api_response_with_zero_does_not_clear_flag`)

Run: `pytest tests/agent/test_context_compressor.py`.

## Risk & impact

- Behavior change is scoped to post-compression cycles with an unconfirmed estimate within 10% of threshold; all other paths are unchanged.
- Trade-off: when an estimate sits in that narrow band, compression is delayed by exactly one API turn (until the precise count is known). Because the deferral lifts as soon as a real `prompt_tokens > 0` is reported, a genuinely over-threshold session compresses on the next turn rather than looping.
- Safety valve: estimates 10% or more over threshold bypass the deferral, preventing unbounded context growth.
- New state (`_last_prompt_tokens_is_estimate`) defaults to `False`, so existing/restored sessions behave as before until the next compression sets it.

Closes #27566
