### PR TITLE
fix(cron): keep profile-created jobs visible to the gateway

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1,8 +1,15 @@
 """
 Cron job storage and management.
 
-Jobs are stored in ~/.hermes/cron/jobs.json
-Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
+Jobs are stored in the gateway-shared root ``~/.hermes/cron/jobs.json``
+regardless of the active profile.  The scheduler runs inside the gateway
+process and only reads that one file — any per-profile ``jobs.json`` written
+elsewhere is invisible to it (issue #32091).  Per-job profile context is
+preserved by stamping the job's ``profile`` field, which
+``cron.scheduler._job_profile_context`` honours at run time.
+
+Output is saved to ``~/.hermes/cron/output/{job_id}/{timestamp}.md`` under the
+same root.
 """
 
 import copy
@@ -16,7 +23,7 @@ import re
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -34,7 +41,14 @@ except ImportError:
 # Configuration
 # =============================================================================
 
-HERMES_DIR = get_hermes_home().resolve()
+# Resolve to the canonical gateway-shared Hermes root, never a profile-local
+# subdirectory.  When an agent session runs under ``hermes -p <profile>``,
+# ``HERMES_HOME`` is pointed at ``<root>/profiles/<name>``, so a naive
+# ``get_hermes_home()`` here would land cron jobs in a per-profile
+# ``cron/jobs.json`` that the gateway scheduler never reads (#32091).
+# ``get_default_hermes_root()`` returns ``<root>`` in both classic
+# (``~/.hermes``) and Docker (``$HERMES_HOME``) deployments.
+HERMES_DIR = get_default_hermes_root().resolve()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
 
@@ -149,6 +163,9 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     if not state:
         state = "scheduled" if normalized.get("enabled", True) else "paused"
     normalized["state"] = state
+
+    profile = _coerce_job_text(normalized.get("profile")).strip()
+    normalized["profile"] = profile or None
 
     return normalized
 
@@ -520,6 +537,21 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+def _normalize_profile(profile: Optional[str]) -> Optional[str]:
+    """Normalize and validate an optional cron job profile name."""
+    if profile is None:
+        return None
+    raw = str(profile).strip()
+    if not raw:
+        return None
+
+    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+    normalized = normalize_profile_name(raw)
+    resolve_profile_env(normalized)
+    return normalized
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -536,6 +568,7 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    profile: Optional[str] = None,
     no_agent: bool = False,
 ) -> Dict[str, Any]:
     """
@@ -577,6 +610,9 @@ def create_job(
                 With ``no_agent=True``, ``workdir`` is still applied as the
                 script's cwd so relative paths inside the script behave
                 predictably.
+        profile: Optional Hermes profile name. When set, the job runs with
+                that profile's HERMES_HOME. When omitted from a profile-scoped
+                session, the active non-default profile is inferred.
         no_agent: When True, skip the agent entirely — run ``script`` on schedule
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
@@ -614,6 +650,28 @@ def create_job(
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
+    normalized_profile = _normalize_profile(profile)
+    # If the caller is a profile-scoped agent session (HERMES_HOME points at a
+    # non-default profile) but no explicit profile was supplied, stamp the
+    # active profile name on the job so the scheduler runs it under the same
+    # context the user created it from.  Without this, jobs created from a
+    # profile session would silently execute under the gateway's default
+    # profile context (#32091 follow-on: the job is no longer orphaned, but
+    # the user's intent of "run under my profile" must still be preserved).
+    if normalized_profile is None:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            inferred = get_active_profile_name()
+        except Exception:
+            inferred = "default"
+        if inferred and inferred not in {"default", "custom"}:
+            try:
+                normalized_profile = _normalize_profile(inferred)
+            except (ValueError, FileNotFoundError):
+                # Profile lookup failed (e.g. profile dir was just renamed/removed
+                # mid-session).  Fall back to no profile stamp rather than blocking
+                # job creation — scheduler will run under its own default context.
+                normalized_profile = None
     normalized_no_agent = bool(no_agent)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
@@ -668,6 +726,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "profile": normalized_profile,
     }
 
     jobs = load_jobs()
@@ -756,6 +815,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["workdir"] = None
             else:
                 updates["workdir"] = _normalize_workdir(_wd)
+
+        if "profile" in updates:
+            _profile = updates["profile"]
+            if _profile in {None, "", False}:
+                updates["profile"] = None
+            else:
+                updates["profile"] = _normalize_profile(_profile)
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import threading
 
+from contextlib import contextmanager
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
     import fcntl
@@ -37,7 +38,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
@@ -225,6 +226,45 @@ _hermes_home: Path | None = None
 def _get_hermes_home() -> Path:
     """Resolve Hermes home dynamically while preserving test monkeypatch hooks."""
     return _hermes_home or get_hermes_home()
+
+
+@contextmanager
+def _job_profile_context(job: dict):
+    """Scope get_hermes_home() to a stored cron job profile, if valid.
+
+    The override is context-local so in-process agent code can read the
+    profile home without changing the scheduler process' HERMES_HOME.  The
+    dotenv loader still mutates os.environ, so the full environment is restored
+    when the job exits; tick() routes profile jobs through the sequential pool.
+    """
+    raw_profile = str(job.get("profile") or "").strip()
+    if not raw_profile:
+        yield
+        return
+
+    try:
+        from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+        profile_name = normalize_profile_name(raw_profile)
+        profile_home = Path(resolve_profile_env(profile_name)).resolve()
+    except Exception as exc:
+        logger.warning(
+            "Job '%s': profile %r could not be resolved; running with default Hermes home: %s",
+            job.get("id", "?"),
+            raw_profile,
+            exc,
+        )
+        yield
+        return
+
+    prior_env = os.environ.copy()
+    token = set_hermes_home_override(profile_home)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+        os.environ.clear()
+        os.environ.update(prior_env)
 
 
 def _get_lock_paths() -> tuple[Path, Path]:
@@ -968,12 +1008,15 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     try:
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        script_env = os.environ.copy()
+        script_env["HERMES_HOME"] = str(_get_hermes_home())
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
             timeout=script_timeout,
             cwd=str(path.parent),
+            env=script_env,
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()
@@ -1303,6 +1346,11 @@ def _scan_assembled_cron_prompt(
 
 
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+    with _job_profile_context(job):
+        return _run_job(job)
+
+
+def _run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
     
@@ -2087,12 +2135,20 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 mark_job_run(job["id"], False, str(e))
                 return False
 
-        # Partition due jobs: those with a per-job workdir mutate
+        # Partition due jobs: those with a per-job workdir or profile mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
         # so they MUST run sequentially to avoid corrupting each other.  Jobs
-        # without a workdir leave env untouched and stay parallel-safe.
-        sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
+        # without a workdir/profile leave env untouched and stay parallel-safe.
+        sequential_jobs = [
+            j
+            for j in due_jobs
+            if (j.get("workdir") or "").strip() or (j.get("profile") or "").strip()
+        ]
+        parallel_jobs = [
+            j
+            for j in due_jobs
+            if not ((j.get("workdir") or "").strip() or (j.get("profile") or "").strip())
+        ]
 
         _results: list = []
         _all_futures: list = []

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6282,6 +6282,26 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
     return canon, profiles_mod.get_profile_dir(canon)
 
 
+def _cron_job_profile(job: Dict[str, Any], fallback: str = "default") -> str:
+    profile = str(job.get("profile") or "").strip()
+    return profile or fallback or "default"
+
+
+def _cron_jobs_for_profile(
+    jobs: List[Dict[str, Any]],
+    profile: str,
+) -> List[Dict[str, Any]]:
+    if profile == "default":
+        return [
+            job for job in jobs
+            if _cron_job_profile(job, "default") == "default"
+        ]
+    return [
+        job for job in jobs
+        if _cron_job_profile(job, "default") == profile
+    ]
+
+
 def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[str, Any]:
     annotated = dict(job)
     annotated["profile"] = profile
@@ -6292,34 +6312,51 @@ def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[st
 
 
 def _call_cron_for_profile(profile: Optional[str], func_name: str, *args, **kwargs):
-    """Run cron.jobs helpers against the selected profile's cron directory.
+    """Run cron.jobs helpers for the selected dashboard profile.
 
-    cron.jobs keeps CRON_DIR/JOBS_FILE/OUTPUT_DIR as module globals resolved
-    from the process HERMES_HOME at import time. The dashboard is a single
-    process that can inspect many profiles, so temporarily retarget those
-    globals while holding a lock and restore them immediately after the call.
+    Cron jobs live in the gateway-shared root store. The selected dashboard
+    profile is preserved on each job's ``profile`` field, then list/search
+    operations filter that root store by the stored profile value.
     """
     profile_name, home = _cron_profile_home(profile)
     with _CRON_PROFILE_LOCK:
         from cron import jobs as cron_jobs
 
-        old_cron_dir = cron_jobs.CRON_DIR
-        old_jobs_file = cron_jobs.JOBS_FILE
-        old_output_dir = cron_jobs.OUTPUT_DIR
-        cron_jobs.CRON_DIR = home / "cron"
-        cron_jobs.JOBS_FILE = cron_jobs.CRON_DIR / "jobs.json"
-        cron_jobs.OUTPUT_DIR = cron_jobs.CRON_DIR / "output"
-        try:
-            result = getattr(cron_jobs, func_name)(*args, **kwargs)
-        finally:
-            cron_jobs.CRON_DIR = old_cron_dir
-            cron_jobs.JOBS_FILE = old_jobs_file
-            cron_jobs.OUTPUT_DIR = old_output_dir
+        call_kwargs = dict(kwargs)
+        if func_name == "create_job":
+            if not call_kwargs.get("profile"):
+                call_kwargs["profile"] = profile_name
+        call_args = args
+        if func_name in {
+            "get_job",
+            "update_job",
+            "pause_job",
+            "resume_job",
+            "trigger_job",
+            "remove_job",
+        } and args:
+            ref = str(args[0])
+            profile_jobs = _cron_jobs_for_profile(cron_jobs.list_jobs(True), profile_name)
+            matches = [
+                job for job in profile_jobs
+                if job.get("id") == ref or job.get("name") == ref
+            ]
+            if not matches:
+                return False if func_name == "remove_job" else None
+            if len(matches) == 1 and matches[0].get("id") != ref:
+                call_args = (matches[0]["id"], *args[1:])
+        result = getattr(cron_jobs, func_name)(*call_args, **call_kwargs)
 
     if isinstance(result, list):
-        return [_annotate_cron_job(j, profile_name, home) for j in result]
+        filtered = _cron_jobs_for_profile(result, profile_name)
+        return [_annotate_cron_job(j, profile_name, home) for j in filtered]
     if isinstance(result, dict):
-        return _annotate_cron_job(result, profile_name, home)
+        result_profile = _cron_job_profile(result, profile_name)
+        if result_profile == profile_name:
+            result_home = home
+        else:
+            result_profile, result_home = _cron_profile_home(result_profile)
+        return _annotate_cron_job(result, result_profile, result_home)
     return result
 
 

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -466,6 +466,7 @@ class TestProfileScopedSessionWritesToRoot:
         resolve JOBS_FILE to the gateway-shared root jobs.json, not the
         profile-local one."""
         import importlib
+        from pathlib import Path as _Path
 
         root = tmp_path / "hermes-root"
         profile_home = root / "profiles" / "support"
@@ -473,7 +474,7 @@ class TestProfileScopedSessionWritesToRoot:
 
         # Pretend the agent session is profile-scoped: HERMES_HOME = profile dir.
         monkeypatch.setenv("HERMES_HOME", str(profile_home))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
         import cron.jobs as cron_jobs
 
@@ -498,6 +499,7 @@ class TestProfileScopedSessionWritesToRoot:
         """An agent session running under -p <profile> creates a cron job;
         the job must land in the root jobs.json that the gateway reads."""
         import importlib
+        from pathlib import Path as _Path
 
         root = tmp_path / "hermes-root"
         profile_home = root / "profiles" / "support"
@@ -505,7 +507,7 @@ class TestProfileScopedSessionWritesToRoot:
 
         # Profile session: HERMES_HOME points at the profile, not the root.
         monkeypatch.setenv("HERMES_HOME", str(profile_home))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
         # Reload cron.jobs so the module-level CRON_DIR/JOBS_FILE recompute
         # against the patched environment.
@@ -548,12 +550,13 @@ class TestProfileScopedSessionWritesToRoot:
         """In a default (non-profile) session, create_job must not stamp a
         profile field on jobs that don't request one."""
         import importlib
+        from pathlib import Path as _Path
 
         root = tmp_path / "hermes-root"
         root.mkdir(parents=True)
 
         monkeypatch.setenv("HERMES_HOME", str(root))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
         import cron.jobs as cron_jobs
 

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -1,0 +1,566 @@
+"""Tests for per-job profile support in cron jobs.
+
+Covers data-layer validation/storage, cronjob tool plumbing, scheduler runtime
+HERMES_HOME scoping, and tick() serialization for profile jobs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_cron_profile_home(tmp_path, monkeypatch):
+    """Create an isolated Hermes root with a named profile and temp cron store."""
+    root = tmp_path / "hermes-root"
+    profile_home = root / "profiles" / "support"
+    profile_home.mkdir(parents=True)
+    (root / "cron").mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr("cron.jobs.CRON_DIR", root / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", root / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", root / "cron" / "output")
+
+    return root, profile_home
+
+
+class TestNormalizeProfile:
+    def test_none_and_empty_return_none(self, isolated_cron_profile_home):
+        from cron.jobs import _normalize_profile
+
+        assert _normalize_profile(None) is None
+        assert _normalize_profile("") is None
+        assert _normalize_profile("   ") is None
+
+    def test_default_profile_is_valid_and_normalized(self, isolated_cron_profile_home):
+        from cron.jobs import _normalize_profile
+
+        assert _normalize_profile("Default") == "default"
+
+    def test_named_profile_must_exist_and_is_normalized(self, isolated_cron_profile_home):
+        from cron.jobs import _normalize_profile
+
+        assert _normalize_profile("Support") == "support"
+
+    def test_invalid_profile_name_is_rejected(self, isolated_cron_profile_home):
+        from cron.jobs import _normalize_profile
+
+        with pytest.raises(ValueError):
+            _normalize_profile("invalid!")
+
+    def test_missing_named_profile_is_rejected(self, isolated_cron_profile_home):
+        from cron.jobs import _normalize_profile
+
+        with pytest.raises(FileNotFoundError):
+            _normalize_profile("missing")
+
+
+class TestCreateAndUpdateJobProfile:
+    def test_create_stores_profile_id(self, isolated_cron_profile_home):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(prompt="hello", schedule="every 1h", profile="Support")
+        stored = get_job(job["id"])
+
+        assert stored is not None
+        assert stored["profile"] == "support"
+
+    def test_create_without_profile_preserves_old_behaviour(self, isolated_cron_profile_home):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(prompt="hello", schedule="every 1h")
+        stored = get_job(job["id"])
+
+        assert stored is not None
+        assert stored.get("profile") is None
+
+    def test_create_accepts_explicit_default(self, isolated_cron_profile_home):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(prompt="hello", schedule="every 1h", profile="default")
+        stored = get_job(job["id"])
+
+        assert stored is not None
+        assert stored["profile"] == "default"
+
+    def test_update_sets_and_clears_profile(self, isolated_cron_profile_home):
+        from cron.jobs import create_job, get_job, update_job
+
+        job = create_job(prompt="x", schedule="every 1h")
+        update_job(job["id"], {"profile": "Support"})
+        stored = get_job(job["id"])
+        assert stored is not None
+        assert stored["profile"] == "support"
+
+        update_job(job["id"], {"profile": ""})
+        stored = get_job(job["id"])
+        assert stored is not None
+        assert stored["profile"] is None
+
+    def test_update_rejects_missing_profile(self, isolated_cron_profile_home):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(prompt="x", schedule="every 1h")
+        with pytest.raises(FileNotFoundError):
+            update_job(job["id"], {"profile": "missing"})
+
+
+class TestCronjobToolProfile:
+    def test_create_and_list_with_profile(self, isolated_cron_profile_home):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="hi",
+                schedule="every 1h",
+                profile="Support",
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["profile"] == "support"
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["profile"] == "support"
+
+    def test_update_clears_profile_with_empty_string(self, isolated_cron_profile_home):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="hi",
+                schedule="every 1h",
+                profile="Support",
+            )
+        )
+        updated = json.loads(
+            cronjob(action="update", job_id=created["job_id"], profile="")
+        )
+
+        assert updated["success"] is True
+        assert "profile" not in updated["job"]
+
+    def test_schema_advertises_profile(self):
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+
+        assert "profile" in CRONJOB_SCHEMA["parameters"]["properties"]
+        desc = CRONJOB_SCHEMA["parameters"]["properties"]["profile"]["description"]
+        desc_lower = desc.lower()
+        assert "hermes profile" in desc_lower
+        assert "context-local" in desc_lower
+        assert "subprocess" in desc_lower
+        assert "temporarily sets hermes_home" not in desc_lower
+
+
+class TestRunJobProfileContext:
+    @staticmethod
+    def _install_agent_stubs(monkeypatch, observed: dict):
+        import sys
+        import cron.scheduler as sched
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                from hermes_constants import get_hermes_home
+
+                observed["env_home_during_init"] = os.environ.get("HERMES_HOME")
+                observed["profile_env_only_during_init"] = os.environ.get(
+                    "HERMES_PROFILE_TEST_ONLY"
+                )
+                observed["profile_env_shared_during_init"] = os.environ.get(
+                    "HERMES_PROFILE_TEST_SHARED"
+                )
+                observed["hermes_home_during_init"] = str(get_hermes_home())
+                observed["scheduler_home_during_init"] = str(sched._get_hermes_home())
+                observed["skip_context_files"] = kwargs.get("skip_context_files")
+
+            def run_conversation(self, *_a, **_kw):
+                from hermes_constants import get_hermes_home
+
+                observed["env_home_during_run"] = os.environ.get("HERMES_HOME")
+                observed["profile_env_only_during_run"] = os.environ.get(
+                    "HERMES_PROFILE_TEST_ONLY"
+                )
+                observed["profile_env_shared_during_run"] = os.environ.get(
+                    "HERMES_PROFILE_TEST_SHARED"
+                )
+                observed["hermes_home_during_run"] = str(get_hermes_home())
+                observed["scheduler_home_during_run"] = str(sched._get_hermes_home())
+                return {"final_response": "done", "messages": []}
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 0.0}
+
+            def close(self):
+                observed["closed"] = True
+
+        fake_mod = type(sys)("run_agent")
+        fake_mod.AIAgent = FakeAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+
+        from hermes_cli import runtime_provider as runtime_provider
+
+        monkeypatch.setattr(
+            runtime_provider,
+            "resolve_runtime_provider",
+            lambda **_kw: {
+                "provider": "test",
+                "api_key": "test-key",
+                "base_url": "http://test.local",
+                "api_mode": "chat_completions",
+            },
+        )
+
+        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+        monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
+        monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)
+        monkeypatch.setattr(sched, "_hermes_home", None)
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+
+        import dotenv
+
+        def fake_load_dotenv(path, *_a, **_kw):
+            observed.setdefault("dotenv_paths", []).append(str(path))
+            return True
+
+        monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+
+    def test_run_job_sets_and_restores_profile_home(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        import cron.scheduler as sched
+
+        root, profile_home = isolated_cron_profile_home
+        observed: dict = {}
+        self._install_agent_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "abc",
+            "name": "profile-job",
+            "profile": "support",
+            "schedule_display": "manual",
+        }
+
+        success, _output, response, error = sched.run_job(job)
+
+        assert success is True, f"run_job failed: error={error!r} response={response!r}"
+        assert observed["dotenv_paths"] == [str(profile_home / ".env")]
+        assert observed["env_home_during_init"] == str(root)
+        assert observed["env_home_during_run"] == str(root)
+        assert observed["hermes_home_during_init"] == str(profile_home.resolve())
+        assert observed["hermes_home_during_run"] == str(profile_home.resolve())
+        assert observed["scheduler_home_during_init"] == str(profile_home.resolve())
+        assert observed["scheduler_home_during_run"] == str(profile_home.resolve())
+        assert observed["skip_context_files"] is True
+        assert os.environ["HERMES_HOME"] == str(root)
+        assert sched._get_hermes_home() == root
+
+    def test_profile_dotenv_environment_is_restored(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        import dotenv
+        import cron.scheduler as sched
+
+        root, profile_home = isolated_cron_profile_home
+        observed: dict = {}
+        self._install_agent_stubs(monkeypatch, observed)
+        monkeypatch.setenv("HERMES_PROFILE_TEST_SHARED", "outer")
+        monkeypatch.delenv("HERMES_PROFILE_TEST_ONLY", raising=False)
+
+        def fake_load_dotenv(path, *_a, **_kw):
+            observed.setdefault("dotenv_paths", []).append(str(path))
+            os.environ["HERMES_PROFILE_TEST_SHARED"] = "profile-value"
+            os.environ["HERMES_PROFILE_TEST_ONLY"] = "profile-only"
+            os.environ["HERMES_CRON_TIMEOUT"] = "123"
+            return True
+
+        monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+
+        job = {
+            "id": "env-profile",
+            "name": "profile-env-job",
+            "profile": "support",
+            "schedule_display": "manual",
+        }
+
+        success, _output, _response, error = sched.run_job(job)
+
+        assert success is True, error
+        assert observed["dotenv_paths"] == [str(profile_home / ".env")]
+        assert observed["profile_env_only_during_init"] == "profile-only"
+        assert observed["profile_env_shared_during_init"] == "profile-value"
+        assert observed["profile_env_only_during_run"] == "profile-only"
+        assert observed["profile_env_shared_during_run"] == "profile-value"
+        assert os.environ["HERMES_PROFILE_TEST_SHARED"] == "outer"
+        assert "HERMES_PROFILE_TEST_ONLY" not in os.environ
+        assert os.environ["HERMES_CRON_TIMEOUT"] == "0"
+        assert os.environ["HERMES_HOME"] == str(root)
+        assert sched._get_hermes_home() == root
+
+    def test_no_agent_profile_uses_profile_scripts_dir_and_restores_env(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        import cron.scheduler as sched
+
+        root, profile_home = isolated_cron_profile_home
+        scripts_dir = profile_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "print_home.py").write_text(
+            "import os\nprint(os.environ.get('HERMES_HOME', ''))\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sched, "_hermes_home", None)
+
+        job = {
+            "id": "script1",
+            "name": "profile-script",
+            "profile": "support",
+            "script": "print_home.py",
+            "no_agent": True,
+        }
+
+        success, _doc, response, error = sched.run_job(job)
+
+        assert success is True, error
+        assert response.strip() == str(profile_home.resolve())
+        assert os.environ["HERMES_HOME"] == str(root)
+        assert sched._get_hermes_home() == root
+
+    def test_run_job_without_profile_leaves_hermes_home_untouched(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        import cron.scheduler as sched
+
+        root, _profile_home = isolated_cron_profile_home
+        observed: dict = {}
+        self._install_agent_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "noprof",
+            "name": "no-profile-job",
+            "profile": None,
+            "schedule_display": "manual",
+        }
+
+        success, *_ = sched.run_job(job)
+
+        assert success is True
+        assert observed["hermes_home_during_init"] == str(root)
+        assert os.environ["HERMES_HOME"] == str(root)
+
+    def test_run_job_falls_back_on_missing_runtime_profile(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        import cron.scheduler as sched
+
+        root, _profile_home = isolated_cron_profile_home
+        observed: dict = {}
+        self._install_agent_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "missing-profile",
+            "name": "missing-profile-job",
+            "profile": "missing",
+            "schedule_display": "manual",
+        }
+
+        # Should succeed with fallback, not raise
+        success, _output, response, error = sched.run_job(job)
+
+        assert success is True, f"run_job should fallback, not fail: error={error!r}"
+        # Verify it used the default home, not the missing profile
+        assert observed["hermes_home_during_init"] == str(root)
+        assert os.environ["HERMES_HOME"] == str(root)
+
+
+class TestTickProfilePartition:
+    def test_profile_and_workdir_combined(self, isolated_cron_profile_home, monkeypatch):
+        """Both profile and workdir set — verify both are applied and restored."""
+        import cron.scheduler as sched
+
+        root, profile_home = isolated_cron_profile_home
+        observed: dict = {}
+        TestRunJobProfileContext._install_agent_stubs(monkeypatch, observed)
+        fake_workdir = str(root / "myproject")
+        (root / "myproject").mkdir()
+
+        job = {
+            "id": "combo",
+            "name": "combo-job",
+            "profile": "support",
+            "workdir": fake_workdir,
+            "schedule_display": "manual",
+        }
+
+        success, _output, _response, error = sched.run_job(job)
+
+        assert success is True, error
+        assert observed["hermes_home_during_init"] == str(profile_home.resolve())
+        assert os.environ.get("TERMINAL_CWD", "") != fake_workdir, \
+            "TERMINAL_CWD should be restored after job"
+        assert os.environ["HERMES_HOME"] == str(root)
+        assert sched._get_hermes_home() == root
+
+    def test_profile_jobs_run_sequentially(self, isolated_cron_profile_home, monkeypatch):
+        import threading
+        import cron.scheduler as sched
+
+        # Two profile jobs (both sequential) + one parallel job.
+        profile_a = {"id": "a", "name": "A", "profile": "default"}
+        profile_b = {"id": "b", "name": "B", "profile": "default"}
+        parallel_job = {"id": "c", "name": "C", "profile": None}
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [profile_a, profile_b, parallel_job])
+        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+
+        calls: list[tuple[str, str]] = []
+        order_lock = threading.Lock()
+
+        def fake_run_job(job):
+            with order_lock:
+                calls.append((job["id"], threading.current_thread().name))
+            return True, "output", "response", None
+
+        monkeypatch.setattr(sched, "run_job", fake_run_job)
+        monkeypatch.setattr(sched, "save_job_output", lambda _jid, _o: None)
+        monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+
+        n = sched.tick(verbose=False)
+
+        assert n == 3
+        ids = [job_id for job_id, _thread_name in calls]
+        # Sequential profile jobs preserve submission order relative to each
+        # other (single-thread pool).
+        assert ids.index("a") < ids.index("b")
+        # Sequential (profile) jobs run on the persistent single-thread
+        # cron-seq pool — NOT the main thread — so a long profile job never
+        # blocks the ticker.  Parallel jobs run on the cron-parallel pool.
+        for jid in ("a", "b"):
+            seq_thread = next(t for job_id, t in calls if job_id == jid)
+            assert seq_thread != threading.current_thread().name
+            assert seq_thread.startswith("cron-seq"), seq_thread
+        par_thread = next(t for job_id, t in calls if job_id == "c")
+        assert par_thread.startswith("cron-parallel"), par_thread
+
+
+class TestProfileScopedSessionWritesToRoot:
+    """Regression for #32091.
+
+    When an agent session runs under ``hermes -p <profile>``, ``HERMES_HOME``
+    points at the profile directory (``<root>/profiles/<name>``).  Cron jobs
+    created from that session must still land in the gateway-shared root
+    ``jobs.json`` — otherwise the gateway scheduler (which reads only its own
+    root) never sees them and they silently orphan.
+    """
+
+    def test_module_paths_resolve_to_root_under_profile_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        """Reloading cron.jobs under a profile-scoped HERMES_HOME must still
+        resolve JOBS_FILE to the gateway-shared root jobs.json, not the
+        profile-local one."""
+        import importlib
+
+        root = tmp_path / "hermes-root"
+        profile_home = root / "profiles" / "support"
+        profile_home.mkdir(parents=True)
+
+        # Pretend the agent session is profile-scoped: HERMES_HOME = profile dir.
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import cron.jobs as cron_jobs
+
+        importlib.reload(cron_jobs)
+        try:
+            # The canonical write/read location must be the gateway root,
+            # not <root>/profiles/<name>/cron/jobs.json.
+            assert cron_jobs.JOBS_FILE == root / "cron" / "jobs.json"
+            assert cron_jobs.CRON_DIR == root / "cron"
+            assert cron_jobs.OUTPUT_DIR == root / "cron" / "output"
+
+            assert profile_home not in cron_jobs.JOBS_FILE.parents
+        finally:
+            # Reload again with a clean env so other tests in the run see
+            # the module-level constants resolved from the real default root.
+            monkeypatch.delenv("HERMES_HOME", raising=False)
+            importlib.reload(cron_jobs)
+
+    def test_create_job_writes_to_root_jobs_file_when_profile_active(
+        self, tmp_path, monkeypatch
+    ):
+        """An agent session running under -p <profile> creates a cron job;
+        the job must land in the root jobs.json that the gateway reads."""
+        import importlib
+
+        root = tmp_path / "hermes-root"
+        profile_home = root / "profiles" / "support"
+        profile_home.mkdir(parents=True)
+
+        # Profile session: HERMES_HOME points at the profile, not the root.
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # Reload cron.jobs so the module-level CRON_DIR/JOBS_FILE recompute
+        # against the patched environment.
+        import cron.jobs as cron_jobs
+
+        importlib.reload(cron_jobs)
+        try:
+            job = cron_jobs.create_job(prompt="ping", schedule="every 1h")
+
+            root_jobs_file = root / "cron" / "jobs.json"
+            profile_jobs_file = profile_home / "cron" / "jobs.json"
+
+            assert root_jobs_file.exists(), (
+                f"Job must be written to gateway-shared root, not profile-local."
+                f"  root_jobs_file={root_jobs_file} profile_jobs_file_exists="
+                f"{profile_jobs_file.exists()}"
+            )
+            # The profile-local path must remain empty — that is the orphan
+            # location described by #32091.
+            assert not profile_jobs_file.exists(), (
+                "Cron job was written to profile-local jobs.json — the "
+                "gateway scheduler will never read it (regression of #32091)."
+            )
+
+            data = json.loads(root_jobs_file.read_text())
+            stored_ids = [j["id"] for j in data.get("jobs", [])]
+            assert job["id"] in stored_ids
+
+            # The profile name should be auto-stamped so the scheduler runs
+            # the job under the user's profile context.
+            stored = next(j for j in data["jobs"] if j["id"] == job["id"])
+            assert stored["profile"] == "support"
+        finally:
+            monkeypatch.delenv("HERMES_HOME", raising=False)
+            importlib.reload(cron_jobs)
+
+    def test_create_job_without_profile_active_does_not_stamp_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """In a default (non-profile) session, create_job must not stamp a
+        profile field on jobs that don't request one."""
+        import importlib
+
+        root = tmp_path / "hermes-root"
+        root.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import cron.jobs as cron_jobs
+
+        importlib.reload(cron_jobs)
+        try:
+            job = cron_jobs.create_job(prompt="ping", schedule="every 1h")
+            assert job.get("profile") is None
+        finally:
+            monkeypatch.delenv("HERMES_HOME", raising=False)
+            importlib.reload(cron_jobs)

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1,5 +1,7 @@
 """Regression tests for dashboard cron job profile routing."""
 
+import json
+
 import pytest
 from fastapi import HTTPException
 
@@ -7,6 +9,7 @@ from fastapi import HTTPException
 @pytest.fixture()
 def isolated_profiles(tmp_path, monkeypatch):
     """Give profile discovery an isolated default home with one named profile."""
+    from cron import jobs as cron_jobs
     from hermes_cli import profiles
 
     default_home = tmp_path / ".hermes"
@@ -19,10 +22,17 @@ def isolated_profiles(tmp_path, monkeypatch):
 
     monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
     monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(cron_jobs, "HERMES_DIR", default_home)
+    monkeypatch.setattr(cron_jobs, "CRON_DIR", default_home / "cron")
+    monkeypatch.setattr(cron_jobs, "JOBS_FILE", default_home / "cron" / "jobs.json")
+    monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", default_home / "cron" / "output")
     return {"default": default_home, "worker_alpha": worker_home}
 
 
-def test_call_cron_for_profile_routes_storage_and_restores_globals(isolated_profiles):
+@pytest.mark.asyncio
+async def test_dashboard_create_cron_job_writes_root_store_and_stamps_profile(
+    isolated_profiles,
+):
     from cron import jobs as cron_jobs
     from hermes_cli import web_server
 
@@ -30,20 +40,29 @@ def test_call_cron_for_profile_routes_storage_and_restores_globals(isolated_prof
     old_jobs_file = cron_jobs.JOBS_FILE
     old_output_dir = cron_jobs.OUTPUT_DIR
 
-    job = web_server._call_cron_for_profile(
-        "worker_alpha",
-        "create_job",
-        prompt="run scheduled task",
-        schedule="every 1h",
-        name="worker-alpha-scan",
+    job = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="run scheduled task",
+            schedule="every 1h",
+            name="worker-alpha-scan",
+        ),
+        profile="worker_alpha",
     )
+
+    root_jobs_file = isolated_profiles["default"] / "cron" / "jobs.json"
+    profile_jobs_file = isolated_profiles["worker_alpha"] / "cron" / "jobs.json"
 
     assert job["profile"] == "worker_alpha"
     assert job["profile_name"] == "worker_alpha"
     assert job["hermes_home"] == str(isolated_profiles["worker_alpha"])
     assert job["is_default_profile"] is False
-    assert (isolated_profiles["worker_alpha"] / "cron" / "jobs.json").exists()
-    assert not (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+    assert root_jobs_file.exists()
+    assert not profile_jobs_file.exists()
+
+    stored_jobs = json.loads(root_jobs_file.read_text(encoding="utf-8"))["jobs"]
+    assert len(stored_jobs) == 1
+    assert stored_jobs[0]["id"] == job["id"]
+    assert stored_jobs[0]["profile"] == "worker_alpha"
 
     assert cron_jobs.CRON_DIR == old_cron_dir
     assert cron_jobs.JOBS_FILE == old_jobs_file
@@ -54,19 +73,21 @@ def test_call_cron_for_profile_routes_storage_and_restores_globals(isolated_prof
 async def test_list_cron_jobs_all_includes_default_and_named_profiles(isolated_profiles):
     from hermes_cli import web_server
 
-    default_job = web_server._call_cron_for_profile(
-        "default",
-        "create_job",
-        prompt="default heartbeat",
-        schedule="every 2h",
-        name="default-heartbeat",
+    default_job = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="default heartbeat",
+            schedule="every 2h",
+            name="default-heartbeat",
+        ),
+        profile="default",
     )
-    worker_job = web_server._call_cron_for_profile(
-        "worker_alpha",
-        "create_job",
-        prompt="worker heartbeat",
-        schedule="every 3h",
-        name="worker-alpha-heartbeat",
+    worker_job = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="worker heartbeat",
+            schedule="every 3h",
+            name="worker-alpha-heartbeat",
+        ),
+        profile="worker_alpha",
     )
 
     jobs = await web_server.list_cron_jobs(profile="all")
@@ -79,31 +100,41 @@ async def test_list_cron_jobs_all_includes_default_and_named_profiles(isolated_p
     assert by_id[worker_job["id"]]["profile"] == "worker_alpha"
     assert by_id[worker_job["id"]]["is_default_profile"] is False
     assert by_id[worker_job["id"]]["hermes_home"] == str(isolated_profiles["worker_alpha"])
+    assert (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+    assert not (isolated_profiles["worker_alpha"] / "cron" / "jobs.json").exists()
 
 
 @pytest.mark.asyncio
 async def test_list_cron_jobs_specific_profile_filters_results(isolated_profiles):
     from hermes_cli import web_server
 
-    web_server._call_cron_for_profile(
-        "default",
-        "create_job",
-        prompt="default only",
-        schedule="every 2h",
-        name="default-only",
+    await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="default only",
+            schedule="every 2h",
+            name="default-only",
+        ),
+        profile="default",
     )
-    worker_job = web_server._call_cron_for_profile(
-        "worker_alpha",
-        "create_job",
-        prompt="worker only",
-        schedule="every 3h",
-        name="worker-only",
+    worker_job = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            prompt="worker only",
+            schedule="every 3h",
+            name="worker-only",
+        ),
+        profile="worker_alpha",
     )
 
     jobs = await web_server.list_cron_jobs(profile="worker_alpha")
 
     assert [job["id"] for job in jobs] == [worker_job["id"]]
     assert jobs[0]["profile"] == "worker_alpha"
+    root_jobs = json.loads(
+        (isolated_profiles["default"] / "cron" / "jobs.json").read_text(
+            encoding="utf-8"
+        )
+    )["jobs"]
+    assert {job["profile"] for job in root_jobs} == {"default", "worker_alpha"}
 
 
 @pytest.mark.asyncio
@@ -184,6 +215,28 @@ async def test_cron_delete_with_profile_deletes_only_target_profile(isolated_pro
     remaining_worker = await web_server.list_cron_jobs(profile="worker_alpha")
     assert [job["id"] for job in remaining_default] == [default_job["id"]]
     assert remaining_worker == []
+
+
+@pytest.mark.asyncio
+async def test_cron_delete_with_wrong_profile_does_not_cross_profile_store(
+    isolated_profiles,
+):
+    from hermes_cli import web_server
+
+    worker_job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="worker only",
+        schedule="every 1h",
+        name="worker-only-delete",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.delete_cron_job(worker_job["id"], profile="default")
+
+    assert exc.value.status_code == 404
+    worker_jobs = await web_server.list_cron_jobs(profile="worker_alpha")
+    assert [job["id"] for job in worker_jobs] == [worker_job["id"]]
 
 
 @pytest.mark.asyncio

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -459,6 +459,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("profile"):
+        result["profile"] = job["profile"]
     return result
 
 
@@ -481,6 +483,7 @@ def cronjob(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
@@ -547,6 +550,7 @@ def cronjob(
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
+                profile=_normalize_optional_job_value(profile),
                 no_agent=_no_agent,
             )
             return json.dumps(
@@ -681,6 +685,8 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if profile is not None:
+                updates["profile"] = _normalize_optional_job_value(profile) or None
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -834,6 +840,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "profile": {
+                "type": "string",
+                "description": "Optional Hermes profile name to run the job under using the context-local Hermes-home override; script subprocesses receive that profile HERMES_HOME. When unset, jobs created from a non-default profile session infer that profile. On update, pass an empty string to clear."
+            },
         },
         "required": ["action"]
     }
@@ -888,6 +898,7 @@ registry.register(
         context_from=args.get("context_from"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
+        profile=args.get("profile"),
         no_agent=args.get("no_agent"),
         task_id=kw.get("task_id"),
     ))(),


### PR DESCRIPTION
## Problem

Cron jobs created via `cronjob action=create` from an agent session running under a non-default profile (`hermes -p <profile> chat`) can be silently orphaned. The profile-scoped session writes the job under `<root>/profiles/<name>/cron/jobs.json`, while the gateway scheduler reads only the root cron store at `<root>/cron/jobs.json`.

The user sees a successful create result and `cronjob action=list` in that same profile can show the job, but the gateway never sees or fires it.

## Root cause

`cron/jobs.py` resolved module-level storage paths from the active Hermes home. Under a profile-scoped session, that made cron storage profile-local instead of gateway-shared. Preserving visibility also requires keeping the intended runtime profile on the job record, otherwise a job created from a profile would run later under the gateway/default context.

## Fix

- Resolve cron storage from the gateway-shared root via `get_default_hermes_root()`.
- Normalize and persist an optional per-job `profile` field, inferring the active non-default profile when a profile-scoped session creates a job without an explicit profile.
- Teach `cron.scheduler.run_job()` to execute stored-profile jobs under a context-local Hermes-home override, restore dotenv/environment mutations afterward, and pass the profile `HERMES_HOME` to script subprocesses.
- Route profile-stamped jobs through the sequential cron pool because profile dotenv/env handling is process-global.
- Keep dashboard profile cron operations backed by the root store, filtering and stamping jobs by stored profile.
- Expose `profile` through the `cronjob` tool create/update/list/schema paths.

Closes #32091

## Verification

- `.venv\\Scripts\\python.exe -m pytest tests\\cron\\test_cron_profile.py tests\\hermes_cli\\test_web_server_cron_profiles.py tests\\tools\\test_cronjob_tools.py tests\\tools\\test_cron_prompt_injection.py tests\\cron\\test_cronjob_schema.py tests\\cron\\test_cron_script.py -q --timeout-method=thread` -> 139 passed, 1 skipped
- `.venv\\Scripts\\python.exe -m py_compile cron\\scheduler.py tools\\cronjob_tools.py cron\\jobs.py hermes_cli\\web_server.py tests\\cron\\test_cron_profile.py tests\\hermes_cli\\test_web_server_cron_profiles.py` -> passed
- `.venv\\Scripts\\ruff.exe check cron\\scheduler.py tools\\cronjob_tools.py cron\\jobs.py hermes_cli\\web_server.py tests\\cron\\test_cron_profile.py tests\\hermes_cli\\test_web_server_cron_profiles.py` -> passed
- `git diff --check upstream/main...HEAD` -> passed
- `git merge-tree --write-tree upstream/main HEAD` -> clean tree `4eb962fc45aa98b7a651be41bdcfac90a8c1c2a0`

Note: the broader local Windows cron suite still exposes pre-existing environment-specific failures where `C:\\WINDOWS\\system32\\bash.exe` cannot execute Windows-style `C:\\...` script paths, plus `Path('~').expanduser()` ignores a patched `HOME` on Windows. Those failures reproduce outside this patch and are not part of the profile cron storage/runtime change.