### PR TITLE
fix(bluebubbles): use 127.0.0.1 instead of localhost in webhook URL (fixes #8512)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -227,7 +227,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
         if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -423,19 +423,19 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalises local hosts to '127.0.0.1'."""
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to 127.0.0.1
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
     @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
     def test_local_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## What does this PR do?

On macOS, Node.js resolves `localhost` to IPv6 `::1` by default, but aiohttp binds to IPv4 `127.0.0.1`. When the BlueBubbles adapter constructs the webhook URL, it normalizes all loopback addresses (`0.0.0.0`, `127.0.0.1`, `localhost`, `::`) to `localhost`. The BlueBubbles server then tries to connect via IPv6, which fails silently with `ECONNREFUSED ::1:<port>`, causing all inbound iMessages to be dropped.

**Fix**: Normalize loopback addresses to `127.0.0.1` explicitly, matching the aiohttp bind address.
## Related Issue

Fixes #8512

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`: Changed `_webhook_url` property to normalize loopback hosts to `127.0.0.1` instead of `localhost`
- `tests/gateway/test_bluebubbles.py`: Updated `TestBlueBubblesWebhookUrl` assertions to expect `127.0.0.1`

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `gateway/platforms/bluebubbles.py:_webhook_url` (single property, 6 lines)
- Blast radius: LOW — only affects BlueBubbles webhook URL construction
- Related patterns: `DEFAULT_WEBHOOK_HOST = "127.0.0.1"` (line 41) already uses IPv4 for the default; this fix makes the normalization consistent

## Checklist
- [x] Focused on one root cause
- [x] Small diff (2 files, 5 insertions, 5 deletions)
- [x] Regression tests updated
- [x] No unrelated changes