### PR TITLE
fix(discord): send tool-using responses (api_calls>=2)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3780,6 +3780,15 @@ class BasePlatformAdapter(ABC):
                 # where Telegram's sendPhoto recompression destroys legibility.
                 force_document_attachments = "[[as_document]]" in response
 
+                # Preserve the pre-extract response so we can recover from a
+                # pipeline that silently strips a non-empty tool-using reply
+                # down to empty text (#29346).  Tool-using responses on Discord
+                # were getting reduced to "" by the extract_* helpers when no
+                # image / media / local-file attachment was produced, which
+                # bypassed the ``if text_content:`` send guard below and
+                # dropped the final answer with no error logged.
+                _response_pre_extract = response
+
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
                 media_files = self.filter_media_delivery_paths(media_files)
@@ -3808,7 +3817,36 @@ class BasePlatformAdapter(ABC):
                     local_files = self.filter_local_delivery_paths(local_files)
                     if local_files:
                         logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
-                
+
+                # Recover from "response stripped to empty" on Discord (#29346).
+                # If the extract pipeline reduced a non-empty reply to "" but
+                # produced no native attachment to deliver in its place, fall
+                # back to sending a sanitized copy of the original response so
+                # the user actually receives the answer.  Scoped to Discord
+                # because that's where the reproducer is confirmed; other
+                # adapters keep current behavior to avoid unintended
+                # regressions in their delivery pipelines.
+                if (
+                    self.platform == Platform.DISCORD
+                    and not text_content
+                    and not images
+                    and not local_files
+                    and not media_files
+                    and _response_pre_extract
+                    and _response_pre_extract.strip()
+                ):
+                    _fallback_text = _response_pre_extract
+                    _fallback_text = _fallback_text.replace("[[audio_as_voice]]", "")
+                    _fallback_text = _fallback_text.replace("[[as_document]]", "")
+                    _fallback_text = re.sub(r"MEDIA:\s*\S+", "", _fallback_text).strip()
+                    if _fallback_text:
+                        logger.warning(
+                            "[%s] Response stripped to empty after extract pipeline "
+                            "(orig=%d chars). Sending raw response as fallback.",
+                            self.name, len(_response_pre_extract),
+                        )
+                        text_content = _fallback_text
+
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is

--- a/tests/gateway/test_discord_tool_response_drop.py
+++ b/tests/gateway/test_discord_tool_response_drop.py
@@ -1,0 +1,278 @@
+"""Regression tests for Discord tool-using response silent drop (issue #29346).
+
+When the agent returns a non-empty response that the extract pipeline
+(extract_media / extract_images / extract_local_files / inline directive
+strips) happens to reduce to an empty string, the ``if text_content:`` guard
+in ``BasePlatformAdapter._process_message_background`` previously bypassed
+the send entirely. The symptom was a ``response ready`` log followed by
+silence — no ``Sending response`` line, no error — and the final answer
+never reaching the Discord channel.
+
+The fix preserves the pre-extract response and, when no native attachment
+was produced to deliver in its place, sanitizes the original text and
+sends it as a fallback (with a WARNING log so the silent-drop pattern is
+observable next time it happens).
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class DummyDiscordAdapter(BasePlatformAdapter):
+    """Minimal BasePlatformAdapter wired to Platform.DISCORD for dispatch tests."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.DISCORD)
+        self.sent: list[dict] = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="discord-1")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class DummyTelegramAdapter(BasePlatformAdapter):
+    """Non-Discord adapter used to assert the fallback is Discord-scoped."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
+        self.sent: list[dict] = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="tg-1")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _make_event(platform: Platform, chat_id: str = "111", message_id: str = "m1") -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            chat_type="dm",
+        ),
+        message_id=message_id,
+    )
+
+
+async def _hold_typing(_chat_id, interval=2.0, metadata=None, stop_event=None):
+    if stop_event is not None:
+        await stop_event.wait()
+    else:
+        await asyncio.Event().wait()
+
+
+class TestDiscordEmptyAfterStripFallback:
+    """When extract pipeline strips a non-empty response to empty on Discord,
+    the original response (sanitized) must still be delivered (#29346)."""
+
+    @pytest.mark.asyncio
+    async def test_response_reduced_to_empty_is_recovered_and_sent(self, monkeypatch, caplog):
+        """Simulate the exact failure mode: handler returns non-empty content
+        but the extract pipeline strips it to empty.  Patch the extract helpers
+        on the adapter instance to be deterministic — the bug is in the SEND
+        path's handling of an empty result, not the strip heuristics themselves.
+        """
+        adapter = DummyDiscordAdapter()
+        adapter._keep_typing = _hold_typing
+
+        tool_response = (
+            "Based on my search, the cheapest TPE-PAR flight on Dec 14 is $632 "
+            "via Saudia. Here are the top options sorted by price..."
+        ) * 5  # Mimic a 1000+ char tool-using response from the issue
+        assert len(tool_response) > 500
+
+        async def handler(_event):
+            return tool_response
+
+        adapter.set_message_handler(handler)
+
+        # Force the strip pipeline to reduce text_content to "" — this is what
+        # made the bug invisible.  No images / local files / media extracted.
+        monkeypatch.setattr(
+            type(adapter), "extract_media", staticmethod(lambda content: ([], content))
+        )
+        monkeypatch.setattr(
+            type(adapter), "extract_images", staticmethod(lambda content: ([], ""))
+        )
+        monkeypatch.setattr(
+            type(adapter),
+            "extract_local_files",
+            staticmethod(lambda content: ([], "")),
+        )
+
+        event = _make_event(Platform.DISCORD)
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.base"):
+            await adapter._process_message_background(event, build_session_key(event.source))
+
+        # Critical assertion: the response WAS delivered, not silently dropped.
+        assert len(adapter.sent) == 1, (
+            f"Expected 1 send (the recovered response), got {len(adapter.sent)}: {adapter.sent}"
+        )
+        assert adapter.sent[0]["content"] == tool_response
+
+        # A WARNING must be logged so future occurrences are observable.
+        warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "stripped to empty" in r.getMessage().lower() for r in warning_logs
+        ), f"Expected 'stripped to empty' warning, got: {[r.getMessage() for r in warning_logs]}"
+
+    @pytest.mark.asyncio
+    async def test_directives_stripped_from_fallback_text(self, monkeypatch):
+        """Fallback must sanitize internal directives so they don't leak to
+        the user. This mirrors the strips performed on the normal path."""
+        adapter = DummyDiscordAdapter()
+        adapter._keep_typing = _hold_typing
+
+        raw = (
+            "[[audio_as_voice]]\n"
+            "[[as_document]]\n"
+            "MEDIA: /tmp/nope.ogg\n"
+            "The real answer the user should see."
+        )
+
+        async def handler(_event):
+            return raw
+
+        adapter.set_message_handler(handler)
+
+        # Pipeline reduces to empty but no attachments are produced (e.g.
+        # MEDIA path didn't validate as a real file → media_files is []).
+        monkeypatch.setattr(
+            type(adapter), "extract_media", staticmethod(lambda content: ([], content))
+        )
+        monkeypatch.setattr(
+            type(adapter), "extract_images", staticmethod(lambda content: ([], ""))
+        )
+        monkeypatch.setattr(
+            type(adapter),
+            "extract_local_files",
+            staticmethod(lambda content: ([], "")),
+        )
+
+        event = _make_event(Platform.DISCORD)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert len(adapter.sent) == 1
+        delivered = adapter.sent[0]["content"]
+        assert "[[audio_as_voice]]" not in delivered
+        assert "[[as_document]]" not in delivered
+        assert "MEDIA:" not in delivered
+        assert "The real answer the user should see." in delivered
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_attachment_produced(self, monkeypatch):
+        """When an image/media/local-file attachment IS extracted, the empty
+        text_content is intentional — fallback must NOT re-send the response
+        text and duplicate the attachment's content."""
+        adapter = DummyDiscordAdapter()
+        adapter._keep_typing = _hold_typing
+
+        async def handler(_event):
+            return "![chart](https://example.com/chart.png)"
+
+        adapter.set_message_handler(handler)
+
+        # Simulate extract_images consuming the entire response → text empty,
+        # but an image WAS extracted to send natively.
+        monkeypatch.setattr(
+            type(adapter), "extract_media", staticmethod(lambda content: ([], content))
+        )
+        monkeypatch.setattr(
+            type(adapter),
+            "extract_images",
+            staticmethod(lambda content: ([("https://example.com/chart.png", "chart")], "")),
+        )
+        monkeypatch.setattr(
+            type(adapter),
+            "extract_local_files",
+            staticmethod(lambda content: ([], "")),
+        )
+        # Stub the native image-send path so the test doesn't try to upload.
+        adapter.send_multiple_images = lambda *a, **kw: asyncio.sleep(0, result=None)
+
+        event = _make_event(Platform.DISCORD)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        # No text send — the image-only response is delivered as a native
+        # attachment, NOT as a text echo of the original markdown.
+        assert adapter.sent == [], (
+            f"Expected no text send when image attachment handles delivery, got: {adapter.sent}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_is_discord_scoped(self, monkeypatch):
+        """Other platforms keep current behavior to avoid unintended
+        regressions in their own pipelines."""
+        adapter = DummyTelegramAdapter()
+        adapter._keep_typing = _hold_typing
+
+        async def handler(_event):
+            return "non-empty tool reply"
+
+        adapter.set_message_handler(handler)
+
+        monkeypatch.setattr(
+            type(adapter), "extract_media", staticmethod(lambda content: ([], content))
+        )
+        monkeypatch.setattr(
+            type(adapter), "extract_images", staticmethod(lambda content: ([], ""))
+        )
+        monkeypatch.setattr(
+            type(adapter),
+            "extract_local_files",
+            staticmethod(lambda content: ([], "")),
+        )
+
+        event = _make_event(Platform.TELEGRAM)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        # Telegram path is unchanged: empty text_content → no send.
+        assert adapter.sent == []


### PR DESCRIPTION
## Problem

On Discord, tool-using replies (`api_calls >= 2`) were silently dropped. The log showed `response ready: ... api_calls=2 response=NNNN chars` and then nothing — no `Sending response` line, no error — and the answer never reached the channel. Single-call replies (`api_calls == 1`) were largely unaffected because their typically smaller content rarely tripped the strip path.

## Root cause

In `BasePlatformAdapter._process_message_background` (`gateway/platforms/base.py`), the response passes through an extract pipeline: `extract_media` -> `extract_images` -> inline-directive strips -> `extract_local_files`. When that pipeline reduced a non-empty reply to `""` while producing no native attachment (no image / media / local file), the downstream `if text_content:` send guard was skipped, so the message was dropped with nothing logged.

## Fix

Recover the stripped reply on Discord and make the drop observable.

- Snapshot the pre-extract response into `_response_pre_extract` before the pipeline runs.
- After the extract steps, add a recovery branch gated on `self.platform == Platform.DISCORD and not text_content and not images and not local_files and not media_files and _response_pre_extract.strip()`.
- When that branch fires, sanitize the snapshot — remove `[[audio_as_voice]]`, `[[as_document]]`, and `MEDIA:<path>` directives (`re.sub(r"MEDIA:\s*\S+", ...)`) — and, if anything remains, assign it to `text_content` so the existing send path delivers it.
- Emit a `WARNING` (`Response stripped to empty after extract pipeline (orig=%d chars). Sending raw response as fallback.`) including the original char count, so the silent-drop pattern is visible next time.
- The recovery is intentionally scoped to Discord because that is the confirmed reproducer; other adapters keep current behavior. It also does nothing when a real attachment was extracted (image/media/local file), avoiding a duplicate text echo alongside the native attachment.

## Testing

New regression suite `tests/gateway/test_discord_tool_response_drop.py` (4 cases) added in the diff. The extract helpers are monkeypatched to deterministically reduce text to empty, isolating the send-path bug from the strip heuristics:

- `test_response_reduced_to_empty_is_recovered_and_sent`: a multi-hundred-char tool reply (the issue's repeated sample string, `assert len > 500`) stripped to empty is still sent (exactly one send) and a `stripped to empty` WARNING is logged.
- `test_directives_stripped_from_fallback_text`: `[[audio_as_voice]]`, `[[as_document]]`, and `MEDIA:` directives are removed from the fallback text while the real answer survives.
- `test_no_fallback_when_attachment_produced`: when an image attachment is extracted (empty text is intentional), no text fallback is sent, so the attachment content is not duplicated.
- `test_fallback_is_discord_scoped`: a Telegram adapter with the same empty-after-strip condition sends nothing, confirming the fallback is Discord-only.

Per the PR description, the author also ran `pytest tests/gateway/test_platform_base.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_delivery.py tests/gateway/test_discord_tool_response_drop.py` (138 passed, 2 skipped) and confirmed the recovery tests fail (0 sends) when the `base.py` change is reverted. These run results are reported by the author and not reproduced here.

## Risk & impact

- Behavior change is limited to Discord and only triggers on the previously-broken path (non-empty reply reduced to empty with no attachment); the normal send path is untouched.
- Other platforms are explicitly excluded, so their delivery pipelines are unaffected.
- The fallback re-uses the original response only after sanitizing internal directives, so directives cannot leak to users; the attachment guard prevents duplicate delivery.
- Adds one `WARNING` log line when recovery fires, improving observability of this class of failure.

Closes #29346
