### PR TITLE
fix: remove redundant f-prefix from 3 f-strings without placeholders (F541)

### DIFF
--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -113,3 +113,28 @@ class TestLintWorkflow:
             pytest.fail(f"lint.yml is not valid YAML: {exc}")
         assert isinstance(parsed, dict)
         assert "jobs" in parsed
+
+
+class TestToolsLint:
+    """Lint-regression guards for specific rules in tools/."""
+
+    def test_tools_dir_has_zero_f541_violations(self):
+        """tools/ must have zero F541 (f-string without placeholders) violations.
+        F541 catches f-strings that have no interpolation expressions, which
+        are a bug-magnet when auto-formatters or refactoring tools replace
+        a regular string with an f-string without adding placeholders.
+        Having the test means CI catches re-introductions."""
+        import subprocess, sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=F541",
+             "--output-format=concise", str(REPO_ROOT / "tools")],
+            capture_output=True, text=True,
+        )
+
+        assert result.returncode == 0, (
+            "tools/ has %d F541 violation(s):\n%s" % (
+                result.stdout.count(": error[F541]"),
+                result.stdout,
+            )
+        )

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -664,7 +664,7 @@ class CheckpointManager:
 
         ref = _ref_name(_project_hash(abs_dir))
         ok, stdout, _ = _run_git(
-            ["log", ref, f"--format=%H|%h|%aI|%s", "-n", str(self.max_snapshots)],
+            ["log", ref, "--format=%H|%h|%aI|%s", "-n", str(self.max_snapshots)],
             store, abs_dir,
             allowed_returncodes={128, 129},
         )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1215,7 +1215,7 @@ def _dump_subagent_timeout_diagnostic(
         def _w(line: str = "") -> None:
             lines.append(line)
 
-        _w(f"# Subagent timeout diagnostic — issue #14726")
+        _w("# Subagent timeout diagnostic — issue #14726")
         _w(f"# Generated: {_dt.datetime.now().isoformat()}")
         _w("")
         _w("## Timeout")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1703,7 +1703,7 @@ async def _send_qqbot(pconfig, chat_id, message):
             token_data = token_resp.json()
             access_token = token_data.get("access_token")
             if not access_token:
-                return _error(f"QQBot: no access_token in response")
+                return _error("QQBot: no access_token in response")
 
             # Step 2: Send message via REST
             # QQ Bot API has separate endpoints for channels, C2C, and groups.


### PR DESCRIPTION
## Summary

Fixes 3 F541 (f-string without placeholders) violations in the `tools/` directory and adds a regression test to prevent re-introduction.

### Changes

- **tools/checkpoint_manager.py**: Remove redundant `f` prefix from `"--format=%H|%h|%aI|%s"` (git format specifiers are not Python interpolations)
- **tools/delegate_tool.py**: Remove redundant `f` prefix from diagnostic header comment
- **tools/send_message_tool.py**: Remove redundant `f` prefix from QQBot error message

### Test Plan

- [x] TDD cycle: RED (test failed with 3 violations) → GREEN (fixes applied, test passes)
- [x] New regression test `test_tools_dir_has_zero_f541_violations` added
- [x] All 6 lint config tests pass (6/6)
- [x] All modified files pass `ruff check`
- [x] Independent code reviewer: PASSED (no security concerns, no logic errors)

### TDD Verification

```
# RED — test failed, proving the violations exist
$ pytest tests/test_lint_config.py::TestToolsLint::test_tools_dir_has_zero_f541_violations -v
> FAILED (returns 3 violations)

# GREEN — after fix, test passes
$ pytest tests/test_lint_config.py::TestToolsLint::test_tools_dir_has_zero_f541_violations -v
> PASSED
```

---
**CI Note:** The `needs-review` label could not be added automatically (requires admin rights on upstream). A human reviewer should add the label when triaging.