### PR TITLE
feat(kanban): per-run session_id storage primitives for resume-on-respawn (#33873)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -945,7 +945,14 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    -- Persisted ``hermes chat`` session id, captured by the worker via
+    -- ``kanban_register_session`` on startup. Used by the dispatcher on
+    -- the next respawn (after unblock or reclaim) to launch with
+    -- ``--resume <session_id>`` so the new worker continues from the
+    -- prior conversation instead of starting fresh. NULL while the
+    -- worker has not registered, or for runs predating this column.
+    session_id          TEXT
 );
 
 -- Subscription from a gateway source (platform + chat + thread) to a
@@ -1531,6 +1538,28 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
+
+    # task_runs gained a per-run ``session_id`` column for the worker's
+    # ``hermes chat`` session — distinct from ``tasks.session_id`` which
+    # records the *originating* agent session that created the task.
+    # Captured by the worker via ``kanban_register_session`` on startup;
+    # consumed by the dispatcher on next respawn to launch with
+    # ``--resume <session_id>`` so the worker continues from the prior
+    # conversation. NULL on legacy runs and any run where the worker
+    # never called the registration tool. See issue #33873.
+    runs_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if runs_table_exists:
+        runs_cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        if "session_id" not in runs_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "session_id", "session_id TEXT"
+            )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -2353,6 +2382,59 @@ def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
         "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
     ).fetchone()
     return int(row["current_run_id"]) if row and row["current_run_id"] else None
+
+
+def set_run_session_id(
+    conn: sqlite3.Connection, run_id: int, session_id: str
+) -> bool:
+    """Persist a worker's ``hermes chat`` session id on its run row.
+
+    Called by the ``kanban_register_session`` MCP tool on worker startup.
+    Idempotent: re-calling with the same value is a no-op; overwriting
+    with a different value is allowed (a worker that crashes and is
+    auto-resumed registers afresh; we want the latest one).
+
+    Returns ``True`` if the row was updated, ``False`` if no row matched
+    (unknown ``run_id``). The caller should treat ``False`` as a hard
+    error — registering a session against an absent run is a worker
+    misconfiguration, not a transient state.
+    """
+    cleaned = (session_id or "").strip()
+    if not cleaned:
+        return False
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE task_runs SET session_id = ? WHERE id = ?",
+            (cleaned, int(run_id)),
+        )
+        return cur.rowcount == 1
+
+
+def latest_session_id_for_task(
+    conn: sqlite3.Connection, task_id: str
+) -> Optional[str]:
+    """Return the most recent non-NULL ``session_id`` across runs of a task.
+
+    Used by the dispatcher on respawn (after unblock or reclaim) to look
+    up the prior worker's session and launch the new worker with
+    ``--resume <session_id>``. ``None`` means there is no prior session
+    to resume — either the task has never run, every prior run predates
+    the column, or no prior worker called ``kanban_register_session``.
+
+    Ordering by ``started_at DESC`` (not ``id DESC``) so manual reseats
+    of runs preserve dispatch ordering — see the manual-resume recipe
+    discussion in issue #33873.
+    """
+    row = conn.execute(
+        "SELECT session_id FROM task_runs "
+        "WHERE task_id = ? AND session_id IS NOT NULL "
+        "ORDER BY started_at DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    val = row["session_id"]
+    return str(val) if val else None
 
 
 def _synthesize_ended_run(

--- a/tests/hermes_cli/test_kanban_resume_session.py
+++ b/tests/hermes_cli/test_kanban_resume_session.py
@@ -1,0 +1,206 @@
+"""Per-run worker session_id capture for dispatcher resume-on-respawn.
+
+These cover the helpers added for issue #33873 — the goal is for the
+dispatcher to launch the next worker for a task with ``--resume <id>``
+so the new worker continues the prior conversation instead of starting
+fresh. The dispatcher-side wiring lives elsewhere; this file pins the
+storage primitives (schema migration + the two query helpers).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB (mirrors the rig used
+    by test_kanban_db.py)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _make_task_with_run(conn, *, title: str = "t") -> tuple[str, int]:
+    """Create a running task and synthesize a matching run row.
+
+    Mirrors the post-claim state the dispatcher leaves a task in: status
+    ``running`` and a ``task_runs`` row pointed at by ``current_run_id``.
+    Going through ``claim_task`` would require navigating ``todo → ready``
+    promotion first; this short-circuit keeps the per-helper tests
+    focused on the helpers themselves.
+
+    No outer ``write_txn`` here: ``create_task`` opens its own, and
+    helpers like ``set_run_session_id`` open theirs. Nesting would raise
+    ``cannot start a transaction within a transaction``.
+    """
+    task_id = kb.create_task(
+        conn, title=title, assignee="default", initial_status="running"
+    )
+    cur = conn.execute(
+        "INSERT INTO task_runs (task_id, profile, status, started_at) "
+        "VALUES (?, 'default', 'running', strftime('%s','now'))",
+        (task_id,),
+    )
+    run_id = int(cur.lastrowid)
+    conn.execute(
+        "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+        (run_id, task_id),
+    )
+    conn.commit()
+    return task_id, run_id
+
+
+# ---------------------------------------------------------------------------
+# Schema migration
+# ---------------------------------------------------------------------------
+
+def test_migration_adds_session_id_to_task_runs(kanban_home):
+    with kb.connect() as conn:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+    assert "session_id" in cols
+
+
+def test_migration_is_idempotent_on_existing_db(kanban_home):
+    # Re-running init_db on a DB that already has session_id should not raise
+    # or duplicate the column.
+    kb.init_db()
+    with kb.connect() as conn:
+        cols = [row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")]
+    assert cols.count("session_id") == 1
+
+
+# ---------------------------------------------------------------------------
+# set_run_session_id
+# ---------------------------------------------------------------------------
+
+def test_set_run_session_id_persists(kanban_home):
+    with kb.connect() as conn:
+        _, run_id = _make_task_with_run(conn)
+        assert kb.set_run_session_id(conn, run_id, "20260528_120000_abcdef")
+        row = conn.execute(
+            "SELECT session_id FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+    assert row["session_id"] == "20260528_120000_abcdef"
+
+
+def test_set_run_session_id_rejects_empty(kanban_home):
+    with kb.connect() as conn:
+        _, run_id = _make_task_with_run(conn)
+        assert not kb.set_run_session_id(conn, run_id, "")
+        assert not kb.set_run_session_id(conn, run_id, "   ")
+
+
+def test_set_run_session_id_returns_false_for_unknown_run(kanban_home):
+    with kb.connect() as conn:
+        # No claim → no run row → unknown run id.
+        assert not kb.set_run_session_id(conn, 99999, "20260528_120000_abcdef")
+
+
+def test_set_run_session_id_overwrites(kanban_home):
+    """A worker that re-registers (e.g. after an in-process resume) wins
+    over the prior value. Per-run latest-wins semantics matter so the
+    dispatcher always reads the freshest session id for that run."""
+    with kb.connect() as conn:
+        _, run_id = _make_task_with_run(conn)
+        assert kb.set_run_session_id(conn, run_id, "first")
+        assert kb.set_run_session_id(conn, run_id, "second")
+        row = conn.execute(
+            "SELECT session_id FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+    assert row["session_id"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# latest_session_id_for_task
+# ---------------------------------------------------------------------------
+
+def test_latest_session_id_none_when_no_runs(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="default")
+        assert kb.latest_session_id_for_task(conn, task_id) is None
+
+
+def test_latest_session_id_none_when_no_session_recorded(kanban_home):
+    """Run exists but worker never called kanban_register_session."""
+    with kb.connect() as conn:
+        task_id, _ = _make_task_with_run(conn)
+        assert kb.latest_session_id_for_task(conn, task_id) is None
+
+
+def test_latest_session_id_returns_recorded(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _make_task_with_run(conn)
+        kb.set_run_session_id(conn, run_id, "sess-A")
+        assert kb.latest_session_id_for_task(conn, task_id) == "sess-A"
+
+
+def test_latest_session_id_picks_most_recent_run(kanban_home):
+    """A task that has been reclaimed accumulates multiple runs. The
+    dispatcher should resume the most recent session, not the oldest."""
+    with kb.connect() as conn:
+        task_id, run1 = _make_task_with_run(conn)
+        kb.set_run_session_id(conn, run1, "sess-old")
+        # Synthesize the reclaim → fresh claim cycle: ended row for run1,
+        # new running row for run2.
+        conn.execute(
+            "UPDATE task_runs SET status='reclaimed', outcome='reclaimed', "
+            "ended_at=strftime('%s','now') WHERE id=?",
+            (run1,),
+        )
+        cur = conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, started_at) "
+            "VALUES (?, 'default', 'running', strftime('%s','now') + 1)",
+            (task_id,),
+        )
+        run2 = int(cur.lastrowid)
+        conn.execute(
+            "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+            (run2, task_id),
+        )
+        conn.commit()
+        kb.set_run_session_id(conn, run2, "sess-new")
+        assert kb.latest_session_id_for_task(conn, task_id) == "sess-new"
+
+
+def test_latest_session_id_skips_null_sessions(kanban_home):
+    """If the latest run has no session id (worker crashed before
+    registering) but an earlier run does, fall back to the earlier one
+    rather than returning None and losing resumability."""
+    with kb.connect() as conn:
+        task_id, run1 = _make_task_with_run(conn)
+        kb.set_run_session_id(conn, run1, "sess-A")
+        # Synthesize a later run that never registered a session.
+        conn.execute(
+            "UPDATE task_runs SET status='reclaimed', outcome='reclaimed', "
+            "ended_at=strftime('%s','now') WHERE id=?",
+            (run1,),
+        )
+        cur = conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, started_at) "
+            "VALUES (?, 'default', 'running', strftime('%s','now') + 1)",
+            (task_id,),
+        )
+        conn.execute(
+            "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+            (int(cur.lastrowid), task_id),
+        )
+        conn.commit()
+        assert kb.latest_session_id_for_task(conn, task_id) == "sess-A"
+
+
+def test_latest_session_id_isolated_per_task(kanban_home):
+    with kb.connect() as conn:
+        t1, run1 = _make_task_with_run(conn, title="one")
+        t2, run2 = _make_task_with_run(conn, title="two")
+        kb.set_run_session_id(conn, run1, "sess-one")
+        kb.set_run_session_id(conn, run2, "sess-two")
+        assert kb.latest_session_id_for_task(conn, t1) == "sess-one"
+        assert kb.latest_session_id_for_task(conn, t2) == "sess-two"


### PR DESCRIPTION
## What this is

**Draft** PR for #33873 — adds the storage primitives the dispatcher will need to launch the next worker for a task with `--resume <session_id>` so the new worker continues the prior conversation instead of starting fresh.

Deliberately **not** wired through to the dispatcher or the worker-facing tool yet. The goal of this PR is to ground the design discussion on concrete code — once direction is confirmed in the issue, the remaining pieces follow.

## What's included

- `task_runs.session_id` (nullable TEXT) — distinct from the existing `tasks.session_id` which records the *originating* agent session. Migration is gated on `task_runs` existing and idempotent via the existing `_add_column_if_missing` helper.
- `set_run_session_id(run_id, session_id)` — idempotent per-run write. Returns False on empty input or unknown run.
- `latest_session_id_for_task(task_id)` — most-recent non-NULL session id across runs of a task, ordered by `started_at DESC`. Skips NULL so a later run that crashed before registering doesn't lose resumability.
- 12 new tests covering migration idempotence, the two helpers, and the multi-run reclaim-cycle case.

## What's pending (awaiting design feedback)

These are the bits I'd want a maintainer steer on before implementing:

- **MCP tool `kanban_register_session`** for the worker to register its session id on startup. Cleanest, but a new tool — could also be done via stdout parsing or an env-var-to-DB bridge. Open question 1 in #33873.
- **Dispatcher-side `--resume` injection** in `_default_spawn`. The lookup is `latest_session_id_for_task`; the wiring is ~10 lines. The semantic question is what `-q` prompt to pass alongside (open question 2).
- **Config knob** `kanban.resume_on_respawn` (default `false` while bedding in).
- **Worker-skill update** documenting the new tool + when it fires.

## Tests

- `tests/hermes_cli/test_kanban_resume_session.py`: 12 passing.
- `tests/hermes_cli/test_kanban_db.py` + `test_kanban_db_init.py`: 202 still passing (no regressions).
- `ruff check` clean on both touched files.

## Notes for the reviewer

- I left the new column with no index. `latest_session_id_for_task` filters on `task_id` which already has `idx_runs_task ON task_runs(task_id, started_at)` — that should cover the read path. Happy to add a dedicated index if profiling shows it's needed.
- The docstring on the migration entry explicitly distinguishes the new column from the existing `tasks.session_id` so future readers don't conflate them.
- The schema comment in `CREATE TABLE task_runs` cross-references the issue for context.

Closes part of #33873 (storage layer). The dispatcher wiring will be a follow-up PR.
