### PR TITLE
fix(dashboard): auto-reload SPA on stale-token 401 in loopback mode

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -91,6 +91,43 @@ export async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> 
       // Never resolve — the page is about to unload.
       return new Promise<T>(() => {});
     }
+    // Loopback mode: ``_SESSION_TOKEN`` rotates on every server restart
+    // (``hermes update``, ``hermes gateway restart``, etc.). A tab kept
+    // open across the restart holds the OLD token in
+    // ``window.__HERMES_SESSION_TOKEN__`` from the previous HTML render,
+    // so every fetch returns 401. The HTML is served ``Cache-Control:
+    // no-store`` so a reload picks up the freshly-injected token. Trigger
+    // that reload once on the first stale-token 401 — gated mode is
+    // handled above, so reaching here in gated mode means a real
+    // middleware failure that should not reload-loop.
+    if (!window.__HERMES_AUTH_REQUIRED__) {
+      let alreadyReloaded = false;
+      try {
+        alreadyReloaded =
+          sessionStorage.getItem("hermes.tokenReloadAttempted") === "1";
+      } catch {
+        /* SSR / privacy mode — fall through to throw */
+      }
+      if (!alreadyReloaded) {
+        try {
+          sessionStorage.setItem("hermes.tokenReloadAttempted", "1");
+        } catch {
+          /* SSR / privacy mode — best effort */
+        }
+        window.location.reload();
+        return new Promise<T>(() => {});
+      }
+    }
+  }
+  if (res.ok) {
+    // Clear the stale-token reload guard: a successful 2xx proves the
+    // current ``window.__HERMES_SESSION_TOKEN__`` is valid, so the next
+    // 401 — if any — should be allowed to trigger its own reload cycle.
+    try {
+      sessionStorage.removeItem("hermes.tokenReloadAttempted");
+    } catch {
+      /* SSR / privacy mode — ignore */
+    }
   }
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);


### PR DESCRIPTION
Auto-reloads the SPA on a loopback-mode 401 so users don't have to manually clear site data or hard-refresh after every `hermes update` / `hermes gateway restart`.

## The bug

`hermes_cli/web_server.py:88`:

```python
# Generated fresh on every server start — dies when the process exits.
_SESSION_TOKEN = secrets.token_urlsafe(32)
```

The token is injected into the SPA HTML at render time. A dashboard tab kept open across a server restart holds the OLD token in `window.__HERMES_SESSION_TOKEN__`, so every subsequent `/api/*` fetch from that tab returns `401: Unauthorized`.

Symptoms reported in #24186 / #25275 (same root cause on two endpoints):

- `Failed to load Kanban board: 401: {"detail":"Unauthorized"}` — from `/api/plugins/kanban/*`
- `Analytics dashboard API returns 401 Unauthorized` — from `/api/analytics/*`
- Reporter @Irreq independently confirmed: *"Clearing cookies and site data solved the 401 message for me on Firefox"* — which forced a full reload that re-fetched the HTML and re-injected the new token.

The token rotation itself is intentional (security property: a stolen token can't survive a server restart). The HTML response already sets `Cache-Control: no-store, no-cache, must-revalidate`. So a reload reliably picks up the new token — users just had to know they needed to refresh.

## The fix

`fetchJSON` in `web/src/lib/api.ts` now detects this case and triggers the reload automatically.

```js
if (!window.__HERMES_AUTH_REQUIRED__) {
  // Loopback mode — gated mode redirects via login_url above
  if (sessionStorage.getItem("hermes.tokenReloadAttempted") !== "1") {
    sessionStorage.setItem("hermes.tokenReloadAttempted", "1");
    window.location.reload();
    return new Promise<T>(() => {});  // never resolve — page is about to unload
  }
}
```

Guards:

| Condition | Behavior |
|---|---|
| Loopback mode (`!__HERMES_AUTH_REQUIRED__`) AND first 401 | Reload, set flag |
| Loopback mode AND flag already set (post-reload still 401) | Falls through to throw — same as today, no reload loop |
| Gated mode with `error: "unauthenticated"` + `login_url` | Existing Phase 6 redirect path, unchanged |
| Gated mode with domain-level 401 (no `login_url`) | Falls through to throw, unchanged |
| Any 2xx response | Clears the reload-attempted flag → next server restart in the same tab gets its own reload cycle |

## Validation

- `npx tsc -b --noEmit` — clean
- `npm run build` — clean (vite production bundle)
- Bundle includes the new code: `grep -c "tokenReloadAttempted" hermes_cli/web_dist/assets/index-*.js → 1`
- `pytest tests/hermes_cli/test_web_server.py` — 150/150 passing (server-side untouched, just confirming nothing cross-cuts broke)

## Out of scope (handled in the close)

The remaining content in #24186 / #25275:

- @fwends's "entire Kanban board lost" follow-up — the kanban corruption cluster (#29610, #30445, #31502, #30908, #31618, #31736, #32424) is fixed on main via the WAL-pragma-skip / connect_closing / torn-write defenses / 5-min quarantine retry. All closed with credit earlier today.
- @fwends's `COLUMN_LABEL is not defined` rendering error — separate kanban-dashboard SSR bug already tracked as duplicate of #24188.

## Credit

- @fwends — original bug report (#24186) with environment details and version pin
- @Irreq — independent reproduction + the "clear cookies and site data" workaround that confirmed the diagnosis (stale token, not server-side regression)
- @konsisumer — cross-link to #25275 (correct duplicate identification)

## Infographic

![dashboard-401-auto-reload](https://v3b.fal.media/files/b/0a9c0484/7u6WrBTCL4P0G6xHYR2MX_yVB62acz.png)
