### PR TITLE
fix(telegram): persist clarify-button resolver state across restarts

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3585,12 +3585,71 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 session_key = self._clarify_state.get(clarify_id)
                 if not session_key:
+                    # Adapter map lost (gateway restart, #32762) — fall
+                    # back to the clarify primitive, which is rehydrated
+                    # from disk on startup.  If the entry survived the
+                    # restart, recover the session_key so the tap is
+                    # acknowledged instead of silently dropped.
+                    try:
+                        from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
+                        _persisted = _clarify_entries.get(clarify_id)
+                        if _persisted is not None:
+                            session_key = _persisted.session_key
+                            self._clarify_state[clarify_id] = session_key
+                    except Exception:
+                        pass
+                if not session_key:
                     await query.answer(text="This prompt has already been resolved.")
                     return
 
                 user_display = getattr(query.from_user, "first_name", "User")
+                stale_prompt_text = "This prompt is no longer active. Please ask again."
+                restart_ack_text = (
+                    "⚠️ Session restarted — this prompt cannot continue. "
+                    "Please /retry."
+                )
+
+                entry = None
+                try:
+                    from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
+                    entry = _clarify_entries.get(clarify_id)
+                except Exception:
+                    entry = None
+                if entry is None:
+                    self._clarify_state.pop(clarify_id, None)
+                    await query.answer(text=stale_prompt_text)
+                    return
+
+                _entry_restored = False
+                try:
+                    from tools.clarify_gateway import was_restored as _was_restored
+                    _entry_restored = bool(_was_restored(clarify_id))
+                except Exception:
+                    _entry_restored = bool(getattr(entry, "restored", False))
 
                 if choice_token == "other":
+                    if _entry_restored:
+                        self._clarify_state.pop(clarify_id, None)
+                        try:
+                            from tools.clarify_gateway import resolve_gateway_clarify
+                            resolve_gateway_clarify(clarify_id, "")
+                        except Exception as exc:
+                            logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
+                        await query.answer(text=restart_ack_text)
+                        try:
+                            await query.edit_message_text(
+                                text=(
+                                    f"❓ {_html.escape(query.message.text or '')}\n\n"
+                                    f"<i>⚠️ Gateway restarted before this prompt was answered — "
+                                    f"please /retry to re-run the agent.</i>"
+                                ),
+                                parse_mode=ParseMode.HTML,
+                                reply_markup=None,
+                            )
+                        except Exception:
+                            pass
+                        return
+
                     # Flip into text-capture mode and tell the user to type
                     # their answer.  The gateway's text-intercept will pick
                     # up the next message in this session and resolve the
@@ -3599,9 +3658,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     # is cleared by something else.
                     try:
                         from tools.clarify_gateway import mark_awaiting_text
-                        mark_awaiting_text(clarify_id)
+                        marked = mark_awaiting_text(clarify_id)
                     except Exception as exc:
                         logger.warning("[%s] mark_awaiting_text failed: %s", self.name, exc)
+                        marked = False
+                    if not marked:
+                        self._clarify_state.pop(clarify_id, None)
+                        await query.answer(text=stale_prompt_text)
+                        return
 
                     await query.answer(text="✏️ Type your answer in the chat.")
                     try:
@@ -3625,13 +3689,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 # clarify primitive.  Fall back to the index if the entry
                 # has been cleaned up (race with timeout / session reset).
                 resolved_text: Optional[str] = None
-                try:
-                    from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
-                    entry = _clarify_entries.get(clarify_id)
-                    if entry and entry.choices and 0 <= idx < len(entry.choices):
-                        resolved_text = entry.choices[idx]
-                except Exception:
-                    resolved_text = None
+                if entry.choices and 0 <= idx < len(entry.choices):
+                    resolved_text = entry.choices[idx]
 
                 if resolved_text is None:
                     # Race: entry vanished. Echo the index as a number so
@@ -3648,10 +3707,35 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
                     resolved = False
 
-                await query.answer(text=f"✓ {resolved_text[:60]}")
+                if _entry_restored:
+                    ack_text = (
+                        "⚠️ Session restarted — your answer was recorded but "
+                        "the agent run ended. Please /retry."
+                    )
+                    edited_text = (
+                        f"❓ {_html.escape(query.message.text or '')}\n\n"
+                        f"<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}\n\n"
+                        f"<i>⚠️ Gateway restarted before this answer arrived — "
+                        f"please /retry to re-run the agent.</i>"
+                    )
+                else:
+                    if resolved:
+                        ack_text = f"✓ {resolved_text[:60]}"
+                        edited_text = (
+                            f"❓ {_html.escape(query.message.text or '')}\n\n"
+                            f"<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}"
+                        )
+                    else:
+                        ack_text = stale_prompt_text
+                        edited_text = (
+                            f"❓ {_html.escape(query.message.text or '')}\n\n"
+                            f"<i>Prompt is no longer active. Please ask again.</i>"
+                        )
+
+                await query.answer(text=ack_text)
                 try:
                     await query.edit_message_text(
-                        text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                        text=edited_text,
                         parse_mode=ParseMode.HTML,
                         reply_markup=None,
                     )
@@ -3660,8 +3744,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 if resolved:
                     logger.info(
-                        "Telegram clarify button resolved (id=%s, choice=%r, user=%s)",
-                        clarify_id, resolved_text, user_display,
+                        "Telegram clarify button resolved (id=%s, choice=%r, user=%s, restored=%s)",
+                        clarify_id, resolved_text, user_display, _entry_restored,
                     )
                 else:
                     logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4764,6 +4764,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Process checkpoint recovery: %s", e)
 
+        # Re-hydrate pending clarify-button entries (#32762).  When the
+        # gateway is killed by SIGTERM between an agent posting a clarify
+        # prompt and the user tapping a button, the in-memory entry was
+        # lost and the tap silently failed.  Restoring from the JSON
+        # sidecar lets the next process at least acknowledge the tap and
+        # tell the user the session was reset.  Best-effort.
+        try:
+            from tools import clarify_gateway as _clarify_mod
+            _restored = _clarify_mod.restore_pending()
+            if _restored:
+                logger.info(
+                    "Recovered %d pending clarify entr%s from previous run",
+                    len(_restored), "y" if len(_restored) == 1 else "ies",
+                )
+        except Exception as e:
+            logger.warning("Clarify state recovery: %s", e)
+
         # Suspend sessions that were active when the gateway last exited.
         # This prevents stuck sessions from being blindly resumed on restart,
         # which can create an unrecoverable loop (#7536).  Suspended sessions
@@ -6519,6 +6536,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # so the user can retry; if it times out, the agent unblocks
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
+                try:
+                    _clarify_was_restored = bool(
+                        _clarify_mod.was_restored(_pending_clarify.clarify_id)
+                    )
+                except Exception:
+                    _clarify_was_restored = bool(
+                        getattr(_pending_clarify, "restored", False)
+                    )
                 _resolved = _clarify_mod.resolve_gateway_clarify(
                     _pending_clarify.clarify_id, _raw_clarify_reply,
                 )
@@ -6527,10 +6552,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Gateway intercepted clarify text response (session=%s, id=%s)",
                         _quick_key, _pending_clarify.clarify_id,
                     )
+                    if _clarify_was_restored:
+                        return (
+                            "⚠️ Gateway restarted before this clarify response "
+                            "arrived, so the previous agent run is no longer "
+                            "waiting. Please /retry to re-run it."
+                        )
                     # Acknowledge with empty string so adapters that emit
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+                logger.warning(
+                    "Gateway clarify text response could not resolve stale prompt "
+                    "(session=%s, id=%s)",
+                    _quick_key, _pending_clarify.clarify_id,
+                )
+                return "This clarify prompt is no longer active. Please ask again."
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -7,6 +7,7 @@ Mirrors test_telegram_approval_buttons.py for the new ``send_clarify`` and
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -48,7 +49,9 @@ def _ensure_telegram_mock():
 _ensure_telegram_mock()
 
 from gateway.platforms.telegram import TelegramAdapter
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, build_session_key
 
 
 def _make_adapter(extra=None):
@@ -243,6 +246,35 @@ class TestTelegramClarifyCallback:
         query.edit_message_text.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_numeric_choice_with_stale_adapter_state_shows_expired(self):
+        adapter = _make_adapter()
+        adapter._clarify_state["cidExpired"] = "sk-expired"
+
+        query = AsyncMock()
+        query.data = "cl:cidExpired:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.text = "Pick"
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_called_once()
+        ack_text = query.answer.call_args[1]["text"].lower()
+        assert "\u2713" not in ack_text
+        assert "no longer" in ack_text or "expired" in ack_text
+        assert "cidExpired" not in adapter._clarify_state
+
+    @pytest.mark.asyncio
     async def test_other_button_flips_to_text_mode(self):
         from tools import clarify_gateway as cm
 
@@ -280,6 +312,36 @@ class TestTelegramClarifyCallback:
             entry = cm._entries.get("cidB")
         assert entry is not None
         assert not entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_other_button_with_stale_adapter_state_shows_expired(self):
+        adapter = _make_adapter()
+        adapter._clarify_state["cidOtherExpired"] = "sk-other-expired"
+
+        query = AsyncMock()
+        query.data = "cl:cidOtherExpired:other"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.text = "Pick"
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_called_once()
+        ack_text = query.answer.call_args[1]["text"].lower()
+        assert "type your answer" not in ack_text
+        assert "no longer" in ack_text or "expired" in ack_text
+        query.edit_message_text.assert_not_called()
+        assert "cidOtherExpired" not in adapter._clarify_state
 
     @pytest.mark.asyncio
     async def test_already_resolved(self):
@@ -352,6 +414,120 @@ class TestTelegramClarifyCallback:
         assert adapter._clarify_state["cidC"] == "sk-auth"
 
     @pytest.mark.asyncio
+    async def test_button_after_gateway_restart_recovers_session(self, tmp_path):
+        """Regression for #32762: when the gateway is killed between an
+        agent posting a clarify prompt and the user tapping a button, the
+        adapter-side ``_clarify_state`` map is empty.  The callback must
+        fall back to the persisted clarify primitive (rehydrated on
+        boot), acknowledge the tap, and tell the user the session was
+        reset instead of silently saying "already resolved".
+        """
+        from tools import clarify_gateway as cm
+
+        # Simulate: previous process registered "cidR" and persisted it.
+        cm.set_persist_path(tmp_path / "clarify_pending.json")
+        try:
+            cm.register("cidR", "sk-restart", "Pick", ["red", "green"])
+
+            # Simulate SIGTERM: wipe in-memory state and rehydrate.
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
+            restored = cm.restore_pending(timeout_seconds=600.0)
+            assert len(restored) == 1
+            restored_entry = restored[0]
+
+            # New process: adapter has an empty _clarify_state map.
+            adapter = _make_adapter()
+            assert "cidR" not in adapter._clarify_state
+
+            query = AsyncMock()
+            query.data = "cl:cidR:1"  # green
+            query.message = MagicMock()
+            query.message.chat_id = 12345
+            query.message.text = "Pick"
+            query.from_user = MagicMock()
+            query.from_user.id = "777"
+            query.from_user.first_name = "Tester"
+            query.answer = AsyncMock()
+            query.edit_message_text = AsyncMock()
+
+            update = MagicMock()
+            update.callback_query = query
+            context = MagicMock()
+
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+                await adapter._handle_callback_query(update, context)
+
+            # Tap was acknowledged (not silently dropped, not "already resolved").
+            query.answer.assert_called_once()
+            ack_text = query.answer.call_args[1]["text"].lower()
+            assert "already" not in ack_text
+            assert "session restarted" in ack_text or "restart" in ack_text
+
+            # The clarify primitive recorded the user's choice on the
+            # restored entry.  (Restored entries are cleaned out of
+            # _entries immediately on resolve; no waiter does it, so
+            # we read the response off the restored_entry reference.)
+            assert restored_entry.response == "green"
+            assert restored_entry.event.is_set()
+
+            # Original message edited with the "session restarted" hint.
+            query.edit_message_text.assert_called_once()
+            edited = query.edit_message_text.call_args[1]["text"].lower()
+            assert "retry" in edited or "restart" in edited
+        finally:
+            cm.set_persist_path(None)
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
+
+    @pytest.mark.asyncio
+    async def test_other_button_after_gateway_restart_shows_retry_instead_of_text_capture(self, tmp_path):
+        from tools import clarify_gateway as cm
+
+        cm.set_persist_path(tmp_path / "clarify_pending.json")
+        try:
+            cm.register("cidOtherRestored", "sk-other-restored", "Pick", ["red", "green"])
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
+            restored = cm.restore_pending(timeout_seconds=600.0)
+            assert len(restored) == 1
+
+            adapter = _make_adapter()
+
+            query = AsyncMock()
+            query.data = "cl:cidOtherRestored:other"
+            query.message = MagicMock()
+            query.message.chat_id = 12345
+            query.message.text = "Pick"
+            query.from_user = MagicMock()
+            query.from_user.id = "777"
+            query.from_user.first_name = "Tester"
+            query.answer = AsyncMock()
+            query.edit_message_text = AsyncMock()
+
+            update = MagicMock()
+            update.callback_query = query
+            context = MagicMock()
+
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+                await adapter._handle_callback_query(update, context)
+
+            query.answer.assert_called_once()
+            ack_text = query.answer.call_args[1]["text"].lower()
+            assert "type your answer" not in ack_text
+            assert "restart" in ack_text or "retry" in ack_text
+            assert cm.get_pending_for_session("sk-other-restored") is None
+            assert "cidOtherRestored" not in adapter._clarify_state
+        finally:
+            cm.set_persist_path(None)
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
+
+    @pytest.mark.asyncio
     async def test_invalid_choice_token(self):
         from tools import clarify_gateway as cm
 
@@ -382,6 +558,69 @@ class TestTelegramClarifyCallback:
         assert not entry.event.is_set()
         query.answer.assert_called_once()
         assert "invalid" in query.answer.call_args[1]["text"].lower()
+
+
+class TestGatewayClarifyTextIntercept:
+    """Verify free-form clarify replies do not vanish after restore."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @staticmethod
+    def _make_source() -> SessionSource:
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="u1",
+            chat_id="c1",
+            user_name="tester",
+            chat_type="dm",
+        )
+
+    @classmethod
+    def _make_event(cls, text: str) -> MessageEvent:
+        return MessageEvent(text=text, source=cls._make_source(), message_id="m1")
+
+    @staticmethod
+    def _make_runner():
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = MagicMock()
+        runner.adapters = {Platform.TELEGRAM: MagicMock()}
+        runner.session_store = None
+        runner.hooks = SimpleNamespace(emit_collect=MagicMock(return_value=[]))
+        runner._update_prompt_pending = {}
+        runner._is_user_authorized = lambda _source: True
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_restored_open_ended_text_reply_returns_retry_hint(self, tmp_path):
+        from tools import clarify_gateway as cm
+
+        cm.set_persist_path(tmp_path / "clarify_pending.json")
+        try:
+            source = self._make_source()
+            session_key = build_session_key(source)
+            cm.register("cidOpenRestored", session_key, "What should I use?", None)
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
+            restored = cm.restore_pending(timeout_seconds=600.0)
+            assert len(restored) == 1
+            assert restored[0].restored is True
+
+            runner = self._make_runner()
+            result = await runner._handle_message(self._make_event("custom value"))
+
+            assert result
+            lowered = result.lower()
+            assert "restart" in lowered or "retry" in lowered
+            assert cm.get_pending_for_session(session_key) is None
+        finally:
+            cm.set_persist_path(None)
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
 
 
 # ===========================================================================

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -221,6 +221,185 @@ class TestGatewayTextIntercept:
         pending = cm.get_pending_for_session("sk-tf")
         assert pending is not None
         assert pending.clarify_id == "id-tf"
-        
+
         # Clean up
         cm.clear_session("sk-tf")
+
+
+# ===========================================================================
+# Persistence (#32762): entries survive a SIGTERM restart
+# ===========================================================================
+
+class TestClarifyPersistence:
+    """Pending clarify entries must survive a gateway restart so late
+    button taps are acknowledged instead of silently dropped (#32762).
+    """
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def _isolate_persist(self, tmp_path):
+        from tools import clarify_gateway as cm
+        path = tmp_path / "clarify_pending.json"
+        cm.set_persist_path(path)
+        return path
+
+    def _reset_persist(self):
+        from tools import clarify_gateway as cm
+        cm.set_persist_path(None)
+
+    def test_register_writes_persist_file(self, tmp_path):
+        """register() flushes the entry to the JSON sidecar."""
+        from tools import clarify_gateway as cm
+        import json
+
+        path = self._isolate_persist(tmp_path)
+        try:
+            cm.register("p1", "sk-p1", "Pick?", ["a", "b"])
+            assert path.exists()
+            payload = json.loads(path.read_text())
+            ids = [e["clarify_id"] for e in payload["entries"]]
+            assert "p1" in ids
+        finally:
+            self._reset_persist()
+
+    def test_restore_round_trip_survives_simulated_restart(self, tmp_path):
+        """Register, wipe in-memory state (SIGTERM), then restore_pending
+        rebuilds _entries with restored=True; resolve still acknowledges
+        the late tap.
+        """
+        from tools import clarify_gateway as cm
+
+        path = self._isolate_persist(tmp_path)
+        try:
+            cm.register("p2", "sk-p2", "Pick?", ["x", "y"])
+            assert path.exists()
+
+            # Simulate SIGTERM: new process boots with empty memory.
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
+
+            # New gateway calls restore_pending on startup.
+            restored = cm.restore_pending(timeout_seconds=600.0)
+            assert len(restored) == 1
+            entry = restored[0]
+            assert entry.clarify_id == "p2"
+            assert entry.session_key == "sk-p2"
+            assert entry.choices == ["x", "y"]
+            assert entry.restored is True
+            assert cm.was_restored("p2") is True
+
+            # Late button tap now lands on the restored entry instead of
+            # returning False; this is the user-visible bug from #32762.
+            # Capture the entry reference before resolve, since restored
+            # entries are cleaned out of _entries immediately on resolve
+            # (no waiter to do it).
+            with cm._lock:
+                live_entry = cm._entries["p2"]
+            ok = cm.resolve_gateway_clarify("p2", "x")
+            assert ok is True
+            assert live_entry.response == "x"
+            assert live_entry.event.is_set()
+            with cm._lock:
+                assert "p2" not in cm._entries
+            # Persist file no longer references the resolved entry.
+            import json
+            payload = json.loads(path.read_text())
+            assert all(e["clarify_id"] != "p2" for e in payload["entries"])
+        finally:
+            self._reset_persist()
+
+    def test_restore_drops_expired_entries(self, tmp_path):
+        """Entries older than the configured timeout are dropped; the
+        agent that asked has long given up."""
+        from tools import clarify_gateway as cm
+        import time as _t
+
+        path = self._isolate_persist(tmp_path)
+        try:
+            entry = cm.register("p3", "sk-p3", "Pick?", ["a"])
+            # Backdate the on-disk record so restore_pending sees it as
+            # past-timeout.
+            import json
+            payload = json.loads(path.read_text())
+            for raw in payload["entries"]:
+                raw["registered_at"] = _t.time() - 3600.0
+            path.write_text(json.dumps(payload))
+
+            # Clear in-memory and restore with a 600s timeout.
+            with cm._lock:
+                cm._entries.clear()
+                cm._session_index.clear()
+            restored = cm.restore_pending(timeout_seconds=600.0)
+            assert restored == []
+            assert "p3" not in cm._entries
+            # And the persist file no longer references the dropped id.
+            payload2 = json.loads(path.read_text())
+            assert all(e["clarify_id"] != "p3" for e in payload2["entries"])
+        finally:
+            self._reset_persist()
+
+    def test_wait_for_response_removes_persisted_entry(self, tmp_path):
+        """When wait_for_response times out, the persisted record is
+        removed so the next restart doesn't replay a stale entry."""
+        from tools import clarify_gateway as cm
+        import json
+
+        path = self._isolate_persist(tmp_path)
+        try:
+            cm.register("p4", "sk-p4", "Pick?", ["a"])
+            assert path.exists()
+            cm.wait_for_response("p4", timeout=0.05)
+            payload = json.loads(path.read_text())
+            assert all(e["clarify_id"] != "p4" for e in payload["entries"])
+        finally:
+            self._reset_persist()
+
+    def test_clear_session_removes_persisted_entries(self, tmp_path):
+        """clear_session() prunes the JSON sidecar so suspended sessions
+        don't leave ghost entries that a future restart would restore."""
+        from tools import clarify_gateway as cm
+        import json
+
+        path = self._isolate_persist(tmp_path)
+        try:
+            cm.register("p5", "sk-p5", "Pick?", ["a"])
+            cm.register("p6", "sk-p5", "Pick?", ["b"])
+            cm.clear_session("sk-p5")
+            payload = json.loads(path.read_text())
+            ids = [e["clarify_id"] for e in payload["entries"]]
+            assert "p5" not in ids
+            assert "p6" not in ids
+        finally:
+            self._reset_persist()
+
+    def test_restore_skips_duplicate_in_memory_entry(self, tmp_path):
+        """If a clarify_id is already live in memory, restore_pending
+        must not clobber the live entry (which has a real Event a thread
+        may be waiting on)."""
+        from tools import clarify_gateway as cm
+
+        path = self._isolate_persist(tmp_path)
+        try:
+            live = cm.register("p7", "sk-p7", "Q?", ["a"])
+            # Persist file now exists.  Restoring with the live entry
+            # still in _entries must be a no-op for that id.
+            restored = cm.restore_pending(timeout_seconds=600.0)
+            assert restored == []
+            with cm._lock:
+                assert cm._entries["p7"] is live
+        finally:
+            self._reset_persist()
+
+    def test_was_restored_false_for_live_entry(self, tmp_path):
+        """was_restored() distinguishes live entries from rehydrated ones."""
+        from tools import clarify_gateway as cm
+
+        path = self._isolate_persist(tmp_path)
+        try:
+            cm.register("p8", "sk-p8", "Q?", ["a"])
+            assert cm.was_restored("p8") is False
+            assert cm.was_restored("nope") is False
+        finally:
+            self._reset_persist()

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -31,10 +31,14 @@ Two delivery paths from the adapter:
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -54,6 +58,13 @@ class _ClarifyEntry:
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
+    registered_at: float = field(default_factory=time.time)
+    # True when this entry was restored from disk after a gateway restart —
+    # no agent thread is waiting on ``event``.  The button callback can
+    # still record the user's response (so the tap is acknowledged instead
+    # of silently dropped — see #32762) but the agent run that originally
+    # asked is gone, and the user will need to re-trigger it.
+    restored: bool = False
 
     def signature(self) -> Dict[str, object]:
         return {
@@ -63,12 +74,201 @@ class _ClarifyEntry:
             "choices": list(self.choices) if self.choices else None,
         }
 
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize the persistable fields (excludes runtime-only Event/response)."""
+        return {
+            "clarify_id": self.clarify_id,
+            "session_key": self.session_key,
+            "question": self.question,
+            "choices": list(self.choices) if self.choices else None,
+            "awaiting_text": self.awaiting_text,
+            "registered_at": self.registered_at,
+        }
+
 
 _lock = threading.RLock()
 # clarify_id → _ClarifyEntry  (primary lookup for button callbacks)
 _entries: Dict[str, _ClarifyEntry] = {}
 # session_key → list[clarify_id]  (FIFO; for text-fallback intercept and session cleanup)
 _session_index: Dict[str, List[str]] = {}
+
+
+# =========================================================================
+# On-disk persistence (#32762)
+# =========================================================================
+# In-memory state is lost when the gateway receives SIGTERM (launchd
+# watchdog, systemd unit restart, ``hermes gateway restart``, etc).  Any
+# button tap that arrives during the window between "agent posted the
+# clarify prompt" and "gateway came back up" used to silently fail
+# (``resolve_gateway_clarify`` returned False with no user feedback).
+#
+# We persist a minimal JSON sidecar so the next process can re-hydrate
+# pending entries on startup, expire any that aged past the timeout, and
+# at least acknowledge late taps to the user.  The agent thread that
+# called ``wait_for_response`` is gone after a restart — restored entries
+# carry ``restored=True`` so callers can tell the difference and surface
+# the right message ("session was restarted; please /retry").
+_PERSIST_FILENAME = "clarify_pending.json"
+_persist_path_override: Optional[Path] = None
+
+
+def _persist_path() -> Optional[Path]:
+    """Return the JSON sidecar path, honouring tests' override.
+
+    Returns ``None`` if the Hermes home directory can't be located — in
+    which case persistence is silently skipped and the module degrades to
+    its old in-memory-only behaviour.
+    """
+    if _persist_path_override is not None:
+        return _persist_path_override
+    try:
+        from hermes_constants import get_hermes_home
+        return get_hermes_home() / _PERSIST_FILENAME
+    except Exception:
+        return None
+
+
+def set_persist_path(path: Optional[Path]) -> None:
+    """Override the persistence path (test seam)."""
+    global _persist_path_override
+    _persist_path_override = path
+
+
+def _atomic_write_json(path: Path, payload: object) -> None:
+    """Write ``payload`` to ``path`` atomically via a sibling tempfile.
+
+    Never raises — persistence is best-effort; the gateway must keep
+    running even if the state dir is read-only or full.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh)
+                fh.flush()
+                try:
+                    os.fsync(fh.fileno())
+                except Exception:
+                    pass
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except Exception:
+                pass
+            raise
+    except Exception as exc:  # pragma: no cover - best-effort
+        logger.debug("clarify_gateway: persist write failed: %s", exc)
+
+
+def _flush_persist_locked() -> None:
+    """Write the current ``_entries`` snapshot to disk.  Caller holds _lock."""
+    path = _persist_path()
+    if path is None:
+        return
+    payload = {
+        "version": 1,
+        "entries": [e.to_dict() for e in _entries.values()],
+    }
+    _atomic_write_json(path, payload)
+
+
+def _load_persist_payload() -> Optional[Dict[str, object]]:
+    path = _persist_path()
+    if path is None or not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("clarify_gateway: persist read failed: %s", exc)
+        return None
+
+
+def restore_pending(
+    timeout_seconds: Optional[float] = None,
+    now: Optional[float] = None,
+) -> List[_ClarifyEntry]:
+    """Re-hydrate pending clarify entries from disk.
+
+    Called by the gateway on startup so a button tap that arrives after a
+    restart can still be acknowledged (#32762).  Entries whose age exceeds
+    ``timeout_seconds`` are dropped — the agent that asked has long given
+    up.  Returns the list of restored entries (caller can log a count).
+
+    Restored entries carry ``restored=True`` and have no thread waiting on
+    their ``event``; ``resolve_gateway_clarify`` still records the
+    response so the user-visible tap acknowledgement works.
+    """
+    payload = _load_persist_payload()
+    if not payload:
+        return []
+
+    if timeout_seconds is None:
+        timeout_seconds = float(get_clarify_timeout())
+    if now is None:
+        now = time.time()
+
+    restored: List[_ClarifyEntry] = []
+    expired = 0
+    with _lock:
+        for raw in payload.get("entries", []) or []:
+            try:
+                clarify_id = str(raw["clarify_id"])
+                session_key = str(raw["session_key"])
+                question = str(raw.get("question") or "")
+                choices_raw = raw.get("choices")
+                choices = (
+                    [str(c) for c in choices_raw]
+                    if isinstance(choices_raw, list) and choices_raw
+                    else None
+                )
+                registered_at = float(raw.get("registered_at") or now)
+                awaiting_text = bool(raw.get("awaiting_text"))
+            except Exception:
+                continue
+
+            # Drop entries already older than the timeout — the agent
+            # that asked is gone and re-delivering would be confusing.
+            age = max(now - registered_at, 0.0)
+            if age >= timeout_seconds:
+                expired += 1
+                continue
+
+            # Don't clobber a live in-memory entry (e.g. duplicate restore).
+            if clarify_id in _entries:
+                continue
+
+            entry = _ClarifyEntry(
+                clarify_id=clarify_id,
+                session_key=session_key,
+                question=question,
+                choices=choices,
+                awaiting_text=awaiting_text,
+                registered_at=registered_at,
+                restored=True,
+            )
+            _entries[clarify_id] = entry
+            _session_index.setdefault(session_key, []).append(clarify_id)
+            restored.append(entry)
+
+        if restored or expired:
+            _flush_persist_locked()
+
+    if restored:
+        logger.info(
+            "clarify_gateway: restored %d pending clarify entr%s from disk "
+            "(%d expired)",
+            len(restored), "y" if len(restored) == 1 else "ies", expired,
+        )
+    elif expired:
+        logger.info(
+            "clarify_gateway: dropped %d expired clarify entr%s from disk",
+            expired, "y" if expired == 1 else "ies",
+        )
+    return restored
 
 
 # =========================================================================
@@ -97,6 +297,7 @@ def register(
     with _lock:
         _entries[clarify_id] = entry
         _session_index.setdefault(session_key, []).append(clarify_id)
+        _flush_persist_locked()
     return entry
 
 
@@ -139,6 +340,7 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
             ids.remove(clarify_id)
             if not ids:
                 _session_index.pop(entry.session_key, None)
+        _flush_persist_locked()
 
     return entry.response
 
@@ -152,6 +354,13 @@ def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
 
     Returns True if an entry was found and resolved, False otherwise
     (already resolved, expired, or never existed).
+
+    For entries restored from disk after a gateway restart (#32762), no
+    agent thread is waiting — setting ``event`` is a no-op — but we still
+    return True so the platform callback can acknowledge the tap to the
+    user instead of silently dropping it.  Restored entries are also
+    cleaned out of the persistence sidecar immediately, since there's no
+    ``wait_for_response`` thread to do it on the way out.
     """
     with _lock:
         entry = _entries.get(clarify_id)
@@ -159,7 +368,30 @@ def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
             return False
     entry.response = str(response) if response is not None else ""
     entry.event.set()
+    if entry.restored:
+        # No waiter to clean up after itself — drop it now so the next
+        # restart doesn't replay an already-answered entry.
+        with _lock:
+            _entries.pop(clarify_id, None)
+            ids = _session_index.get(entry.session_key)
+            if ids and clarify_id in ids:
+                ids.remove(clarify_id)
+                if not ids:
+                    _session_index.pop(entry.session_key, None)
+            _flush_persist_locked()
     return True
+
+
+def was_restored(clarify_id: str) -> bool:
+    """Return True if this clarify entry was re-hydrated from disk.
+
+    Lets adapters distinguish "we resolved an active agent's clarify" from
+    "we acknowledged a late tap whose agent was lost to a restart" so they
+    can tailor the user-visible message (see #32762).
+    """
+    with _lock:
+        entry = _entries.get(clarify_id)
+        return bool(entry and entry.restored)
 
 
 def get_pending_for_session(session_key: str) -> Optional[_ClarifyEntry]:
@@ -190,6 +422,7 @@ def mark_awaiting_text(clarify_id: str) -> bool:
         if entry is None:
             return False
         entry.awaiting_text = True
+        _flush_persist_locked()
         return True
 
 
@@ -210,6 +443,7 @@ def clear_session(session_key: str) -> int:
     with _lock:
         ids = list(_session_index.pop(session_key, []) or [])
         entries = [_entries.pop(cid, None) for cid in ids]
+        _flush_persist_locked()
     cancelled = 0
     for entry in entries:
         if entry is None:


### PR DESCRIPTION
## Summary
- Persists pending clarify prompts to a profile-scoped JSON sidecar so SIGTERM/restart does not erase the resolver state.
- Restores non-expired pending clarify entries on gateway startup and records late taps on restored entries.
- Updates Telegram clarify callbacks and text fallback handling so users get an explicit restart/retry hint instead of a dead button or silent drop.
- Rebased onto `upstream/main` at `d0e017bac`; latest merge-tree check against `b1af653bf` remains clean.

## Review notes
- Addresses #32762.
- Reviewed the competing PR note from `alt-glitch`: #32878 is closed, #33073 is still open, and this branch keeps the combined path here: persistence + startup restore + Telegram late-tap recovery.

## TDD / verification
- RED: `python -m pytest tests/tools/test_clarify_gateway.py::TestClarifyPersistence::test_register_writes_persist_file -q --timeout-method=thread` failed on `upstream/main` with `AttributeError: module 'tools.clarify_gateway' has no attribute 'set_persist_path'`.
- GREEN/rebased verification: `.venv\Scripts\python.exe -m pytest tests\tools\test_clarify_gateway.py tests\gateway\test_telegram_clarify_buttons.py -q --timeout-method=thread` -> 39 passed.
- `.venv\Scripts\ruff.exe check tools\clarify_gateway.py gateway\platforms\telegram.py gateway\run.py tests\tools\test_clarify_gateway.py tests\gateway\test_telegram_clarify_buttons.py` -> passed.
- `.venv\Scripts\python.exe -m py_compile tools\clarify_gateway.py gateway\platforms\telegram.py gateway\run.py tests\tools\test_clarify_gateway.py tests\gateway\test_telegram_clarify_buttons.py` -> passed.
- `git diff --check` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> clean (`7c5a53bc0d2bca9d16bb127b60ee5bfa8e1f9f0c`).