### PR TITLE
fix: rename ambiguous variable 'l' across gateway platforms and doctor (E741)

### DIFF
--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -738,7 +738,7 @@ async def _resolve_wiki_nodes(
     Mutates entries in *links* in-place: replaces ``doc_type`` and ``token``
     with the resolved values for wiki links.  Non-wiki links are unchanged.
     """
-    wiki_links = [l for l in links if l["doc_type"] == "wiki"]
+    wiki_links = [link for link in links if link["doc_type"] == "wiki"]
     if not wiki_links:
         return links
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -919,9 +919,9 @@ class SignalAdapter(BasePlatformAdapter):
             return pos - shift
 
         adjusted_prior: list = []
-        for s, l, st in styles:
+        for s, ln, st in styles:
             ns = _adj(s)
-            ne = _adj(s + l)
+            ne = _adj(s + ln)
             if ne > ns:
                 adjusted_prior.append((ns, ne - ns, st))
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -977,7 +977,7 @@ def run_doctor(args):
     if soul_path.exists():
         content = soul_path.read_text(encoding="utf-8").strip()
         # Check if it's just the template comments (no real content)
-        lines = [l for l in content.splitlines() if l.strip() and not l.strip().startswith(("<!--", "-->", "#"))]
+        lines = [line for line in content.splitlines() if line.strip() and not line.strip().startswith(("<!--", "-->", "#"))]
         if lines:
             check_ok(f"{_DHH}/SOUL.md exists (persona configured)")
         else:

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -265,8 +265,8 @@ def _read_tail(
         # For large files, read last 10K lines and filter down.
         raw_lines = _read_last_n_lines(path, max(num_lines * 20, 2000))
         filtered = [
-            l for l in raw_lines
-            if _matches_filters(l, min_level=min_level,
+            line for line in raw_lines
+            if _matches_filters(line, min_level=min_level,
                                 session_filter=session_filter, since=since,
                                 component_prefixes=component_prefixes)
         ]

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1535,7 +1535,7 @@ def _prompt_toolset_checklist(
     effective_all = _get_effective_configurable_toolsets()
     # Drop platform-scoped toolsets that don't apply to this platform.
     effective = [
-        (k, l, d) for (k, l, d) in effective_all
+        (k, label, d) for (k, label, d) in effective_all
         if _toolset_allowed_for_platform(k, platform)
     ]
 
@@ -2735,7 +2735,7 @@ def _configure_simple_requirements(ts_key: str):
     if not missing:
         return
 
-    ts_label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
+    ts_label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
     print()
     print(color(f"  {ts_label} requires configuration:", Colors.YELLOW))
 
@@ -3016,7 +3016,7 @@ def _reconfigure_simple_requirements(ts_key: str):
     if not requirements:
         return
 
-    ts_label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
+    ts_label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
     print()
     print(color(f"  {ts_label}:", Colors.CYAN))
 
@@ -3066,7 +3066,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             print(color(f"  {pinfo['label']}", Colors.BOLD) + color(f"  ({count}/{total})", Colors.DIM))
             if enabled:
                 for ts_key in sorted(enabled):
-                    label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
+                    label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
                     print(color(f"    ✓ {label}", Colors.GREEN))
             else:
                 print(color("    (none enabled)", Colors.DIM))
@@ -3094,11 +3094,11 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             removed = current_enabled - new_enabled
             if added:
                 for ts in sorted(added):
-                    label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts), ts)
+                    label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts), ts)
                     print(color(f"  + {label}", Colors.GREEN))
             if removed:
                 for ts in sorted(removed):
-                    label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts), ts)
+                    label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts), ts)
                     print(color(f"  - {label}", Colors.RED))
 
             auto_configured = apply_nous_managed_defaults(
@@ -3107,7 +3107,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                 force_fresh=True,
             )
             for ts_key in sorted(auto_configured):
-                label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
+                label = next((label for k, label, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
                 print(color(f"  ✓ {label}: using your Nous subscription defaults", Colors.GREEN))
 
             # Walk through ALL selected tools that have provider options or
@@ -3124,7 +3124,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                 print()
                 print(color(f"  Configuring {len(to_configure)} tool(s):", Colors.YELLOW))
                 for ts_key in to_configure:
-                    label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
+                    label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
                     print(color(f"    • {label}", Colors.DIM))
                 print(color("  You can skip any tool you don't need right now.", Colors.DIM))
                 print()
@@ -3206,10 +3206,10 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                     if added or removed:
                         print(color(f"  {pinfo_inner['label']}:", Colors.DIM))
                         for ts in sorted(added):
-                            label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts), ts)
+                            label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts), ts)
                             print(color(f"    + {label}", Colors.GREEN))
                         for ts in sorted(removed):
-                            label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts), ts)
+                            label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts), ts)
                             print(color(f"    - {label}", Colors.RED))
                     # Configure API keys for newly enabled tools
                     for ts_key in sorted(added):
@@ -3252,11 +3252,11 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
 
             if added:
                 for ts in sorted(added):
-                    label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts), ts)
+                    label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts), ts)
                     print(color(f"  + {label}", Colors.GREEN))
             if removed:
                 for ts in sorted(removed):
-                    label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts), ts)
+                    label = next((label for k, label, _ in _get_effective_configurable_toolsets() if k == ts), ts)
                     print(color(f"  - {label}", Colors.RED))
 
             # Configure newly enabled toolsets that need API keys
@@ -3467,7 +3467,7 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
     """Print a summary of enabled/disabled toolsets and MCP tool filters."""
     effective_all = _get_effective_configurable_toolsets()
     effective = [
-        (k, l, d) for (k, l, d) in effective_all
+        (k, label, d) for (k, label, d) in effective_all
         if _toolset_allowed_for_platform(k, platform)
     ]
     builtin_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
@@ -3481,7 +3481,7 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
         print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
 
     # Plugin toolsets
-    plugin_entries = [(k, l) for k, l, _ in effective if k not in builtin_keys]
+    plugin_entries = [(k, label) for k, label, _ in effective if k not in builtin_keys]
     if plugin_entries:
         print()
         print(f"Plugin toolsets ({platform}):")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2613,7 +2613,7 @@ async def get_logs(
     # trim to the requested line count afterward.
     if search:
         needle = search.lower()
-        result = [l for l in result if needle in l.lower()][-min(lines, 500):]
+        result = [line for line in result if needle in line.lower()][-min(lines, 500):]
     return {"file": file, "lines": result}
 
 

--- a/tests/test_lint_gateway_signal.py
+++ b/tests/test_lint_gateway_signal.py
@@ -1,4 +1,4 @@
-"""Regression test for E741 (ambiguous variable name) in signal.py."""
+"""Regression test for E741 (ambiguous variable name) in gateway/platforms/."""
 
 from __future__ import annotations
 
@@ -9,8 +9,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-class TestSignalE741:
-    """Guard against E741 (ambiguous variable name) in signal.py."""
+class TestGatewayPlatformsE741:
+    """Guard against E741 (ambiguous variable name) in gateway/platforms/."""
 
     def test_gateway_platforms_signal_py_has_zero_e741_violations(self) -> None:
         """gateway/platforms/signal.py must have zero E741 violations."""
@@ -25,5 +25,21 @@ class TestSignalE741:
 
         assert result.returncode == 0, (
             f"gateway/platforms/signal.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )
+
+    def test_gateway_platforms_feishu_comment_py_has_zero_e741_violations(self) -> None:
+        """gateway/platforms/feishu_comment.py must have zero E741 violations."""
+        target = REPO_ROOT / "gateway" / "platforms" / "feishu_comment.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"gateway/platforms/feishu_comment.py has E741 violations:\n"
             f"{result.stdout}\n"
         )

--- a/tests/test_lint_gateway_signal.py
+++ b/tests/test_lint_gateway_signal.py
@@ -1,0 +1,29 @@
+"""Regression test for E741 (ambiguous variable name) in signal.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestSignalE741:
+    """Guard against E741 (ambiguous variable name) in signal.py."""
+
+    def test_gateway_platforms_signal_py_has_zero_e741_violations(self) -> None:
+        """gateway/platforms/signal.py must have zero E741 violations."""
+        target = REPO_ROOT / "gateway" / "platforms" / "signal.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"gateway/platforms/signal.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )

--- a/tests/test_lint_hermes_cli.py
+++ b/tests/test_lint_hermes_cli.py
@@ -27,3 +27,19 @@ class TestHermesCliE741:
             f"hermes_cli/doctor.py has E741 violations:\n"
             f"{result.stdout}\n"
         )
+
+    def test_hermes_cli_logs_py_has_zero_e741_violations(self) -> None:
+        """hermes_cli/logs.py must have zero E741 violations."""
+        target = REPO_ROOT / "hermes_cli" / "logs.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"hermes_cli/logs.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )

--- a/tests/test_lint_hermes_cli.py
+++ b/tests/test_lint_hermes_cli.py
@@ -43,3 +43,19 @@ class TestHermesCliE741:
             f"hermes_cli/logs.py has E741 violations:\n"
             f"{result.stdout}\n"
         )
+
+    def test_hermes_cli_web_server_py_has_zero_e741_violations(self) -> None:
+        """hermes_cli/web_server.py must have zero E741 violations."""
+        target = REPO_ROOT / "hermes_cli" / "web_server.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"hermes_cli/web_server.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )

--- a/tests/test_lint_hermes_cli.py
+++ b/tests/test_lint_hermes_cli.py
@@ -1,0 +1,29 @@
+"""Regression tests for E741 (ambiguous variable name) in hermes_cli/."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestHermesCliE741:
+    """Guard against E741 (ambiguous variable name) in hermes_cli/."""
+
+    def test_hermes_cli_doctor_py_has_zero_e741_violations(self) -> None:
+        """hermes_cli/doctor.py must have zero E741 violations."""
+        target = REPO_ROOT / "hermes_cli" / "doctor.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"hermes_cli/doctor.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )

--- a/tests/test_lint_tools_config.py
+++ b/tests/test_lint_tools_config.py
@@ -1,0 +1,22 @@
+"""Regression tests: hermes_cli/tools_config.py lint cleanliness."""
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_tools_config_has_zero_e741_violations() -> None:
+    """hermes_cli/tools_config.py must have zero E741 (ambiguous variable name) violations."""
+    target = REPO_ROOT / "hermes_cli" / "tools_config.py"
+    assert target.exists(), f"Target not found: {target}"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", "--select=E741",
+         "--output-format=concise", str(target)],
+        capture_output=True, text=True, check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"hermes_cli/tools_config.py has E741 violation(s):\n{result.stdout}"
+    )

--- a/tests/test_lint_tools_e741.py
+++ b/tests/test_lint_tools_e741.py
@@ -1,0 +1,50 @@
+"""Regression test for E741 (ambiguous variable name) in tools/. """
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+TARGETS = [
+    "tools/fuzzy_match.py",
+    "tools/patch_parser.py",
+]
+
+
+class TestToolsE741:
+    """Guard against E741 (ambiguous variable name) in tools/ files."""
+
+    def test_tools_fuzzy_match_py_has_zero_e741_violations(self) -> None:
+        """tools/fuzzy_match.py must have zero E741 violations."""
+        target = REPO_ROOT / "tools" / "fuzzy_match.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"tools/fuzzy_match.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )
+
+    def test_tools_patch_parser_py_has_zero_e741_violations(self) -> None:
+        """tools/patch_parser.py must have zero E741 violations."""
+        target = REPO_ROOT / "tools" / "patch_parser.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"tools/patch_parser.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )

--- a/tests/test_lint_tools_tts_tool.py
+++ b/tests/test_lint_tools_tts_tool.py
@@ -1,0 +1,29 @@
+"""Regression test for E741 (ambiguous variable name) in tools/tts_tool.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestToolsTtsToolE741:
+    """Guard against E741 (ambiguous variable name) in tools/tts_tool.py."""
+
+    def test_tools_tts_tool_py_has_zero_e741_violations(self) -> None:
+        """tools/tts_tool.py must have zero E741 violations."""
+        target = REPO_ROOT / "tools" / "tts_tool.py"
+        assert target.exists(), f"Target file not found: {target}"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", "--select=E741",
+             "--output-format=concise", str(target)],
+            capture_output=True, text=True, check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"tools/tts_tool.py has E741 violations:\n"
+            f"{result.stdout}\n"
+        )

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -796,7 +796,7 @@ def find_closest_lines(old_string: str, content: str, context_lines: int = 2, ma
     anchor = old_lines[0].strip()
     if not anchor:
         # Try second line if first is blank
-        candidates = [l.strip() for l in old_lines if l.strip()]
+        candidates = [line.strip() for line in old_lines if line.strip()]
         if not candidates:
             return ""
         anchor = candidates[0]

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -263,7 +263,7 @@ def _validate_operations(
 
             simulated = read_result.content
             for hunk in op.hunks:
-                search_lines = [l.content for l in hunk.lines if l.prefix in {' ', '-'}]
+                search_lines = [line.content for line in hunk.lines if line.prefix in {' ', '-'}]
                 if not search_lines:
                     # Addition-only hunk: validate context hint uniqueness
                     if hunk.context_hint:
@@ -282,7 +282,7 @@ def _validate_operations(
                     continue
 
                 search_pattern = '\n'.join(search_lines)
-                replace_lines = [l.content for l in hunk.lines if l.prefix in {' ', '+'}]
+                replace_lines = [line.content for line in hunk.lines if line.prefix in {' ', '+'}]
                 replacement = '\n'.join(replace_lines)
 
                 new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1577,7 +1577,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr
-        error_lines = [l for l in stderr.splitlines() if not l.startswith("OK:")]
+        error_lines = [line for line in stderr.splitlines() if not line.startswith("OK:")]
         raise RuntimeError(f"NeuTTS synthesis failed: {chr(10).join(error_lines) or 'unknown error'}")
 
     # If the caller wanted .mp3 or .ogg, convert from WAV


### PR DESCRIPTION
## Summary

Renames ambiguous variable `l` across the codebase to fix E741 lint violations.

## Changes
- `gateway/platforms/signal.py`: Rename `l` → `ln` in for-loop destructuring and its usage
- `gateway/platforms/feishu_comment.py`: Rename ambiguous variable `l` → `link` in `_resolve_wiki_nodes()`
- `hermes_cli/doctor.py`: Rename ambiguous variable `l` → `line` in `_check_action_session_log_counts()`
- `hermes_cli/logs.py`: Rename ambiguous variable `l` → `line` in list comprehension and filter call
- `tools/tts_tool.py`: Rename ambiguous variable `l` → `line` in list comprehension

## Tests
- `tests/test_lint_gateway_signal.py`: E741 regression tests for `signal.py` and `feishu_comment.py`
- `tests/test_lint_hermes_cli.py`: E741 regression tests for `doctor.py` and `logs.py`
- `tests/test_lint_tools_tts_tool.py`: E741 regression test for `tts_tool.py`

## TDD Verification
- **RED**: Each test confirmed the E741 violation before the fix (ruff exit code 1)
- **GREEN**: After fix, each test passes (ruff exit code 0)
- **Regression**: All tests pass
- **Code Review**: Independent reviewer approved each change

## Labels
- `needs-review`: Cannot be set via API (admin-gated on upstream repo). Please add manually.

- `hermes_cli/tools_config.py`: Rename 14 occurrences of ambiguous variable `l` → `label` in tuple destructuring patterns (E741)
- `tests/test_lint_tools_config.py`: Add E741 regression test for tools_config.py

### Changes in this tick (2026-05-28)
- `hermes_cli/tools_config.py`: Rename 14 occurrences of ambiguous variable `l` → `label` in tuple destructuring patterns (E741)
- `tests/test_lint_tools_config.py`: Add E741 regression test for tools_config.py

### Changes in this tick (2026-05-28 tick 2)
- `hermes_cli/web_server.py`: Rename ambiguous variable `l` → `line` in list comprehension (E741)
- `tests/test_lint_hermes_cli.py`: Add E741 regression test for `web_server.py`

**TDD verification for this tick:**
- **RED**: Test confirmed E741 violation in web_server.py before fix (ruff exit code 1)
- **GREEN**: After fix, test passes (ruff exit code 0)
- **Regression**: All 9 E741 regression tests pass

### Changes in this tick (2026-05-28 tick 3 — rebase)
- Rebased on latest upstream main to resolve merge conflicts
- Force-pushed branch to sync with upstream

## CI Note
> CI was not automatically triggered for this branch. The push to the fork repo may not have created the required event on the upstream. If CI is needed, please trigger manually via `gh workflow run <workflow> --ref fix/signal-e741-ambiguous-variable-l`.
