### PR TITLE
fix(cron): surface and recover cron ticker failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15541,6 +15541,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     """
     from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.status import write_cron_ticker_heartbeat
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -15550,71 +15551,98 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
+    # Record an initial heartbeat so `hermes cron status` doesn't report the
+    # ticker as dead during the first tick window.
+    write_cron_ticker_heartbeat()
     while not stop_event.is_set():
+        # Outer ``BaseException`` wrap so anything raised inside this tick —
+        # including ``SystemExit``/``KeyboardInterrupt`` smuggled out by a
+        # C extension — gets logged with a traceback and the loop survives
+        # instead of the ticker dying silently. See #32612.
         try:
-            cron_tick(verbose=False, adapters=adapters, loop=loop, sync=False)
-        except Exception as e:
-            logger.debug("Cron tick error: %s", e)
-
-        tick_count += 1
-
-        if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
             try:
-                from gateway.channel_directory import build_channel_directory
-                if loop is not None:
-                    # build_channel_directory is async (Slack web calls), and
-                    # this ticker runs in a background thread. Schedule onto
-                    # the gateway event loop and wait briefly for completion
-                    # so refresh failures are still logged via the except.
-                    fut = safe_schedule_threadsafe(
-                        build_channel_directory(adapters), loop,
-                        logger=logger,
-                        log_message="Channel directory refresh scheduling error",
+                cron_tick(verbose=False, adapters=adapters, loop=loop, sync=False)
+            except Exception as e:
+                # Promoted from DEBUG → WARNING so operators actually see
+                # transient tick failures in the default INFO-level log.
+                logger.warning("Cron tick error: %s", e, exc_info=True)
+
+            tick_count += 1
+
+            if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
+                try:
+                    from gateway.channel_directory import build_channel_directory
+                    if loop is not None:
+                        # build_channel_directory is async (Slack web calls), and
+                        # this ticker runs in a background thread. Schedule onto
+                        # the gateway event loop and wait briefly for completion
+                        # so refresh failures are still logged via the except.
+                        fut = safe_schedule_threadsafe(
+                            build_channel_directory(adapters), loop,
+                            logger=logger,
+                            log_message="Channel directory refresh scheduling error",
+                        )
+                        if fut is not None:
+                            fut.result(timeout=30)
+                except Exception as e:
+                    logger.debug("Channel directory refresh error: %s", e)
+
+            if tick_count % IMAGE_CACHE_EVERY == 0:
+                try:
+                    removed = cleanup_image_cache(max_age_hours=24)
+                    if removed:
+                        logger.info("Image cache cleanup: removed %d stale file(s)", removed)
+                except Exception as e:
+                    logger.debug("Image cache cleanup error: %s", e)
+                try:
+                    removed = cleanup_document_cache(max_age_hours=24)
+                    if removed:
+                        logger.info("Document cache cleanup: removed %d stale file(s)", removed)
+                except Exception as e:
+                    logger.debug("Document cache cleanup error: %s", e)
+
+            if tick_count % PASTE_SWEEP_EVERY == 0:
+                try:
+                    deleted, remaining = _sweep_expired_pastes()
+                    if deleted:
+                        logger.info(
+                            "Paste sweep: deleted %d expired paste(s), %d pending",
+                            deleted, remaining,
+                        )
+                except Exception as e:
+                    logger.debug("Paste sweep error: %s", e)
+
+            # Curator — piggy-back on the existing cron ticker so long-running
+            # gateways get weekly skill maintenance without needing restarts.
+            # maybe_run_curator() is internally gated by config.interval_hours
+            # (7 days by default), so CURATOR_EVERY is just the poll rate — the
+            # real work only fires once per config interval.
+            if tick_count % CURATOR_EVERY == 0:
+                try:
+                    from agent.curator import maybe_run_curator
+                    maybe_run_curator(
+                        idle_for_seconds=float("inf"),
+                        on_summary=lambda msg: logger.info("curator: %s", msg),
                     )
-                    if fut is not None:
-                        fut.result(timeout=30)
-            except Exception as e:
-                logger.debug("Channel directory refresh error: %s", e)
+                except Exception as e:
+                    logger.debug("Curator tick error: %s", e)
+        except BaseException as e:
+            # Catch BaseException (SystemExit, KeyboardInterrupt, anything a
+            # C extension raises through Python) so a transient fault inside
+            # a tick can't permanently kill the ticker thread without leaving
+            # a trace. The thread re-enters the loop on the next interval.
+            # See #32612 for the silent-death scenario this guards against.
+            logger.error(
+                "Cron ticker recovered from fatal error: %s", e, exc_info=True,
+            )
 
-        if tick_count % IMAGE_CACHE_EVERY == 0:
-            try:
-                removed = cleanup_image_cache(max_age_hours=24)
-                if removed:
-                    logger.info("Image cache cleanup: removed %d stale file(s)", removed)
-            except Exception as e:
-                logger.debug("Image cache cleanup error: %s", e)
-            try:
-                removed = cleanup_document_cache(max_age_hours=24)
-                if removed:
-                    logger.info("Document cache cleanup: removed %d stale file(s)", removed)
-            except Exception as e:
-                logger.debug("Document cache cleanup error: %s", e)
-
-        if tick_count % PASTE_SWEEP_EVERY == 0:
-            try:
-                deleted, remaining = _sweep_expired_pastes()
-                if deleted:
-                    logger.info(
-                        "Paste sweep: deleted %d expired paste(s), %d pending",
-                        deleted, remaining,
-                    )
-            except Exception as e:
-                logger.debug("Paste sweep error: %s", e)
-
-        # Curator — piggy-back on the existing cron ticker so long-running
-        # gateways get weekly skill maintenance without needing restarts.
-        # maybe_run_curator() is internally gated by config.interval_hours
-        # (7 days by default), so CURATOR_EVERY is just the poll rate — the
-        # real work only fires once per config interval.
-        if tick_count % CURATOR_EVERY == 0:
-            try:
-                from agent.curator import maybe_run_curator
-                maybe_run_curator(
-                    idle_for_seconds=float("inf"),
-                    on_summary=lambda msg: logger.info("curator: %s", msg),
-                )
-            except Exception as e:
-                logger.debug("Curator tick error: %s", e)
+        # Refresh heartbeat after the tick body completes (whether it raised
+        # or not). This lets `hermes cron status` distinguish "ticker thread
+        # is alive" from "gateway process is alive" — see #32612.
+        try:
+            write_cron_ticker_heartbeat()
+        except Exception as e:  # pragma: no cover - heartbeat is best-effort
+            logger.debug("Cron ticker heartbeat write failed: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -30,6 +30,7 @@ else:
 
 _GATEWAY_KIND = "hermes-gateway"
 _RUNTIME_STATUS_FILE = "gateway_state.json"
+_CRON_TICKER_HEARTBEAT_FILE = "cron_ticker.heartbeat"
 _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
@@ -58,6 +59,32 @@ def _get_gateway_lock_path(pid_path: Optional[Path] = None) -> Path:
 def _get_runtime_status_path() -> Path:
     """Return the persisted runtime health/status file path."""
     return _get_pid_path().with_name(_RUNTIME_STATUS_FILE)
+
+
+def _get_cron_ticker_heartbeat_path() -> Path:
+    """Return the path to the cron-ticker heartbeat file.
+
+    The ticker writes its last-tick timestamp here so external readers
+    (``hermes cron status``) can tell whether the ticker thread is still
+    alive, separate from whether the gateway *process* is alive.
+    """
+    return _get_pid_path().with_name(_CRON_TICKER_HEARTBEAT_FILE)
+
+
+def write_cron_ticker_heartbeat() -> None:
+    """Persist a heartbeat marker showing the ticker is alive."""
+    path = _get_cron_ticker_heartbeat_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _write_json_file(path, {"last_tick_at": _utc_now_iso()})
+    except OSError:
+        # Heartbeat is best-effort; never let it kill the ticker.
+        pass
+
+
+def read_cron_ticker_heartbeat() -> Optional[dict[str, Any]]:
+    """Read the cron-ticker heartbeat, returning ``None`` if missing/unreadable."""
+    return _read_json_file(_get_cron_ticker_heartbeat_path())
 
 
 def _get_lock_dir() -> Path:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -151,6 +151,41 @@ def cron_tick():
     tick(verbose=True)
 
 
+def _cron_ticker_liveness(interval_seconds: int = 60):
+    """Return ``(is_alive, last_tick_at, age_seconds)`` for the cron ticker.
+
+    Reads the heartbeat file the gateway's ticker thread writes after every
+    tick. If the file is missing or older than ``2 * interval_seconds``, the
+    ticker is considered dead — covers the silent-death case in #32612 where
+    the gateway process is alive but the ticker thread is not.
+    """
+    from datetime import datetime, timezone
+
+    try:
+        from gateway.status import read_cron_ticker_heartbeat
+    except ImportError:
+        return None, None, None
+
+    record = read_cron_ticker_heartbeat()
+    if not record:
+        return False, None, None
+
+    raw = record.get("last_tick_at")
+    if not isinstance(raw, str):
+        return False, None, None
+
+    try:
+        last_tick = datetime.fromisoformat(raw)
+    except ValueError:
+        return False, raw, None
+
+    if last_tick.tzinfo is None:
+        last_tick = last_tick.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - last_tick).total_seconds()
+    is_alive = age <= max(2 * interval_seconds, 5)
+    return is_alive, raw, age
+
+
 def cron_status():
     """Show cron execution status."""
     from cron.jobs import list_jobs
@@ -160,8 +195,25 @@ def cron_status():
 
     pids = find_gateway_pids()
     if pids:
-        print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
-        print(f"  PID: {', '.join(map(str, pids))}")
+        ticker_alive, last_tick_at, age = _cron_ticker_liveness()
+        if ticker_alive:
+            print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+            print(f"  PID: {', '.join(map(str, pids))}")
+            if last_tick_at:
+                print(color(f"  Ticker: alive (last tick {last_tick_at})", Colors.DIM))
+        else:
+            # Gateway process exists but the ticker thread isn't ticking. This
+            # is the silent-failure mode from #32612 — call it out loudly so
+            # the operator doesn't see a green check while jobs aren't firing.
+            print(color("⚠ Gateway is running but cron ticker is NOT alive — jobs are NOT firing", Colors.YELLOW))
+            print(f"  PID: {', '.join(map(str, pids))}")
+            if last_tick_at:
+                age_display = f"{age:.0f}s ago" if isinstance(age, (int, float)) else last_tick_at
+                print(color(f"  Last tick: {last_tick_at} ({age_display})", Colors.YELLOW))
+            else:
+                print(color("  Last tick: never (no heartbeat written)", Colors.YELLOW))
+            print(color("  Restart the gateway to revive the ticker:", Colors.DIM))
+            print(color("    hermes gateway restart", Colors.DIM))
     else:
         print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
         print()

--- a/tests/cron/test_cron_ticker_watchdog.py
+++ b/tests/cron/test_cron_ticker_watchdog.py
@@ -1,0 +1,218 @@
+"""Regression tests for the gateway cron-ticker watchdog (#32612).
+
+Before this fix the ticker thread silently died if ``cron.scheduler.tick``
+raised: the error was logged at DEBUG (invisible at the default INFO
+level) and a ``BaseException`` would tear the thread down entirely. The
+operator had no way of knowing because ``hermes cron status`` only
+checked whether the gateway *process* was alive, not whether the ticker
+thread was still ticking.
+
+The fix:
+- Promotes per-tick exception logging to WARNING with a traceback.
+- Wraps the tick body in an outer ``except BaseException`` so a transient
+  fault cannot permanently kill the thread.
+- Writes a heartbeat after every tick.
+- ``hermes cron status`` reads that heartbeat and reports the ticker as
+  dead when it stops being refreshed.
+"""
+
+import logging
+import threading
+import time
+
+import pytest
+
+
+def _drive_ticker_until(*, tick_impl, monkeypatch, caplog,
+                        min_calls=2, max_seconds=2.0):
+    """Run ``_start_cron_ticker`` for a couple of iterations with stubs.
+
+    The real ticker calls ``cron.scheduler.tick`` plus a handful of
+    housekeeping helpers (image-cache cleanup, paste sweep, curator). The
+    test only cares about exception recovery + heartbeat semantics, so we
+    monkeypatch the heavy collaborators with no-ops and inject ``tick_impl``
+    as the tick body.
+    """
+    # Import lazily; gateway/run.py is a giant module and we want test
+    # collection to stay cheap.
+    from gateway import run as gateway_run
+
+    # Replace ``cron.scheduler.tick`` (the symbol the ticker imports at
+    # call time) and the cheap housekeeping helpers so we exercise only the
+    # exception-handling and heartbeat paths.
+    monkeypatch.setattr("cron.scheduler.tick", tick_impl)
+    monkeypatch.setattr("gateway.platforms.base.cleanup_image_cache",
+                        lambda *a, **kw: 0)
+    monkeypatch.setattr("gateway.platforms.base.cleanup_document_cache",
+                        lambda *a, **kw: 0)
+    monkeypatch.setattr("hermes_cli.debug._sweep_expired_pastes",
+                        lambda *a, **kw: (0, 0))
+
+    stop_event = threading.Event()
+
+    def runner():
+        # interval=0 so the loop iterates as fast as the wait/stop_event
+        # permits, instead of sleeping 60 seconds between ticks.
+        gateway_run._start_cron_ticker(stop_event, interval=0)
+
+    thread = threading.Thread(target=runner, daemon=True)
+    with caplog.at_level(logging.DEBUG, logger=gateway_run.logger.name):
+        thread.start()
+        deadline = time.monotonic() + max_seconds
+        while time.monotonic() < deadline:
+            if tick_impl.call_count >= min_calls:
+                break
+            time.sleep(0.02)
+        stop_event.set()
+        thread.join(timeout=2.0)
+
+    assert not thread.is_alive(), "cron ticker thread did not stop"
+    return tick_impl
+
+
+class _CountingTick:
+    """Callable that records its call count and optionally raises."""
+
+    def __init__(self, raises=None, raise_on=()):
+        self._raises = raises
+        self._raise_on = set(raise_on)
+        self.call_count = 0
+
+    def __call__(self, *args, **kwargs):
+        self.call_count += 1
+        if self._raises is not None and self.call_count in self._raise_on:
+            raise self._raises
+
+
+class TestTickerSurvivesExceptions:
+    def test_transient_exception_logged_at_warning_and_loop_continues(
+        self, monkeypatch, caplog
+    ):
+        """A regular ``Exception`` inside ``cron_tick`` must NOT kill the
+        ticker. Before the fix it was logged at DEBUG (invisible by
+        default) and any repeat of the same failure was effectively
+        silent. The fix promotes it to WARNING + ``exc_info``."""
+        tick = _CountingTick(
+            raises=RuntimeError("boom"),
+            raise_on={1},  # first call raises, subsequent calls succeed
+        )
+
+        _drive_ticker_until(
+            tick_impl=tick, monkeypatch=monkeypatch, caplog=caplog,
+        )
+
+        assert tick.call_count >= 2, "ticker did not retry after exception"
+
+        warning_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "Cron tick error" in r.message
+        ]
+        assert warning_records, (
+            "Expected WARNING-level 'Cron tick error' record; got: "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+    def test_base_exception_caught_and_logged_and_ticker_recovers(
+        self, monkeypatch, caplog
+    ):
+        """A ``BaseException`` (e.g. ``SystemExit`` smuggled out by a C
+        extension) historically killed the ticker thread silently. The
+        outer ``except BaseException`` must log it at ERROR and let the
+        loop continue."""
+        tick = _CountingTick(
+            raises=SystemExit("hostile c-extension"),
+            raise_on={1},
+        )
+
+        _drive_ticker_until(
+            tick_impl=tick, monkeypatch=monkeypatch, caplog=caplog,
+        )
+
+        assert tick.call_count >= 2, (
+            "ticker died on BaseException; silent-failure regression #32612"
+        )
+
+        error_records = [
+            r for r in caplog.records
+            if r.levelno >= logging.ERROR
+            and "Cron ticker recovered from fatal error" in r.message
+        ]
+        assert error_records, (
+            "Expected ERROR-level recovery log for BaseException; got: "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+
+class TestHeartbeatVisibility:
+    def test_ticker_writes_heartbeat_each_tick(self, monkeypatch, caplog):
+        """The heartbeat file must be refreshed after every tick; that is
+        the signal ``hermes cron status`` reads to tell the ticker thread
+        apart from the gateway process."""
+        tick = _CountingTick()
+        _drive_ticker_until(
+            tick_impl=tick, monkeypatch=monkeypatch, caplog=caplog,
+        )
+
+        from gateway.status import read_cron_ticker_heartbeat
+
+        beat = read_cron_ticker_heartbeat()
+        assert beat is not None, "ticker never wrote a heartbeat"
+        assert "last_tick_at" in beat
+
+    def test_cron_status_reports_ticker_dead_when_heartbeat_stale(
+        self, monkeypatch, capsys
+    ):
+        """``hermes cron status`` must NOT report ``cron jobs will fire
+        automatically`` when the heartbeat is stale, even if a gateway
+        process is alive. This is the misleading-status bug from #32612."""
+        import os
+
+        from gateway.status import _get_cron_ticker_heartbeat_path
+        from hermes_cli import cron as cron_cli
+
+        # Fake "a gateway process is running" so the only signal of
+        # trouble is the stale heartbeat.
+        monkeypatch.setattr(
+            "hermes_cli.gateway.find_gateway_pids", lambda: [os.getpid()]
+        )
+
+        path = _get_cron_ticker_heartbeat_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"last_tick_at": "2000-01-01T00:00:00+00:00"}')
+
+        cron_cli.cron_status()
+        out = capsys.readouterr().out
+
+        assert "cron ticker is NOT alive" in out, (
+            f"status did not warn about dead ticker; got:\n{out}"
+        )
+        assert "cron jobs will fire automatically" not in out, (
+            f"status falsely claimed cron jobs would fire; got:\n{out}"
+        )
+
+    def test_cron_status_happy_path_when_heartbeat_fresh(
+        self, monkeypatch, capsys
+    ):
+        """When the heartbeat is fresh the status command should keep its
+        existing green message; no regression for the healthy case."""
+        import os
+        from datetime import datetime, timezone
+
+        from gateway.status import _get_cron_ticker_heartbeat_path
+        from hermes_cli import cron as cron_cli
+
+        monkeypatch.setattr(
+            "hermes_cli.gateway.find_gateway_pids", lambda: [os.getpid()]
+        )
+
+        path = _get_cron_ticker_heartbeat_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            f'{{"last_tick_at": "{datetime.now(timezone.utc).isoformat()}"}}'
+        )
+
+        cron_cli.cron_status()
+        out = capsys.readouterr().out
+
+        assert "cron jobs will fire automatically" in out
+        assert "cron ticker is NOT alive" not in out


### PR DESCRIPTION
## Problem

The gateway cron ticker can die or stall silently, leaving scheduled jobs unfired while the gateway process still looks healthy.

The old behavior had three visibility gaps:

- per-tick `cron.scheduler.tick` failures were logged at DEBUG;
- `BaseException` escaping the tick body could terminate the ticker thread;
- `hermes cron status` only checked whether the gateway process existed, not whether the ticker thread was still ticking.

## Fix

This PR keeps the existing ticker loop and adds targeted visibility/recovery:

- `gateway/run.py`: log recoverable `cron_tick` exceptions at WARNING with traceback.
- `gateway/run.py`: wrap the tick body in an outer `except BaseException` so fatal escapes are logged and the loop continues.
- `gateway/run.py`: write a best-effort ticker heartbeat at startup and after each tick.
- `gateway/status.py`: add heartbeat read/write helpers beside the gateway pid/runtime status files.
- `hermes_cli/cron.py`: report a live gateway with a missing/stale heartbeat as unhealthy instead of showing the green “cron jobs will fire automatically” message.

No new watchdog subsystem or extra thread is added.

## Review context

A collaborator noted this competes with #32616, #32666, and #33527, and called this PR the most comprehensive consolidation. Current state checked during rebase: #32616 is closed; #32666 and #33527 remain open. This PR keeps the consolidation path: logging + BaseException recovery + heartbeat/status surfacing.

## Testing

- Red check on current `upstream/main`: `pytest tests/cron/test_cron_ticker_watchdog.py -q --timeout-method=thread` failed on the expected missing behaviors: DEBUG-only tick logging, ticker death on `BaseException`, and missing heartbeat helpers.
- `pytest tests/cron/test_cron_ticker_watchdog.py -q --timeout-method=thread` -> 5 passed.
- `ruff check gateway/run.py gateway/status.py hermes_cli/cron.py tests/cron/test_cron_ticker_watchdog.py` -> passed.
- `python -m py_compile gateway/run.py gateway/status.py hermes_cli/cron.py tests/cron/test_cron_ticker_watchdog.py` -> passed.
- `git diff --check upstream/main...HEAD` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> clean.

Closes #32612