### PR TITLE
feat(discord): auto-rename generic thread titles

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1206,6 +1206,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD and "auto_rename_threads" in platform_cfg:
+                    bridged["auto_rename_threads"] = platform_cfg["auto_rename_threads"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5469,6 +5469,7 @@ class BasePlatformAdapter(ABC):
         message_id: Optional[str] = None,
         role_authorized: bool = False,
         auto_thread_created: bool = False,
+        auto_thread_rename_allowed: bool = False,
         auto_thread_initial_name: Optional[str] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
@@ -5492,6 +5493,7 @@ class BasePlatformAdapter(ABC):
             message_id=str(message_id) if message_id else None,
             role_authorized=role_authorized,
             auto_thread_created=auto_thread_created,
+            auto_thread_rename_allowed=auto_thread_rename_allowed,
             auto_thread_initial_name=auto_thread_initial_name,
         )
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13686,7 +13686,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return (
             source.platform == Platform.DISCORD
             and source.chat_type == "thread"
-            and bool(getattr(source, "auto_thread_created", False))
+            and (
+                bool(getattr(source, "auto_thread_created", False))
+                or bool(getattr(source, "auto_thread_rename_allowed", False))
+            )
             and bool(source.thread_id)
             and bool(getattr(source, "auto_thread_initial_name", None))
         )
@@ -19278,11 +19281,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             title,
                         )
                     elif self._is_discord_auto_thread_lane(source):
-                        maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_discord_semantic_thread_rename(
-                            source,
-                            effective_session_id,
-                            title,
-                        )
+                        _title_db = getattr(self._session_db, "_db", self._session_db)
+                        _existing_title = _title_db.get_session_title(effective_session_id)
+                        if isinstance(_existing_title, str) and _existing_title.strip():
+                            self._schedule_discord_semantic_thread_rename(
+                                source,
+                                effective_session_id,
+                                _existing_title,
+                            )
+                        else:
+                            maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_discord_semantic_thread_rename(
+                                source,
+                                effective_session_id,
+                                title,
+                            )
                     maybe_auto_title(
                         getattr(self._session_db, "_db", self._session_db),
                         effective_session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13682,7 +13682,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return cleaned
 
     def _is_discord_auto_thread_lane(self, source: SessionSource) -> bool:
-        """Return True only for Discord threads Hermes just auto-created."""
+        """Return True for explicitly provenance-gated Discord thread renames."""
         return (
             source.platform == Platform.DISCORD
             and source.chat_type == "thread"
@@ -13714,7 +13714,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_id: str,
         title: str,
     ) -> None:
-        """Best-effort semantic rename of a newly auto-created Discord thread."""
+        """Best-effort guarded semantic rename of a Discord thread."""
         if not await asyncio.to_thread(self._is_discord_auto_thread_lane, source):
             return
         adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -182,12 +182,11 @@ class SessionSource:
     # namespacing and the per-turn config/credential scope.
     profile: Optional[str] = None
 
-    # Discord auto-thread metadata.  Newly auto-created Discord threads start
-    # with a fast placeholder title from the raw message, then the gateway can
-    # rename them after the first agent turn using the generated session title.
-    # Keep this explicit so pre-existing or human-renamed threads are not
-    # mistaken for safe rename targets.
+    # Discord semantic-rename provenance. Newly auto-created threads and opted-in
+    # pre-existing generic threads store the exact observed name so a later
+    # semantic rename can refuse to overwrite a human change.
     auto_thread_created: bool = False
+    auto_thread_rename_allowed: bool = False
     auto_thread_initial_name: Optional[str] = None
 
     # Internal, wire-INVISIBLE trust signal: True when this event was delivered
@@ -265,6 +264,8 @@ class SessionSource:
             d["profile"] = self.profile
         if self.auto_thread_created:
             d["auto_thread_created"] = True
+        if self.auto_thread_rename_allowed:
+            d["auto_thread_rename_allowed"] = True
         if self.auto_thread_initial_name:
             d["auto_thread_initial_name"] = self.auto_thread_initial_name
         return d
@@ -289,6 +290,7 @@ class SessionSource:
             message_id=data.get("message_id"),
             profile=data.get("profile"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),
+            auto_thread_rename_allowed=bool(data.get("auto_thread_rename_allowed", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
         )
     

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -47,6 +47,14 @@ _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_GENERIC_THREAD_TITLES = frozenset({
+    "thread", "new thread", "nova thread", "untitled", "sem titulo", "sem título",
+    "discussion", "discussao", "discussão", "topic", "topico", "tópico",
+})
+_DISCORD_GENERIC_THREAD_PREFIXES = (
+    "new thread", "nova thread", "thread-", "thread ", "untitled", "sem titulo", "sem título",
+)
+_DISCORD_THREAD_TRAILING_TRUNCATION_RE = re.compile(r"(?:\.{2,}|…|⋯|‥)\s*$")
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -272,6 +280,20 @@ def _clean_discord_id(entry: str) -> str:
     if entry.lower().startswith("user:"):
         entry = entry[5:]
     return entry.strip()
+
+
+def _discord_thread_title_looks_generic(name: str) -> bool:
+    """Return whether an opted-in existing thread is safe to retitle."""
+    raw = str(name or "").strip()
+    lowered = re.sub(r"\s+", " ", raw).lower()
+    return (
+        not lowered
+        or lowered in _DISCORD_GENERIC_THREAD_TITLES
+        or any(lowered.startswith(prefix) for prefix in _DISCORD_GENERIC_THREAD_PREFIXES)
+        or bool(re.search(r"https?://\S+", raw, re.IGNORECASE))
+        or bool(_DISCORD_THREAD_TRAILING_TRUNCATION_RE.search(raw))
+        or utf16_len(raw) >= 80
+    )
 
 
 def check_discord_requirements() -> bool:
@@ -901,6 +923,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # Mirrors the Telegram #58563 fix. Entries are dropped on finalize.
         self._last_overflow_preview: Dict[tuple, str] = {}
         self._warned_fail_closed_default = False
+
+    def _auto_rename_existing_threads_enabled(self) -> bool:
+        raw = self.config.extra.get("auto_rename_threads") if isinstance(self.config.extra, dict) else None
+        if isinstance(raw, dict):
+            return bool(raw.get("enabled", False))
+        return bool(raw)
 
     def _handle_bot_task_done(self, task: asyncio.Task) -> None:
         """Surface post-startup discord.py task exits to the gateway supervisor.
@@ -6326,6 +6354,17 @@ class DiscordAdapter(BasePlatformAdapter):
         # so forum descriptions (e.g. project instructions) appear in the session context.
         chat_topic = self._get_effective_topic(message.channel, is_thread=is_thread)
 
+        # Opted-in pre-existing generic threads reuse the durable semantic-title
+        # path used by Hermes-created threads. The exact name observed at ingress
+        # is persisted and rename_thread() applies only if it still matches.
+        existing_thread_name = str(getattr(effective_channel, "name", "") or "")
+        auto_thread_rename_allowed = (
+            is_thread
+            and auto_threaded_channel is None
+            and self._auto_rename_existing_threads_enabled()
+            and _discord_thread_title_looks_generic(existing_thread_name)
+        )
+
         # Build source
         guild = getattr(message, "guild", None)
         source = self.build_source(
@@ -6342,10 +6381,13 @@ class DiscordAdapter(BasePlatformAdapter):
             message_id=str(message.id),
             role_authorized=role_authorized,
             auto_thread_created=auto_threaded_channel is not None,
+            auto_thread_rename_allowed=auto_thread_rename_allowed,
             auto_thread_initial_name=(
                 getattr(auto_threaded_channel, "_hermes_auto_thread_initial_name", None)
                 or self._derive_auto_thread_name(message.content or "")
-            ) if auto_threaded_channel is not None else None,
+            ) if auto_threaded_channel is not None else (
+                existing_thread_name if auto_thread_rename_allowed else None
+            ),
         )
 
         # Build media URLs -- download image attachments to local cache so the

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.session import SessionSource
 
 
 def _ensure_discord_mock():
@@ -75,7 +76,10 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _discord_thread_title_looks_generic,
+)
 
 
 class FakeTree:
@@ -841,6 +845,38 @@ async def test_auto_thread_source_carries_initial_name_for_semantic_rename(adapt
     source = captured_events[0].source
     assert source.auto_thread_created is True
     assert source.auto_thread_initial_name == "raw user prompt"
+
+
+def test_existing_thread_generic_title_classifier():
+    assert _discord_thread_title_looks_generic("nova thread") is True
+    assert _discord_thread_title_looks_generic("Investigate recurring Discord title failures…") is True
+    assert _discord_thread_title_looks_generic("Falha recorrente do parity guard") is False
+
+
+@pytest.mark.asyncio
+async def test_opted_in_existing_generic_thread_uses_durable_semantic_rename_lane(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    adapter.config.extra["auto_rename_threads"] = {"enabled": True}
+    captured_events = []
+
+    async def capture_handle(event):
+        captured_events.append(event)
+
+    adapter.handle_message = capture_handle
+    msg = _fake_message(
+        _FakeThreadChannel(name="nova thread"),
+        content="Investigate recurring parity guard failures",
+    )
+
+    await adapter._handle_message(msg)
+
+    source = captured_events[0].source
+    assert source.auto_thread_created is False
+    assert source.auto_thread_rename_allowed is True
+    assert source.auto_thread_initial_name == "nova thread"
+    restored = SessionSource.from_dict(source.to_dict())
+    assert restored.auto_thread_rename_allowed is True
+    assert restored.auto_thread_initial_name == "nova thread"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -100,6 +100,19 @@ def _make_discord_auto_thread_source() -> SessionSource:
     )
 
 
+def _make_discord_existing_thread_rename_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="999",
+        chat_type="thread",
+        user_id="user-1",
+        thread_id="999",
+        parent_chat_id="100",
+        auto_thread_rename_allowed=True,
+        auto_thread_initial_name="nova thread",
+    )
+
+
 def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
@@ -253,6 +266,47 @@ async def test_run_agent_passes_discord_auto_thread_title_callback(monkeypatch, 
     assert mock_schedule.call_args.args[2] == "Semantic Session Title"
 
 
+@pytest.mark.asyncio
+async def test_existing_thread_reuses_durable_session_title(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    title_db = MagicMock()
+    title_db.get_session_title.return_value = "Existing semantic title"
+    runner._session_db = SimpleNamespace(_db=title_db)  # type: ignore[assignment]
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    with patch.object(runner, "_schedule_discord_semantic_thread_rename") as mock_schedule:
+        await runner._run_agent(
+            message="Investigate recurring parity guard failures",
+            context_prompt="",
+            history=[],
+            source=_make_discord_existing_thread_rename_source(),
+            session_id="session-1",
+            session_key="agent:main:discord:thread:999",
+        )
+
+    mock_schedule.assert_called_once()
+    assert mock_schedule.call_args.args[2] == "Existing semantic title"
+
+
 def test_session_source_preserves_discord_auto_thread_metadata():
     source = _make_discord_auto_thread_source()
 
@@ -260,3 +314,13 @@ def test_session_source_preserves_discord_auto_thread_metadata():
 
     assert restored.auto_thread_created is True
     assert restored.auto_thread_initial_name == "raw user prompt"
+
+
+def test_existing_thread_rename_source_uses_semantic_title_lane():
+    runner = _make_runner()
+    source = _make_discord_existing_thread_rename_source()
+
+    assert runner._is_discord_auto_thread_lane(source) is True
+    restored = SessionSource.from_dict(source.to_dict())
+    assert restored.auto_thread_rename_allowed is True
+    assert restored.auto_thread_initial_name == "nova thread"

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -11,7 +11,7 @@ import yaml
 
 import gateway.run as gateway_run
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, utf16_len
 from gateway.session import SessionSource
 
 
@@ -221,8 +221,13 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
 
 
+@pytest.mark.parametrize(
+    "source",
+    [_make_discord_auto_thread_source(), _make_discord_existing_thread_rename_source()],
+    ids=["hermes-created", "opted-in-generic-existing"],
+)
 @pytest.mark.asyncio
-async def test_run_agent_passes_discord_auto_thread_title_callback(monkeypatch, tmp_path):
+async def test_run_agent_passes_discord_thread_title_callback(monkeypatch, tmp_path, source):
     _install_fake_agent(monkeypatch)
     runner = _make_runner()
     runner._session_db = SimpleNamespace(_db=MagicMock())  # type: ignore[assignment]
@@ -247,17 +252,19 @@ async def test_run_agent_passes_discord_auto_thread_title_callback(monkeypatch, 
     import hermes_cli.tools_config as tools_config
     monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
 
+    inbound_message = "Investigate recurring parity guard failures"
     with patch("agent.title_generator.maybe_auto_title") as mock_title:
         await runner._run_agent(
-            message="raw user prompt",
+            message=inbound_message,
             context_prompt="",
             history=[],
-            source=_make_discord_auto_thread_source(),
+            source=source,
             session_id="session-1",
             session_key="agent:main:discord:thread:999",
         )
 
     mock_title.assert_called_once()
+    assert mock_title.call_args.args[2] == inbound_message
     callback = mock_title.call_args.kwargs["title_callback"]
     with patch.object(runner, "_schedule_discord_semantic_thread_rename") as mock_schedule:
         callback("Semantic Session Title")
@@ -324,3 +331,12 @@ def test_existing_thread_rename_source_uses_semantic_title_lane():
     restored = SessionSource.from_dict(source.to_dict())
     assert restored.auto_thread_rename_allowed is True
     assert restored.auto_thread_initial_name == "nova thread"
+
+
+def test_discord_thread_title_truncation_is_utf16_safe():
+    runner = _make_runner()
+
+    title = runner._sanitize_discord_thread_title("😀" * 50)
+
+    assert utf16_len(title) <= 80
+    assert title.endswith("...")

--- a/tests/test_gateway_streaming_nested_config.py
+++ b/tests/test_gateway_streaming_nested_config.py
@@ -41,3 +41,13 @@ class TestStreamingConfigNested:
         })
         assert cfg.streaming.enabled is True
         assert cfg.streaming.transport == "edit"
+
+
+def test_discord_auto_rename_threads_bridges_into_platform_extra():
+    from gateway.config import Platform
+
+    cfg = _load_with_yaml_dict({
+        "discord": {"enabled": True, "auto_rename_threads": {"enabled": True}},
+    })
+
+    assert cfg.platforms[Platform.DISCORD].extra["auto_rename_threads"] == {"enabled": True}

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -17,7 +17,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
 | **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. Messages in these channels are answered inline — auto-threading is skipped so the channel stays a lightweight chat. |
-| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
+| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. Optional semantic retitling can improve pre-existing generic thread names. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
 
@@ -188,6 +188,7 @@ These are the minimum permissions your bot needs:
 ### Recommended Additional Permissions
 
 - **Send Messages in Threads** — respond in thread conversations
+- **Manage Threads** — required only when `discord.auto_rename_threads` is enabled
 - **Add Reactions** — react to messages for acknowledgment
 
 ### Permission Integers
@@ -318,6 +319,8 @@ discord:
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
+  auto_rename_threads:            # Opt in existing generic threads to semantic retitling
+    enabled: false
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
@@ -383,6 +386,18 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
 Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+
+#### `discord.auto_rename_threads`
+
+**Type:** object — **Default:** disabled
+
+When enabled, a pre-existing Discord thread whose current name is generic, truncated, URL-heavy, or at Discord's title limit joins the existing semantic session-title flow after the next successful exchange. The original name is persisted with the session and the rename is applied only if the thread still has that exact name, so a human rename made after message ingress always wins. Hermes-created auto-threads already use this guarded semantic-title flow without this option.
+
+```yaml
+discord:
+  auto_rename_threads:
+    enabled: true
+```
 
 #### `discord.reactions`
 


### PR DESCRIPTION
## What does this PR do?

Extends the existing guarded Discord semantic-title flow to pre-existing threads whose titles are generic, truncated, URL-heavy, or at Discord's title limit.

The feature remains opt-in (`discord.auto_rename_threads.enabled: false`). It does not add another title generator or rename path:

- the inbound message and first successful assistant response feed Hermes' existing session-title generator;
- existing durable session titles are reused without another model call;
- the exact Discord title observed at ingress is serialized with the session source;
- the existing `rename_thread(..., only_if_current_name=...)` guard prevents overwriting a human rename;
- the existing UTF-16 helpers enforce Discord's title budget safely.

Hermes-created auto-threads already use this flow. This PR only opts pre-existing generic threads into it.

## Related Issue

Related to #29983, #26477, #15757, #30559.

## Type of Change

- [x] Feature
- [x] Documentation
- [x] Tests

## Changes Made

- Detect a narrow set of generic/truncated/noisy existing Discord thread titles.
- Persist explicit `auto_thread_rename_allowed` provenance and the expected current title in `SessionSource`.
- Reuse the current semantic session-title callback and guarded Discord `rename_thread` implementation.
- Bridge `discord.auto_rename_threads` into Discord platform config.
- Document the opt-in setting and `Manage Threads` permission.

## Review Feedback Addressed

- Candidate generation now starts from the inbound message through the existing semantic-title flow; the generic current title is never used as the candidate.
- No code-point title slicing was added; the current UTF-16-aware rename helper is reused.
- Provenance is serialized, and rename is conditional on the exact expected current name.
- Regression coverage includes the enabled `nova thread` path, serialization, existing durable titles, config bridging, and human-name preservation.

## Validation

```text
531 passed, 1 skipped, 2 pre-existing warnings
ruff: all checks passed
git diff --check: clean
py_compile: passed
```

## Checklist

- [x] Current upstream `main` used as base
- [x] Focused and Discord-adjacent tests pass
- [x] Documentation updated
- [x] Contributor-safe GitHub noreply author identity
