### PR TITLE
fix(telegram): re-check auth for model picker callbacks

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2911,6 +2911,22 @@ class TelegramAdapter(BasePlatformAdapter):
         self, query, data: str, chat_id: str
     ) -> None:
         """Handle model picker inline keyboard callbacks (mp:/mm:/mb:/mx:/mg:)."""
+        query_message = getattr(query, "message", None)
+        query_chat = getattr(query_message, "chat", None)
+        query_chat_type = getattr(query_chat, "type", None)
+        query_thread_id = getattr(query_message, "message_thread_id", None)
+        caller_id = str(getattr(getattr(query, "from_user", None), "id", ""))
+        caller_name = getattr(getattr(query, "from_user", None), "first_name", None)
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=caller_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to change models.")
+            return
+
         state = self._model_picker_state.get(chat_id)
         if not state:
             await query.answer(text="Picker expired — use /model again.")

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -74,6 +74,7 @@ class TestTelegramModelPicker:
     @pytest.mark.asyncio
     async def test_back_button_escapes_dynamic_provider_label(self):
         adapter = _make_adapter()
+        adapter._is_callback_user_authorized = MagicMock(return_value=True)
         adapter._model_picker_state["12345"] = {
             "providers": [{"slug": "provider_one", "name": "Provider One", "total_models": 1, "is_current": True}],
             "current_model": "model_1",
@@ -110,6 +111,7 @@ class TestTelegramModelPicker:
         edit_message_text block so it lived inside the except branch and
         only fired when the callback raised."""
         adapter = _make_adapter()
+        adapter._is_callback_user_authorized = MagicMock(return_value=True)
         callback = AsyncMock(return_value="Switched to `gpt-5`")
         adapter._model_picker_state["12345"] = {
             "providers": [
@@ -145,6 +147,46 @@ class TestTelegramModelPicker:
         assert "`gpt-5`" in edit_kwargs["text"]
         # State is cleaned up after a successful switch.
         assert "12345" not in adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_callback_cannot_switch_model(self):
+        adapter = _make_adapter()
+        adapter._is_callback_user_authorized = MagicMock(return_value=False)
+        callback = AsyncMock(return_value="Switched to `gpt-5`")
+        adapter._model_picker_state["12345"] = {
+            "providers": [
+                {"slug": "openai", "name": "OpenAI", "total_models": 1, "is_current": True}
+            ],
+            "current_model": "model_1",
+            "current_provider": "openai",
+            "session_key": "s",
+            "on_model_selected": callback,
+            "selected_provider": "openai",
+            "model_list": ["gpt-5"],
+            "msg_id": 42,
+        }
+
+        query = AsyncMock()
+        query.data = "mm:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "group"
+        query.from_user = MagicMock()
+        query.from_user.id = 999
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        callback.assert_not_awaited()
+        query.edit_message_text.assert_not_awaited()
+        query.answer.assert_awaited_once_with(text="⛔ You are not authorized to change models.")
+        assert "12345" in adapter._model_picker_state
 
     @pytest.mark.asyncio
     async def test_retries_without_thread_when_thread_not_found(self):


### PR DESCRIPTION
## Summary

This hardens Telegram model picker callbacks by enforcing the same callback-user authorization check already used by other gated Telegram button flows.

Previously, `mp:`, `mg:`, `mb`, `mx`, and `mm:` model picker callbacks could reach the picker handler without re-validating the caller. In shared chats, that allowed an unauthorized user to press picker buttons and trigger a session model switch.

## What changed

- Added an authorization check at the start of the Telegram model picker callback handler.
- Fail closed with an explicit denial message when the callback user is not authorized.
- Kept the guard in the handler itself so the protection still applies even if the handler is invoked through another path later.
- Updated existing model picker tests to account for the new guard.
- Added a regression test covering an unauthorized `mm:` callback attempt.

## Security impact

This restores the trust model for Telegram interactive callbacks:

- session/chat routing state is no longer treated as authorization
- unauthorized users cannot switch models through shared inline buttons
- model picker behavior is now aligned with existing approval and slash-confirm callback protections

## Files changed

- `gateway/platforms/telegram.py`
- `tests/gateway/test_telegram_model_picker.py`

## Tests

### Ran

```bash
pytest -o addopts='' -p no:pytest_timeout -p no:timeout tests/gateway/test_telegram_model_picker.py tests/gateway/test_telegram_callback_auth_fail_closed.py tests/gateway/test_telegram_approval_buttons.py -q

30 passed in 1.10s