### PR TITLE
docs(xai-oauth): note bare-code manual-paste form from #33880

### DIFF
--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -40,7 +40,7 @@ hermes auth add xai-oauth --manual-paste
 # → Paste it back into the terminal at the "Callback URL:" prompt.
 ```
 
-The same flag works on `hermes model --manual-paste` for the integrated model picker. A bare `?code=...&state=...` query fragment is accepted too if you don't want to paste the whole URL.
+The same flag works on `hermes model --manual-paste` for the integrated model picker. Hermes accepts three callback paste forms interchangeably: the full URL, a bare `?code=...&state=...` query fragment, or — when the upstream consent page renders the authorization code in-page instead of redirecting (xAI's current behavior on browser-based consoles) — just the bare code value on its own.
 
 Hermes uses the **same PKCE verifier, state and nonce** for both paths, so the upstream OAuth flow is byte-identical — `--manual-paste` is purely a transport change for the callback hop and is not a security downgrade.
 

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -94,6 +94,8 @@ hermes model --manual-paste
 
 See [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md#browser-only-remote-cloud-shell--codespaces--ec2-instance-connect) for the full walkthrough. Regression fix for [#26923](https://github.com/NousResearch/hermes-agent/issues/26923).
 
+If the consent page renders the authorization code directly on the page (xAI's current behavior on browser-based consoles) instead of redirecting to your `127.0.0.1:56121/callback`, paste **just the bare code value** at the `Callback URL:` prompt — Hermes accepts the full URL, a bare `?code=...&state=...` query fragment, or a bare code interchangeably.
+
 ## How the Login Works
 
 1. Hermes opens your browser to `accounts.x.ai`.


### PR DESCRIPTION
Adds a short note in both `xai-grok-oauth.md` and `oauth-over-ssh.md` documenting the **bare-code manual-paste** form that #33880 just shipped.

After #33880, `_parse_pasted_callback` accepts three forms (auth.py L3118-3133 docstring):

* full URL — `http://127.0.0.1:56121/callback?code=...&state=...`
* bare query string — `?code=...&state=...`
* **bare code (no state)** — the new form, for upstreams whose consent page renders the authorization code in-page instead of redirecting (xAI's current behavior on Cloud Shell / Codespaces / EC2 Instance Connect / Gitpod, per #26923)

The in-CLI prompt (`hermes auth add xai-oauth --manual-paste`) already mentions the bare-code option (auth.py L3183-3186), but the two user-facing guides still describe only the first two forms, so a user reading docs first will still be waiting for a "failed callback URL page" that xAI no longer produces.

This PR mirrors the in-CLI wording so docs and prompt agree.

If this has already landed via a separate patch, feel free to close + mark accordingly.
