### PR TITLE
fix: allow cron memory provider tool opt-in

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -110,6 +110,30 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         )
         return None
 
+
+def _cron_job_requests_memory_provider_tools(job: dict, cfg: dict) -> bool:
+    """Return True only when cron explicitly opts into memory-provider tools.
+
+    Cron agents skip memory by default so scheduled prompts do not silently
+    corrupt user representations or touch external memory providers.  The
+    resolved default cron toolset may include the legacy ``memory`` tool via
+    composite expansion, so this must inspect only explicit selections: a
+    per-job ``enabled_toolsets`` entry or a saved ``platform_toolsets.cron``
+    list from ``hermes tools``.
+    """
+    per_job = job.get("enabled_toolsets")
+    if isinstance(per_job, list):
+        return "memory" in {str(toolset) for toolset in per_job}
+
+    try:
+        platform_toolsets = (cfg or {}).get("platform_toolsets") or {}
+        cron_toolsets = platform_toolsets.get("cron")
+    except AttributeError:
+        return False
+    if not isinstance(cron_toolsets, list):
+        return False
+    return "memory" in {str(toolset) for toolset in cron_toolsets}
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -1622,6 +1646,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 job_id, _mcp_exc,
             )
 
+        _cron_enabled_toolsets = _resolve_cron_enabled_toolsets(job, _cfg)
+        _cron_memory_opt_in = _cron_job_requests_memory_provider_tools(job, _cfg)
         agent = AIAgent(
             model=model,
             api_key=runtime.get("api_key"),
@@ -1640,7 +1666,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
-            enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
+            enabled_toolsets=_cron_enabled_toolsets,
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
@@ -1649,7 +1675,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            # Cron skips memory by default so scheduled prompts don't silently
+            # corrupt user representations. Jobs that explicitly opt into the
+            # `memory` toolset need the memory manager initialized so provider
+            # tools such as `mnemosyne_recall` can be injected and routed.
+            skip_memory=not _cron_memory_opt_in,
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1021,6 +1021,75 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
 
+    def test_run_job_skips_memory_by_default(self, tmp_path):
+        """Default cron runs should not initialize persistent memory providers."""
+        job = {
+            "id": "default-memory-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is True
+
+    def test_run_job_memory_toolset_initializes_memory_provider_tools(self, tmp_path):
+        """Explicit memory opt-in lets cron expose provider tools.
+
+        Regression: cron passed ``skip_memory=True`` unconditionally, so a job
+        with ``enabled_toolsets=["memory"]`` could get the legacy memory tool
+        but never initialize MemoryManager-backed provider tools such as
+        ``mnemosyne_recall``.
+        """
+        job = {
+            "id": "memory-provider-tool-job",
+            "name": "test",
+            "prompt": "hello",
+            "enabled_toolsets": ["memory"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["enabled_toolsets"] == ["memory"]
+        assert kwargs["skip_memory"] is False
+
+    def test_run_job_platform_memory_toolset_initializes_memory_provider_tools(self, tmp_path):
+        """An explicit cron platform memory toolset is also an opt-in."""
+        (tmp_path / "config.yaml").write_text(
+            "platform_toolsets:\n"
+            "  cron:\n"
+            "    - memory\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "platform-memory-provider-tool-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert "memory" in kwargs["enabled_toolsets"]
+        assert kwargs["skip_memory"] is False
+
     def test_run_job_disabled_toolsets_layer_user_config_on_baseline(self, tmp_path):
         """agent.disabled_toolsets must be honoured in cron — issue #25752.
 


### PR DESCRIPTION
## Summary
- keep cron memory skipped by default, preserving the existing safety invariant
- allow explicit cron memory opt-in (`enabled_toolsets: ["memory"]` or `platform_toolsets.cron`) to initialize MemoryManager-backed provider tools
- add regression coverage for default skip behavior and explicit memory opt-in paths

## Why
Cron jobs pass `skip_memory=True` today, which prevents memory provider tools from being initialized. A cron job can opt into the legacy `memory` toolset but still cannot call provider-backed tools such as `mnemosyne_recall`. This makes memory-aware scheduled jobs fail even when the operator explicitly enabled memory tools.

The change keeps default cron runs isolated from memory providers, but makes explicit memory opt-in meaningful.

## Test Plan
- `python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py`
- `python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='`
