### PR TITLE
fix(api-server): require auth for /health/detailed

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1029,8 +1029,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Returns gateway state, connected platforms, PID, and uptime so the
         dashboard can display full status without needing a shared PID file or
-        /proc access.  No authentication required.
+        /proc access. Protected by the same bearer auth as the rest of the API
+        server when API_SERVER_KEY is configured.
         """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
         from gateway.status import read_runtime_status
 
         runtime = read_runtime_status() or {}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -553,13 +553,19 @@ class TestHealthDetailedEndpoint:
                 assert data["platforms"] == {}
 
     @pytest.mark.asyncio
-    async def test_health_detailed_does_not_require_auth(self, auth_adapter):
-        """Health detailed endpoint should be accessible without auth, like /health."""
+    async def test_health_detailed_requires_auth_when_key_configured(self, auth_adapter):
+        """Health detailed should follow the API server bearer-auth contract."""
         app = _create_app(auth_adapter)
         with patch("gateway.status.read_runtime_status", return_value=None):
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
-                assert resp.status == 200
+                assert resp.status == 401
+
+                authed = await cli.get(
+                    "/health/detailed",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert authed.status == 200
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -227,7 +227,7 @@ Health check. Returns `{"status": "ok"}`. Also available at **GET /v1/health** f
 
 ### GET /health/detailed
 
-Extended health check that also reports active sessions, running agents, and resource usage. Useful for monitoring/observability tooling.
+Extended health check that also reports active sessions, running agents, and resource usage. Useful for monitoring/observability tooling. Unlike `GET /health`, this endpoint follows the standard bearer auth requirement and expects `Authorization: Bearer $API_SERVER_KEY`.
 
 ## Runs API (streaming-friendly alternative)
 


### PR DESCRIPTION
## Summary

This change secures the detailed health endpoint by requiring bearer authentication on `/health/detailed` whenever `API_SERVER_KEY` is configured.

It keeps `/health` public for basic liveness checks, updates the API server implementation to enforce the existing auth contract, aligns the regression test coverage with the intended behavior, and documents the distinction between the public and authenticated health endpoints.

## Testing

- `tests/gateway/test_api_server.py::TestHealthDetailedEndpoint::test_health_detailed_returns_ok` — passed
- `tests/gateway/test_api_server.py::TestHealthDetailedEndpoint::test_health_detailed_no_runtime_status` — passed
- `tests/gateway/test_api_server.py::TestHealthDetailedEndpoint::test_health_detailed_requires_auth_when_key_configured` — passed
- `tests/gateway/test_api_server.py::TestModelsEndpoint::test_models_requires_auth` — passed
- `tests/gateway/test_api_server.py::TestCapabilitiesEndpoint::test_capabilities_requires_auth_when_key_configured` — passed
- `tests/gateway/test_api_server.py::TestEndpointAuth::test_models_requires_auth` — passed
- `tests/gateway/test_api_server.py::TestEndpointAuth::test_health_does_not_require_auth` — passed

Test summary: `7 passed, 149 deselected`

