### PR TITLE
fix(telegram): surface retry hint instead of silently dropping the message after /stop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1806,6 +1806,12 @@ def _normalize_empty_agent_response(
     Consolidates the existing ``failed`` handler and adds a catch-all for
     the case where the agent did work (api_calls > 0) but returned no text.
     Fix for #18765.
+
+    Also surfaces a retry hint when the agent never ran at all
+    (api_calls == 0) for a non-interrupted, non-failed turn -- this is the
+    silent-drop pattern observed after ``/stop`` where the next user
+    message hits a stale generation token and returns an empty result,
+    leaving the platform with nothing to send. (#31884)
     """
     if response:
         return response
@@ -1836,6 +1842,22 @@ def _normalize_empty_agent_response(
         return (
             "⚠️ Processing completed but no response was generated. "
             "This may be a transient error — try sending your message again."
+        )
+
+    # api_calls == 0, not failed, not interrupted: the agent never ran for
+    # this turn. This is the post-/stop generation-race pattern where the
+    # gateway would otherwise silently drop the turn (response=0 chars) and
+    # the user sees no reply at all. Surface a short retry hint so the
+    # message isn't lost in silence. (#31884)
+    if (
+        api_calls == 0
+        and not agent_result.get("interrupted")
+        and not agent_result.get("failed")
+        and not agent_result.get("partial")
+    ):
+        return (
+            "⚠️ Your message wasn't processed (the previous turn was still "
+            "being cleaned up). Please send it again."
         )
 
     return response

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -415,6 +415,31 @@ class TestGatewaySurfacesNullResponse:
 
         assert result == "Hello!"
 
+    def test_silent_drop_after_stop_surfaces_hint(self):
+        """Regression for #31884: after /stop, the next user message hits a
+        stale generation token in _run_agent and returns with api_calls=0,
+        no failure, no interruption. Without normalization the gateway
+        silently drops the turn (response=0 chars). Surface a retry hint
+        so the user knows the message was lost."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": "",
+            "api_calls": 0,
+            "failed": False,
+            "interrupted": False,
+            "partial": False,
+        }
+
+        response = agent_result.get("final_response") or ""
+        result = _normalize_empty_agent_response(
+            agent_result, response, history_len=10,
+        )
+
+        assert result, "Silent-drop turn must surface a user-facing hint"
+        lowered = result.lower()
+        assert "send it again" in lowered or "try again" in lowered
+
 
 # ===========================================================================
 # Prune: finalize_orphaned_compression_sessions


### PR DESCRIPTION
## Summary
- Surfaces a short retry hint when a post-`/stop` generation race returns an empty, zero-API-call, non-failed agent result.
- Keeps existing empty-response behavior for interrupted, failed, partial, and real API-call cases.
- Rebases the original one-commit fix onto `upstream/main` at `d0e017bac`; latest merge-tree check against `b1af653bf` remains clean.

## Review notes
- Addresses #31884.
- No PR comments were present when rechecked.

## TDD / verification
- RED: `.venv\Scripts\python.exe -m pytest tests\test_lazy_session_regressions.py::TestGatewaySurfacesNullResponse::test_silent_drop_after_stop_surfaces_hint -q --timeout-method=thread` failed on `upstream/main` because `_normalize_empty_agent_response` returned `""`.
- GREEN: `.venv\Scripts\python.exe -m pytest tests\test_lazy_session_regressions.py::TestGatewaySurfacesNullResponse::test_silent_drop_after_stop_surfaces_hint -q --timeout-method=thread` -> 1 passed.
- Rebased verification: `.venv\Scripts\python.exe -m pytest tests\test_lazy_session_regressions.py -q --timeout-method=thread` -> 18 passed, 1 existing Discord `audioop` deprecation warning.
- `.venv\Scripts\ruff.exe check gateway\run.py tests\test_lazy_session_regressions.py` -> passed.
- `.venv\Scripts\python.exe -m py_compile gateway\run.py tests\test_lazy_session_regressions.py` -> passed.
- `git diff --check` -> passed.
- `git merge-tree --write-tree upstream/main HEAD` -> clean (`c2b7d45909cbeb48117369fbe94ce3cf1544ef9e`).