### PR TITLE
feat(memory/mem0): config knobs for turn-sync and LLM extraction

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -28,6 +28,20 @@ Config file: `$HERMES_HOME/mem0.json`
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `true` | Enable reranking for recall |
+| `auto_sync_turns` | `true` | Write every turn to Mem0. Set `false` to skip turn-by-turn writes entirely — only explicit `mem0_conclude` calls will store memories. |
+| `auto_extract_facts` | `true` | When `auto_sync_turns` is `true`, controls whether Mem0's server-side LLM extracts facts from each turn (`true`, legacy) or stores the messages verbatim (`false`). No effect when `auto_sync_turns` is `false`. |
+
+### Reducing noise
+
+For long-running gateway or CLI sessions, the default behaviour can grow
+your Mem0 store with low-value entries (extracted "User …" facts or
+verbatim chat lines). Two recommended overrides:
+
+- **Quiet store, server-side extraction off:** `auto_sync_turns: true`,
+  `auto_extract_facts: false`. Every turn is written verbatim — searchable
+  but not LLM-summarized.
+- **Manual-only:** `auto_sync_turns: false`. Mem0 only stores what you
+  explicitly call `mem0_conclude` on.
 
 ## Tools
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -52,6 +52,15 @@ def _load_config() -> dict:
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "rerank": True,
         "keyword_search": False,
+        # Whether to write every turn to Mem0 for server-side fact extraction.
+        # Defaults to True (legacy behaviour). Set False to skip turn-by-turn
+        # writes entirely — only mem0_conclude() will store memories.
+        "auto_sync_turns": True,
+        # When auto_sync_turns is True, controls whether Mem0's server-side
+        # LLM extracts facts from the turn (True, legacy) or just stores
+        # the messages verbatim (False). Has no effect when auto_sync_turns
+        # is False.
+        "auto_extract_facts": True,
     }
 
     config_path = get_hermes_home() / "mem0.json"
@@ -127,6 +136,8 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = "hermes-user"
         self._agent_id = "hermes"
         self._rerank = True
+        self._auto_sync_turns = True
+        self._auto_extract_facts = True
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
@@ -163,6 +174,8 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
+            {"key": "auto_sync_turns", "description": "Write every turn to Mem0 (set false to only store via mem0_conclude)", "default": "true", "choices": ["true", "false"]},
+            {"key": "auto_extract_facts", "description": "Run Mem0 server-side LLM fact extraction on turn writes", "default": "true", "choices": ["true", "false"]},
         ]
 
     def _get_client(self):
@@ -208,6 +221,8 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
         self._agent_id = self._config.get("agent_id", "hermes")
         self._rerank = self._config.get("rerank", True)
+        self._auto_sync_turns = bool(self._config.get("auto_sync_turns", True))
+        self._auto_extract_facts = bool(self._config.get("auto_extract_facts", True))
 
     def _read_filters(self) -> Dict[str, Any]:
         """Filters for search/get_all — scoped to user only for cross-session recall."""
@@ -270,7 +285,16 @@ class Mem0MemoryProvider(MemoryProvider):
         self._prefetch_thread.start()
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
+        """Send the turn to Mem0 for server-side fact extraction (non-blocking).
+
+        Gated by ``auto_sync_turns`` (default True). When False, this method
+        becomes a no-op and only explicit ``mem0_conclude`` calls write to
+        Mem0. ``auto_extract_facts`` (default True) controls whether the
+        Mem0 server runs LLM fact extraction on the turn (passed through
+        as the ``infer`` kwarg).
+        """
+        if not self._auto_sync_turns:
+            return
         if self._is_breaker_open():
             return
 
@@ -281,7 +305,11 @@ class Mem0MemoryProvider(MemoryProvider):
                     {"role": "user", "content": user_content},
                     {"role": "assistant", "content": assistant_content},
                 ]
-                client.add(messages, **self._write_filters())
+                client.add(
+                    messages,
+                    **self._write_filters(),
+                    infer=self._auto_extract_facts,
+                )
                 self._record_success()
             except Exception as e:
                 self._record_failure()

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -91,6 +91,8 @@ class TestMem0FiltersV2:
         call = client.captured_add[0]
         assert call["user_id"] == "u123"
         assert call["agent_id"] == "hermes"
+        # Default: auto_extract_facts=True, so infer should be True
+        assert call["infer"] is True
 
     def test_conclude_uses_write_filters(self, monkeypatch):
         client = FakeClientV2()
@@ -225,3 +227,110 @@ class TestMem0Defaults:
         provider.initialize("test")
 
         assert provider._agent_id == "hermes"
+
+    def test_default_auto_sync_turns_true(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+
+        assert provider._auto_sync_turns is True
+
+    def test_default_auto_extract_facts_true(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+
+        assert provider._auto_extract_facts is True
+
+
+# ---------------------------------------------------------------------------
+# Plan B knobs: auto_sync_turns + auto_extract_facts
+# ---------------------------------------------------------------------------
+
+
+class TestMem0SyncGating:
+    """auto_sync_turns and auto_extract_facts control sync_turn write behaviour."""
+
+    def _make_provider(self, monkeypatch, client, *, auto_sync_turns=True, auto_extract_facts=True):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._auto_sync_turns = auto_sync_turns
+        provider._auto_extract_facts = auto_extract_facts
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_sync_turn_noop_when_auto_sync_turns_false(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client, auto_sync_turns=False)
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+        # No worker thread should have been started — but guard with a join if it was.
+        if provider._sync_thread is not None:
+            provider._sync_thread.join(timeout=2)
+
+        assert client.captured_add == []
+
+    def test_sync_turn_passes_infer_false_when_extract_disabled(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(
+            monkeypatch, client, auto_sync_turns=True, auto_extract_facts=False
+        )
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+        provider._sync_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+        assert client.captured_add[0]["infer"] is False
+
+    def test_sync_turn_passes_infer_true_when_extract_enabled(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(
+            monkeypatch, client, auto_sync_turns=True, auto_extract_facts=True
+        )
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+        provider._sync_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+        assert client.captured_add[0]["infer"] is True
+
+    def test_conclude_always_uses_infer_false_regardless_of_extract_flag(self, monkeypatch):
+        """mem0_conclude is the 'store verbatim' contract — must never run extraction."""
+        client = FakeClientV2()
+        provider = self._make_provider(
+            monkeypatch, client, auto_sync_turns=False, auto_extract_facts=True
+        )
+
+        provider.handle_tool_call("mem0_conclude", {"conclusion": "fact A"})
+
+        assert len(client.captured_add) == 1
+        assert client.captured_add[0]["infer"] is False
+
+    def test_config_load_picks_up_auto_sync_turns_from_json(self, monkeypatch, tmp_path):
+        """mem0.json overrides should set _auto_sync_turns on initialize()."""
+        import json as _json
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(_json.dumps({"auto_sync_turns": False}))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+
+        assert provider._auto_sync_turns is False
+
+    def test_config_load_picks_up_auto_extract_facts_from_json(self, monkeypatch, tmp_path):
+        import json as _json
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(_json.dumps({"auto_extract_facts": False}))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test")
+
+        assert provider._auto_extract_facts is False


### PR DESCRIPTION
Add two knobs to plugins/memory/mem0:

- auto_sync_turns (default: true) — when false, sync_turn becomes a no-op and only explicit mem0_conclude() calls write to Mem0.
- auto_extract_facts (default: true) — when auto_sync_turns is true, controls whether Mem0's server-side LLM extracts facts from each turn (passed as the 'infer' kwarg to client.add).

Both default to true so behaviour is unchanged for existing users. Long-running gateway/CLI sessions can opt into a quieter store by flipping one or both off via $HERMES_HOME/mem0.json:

  {"auto_extract_facts": false}   # store turns verbatim, no extraction
  {"auto_sync_turns": false}      # only mem0_conclude writes anything

mem0_conclude continues to use infer=False unconditionally — it's the 'store verbatim' contract regardless of the auto_extract_facts setting.

Tests cover all four combinations plus config-load from mem0.json.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

