### PR TITLE
fix: pass code_file=True to redact_sensitive_text in execute_code and terminal

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -979,7 +979,7 @@ def _execute_remote(
 
     # Redact secrets
     from agent.redact import redact_sensitive_text
-    stdout_text = redact_sensitive_text(stdout_text)
+    stdout_text = redact_sensitive_text(stdout_text, code_file=True)
 
     # Build response
     result: Dict[str, Any] = {
@@ -1362,8 +1362,8 @@ def execute_code(
         # but scripts can still read secrets from disk (e.g. open('~/.hermes/.env')).
         # This ensures leaked secrets never enter the model context.
         from agent.redact import redact_sensitive_text
-        stdout_text = redact_sensitive_text(stdout_text)
-        stderr_text = redact_sensitive_text(stderr_text)
+        stdout_text = redact_sensitive_text(stdout_text, code_file=True)
+        stderr_text = redact_sensitive_text(stderr_text, code_file=True)
 
         # Build response
         result: Dict[str, Any] = {

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2147,7 +2147,7 @@ def terminal_tool(
 
             # Redact secrets from command output (catches env/printenv leaking keys)
             from agent.redact import redact_sensitive_text
-            output = redact_sensitive_text(output.strip()) if output else ""
+            output = redact_sensitive_text(output.strip(), code_file=True) if output else ""
 
             # Interpret non-zero exit codes that aren't real errors
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")


### PR DESCRIPTION
## Fixes NousResearch/hermes-agent#33801

### Problem

`redact_sensitive_text()` corrupts code syntax in tool output from `execute_code` and `terminal`. The function has a `code_file=True` parameter that skips ENV-assignment and JSON-field regex patterns which cause false positives on code output.

`file_tools.py` already uses `code_file=True` for both `read_file` (line 573) and `write_file` (line 996), but `code_execution_tool.py` and `terminal_tool.py` were missing it.

### Fix

Added `code_file=True` to all 4 `redact_sensitive_text` calls:

- `tools/code_execution_tool.py` line 998: stdout_text
- `tools/code_execution_tool.py` line 1381: stdout_text  
- `tools/code_execution_tool.py` line 1382: stderr_text
- `tools/terminal_tool.py` line 2122: output

### Behavior Change

| Pattern | Before (broken) | After (fixed) |
|---------|-----------------|---------------|
| `MAX_TOKENS = 100` | `MAX_TOKENS = ***` | `MAX_TOKENS = 100` |
| `"apiKey": "test"` | `"apiKey": "***"` | `"apiKey": "test"` |
| `sk-proj-abc123...` | `sk-pro...1234` (still redacted) | `sk-pro...1234` (still redacted) |

Prefix patterns, auth headers, private keys, DB connstrings, JWTs, and URL secrets are still redacted even with `code_file=True`.