### PR TITLE
Add ProofRelay MCP catalog entry

### DIFF
--- a/optional-mcps/proofrelay/manifest.yaml
+++ b/optional-mcps/proofrelay/manifest.yaml
@@ -1,0 +1,32 @@
+# Hermes MCP catalog entry for a public-safe remote ProofRelay verifier.
+# No authentication, local install, secrets, or customer data are required.
+manifest_version: 1
+
+name: proofrelay
+description: Verify non-confidential MCP/tool evidence bundles from Hermes before users rely on agent outputs.
+source: https://github.com/GENESISRE/proofrelay
+
+transport:
+  type: http
+  url: https://mcp.genesisre.io/mcp
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - proofrelay.get_verifier_status
+    - proofrelay.recommend_checkpoint
+    - proofrelay.verify_bundle
+
+post_install: |
+  ProofRelay is a read-only remote MCP verifier for non-confidential evidence
+  bundles. Start with synthetic or public-safe hashes only; do not send secrets,
+  prompts, raw logs, customer files, wallet keys, payment credentials, or source
+  code.
+
+  The default tool selection is intentionally narrow. You can enable additional
+  ProofRelay tools after install with:
+    hermes mcp configure proofrelay
+
+  Public Hermes setup notes: https://genesisre.io/proofrelay/hermes


### PR DESCRIPTION
## Summary

Adds `proofrelay` to the Hermes optional MCP catalog as a remote HTTP MCP server.

ProofRelay is a read-only verifier for non-confidential MCP/tool evidence bundles. The default tool selection is intentionally narrow:

- `proofrelay.get_verifier_status`
- `proofrelay.recommend_checkpoint`
- `proofrelay.verify_bundle`

The manifest requires no local install, no authentication, and no secrets.

## Safety boundary

The catalog entry and post-install note tell users to start with synthetic or public-safe hashes only and not to send secrets, prompts, raw logs, customer files, wallet keys, payment credentials, or source code.

## Validation

- `python3 -m pytest -o addopts='' tests/hermes_cli/test_mcp_catalog.py -q`
- Result: `34 passed in 4.44s`

The default repository pytest config in this local environment references pytest-timeout addopts, so I disabled addopts for this targeted catalog validation rather than installing dependencies.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author