### PR TITLE
feat: add api_mode=responses for generic OpenAI Responses API (#33600)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -214,7 +214,106 @@ def interruptible_api_call(agent, api_kwargs: dict):
         else:
             agent._close_request_openai_client(request_client, reason=reason)
 
-    def _call():
+    def _normalize_responses_to_chat(raw_response: Any) -> Any:
+        """Normalize an OpenAI Responses API response to chat.completions shape.
+
+        The Responses API returns a different object shape than chat.completions.
+        This converts it so the agent loop can treat it uniformly.
+        """
+        from types import SimpleNamespace
+
+        # Extract text content — responses API stores output in .output items
+        text_parts: list[str] = []
+        tool_calls: list[Any] = []
+
+        output = getattr(raw_response, "output", None) or []
+        if isinstance(output, list):
+            for item in output:
+                item_type = getattr(item, "type", "") or ""
+                if item_type == "message":
+                    content = getattr(item, "content", None) or []
+                    for block in (content if isinstance(content, list) else []):
+                        block_type = getattr(block, "type", "") or ""
+                        if block_type == "output_text":
+                            txt = getattr(block, "text", "") or ""
+                            if txt:
+                                text_parts.append(txt)
+                elif item_type == "function_call":
+                    arguments = getattr(item, "arguments", "{}") or "{}"
+                    if isinstance(arguments, dict):
+                        import json as _json
+
+                        arguments = _json.dumps(arguments)
+                    tool_calls.append(
+                        SimpleNamespace(
+                            id=getattr(item, "call_id", None) or getattr(item, "id", "") or "fc_0",
+                            type="function",
+                            function=SimpleNamespace(
+                                name=getattr(item, "name", "tool") or "tool",
+                                arguments=arguments,
+                            ),
+                        )
+                    )
+                elif item_type == "tool_call":
+                    arguments = getattr(item, "arguments", "{}") or "{}"
+                    if isinstance(arguments, dict):
+                        import json as _json
+
+                        arguments = _json.dumps(arguments)
+                    tool_calls.append(
+                        SimpleNamespace(
+                            id=getattr(item, "call_id", None) or getattr(item, "id", "") or "tc_0",
+                            type="function",
+                            function=SimpleNamespace(
+                                name=getattr(item, "name", "tool") or "tool",
+                                arguments=arguments,
+                            ),
+                        )
+                    )
+
+        # Fallback: some responses APIs expose .output_text directly
+        if not text_parts and not tool_calls:
+            output_text = getattr(raw_response, "output_text", None)
+            if isinstance(output_text, str) and output_text:
+                text_parts = [output_text]
+
+        content = "\n".join(text_parts) if text_parts else None
+
+        # Build the chat.completions-style response
+        usage = getattr(raw_response, "usage", None)
+        prompt_tokens = getattr(usage, "input_tokens", 0) or 0 if usage else 0
+        completion_tokens = getattr(usage, "output_tokens", 0) or 0 if usage else 0
+
+        message = SimpleNamespace(
+            content=content,
+            tool_calls=tool_calls if tool_calls else [],
+            role="assistant",
+            reasoning=None,
+        )
+
+        finish_reason = "stop"
+        if tool_calls:
+            finish_reason = "tool_calls"
+
+        return SimpleNamespace(
+            id=getattr(raw_response, "id", "") or "",
+            model=getattr(raw_response, "model", "") or "",
+            choices=[
+                SimpleNamespace(
+                    finish_reason=finish_reason,
+                    index=0,
+                    message=message,
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+            created=int(getattr(raw_response, "created", 0) or 0),
+        )
+
+    def _call() -> None:
         try:
             if agent.api_mode == "codex_responses":
                 request_client = _set_request_client(
@@ -230,6 +329,18 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             elif agent.api_mode == "anthropic_messages":
                 result["response"] = agent._anthropic_messages_create(api_kwargs)
+            elif agent.api_mode == "responses":
+                # OpenAI Responses API (non-Codex custom provider).
+                # Calls client.responses.create() and normalizes the response
+                # to the chat.completions shape the agent loop expects (#33600).
+                request_client = _set_request_client(
+                    agent._create_request_openai_client(
+                        reason="responses_api_request",
+                        api_kwargs=api_kwargs,
+                    )
+                )
+                raw_response = request_client.responses.create(**api_kwargs)
+                result["response"] = _normalize_responses_to_chat(raw_response)
             elif agent.api_mode == "bedrock_converse":
                 # Bedrock uses boto3 directly — no OpenAI client needed.
                 # normalize_converse_response produces an OpenAI-compatible

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -242,6 +242,10 @@ _VALID_API_MODES = {
     "codex_responses",
     "anthropic_messages",
     "bedrock_converse",
+    # Generic OpenAI Responses API dispatch — used by custom providers
+    # (e.g. provider: custom, api_mode: responses) that expose a
+    # /v1/responses endpoint instead of /v1/chat/completions (#33600).
+    "responses",
     # Optional opt-in: hand the entire turn to a `codex app-server` subprocess
     # so terminal/file-ops/patching/sandboxing run inside Codex's own runtime
     # instead of Hermes' tool dispatch. Gated behind config key


### PR DESCRIPTION
## What does this PR do?

Adds `api_mode='responses'` for custom providers using the OpenAI Responses API (`/v1/responses`). Generic (non-Codex) dispatch.

Fixes #33600

## Type of Change

- [x] ✨ New feature

## Changes Made

- `hermes_cli/runtime_provider.py`: Added `"responses"` to `_VALID_API_MODES`
- `agent/chat_completion_helpers.py`: Added `_normalize_responses_to_chat()` + `responses` api_mode branch in `_call()`

## How to Test

1. Configure custom provider with `api_mode: responses` in config.yaml
2. Use `hermes model` to select custom provider
3. Send message — verify responses work with text and tool calls

## Checklist

- [x] I have tested these changes locally