### PR TITLE
fix(tui): keep stdin handler responsive during agent work

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-stdin-recovery.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-stdin-recovery.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import App from './components/App.js'
+
+// Regression for issue #31486: when processInput throws inside the
+// handleReadable read loop, any bytes still buffered in stdin are stranded
+// because Node only emits 'readable' on buffer transitions, not for data
+// the consumer has already been notified about. Without a re-pump, the
+// TUI freezes; stdin appears wedged while the agent loop keeps running.
+
+const makeFakeStdin = (initialChunks: Array<string | null>) => {
+  const queue: Array<string | null> = [...initialChunks]
+  const readableListeners: Array<() => void> = []
+
+  return {
+    addListener: vi.fn((event: string, fn: () => void) => {
+      if (event === 'readable') {
+        readableListeners.push(fn)
+      }
+    }),
+    listeners: vi.fn((event: string) => (event === 'readable' ? [...readableListeners] : [])),
+    read: vi.fn(() => (queue.length > 0 ? queue.shift()! : null)),
+    get readableLength() {
+      return queue.filter(c => c !== null).reduce((n, c) => n + (c as string).length, 0)
+    }
+  }
+}
+
+const noopStream = { isTTY: false, write: () => true } as unknown as NodeJS.WriteStream
+
+const makeApp = (stdin: ReturnType<typeof makeFakeStdin>) => {
+  // Construct a real App instance with minimal props. PureComponent only
+  // stores `props`; class-field arrows (including handleReadable) bind to
+  // the instance during construction.
+  const app = new App({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: noopStream,
+    stderr: noopStream,
+    exitOnCtrlC: false,
+    onExit: vi.fn(),
+    terminalColumns: 80,
+    terminalRows: 24,
+    selection: undefined as any,
+    onSelectionChange: vi.fn(),
+    onClickAt: vi.fn(() => false),
+    onMouseDownAt: vi.fn(() => undefined),
+    onMouseUpAt: vi.fn(),
+    onMouseDragAt: vi.fn(),
+    onHoverAt: vi.fn(),
+    onCopySelectionNoClear: vi.fn(async () => ''),
+    getSelectedText: vi.fn(() => ''),
+    getHyperlinkAt: vi.fn(() => undefined),
+    onOpenHyperlink: vi.fn(),
+    onMultiClick: vi.fn(),
+    onSelectionDrag: vi.fn(),
+    onStdinResume: vi.fn(),
+    dispatchKeyboardEvent: vi.fn(),
+    children: null as any
+  } as any)
+
+  ;(app as any).rawModeEnabledCount = 1
+
+  return app
+}
+
+describe('App.handleReadable error recovery (issue #31486)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('re-pumps the readable handler when bytes remain buffered after a throw', () => {
+    const stdin = makeFakeStdin(['boom', 'queued-keystroke', null])
+    const app = makeApp(stdin)
+
+    let calls = 0
+
+    ;(app as any).processInput = vi.fn((chunk: string) => {
+      calls++
+
+      if (calls === 1) {
+        throw new Error('synthetic processInput failure')
+      }
+
+      void chunk
+    })
+
+    ;(app as any).handleReadable()
+
+    // First handler run threw mid-loop. The remaining chunk is still in
+    // the fake stdin buffer; without the re-pump, Node would never call
+    // the listener again because no new bytes arrive.
+    expect((app as any).processInput).toHaveBeenCalledTimes(1)
+
+    vi.runAllTimers()
+
+    expect((app as any).processInput).toHaveBeenCalledTimes(2)
+    expect((app as any).processInput).toHaveBeenLastCalledWith('queued-keystroke')
+  })
+
+  it('does not re-pump when raw mode has been fully disabled during recovery', () => {
+    const stdin = makeFakeStdin(['boom', 'stranded', null])
+
+    const app = makeApp(stdin)
+
+    ;(app as any).processInput = vi.fn(() => {
+      // Simulate a useInput handler that disabled raw mode and threw.
+      ;(app as any).rawModeEnabledCount = 0
+      throw new Error('synthetic')
+    })
+
+    ;(app as any).handleReadable()
+    vi.runAllTimers()
+
+    expect((app as any).processInput).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -457,6 +457,19 @@ export default class App extends PureComponent<Props, State> {
         })
         stdin.addListener('readable', this.handleReadable)
       }
+
+      // Issue #31486: even after re-attaching, any bytes already buffered
+      // when the loop threw are stranded because Node only fires 'readable'
+      // on buffer transitions, not for data the consumer already saw. Schedule
+      // one drain on the next macrotask so the handler runs against a fresh
+      // try/catch and clears whatever is left.
+      if (this.rawModeEnabledCount > 0 && stdin.readableLength > 0) {
+        setImmediate(() => {
+          if (this.rawModeEnabledCount > 0 && this.props.stdin.readableLength > 0) {
+            this.handleReadable()
+          }
+        })
+      }
     }
   }
   handleInput = (input: string | undefined): void => {


### PR DESCRIPTION
## Problem

The TUI can wedge stdin when `App.handleReadable` throws while bytes are still buffered. The agent loop continues, but keystrokes appear frozen because the handler re-attaches the `readable` listener without draining data that Node already notified the consumer about.

## Root cause

Node emits `readable` on buffer transitions, not for bytes that were already present when the handler threw. If `processInput` fails mid-loop, a later listener re-attachment is not enough: buffered bytes can remain stranded until a new byte arrives, and during a long agent turn that may not happen.

## Fix

In `ui-tui/packages/hermes-ink/src/ink/components/App.tsx`, keep the existing error recovery and add one focused re-pump:

- after re-attaching the readable listener, if raw mode is still active and `stdin.readableLength > 0`, schedule `setImmediate(() => this.handleReadable())`;
- re-check raw mode and readable length inside the callback before running;
- preserve the newer upstream raw-mode and mouse-tracking recovery code.

The top-level comment on this PR reports a related Desktop/dashboard control-plane starvation shape under #31486. I left that out of this PR’s code scope; this change only addresses the Ink stdin/readable recovery path.

## Testing

- Red check on current `upstream/main`: `npm run test --prefix ui-tui -- packages/hermes-ink/src/ink/app-stdin-recovery.test.ts` failed because the queued buffered chunk was not re-pumped.
- `npm run test --prefix ui-tui -- packages/hermes-ink/src/ink/app-stdin-recovery.test.ts` -> 1 file passed, 2 tests passed.
- `npx eslint packages/hermes-ink/src/ink/components/App.tsx packages/hermes-ink/src/ink/app-stdin-recovery.test.ts` -> passed.
- `npm run typecheck --prefix ui-tui` -> passed.
- `git diff --check upstream/main...HEAD` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> clean.

Closes #31486