### PR TITLE
feat(credential-pool): mark revoked/invalidated credentials as permanently dead

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -648,6 +648,28 @@ def recover_with_credential_pool(
             return True, False
         return False, True
 
+    if effective_reason == FailoverReason.auth_permanent:
+        # The credential is permanently invalid (revoked, deactivated, etc.).
+        # Skip the refresh attempt entirely — OAuth refresh cannot fix a revoked
+        # key.  Mark as dead and rotate immediately.
+        _ra().logger.info(
+            "Credential %s — permanent auth failure from %s; "
+            "marking dead and rotating (no refresh attempted).",
+            status_code if status_code is not None else "auth_permanent",
+            agent.provider or "provider",
+        )
+        rotate_status = status_code if status_code is not None else 401
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        if next_entry is not None:
+            _ra().logger.info(
+                "Credential %s (auth_permanent) — rotated to pool entry %s",
+                rotate_status,
+                getattr(next_entry, "id", "?"),
+            )
+            agent._swap_credential(next_entry)
+            return True, False
+        return False, has_retried_429
+
     if effective_reason == FailoverReason.auth:
         # Subscription/entitlement 403s look like auth failures on the wire
         # but refresh cannot fix them — the OAuth token is already valid,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -55,6 +55,7 @@ def _load_config_safe() -> Optional[dict]:
 
 STATUS_OK = "ok"
 STATUS_EXHAUSTED = "exhausted"
+STATUS_DEAD = "dead"  # Terminal state — credential permanently removed from rotation
 
 AUTH_TYPE_OAUTH = "oauth"
 AUTH_TYPE_API_KEY = "api_key"
@@ -207,6 +208,44 @@ def _exhausted_ttl(error_code: Optional[int]) -> int:
     if error_code == 429:
         return EXHAUSTED_TTL_429_SECONDS
     return EXHAUSTED_TTL_DEFAULT_SECONDS
+
+
+# Patterns that indicate a permanent auth failure — the credential will never
+# recover and should be permanently removed from rotation (STATUS_DEAD) rather
+# than given a cooldown window.
+_PERMANENT_AUTH_PATTERNS: tuple[str, ...] = (
+    "token_invalidated",
+    "token_revoked",
+    "invalid_api_key",
+    "api key has been revoked",
+    "api key is invalid",
+    "api key not found",
+    "key has been deactivated",
+    "account has been deactivated",
+    "account is deactivated",
+)
+
+
+def _is_permanent_auth_failure(
+    status_code: Optional[int],
+    error_context: Optional[Dict[str, Any]],
+) -> bool:
+    """Return True if the error is a permanent auth failure that warrants STATUS_DEAD.
+
+    Checks both the status code (401/403) and the error message for patterns
+    that indicate the credential itself is terminally invalid (revoked, deactivated,
+    invalidated) — as opposed to a transient token expiry that refresh can fix.
+    """
+    if status_code not in (401, 403):
+        return False
+    if not error_context:
+        return False
+    # Combine all message-like fields for pattern matching
+    haystack = " ".join(
+        str(error_context.get(k) or "").lower()
+        for k in ("message", "reason", "code", "error")
+    )
+    return any(p in haystack for p in _PERMANENT_AUTH_PATTERNS)
 
 
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:
@@ -445,6 +484,30 @@ class CredentialPool:
         error_context: Optional[Dict[str, Any]] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
+
+        # Permanent auth failures (revoked, invalidated, deactivated keys) are
+        # terminal — the credential will never recover.  Mark as STATUS_DEAD
+        # with no reset_at so it never re-enters rotation.
+        if _is_permanent_auth_failure(status_code, error_context):
+            _label = entry.label or entry.id[:8]
+            logger.info(
+                "credential pool: marking %s DEAD (permanent auth failure: %s)",
+                _label,
+                normalized_error.get("message", "(no message)")[:120],
+            )
+            updated = replace(
+                entry,
+                last_status=STATUS_DEAD,
+                last_status_at=time.time(),
+                last_error_code=status_code,
+                last_error_reason=normalized_error.get("reason"),
+                last_error_message=normalized_error.get("message"),
+                last_error_reset_at=None,  # No cooldown — permanent
+            )
+            self._replace_entry(entry, updated)
+            self._persist()
+            return updated
+
         updated = replace(
             entry,
             last_status=STATUS_EXHAUSTED,
@@ -1203,6 +1266,9 @@ class CredentialPool:
                 if synced is not entry:
                     entry = synced
                     cleared_any = True
+            # STATUS_DEAD: permanently removed from rotation — never re-enter.
+            if entry.last_status == STATUS_DEAD:
+                continue
             if entry.last_status == STATUS_EXHAUSTED:
                 exhausted_until = _exhausted_until(entry)
                 if exhausted_until is not None and now < exhausted_until:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -689,6 +689,26 @@ def _classify_by_status(
         # the retryability check in run_agent.py.  If those succeed, the
         # loop `continue`s.  If they fail, retryable=False ensures we
         # hit the client-error abort path (which tries fallback first).
+        #
+        # Permanent auth failures (revoked/invalidated keys) get a
+        # distinct classification so the credential pool can mark them
+        # as terminally dead instead of putting them in cooldown rotation.
+        _PERMANENT_401_SIGNALS = (
+            "token_invalidated",
+            "token_revoked",
+            "invalid_api_key",
+            "api key has been revoked",
+            "api key is invalid",
+            "api key not found",
+            "key has been deactivated",
+        )
+        if any(s in error_msg for s in _PERMANENT_401_SIGNALS):
+            return result_fn(
+                FailoverReason.auth_permanent,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
+            )
         return result_fn(
             FailoverReason.auth,
             retryable=False,

--- a/tests/agent/test_credential_pool_dead_state.py
+++ b/tests/agent/test_credential_pool_dead_state.py
@@ -1,0 +1,312 @@
+"""Tests for STATUS_DEAD: permanent auth failure handling in credential pool.
+
+Verifies that token_invalidated/token_revoked errors cause credentials to be
+permanently removed from rotation (STATUS_DEAD) instead of getting a temporary
+exhausted cooldown (STATUS_EXHAUSTED) that lets them re-enter after 5 minutes.
+
+Issue: https://github.com/NousResearch/hermes-agent/issues/32849
+"""
+
+import json
+import time
+from dataclasses import replace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.credential_pool import (
+    STATUS_DEAD,
+    STATUS_EXHAUSTED,
+    STATUS_OK,
+    CredentialPool,
+    PooledCredential,
+    _is_permanent_auth_failure,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_entry(
+    entry_id: str = "test-1",
+    label: str = "Test Key",
+    last_status: str | None = None,
+) -> PooledCredential:
+    return PooledCredential(
+        provider="openrouter",
+        id=entry_id,
+        label=label,
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="sk-test-fake-key",
+        last_status=last_status,
+    )
+
+
+def _make_pool(n_entries: int = 3) -> CredentialPool:
+    """Create a pool with n_entries fake credentials (no file I/O)."""
+    entries = [
+        _make_entry(entry_id=f"key-{i}", label=f"Key {i}")
+        for i in range(n_entries)
+    ]
+    with patch.object(CredentialPool, "_persist"):
+        pool = CredentialPool.__new__(CredentialPool)
+        pool.provider = "openrouter"
+        pool._entries = entries
+        pool._current_id = entries[0].id
+        pool._strategy = "fill_first"
+        pool._lock = MagicMock()
+        pool._lock.__enter__ = MagicMock(return_value=None)
+        pool._lock.__exit__ = MagicMock(return_value=False)
+        pool._active_leases = {}
+        pool._max_concurrent = 1
+        pool._persist = MagicMock()
+    return pool
+
+
+# ── _is_permanent_auth_failure ──────────────────────────────────────────
+
+
+class TestIsPermanentAuthFailure:
+    """Test the pattern-matching function that distinguishes permanent vs transient."""
+
+    @pytest.mark.parametrize(
+        "message, expected",
+        [
+            ("token_invalidated", True),
+            ("Error: token_invalidated for key", True),
+            ("token_revoked", True),
+            ("The token_revoked error occurred", True),
+            ("invalid_api_key", True),
+            ("API key has been revoked", True),
+            ("API key is invalid", True),
+            ("API key not found", True),
+            ("key has been deactivated", True),
+            # Transient patterns — should NOT be permanent
+            ("token expired", False),
+            ("Token has been invalidated", False),  # spaces, not underscore — not our pattern
+            ("authentication required", False),
+            ("unauthorized access", False),
+            ("rate limit exceeded", False),
+            ("", False),
+        ],
+    )
+    def test_message_patterns(self, message: str, expected: bool):
+        ctx = {"message": message, "reason": "", "code": "", "error": ""}
+        assert _is_permanent_auth_failure(401, ctx) is expected
+
+    def test_reason_field_also_checked(self):
+        ctx = {"message": "", "reason": "token_invalidated", "code": "", "error": ""}
+        assert _is_permanent_auth_failure(401, ctx) is True
+
+    def test_error_field_also_checked(self):
+        ctx = {"message": "", "reason": "", "code": "", "error": "token_revoked"}
+        assert _is_permanent_auth_failure(401, ctx) is True
+
+    def test_non_401_status_not_permanent(self):
+        ctx = {"message": "token_revoked", "reason": "", "code": "", "error": ""}
+        # 429 with "token_revoked" in message — not an auth status code
+        assert _is_permanent_auth_failure(429, ctx) is False
+
+    def test_403_can_be_permanent(self):
+        ctx = {"message": "account is deactivated", "reason": "", "code": "", "error": ""}
+        assert _is_permanent_auth_failure(403, ctx) is True
+
+    def test_none_context_not_permanent(self):
+        assert _is_permanent_auth_failure(401, None) is False
+
+    def test_empty_context_not_permanent(self):
+        assert _is_permanent_auth_failure(401, {}) is False
+
+
+# ── _mark_exhausted → STATUS_DEAD ──────────────────────────────────────
+
+
+class TestMarkExhaustedDead:
+    """Test that _mark_exhausted uses STATUS_DEAD for permanent failures."""
+
+    def test_permanent_401_gets_dead_status(self):
+        pool = _make_pool(2)
+        entry = pool._entries[0]
+
+        error_ctx = {
+            "message": "token_invalidated: the API key has been revoked",
+            "reason": "token_invalidated",
+        }
+        updated = pool._mark_exhausted(entry, status_code=401, error_context=error_ctx)
+
+        assert updated.last_status == STATUS_DEAD
+        assert updated.last_error_reset_at is None  # No cooldown
+        assert updated.last_error_code == 401
+
+    def test_transient_401_gets_exhausted_status(self):
+        pool = _make_pool(2)
+        entry = pool._entries[0]
+
+        error_ctx = {
+            "message": "Unauthorized: token expired",
+            "reason": "auth",
+        }
+        updated = pool._mark_exhausted(entry, status_code=401, error_context=error_ctx)
+
+        assert updated.last_status == STATUS_EXHAUSTED
+        # reset_at may be None if no provider-supplied timestamp;
+        # _exhausted_until() falls back to last_status_at + TTL
+        from agent.credential_pool import _exhausted_until
+        cooldown = _exhausted_until(updated)
+        assert cooldown is not None and cooldown > time.time()  # Has cooldown window
+
+    def test_429_stays_exhausted(self):
+        pool = _make_pool(2)
+        entry = pool._entries[0]
+
+        error_ctx = {"message": "rate limit exceeded"}
+        updated = pool._mark_exhausted(entry, status_code=429, error_context=error_ctx)
+
+        assert updated.last_status == STATUS_EXHAUSTED
+
+
+# ── _available_entries skips DEAD ──────────────────────────────────────
+
+
+class TestAvailableEntriesSkipsDead:
+    """Test that STATUS_DEAD entries are never returned as available."""
+
+    def test_dead_entry_excluded_from_available(self):
+        pool = _make_pool(3)
+        # Mark first entry as dead
+        dead_entry = replace(pool._entries[0], last_status=STATUS_DEAD)
+        pool._entries[0] = dead_entry
+
+        available = pool._available_entries(clear_expired=True)
+        assert len(available) == 2
+        assert all(e.last_status != STATUS_DEAD for e in available)
+
+    def test_dead_entry_never_resurrects_after_time(self):
+        pool = _make_pool(3)
+        # Mark first entry as dead (with timestamp in the past)
+        dead_entry = replace(
+            pool._entries[0],
+            last_status=STATUS_DEAD,
+            last_status_at=time.time() - 3600,  # 1 hour ago
+        )
+        pool._entries[0] = dead_entry
+
+        # Even with clear_expired=True, dead entries stay dead
+        available = pool._available_entries(clear_expired=True)
+        assert len(available) == 2
+
+    def test_all_dead_returns_empty(self):
+        pool = _make_pool(2)
+        pool._entries = [
+            replace(e, last_status=STATUS_DEAD)
+            for e in pool._entries
+        ]
+
+        available = pool._available_entries(clear_expired=True)
+        assert available == []
+
+
+# ── mark_exhausted_and_rotate with dead ─────────────────────────────────
+
+
+class TestMarkExhaustedAndRotateDead:
+    """Integration test: mark_exhausted_and_rotate correctly handles permanent failures."""
+
+    def test_permanent_failure_rotates_past_dead(self):
+        pool = _make_pool(3)
+
+        error_ctx = {
+            "message": "invalid_api_key: the key has been deactivated",
+            "reason": "invalid_api_key",
+        }
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=401,
+            error_context=error_ctx,
+            api_key_hint="sk-test-fake-key",
+        )
+
+        # Should rotate to a different entry
+        assert next_entry is not None
+        assert next_entry.id != "key-0"
+
+        # Original entry should be dead
+        original = pool._entries[0]
+        assert original.last_status == STATUS_DEAD
+
+    def test_permanent_failure_then_rotation_excludes_dead(self):
+        """After marking dead, subsequent rotations skip the dead entry."""
+        pool = _make_pool(3)
+
+        # Kill key-0
+        error_ctx = {"message": "token_revoked"}
+        pool.mark_exhausted_and_rotate(
+            status_code=401,
+            error_context=error_ctx,
+            api_key_hint="sk-test-fake-key",
+        )
+
+        # Now kill key-1 with a transient error
+        pool._current_id = pool._entries[1].id
+        pool.mark_exhausted_and_rotate(status_code=429)
+
+        # Next available should be key-2, not key-0 (dead)
+        available = pool._available_entries(clear_expired=False)
+        ids = [e.id for e in available]
+        assert "key-0" not in ids  # Dead — excluded
+        assert "key-2" in ids      # Still available
+
+
+# ── error_classifier integration ────────────────────────────────────────
+
+
+class TestErrorClassifierPermanentAuth:
+    """Verify error_classifier returns auth_permanent for permanent 401 errors."""
+
+    def test_token_revoked_classified_permanent(self):
+        from agent.error_classifier import FailoverReason, classify_api_error
+
+        exc = Exception("401 token_revoked: The API key has been invalidated")
+        exc.status_code = 401  # type: ignore[attr-defined]
+        result = classify_api_error(exc)
+        assert result.reason == FailoverReason.auth_permanent
+        assert result.should_rotate_credential is True
+        assert result.retryable is False
+
+    def test_invalid_api_key_classified_permanent(self):
+        from agent.error_classifier import FailoverReason, classify_api_error
+
+        exc = Exception('{"error": {"message": "invalid_api_key", "code": 401}}')
+        exc.status_code = 401  # type: ignore[attr-defined]
+        result = classify_api_error(exc)
+        assert result.reason == FailoverReason.auth_permanent
+
+    def test_transient_401_stays_auth(self):
+        from agent.error_classifier import FailoverReason, classify_api_error
+
+        exc = Exception("Unauthorized: token expired")
+        exc.status_code = 401  # type: ignore[attr-defined]
+        result = classify_api_error(exc)
+        assert result.reason == FailoverReason.auth
+        assert result.reason != FailoverReason.auth_permanent
+
+
+# ── reset_statuses can revive dead entries ──────────────────────────────
+
+
+class TestResetStatusesRevivesDead:
+    """Manual reset (user action) should clear STATUS_DEAD too."""
+
+    def test_reset_clears_dead(self):
+        pool = _make_pool(2)
+        pool._entries[0] = replace(
+            pool._entries[0],
+            last_status=STATUS_DEAD,
+            last_error_code=401,
+            last_error_message="token_revoked",
+        )
+
+        count = pool.reset_statuses()
+        assert count == 1
+        assert pool._entries[0].last_status is None


### PR DESCRIPTION
## Summary

Fixes #32849 — credential pool treats `token_invalidated`/`token_revoked` errors as temporary exhaustion (5min cooldown → re-enter rotation) instead of permanently removing the credential.

## Problem

The credential pool has only two states: `STATUS_OK` and `STATUS_EXHAUSTED`. All 401 errors get a 5-minute cooldown, after which the credential re-enters rotation. For permanently invalid credentials (revoked keys, deactivated accounts), this creates an infinite retry cycle:

1. 401 `token_revoked` → marked `exhausted` (TTL=5min)
2. 5 minutes later → cooldown expires → credential back in rotation
3. GOTO 1

## Solution

Three-layer defense:

| Layer | File | Change |
|-------|------|--------|
| **Classification** | `error_classifier.py` | 401 messages containing `token_revoked`, `invalid_api_key`, `key has been deactivated`, etc. → `FailoverReason.auth_permanent` (instead of `auth`) |
| **State** | `credential_pool.py` | New `STATUS_DEAD = "dead"` terminal state. `_mark_exhausted()` uses `STATUS_DEAD` for permanent failures (no `reset_at`). `_available_entries()` permanently skips DEAD entries. `reset_statuses()` can still revive (manual user action). |
| **Recovery** | `agent_runtime_helpers.py` | `auth_permanent` path skips the OAuth refresh attempt entirely and goes straight to mark-as-dead + rotate. |

## Testing

- **33 new tests** in `test_credential_pool_dead_state.py`
- **150 existing** `test_error_classifier.py` tests all pass (zero regression)

### Test coverage

- `_is_permanent_auth_failure()`: pattern matching for 15 message variants
- `_mark_exhausted()`: permanent → DEAD, transient → EXHAUSTED, 429 → EXHAUSTED
- `_available_entries()`: DEAD entries never returned, never resurrect after time
- `mark_exhausted_and_rotate()`: integration test with rotation
- `error_classifier`: `token_revoked` → `auth_permanent`, transient 401 stays `auth`
- `reset_statuses()`: manual reset can revive DEAD entries

## Checklist

- [x] Code follows project style (ruff check passes)
- [x] Tests added and passing (33/33)
- [x] No regression in existing tests (150/150 error_classifier tests pass)
- [x] Minimal diff — 108 lines added, 0 removed across 3 source files
