### PR TITLE
fix: replace Optional[callable] with Optional[Callable] in type annotations

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,7 +25,7 @@ import ssl
 import threading
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Callable
 
 from agent.anthropic_adapter import _is_oauth_token
 from agent.auxiliary_client import set_runtime_main
@@ -266,7 +266,7 @@ def run_conversation(
     system_message: str = None,
     conversation_history: List[Dict[str, Any]] = None,
     task_id: str = None,
-    stream_callback: Optional[callable] = None,
+    stream_callback: Optional[Callable[[str], None]] = None,
     persist_user_message: Optional[str] = None,
 ) -> Dict[str, Any]:
     """

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -117,7 +117,7 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
-        on_new_message: Optional[callable] = None,
+        on_new_message: Optional[Callable[[], None]] = None,
         initial_reply_to_id: Optional[str] = None,
     ):
         self.adapter = adapter

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -17,7 +17,7 @@ import os
 import sys
 import time
 import logging
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import requests
 
@@ -107,7 +107,7 @@ def wait_for_registration_success(
     device_code: str,
     interval: int = 3,
     expires_in: int = 7200,
-    on_waiting: Optional[callable] = None,
+    on_waiting: Optional[Callable[[], None]] = None,
 ) -> Tuple[str, str]:
     """Block until the registration succeeds or times out.
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -26,7 +26,7 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
     from hermes_constants import get_hermes_home
@@ -340,7 +340,7 @@ def quick() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def deep(
-    confirm: Optional[callable] = None,
+    confirm: Optional[Callable[[Dict[str, Any]], bool]] = None,
 ) -> Dict[str, Any]:
     """Deep cleanup.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -51,7 +51,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Callable
 from urllib.parse import urlparse, parse_qs, urlunparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
@@ -4188,14 +4188,14 @@ class AIAgent:
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
         task_id: str = None,
-        stream_callback: Optional[callable] = None,
+        stream_callback: Optional[Callable[[str], None]] = None,
         persist_user_message: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
         return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
 
-    def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
+    def chat(self, message: str, stream_callback: Optional[Callable[[str], None]] = None) -> str:
         """
         Simple chat interface that returns just the final response.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -28,7 +28,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from toolsets import TOOLSETS
 
@@ -691,7 +691,7 @@ def _build_child_progress_callback(
     depth: Optional[int] = None,
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
-) -> Optional[callable]:
+) -> Optional[Callable[..., None]]:
     """Build a callback that relays child agent tool calls to the parent display.
 
     Two display paths:


### PR DESCRIPTION
## Problem

The builtin `callable` is not a valid generic type for static type checkers like mypy/pyright. While `Optional[callable]` works at runtime (Python accepts it), it's technically incorrect and would flag errors in strict type-checking mode.

This pattern appeared in 6 files across the codebase.

## Fix

Replace all instances of `Optional[callable]` with the correct `Optional[Callable[...]]` annotation, adding the missing `Callable` import where needed.

### Files changed:
- **hermes_cli/dingtalk_auth.py** — `on_waiting: Optional[Callable[[], None]]`
- **run_agent.py** — `stream_callback: Optional[Callable[[str], None]]` (2 places)
- **agent/conversation_loop.py** — `stream_callback: Optional[Callable[[str], None]]`
- **gateway/stream_consumer.py** — `on_new_message: Optional[Callable[[], None]]` (already had `Callable` imported but used lowercase)
- **tools/delegate_tool.py** — return type `Optional[Callable[..., None]]`
- **plugins/disk-cleanup/disk_cleanup.py** — `confirm: Optional[Callable[[Dict[str, Any]], bool]]`

## Testing
- No runtime behavior change — this is purely a type annotation fix
- All 6 files pass lint checks (no new errors introduced)