### PR TITLE
docs: clarify file_path parameter constraints in skill_manage tool

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -983,8 +983,11 @@ SKILL_MANAGE_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Path to a supporting file within the skill directory. "
-                    "For 'write_file'/'remove_file': required, must be under references/, "
-                    "templates/, scripts/, or assets/. "
+                    "For 'write_file'/'remove_file': required and MUST include a subdirectory prefix — "
+                    "one of references/, templates/, scripts/, or assets/. "
+                    "Bare filenames like 'SKILL.md', 'readme.md', or 'config.yaml' are REJECTED with a "
+                    "security error. Examples of valid paths: 'references/api.md', 'templates/config.yaml', "
+                    "'scripts/validate.py', 'assets/cover.png'. "
                     "For 'patch': optional, defaults to SKILL.md if omitted."
                 )
             },


### PR DESCRIPTION
The file_path description was vague about the subdirectory prefix requirement. Expand to state that bare filenames are rejected and provide concrete examples.