### PR TITLE
feat: cross-session workspace awareness

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -933,6 +933,16 @@ def run_conversation(
                         _injections.append(_fenced)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
+                # Workspace awareness: surface other hermes sessions in
+                # the same working directory (top-level sessions only).
+                if not getattr(agent, "_parent_session_id", None):
+                    try:
+                        from agent.workspace_awareness import build_context_block
+                        _ws_context = build_context_block(agent.session_id)
+                        if _ws_context:
+                            _injections.append(_ws_context)
+                    except Exception:
+                        pass  # best-effort convenience
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):

--- a/agent/workspace_awareness.py
+++ b/agent/workspace_awareness.py
@@ -1,0 +1,331 @@
+"""
+Cross-session workspace awareness.
+
+Writes a lightweight presence file after significant tool calls so that
+other hermes sessions sharing the same working directory can discover each
+other.  At turn start each session reads the directory and, when other live
+sessions exist, builds a compact workspace context block that is injected
+into the user message.
+
+Presence is determined by *process liveness* (``os.kill(pid, 0)``) — no
+time-based staleness heuristics.  Dead sessions are detected instantly and
+their stale files are removed on the next read.
+
+Design
+------
+* **Per-session files** — ``activity/sessions/<session_id>.json`` under
+  ``$HERMES_HOME``.  Each session writes only its own file → no locking
+  needed.  Atomic writes via temp-file + ``os.replace()``.
+* **cwd filter** — only sessions sharing the same working directory are
+  surfaced.  Sessions in different repos never see each other.
+* **Write-on-action** — presence is updated after tool calls that have
+  side-effects (writes, terminal, etc.).  Read-only tools are skipped.
+* **Fail-open** — any error during update or read is silently swallowed;
+  workspace awareness is a best-effort convenience, not a critical path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# ── configuration ────────────────────────────────────────────────────────
+
+# Tools that only read — updating presence for them is noise.
+_SKIP_TOOLS: frozenset[str] = frozenset({
+    "read_file",
+    "search_files",
+    "web_search",
+    "web_extract",
+    "session_search",
+    "browser_snapshot",
+    "vision_analyze",
+    "video_analyze",
+    "browser_console",
+    "browser_get_images",
+    "clarify",
+    "memory",
+    "send_message",
+    "todo",
+    "skills_list",
+    "skill_view",
+})
+
+# Maximum actions to retain per session (ring buffer).
+_MAX_ACTIONS = 2
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _sessions_dir() -> Path:
+    """Return ``$HERMES_HOME/activity/sessions/``, creating if needed."""
+    d = get_hermes_home() / "activity" / "sessions"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _detect_profile() -> str:
+    """Best-effort profile detection.
+
+    Checks (in order):
+    1. ``HERMES_KANBAN_PROFILE`` — set by the kanban dispatcher
+    2. ``HERMES_PROFILE`` — set by the gateway / CLI
+    3. ``"default"`` — fallback
+    """
+    return os.environ.get(
+        "HERMES_KANBAN_PROFILE",
+        os.environ.get("HERMES_PROFILE", "default"),
+    )
+
+
+def _extract_target(tool_name: str, args: dict) -> str:
+    """Extract a human-readable target string from tool arguments."""
+    if tool_name in ("write_file", "read_file"):
+        return str(args.get("path", ""))
+    if tool_name == "patch":
+        return str(args.get("path", args.get("file_path", "")))
+    if tool_name == "terminal":
+        cmd = str(args.get("command", ""))
+        return cmd[:80]  # truncate long commands
+    if tool_name == "web_search":
+        return str(args.get("query", ""))[:80]
+    if tool_name == "browser_navigate":
+        return str(args.get("url", ""))
+    if tool_name in ("browser_click", "browser_type"):
+        return str(args.get("ref", ""))
+    if tool_name == "kanban_create":
+        return str(args.get("title", ""))
+    return ""
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if *pid* refers to a running process."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+# ── public API ───────────────────────────────────────────────────────────
+
+def update_presence(
+    session_id: str,
+    tool_name: str,
+    args: dict,
+    cwd: Optional[str] = None,
+    task_id: Optional[str] = None,
+) -> None:
+    """Update this session's presence file after a tool call.
+
+    Called from ``model_tools.handle_function_call`` after every tool
+    dispatch.  No-op for read-only tools and when the feature is disabled.
+
+    Parameters
+    ----------
+    session_id:
+        The hermes session ID (``agent.session_id``).
+    tool_name:
+        Name of the dispatched tool (e.g. ``"file_write"``).
+    args:
+        Raw tool arguments dict.
+    cwd:
+        Working directory at dispatch time.  Defaults to ``os.getcwd()``.
+    task_id:
+        Kanban task ID, if this session is a spawned worker.
+    """
+    # ── guard: disabled? ─────────────────────────────────────────────
+    if os.environ.get("HERMES_WORKSPACE_AWARENESS") == "0":
+        return
+
+    # ── guard: read-only tool? ───────────────────────────────────────
+    if tool_name in _SKIP_TOOLS:
+        return
+
+    if cwd is None:
+        cwd = os.getcwd()
+
+    target = _extract_target(tool_name, args)
+    profile = _detect_profile()
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # Load existing file to preserve action history.
+    path = _sessions_dir() / f"{session_id}.json"
+    existing: dict[str, Any] = {}
+    try:
+        if path.exists():
+            existing = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        pass  # corrupt or unreadable — start fresh
+
+    # Build / update the record.
+    last_actions: list[dict] = existing.get("last_actions", [])
+    last_actions.append({"tool": tool_name, "target": target, "ts": now_iso})
+    if len(last_actions) > _MAX_ACTIONS:
+        last_actions = last_actions[-_MAX_ACTIONS:]
+
+    record: dict[str, Any] = {
+        "session_id": session_id,
+        "pid": os.getpid(),
+        "profile": profile,
+        "cwd": cwd,
+        "task_id": task_id or "",
+        "ts": now_iso,
+        "last_actions": last_actions,
+    }
+
+    # Atomic write: temp file + rename.
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(record, ensure_ascii=False))
+        os.replace(tmp, path)
+    except OSError:
+        pass  # best-effort
+
+
+def _read_all_sessions() -> list[dict]:
+    """Return parsed presence records for all sessions (including stale ones)."""
+    sessions: list[dict] = []
+    sd = _sessions_dir()
+    try:
+        for entry in sd.iterdir():
+            if not entry.is_file() or entry.suffix != ".json":
+                continue
+            try:
+                data = json.loads(entry.read_text())
+                if isinstance(data, dict) and data.get("session_id"):
+                    sessions.append(data)
+            except (json.JSONDecodeError, OSError):
+                # Stale or corrupt — remove it.
+                try:
+                    entry.unlink(missing_ok=True)
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return sessions
+
+
+def get_coworkers(my_session_id: str, my_cwd: str) -> list[dict]:
+    """Return active other sessions sharing *my_cwd*.
+
+    Each returned dict has keys: ``session_id``, ``profile``, ``ts``,
+    ``last_actions`` (list of ``{tool, target, ts}``), ``seconds_ago``.
+    """
+    all_sessions = _read_all_sessions()
+    now = time.time()
+    coworkers: list[dict] = []
+
+    for s in all_sessions:
+        sid = s.get("session_id", "")
+        if sid == my_session_id:
+            continue  # skip self
+
+        pid = s.get("pid", 0)
+        if not _pid_alive(pid):
+            # Dead session — clean up stale file.
+            _cleanup_stale(sid)
+            continue
+
+        s_cwd = s.get("cwd", "")
+        if s_cwd != my_cwd:
+            continue  # different directory — not relevant
+
+        # Calculate seconds since last update.
+        try:
+            ts = datetime.fromisoformat(s.get("ts", ""))
+            seconds_ago = int((now - ts.timestamp()))
+        except (ValueError, OSError):
+            seconds_ago = 999
+
+        coworkers.append({
+            "session_id": sid,
+            "profile": s.get("profile", "?"),
+            "ts": s.get("ts", ""),
+            "last_actions": s.get("last_actions", []),
+            "seconds_ago": max(seconds_ago, 0),
+        })
+
+    # Sort: most recently active first.
+    coworkers.sort(key=lambda c: c["seconds_ago"])
+    return coworkers
+
+
+def _cleanup_stale(session_id: str) -> None:
+    """Remove a stale presence file for a dead session."""
+    path = _sessions_dir() / f"{session_id}.json"
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def build_context_block(session_id: str, cwd: Optional[str] = None) -> Optional[str]:
+    """Build the workspace awareness context block for injection.
+
+    Returns ``None`` when no other sessions are active in the same cwd
+    → zero prompt tokens overhead.
+    """
+    if os.environ.get("HERMES_WORKSPACE_AWARENESS") == "0":
+        return None
+
+    if cwd is None:
+        cwd = os.getcwd()
+
+    coworkers = get_coworkers(session_id, cwd)
+    if not coworkers:
+        return None
+
+    # Map cwd to ~/ if under HOME for readability.
+    home = os.path.expanduser("~")
+    cwd_display = cwd.replace(home, "~", 1) if cwd.startswith(home) else cwd
+
+    profile = _detect_profile()
+    lines = [
+        "══ WORKSPACE ══",
+        f"  you: session {session_id[:8]} ({profile}) in {cwd_display}",
+    ]
+
+    count = len(coworkers)
+    s_label = "session" if count == 1 else "sessions"
+    lines.append(f"  {count} other hermes {s_label} active here:")
+
+    for c in coworkers:
+        sid_short = c["session_id"][:8]
+        prof = c["profile"]
+        ago = c["seconds_ago"]
+        ago_str = f"{ago}s ago" if ago < 60 else f"{ago // 60}m ago"
+        lines.append(f"    {sid_short} ({prof}) — last seen {ago_str}")
+
+        for action in c["last_actions"]:
+            tool = action.get("tool", "?")
+            target = action.get("target", "")
+            if target:
+                lines.append(f"      {tool} → {target}")
+            else:
+                lines.append(f"      {tool}")
+
+    # Collect files modified by other sessions.
+    modified: set[str] = set()
+    for c in coworkers:
+        for action in c.get("last_actions", []):
+            tname = action.get("tool", "")
+            target = action.get("target", "")
+            if tname in ("write_file", "patch") and target:
+                # Extract just the filename for brevity.
+                modified.add(Path(target).name)
+    if modified:
+        files_str = ", ".join(sorted(modified))
+        lines.append(f"  files modified by other sessions: {files_str}")
+
+    return "\n".join(lines)

--- a/model_tools.py
+++ b/model_tools.py
@@ -861,6 +861,21 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("post_tool_call hook error: %s", _hook_err)
 
+        # ── workspace awareness ───────────────────────────────────────
+        # Let other hermes sessions in the same cwd know what we're doing.
+        try:
+            from agent.workspace_awareness import update_presence
+            _ws_session_id = session_id or os.environ.get("HERMES_SESSION_ID", "")
+            if _ws_session_id:
+                update_presence(
+                    session_id=_ws_session_id,
+                    tool_name=function_name,
+                    args=function_args,
+                    task_id=task_id,
+                )
+        except Exception:
+            pass  # best-effort — never crash on presence failure
+
         # Generic tool-result canonicalization seam: plugins receive the
         # final result string (JSON, usually) and may replace it by
         # returning a string from transform_tool_result. Runs after

--- a/tests/agent/test_workspace_awareness.py
+++ b/tests/agent/test_workspace_awareness.py
@@ -1,0 +1,289 @@
+"""Tests for ``agent.workspace_awareness``."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent import workspace_awareness as wa
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _write_session_file(
+    sessions_dir: Path,
+    session_id: str,
+    pid: int | None = None,
+    profile: str = "test-profile",
+    cwd: str = "/tmp/test-project",
+    last_actions: list[dict] | None = None,
+) -> Path:
+    """Write a synthetic presence file and return its path."""
+    if pid is None:
+        pid = os.getpid()  # alive by default
+    if last_actions is None:
+        last_actions = [
+            {"tool": "write_file", "target": "test.py", "ts": "2026-01-01T00:00:00Z"},
+        ]
+    record = {
+        "session_id": session_id,
+        "pid": pid,
+        "profile": profile,
+        "cwd": cwd,
+        "task_id": "",
+        "ts": "2026-01-01T00:00:00Z",
+        "last_actions": last_actions,
+    }
+    path = sessions_dir / f"{session_id}.json"
+    path.write_text(json.dumps(record))
+    return path
+
+
+# ── tests ────────────────────────────────────────────────────────────────
+
+class TestUpdatePresence:
+    """Tests for ``update_presence()``."""
+
+    def test_writes_file(self, monkeypatch, tmp_path: Path):
+        """update_presence writes a valid JSON file."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        wa.update_presence(
+            session_id="sess-abc",
+            tool_name="write_file",
+            args={"path": "/tmp/foo.py"},
+            cwd="/tmp/project",
+        )
+
+        path = tmp_path / "sess-abc.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["session_id"] == "sess-abc"
+        assert data["profile"] == "default"
+        assert data["cwd"] == "/tmp/project"
+        assert len(data["last_actions"]) == 1
+        assert data["last_actions"][0]["tool"] == "write_file"
+        assert data["last_actions"][0]["target"] == "/tmp/foo.py"
+
+    def test_skips_readonly_tools(self, monkeypatch, tmp_path: Path):
+        """Read-only tools are not logged."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        wa.update_presence(
+            session_id="sess-abc",
+            tool_name="read_file",
+            args={"path": "/tmp/foo.py"},
+        )
+
+        path = tmp_path / "sess-abc.json"
+        assert not path.exists()
+
+    def test_keeps_last_two_actions(self, monkeypatch, tmp_path: Path):
+        """Only the last 2 actions are retained."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        sid = "sess-abc"
+        for i in range(3):
+            wa.update_presence(
+                session_id=sid,
+                tool_name="write_file",
+                args={"path": f"file_{i}.py"},
+                cwd="/tmp/project",
+            )
+
+        data = json.loads((tmp_path / f"{sid}.json").read_text())
+        assert len(data["last_actions"]) == 2
+        assert data["last_actions"][0]["target"] == "file_1.py"
+        assert data["last_actions"][1]["target"] == "file_2.py"
+
+    def test_respects_disabled_env(self, monkeypatch, tmp_path: Path):
+        """HERMES_WORKSPACE_AWARENESS=0 disables the feature."""
+        monkeypatch.setenv("HERMES_WORKSPACE_AWARENESS", "0")
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        wa.update_presence(
+            session_id="sess-abc",
+            tool_name="write_file",
+            args={"path": "/tmp/foo.py"},
+        )
+
+        path = tmp_path / "sess-abc.json"
+        assert not path.exists()
+
+    def test_target_extraction_terminal(self, monkeypatch, tmp_path: Path):
+        """Terminal commands are truncated to 80 chars in target."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        long_cmd = "pip install " + "x" * 100
+        wa.update_presence(
+            session_id="sess-abc",
+            tool_name="terminal",
+            args={"command": long_cmd},
+            cwd="/tmp/project",
+        )
+
+        data = json.loads((tmp_path / "sess-abc.json").read_text())
+        target = data["last_actions"][0]["target"]
+        assert len(target) <= 80
+
+
+class TestGetCoworkers:
+    """Tests for ``get_coworkers()``."""
+
+    def test_returns_other_sessions_same_cwd(self, monkeypatch, tmp_path: Path):
+        """Sessions in the same cwd are returned."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        _write_session_file(tmp_path, "other-1", cwd="/tmp/project")
+        _write_session_file(tmp_path, "other-2", cwd="/tmp/other-dir")
+
+        coworkers = wa.get_coworkers("my-session", "/tmp/project")
+        assert len(coworkers) == 1
+        assert coworkers[0]["session_id"] == "other-1"
+
+    def test_excludes_self(self, monkeypatch, tmp_path: Path):
+        """The calling session is excluded from results."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        _write_session_file(tmp_path, "my-session", cwd="/tmp/project")
+        _write_session_file(tmp_path, "other-1", cwd="/tmp/project")
+
+        coworkers = wa.get_coworkers("my-session", "/tmp/project")
+        assert len(coworkers) == 1
+        assert coworkers[0]["session_id"] == "other-1"
+
+    def test_excludes_dead_pids(self, monkeypatch, tmp_path: Path):
+        """Sessions with dead PIDs are excluded and cleaned up."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        # Use PID 1 (always init, always alive but not ours) — but we mock
+        # _pid_alive to control liveness.
+        _write_session_file(tmp_path, "dead-session", pid=99999, cwd="/tmp/project")
+        _write_session_file(tmp_path, "alive-session", pid=os.getpid(), cwd="/tmp/project")
+
+        # Mock _pid_alive: only our own PID is alive.
+        def _mock_pid_alive(pid: int) -> bool:
+            return pid == os.getpid()
+
+        with patch.object(wa, "_pid_alive", _mock_pid_alive):
+            coworkers = wa.get_coworkers("my-session", "/tmp/project")
+
+        assert len(coworkers) == 1
+        assert coworkers[0]["session_id"] == "alive-session"
+
+    def test_excludes_different_cwd(self, monkeypatch, tmp_path: Path):
+        """Sessions in a different cwd are not returned."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        _write_session_file(tmp_path, "other-1", cwd="/tmp/project-a")
+        _write_session_file(tmp_path, "other-2", cwd="/tmp/project-b")
+
+        coworkers = wa.get_coworkers("my-session", "/tmp/project-a")
+        assert len(coworkers) == 1
+        assert coworkers[0]["session_id"] == "other-1"
+
+
+class TestBuildContextBlock:
+    """Tests for ``build_context_block()``."""
+
+    def test_returns_none_when_no_coworkers(self, monkeypatch, tmp_path: Path):
+        """None returned when no other sessions are active."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        result = wa.build_context_block("my-session", "/tmp/project")
+        assert result is None
+
+    def test_returns_context_with_one_coworker(self, monkeypatch, tmp_path: Path):
+        """Context block with a single coworker."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        _write_session_file(
+            tmp_path,
+            "other-1",
+            pid=os.getpid(),
+            profile="coder",
+            cwd="/tmp/project",
+            last_actions=[
+                {"tool": "write_file", "target": "/tmp/project/main.py", "ts": "2026-01-01T00:00:00Z"},
+            ],
+        )
+
+        result = wa.build_context_block("my-session", "/tmp/project")
+        assert result is not None
+        assert "══ WORKSPACE ══" in result
+        assert "1 other hermes session" in result
+        assert "coder" in result
+        assert "write_file" in result
+        assert "main.py" in result
+
+    def test_shows_multiple_coworkers(self, monkeypatch, tmp_path: Path):
+        """Context block with multiple coworkers."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        _write_session_file(
+            tmp_path, "other-1", pid=os.getpid(), profile="coder", cwd="/tmp/project",
+            last_actions=[
+                {"tool": "write_file", "target": "/tmp/project/a.py", "ts": "2026-01-01T00:00:00Z"},
+            ],
+        )
+        _write_session_file(
+            tmp_path, "other-2", pid=os.getpid(), profile="researcher", cwd="/tmp/project",
+            last_actions=[
+                {"tool": "web_search", "target": "qwen lora", "ts": "2026-01-01T00:00:00Z"},
+            ],
+        )
+
+        result = wa.build_context_block("my-session", "/tmp/project")
+        assert result is not None
+        assert "2 other hermes sessions" in result
+        assert "coder" in result
+        assert "researcher" in result
+
+    def test_shows_modified_files(self, monkeypatch, tmp_path: Path):
+        """Context block includes files modified by other sessions."""
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        _write_session_file(
+            tmp_path, "other-1", pid=os.getpid(), profile="coder", cwd="/tmp/project",
+            last_actions=[
+                {"tool": "write_file", "target": "/tmp/project/a.py", "ts": "2026-01-01T00:00:00Z"},
+                {"tool": "patch", "target": "/tmp/project/b.py", "ts": "2026-01-01T00:00:00Z"},
+            ],
+        )
+
+        result = wa.build_context_block("my-session", "/tmp/project")
+        assert result is not None
+        assert "files modified by other sessions" in result
+        assert "a.py" in result
+        assert "b.py" in result
+
+    def test_respects_disabled_env(self, monkeypatch, tmp_path: Path):
+        """HERMES_WORKSPACE_AWARENESS=0 returns None."""
+        monkeypatch.setenv("HERMES_WORKSPACE_AWARENESS", "0")
+        monkeypatch.setattr(wa, "_sessions_dir", lambda: tmp_path)
+        monkeypatch.setattr(wa, "get_hermes_home", lambda: tmp_path)
+
+        _write_session_file(
+            tmp_path, "other-1", pid=os.getpid(), profile="coder", cwd="/tmp/project",
+        )
+
+        result = wa.build_context_block("my-session", "/tmp/project")
+        assert result is None


### PR DESCRIPTION
> **Submitted as a draft** — I'm a bit swamped right now but hoping others might chime in with feedback while I'm busy. Thanks for looking! 🙏

---

## feat: cross-session workspace awareness

When multiple hermes sessions work in the same directory, each session now sees a compact workspace status block at turn start showing other active sessions, what they're doing, and which files they've modified.

### Problem

Two hermes terminal sessions in the same project directory have zero visibility into each other. Session A modifies files; session B sees the changes, attributes them to its own tool calls, and makes bad decisions.

### Solution

A lightweight presence system: each session writes a tiny JSON file (`$HERMES_HOME/activity/sessions/<session_id>.json`) after tool calls that have side-effects (writes, terminal, web searches, etc.). Read-only tools are skipped. At turn start, sessions read the directory and inject a workspace status block:

```
══ WORKSPACE ══
  you: session abc12345 (default) in ~/code/nixos-gui
  1 other hermes session active here:
    def45678 (kanban-coder) — last seen 12s ago
      write_file → src/ui/pages/services.py
      patch → src/ui/components/icons.py
  files modified by other sessions: icons.py, services.py
```

When no other sessions are active in the same directory: **nothing is injected** — zero prompt token overhead.

### How presence is determined

Per-session JSON files under `$HERMES_HOME/activity/sessions/`. Each session writes only its own file → no locking. Presence is determined by **process liveness** (`os.kill(pid, 0)`), not timestamp heuristics. Dead sessions are detected instantly and their stale files removed.

### Scope

Only sessions sharing the same **working directory** (`os.getcwd()`) are surfaced. Sessions in different repos never see each other. Top-level sessions only — subagent sessions (`delegate_task`) are excluded.

### Opt-out

Set `HERMES_WORKSPACE_AWARENESS=0` to disable. When disabled: zero I/O, zero overhead.

### Changes

| file | change |
|---|---|
| `agent/workspace_awareness.py` | new — presence write + context block |
| `model_tools.py` | +15 lines — `update_presence()` after tool dispatch |
| `agent/conversation_loop.py` | +10 lines — `build_context_block()` during context injection |
| `tests/agent/test_workspace_awareness.py` | new — 14 tests covering write, read, filtering, context block |

~645 lines total including tests. No new dependencies.