### PR TITLE
fix(update): handle broken Windows project venv

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7195,8 +7195,8 @@ def _update_via_zip(args):
 
     pip_cmd = [sys.executable, "-m", "pip"]
     uv_bin = shutil.which("uv") or _ensure_uv_for_termux(pip_cmd)
-    if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+    if uv_bin and (not _is_windows() or _venv_python() is not None):
+        uv_env = _uv_install_env()
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -7797,6 +7797,34 @@ def _venv_scripts_dir() -> Path | None:
     return scripts if scripts.is_dir() else None
 
 
+def _venv_python() -> Path | None:
+    """Return the project venv Python executable when the venv is usable."""
+    venv_dir = PROJECT_ROOT / "venv"
+    python_path = venv_dir / ("Scripts/python.exe" if _is_windows() else "bin/python")
+    return python_path if python_path.is_file() else None
+
+
+def _entrypoint_scripts_dir() -> Path | None:
+    """Return the scripts directory for the active interpreter."""
+    if _is_windows():
+        scripts = Path(sys.executable).resolve().parent / "Scripts"
+    else:
+        scripts = Path(sys.executable).resolve().parent
+    return scripts if scripts.is_dir() else None
+
+
+def _uv_install_env() -> dict[str, str]:
+    """Build an env for uv without pointing at a broken project venv."""
+    env = dict(os.environ)
+    venv_python = _venv_python()
+    if venv_python is not None:
+        env["VIRTUAL_ENV"] = str(PROJECT_ROOT / "venv")
+    else:
+        env.pop("VIRTUAL_ENV", None)
+        env.setdefault("UV_PYTHON", sys.executable)
+    return env
+
+
 def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:
     """Entry-point shims that uv may try to rewrite during ``pip install -e .``.
 
@@ -7808,7 +7836,8 @@ def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:
         return []
     return [
         scripts_dir / "hermes.exe",
-        scripts_dir / "hermes-gateway.exe",
+        scripts_dir / "hermes-agent.exe",
+        scripts_dir / "hermes-acp.exe",
     ]
 
 
@@ -8186,7 +8215,11 @@ def _install_python_dependencies_with_optional_fallback(
     copies (Windows blocks REPLACE on a running .exe but allows RENAME). See
     ``_quarantine_running_hermes_exe`` for the rationale.
     """
-    scripts_dir = _venv_scripts_dir() if _is_windows() else None
+    scripts_dir = (
+        _venv_scripts_dir() or _entrypoint_scripts_dir()
+        if _is_windows()
+        else None
+    )
 
     def _install(args: list[str]) -> None:
         moved: list[tuple[Path, Path]] = []
@@ -9258,8 +9291,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         uv_bin = shutil.which("uv") or _ensure_uv_for_termux(pip_cmd)
         install_group = "all"
 
-        if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        if uv_bin and (not _is_windows() or _venv_python() is not None):
+            uv_env = _uv_install_env()
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -298,7 +298,10 @@ def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch
 def _setup_update_mocks(monkeypatch, tmp_path):
     """Common setup for cmd_update tests."""
     (tmp_path / ".git").mkdir()
+    scripts_dir = tmp_path / "Scripts"
+    scripts_dir.mkdir()
     monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hermes_main, "_entrypoint_scripts_dir", lambda: scripts_dir)
     monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
     monkeypatch.setattr(hermes_main, "_restore_stashed_changes", lambda *a, **kw: True)
     monkeypatch.setattr(hermes_config, "get_missing_env_vars", lambda required_only=True: [])
@@ -312,6 +315,7 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
     """When .[all] fails, update should keep base deps and retry extras individually."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_venv_python", lambda: tmp_path / "venv" / "Scripts" / "python.exe")
     monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
     monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda group="all": ["matrix", "mcp"])
 
@@ -319,13 +323,13 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
-        if cmd == ["git", "fetch", "origin"]:
+        if cmd[-2:] == ["fetch", "origin"]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+        if cmd[-3:] == ["rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
-        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+        if cmd[-3:] == ["rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
+        if cmd[-4:] == ["pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]"]:
             raise CalledProcessError(returncode=1, cmd=cmd)
@@ -362,19 +366,20 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     """When .[all] succeeds, no fallback should be attempted."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_venv_python", lambda: tmp_path / "venv" / "Scripts" / "python.exe")
     monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
 
     recorded = []
 
     def fake_run(cmd, **kwargs):
         recorded.append(cmd)
-        if cmd == ["git", "fetch", "origin"]:
+        if cmd[-2:] == ["fetch", "origin"]:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+        if cmd[-3:] == ["rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
-        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+        if cmd[-3:] == ["rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
+        if cmd[-4:] == ["pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -387,9 +392,12 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     assert ".[all]" in install_cmds[0]
 
 
-def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
+def test_install_with_optional_fallback_honors_custom_group(monkeypatch, tmp_path):
     """Termux update path should target .[termux-all] when requested."""
     calls = []
+    scripts_dir = tmp_path / "Scripts"
+    scripts_dir.mkdir()
+    monkeypatch.setattr(hermes_main, "_entrypoint_scripts_dir", lambda: scripts_dir)
     monkeypatch.setattr(
         hermes_main,
         "_load_installable_optional_extras",
@@ -415,6 +423,55 @@ def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
         ["/usr/bin/uv", "pip", "install", "-e", ".[termux]"],
         ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]"],
     ]
+
+
+def test_uv_install_env_ignores_broken_project_venv(monkeypatch, tmp_path):
+    """Windows git installs may have a stale venv directory without python.exe."""
+    project_root = tmp_path / "hermes-agent"
+    (project_root / "venv" / "Scripts").mkdir(parents=True)
+    active_python = tmp_path / "Python313" / "python.exe"
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_main.sys, "executable", str(active_python))
+    monkeypatch.setenv("VIRTUAL_ENV", str(project_root / "venv"))
+    monkeypatch.delenv("UV_PYTHON", raising=False)
+
+    env = hermes_main._uv_install_env()
+
+    assert "VIRTUAL_ENV" not in env
+    assert env["UV_PYTHON"] == str(active_python)
+
+
+def test_cmd_update_uses_pip_when_windows_project_venv_is_broken(monkeypatch, tmp_path):
+    """Global Windows installs should not let uv remove console scripts."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_main, "_venv_python", lambda: None)
+    monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
+
+    recorded = []
+
+    def fake_run(cmd, **kwargs):
+        recorded.append(cmd)
+        if cmd[-2:] == ["fetch", "origin"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[-3:] == ["rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if cmd[-3:] == ["rev-list", "HEAD..origin/main", "--count"]:
+            return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+        if cmd[-4:] == ["pull", "--ff-only", "origin", "main"]:
+            return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    install_cmds = [c for c in recorded if "pip" in c and "install" in c]
+    assert install_cmds
+    assert install_cmds[0][:3] == [hermes_main.sys.executable, "-m", "pip"]
 
 
 def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch, capsys):
@@ -492,7 +549,7 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 1
-    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+    assert reset_calls[0][-3:] == ["reset", "--hard", "origin/main"]
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -101,6 +101,14 @@ $ hermes update
 
 Close the listed processes and re-run. If you're sure the concurrent process won't interfere (rare — usually only useful when an antivirus shim is mis-attributed), pass `--force` to skip the check. In that case the updater will still retry the `.exe` rename with exponential backoff and, on stubborn locks, schedule the replacement for next reboot via `MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT)` so the update can complete.
 
+### Windows: stale project venv during dependency install
+
+Some native Windows git installs use a global Python entry point, such as `C:\Python313\Scripts\hermes.exe`, while the editable checkout lives under `%LOCALAPPDATA%\hermes\hermes-agent`. In that layout, a stale `venv\Scripts\` directory may exist without `python.exe`. `hermes update` ignores that broken project venv and installs through the active Python interpreter instead, preventing failures like:
+
+```
+Failed to inspect Python interpreter from active virtual environment at `venv\Scripts\python.exe`
+```
+
 Expected output looks like:
 
 ```


### PR DESCRIPTION
## Summary
- avoid forcing uv to use a stale Windows project venv without python.exe
- use the active Python/pip path for global editable Windows installs so console-script shims are preserved
- document the stale-project-venv update failure mode

## Tests
- C:\\Python313\\python.exe -m pytest tests\\hermes_cli\\test_update_autostash.py -q --timeout-method=thread
- C:\\Python313\\python.exe -m py_compile hermes_cli\\main.py
- C:\\Python313\\Scripts\\hermes.exe update
- C:\\Python313\\Scripts\\hermes.exe --version