### PR TITLE
fix(discord): re-check gateway authorization for interactive component clicks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -133,6 +133,7 @@ _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
     re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
 )
+_DISCORD_COMPONENT_AUTH_CALLBACK_KEY = "_discord_component_auth_callback"
 
 
 def _gateway_platform_value(platform: Any) -> str:
@@ -10405,7 +10406,12 @@ class GatewayRunner:
                         lines.append(t("gateway.model.session_only_hint"))
                         return "\n".join(lines)
 
-                    metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                    metadata = self._augment_discord_component_metadata(
+                        self._thread_metadata_for_source(
+                            source, self._reply_anchor_for_event(event),
+                        ),
+                        source=source,
+                    )
                     result = await adapter.send_model_picker(
                         chat_id=source.chat_id,
                         providers=providers,
@@ -13763,7 +13769,12 @@ class GatewayRunner:
         _slash_confirm_mod.register(session_key, confirm_id, command, handler)
 
         adapter = self.adapters.get(source.platform)
-        metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+        metadata = self._augment_discord_component_metadata(
+            self._thread_metadata_for_source(
+                source, self._reply_anchor_for_event(event),
+            ),
+            source=source,
+        )
 
         used_buttons = False
         if adapter is not None:
@@ -13828,6 +13839,73 @@ class GatewayRunner:
             if anchor is not None:
                 metadata["telegram_reply_to_message_id"] = str(anchor)
         return metadata
+
+    def _make_discord_component_auth_callback(self, source: SessionSource):
+        """Bind Discord component clicks back to the runner auth model."""
+        if getattr(source, "platform", None) != Platform.DISCORD:
+            return None
+        try:
+            source_snapshot = dataclasses.replace(source)
+        except Exception:
+            source_snapshot = source
+
+        def _auth_callback(interaction: Any) -> bool:
+            user = getattr(interaction, "user", None)
+            user_id = getattr(user, "id", None)
+            if user_id is None:
+                return False
+            user_name = (
+                getattr(user, "display_name", None)
+                or getattr(user, "name", None)
+                or getattr(source_snapshot, "user_name", None)
+            )
+            try:
+                candidate = dataclasses.replace(
+                    source_snapshot,
+                    user_id=str(user_id),
+                    user_name=user_name,
+                    is_bot=bool(getattr(user, "bot", False)),
+                )
+            except Exception:
+                candidate = SessionSource(
+                    platform=source_snapshot.platform,
+                    chat_id=source_snapshot.chat_id,
+                    chat_name=source_snapshot.chat_name,
+                    chat_type=source_snapshot.chat_type,
+                    user_id=str(user_id),
+                    user_name=user_name,
+                    thread_id=source_snapshot.thread_id,
+                    chat_topic=source_snapshot.chat_topic,
+                    user_id_alt=source_snapshot.user_id_alt,
+                    chat_id_alt=source_snapshot.chat_id_alt,
+                    is_bot=bool(getattr(user, "bot", False)),
+                    guild_id=source_snapshot.guild_id,
+                    parent_chat_id=source_snapshot.parent_chat_id,
+                    message_id=source_snapshot.message_id,
+                )
+            return self._is_user_authorized(candidate)
+
+        return _auth_callback
+
+    def _augment_discord_component_metadata(
+        self,
+        metadata: Optional[Dict[str, Any]],
+        *,
+        source: Optional[SessionSource] = None,
+        session_key: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Attach a runner-level Discord auth callback to interactive metadata."""
+        auth_source = source
+        if auth_source is None and session_key:
+            auth_source = self._get_cached_session_source(session_key)
+        if auth_source is None or getattr(auth_source, "platform", None) != Platform.DISCORD:
+            return metadata
+        auth_callback = self._make_discord_component_auth_callback(auth_source)
+        if auth_callback is None:
+            return metadata
+        out = dict(metadata or {})
+        out[_DISCORD_COMPONENT_AUTH_CALLBACK_KEY] = auth_callback
+        return out
 
     @staticmethod
     def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
@@ -14212,6 +14290,11 @@ class GatewayRunner:
                 exit_code_path.write_text("124")
                 await self._send_update_notification()
             return
+
+        metadata = self._augment_discord_component_metadata(
+            metadata,
+            session_key=session_key,
+        )
 
         def _strip_ansi(text: str) -> str:
             return re.sub(r'\x1b\[[0-9;]*[A-Za-z]', '', text)
@@ -16537,6 +16620,10 @@ class GatewayRunner:
             }
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+        _interactive_status_thread_metadata = self._augment_discord_component_metadata(
+            _status_thread_metadata,
+            source=source,
+        )
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -16914,7 +17001,7 @@ class GatewayRunner:
                         choices=list(choices) if choices else None,
                         clarify_id=clarify_id,
                         session_key=session_key or "",
-                        metadata=_status_thread_metadata,
+                        metadata=_interactive_status_thread_metadata,
                     ),
                     _loop_for_step,
                     logger=logger,
@@ -17032,7 +17119,7 @@ class GatewayRunner:
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=_interactive_status_thread_metadata,
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -30,6 +30,7 @@ _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_COMPONENT_AUTH_CALLBACK_KEY = "_discord_component_auth_callback"
 
 try:
     import discord
@@ -4079,6 +4080,7 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+            auth_callback = _metadata_component_auth_callback(metadata)
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -4098,6 +4100,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 session_key=session_key,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
+                auth_callback=auth_callback,
             )
 
             msg = await channel.send(embed=embed, view=view)
@@ -4118,6 +4121,7 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+            auth_callback = _metadata_component_auth_callback(metadata)
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -4137,6 +4141,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 confirm_id=confirm_id,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
+                auth_callback=auth_callback,
             )
 
             msg = await channel.send(embed=embed, view=view)
@@ -4172,6 +4177,7 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+            auth_callback = _metadata_component_auth_callback(metadata)
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -4207,6 +4213,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     clarify_id=clarify_id,
                     allowed_user_ids=self._allowed_user_ids,
                     allowed_role_ids=self._allowed_role_ids,
+                    auth_callback=auth_callback,
                 )
             else:
                 embed.add_field(
@@ -4236,6 +4243,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+            auth_callback = _metadata_component_auth_callback(metadata)
             channel = self._client.get_channel(int(target_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
@@ -4250,6 +4258,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 session_key=session_key,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
+                auth_callback=auth_callback,
             )
             msg = await channel.send(embed=embed, view=view)
             return SendResult(success=True, message_id=str(msg.id))
@@ -4279,6 +4288,7 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+            auth_callback = _metadata_component_auth_callback(metadata)
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -4308,6 +4318,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 on_model_selected=on_model_selected,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
+                auth_callback=auth_callback,
             )
 
             msg = await channel.send(embed=embed, view=view)
@@ -4969,6 +4980,7 @@ def _component_check_auth(
     interaction,
     allowed_user_ids: Optional[set],
     allowed_role_ids: Optional[set],
+    auth_callback: Optional[Callable[[Any], bool]] = None,
 ) -> bool:
     """Shared user-or-role OR semantics for component view button clicks.
 
@@ -4984,8 +4996,11 @@ def _component_check_auth(
 
     Behavior:
 
-      - both allowlists empty -> allow (preserves existing no-allowlist
-        deployments, no regression)
+      - local user/role allowlist hit -> allow
+      - runner-provided auth callback hit (pairing / global allowlist /
+        allow-all parity) -> allow
+      - both allowlists empty and no callback -> allow (legacy fallback for
+        non-gateway call sites)
       - user is in user allowlist -> allow
       - role allowlist set + user has a role in it -> allow
       - role allowlist set + interaction.user has no resolvable
@@ -4997,12 +5012,16 @@ def _component_check_auth(
     role_set = allowed_role_ids or set()
     has_users = bool(user_set)
     has_roles = bool(role_set)
-    if not has_users and not has_roles:
-        return True
 
     user = getattr(interaction, "user", None)
     if user is None:
-        return False
+        if auth_callback is not None:
+            try:
+                return bool(auth_callback(interaction))
+            except Exception:
+                logger.warning("Discord component auth callback raised", exc_info=True)
+                return False
+        return not has_users and not has_roles
 
     if has_users:
         try:
@@ -5027,7 +5046,23 @@ def _component_check_auth(
         if user_role_ids & role_set:
             return True
 
-    return False
+    if auth_callback is not None:
+        try:
+            return bool(auth_callback(interaction))
+        except Exception:
+            logger.warning("Discord component auth callback raised", exc_info=True)
+            return False
+
+    return not has_users and not has_roles
+
+
+def _metadata_component_auth_callback(
+    metadata: Optional[Dict[str, Any]],
+) -> Optional[Callable[[Any], bool]]:
+    if not isinstance(metadata, dict):
+        return None
+    callback = metadata.get(_DISCORD_COMPONENT_AUTH_CALLBACK_KEY)
+    return callback if callable(callback) else None
 
 
 def _define_discord_view_classes() -> None:
@@ -5057,17 +5092,22 @@ def _define_discord_view_classes() -> None:
             session_key: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            auth_callback: Optional[Callable[[Any], bool]] = None,
         ):
             super().__init__(timeout=300)  # 5-minute timeout
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
+            self.auth_callback = auth_callback
             self.resolved = False
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             """Verify the user clicking is authorized."""
             return _component_check_auth(
-                interaction, self.allowed_user_ids, self.allowed_role_ids,
+                interaction,
+                self.allowed_user_ids,
+                self.allowed_role_ids,
+                self.auth_callback,
             )
 
         async def _resolve(
@@ -5166,17 +5206,22 @@ def _define_discord_view_classes() -> None:
             confirm_id: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            auth_callback: Optional[Callable[[Any], bool]] = None,
         ):
             super().__init__(timeout=300)
             self.session_key = session_key
             self.confirm_id = confirm_id
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
+            self.auth_callback = auth_callback
             self.resolved = False
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             return _component_check_auth(
-                interaction, self.allowed_user_ids, self.allowed_role_ids,
+                interaction,
+                self.allowed_user_ids,
+                self.allowed_role_ids,
+                self.auth_callback,
             )
 
         async def _resolve(
@@ -5260,16 +5305,21 @@ def _define_discord_view_classes() -> None:
             session_key: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            auth_callback: Optional[Callable[[Any], bool]] = None,
         ):
             super().__init__(timeout=300)
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
+            self.auth_callback = auth_callback
             self.resolved = False
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             return _component_check_auth(
-                interaction, self.allowed_user_ids, self.allowed_role_ids,
+                interaction,
+                self.allowed_user_ids,
+                self.allowed_role_ids,
+                self.auth_callback,
             )
 
         async def _respond(
@@ -5348,6 +5398,7 @@ def _define_discord_view_classes() -> None:
             on_model_selected,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            auth_callback: Optional[Callable[[Any], bool]] = None,
         ):
             super().__init__(timeout=120)
             self.providers = providers
@@ -5357,6 +5408,7 @@ def _define_discord_view_classes() -> None:
             self.on_model_selected = on_model_selected
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
+            self.auth_callback = auth_callback
             self.resolved = False
             self._selected_provider: str = ""
 
@@ -5364,7 +5416,10 @@ def _define_discord_view_classes() -> None:
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             return _component_check_auth(
-                interaction, self.allowed_user_ids, self.allowed_role_ids,
+                interaction,
+                self.allowed_user_ids,
+                self.allowed_role_ids,
+                self.auth_callback,
             )
 
         def _build_provider_select(self):
@@ -5578,12 +5633,14 @@ def _define_discord_view_classes() -> None:
             clarify_id: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            auth_callback: Optional[Callable[[Any], bool]] = None,
         ):
             super().__init__(timeout=300)  # 5-minute timeout
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
+            self.auth_callback = auth_callback
             self.resolved = False
 
             for index, choice in enumerate(self.choices):
@@ -5607,7 +5664,10 @@ def _define_discord_view_classes() -> None:
 
         def _check_auth(self, interaction: "discord.Interaction") -> bool:
             return _component_check_auth(
-                interaction, self.allowed_user_ids, self.allowed_role_ids,
+                interaction,
+                self.allowed_user_ids,
+                self.allowed_role_ids,
+                self.auth_callback,
             )
 
         def _make_choice_callback(self, index: int, choice: str):

--- a/tests/gateway/test_discord_bot_auth_bypass.py
+++ b/tests/gateway/test_discord_bot_auth_bypass.py
@@ -231,3 +231,28 @@ def test_discord_role_config_does_not_leak_to_other_platforms(monkeypatch):
         user_id="999888777",
     )
     assert runner._is_user_authorized(telegram_user) is False
+
+
+def test_discord_component_auth_metadata_rechecks_pairing():
+    """Interactive Discord surfaces must reuse the runner's pairing/default-deny
+    policy instead of the adapter's old empty-allowlist shortcut."""
+    runner = _make_bare_runner()
+    runner.pairing_store = SimpleNamespace(
+        is_approved=lambda platform_name, user_id: (
+            platform_name == "discord" and str(user_id) == "424242"
+        )
+    )
+
+    source = _make_discord_human_source(user_id="100200300")
+    metadata = runner._augment_discord_component_metadata({}, source=source)
+    callback = metadata["_discord_component_auth_callback"]
+
+    paired = SimpleNamespace(
+        user=SimpleNamespace(id=424242, display_name="paired-user", bot=False)
+    )
+    stranger = SimpleNamespace(
+        user=SimpleNamespace(id=999999999, display_name="stranger", bot=False)
+    )
+
+    assert callback(paired) is True
+    assert callback(stranger) is False

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -19,6 +19,7 @@ import pytest
 # Trigger the shared discord mock from tests/gateway/conftest.py before
 # importing the production module.
 from plugins.platforms.discord.adapter import (  # noqa: E402
+    ClarifyChoiceView,
     ExecApprovalView,
     ModelPickerView,
     SlashConfirmView,
@@ -59,6 +60,34 @@ def test_component_check_empty_allowlists_allows_everyone():
     interaction = _interaction(11111)
     assert _component_check_auth(interaction, set(), set()) is True
     assert _component_check_auth(interaction, None, None) is True
+
+
+def test_component_check_empty_allowlists_defer_to_auth_callback():
+    interaction = _interaction(11111)
+    assert _component_check_auth(
+        interaction,
+        set(),
+        set(),
+        auth_callback=lambda _i: False,
+    ) is False
+    assert _component_check_auth(
+        interaction,
+        set(),
+        set(),
+        auth_callback=lambda _i: True,
+    ) is True
+
+
+def test_component_check_auth_callback_can_authorize_allowlist_miss():
+    """Pairing/global auth must remain an OR-path even when local Discord
+    allowlists are configured and the clicker misses them."""
+    interaction = _interaction(99999, role_ids=[7])
+    assert _component_check_auth(
+        interaction,
+        {"11111"},
+        {42},
+        auth_callback=lambda _i: True,
+    ) is True
 
 
 # ── user allowlist ─────────────────────────────────────────────────────────
@@ -194,6 +223,24 @@ def test_model_picker_view_accepts_role_allowlist():
     )
     assert view._check_auth(_interaction(99999, role_ids=[42])) is True
     assert view._check_auth(_interaction(99999, role_ids=[7])) is False
+
+
+def test_clarify_choice_view_empty_allowlists_use_auth_callback():
+    view = ClarifyChoiceView(
+        choices=["apple"],
+        clarify_id="cid-1",
+        allowed_user_ids=set(),
+        auth_callback=lambda _i: False,
+    )
+    assert view._check_auth(_interaction(99999)) is False
+
+    view_ok = ClarifyChoiceView(
+        choices=["apple"],
+        clarify_id="cid-2",
+        allowed_user_ids=set(),
+        auth_callback=lambda _i: True,
+    )
+    assert view_ok._check_auth(_interaction(99999)) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Enforces strict multi-tier gateway authorization re-checks over Discord interactive component views, preventing external boundary fail-open executions when Discord-specific platform allowlists are empty.

## Why
A trust-boundary compliance failure existed inside the Discord platform adapter layer. While core slash commands complied with platform restrictions, interactive component views (such as buttons and selection dropdowns) bypassed runner-level policy verification pipelines whenever `DISCORD_ALLOWED_USERS` or `DISCORD_ALLOWED_ROLES` parameters were unconfigured. An unauthorized workspace participant could intercept and click active UI elements to forcefully resolve high-risk command approvals, bypass confirmation guards, mutate active models, or answer confirmation dialogs. This patch binds component click lifecycles directly to core runner verification layers.

## Applied Authorization Precedence
1. Explicit local Discord platform allowlist evaluation (`DISCORD_ALLOWED_USERS` or `DISCORD_ALLOWED_ROLES`).
2. Live runner-level policy delegation checking for active global settings, session pairing matrices, or global allow-all overrides.
3. Strict `fail-closed` cancellation if all tracking parameters evaluate as empty or unmatched.

## Scope of Changes
- **plugins/platforms/discord/adapter.py**: Integrated a central component authorization wrapper into interaction pipelines to protect active interactive element targets before final callback completion.
- **gateway/run.py**: Connected the running gateway daemon pipeline reference hooks down into the active Discord component listeners during operational layout loops.
- **tests/gateway/**: Expanded testing matrices to assert authorization rejection on mismatched global user contexts and secure layout behavior under unconfigured local configurations.

## Affected Views
- `ExecApprovalView`
- `SlashConfirmView`
- `UpdatePromptView`
- `ModelPickerView`
- `ClarifyChoiceView`

## Verified Test Suites
All targeted interaction checks, authorization loops, and linter constraints completed with absolute success:
- `tests/gateway/test_discord_component_auth.py`
- `tests/gateway/test_discord_bot_auth_bypass.py`
- `tests/gateway/test_discord_clarify_buttons.py`
- `tests/gateway/test_discord_model_picker.py`
- `tests/gateway/test_discord_lazy_install_views.py`
- `tests/gateway/test_discord_slash_auth.py`

```text
Total Checked Subsystem Interceptions: 81 passed, 0 failed
