### PR TITLE
docs: add MCP registry server metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nousresearch/hermes-agent",
+  "description": "Expose Hermes sessions, messages, search, attachments, and chat control to MCP clients.",
+  "title": "Hermes Agent",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github",
+    "id": "1024554267"
+  },
+  "version": "0.14.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "hermes-agent[mcp]",
+      "version": "0.14.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "HERMES_HOME",
+          "description": "Optional Hermes profile/config directory to expose sessions from. Defaults to ~/.hermes.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "tool": "manual-pr",
+      "version": "1.0.0",
+      "notes": "Hermes MCP support is provided by the hermes mcp serve subcommand. Some clients may need fallback install instructions if they do not support PyPI extras in identifiers."
+    }
+  }
+}

--- a/tests/test_mcp_server_json.py
+++ b/tests/test_mcp_server_json.py
@@ -1,0 +1,42 @@
+import json
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_server_json_launches_hermes_mcp_serve_from_pypi_extra():
+    data = json.loads((ROOT / "server.json").read_text())
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+
+
+    assert data["$schema"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+    assert data["name"] == "io.github.nousresearch/hermes-agent"
+    assert data["repository"] == {
+        "url": "https://github.com/NousResearch/hermes-agent",
+        "source": "github",
+        "id": "1024554267",
+    }
+
+    assert data["version"] == project["version"]
+    assert len(data["packages"]) == 1
+    package = data["packages"][0]
+    assert package["registryType"] == "pypi"
+    assert package["registryBaseUrl"] == "https://pypi.org"
+    assert package["identifier"] == f"{project['name']}[mcp]"
+    assert package["version"] == project["version"]
+    assert package["runtimeHint"] == "uvx"
+    assert package["transport"] == {"type": "stdio"}
+    assert package["packageArguments"] == [
+        {"type": "positional", "value": "mcp"},
+        {"type": "positional", "value": "serve"},
+    ]
+
+
+def test_server_json_registry_metadata_stays_small_and_allowed():
+    data = json.loads((ROOT / "server.json").read_text())
+
+    assert set(data["_meta"]) == {"io.modelcontextprotocol.registry/publisher-provided"}
+    publisher_meta = data["_meta"]["io.modelcontextprotocol.registry/publisher-provided"]
+    assert len(json.dumps(publisher_meta).encode()) < 4096


### PR DESCRIPTION
## Summary
- Add root `server.json` metadata for publishing Hermes Agent's MCP server to MCP registries.
- Describe the PyPI/`uvx` launch path using `hermes-agent[mcp]` plus fixed `mcp serve` package arguments.
- Add a small regression test that keeps the registry metadata aligned with `pyproject.toml` and official registry `_meta` constraints.

## Validation
- `python -m pytest tests/test_mcp_server_json.py -q`
- Validated `server.json` with `jsonschema.Draft7Validator` against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`

## Notes
- Some MCP clients may not yet parse PyPI extras in registry identifiers; the publisher metadata calls out that those clients should use fallback install docs.
