### PR TITLE
feat: semantic model inference for custom providers + reasoning effort fixes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -129,9 +129,29 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
 
     overrides = dict(getattr(agent, "request_overrides", {}) or {})
     merged_extra_body = dict(extra_body)
+
+    # ``custom_providers[].extra_body`` is a static endpoint default.  Runtime
+    # controls such as /reasoning are resolved later into provider-profile
+    # top-level kwargs (for OpenAI-family custom endpoints) or ``think: false``
+    # (for Ollama-style endpoints).  Leaving a static ``reasoning_effort`` here
+    # makes it win again during request-overrides merge, so /reasoning appears
+    # to change state while the wire payload remains pinned to the configured
+    # default (for example xhigh).
+    if "reasoning_effort" in merged_extra_body:
+        model = str(getattr(agent, "model", "") or "")
+        try:
+            from agent.models_dev import infer_semantic_provider_for_model
+            semantic_provider = infer_semantic_provider_for_model("custom", model)
+        except Exception:
+            semantic_provider = None
+        if semantic_provider == "openai":
+            merged_extra_body.pop("reasoning_effort", None)
+
     existing_extra_body = overrides.get("extra_body")
     if isinstance(existing_extra_body, dict):
         merged_extra_body.update(existing_extra_body)
+    if not merged_extra_body:
+        return
     overrides["extra_body"] = merged_extra_body
     agent.request_overrides = overrides
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -135,6 +135,83 @@ class ProviderInfo:
 
 
 # ---------------------------------------------------------------------------
+# Semantic provider inference for custom/relay endpoints
+# ---------------------------------------------------------------------------
+
+
+def infer_semantic_provider_for_model(provider: str, model: str) -> str:
+    """Return the provider whose model semantics should be used.
+
+    Custom providers are often OpenAI-compatible relay endpoints: the route is
+    user-defined, but the model id still belongs to an upstream model family.
+    When the route provider is ``custom`` and the model slug is high-confidence,
+    infer that upstream provider so metadata lookups (context, tools, vision,
+    reasoning) can reuse the same models.dev records as first-party providers.
+
+    Unknown/custom local model names intentionally stay ``custom``.
+    """
+    provider_norm = (provider or "").strip().lower()
+    model_norm = (model or "").strip().lower()
+    if provider_norm != "custom" or not model_norm:
+        return provider_norm
+
+    # Strip common catalog prefixes users may paste into a custom relay model
+    # field; the relay still receives the original model string elsewhere.
+    if "/" in model_norm:
+        prefix, suffix = model_norm.split("/", 1)
+        prefix_map = {
+            "openai": "openai",
+            "anthropic": "anthropic",
+            "deepseek": "deepseek",
+            "xai": "xai",
+            "google": "gemini",
+            "google-gemini": "gemini",
+            "gemini": "gemini",
+            "alibaba": "alibaba",
+            "qwen": "alibaba",
+            "zai": "zai",
+            "z-ai": "zai",
+            "glm": "zai",
+            "kimi": "kimi",
+            "moonshot": "kimi",
+            "minimax": "minimax",
+        }
+        mapped = prefix_map.get(prefix)
+        if mapped and suffix:
+            return mapped
+
+    # Bare OpenAI / GPT family slugs. Keep this intentionally conservative:
+    # these names are globally recognisable and commonly relayed unchanged.
+    openai_prefixes = (
+        "gpt-",
+        "o1-", "o3-", "o4-",
+        "chatgpt-",
+        "codex-",
+    )
+    if model_norm.startswith(openai_prefixes) or model_norm in {"o1", "o3", "o4"}:
+        return "openai"
+
+    if model_norm.startswith(("claude-", "anthropic.claude-")):
+        return "anthropic"
+    if model_norm.startswith(("deepseek-", "deepseek/")):
+        return "deepseek"
+    if model_norm.startswith(("grok-", "xai/")):
+        return "xai"
+    if model_norm.startswith(("gemini-", "gemma-")):
+        return "gemini"
+    if model_norm.startswith(("qwen", "qwq", "dashscope/")):
+        return "alibaba"
+    if model_norm.startswith(("glm-", "zai/", "z-ai/")):
+        return "zai"
+    if model_norm.startswith(("kimi-", "moonshot-")):
+        return "kimi"
+    if model_norm.startswith("minimax-"):
+        return "minimax"
+
+    return provider_norm
+
+
+# ---------------------------------------------------------------------------
 # Provider ID mapping: Hermes ↔ models.dev
 # ---------------------------------------------------------------------------
 
@@ -324,6 +401,7 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     Returns the context window in tokens, or None if not found.
     Handles case-insensitive matching and filters out context=0 entries.
     """
+    provider = infer_semantic_provider_for_model(provider, model)
     mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
     if not mdev_provider_id:
         return None
@@ -410,11 +488,12 @@ class ModelCapabilities:
     model_family: str = ""
 
 
-def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
+def _get_provider_models(provider: str, model: str = "") -> Optional[Dict[str, Any]]:
     """Resolve a Hermes provider ID to its models dict from models.dev.
 
     Returns the models dict or None if the provider is unknown or has no data.
     """
+    provider = infer_semantic_provider_for_model(provider, model)
     mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
     if not mdev_provider_id:
         return None
@@ -461,7 +540,7 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
       - limit.output  (int) → max_output_tokens
       - family     (str)   → model_family
     """
-    models = _get_provider_models(provider)
+    models = _get_provider_models(provider, model)
     if models is None:
         return None
 

--- a/agent/reasoning_efforts.py
+++ b/agent/reasoning_efforts.py
@@ -1,0 +1,46 @@
+"""Reasoning-effort capability resolution helpers.
+
+Hermes accepts reasoning-effort values as user intent.  Provider APIs expose
+smaller, provider-specific wire vocabularies, so profiles should resolve the
+requested intent against a declared capability set before sending it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+def resolve_reasoning_effort(
+    requested: str | None,
+    *,
+    allowed: Iterable[str],
+    aliases: Mapping[str, str] | None = None,
+) -> str | None:
+    """Resolve a requested reasoning effort to a provider-supported wire value.
+
+    ``requested`` is Hermes' internal/user-facing intent. ``allowed`` is the
+    provider/model's wire vocabulary. ``aliases`` maps internal intents such as
+    ``max`` to the nearest supported wire value for that capability set.
+
+    Returns ``None`` when the request cannot be represented safely.  Callers
+    should then omit the field and let the provider default rather than guess.
+    """
+    effort = str(requested or "").strip().lower()
+    if not effort:
+        return None
+
+    normalized_aliases = {
+        str(src).strip().lower(): str(dst).strip().lower()
+        for src, dst in (aliases or {}).items()
+        if str(src).strip() and str(dst).strip()
+    }
+    effort = normalized_aliases.get(effort, effort)
+
+    normalized_allowed = {
+        str(item).strip().lower()
+        for item in allowed
+        if str(item).strip()
+    }
+    if effort in normalized_allowed:
+        return effort
+    return None

--- a/cli.py
+++ b/cli.py
@@ -9631,7 +9631,7 @@ class HermesCLI:
 
         Usage:
             /reasoning              Show current effort level and display state
-            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh)
+            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh, max)
             /reasoning show|on      Show model thinking/reasoning in output
             /reasoning hide|off     Hide model thinking/reasoning from output
         """
@@ -9649,7 +9649,7 @@ class HermesCLI:
             display_state = "on ✓" if self.show_reasoning else "off"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state}{_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|show|hide>{_RST}")
             return
 
         arg = parts[1].strip().lower()
@@ -9675,7 +9675,7 @@ class HermesCLI:
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
             _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
-            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
+            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh, max{_RST}")
             _cprint(f"  {_DIM}Display:      show, hide{_RST}")
             return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2831,7 +2831,7 @@ class GatewayRunner:
         """Load reasoning effort from config.yaml.
 
         Reads agent.reasoning_effort from config.yaml. Valid: "none",
-        "minimal", "low", "medium", "high", "xhigh". Returns None to use
+        "minimal", "low", "medium", "high", "xhigh", "max". Returns None to use
         default (medium).
         """
         from hermes_constants import parse_reasoning_effort
@@ -11996,7 +11996,7 @@ class GatewayRunner:
             return t("gateway.reasoning.reset_done")
         if effort == "none":
             parsed = {"enabled": False}
-        elif effort in {"minimal", "low", "medium", "high", "xhigh"}:
+        elif effort in {"minimal", "low", "medium", "high", "xhigh", "max"}:
             parsed = {"enabled": True, "effort": effort}
         else:
             return t(

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -144,7 +144,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide]",
-               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
+               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "show", "hide", "on", "off")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status]",
                subcommands=("normal", "fast", "status", "on", "off")),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4613,7 +4613,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
             str(effort).strip().lower() for effort in efforts if str(effort).strip()
         )
     )
-    canonical_order = ("minimal", "low", "medium", "high", "xhigh")
+    canonical_order = ("minimal", "low", "medium", "high", "xhigh", "max")
     ordered = [effort for effort in canonical_order if effort in deduped]
     ordered.extend(effort for effort in deduped if effort not in canonical_order)
     if not ordered:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -300,13 +300,13 @@ def get_subprocess_home() -> str | None:
     return None
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none".
     Returns {"enabled": True, "effort": <level>} for valid effort levels.

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -9,28 +9,13 @@ Ollama instances. Key quirks:
 from typing import Any
 
 from agent.models_dev import infer_semantic_provider_for_model
+from agent.reasoning_efforts import resolve_reasoning_effort
 from providers import register_provider
 from providers.base import ProviderProfile
 
 
 _OPENAI_FAMILY_CUSTOM_REASONING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
 _OPENAI_FAMILY_CUSTOM_EFFORT_ALIASES = {"max": "xhigh"}
-
-
-def _resolve_openai_family_custom_reasoning_effort(effort: str) -> str | None:
-    """Map Hermes' internal reasoning intent to a GPT/OpenAI-compatible value.
-
-    ``max`` is an internal "highest available" intent in Hermes.  GPT-family
-    OpenAI-compatible endpoints commonly accept ``xhigh`` as the highest wire
-    value, while many reject literal ``max``.  Keep provider-specific profiles
-    that genuinely support ``max`` free to send it; only clamp the custom
-    OpenAI-family fallback here.
-    """
-    effort = (effort or "").strip().lower()
-    effort = _OPENAI_FAMILY_CUSTOM_EFFORT_ALIASES.get(effort, effort)
-    if effort in _OPENAI_FAMILY_CUSTOM_REASONING_EFFORTS:
-        return effort
-    return None
 
 
 class CustomProfile(ProviderProfile):
@@ -63,7 +48,11 @@ class CustomProfile(ProviderProfile):
             elif _effort:
                 model = str(ctx.get("model") or "")
                 if infer_semantic_provider_for_model("custom", model) == "openai":
-                    _wire_effort = _resolve_openai_family_custom_reasoning_effort(_effort)
+                    _wire_effort = resolve_reasoning_effort(
+                        _effort,
+                        allowed=_OPENAI_FAMILY_CUSTOM_REASONING_EFFORTS,
+                        aliases=_OPENAI_FAMILY_CUSTOM_EFFORT_ALIASES,
+                    )
                     if _wire_effort:
                         top_level["reasoning_effort"] = _wire_effort
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -13,6 +13,26 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 
+_OPENAI_FAMILY_CUSTOM_REASONING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
+_OPENAI_FAMILY_CUSTOM_EFFORT_ALIASES = {"max": "xhigh"}
+
+
+def _resolve_openai_family_custom_reasoning_effort(effort: str) -> str | None:
+    """Map Hermes' internal reasoning intent to a GPT/OpenAI-compatible value.
+
+    ``max`` is an internal "highest available" intent in Hermes.  GPT-family
+    OpenAI-compatible endpoints commonly accept ``xhigh`` as the highest wire
+    value, while many reject literal ``max``.  Keep provider-specific profiles
+    that genuinely support ``max`` free to send it; only clamp the custom
+    OpenAI-family fallback here.
+    """
+    effort = (effort or "").strip().lower()
+    effort = _OPENAI_FAMILY_CUSTOM_EFFORT_ALIASES.get(effort, effort)
+    if effort in _OPENAI_FAMILY_CUSTOM_REASONING_EFFORTS:
+        return effort
+    return None
+
+
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
 
@@ -43,7 +63,9 @@ class CustomProfile(ProviderProfile):
             elif _effort:
                 model = str(ctx.get("model") or "")
                 if infer_semantic_provider_for_model("custom", model) == "openai":
-                    top_level["reasoning_effort"] = _effort
+                    _wire_effort = _resolve_openai_family_custom_reasoning_effort(_effort)
+                    if _wire_effort:
+                        top_level["reasoning_effort"] = _wire_effort
 
         return extra_body, top_level
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -8,6 +8,7 @@ Ollama instances. Key quirks:
 
 from typing import Any
 
+from agent.models_dev import infer_semantic_provider_for_model
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -23,6 +24,7 @@ class CustomProfile(ProviderProfile):
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
 
         # Ollama context window
         if ollama_num_ctx:
@@ -30,14 +32,20 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Disable thinking when reasoning is turned off
+        # Disable thinking when reasoning is turned off; otherwise, relay
+        # OpenAI-family custom endpoints inherit OpenAI's top-level
+        # reasoning_effort contract from the model slug (e.g. gpt-5.5).
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
+            elif _effort:
+                model = str(ctx.get("model") or "")
+                if infer_semantic_provider_for_model("custom", model) == "openai":
+                    top_level["reasoning_effort"] = _effort
 
-        return extra_body, {}
+        return extra_body, top_level
 
     def fetch_models(
         self,

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -35,6 +35,31 @@ def test_custom_provider_extra_body_merges_into_request_overrides():
     }
 
 
+def test_custom_provider_openai_extra_body_drops_static_reasoning_effort():
+    agent = SimpleNamespace(
+        provider="custom",
+        model="gpt-5.5",
+        base_url="https://example.test/v1",
+        request_overrides={"service_tier": "priority"},
+    )
+
+    _merge_custom_provider_extra_body(
+        agent,
+        [
+            {
+                "name": "openai-compatible",
+                "base_url": "https://example.test/v1/",
+                "model": "gpt-5.5",
+                "extra_body": {
+                    "reasoning_effort": "xhigh",
+                },
+            }
+        ],
+    )
+
+    assert agent.request_overrides == {"service_tier": "priority"}
+
+
 def test_custom_provider_extra_body_preserves_caller_override():
     agent = SimpleNamespace(
         provider="custom",

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -144,7 +144,7 @@ def test_custom_provider_unknown_model_does_not_emit_reasoning_effort():
     assert top_level == {}
 
 
-def test_custom_provider_openai_semantic_model_passes_max_through():
+def test_custom_provider_openai_semantic_model_maps_max_to_xhigh():
     from providers import get_provider_profile
 
     profile = get_provider_profile("custom")
@@ -154,4 +154,4 @@ def test_custom_provider_openai_semantic_model_passes_max_through():
     )
 
     assert extra_body == {}
-    assert top_level == {"reasoning_effort": "max"}
+    assert top_level == {"reasoning_effort": "xhigh"}

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -91,3 +91,42 @@ def test_custom_provider_extra_body_ignores_other_custom_models():
     )
 
     assert agent.request_overrides == {}
+
+
+def test_custom_provider_openai_semantic_model_emits_dynamic_reasoning_effort():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("custom")
+    extra_body, top_level = profile.build_api_kwargs_extras(
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        model="gpt-5.5",
+    )
+
+    assert extra_body == {}
+    assert top_level == {"reasoning_effort": "xhigh"}
+
+
+def test_custom_provider_unknown_model_does_not_emit_reasoning_effort():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("custom")
+    extra_body, top_level = profile.build_api_kwargs_extras(
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        model="my-local-model",
+    )
+
+    assert extra_body == {}
+    assert top_level == {}
+
+
+def test_custom_provider_openai_semantic_model_passes_max_through():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("custom")
+    extra_body, top_level = profile.build_api_kwargs_extras(
+        reasoning_config={"enabled": True, "effort": "max"},
+        model="gpt-5.5",
+    )
+
+    assert extra_body == {}
+    assert top_level == {"reasoning_effort": "max"}

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -127,6 +127,21 @@ class TestDecideImageInputMode:
         with patch("agent.models_dev.fetch_models_dev", return_value=registry):
             assert decide_image_input_mode("xiaomi", "mimo-v2.5-pro", {}) == "text"
 
+    def test_auto_custom_gpt_uses_openai_semantic_capabilities(self):
+        registry = {
+            "openai": {
+                "models": {
+                    "gpt-5.5": {
+                        "modalities": {"input": ["text", "image"]},
+                        "tool_call": True,
+                        "reasoning": True,
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            assert decide_image_input_mode("custom", "gpt-5.5", {}) == "native"
+
 
 # ─── _coerce_capability_bool ─────────────────────────────────────────────────
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import patch, MagicMock
 
 import pytest
+import agent.models_dev as models_dev
 from agent.models_dev import (
     PROVIDER_TO_MODELS_DEV,
     _extract_context,
@@ -414,3 +415,44 @@ class TestGetModelCapabilities:
         with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
             caps = get_model_capabilities("anthropic", "nonexistent-model")
         assert caps is None
+
+
+class TestCustomSemanticProviderInference:
+    def test_bare_gpt_custom_infers_openai(self):
+        assert models_dev.infer_semantic_provider_for_model("custom", "gpt-5.5") == "openai"
+
+    def test_prefixed_model_custom_infers_prefix_provider(self):
+        assert (
+            models_dev.infer_semantic_provider_for_model("custom", "anthropic/claude-opus-4.7")
+            == "anthropic"
+        )
+
+    def test_unknown_custom_model_stays_custom(self):
+        assert models_dev.infer_semantic_provider_for_model("custom", "my-local-model") == "custom"
+
+    def test_openai_o_series_requires_model_boundary(self):
+        assert models_dev.infer_semantic_provider_for_model("custom", "o3-mini") == "openai"
+        assert models_dev.infer_semantic_provider_for_model("custom", "o365-local") == "custom"
+
+    def test_non_custom_provider_is_unchanged(self):
+        assert models_dev.infer_semantic_provider_for_model("openrouter", "gpt-5.5") == "openrouter"
+
+    def test_custom_gpt_uses_openai_models_dev_context(self):
+        registry = {
+            "openai": {
+                "models": {
+                    "gpt-5.5": {
+                        "limit": {"context": 400000, "output": 128000},
+                        "tool_call": True,
+                        "reasoning": True,
+                    }
+                }
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            assert models_dev.lookup_models_dev_context("custom", "gpt-5.5") == 400000
+            caps = models_dev.get_model_capabilities("custom", "gpt-5.5")
+            assert caps is not None
+            assert caps.supports_reasoning is True
+            assert caps.supports_tools is True
+            assert caps.context_window == 400000

--- a/tests/agent/test_reasoning_efforts.py
+++ b/tests/agent/test_reasoning_efforts.py
@@ -1,0 +1,28 @@
+from agent.reasoning_efforts import resolve_reasoning_effort
+
+
+def test_resolve_reasoning_effort_passes_allowed_value():
+    assert resolve_reasoning_effort(
+        "HIGH",
+        allowed={"low", "medium", "high"},
+    ) == "high"
+
+
+def test_resolve_reasoning_effort_applies_alias_before_allowed_check():
+    assert resolve_reasoning_effort(
+        "max",
+        allowed={"low", "medium", "high", "xhigh"},
+        aliases={"max": "xhigh"},
+    ) == "xhigh"
+
+
+def test_resolve_reasoning_effort_returns_none_for_unsupported_value():
+    assert resolve_reasoning_effort(
+        "max",
+        allowed={"low", "medium", "high"},
+    ) is None
+
+
+def test_resolve_reasoning_effort_ignores_blank_values():
+    assert resolve_reasoning_effort("", allowed={"low"}) is None
+    assert resolve_reasoning_effort(None, allowed={"low"}) is None

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -249,6 +249,20 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["think"] is False
 
+    def test_custom_openai_reasoning_override_not_pinned_by_static_extra_body(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=msgs,
+            provider_profile=profile,
+            reasoning_config={"enabled": True, "effort": "low"},
+            request_overrides={"extra_body": {"custom_flag": True}},
+        )
+        assert kw["reasoning_effort"] == "low"
+        assert kw["extra_body"] == {"custom_flag": True}
+
     def test_gemini_native_without_explicit_reasoning_config_keeps_existing_behavior(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -263,6 +263,18 @@ class TestChatCompletionsBuildKwargs:
         assert kw["reasoning_effort"] == "low"
         assert kw["extra_body"] == {"custom_flag": True}
 
+    def test_custom_openai_reasoning_max_maps_to_xhigh(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=msgs,
+            provider_profile=profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kw["reasoning_effort"] == "xhigh"
+
     def test_gemini_native_without_explicit_reasoning_config_keeps_existing_behavior(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary

When using custom providers (reverse proxies, API aggregators), Hermes cannot infer the upstream model's capabilities from the model name alone. This causes reasoning effort buttons to disappear, context length to fall back to defaults, and capability detection (vision, tools) to fail.

This PR adds semantic model inference for custom providers and fixes reasoning effort handling for proxied OpenAI-family models.

## Changes

### Semantic model inference (`agent/models_dev.py`)

New `infer_semantic_provider_for_model()` function detects the upstream model family (OpenAI, Anthropic, DeepSeek, Gemini, xAI, etc.) from model name patterns. When provider is `custom` and the model slug is high-confidence (e.g. `gpt-5.5`, `claude-opus-4`), the function returns the upstream provider ID so that `lookup_models_dev_context()` and `get_model_capabilities()` can reuse models.dev records as if the model were accessed through a first-party provider.

Unknown/local model names intentionally stay `custom` — the function is conservative by design.

### Reasoning effort resolution (`agent/reasoning_efforts.py`, new)

Extracted reasoning effort capability resolution into a dedicated module with an `allowed` + `aliases` pattern:
- `resolve_reasoning_effort(requested, allowed, aliases)` maps user intent to provider-supported wire values
- Returns `None` when the request cannot be represented, so callers omit the field rather than guess

### Custom provider integration (`plugins/model-providers/custom/__init__.py`)

- OpenAI-family models detected via semantic inference now get `reasoning_effort` as a top-level kwarg (matching OpenAI's API contract) instead of being stuffed into `extra_body`
- `max` effort is aliased to `xhigh` for OpenAI-family models
- Non-OpenAI or unknown models continue to use `think: false` for disabling reasoning

### Static extra_body conflict fix (`agent/agent_init.py`)

When `custom_providers[].extra_body` contains a static `reasoning_effort`, it previously won over the dynamic `/reasoning` command at request-merge time. Now, for OpenAI-family models, the static value is dropped so the runtime control takes effect.

### `max` as a new reasoning effort level

Added `max` to the valid effort vocabulary across CLI, gateway, and constants. For OpenAI-family custom endpoints, `max` resolves to `xhigh` (their highest supported wire value).

## Testing

- `tests/agent/test_reasoning_efforts.py` — resolve logic, aliases, edge cases
- `tests/agent/test_models_dev.py` — semantic inference for various model patterns
- `tests/agent/test_custom_provider_extra_body.py` — static extra_body drop, dynamic effort emission
- `tests/agent/test_image_routing.py` — custom GPT uses OpenAI vision capabilities
- `tests/agent/transports/test_chat_completions.py` — transport-level reasoning_effort wire format
