### PR TITLE
fix(minimax): activate fallback after content-filter stream stalls

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -441,6 +441,7 @@ def run_conversation(
     length_continue_retries = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
+    partial_stream_checkpoint_len: Optional[int] = None
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
@@ -1416,13 +1417,19 @@ def run_conversation(
                             if assistant_message.content:
                                 truncated_response_parts.append(assistant_message.content)
 
+                            _is_partial_stream_stub = (
+                                getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+                            )
+                            _dropped_tools = getattr(
+                                response, "_dropped_tool_names", None
+                            )
+                            if (
+                                _is_partial_stream_stub
+                                and partial_stream_checkpoint_len is None
+                            ):
+                                partial_stream_checkpoint_len = len(messages) - 1
+
                             if length_continue_retries < 3:
-                                _is_partial_stream_stub = (
-                                    getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
-                                )
-                                _dropped_tools = getattr(
-                                    response, "_dropped_tool_names", None
-                                )
 
                                 if _is_partial_stream_stub and _dropped_tools:
                                     _tool_list = ", ".join(_dropped_tools[:3])
@@ -1455,6 +1462,42 @@ def run_conversation(
                                 agent._session_messages = messages
                                 _retry.restart_with_length_continuation = True
                                 break
+
+                            # Continuation retries exhausted. A partial-stream
+                            # stub with dropped tool names means the stream
+                            # repeatedly died mid tool-call. MiniMax content
+                            # filters can produce this signature deterministically,
+                            # so retrying chunk prompts on the same primary keeps
+                            # hitting the same filter. Escalate to the configured
+                            # fallback chain before returning the truncation error.
+                            if (
+                                _is_partial_stream_stub
+                                and _dropped_tools
+                                and agent._fallback_index < len(agent._fallback_chain)
+                            ):
+                                _tool_list = ", ".join(_dropped_tools[:3])
+                                agent._vprint(
+                                    f"{agent.log_prefix}Stream repeatedly stalled mid "
+                                    f"tool-call ({_tool_list}); switching to fallback...",
+                                    force=True,
+                                )
+                                agent._emit_status(
+                                    "Stream stalled mid tool-call; switching to fallback..."
+                                )
+                                if agent._try_activate_fallback():
+                                    if partial_stream_checkpoint_len is not None:
+                                        messages = messages[:partial_stream_checkpoint_len]
+                                    else:
+                                        messages = agent._get_messages_up_to_last_assistant(messages)
+                                    agent._session_messages = messages
+                                    length_continue_retries = 0
+                                    truncated_response_parts = []
+                                    partial_stream_checkpoint_len = None
+                                    retry_count = 0
+                                    compression_attempts = 0
+                                    _retry.primary_recovery_attempted = False
+                                    _retry.restart_with_rebuilt_messages = True
+                                    break
 
                             partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
                             agent._cleanup_task_resources(effective_task_id)
@@ -3277,6 +3320,9 @@ def run_conversation(
             _retry.restart_with_compressed_messages = False
             continue
 
+        if _retry.restart_with_rebuilt_messages:
+            continue
+
         if _retry.restart_with_length_continuation:
             # Progressively boost the output token budget on each retry.
             # Retry 1 → 2× base, retry 2 → 3× base, capped at 32 768.
@@ -4136,6 +4182,7 @@ def run_conversation(
                     final_response = "".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
+                    partial_stream_checkpoint_len = None
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
                 

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -61,6 +61,7 @@ class TurnRetryState:
     # ── Restart signals (read by the outer loop after the attempt) ───────
     restart_with_compressed_messages: bool = False
     restart_with_length_continuation: bool = False
+    restart_with_rebuilt_messages: bool = False
 
     def __iter__(self):
         # Convenience for debugging / tests: iterate (name, value) pairs.

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -29,6 +29,7 @@ EXPECTED_FIELDS = {
     "has_retried_429",
     "restart_with_compressed_messages",
     "restart_with_length_continuation",
+    "restart_with_rebuilt_messages",
 }
 
 

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -362,3 +362,101 @@ class TestConversationLoopPartialStreamContinuation:
         # And the final response stitches both halves together.
         assert "first half of" in result["final_response"]
         assert "forty-two" in result["final_response"]
+
+
+class TestContentFilterStallActivatesFallback:
+    """Regression for issue #32421: when a provider's output-layer content
+    safety filter (e.g. MiniMax ``output new_sensitive (1027)``) terminates
+    a streaming response mid-delivery, the partial-stream stub keeps coming
+    back with the same ``_dropped_tool_names`` because the filter is
+    content-deterministic.  The continuation prompt cannot recover from
+    this on the same primary, so once the bounded continuation budget is
+    exhausted the loop must activate ``fallback_providers`` rather than
+    giving up with ``"Response remained truncated after 3 continuation
+    attempts"``."""
+
+    def test_repeated_dropped_tool_stub_triggers_fallback(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_assistant_msg, _mock_response
+
+        # Three consecutive partial-stream stubs with the same dropped
+        # tool, the MiniMax `output new_sensitive` fingerprint.  Each
+        # carries `_dropped_tool_names=["write_file"]` so the loop's
+        # continuation prompt fires, then re-fires, then exhausts.
+        def _make_filter_stub():
+            return SimpleNamespace(
+                id=PARTIAL_STREAM_STUB_ID,
+                model="minimax/MiniMax-M2.7",
+                choices=[SimpleNamespace(
+                    index=0,
+                    message=_mock_assistant_msg(content="Writing the file..."),
+                    finish_reason=FINISH_REASON_LENGTH,
+                )],
+                usage=None,
+                _dropped_tool_names=["write_file"],
+            )
+
+        # After fallback fires, the next call returns a clean stop response.
+        recovery = _mock_response(
+            content="Done with the smaller chunk.", finish_reason="stop",
+        )
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _make_filter_stub(),  # initial stall, bumps retries to 1
+            _make_filter_stub(),  # retries=2
+            _make_filter_stub(),  # retries=3, exhausted, must escalate
+            recovery,             # served by the fallback provider
+        ]
+
+        # Configure a (mocked) fallback chain so the escalation path has
+        # somewhere to go.  We mock _try_activate_fallback itself so we
+        # don't have to stand up a second provider client; the contract
+        # we're pinning is that the loop *calls* it on this signature.
+        loop_agent._fallback_chain = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.7"}]
+        loop_agent._fallback_index = 0
+        fb_calls = {"n": 0}
+
+        def _fake_activate_fallback(reason=None):
+            fb_calls["n"] += 1
+            loop_agent._fallback_index = len(loop_agent._fallback_chain)
+            return True
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+            patch.object(loop_agent, "_try_activate_fallback",
+                         side_effect=_fake_activate_fallback),
+        ):
+            result = loop_agent.run_conversation("write me a long file")
+
+        assert fb_calls["n"] >= 1, (
+            "Content-filter stream stall (partial-stream-stub + "
+            "_dropped_tool_names) must escalate to the fallback chain once "
+            "continuation retries are exhausted instead of returning "
+            "`Response remained truncated after 3 continuation attempts` "
+            "(issue #32421)."
+        )
+        # The fallback's clean response must surface, not the 3-retry
+        # exhaustion error that the buggy path returned.
+        assert "smaller chunk" in (result.get("final_response") or ""), (
+            "After fallback activation, the recovery response from the "
+            "fallback provider should reach the user."
+        )
+        assert "remained truncated after 3 continuation attempts" not in (
+            result.get("error") or ""
+        )
+
+        fourth_call_kwargs = loop_agent.client.chat.completions.create.call_args_list[3]
+        fourth_messages = (
+            fourth_call_kwargs.kwargs.get("messages")
+            or fourth_call_kwargs.args[0].get("messages")
+        )
+        fourth_text = "\n".join(
+            str(message.get("content") or "") for message in fourth_messages
+        )
+        assert "Writing the file..." not in fourth_text, (
+            "Fallback must start from the clean pre-stall checkpoint, not "
+            "see partial-stream assistant stubs left by the failed primary."
+        )
+        assert "was too large" not in fourth_text
+        assert "network error mid-stream" not in fourth_text


### PR DESCRIPTION
## Problem

When a provider content filter terminates a streaming response mid-delivery, Hermes can receive the partial-stream stub signature repeatedly (`PARTIAL_STREAM_STUB_ID` plus `_dropped_tool_names`). The existing length-continuation path keeps asking the same primary provider to continue/chunk the response, so deterministic filter failures exhaust the continuation budget and return `Response remained truncated after 3 continuation attempts` even when `fallback_providers` is configured.

## Fix

- Hoist partial-stream stub detection outside the continuation-retry branch so the exhaustion path can inspect it.
- Track the clean pre-stall message checkpoint before continuation prompts are appended.
- When the partial-stream/dropped-tool signature persists through the bounded continuation budget and a fallback remains, activate the fallback provider, roll back to the checkpoint, reset retry/compression counters, and rebuild the request against the fallback.
- Add `TurnRetryState.restart_with_rebuilt_messages` for the new outer-loop restart signal.

Plain length truncations and users without fallback providers keep the existing behavior.

## Testing

- Red check on current `upstream/main`: `pytest tests/run_agent/test_partial_stream_finish_reason.py::TestContentFilterStallActivatesFallback::test_repeated_dropped_tool_stub_triggers_fallback -q --timeout-method=thread` failed because `_try_activate_fallback` was never called.
- `pytest tests/run_agent/test_partial_stream_finish_reason.py tests/agent/test_turn_retry_state.py -q --timeout-method=thread` -> 14 passed, 1 warning.
- `ruff check agent/conversation_loop.py agent/turn_retry_state.py tests/agent/test_turn_retry_state.py tests/run_agent/test_partial_stream_finish_reason.py` -> passed.
- `python -m py_compile agent/conversation_loop.py agent/turn_retry_state.py tests/agent/test_turn_retry_state.py tests/run_agent/test_partial_stream_finish_reason.py` -> passed.
- `git diff --check upstream/main...HEAD` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> clean.

Closes #32421