### PR TITLE
fix(cli): rename list_distributions parameter to avoid name shadowing

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1156,7 +1156,7 @@ def main(
     num_workers: int = 4,
     resume: bool = False,
     verbose: bool = False,
-    list_distributions: bool = False,
+    show_distributions: bool = False,
     ephemeral_system_prompt: str = None,
     log_prefix_chars: int = 100,
     providers_allowed: str = None,
@@ -1216,10 +1216,10 @@ def main(
                                --prefill_messages_file=configs/prefill_opus.json
         
         # List available distributions
-        python batch_runner.py --list_distributions
+        python batch_runner.py --show_distributions
     """
     # Handle list distributions
-    if list_distributions:
+    if show_distributions:
         from toolset_distributions import print_distribution_info
 
         print("📊 Available Toolset Distributions")

--- a/tests/test_batch_runner_cli.py
+++ b/tests/test_batch_runner_cli.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Test batch_runner CLI flags to ensure they don't crash
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_show_distributions_flag():
+    """Test that --show_distributions flag works without crashing."""
+    # Find the batch_runner.py file
+    repo_root = Path(__file__).parent.parent
+    batch_runner = repo_root / "batch_runner.py"
+    
+    # Run with --show_distributions flag
+    cmd = [sys.executable, str(batch_runner), "--show_distributions"]
+    
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root)
+    )
+    
+    # Should not crash with TypeError
+    assert result.returncode == 0, f"Command failed: {result.stderr}"
+    
+    # Should output distribution info
+    assert "Available Toolset Distributions" in result.stdout
+    assert "Distribution:" in result.stdout
+    
+    # Should not have the old error
+    assert "TypeError: 'bool' object is not callable" not in result.stderr
+
+
+if __name__ == "__main__":
+    test_show_distributions_flag()
+    print("✅ Test passed: --show_distributions flag works correctly")


### PR DESCRIPTION
## Summary
Fixes #32845 

The `--list_distributions` CLI flag was crashing with `TypeError: 'bool' object is not callable` due to parameter name shadowing the imported function.

## Changes
- Renamed the `list_distributions` parameter to `show_distributions` in `batch_runner.py`
- Updated help text example to use `--show_distributions`
- Added test to verify the flag works correctly

## How to Test
```bash
python batch_runner.py --show_distributions
```

The command should display available toolset distributions without crashing.

## Platform
Tested on macOS