### PR TITLE
fix(api-server): handle json_schema format requests in /v1/responses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2763,6 +2763,17 @@ class APIServerAdapter(BasePlatformAdapter):
         previous_response_id = body.get("previous_response_id")
         conversation = body.get("conversation")
         store = _coerce_request_bool(body.get("store"), default=True)
+        
+        text_format = body.get("text", {}).get("format", {}) if body.get("text") else None
+        
+        if text_format and text_format.get("type") == "json_schema":
+            return web.json_response(
+                _openai_error(
+                    "Structured output (json_schema) is not yet supported on the /v1/responses endpoint. "
+                    "Please use the /v1/chat/completions endpoint with response_format parameter instead."
+                ),
+                status=400
+            )
 
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2774,6 +2774,18 @@ class APIServerAdapter(BasePlatformAdapter):
                 ),
                 status=400
             )
+        
+        tools = body.get("tools", [])
+        for tool in tools:
+            if isinstance(tool, dict):
+                tool_format = tool.get("response_format", {})
+                if tool_format.get("type") == "json_schema":
+                    return web.json_response(
+                        _openai_error(
+                            "Structured output (json_schema) in tool definitions is not yet supported on the /v1/responses endpoint."
+                        ),
+                        status=400
+                    )
 
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:

--- a/tests/gateway/test_api_server_json_schema.py
+++ b/tests/gateway/test_api_server_json_schema.py
@@ -1,0 +1,87 @@
+"""
+Test API server handling of JSON schema structured output requests.
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+@pytest.fixture
+def api_server():
+    """Create APIServerAdapter instance for testing."""
+    config = PlatformConfig(enabled=True, extra={"key": "test-key"})
+    adapter = APIServerAdapter(config)
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_responses_endpoint_rejects_json_schema(api_server):
+    """Test that /v1/responses endpoint properly rejects json_schema format requests."""
+    request = AsyncMock()
+    request.headers = {"Authorization": "Bearer test-key"}
+    request.json = AsyncMock(return_value={
+        "input": "Reply with PONG",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "Probe",
+                "schema": {
+                    "type": "object",
+                    "properties": {"word": {"type": "string"}},
+                    "required": ["word"],
+                    "additionalProperties": False
+                }
+            }
+        }
+    })
+    
+    response = await api_server._handle_responses(request)
+    
+    assert response.status == 400
+    
+    response_data = json.loads(response.text)
+    assert "error" in response_data
+    assert "json_schema" in response_data["error"]["message"]
+    assert "not yet supported" in response_data["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_responses_endpoint_accepts_non_json_schema(api_server):
+    """Test that /v1/responses endpoint works normally without json_schema format."""
+    request = AsyncMock()
+    request.headers = {"Authorization": "Bearer test-key"}
+    request.json = AsyncMock(return_value={
+        "input": "Hello",
+        "instructions": "Be helpful"
+    })
+    
+    with patch.object(api_server, '_run_agent') as mock_run_agent:
+        mock_run_agent.return_value = ({"response": "Hi there!"}, {"total_tokens": 10})
+        
+        response = await api_server._handle_responses(request)
+        
+        assert response.status == 200
+        mock_run_agent.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_responses_endpoint_ignores_empty_text_field(api_server):
+    """Test that empty text field doesn't trigger json_schema check."""
+    request = AsyncMock()
+    request.headers = {"Authorization": "Bearer test-key"}
+    request.json = AsyncMock(return_value={
+        "input": "Hello",
+        "text": {}
+    })
+    
+    with patch.object(api_server, '_run_agent') as mock_run_agent:
+        mock_run_agent.return_value = ({"response": "Hi!"}, {"total_tokens": 5})
+        
+        response = await api_server._handle_responses(request)
+        
+        assert response.status == 200
+        mock_run_agent.assert_called_once()

--- a/tests/gateway/test_api_server_json_schema.py
+++ b/tests/gateway/test_api_server_json_schema.py
@@ -85,3 +85,29 @@ async def test_responses_endpoint_ignores_empty_text_field(api_server):
         
         assert response.status == 200
         mock_run_agent.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_responses_endpoint_rejects_json_schema_in_tools(api_server):
+    """Test that json_schema in tool definitions is also rejected."""
+    request = AsyncMock()
+    request.headers = {"Authorization": "Bearer test-key"}
+    request.json = AsyncMock(return_value={
+        "input": "Use the tool",
+        "tools": [
+            {
+                "name": "get_data",
+                "response_format": {
+                    "type": "json_schema",
+                    "schema": {"type": "object"}
+                }
+            }
+        ]
+    })
+    
+    response = await api_server._handle_responses(request)
+    
+    assert response.status == 400
+    response_data = json.loads(response.text)
+    assert "error" in response_data
+    assert "tool definitions" in response_data["error"]["message"]


### PR DESCRIPTION
## Summary
Fixes #33864

The /v1/responses endpoint was ignoring text.format.type=json_schema field, returning plain text instead of structured JSON.

## Changes
- Added validation to check for json_schema format in request body
- Returns 400 error with message directing to /v1/chat/completions endpoint
- Added tests to verify the behavior

## How to Test
Run the reproduction script from the issue - it now returns a proper error instead of silently ignoring the schema.

## Platform
Tested on macOS