### PR TITLE
fix: scan all kanban boards for active workers

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -661,8 +661,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "usage", help="Show token/cost usage by board/task from the project usage ledger",
     )
     p_usage.add_argument("--task", dest="task_id", default=None, help="Drill down to a single task id")
-    p_usage.add_argument("--refresh", action="store_true", help="Refresh the derived ledger before reading")
-    p_usage.add_argument("--no-refresh", dest="no_refresh", action="store_true", help="Read existing ledger rows without backfill")
+    p_usage_refresh = p_usage.add_mutually_exclusive_group()
+    p_usage_refresh.add_argument("--refresh", dest="refresh", action="store_true", default=None, help="Refresh the derived ledger before reading")
+    p_usage_refresh.add_argument("--no-refresh", dest="refresh", action="store_false", help="Read existing ledger rows without backfill")
     p_usage.add_argument("--json", action="store_true")
 
     # --- notify subscribe / list / remove ---
@@ -2368,7 +2369,7 @@ def _cmd_watch(args: argparse.Namespace) -> int:
 def _cmd_usage(args: argparse.Namespace) -> int:
     from hermes_cli import project_usage_ledger as usage
 
-    refresh = bool(getattr(args, "refresh", False)) or not bool(getattr(args, "no_refresh", False))
+    refresh = bool(getattr(args, "refresh", False))
     board = getattr(args, "board", None)
     if board:
         board = kb._normalize_board_slug(board)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -656,6 +656,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_stats.add_argument("--json", action="store_true")
 
+    # --- usage ---
+    p_usage = sub.add_parser(
+        "usage", help="Show token/cost usage by board/task from the project usage ledger",
+    )
+    p_usage.add_argument("--task", dest="task_id", default=None, help="Drill down to a single task id")
+    p_usage.add_argument("--refresh", action="store_true", help="Refresh the derived ledger before reading")
+    p_usage.add_argument("--no-refresh", dest="no_refresh", action="store_true", help="Read existing ledger rows without backfill")
+    p_usage.add_argument("--json", action="store_true")
+
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
         "notify-subscribe",
@@ -939,6 +948,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "daemon":   _cmd_daemon,
         "watch":    _cmd_watch,
         "stats":    _cmd_stats,
+        "usage":   _cmd_usage,
         "log":      _cmd_log,
         "runs":     _cmd_runs,
         "heartbeat": _cmd_heartbeat,
@@ -1891,7 +1901,11 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 conn, tid,
                 result=args.result,
                 summary=summary,
-                metadata=metadata,
+                metadata=(
+                    __import__("hermes_cli.project_usage_ledger", fromlist=["stamp_usage_metadata"])
+                    .stamp_usage_metadata(metadata, os.environ.get("HERMES_SESSION_ID"))
+                    if os.environ.get("HERMES_KANBAN_TASK") == tid else metadata
+                ),
                 expected_run_id=_worker_run_id_for(tid),
             ):
                 failed.append(tid)
@@ -1943,6 +1957,11 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id_for(tid),
+                metadata=(
+                    __import__("hermes_cli.project_usage_ledger", fromlist=["stamp_usage_metadata"])
+                    .stamp_usage_metadata(None, os.environ.get("HERMES_SESSION_ID"))
+                    if os.environ.get("HERMES_KANBAN_TASK") == tid else None
+                ),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
@@ -2326,6 +2345,68 @@ def _cmd_watch(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         print("\n(stopped)")
         return 0
+
+
+def _cmd_usage(args: argparse.Namespace) -> int:
+    from hermes_cli import project_usage_ledger as usage
+
+    refresh = bool(getattr(args, "refresh", False)) or not bool(getattr(args, "no_refresh", False))
+    board = getattr(args, "board", None)
+    if board:
+        board = kb._normalize_board_slug(board)
+    data = usage.get_summary(
+        board=board,
+        task_id=getattr(args, "task_id", None),
+        refresh=refresh,
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+        return 0
+
+    totals = data.get("totals") or {}
+    print("Project usage" + (f" for board {board}" if board else ""))
+    print(f"  ledger: {data.get('ledger_path')}")
+    if data.get("last_backfill_at"):
+        print(f"  refreshed: {_fmt_ts(int(data['last_backfill_at']))}")
+    if data.get("last_backfill_error"):
+        print(f"  warning: {data['last_backfill_error']}")
+    print(
+        "  total: "
+        f"{int(totals.get('input_tokens') or 0)} in / "
+        f"{int(totals.get('output_tokens') or 0)} out / "
+        f"{int(totals.get('reasoning_tokens') or 0)} reasoning / "
+        f"${float(totals.get('estimated_cost_usd') or 0):.4f} est"
+    )
+    print("\nBy board:")
+    for r in data.get("boards") or []:
+        print(
+            f"  {str(r.get('board_slug')):18s} "
+            f"tasks={int(r.get('tasks') or 0):4d} sessions={int(r.get('sessions') or 0):4d} "
+            f"tok={int(r.get('input_tokens') or 0) + int(r.get('output_tokens') or 0):8d} "
+            f"est=${float(r.get('estimated_cost_usd') or 0):.4f}"
+        )
+    tasks = data.get("tasks") or []
+    if tasks:
+        print("\nTop tasks:")
+        for r in tasks[:25]:
+            title = (r.get("task_title") or "")[:60]
+            print(
+                f"  {str(r.get('task_id')):14s} "
+                f"runs={int(r.get('runs') or 0):3d} "
+                f"tok={int(r.get('input_tokens') or 0) + int(r.get('output_tokens') or 0):8d} "
+                f"est=${float(r.get('estimated_cost_usd') or 0):.4f}  {title}"
+            )
+    runs = data.get("runs") or []
+    if runs:
+        print("\nRuns:")
+        for r in runs:
+            print(
+                f"  #{int(r.get('run_id') or 0):4d} {str(r.get('run_outcome') or r.get('run_status') or '-'):12s} "
+                f"session={str(r.get('session_id') or '-')[:20]:20s} "
+                f"tok={int(r.get('input_tokens') or 0) + int(r.get('output_tokens') or 0):8d} "
+                f"est=${float(r.get('estimated_cost_usd') or 0):.4f}"
+            )
+    return 0
 
 
 def _cmd_stats(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1884,7 +1884,12 @@ def _stamp_worker_usage_metadata(task_id: str, metadata: Optional[dict[str, Any]
         )
     except Exception as exc:
         print(f"kanban: usage metadata unavailable: {exc}", file=sys.stderr)
-        return metadata
+        session_id = os.environ.get("HERMES_SESSION_ID")
+        if not session_id:
+            return metadata
+        fallback = dict(metadata or {})
+        fallback["worker_session_id"] = str(session_id)
+        return fallback
 
 
 def _cmd_complete(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1866,6 +1866,27 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
+def _stamp_worker_usage_metadata(task_id: str, metadata: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Best-effort usage metadata stamping for worker terminal events.
+
+    Completing/blocking a Kanban task must remain reliable even if the optional
+    usage ledger path is unavailable or state.db is temporarily locked/corrupt.
+    The native kanban tools already treat usage stamping as best-effort; keep
+    the CLI path equally defensive.
+    """
+    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+        return metadata
+    try:
+        from hermes_cli import project_usage_ledger
+        return project_usage_ledger.stamp_usage_metadata(
+            metadata,
+            os.environ.get("HERMES_SESSION_ID"),
+        )
+    except Exception as exc:
+        print(f"kanban: usage metadata unavailable: {exc}", file=sys.stderr)
+        return metadata
+
+
 def _cmd_complete(args: argparse.Namespace) -> int:
     """Mark one or more tasks done. Supports a single id or a list."""
     ids = list(args.task_ids or [])
@@ -1901,11 +1922,7 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 conn, tid,
                 result=args.result,
                 summary=summary,
-                metadata=(
-                    __import__("hermes_cli.project_usage_ledger", fromlist=["stamp_usage_metadata"])
-                    .stamp_usage_metadata(metadata, os.environ.get("HERMES_SESSION_ID"))
-                    if os.environ.get("HERMES_KANBAN_TASK") == tid else metadata
-                ),
+                metadata=_stamp_worker_usage_metadata(tid, metadata),
                 expected_run_id=_worker_run_id_for(tid),
             ):
                 failed.append(tid)
@@ -1957,11 +1974,7 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id_for(tid),
-                metadata=(
-                    __import__("hermes_cli.project_usage_ledger", fromlist=["stamp_usage_metadata"])
-                    .stamp_usage_metadata(None, os.environ.get("HERMES_SESSION_ID"))
-                    if os.environ.get("HERMES_KANBAN_TASK") == tid else None
-                ),
+                metadata=_stamp_worker_usage_metadata(tid, None),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1879,9 +1879,12 @@ def _stamp_worker_usage_metadata(task_id: str, metadata: Optional[dict[str, Any]
         return metadata
     try:
         from hermes_cli import project_usage_ledger
-        return project_usage_ledger.stamp_usage_metadata(
+        return project_usage_ledger.stamp_worker_usage_metadata(
+            task_id,
             metadata,
-            os.environ.get("HERMES_SESSION_ID"),
+            on_error=lambda exc: print(
+                f"kanban: usage metadata unavailable: {exc}", file=sys.stderr
+            ),
         )
     except Exception as exc:
         print(f"kanban: usage metadata unavailable: {exc}", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5258,7 +5258,7 @@ def _record_task_failure(
                     "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status = 'running'",
+                    "WHERE id = ? AND status IN ('running', 'ready', 'review')",
                     (restore_status, failures, error[:500], task_id),
                 )
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2713,7 +2713,8 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
+        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at, "
+        "       current_run_id "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
         "  AND claim_expires < ?",
@@ -2763,12 +2764,13 @@ def release_stale_claims(
             row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
         )
         with write_txn(conn):
+            restore_status = _status_after_failed_run(conn, row["id"], row["current_run_id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
-                (row["id"], row["claim_lock"], now),
+                (restore_status, row["id"], row["claim_lock"], now),
             )
             if cur.rowcount != 1:
                 continue
@@ -2791,6 +2793,7 @@ def release_stale_claims(
                 ),
                 "now": now,
                 "host_local": host_local,
+                "restore_status": restore_status,
             }
             payload.update(termination)
             _append_event(
@@ -4382,6 +4385,20 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Events that explicitly put a task back into the spawnable ready queue after
+# earlier work. Respawn guards must not treat PR/success evidence from before
+# one of these handoffs as a reason to skip the newly requested implementation
+# pass.
+_RESPAWN_REQUEUE_EVENT_KINDS = (
+    "unblocked",
+    "review_rejected",
+    "promoted",
+    "reclaimed",
+    "crashed",
+    "timed_out",
+    "spawn_failed",
+)
+
 
 @dataclass
 class DispatchResult:
@@ -4795,6 +4812,7 @@ def enforce_max_runtime(
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "sigkill": killed},
+                restore_status=restore_status,
             )
     return timed_out
 
@@ -4980,8 +4998,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # write_txn so can't nest). ``protocol_violation`` flags the
     # clean-exit-but-still-running case so we can trip the breaker
     # immediately instead of incrementing by 1.
-    crash_details: list[tuple[str, int, str, bool, str]] = []
-    # (task_id, pid, claimer, protocol_violation, error_text)
+    crash_details: list[tuple[str, int, str, bool, str, str]] = []
+    # (task_id, pid, claimer, protocol_violation, error_text, restore_status)
     with write_txn(conn):
         rows = conn.execute(
             "SELECT id, worker_pid, claim_lock, started_at, current_run_id FROM tasks "
@@ -5058,7 +5076,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 crashed.append(row["id"])
                 crash_details.append(
                     (row["id"], pid, row["claim_lock"],
-                     protocol_violation, error_text)
+                     protocol_violation, error_text, restore_status)
                 )
     # Outside the main txn: increment the unified failure counter for
     # each crashed task. If the breaker trips, the task transitions
@@ -5074,10 +5092,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
+        for _, _, _, _, err_text, _restore_status in crash_details:
             fp = _error_fingerprint(err_text)
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
+        for tid, pid, claimer, protocol_violation, error_text, restore_status in crash_details:
             fp = _error_fingerprint(error_text)
             is_systemic = (
                 not protocol_violation
@@ -5091,6 +5109,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},
+                restore_status=restore_status,
             )
             if tripped:
                 auto_blocked.append(tid)
@@ -5108,10 +5127,11 @@ def _record_task_failure(
     error: str,
     *,
     outcome: str,
-    failure_limit: int = None,
+    failure_limit: Optional[int] = None,
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    restore_status: Optional[str] = None,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -5162,7 +5182,8 @@ def _record_task_failure(
         failures = int(row["consecutive_failures"]) + 1
         cur_status = row["status"]
         current_run_id = row["current_run_id"] if "current_run_id" in row.keys() else None
-        restore_status = _status_after_failed_run(conn, task_id, current_run_id)
+        if restore_status is None:
+            restore_status = _status_after_failed_run(conn, task_id, current_run_id)
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -5270,7 +5291,7 @@ def _record_spawn_failure(
     task_id: str,
     error: str,
     *,
-    failure_limit: int = None,
+    failure_limit: Optional[int] = None,
 ) -> bool:
     return _record_task_failure(
         conn, task_id, error,
@@ -5324,12 +5345,28 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
-def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
-    """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
+def _latest_respawn_request_at(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
+    """Latest event timestamp that deliberately returned a task to ready.
 
-    Called per ready task in ``dispatch_once`` before any claim attempt.
-    Returning a reason defers the spawn this tick; the task stays in
-    ``ready`` and gets another chance on the next dispatcher tick.
+    Respawn guards exist to avoid duplicating work after a recent successful
+    run or PR-opening handoff. They should not suppress a later review
+    rejection or manual unblock that explicitly asks the implementation lane
+    to run again on the same task.
+    """
+    placeholders = ", ".join("?" for _ in _RESPAWN_REQUEUE_EVENT_KINDS)
+    row = conn.execute(
+        f"SELECT MAX(created_at) AS ts FROM task_events "
+        f"WHERE task_id = ? AND kind IN ({placeholders})",
+        (task_id, *_RESPAWN_REQUEUE_EVENT_KINDS),
+    ).fetchone()
+    if row is None:
+        return None
+    ts = row["ts"]
+    return int(ts) if ts is not None else None
+
+
+def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    """Return a guard reason that should temporarily suppress auto-spawn.
 
     Checks in priority order:
 
@@ -5345,13 +5382,14 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"recent_success"``
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
-        seconds.  Useful work already succeeded for this task; wait for
-        human review rather than immediately re-spawning.
+        seconds and no later event explicitly returned the task to the
+        ready queue. Useful work already succeeded for this task; wait
+        for human review rather than immediately re-spawning.
 
     ``"active_pr"``
-        A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        A GitHub PR URL appears in a recent task comment and no later
+        ready-queue handoff superseded it. A prior worker already opened
+        a PR; re-spawning risks a duplicate PR on the same task.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -5371,21 +5409,30 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "blocker_auth"
 
     now = int(time.time())
+    respawn_requested_at = _latest_respawn_request_at(conn, task_id)
 
-    # 2. Completed run within guard window — proof of recent success.
+    # 2. Completed run within guard window — proof of recent success, unless
+    # review/manual handoff returned the same task to implementation later.
     cutoff = now - _RESPAWN_GUARD_SUCCESS_WINDOW
+    success_cutoff = cutoff
+    if respawn_requested_at is not None:
+        success_cutoff = max(success_cutoff, respawn_requested_at + 1)
     if conn.execute(
         "SELECT id FROM task_runs "
         "WHERE task_id = ? AND outcome = 'completed' AND ended_at >= ?",
-        (task_id, cutoff),
+        (task_id, success_cutoff),
     ).fetchone():
         return "recent_success"
 
-    # 3. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 3. GitHub PR URL in a recent comment — prior worker already opened a PR,
+    # unless a later review/manual handoff made the PR comment stale context.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    comment_cutoff = pr_cutoff
+    if respawn_requested_at is not None:
+        comment_cutoff = max(comment_cutoff, respawn_requested_at + 1)
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
+        (task_id, comment_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
             return "active_pr"

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3611,13 +3611,21 @@ def block_task(
         handoff = _latest_review_handoff(conn, task_id) if review_rejection else {}
         implementation_assignee = handoff.get("implementation_assignee")
         effective_metadata = metadata
-        if review_rejection and implementation_assignee:
+        if review_rejection:
             if effective_metadata is None:
                 effective_metadata = {}
             else:
                 effective_metadata = dict(effective_metadata)
-            effective_metadata.setdefault("implementation_assignee", implementation_assignee)
             effective_metadata.setdefault("review_rejection", True)
+            if implementation_assignee:
+                effective_metadata.setdefault("implementation_assignee", implementation_assignee)
+            else:
+                effective_metadata.setdefault("missing_implementation_assignee", True)
+                effective_metadata.setdefault(
+                    "review_rejection_reason",
+                    "Review-origin block could not be returned to an implementation assignee because the latest Review handoff did not record one.",
+                )
+        if review_rejection and implementation_assignee:
             if expected_run_id is None:
                 cur = conn.execute(
                     """
@@ -3697,8 +3705,15 @@ def block_task(
                 metadata=effective_metadata,
             )
         payload = {"reason": reason}
-        if event_kind == "review_rejected":
-            payload["implementation_assignee"] = implementation_assignee
+        if review_rejection:
+            payload["review_rejection"] = True
+            if implementation_assignee:
+                payload["implementation_assignee"] = implementation_assignee
+            else:
+                payload["missing_implementation_assignee"] = True
+                payload["review_rejection_reason"] = effective_metadata.get(
+                    "review_rejection_reason"
+                ) if effective_metadata else None
         _append_event(conn, task_id, event_kind, payload, run_id=run_id)
         return True
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2284,6 +2284,7 @@ def _synthesize_ended_run(
     task_id: str,
     *,
     outcome: str,
+    status: Optional[str] = None,
     summary: Optional[str] = None,
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
@@ -2321,7 +2322,7 @@ def _synthesize_ended_run(
         """,
         (
             task_id, profile, step_key,
-            outcome, outcome,
+            status or outcome, outcome,
             summary, error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
             now, now,
@@ -3211,6 +3212,7 @@ def complete_task(
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="completed",
+                status=target_status,
                 summary=summary if summary is not None else result,
                 metadata=effective_metadata,
             )
@@ -3706,6 +3708,7 @@ def block_task(
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="blocked",
+                status=target_status,
                 summary=reason,
                 metadata=effective_metadata,
             )
@@ -4335,6 +4338,7 @@ def schedule_task(
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="scheduled",
+                status="scheduled",
                 summary=reason,
             )
         _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3438,6 +3438,7 @@ def block_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    metadata: Optional[dict] = None,
 ) -> bool:
     """Transition ``running -> blocked``."""
     with write_txn(conn):
@@ -3474,6 +3475,7 @@ def block_task(
             conn, task_id,
             outcome="blocked", status="blocked",
             summary=reason,
+            metadata=metadata,
         )
         # Synthesize a run when blocking a never-claimed task so the
         # reason is preserved in attempt history.
@@ -3482,6 +3484,7 @@ def block_task(
                 conn, task_id,
                 outcome="blocked",
                 summary=reason,
+                metadata=metadata,
             )
         _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
         return True

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2824,7 +2824,7 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT status, claim_lock, worker_pid, current_run_id FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -2837,18 +2837,19 @@ def reclaim_task(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
     with write_txn(conn):
+        restore_status = _status_after_failed_run(conn, task_id, row["current_run_id"])
         cur = conn.execute(
-            "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+            "UPDATE tasks SET status = ?, claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
             "AND claim_lock IS ?",
-            (task_id, prev_lock),
+            (restore_status, task_id, prev_lock),
         )
         if cur.rowcount != 1:
             return False
         run_id = _end_run(
             conn, task_id,
-            outcome="reclaimed", status="ready",
+            outcome="reclaimed", status=restore_status,
             error=(
                 f"manual_reclaim: {reason}" if reason
                 else f"manual_reclaim lock={prev_lock}"
@@ -2859,6 +2860,7 @@ def reclaim_task(
             "manual": True,
             "reason": reason,
             "prev_lock": prev_lock,
+            "restore_status": restore_status,
         }
         payload.update(termination)
         _append_event(
@@ -5205,7 +5207,7 @@ def _record_task_failure(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('running', 'ready')",
+                    "WHERE id = ? AND status IN ('running', 'ready', 'review')",
                     (failures, error[:500], task_id),
                 )
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3478,8 +3478,8 @@ def block_task(
             metadata=metadata,
         )
         # Synthesize a run when blocking a never-claimed task so the
-        # reason is preserved in attempt history.
-        if run_id is None and reason:
+        # reason/metadata is preserved in attempt history.
+        if run_id is None and (reason or metadata):
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="blocked",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2643,6 +2643,11 @@ def _run_started_from_review(conn: sqlite3.Connection, task_id: str, run_id: Opt
     return _event_payload_dict(row).get("source_status") == "review"
 
 
+def _status_after_failed_run(conn: sqlite3.Connection, task_id: str, run_id: Optional[int]) -> str:
+    """Return the queue status to restore after a failed worker attempt."""
+    return "review" if _run_started_from_review(conn, task_id, run_id) else "ready"
+
+
 def _latest_review_handoff(conn: sqlite3.Connection, task_id: str) -> dict:
     row = conn.execute(
         "SELECT payload FROM task_events "
@@ -4672,7 +4677,8 @@ def enforce_max_runtime(
     """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
 
     Sends SIGTERM, waits a short grace window, then SIGKILL. Emits a
-    ``timed_out`` event and drops the task back to ``ready`` so the next
+    ``timed_out`` event and drops the task back to ``ready`` (or back to
+    ``review`` when the failed attempt was a merge-captain review run) so the next
     dispatcher tick re-spawns it — unless the spawn-failure circuit
     breaker has already given up, in which case the task stays blocked
     where ``_record_spawn_failure`` parked it.
@@ -4687,7 +4693,7 @@ def enforce_max_runtime(
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, "
+        "SELECT t.id, t.worker_pid, t.current_run_id, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
         "       t.max_runtime_seconds, t.claim_lock "
         "FROM tasks t "
@@ -4736,12 +4742,13 @@ def enforce_max_runtime(
                     pass
 
         with write_txn(conn):
+            restore_status = _status_after_failed_run(conn, tid, row["current_run_id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running'",
-                (tid,),
+                (restore_status, tid),
             )
             if cur.rowcount == 1:
                 payload = {
@@ -4823,6 +4830,7 @@ def detect_stale_running(
 
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
+        "       t.current_run_id, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -4853,12 +4861,13 @@ def detect_stale_running(
         )
 
         with write_txn(conn):
+            restore_status = _status_after_failed_run(conn, tid, row["current_run_id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running'",
-                (tid,),
+                (restore_status, tid),
             )
             if cur.rowcount != 1:
                 continue
@@ -4933,8 +4942,9 @@ def _error_fingerprint(error_text: str) -> str:
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
-    Appends a ``crashed`` event and drops the task back to ``ready``.
-    Different from ``release_stale_claims``: this checks liveness
+    Appends a ``crashed`` event and drops the task back to ``ready`` (or
+    back to ``review`` when the failed attempt was a merge-captain review
+    run). Different from ``release_stale_claims``: this checks liveness
     immediately rather than waiting for the claim TTL.
 
     Only considers tasks claimed by *this host* — PIDs from other hosts
@@ -4959,7 +4969,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
+            "SELECT id, worker_pid, claim_lock, started_at, current_run_id FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -5011,11 +5021,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
+            restore_status = _status_after_failed_run(conn, row["id"], row["current_run_id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running'",
-                (row["id"],),
+                (restore_status, row["id"]),
             )
             if cur.rowcount == 1:
                 run_id = _end_run(
@@ -5164,7 +5175,7 @@ def _record_task_failure(
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', "
                     "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('ready', 'running')",
+                    "WHERE id = ? AND status IN ('ready', 'running', 'review')",
                     (failures, error[:500], task_id),
                 )
             run_id = None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3589,6 +3589,33 @@ def edit_completed_task_result(
     return True
 
 
+_REVIEW_REBASE_BLOCKER_MARKERS = (
+    "rebase-required",
+    "branch-staleness",
+    "merge-conflict",
+    "merge conflict",
+    "conflict-resolution",
+    "conflict resolution",
+    "mergeable_state=dirty",
+    "mergeable state dirty",
+    "not current with latest origin/main",
+    "origin/main advanced",
+    "branch needs a rebase",
+)
+
+
+def _review_block_is_rebase_or_conflict(reason: Optional[str]) -> bool:
+    """Return True for Review-origin blockers that belong in Blocked.
+
+    Normal Review cycles (Bugbot findings, requested tests, PR-body/check
+    cleanup) should go back to the implementation assignee in Ready.  Blocked
+    is reserved for branch-staleness / rebase / merge-conflict work that the
+    self-recovery lane can repair and then hand back to Review.
+    """
+    text = (reason or "").casefold()
+    return any(marker in text for marker in _REVIEW_REBASE_BLOCKER_MARKERS)
+
+
 def block_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3599,10 +3626,11 @@ def block_task(
 ) -> bool:
     """Transition ``running -> blocked``.
 
-    When the required Review gate is enabled and the active run started from
-    the Review column, ``kanban_block`` means "Bugbot/review rejected this PR".
-    In that case the task is automatically returned to the original
+    When the active run started from the Review column, ``kanban_block`` is
+    usually a review-cycle rejection and the task is returned to the original
     implementation assignee in ``ready`` instead of getting stuck in Blocked.
+    The exception is a branch-staleness / rebase / merge-conflict blocker;
+    those remain sticky-blocked for the narrow self-recovery handoff lane.
     """
     with write_txn(conn):
         task_row = conn.execute(
@@ -3612,26 +3640,33 @@ def block_task(
         if not task_row:
             return False
         run_for_gate = expected_run_id if expected_run_id is not None else task_row["current_run_id"]
-        review_rejection = review_gate_enabled() and _run_started_from_review(
+        review_origin = _run_started_from_review(
             conn, task_id, int(run_for_gate) if run_for_gate else None
         )
-        handoff = _latest_review_handoff(conn, task_id) if review_rejection else {}
+        review_rebase_blocker = review_origin and _review_block_is_rebase_or_conflict(reason)
+        review_rejection = review_origin and not review_rebase_blocker
+        handoff = _latest_review_handoff(conn, task_id) if review_origin else {}
         implementation_assignee = handoff.get("implementation_assignee")
         effective_metadata = metadata
-        if review_rejection:
+        if review_origin:
             if effective_metadata is None:
                 effective_metadata = {}
             else:
                 effective_metadata = dict(effective_metadata)
-            effective_metadata.setdefault("review_rejection", True)
-            if implementation_assignee:
-                effective_metadata.setdefault("implementation_assignee", implementation_assignee)
+            if review_rebase_blocker:
+                effective_metadata.setdefault("review_rebase_blocker", True)
+                if implementation_assignee:
+                    effective_metadata.setdefault("implementation_assignee", implementation_assignee)
             else:
-                effective_metadata.setdefault("missing_implementation_assignee", True)
-                effective_metadata.setdefault(
-                    "review_rejection_reason",
-                    "Review-origin block could not be returned to an implementation assignee because the latest Review handoff did not record one.",
-                )
+                effective_metadata.setdefault("review_rejection", True)
+                if implementation_assignee:
+                    effective_metadata.setdefault("implementation_assignee", implementation_assignee)
+                else:
+                    effective_metadata.setdefault("missing_implementation_assignee", True)
+                    effective_metadata.setdefault(
+                        "review_rejection_reason",
+                        "Review-origin block could not be returned to an implementation assignee because the latest Review handoff did not record one.",
+                    )
         if review_rejection and implementation_assignee:
             if expected_run_id is None:
                 cur = conn.execute(
@@ -3712,7 +3747,11 @@ def block_task(
                 summary=reason,
                 metadata=effective_metadata,
             )
-        payload = {"reason": reason}
+        payload: dict[str, Any] = {"reason": reason}
+        if review_rebase_blocker:
+            payload["review_rebase_blocker"] = True
+            if implementation_assignee:
+                payload["implementation_assignee"] = implementation_assignee
         if review_rejection:
             payload["review_rejection"] = True
             if implementation_assignee:
@@ -6082,6 +6121,17 @@ def _default_spawn(
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
 
+    # Review-gate policy is board/root-level process state, not profile-local
+    # persona state.  Workers switch HERMES_HOME to their assignee profile
+    # below, so copy the dispatcher's effective review config into env first;
+    # otherwise a merge-captain profile missing the kanban stanza can treat
+    # Review-column blocks as sticky Blocked and skip the Review protocol text.
+    env.setdefault(
+        "HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE",
+        "1" if review_gate_enabled() else "0",
+    )
+    env.setdefault("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", merge_captain_profile())
+
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
     # config.  Without this, `env = dict(os.environ)` copies only the parent's
@@ -6346,8 +6396,8 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
         lines.append(f"Branch:   {task.branch_name}")
     lines.append("")
 
-    if review_gate_enabled():
-        review_run = _run_started_from_review(conn, task_id, task.current_run_id)
+    review_run = _run_started_from_review(conn, task_id, task.current_run_id)
+    if review_gate_enabled() or review_run:
         if review_run:
             handoff = _latest_review_handoff(conn, task_id)
             implementation_assignee = handoff.get("implementation_assignee") or "(unknown)"
@@ -6359,9 +6409,11 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             )
             lines.append(
                 f"Original implementation assignee: {implementation_assignee}. If Bugbot "
-                "finds issues or the branch needs a rebase because another PR merged, call "
-                "kanban_block with the exact required fixes/rebase instructions; Hermes will "
-                "automatically return the card to that assignee in Ready."
+                "finds issues or normal review changes are needed, call kanban_block with "
+                "the exact required fixes; Hermes will automatically return the card to "
+                "that assignee in Ready. Only use a rebase/merge-conflict/blocker reason "
+                "when the branch is stale or conflicted; those cases may enter Blocked for "
+                "narrow self-recovery and then return to Review."
             )
             lines.append(
                 "Only call kanban_complete after the PR is clean, up to date, merged, and the "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2776,7 +2776,7 @@ def release_stale_claims(
                 continue
             run_id = _end_run(
                 conn, row["id"],
-                outcome="reclaimed", status="reclaimed",
+                outcome="reclaimed", status=restore_status,
                 error=f"stale_lock={row['claim_lock']}",
                 metadata=termination,
             )
@@ -2848,7 +2848,7 @@ def reclaim_task(
             return False
         run_id = _end_run(
             conn, task_id,
-            outcome="reclaimed", status="reclaimed",
+            outcome="reclaimed", status="ready",
             error=(
                 f"manual_reclaim: {reason}" if reason
                 else f"manual_reclaim lock={prev_lock}"
@@ -4155,7 +4155,7 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # outcome='reclaimed' so attempt history isn't orphaned.
         run_id = _end_run(
             conn, task_id,
-            outcome="reclaimed", status="reclaimed",
+            outcome="reclaimed", status="archived",
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
@@ -4791,7 +4791,7 @@ def enforce_max_runtime(
                 }
                 run_id = _end_run(
                     conn, tid,
-                    outcome="timed_out", status="timed_out",
+                    outcome="timed_out", status=restore_status,
                     error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                     metadata=payload,
                 )
@@ -4920,7 +4920,7 @@ def detect_stale_running(
 
             run_id = _end_run(
                 conn, tid,
-                outcome="stale", status="stale",
+                outcome="stale", status=restore_status,
                 error=(
                     f"no heartbeat for {int(hb_age)}s "
                     if hb_age is not None
@@ -5064,7 +5064,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             if cur.rowcount == 1:
                 run_id = _end_run(
                     conn, row["id"],
-                    outcome="crashed", status="crashed",
+                    outcome="crashed", status=restore_status,
                     error=error_text,
                     metadata=dict(event_payload),
                 )
@@ -5223,7 +5223,7 @@ def _record_task_failure(
                 # Only the spawn path has an open run to close.
                 run_id = _end_run(
                     conn, task_id,
-                    outcome="gave_up", status="gave_up",
+                    outcome="gave_up", status="blocked",
                     error=error[:500],
                     metadata={
                         "failures": failures,
@@ -5271,7 +5271,7 @@ def _record_task_failure(
                 # Spawn path: close the open run with outcome.
                 run_id = _end_run(
                     conn, task_id,
-                    outcome=outcome, status=outcome,
+                    outcome=outcome, status=restore_status,
                     error=error[:500],
                     metadata={"failures": failures, "restore_status": restore_status},
                 )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3117,7 +3117,7 @@ def complete_task(
             return False
         run_for_gate = expected_run_id if expected_run_id is not None else task_row["current_run_id"]
         route_to_review = review_gate_enabled() and not _run_started_from_review(
-            conn, task_id, int(run_for_gate) if run_for_gate else None
+            conn, task_id, int(run_for_gate) if run_for_gate is not None else None
         )
         effective_metadata = metadata
         if route_to_review:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4399,10 +4399,6 @@ _RESPAWN_REQUEUE_EVENT_KINDS = (
     "unblocked",
     "review_rejected",
     "promoted",
-    "reclaimed",
-    "crashed",
-    "timed_out",
-    "spawn_failed",
 )
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -111,6 +111,56 @@ _IS_WINDOWS = sys.platform == "win32"
 DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 
 
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _kanban_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        kanban = cfg.get("kanban") or {}
+        return kanban if isinstance(kanban, dict) else {}
+    except Exception:
+        return {}
+
+
+def review_gate_enabled() -> bool:
+    """Return True when worker completion must pass through Review first."""
+    env = os.environ.get("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE")
+    if env is not None:
+        return _truthy(env)
+    return _truthy(_kanban_config().get("require_review_before_done"))
+
+
+def merge_captain_profile() -> str:
+    """Profile that owns Review-column / merge-train work."""
+    env = os.environ.get("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE")
+    if env and env.strip():
+        return env.strip()
+    cfg = _kanban_config()
+    for key in ("merge_captain_profile", "merge_train_operator_profile", "review_assignee"):
+        value = cfg.get(key)
+        if value and str(value).strip():
+            return str(value).strip()
+    return "merge-captain"
+
+
+def review_agent_skills() -> list[str]:
+    """Skills to force-load for the Review-column merge captain."""
+    cfg = _kanban_config()
+    value = cfg.get("review_agent_skills")
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return ["cursor-bugbot-sweep", "github-pr-workflow"]
+
+
 def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
     """Return the effective claim TTL, honoring the kanban env override.
 
@@ -2571,6 +2621,38 @@ def claim_review_task(
         return get_task(conn, task_id)
 
 
+def _event_payload_dict(row: sqlite3.Row | None) -> dict:
+    if not row or not row["payload"]:
+        return {}
+    try:
+        payload = json.loads(row["payload"])
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _run_started_from_review(conn: sqlite3.Connection, task_id: str, run_id: Optional[int]) -> bool:
+    if run_id is None:
+        return False
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, int(run_id)),
+    ).fetchone()
+    return _event_payload_dict(row).get("source_status") == "review"
+
+
+def _latest_review_handoff(conn: sqlite3.Connection, task_id: str) -> dict:
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'submitted_for_review' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return _event_payload_dict(row)
+
+
 def heartbeat_claim(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3014,56 +3096,113 @@ def complete_task(
     else:
         verified_cards = []
 
+    route_to_review = False
     with write_txn(conn):
-        if expected_run_id is None:
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
-                """,
-                (result, now, task_id),
-            )
+        task_row = conn.execute(
+            "SELECT status, assignee, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not task_row:
+            return False
+        run_for_gate = expected_run_id if expected_run_id is not None else task_row["current_run_id"]
+        route_to_review = review_gate_enabled() and not _run_started_from_review(
+            conn, task_id, int(run_for_gate) if run_for_gate else None
+        )
+        effective_metadata = metadata
+        if route_to_review:
+            original_assignee = task_row["assignee"]
+            review_assignee = merge_captain_profile()
+            if effective_metadata is None:
+                effective_metadata = {}
+            else:
+                effective_metadata = dict(effective_metadata)
+            effective_metadata.setdefault("implementation_assignee", original_assignee)
+            effective_metadata.setdefault("review_assignee", review_assignee)
+            effective_metadata.setdefault("review_gate", "required")
+            if expected_run_id is None:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'review',
+                           assignee     = ?,
+                           result       = ?,
+                           completed_at = NULL,
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready', 'blocked')
+                    """,
+                    (review_assignee, result, task_id),
+                )
+            else:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'review',
+                           assignee     = ?,
+                           result       = ?,
+                           completed_at = NULL,
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready', 'blocked')
+                       AND current_run_id = ?
+                    """,
+                    (review_assignee, result, task_id, int(expected_run_id)),
+                )
         else:
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
-                   AND current_run_id = ?
-                """,
-                (result, now, task_id, int(expected_run_id)),
-            )
+            if expected_run_id is None:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'done',
+                           result       = ?,
+                           completed_at = ?,
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready', 'blocked')
+                    """,
+                    (result, now, task_id),
+                )
+            else:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'done',
+                           result       = ?,
+                           completed_at = ?,
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready', 'blocked')
+                       AND current_run_id = ?
+                    """,
+                    (result, now, task_id, int(expected_run_id)),
+                )
         if cur.rowcount != 1:
             return False
+        target_status = "review" if route_to_review else "done"
         run_id = _end_run(
             conn, task_id,
-            outcome="completed", status="done",
+            outcome="completed", status=target_status,
             summary=summary if summary is not None else result,
-            metadata=metadata,
+            metadata=effective_metadata,
         )
         # If complete_task was called on a never-claimed task (ready or
-        # blocked → done with no run in flight), synthesize a
+        # blocked → done/review with no run in flight), synthesize a
         # zero-duration run so the handoff fields are persisted in
         # attempt history instead of silently lost.
-        if run_id is None and (summary or metadata or result):
+        if run_id is None and (summary or effective_metadata or result):
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="completed",
                 summary=summary if summary is not None else result,
-                metadata=metadata,
+                metadata=effective_metadata,
             )
         # Carry the handoff summary in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a
@@ -3077,14 +3216,17 @@ def complete_task(
         }
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
+        if route_to_review:
+            completed_payload["implementation_assignee"] = task_row["assignee"]
+            completed_payload["review_assignee"] = merge_captain_profile()
         # Carry artifact paths in the event payload so the gateway
         # notifier can upload them as native attachments alongside the
         # completion message. Workers pass these via
         # ``kanban_complete(artifacts=[...])`` which stashes the list in
         # ``metadata["artifacts"]`` — we promote it onto the event so
         # consumers don't have to fetch the run row to find it.
-        if isinstance(metadata, dict):
-            md_artifacts = metadata.get("artifacts")
+        if isinstance(effective_metadata, dict):
+            md_artifacts = effective_metadata.get("artifacts")
             if isinstance(md_artifacts, (list, tuple)):
                 cleaned_artifacts = [
                     str(p).strip() for p in md_artifacts if isinstance(p, str) and str(p).strip()
@@ -3092,7 +3234,7 @@ def complete_task(
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
         _append_event(
-            conn, task_id, "completed",
+            conn, task_id, "submitted_for_review" if route_to_review else "completed",
             completed_payload,
             run_id=run_id,
         )
@@ -3122,10 +3264,13 @@ def complete_task(
     # just tracks "is there a current pathology the breaker should
     # care about", and a success resets that question.
     _clear_failure_counter(conn, task_id)
-    # Recompute ready status for dependents (separate txn so children see done).
-    recompute_ready(conn)
-    # Clean up the scratch workspace and any stale tmux session for the worker.
-    _cleanup_workspace(conn, task_id)
+    if not route_to_review:
+        # Recompute ready status for dependents only after the merge captain
+        # has approved/merged the PR and the task is truly done.
+        recompute_ready(conn)
+        # Clean up scratch workspace only at final done; the Review column may
+        # still need the implementation branch/workspace for Bugbot fixes.
+        _cleanup_workspace(conn, task_id)
     return True
 
 
@@ -3440,53 +3585,116 @@ def block_task(
     expected_run_id: Optional[int] = None,
     metadata: Optional[dict] = None,
 ) -> bool:
-    """Transition ``running -> blocked``."""
+    """Transition ``running -> blocked``.
+
+    When the required Review gate is enabled and the active run started from
+    the Review column, ``kanban_block`` means "Bugbot/review rejected this PR".
+    In that case the task is automatically returned to the original
+    implementation assignee in ``ready`` instead of getting stuck in Blocked.
+    """
     with write_txn(conn):
-        if expected_run_id is None:
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status       = 'blocked',
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL
-                 WHERE id = ?
-                   AND status IN ('running', 'ready')
-                """,
-                (task_id,),
-            )
+        task_row = conn.execute(
+            "SELECT status, assignee, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not task_row:
+            return False
+        run_for_gate = expected_run_id if expected_run_id is not None else task_row["current_run_id"]
+        review_rejection = review_gate_enabled() and _run_started_from_review(
+            conn, task_id, int(run_for_gate) if run_for_gate else None
+        )
+        handoff = _latest_review_handoff(conn, task_id) if review_rejection else {}
+        implementation_assignee = handoff.get("implementation_assignee")
+        effective_metadata = metadata
+        if review_rejection and implementation_assignee:
+            if effective_metadata is None:
+                effective_metadata = {}
+            else:
+                effective_metadata = dict(effective_metadata)
+            effective_metadata.setdefault("implementation_assignee", implementation_assignee)
+            effective_metadata.setdefault("review_rejection", True)
+            if expected_run_id is None:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'ready',
+                           assignee     = ?,
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready')
+                    """,
+                    (implementation_assignee, task_id),
+                )
+            else:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'ready',
+                           assignee     = ?,
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready')
+                       AND current_run_id = ?
+                    """,
+                    (implementation_assignee, task_id, int(expected_run_id)),
+                )
+            target_status = "ready"
+            event_kind = "review_rejected"
         else:
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status       = 'blocked',
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL
-                 WHERE id = ?
-                   AND status IN ('running', 'ready')
-                   AND current_run_id = ?
-                """,
-                (task_id, int(expected_run_id)),
-            )
+            if expected_run_id is None:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'blocked',
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready')
+                    """,
+                    (task_id,),
+                )
+            else:
+                cur = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status       = 'blocked',
+                           claim_lock   = NULL,
+                           claim_expires= NULL,
+                           worker_pid   = NULL
+                     WHERE id = ?
+                       AND status IN ('running', 'ready')
+                       AND current_run_id = ?
+                    """,
+                    (task_id, int(expected_run_id)),
+                )
+            target_status = "blocked"
+            event_kind = "blocked"
         if cur.rowcount != 1:
             return False
         run_id = _end_run(
             conn, task_id,
-            outcome="blocked", status="blocked",
+            outcome="blocked", status=target_status,
             summary=reason,
-            metadata=metadata,
+            metadata=effective_metadata,
         )
         # Synthesize a run when blocking a never-claimed task so the
         # reason/metadata is preserved in attempt history.
-        if run_id is None and (reason or metadata):
+        if run_id is None and (reason or effective_metadata):
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="blocked",
                 summary=reason,
-                metadata=metadata,
+                metadata=effective_metadata,
             )
-        _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
+        payload = {"reason": reason}
+        if event_kind == "review_rejected":
+            payload["implementation_assignee"] = implementation_assignee
+        _append_event(conn, task_id, event_kind, payload, run_id=run_id)
         return True
 
 
@@ -5453,12 +5661,12 @@ def dispatch_once(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load sdlc-review skill for review agents.  The
-        # _default_spawn function already auto-loads kanban-worker, and
-        # appends task.skills via --skills.  Setting task.skills here
-        # means the review agent gets both kanban-worker (lifecycle)
-        # and sdlc-review (review logic: AC verification, merge, etc.).
-        claimed.skills = ["sdlc-review"]
+        # Force-load merge-train review skills for review agents.  The
+        # _default_spawn function already auto-loads kanban-worker and filters
+        # missing skills against the review profile's Hermes home, so this can
+        # safely name the operator workflow without making missing optional
+        # skills fatal on profiles that do not have a local copy.
+        claimed.skills = review_agent_skills()
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
@@ -5682,6 +5890,40 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
+def _skill_available(hermes_home: Optional[str], skill_name: str) -> bool:
+    """True if ``skill_name`` resolves in the worker's Hermes home.
+
+    Skill names may be unqualified (``kanban-worker``) or category-qualified
+    (``github/cursor-bugbot-sweep``).  Qualified names are checked as a direct
+    relative path under ``skills/``; unqualified names also search nested
+    categories.  Path traversal and absolute paths are rejected.
+    """
+    from pathlib import Path as _Path
+
+    raw = (skill_name or "").strip()
+    if not raw:
+        return False
+    rel = _Path(raw)
+    if rel.is_absolute() or ".." in rel.parts or any(not part for part in rel.parts):
+        return False
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    skills_root = base / "skills"
+    if not skills_root.is_dir():
+        return False
+    direct = skills_root / rel / "SKILL.md"
+    if direct.is_file():
+        return True
+    if len(rel.parts) > 1:
+        return False
+    try:
+        for skill_md in skills_root.rglob(f"{raw}/SKILL.md"):
+            if skill_md.is_file():
+                return True
+    except OSError:
+        pass
+    return False
+
+
 def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     """True if the bundled ``kanban-worker`` skill resolves for the home the
     spawned worker will run under.
@@ -5696,25 +5938,7 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     the kanban lifecycle contract is still injected via ``KANBAN_GUIDANCE``, so
     omitting the flag only drops the supplementary pattern library.
     """
-    from pathlib import Path as _Path
-
-    # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
-    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
-    skills_root = base / "skills"
-    if not skills_root.is_dir():
-        return False
-    # Canonical bundled location first (cheap), then a bounded scan for
-    # profiles that have it nested elsewhere.
-    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
-        return True
-    try:
-        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
-            if skill_md.is_file():
-                return True
-    except OSError:
-        pass
-    return False
+    return _skill_available(hermes_home, "kanban-worker")
 
 
 def _worker_terminal_timeout_env(
@@ -5870,7 +6094,13 @@ def _default_spawn(
     if task.skills:
         for sk in task.skills:
             if sk and sk != "kanban-worker":
-                cmd.extend(["--skills", sk])
+                if _skill_available(env.get("HERMES_HOME"), sk):
+                    cmd.extend(["--skills", sk])
+                else:
+                    _log.warning(
+                        "Skipping unresolved kanban worker skill %s for profile %s",
+                        sk, profile_arg,
+                    )
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     cmd.extend([
@@ -6033,6 +6263,38 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     if task.branch_name:
         lines.append(f"Branch:   {task.branch_name}")
     lines.append("")
+
+    if review_gate_enabled():
+        review_run = _run_started_from_review(conn, task_id, task.current_run_id)
+        if review_run:
+            handoff = _latest_review_handoff(conn, task_id)
+            implementation_assignee = handoff.get("implementation_assignee") or "(unknown)"
+            lines.append("## Mandatory merge-train / Review-column protocol")
+            lines.append(
+                "You are the merge captain for this task, not the implementation worker. "
+                "Run the Cursor/Bugbot PR review workflow, decide merge ordering, and "
+                "serialize merges for parallel PRs."
+            )
+            lines.append(
+                f"Original implementation assignee: {implementation_assignee}. If Bugbot "
+                "finds issues or the branch needs a rebase because another PR merged, call "
+                "kanban_block with the exact required fixes/rebase instructions; Hermes will "
+                "automatically return the card to that assignee in Ready."
+            )
+            lines.append(
+                "Only call kanban_complete after the PR is clean, up to date, merged, and the "
+                "task is truly done."
+            )
+            lines.append("")
+        else:
+            lines.append("## Mandatory Review-column gate")
+            lines.append(
+                "When implementation is complete, call kanban_complete with PR/branch/test "
+                "handoff details. The kernel will move this card to Review and assign it to "
+                f"the merge captain ({merge_captain_profile()}); implementation workers must "
+                "not bypass Review or merge their own parallel PRs."
+            )
+            lines.append("")
 
     if task.body and task.body.strip():
         lines.append("## Body")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -158,7 +158,7 @@ def review_agent_skills() -> list[str]:
         return [part.strip() for part in value.split(",") if part.strip()]
     if isinstance(value, (list, tuple)):
         return [str(part).strip() for part in value if str(part).strip()]
-    return ["cursor-bugbot-sweep", "github-pr-workflow"]
+    return ["github/cursor-bugbot-sweep", "github/github-pr-workflow"]
 
 
 def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5113,8 +5113,10 @@ def _record_task_failure(
 
     * ``release_claim=True, end_run=True`` — spawn-failure path.
       Caller has a running task with an open run; this transitions
-      it back to ``ready`` (or ``blocked`` when the breaker trips),
-      releases the claim, and closes the run with ``outcome=<outcome>``.
+      it back to the run's queue status (``ready`` for implementation,
+      ``review`` for merge-captain review) or ``blocked`` when the
+      breaker trips, releases the claim, and closes the run with
+      ``outcome=<outcome>``.
 
     * ``release_claim=False, end_run=False`` — timeout/crash path.
       Caller has ALREADY flipped the task to ``ready`` and closed the
@@ -5137,13 +5139,15 @@ def _record_task_failure(
     blocked = False
     with write_txn(conn):
         row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries "
+            "SELECT consecutive_failures, status, max_retries, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
             return False
         failures = int(row["consecutive_failures"]) + 1
         cur_status = row["status"]
+        current_run_id = row["current_run_id"] if "current_run_id" in row.keys() else None
+        restore_status = _status_after_failed_run(conn, task_id, current_run_id)
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -5190,6 +5194,7 @@ def _record_task_failure(
                         "trigger_outcome": outcome,
                         "effective_limit": effective_limit,
                         "limit_source": limit_source,
+                        "restore_status": restore_status,
                     },
                 )
             payload = {
@@ -5198,6 +5203,7 @@ def _record_task_failure(
                 "limit_source": limit_source,
                 "error": error[:500],
                 "trigger_outcome": outcome,
+                "restore_status": restore_status,
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)
@@ -5208,13 +5214,14 @@ def _record_task_failure(
         else:
             # Below threshold.
             if release_claim:
-                # Spawn path: transition running → ready + clear claim.
+                # Spawn path: transition running back to the queue status
+                # that produced the failed run, then clear claim state.
                 conn.execute(
-                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
-                    (failures, error[:500], task_id),
+                    (restore_status, failures, error[:500], task_id),
                 )
             else:
                 # Timeout/crash path: task is already at ``ready`` via
@@ -5230,11 +5237,11 @@ def _record_task_failure(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={"failures": failures},
+                    metadata={"failures": failures, "restore_status": restore_status},
                 )
                 _append_event(
                     conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
+                    {"error": error[:500], "failures": failures, "restore_status": restore_status},
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -12,6 +12,7 @@ query-friendly view for dashboards and future reporting jobs.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -104,6 +105,29 @@ def connect(path: Optional[Path] = None) -> sqlite3.Connection:
     else:
         conn.execute("UPDATE schema_version SET version = ?", (LEDGER_SCHEMA_VERSION,))
     return conn
+
+
+@contextlib.contextmanager
+def _ledger_write_txn(conn: sqlite3.Connection):
+    """Batch ledger writes in one explicit transaction.
+
+    Ledger connections are intentionally opened in autocommit mode so simple
+    dashboard operations stay straightforward. Backfill is different: it can
+    perform hundreds of `_upsert_entry` calls, and without an explicit
+    transaction each one commits independently. Reuse a caller's active
+    transaction if present; otherwise wrap the batch in BEGIN IMMEDIATE.
+    """
+    if conn.in_transaction:
+        yield conn
+        return
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield conn
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    else:
+        conn.execute("COMMIT")
 
 
 def _json_loads(raw: Any) -> dict[str, Any]:
@@ -231,7 +255,8 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
     board_errors: list[str] = []
 
     if not state_path.exists():
-        lconn.execute("INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)", (f"missing state db: {state_path}",))
+        with _ledger_write_txn(lconn):
+            lconn.execute("INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)", (f"missing state db: {state_path}",))
         if owns_conn:
             lconn.close()
         return {"session_entries": 0, "run_entries": 0, "boards": 0, "ledger_path": str(ledger_path())}
@@ -240,130 +265,131 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
     try:
         sconn = sqlite3.connect(str(state_path), timeout=30)
         sconn.row_factory = sqlite3.Row
-        # First materialize all board/task/run usage entries.  A run can link
-        # to a worker session via task_runs.metadata.worker_session_id or to an
-        # originating session via tasks.session_id.
-        boards = kanban_db.list_boards(include_archived=False)
-        for board in boards:
-            slug = board.get("slug") or kanban_db.DEFAULT_BOARD
-            try:
-                kanban_db.init_db(board=slug)
-                kconn = kanban_db.connect(board=slug)
-            except Exception as exc:
-                msg = f"{slug}: {exc}"
-                board_errors.append(msg)
-                log.warning("project usage backfill skipped board %s: %s", slug, exc)
-                continue
-            try:
-                rows = kconn.execute(
-                    """
-                    SELECT
-                        r.id AS run_id,
-                        r.task_id AS task_id,
-                        r.status AS run_status,
-                        r.outcome AS run_outcome,
-                        r.started_at AS run_started_at,
-                        r.ended_at AS run_ended_at,
-                        r.metadata AS run_metadata,
-                        t.title AS task_title,
-                        t.status AS task_status,
-                        t.session_id AS task_session_id
-                    FROM task_runs r
-                    LEFT JOIN tasks t ON t.id = r.task_id
-                    ORDER BY r.id
-                    """
-                ).fetchall()
-                for row in rows:
-                    meta = _json_loads(row["run_metadata"])
-                    session_id = (
-                        meta.get("worker_session_id")
-                        or meta.get("session_id")
-                        or row["task_session_id"]
-                    )
-                    if session_id:
-                        linked_sessions.add(str(session_id))
-                    session_row = _get_state_session(sconn, session_id)
-                    values = _session_values(session_row)
-                    if session_id:
-                        session_key = (str(row["task_id"]), str(session_id))
-                        if session_key in counted_task_session_usage:
-                            values = _zero_usage_values(values)
-                        else:
-                            counted_task_session_usage.add(session_key)
-                    _upsert_entry(lconn, {
-                        **values,
-                        "source_type": "task_run",
-                        "source_id": f"{slug}:{row['run_id']}",
-                        "board_slug": slug,
-                        "board_name": board.get("name") or slug,
-                        "task_id": row["task_id"],
-                        "task_title": row["task_title"],
-                        "task_status": row["task_status"],
-                        "run_id": row["run_id"],
-                        "run_status": row["run_status"],
-                        "run_outcome": row["run_outcome"],
-                        "started_at": values.get("started_at") or row["run_started_at"],
-                        "ended_at": values.get("ended_at") or row["run_ended_at"],
-                        "metadata": json.dumps(meta, sort_keys=True) if meta else None,
-                        "backfilled_at": now,
-                    })
-                    run_entries += 1
-            except Exception as exc:
-                msg = f"{slug}: {exc}"
-                board_errors.append(msg)
-                log.warning("project usage backfill skipped board %s: %s", slug, exc)
-            finally:
-                kconn.close()
+        with _ledger_write_txn(lconn):
+            # First materialize all board/task/run usage entries.  A run can link
+            # to a worker session via task_runs.metadata.worker_session_id or to an
+            # originating session via tasks.session_id.
+            boards = kanban_db.list_boards(include_archived=False)
+            for board in boards:
+                slug = board.get("slug") or kanban_db.DEFAULT_BOARD
+                try:
+                    kanban_db.init_db(board=slug)
+                    kconn = kanban_db.connect(board=slug)
+                except Exception as exc:
+                    msg = f"{slug}: {exc}"
+                    board_errors.append(msg)
+                    log.warning("project usage backfill skipped board %s: %s", slug, exc)
+                    continue
+                try:
+                    rows = kconn.execute(
+                        """
+                        SELECT
+                            r.id AS run_id,
+                            r.task_id AS task_id,
+                            r.status AS run_status,
+                            r.outcome AS run_outcome,
+                            r.started_at AS run_started_at,
+                            r.ended_at AS run_ended_at,
+                            r.metadata AS run_metadata,
+                            t.title AS task_title,
+                            t.status AS task_status,
+                            t.session_id AS task_session_id
+                        FROM task_runs r
+                        LEFT JOIN tasks t ON t.id = r.task_id
+                        ORDER BY r.id
+                        """
+                    ).fetchall()
+                    for row in rows:
+                        meta = _json_loads(row["run_metadata"])
+                        session_id = (
+                            meta.get("worker_session_id")
+                            or meta.get("session_id")
+                            or row["task_session_id"]
+                        )
+                        if session_id:
+                            linked_sessions.add(str(session_id))
+                        session_row = _get_state_session(sconn, session_id)
+                        values = _session_values(session_row)
+                        if session_id:
+                            session_key = (str(row["task_id"]), str(session_id))
+                            if session_key in counted_task_session_usage:
+                                values = _zero_usage_values(values)
+                            else:
+                                counted_task_session_usage.add(session_key)
+                        _upsert_entry(lconn, {
+                            **values,
+                            "source_type": "task_run",
+                            "source_id": f"{slug}:{row['run_id']}",
+                            "board_slug": slug,
+                            "board_name": board.get("name") or slug,
+                            "task_id": row["task_id"],
+                            "task_title": row["task_title"],
+                            "task_status": row["task_status"],
+                            "run_id": row["run_id"],
+                            "run_status": row["run_status"],
+                            "run_outcome": row["run_outcome"],
+                            "started_at": values.get("started_at") or row["run_started_at"],
+                            "ended_at": values.get("ended_at") or row["run_ended_at"],
+                            "metadata": json.dumps(meta, sort_keys=True) if meta else None,
+                            "backfilled_at": now,
+                        })
+                        run_entries += 1
+                except Exception as exc:
+                    msg = f"{slug}: {exc}"
+                    board_errors.append(msg)
+                    log.warning("project usage backfill skipped board %s: %s", slug, exc)
+                finally:
+                    kconn.close()
 
-        # Remove stale unassigned rows for sessions that are now attributable to
-        # board task_runs. Backfill is idempotent and sessions can become linked
-        # after an earlier pass materialized them as source_type='session'.
-        if linked_sessions:
-            placeholders = ", ".join(["?"] * len(linked_sessions))
+            # Remove stale unassigned rows for sessions that are now attributable to
+            # board task_runs. Backfill is idempotent and sessions can become linked
+            # after an earlier pass materialized them as source_type='session'.
+            if linked_sessions:
+                placeholders = ", ".join(["?"] * len(linked_sessions))
+                lconn.execute(
+                    f"DELETE FROM usage_entries WHERE source_type = 'session' AND source_id IN ({placeholders})",
+                    tuple(linked_sessions),
+                )
+
+            # Also materialize raw sessions that were not attributable to a board.
+            for row in sconn.execute("SELECT * FROM sessions ORDER BY started_at"):
+                if row["id"] in linked_sessions:
+                    continue
+                values = _session_values(row)
+                _upsert_entry(lconn, {
+                    **values,
+                    "source_type": "session",
+                    "source_id": row["id"],
+                    "board_slug": None,
+                    "board_name": None,
+                    "task_id": None,
+                    "task_title": None,
+                    "task_status": None,
+                    "run_id": None,
+                    "run_status": None,
+                    "run_outcome": None,
+                    "metadata": None,
+                    "backfilled_at": now,
+                })
+                session_entries += 1
+
             lconn.execute(
-                f"DELETE FROM usage_entries WHERE source_type = 'session' AND source_id IN ({placeholders})",
-                tuple(linked_sessions),
+                "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_at', ?)",
+                (str(now),),
             )
-
-        # Also materialize raw sessions that were not attributable to a board.
-        for row in sconn.execute("SELECT * FROM sessions ORDER BY started_at"):
-            if row["id"] in linked_sessions:
-                continue
-            values = _session_values(row)
-            _upsert_entry(lconn, {
-                **values,
-                "source_type": "session",
-                "source_id": row["id"],
-                "board_slug": None,
-                "board_name": None,
-                "task_id": None,
-                "task_title": None,
-                "task_status": None,
-                "run_id": None,
-                "run_status": None,
-                "run_outcome": None,
-                "metadata": None,
-                "backfilled_at": now,
-            })
-            session_entries += 1
-
-        lconn.execute(
-            "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_at', ?)",
-            (str(now),),
-        )
-        if board_errors:
-            lconn.execute(
-                "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)",
-                ("; ".join(board_errors),),
-            )
-        else:
-            lconn.execute("DELETE FROM ledger_meta WHERE key = 'last_backfill_error'")
-        return {
-            "session_entries": session_entries,
-            "run_entries": run_entries,
-            "boards": len(boards),
-            "ledger_path": str(ledger_path()),
-        }
+            if board_errors:
+                lconn.execute(
+                    "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)",
+                    ("; ".join(board_errors),),
+                )
+            else:
+                lconn.execute("DELETE FROM ledger_meta WHERE key = 'last_backfill_error'")
+            return {
+                "session_entries": session_entries,
+                "run_entries": run_entries,
+                "boards": len(boards),
+                "ledger_path": str(ledger_path()),
+            }
     finally:
         if sconn is not None:
             sconn.close()

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -169,6 +169,31 @@ def _session_values(row: Optional[sqlite3.Row]) -> dict[str, Any]:
     }
 
 
+def _zero_usage_values(values: dict[str, Any]) -> dict[str, Any]:
+    """Return session identity/timing metadata with additive usage fields zeroed.
+
+    A single Hermes worker session can appear on multiple task_run rows when a
+    task retries or records multiple terminal runs. The source session totals are
+    cumulative for the whole session, so summing them once per run inflates board
+    and project totals. Keep the duplicate run visible for audit/drilldown while
+    counting the session's additive token/cost fields only once.
+    """
+    out = dict(values)
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "reasoning_tokens",
+        "api_call_count",
+        "tool_call_count",
+    ):
+        out[key] = 0
+    out["estimated_cost_usd"] = 0.0
+    out["actual_cost_usd"] = 0.0
+    return out
+
+
 def _upsert_entry(conn: sqlite3.Connection, entry: dict[str, Any]) -> None:
     cols = [
         "source_type", "source_id", "board_slug", "board_name", "task_id",
@@ -201,6 +226,7 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
     session_entries = 0
     run_entries = 0
     linked_sessions: set[str] = set()
+    counted_session_usage: set[str] = set()
 
     if not state_path.exists():
         lconn.execute("INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)", (f"missing state db: {state_path}",))
@@ -253,6 +279,12 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
                         linked_sessions.add(str(session_id))
                     session_row = _get_state_session(sconn, session_id)
                     values = _session_values(session_row)
+                    if session_id:
+                        session_key = str(session_id)
+                        if session_key in counted_session_usage:
+                            values = _zero_usage_values(values)
+                        else:
+                            counted_session_usage.add(session_key)
                     _upsert_entry(lconn, {
                         **values,
                         "source_type": "task_run",

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -1,0 +1,482 @@
+"""Project usage ledger for dashboard-level board/task cost visibility.
+
+The ledger is a derived, idempotently backfilled SQLite database under the
+active Hermes home.  It correlates:
+
+* session usage stored in ``state.db`` (tokens/cost/model/provider), and
+* Kanban board/task/run metadata stored in each board DB.
+
+The source databases remain authoritative; this module only materializes a
+query-friendly view for dashboards and future reporting jobs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+from hermes_state import apply_wal_with_fallback
+from hermes_cli import kanban_db
+
+log = logging.getLogger(__name__)
+
+LEDGER_SCHEMA_VERSION = 1
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS usage_entries (
+    source_type          TEXT NOT NULL,
+    source_id            TEXT NOT NULL,
+    board_slug           TEXT,
+    board_name           TEXT,
+    task_id              TEXT,
+    task_title           TEXT,
+    task_status          TEXT,
+    run_id               INTEGER,
+    run_status           TEXT,
+    run_outcome          TEXT,
+    session_id           TEXT,
+    session_title        TEXT,
+    session_source       TEXT,
+    user_id              TEXT,
+    model                TEXT,
+    billing_provider     TEXT,
+    billing_mode         TEXT,
+    input_tokens         INTEGER NOT NULL DEFAULT 0,
+    output_tokens        INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens    INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens   INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens     INTEGER NOT NULL DEFAULT 0,
+    api_call_count       INTEGER NOT NULL DEFAULT 0,
+    tool_call_count      INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd   REAL,
+    actual_cost_usd      REAL,
+    cost_status          TEXT,
+    started_at           REAL,
+    ended_at             REAL,
+    metadata             TEXT,
+    backfilled_at        REAL NOT NULL,
+    PRIMARY KEY (source_type, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_board ON usage_entries(board_slug);
+CREATE INDEX IF NOT EXISTS idx_usage_task ON usage_entries(task_id);
+CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_entries(session_id);
+CREATE INDEX IF NOT EXISTS idx_usage_started ON usage_entries(started_at DESC);
+
+CREATE TABLE IF NOT EXISTS ledger_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+
+def ledger_path() -> Path:
+    """Return ``<HERMES_HOME>/usage/project_usage.db``."""
+    return get_hermes_home() / "usage" / "project_usage.db"
+
+
+def state_db_path() -> Path:
+    return get_hermes_home() / "state.db"
+
+
+def connect(path: Optional[Path] = None) -> sqlite3.Connection:
+    p = path or ledger_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(p), isolation_level=None, timeout=30)
+    conn.row_factory = sqlite3.Row
+    apply_wal_with_fallback(conn, db_label=f"project_usage.db ({p.name})")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.executescript(SCHEMA_SQL)
+    existing = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+    if existing is None:
+        conn.execute("INSERT INTO schema_version(version) VALUES (?)", (LEDGER_SCHEMA_VERSION,))
+    else:
+        conn.execute("UPDATE schema_version SET version = ?", (LEDGER_SCHEMA_VERSION,))
+    return conn
+
+
+def _json_loads(raw: Any) -> dict[str, Any]:
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(str(raw))
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _get_state_session(conn: sqlite3.Connection, session_id: Optional[str]) -> Optional[sqlite3.Row]:
+    if not session_id:
+        return None
+    return conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+
+
+def _session_values(row: Optional[sqlite3.Row]) -> dict[str, Any]:
+    if row is None:
+        return {
+            "session_id": None,
+            "session_title": None,
+            "session_source": None,
+            "user_id": None,
+            "model": None,
+            "billing_provider": None,
+            "billing_mode": None,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+            "api_call_count": 0,
+            "tool_call_count": 0,
+            "estimated_cost_usd": None,
+            "actual_cost_usd": None,
+            "cost_status": None,
+            "started_at": None,
+            "ended_at": None,
+        }
+    return {
+        "session_id": row["id"],
+        "session_title": row["title"],
+        "session_source": row["source"],
+        "user_id": row["user_id"],
+        "model": row["model"],
+        "billing_provider": row["billing_provider"],
+        "billing_mode": row["billing_mode"],
+        "input_tokens": int(row["input_tokens"] or 0),
+        "output_tokens": int(row["output_tokens"] or 0),
+        "cache_read_tokens": int(row["cache_read_tokens"] or 0),
+        "cache_write_tokens": int(row["cache_write_tokens"] or 0),
+        "reasoning_tokens": int(row["reasoning_tokens"] or 0),
+        "api_call_count": int(row["api_call_count"] or 0),
+        "tool_call_count": int(row["tool_call_count"] or 0),
+        "estimated_cost_usd": row["estimated_cost_usd"],
+        "actual_cost_usd": row["actual_cost_usd"],
+        "cost_status": row["cost_status"],
+        "started_at": row["started_at"],
+        "ended_at": row["ended_at"],
+    }
+
+
+def _upsert_entry(conn: sqlite3.Connection, entry: dict[str, Any]) -> None:
+    cols = [
+        "source_type", "source_id", "board_slug", "board_name", "task_id",
+        "task_title", "task_status", "run_id", "run_status", "run_outcome",
+        "session_id", "session_title", "session_source", "user_id", "model",
+        "billing_provider", "billing_mode", "input_tokens", "output_tokens",
+        "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+        "api_call_count", "tool_call_count", "estimated_cost_usd", "actual_cost_usd",
+        "cost_status", "started_at", "ended_at", "metadata", "backfilled_at",
+    ]
+    placeholders = ", ".join(["?"] * len(cols))
+    updates = ", ".join([f"{c}=excluded.{c}" for c in cols if c not in {"source_type", "source_id"}])
+    conn.execute(
+        f"INSERT INTO usage_entries ({', '.join(cols)}) VALUES ({placeholders}) "
+        f"ON CONFLICT(source_type, source_id) DO UPDATE SET {updates}",
+        tuple(entry.get(c) for c in cols),
+    )
+
+
+def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, Any]:
+    """Backfill the ledger from current ``state.db`` and all Kanban boards.
+
+    Returns a compact summary with the number of session-only and task-run
+    entries materialized.  The operation is safe to call repeatedly.
+    """
+    owns_conn = ledger_conn is None
+    lconn = ledger_conn or connect()
+    now = time.time()
+    state_path = state_db_path()
+    session_entries = 0
+    run_entries = 0
+    linked_sessions: set[str] = set()
+
+    if not state_path.exists():
+        lconn.execute("INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)", (f"missing state db: {state_path}",))
+        if owns_conn:
+            lconn.close()
+        return {"session_entries": 0, "run_entries": 0, "boards": 0, "ledger_path": str(ledger_path())}
+
+    sconn = sqlite3.connect(str(state_path), timeout=30)
+    sconn.row_factory = sqlite3.Row
+    try:
+        # First materialize all board/task/run usage entries.  A run can link
+        # to a worker session via task_runs.metadata.worker_session_id or to an
+        # originating session via tasks.session_id.
+        boards = kanban_db.list_boards(include_archived=False)
+        for board in boards:
+            slug = board.get("slug") or kanban_db.DEFAULT_BOARD
+            try:
+                kanban_db.init_db(board=slug)
+                kconn = kanban_db.connect(board=slug)
+            except Exception as exc:
+                log.warning("project usage backfill skipped board %s: %s", slug, exc)
+                continue
+            try:
+                rows = kconn.execute(
+                    """
+                    SELECT
+                        r.id AS run_id,
+                        r.task_id AS task_id,
+                        r.status AS run_status,
+                        r.outcome AS run_outcome,
+                        r.started_at AS run_started_at,
+                        r.ended_at AS run_ended_at,
+                        r.metadata AS run_metadata,
+                        t.title AS task_title,
+                        t.status AS task_status,
+                        t.session_id AS task_session_id
+                    FROM task_runs r
+                    LEFT JOIN tasks t ON t.id = r.task_id
+                    ORDER BY r.id
+                    """
+                ).fetchall()
+                for row in rows:
+                    meta = _json_loads(row["run_metadata"])
+                    session_id = (
+                        meta.get("worker_session_id")
+                        or meta.get("session_id")
+                        or row["task_session_id"]
+                    )
+                    if session_id:
+                        linked_sessions.add(str(session_id))
+                    session_row = _get_state_session(sconn, session_id)
+                    values = _session_values(session_row)
+                    _upsert_entry(lconn, {
+                        **values,
+                        "source_type": "task_run",
+                        "source_id": f"{slug}:{row['run_id']}",
+                        "board_slug": slug,
+                        "board_name": board.get("name") or slug,
+                        "task_id": row["task_id"],
+                        "task_title": row["task_title"],
+                        "task_status": row["task_status"],
+                        "run_id": row["run_id"],
+                        "run_status": row["run_status"],
+                        "run_outcome": row["run_outcome"],
+                        "started_at": values.get("started_at") or row["run_started_at"],
+                        "ended_at": values.get("ended_at") or row["run_ended_at"],
+                        "metadata": json.dumps(meta, sort_keys=True) if meta else None,
+                        "backfilled_at": now,
+                    })
+                    run_entries += 1
+            finally:
+                kconn.close()
+
+        # Also materialize raw sessions that were not attributable to a board.
+        for row in sconn.execute("SELECT * FROM sessions ORDER BY started_at"):
+            if row["id"] in linked_sessions:
+                continue
+            values = _session_values(row)
+            _upsert_entry(lconn, {
+                **values,
+                "source_type": "session",
+                "source_id": row["id"],
+                "board_slug": None,
+                "board_name": None,
+                "task_id": None,
+                "task_title": None,
+                "task_status": None,
+                "run_id": None,
+                "run_status": None,
+                "run_outcome": None,
+                "metadata": None,
+                "backfilled_at": now,
+            })
+            session_entries += 1
+
+        lconn.execute(
+            "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_at', ?)",
+            (str(now),),
+        )
+        lconn.execute("DELETE FROM ledger_meta WHERE key = 'last_backfill_error'")
+        return {
+            "session_entries": session_entries,
+            "run_entries": run_entries,
+            "boards": len(boards),
+            "ledger_path": str(ledger_path()),
+        }
+    finally:
+        sconn.close()
+        if owns_conn:
+            lconn.close()
+
+
+
+def session_usage_snapshot(session_id: Optional[str]) -> dict[str, Any]:
+    """Return a compact token/cost snapshot for a session id from state.db.
+
+    Intended for embedding into Kanban task_run metadata at terminal
+    transitions.  Missing state/session rows return only ``session_id`` so the
+    ledger can still join/backfill once the session row appears.
+    """
+    if not session_id:
+        return {}
+    snapshot: dict[str, Any] = {"session_id": str(session_id)}
+    p = state_db_path()
+    if not p.exists():
+        return snapshot
+    conn = sqlite3.connect(str(p), timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = _get_state_session(conn, str(session_id))
+        if row is None:
+            return snapshot
+        vals = _session_values(row)
+        for key in (
+            "input_tokens", "output_tokens", "cache_read_tokens",
+            "cache_write_tokens", "reasoning_tokens", "api_call_count",
+            "tool_call_count", "estimated_cost_usd", "actual_cost_usd",
+            "cost_status", "model", "billing_provider", "billing_mode",
+            "started_at", "ended_at",
+        ):
+            snapshot[key] = vals.get(key)
+        return snapshot
+    finally:
+        conn.close()
+
+
+def stamp_usage_metadata(metadata: Optional[dict[str, Any]], session_id: Optional[str]) -> Optional[dict[str, Any]]:
+    """Return metadata with worker_session_id + usage_snapshot merged in."""
+    if not session_id:
+        return metadata
+    out = dict(metadata or {})
+    # Trusted dispatcher/tool metadata wins over any user-supplied/spoofed value.
+    out["worker_session_id"] = str(session_id)
+    out["usage_snapshot"] = session_usage_snapshot(str(session_id))
+    return out
+
+def _totals_where(board: Optional[str] = None, task_id: Optional[str] = None) -> tuple[str, list[Any]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if board:
+        clauses.append("board_slug = ?")
+        params.append(board)
+    if task_id:
+        clauses.append("task_id = ?")
+        params.append(task_id)
+    return ("WHERE " + " AND ".join(clauses)) if clauses else "", params
+
+
+def get_summary(*, board: Optional[str] = None, task_id: Optional[str] = None, refresh: bool = True) -> dict[str, Any]:
+    """Return dashboard-ready per-board totals and task drilldown rows."""
+    conn = connect()
+    try:
+        if refresh:
+            backfill(ledger_conn=conn)
+        where, params = _totals_where(board, task_id)
+        totals = conn.execute(
+            f"""
+            SELECT
+                COUNT(*) AS entries,
+                COUNT(DISTINCT session_id) AS sessions,
+                COUNT(DISTINCT task_id) AS tasks,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(api_call_count), 0) AS api_call_count,
+                COALESCE(SUM(tool_call_count), 0) AS tool_call_count,
+                COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd
+            FROM usage_entries
+            {where}
+            """,
+            params,
+        ).fetchone()
+        board_where = "WHERE board_slug = ?" if board else ""
+        board_params: list[Any] = [board] if board else []
+        board_rows = conn.execute(
+            f"""
+            SELECT
+                COALESCE(board_slug, '__unassigned__') AS board_slug,
+                COALESCE(board_name, 'Unassigned sessions') AS board_name,
+                COUNT(*) AS entries,
+                COUNT(DISTINCT task_id) AS tasks,
+                COUNT(DISTINCT session_id) AS sessions,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd,
+                MAX(started_at) AS latest_started_at
+            FROM usage_entries
+            {board_where}
+            GROUP BY COALESCE(board_slug, '__unassigned__'), COALESCE(board_name, 'Unassigned sessions')
+            ORDER BY estimated_cost_usd DESC, input_tokens + output_tokens DESC
+            """,
+            board_params,
+        ).fetchall()
+        task_where = "WHERE task_id IS NOT NULL"
+        task_params: list[Any] = []
+        if board:
+            task_where += " AND board_slug = ?"
+            task_params.append(board)
+        if task_id:
+            task_where += " AND task_id = ?"
+            task_params.append(task_id)
+        task_rows = conn.execute(
+            f"""
+            SELECT
+                board_slug,
+                board_name,
+                task_id,
+                MAX(task_title) AS task_title,
+                MAX(task_status) AS task_status,
+                COUNT(*) AS runs,
+                COUNT(DISTINCT session_id) AS sessions,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd,
+                MIN(started_at) AS first_started_at,
+                MAX(ended_at) AS last_ended_at
+            FROM usage_entries
+            {task_where}
+            GROUP BY board_slug, board_name, task_id
+            ORDER BY estimated_cost_usd DESC, input_tokens + output_tokens DESC
+            LIMIT 500
+            """,
+            task_params,
+        ).fetchall()
+        run_rows: list[sqlite3.Row] = []
+        if task_id:
+            run_where = "task_id = ?"
+            run_params: list[Any] = [task_id]
+            if board:
+                run_where += " AND board_slug = ?"
+                run_params.append(board)
+            run_rows = conn.execute(
+                f"""
+                SELECT * FROM usage_entries
+                WHERE {run_where}
+                ORDER BY COALESCE(started_at, 0) DESC, run_id DESC
+                LIMIT 200
+                """,
+                run_params,
+            ).fetchall()
+        meta = {r["key"]: r["value"] for r in conn.execute("SELECT key, value FROM ledger_meta")}
+        return {
+            "ledger_path": str(ledger_path()),
+            "last_backfill_at": float(meta["last_backfill_at"]) if meta.get("last_backfill_at") else None,
+            "last_backfill_error": meta.get("last_backfill_error"),
+            "totals": dict(totals) if totals else {},
+            "boards": [dict(r) for r in board_rows],
+            "tasks": [dict(r) for r in task_rows],
+            "runs": [dict(r) for r in run_rows],
+        }
+    finally:
+        conn.close()

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -227,6 +227,7 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
     run_entries = 0
     linked_sessions: set[str] = set()
     counted_task_session_usage: set[tuple[str, str]] = set()
+    board_errors: list[str] = []
 
     if not state_path.exists():
         lconn.execute("INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)", (f"missing state db: {state_path}",))
@@ -247,6 +248,8 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
                 kanban_db.init_db(board=slug)
                 kconn = kanban_db.connect(board=slug)
             except Exception as exc:
+                msg = f"{slug}: {exc}"
+                board_errors.append(msg)
                 log.warning("project usage backfill skipped board %s: %s", slug, exc)
                 continue
             try:
@@ -303,6 +306,10 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
                         "backfilled_at": now,
                     })
                     run_entries += 1
+            except Exception as exc:
+                msg = f"{slug}: {exc}"
+                board_errors.append(msg)
+                log.warning("project usage backfill skipped board %s: %s", slug, exc)
             finally:
                 kconn.close()
 
@@ -342,7 +349,13 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
             "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_at', ?)",
             (str(now),),
         )
-        lconn.execute("DELETE FROM ledger_meta WHERE key = 'last_backfill_error'")
+        if board_errors:
+            lconn.execute(
+                "INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)",
+                ("; ".join(board_errors),),
+            )
+        else:
+            lconn.execute("DELETE FROM ledger_meta WHERE key = 'last_backfill_error'")
         return {
             "session_entries": session_entries,
             "run_entries": run_entries,

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -401,6 +401,54 @@ def _totals_where(board: Optional[str] = None, task_id: Optional[str] = None) ->
     return ("WHERE " + " AND ".join(clauses)) if clauses else "", params
 
 
+def get_task_rollups(
+    *,
+    board: Optional[str] = None,
+    task_ids: Optional[list[str]] = None,
+    refresh: bool = True,
+) -> list[dict[str, Any]]:
+    """Return usage rollups for specific task ids without the dashboard top-N cap."""
+    if not task_ids:
+        return []
+    conn = connect()
+    try:
+        if refresh:
+            backfill(ledger_conn=conn)
+        placeholders = ", ".join(["?"] * len(task_ids))
+        where = f"WHERE task_id IN ({placeholders})"
+        params: list[Any] = list(task_ids)
+        if board:
+            where += " AND board_slug = ?"
+            params.append(board)
+        rows = conn.execute(
+            f"""
+            SELECT
+                board_slug,
+                board_name,
+                task_id,
+                MAX(task_title) AS task_title,
+                MAX(task_status) AS task_status,
+                COUNT(*) AS runs,
+                COUNT(DISTINCT session_id) AS sessions,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd,
+                MIN(started_at) AS first_started_at,
+                MAX(ended_at) AS last_ended_at
+            FROM usage_entries
+            {where}
+            GROUP BY board_slug, board_name, task_id
+            ORDER BY estimated_cost_usd DESC, input_tokens + output_tokens DESC
+            """,
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
 def get_summary(*, board: Optional[str] = None, task_id: Optional[str] = None, refresh: bool = True) -> dict[str, Any]:
     """Return dashboard-ready per-board totals and task drilldown rows."""
     conn = connect()

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_state import apply_wal_with_fallback
@@ -411,6 +412,34 @@ def stamp_usage_metadata(metadata: Optional[dict[str, Any]], session_id: Optiona
     out["worker_session_id"] = str(session_id)
     out["usage_snapshot"] = session_usage_snapshot(str(session_id))
     return out
+
+
+def stamp_worker_usage_metadata(
+    task_id: str,
+    metadata: Optional[dict[str, Any]],
+    *,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> Optional[dict[str, Any]]:
+    """Best-effort usage metadata stamping for the active worker task.
+
+    Both the human/CLI Kanban path and native Kanban tool path close task runs.
+    Keep task completion/blocking reliable even when usage state is absent,
+    locked, or corrupt by falling back to the trusted worker_session_id only.
+    """
+    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+        return metadata
+    session_id = os.environ.get("HERMES_SESSION_ID")
+    if not session_id:
+        return metadata
+    try:
+        return stamp_usage_metadata(metadata, session_id)
+    except Exception as exc:
+        if on_error is not None:
+            on_error(exc)
+        fallback = dict(metadata or {})
+        fallback["worker_session_id"] = str(session_id)
+        return fallback
+
 
 def _totals_where(board: Optional[str] = None, task_id: Optional[str] = None) -> tuple[str, list[Any]]:
     clauses: list[str] = []

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -236,9 +236,10 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
             lconn.close()
         return {"session_entries": 0, "run_entries": 0, "boards": 0, "ledger_path": str(ledger_path())}
 
-    sconn = sqlite3.connect(str(state_path), timeout=30)
-    sconn.row_factory = sqlite3.Row
+    sconn: Optional[sqlite3.Connection] = None
     try:
+        sconn = sqlite3.connect(str(state_path), timeout=30)
+        sconn.row_factory = sqlite3.Row
         # First materialize all board/task/run usage entries.  A run can link
         # to a worker session via task_runs.metadata.worker_session_id or to an
         # originating session via tasks.session_id.
@@ -364,7 +365,8 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
             "ledger_path": str(ledger_path()),
         }
     finally:
-        sconn.close()
+        if sconn is not None:
+            sconn.close()
         if owns_conn:
             lconn.close()
 

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -306,6 +306,16 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
             finally:
                 kconn.close()
 
+        # Remove stale unassigned rows for sessions that are now attributable to
+        # board task_runs. Backfill is idempotent and sessions can become linked
+        # after an earlier pass materialized them as source_type='session'.
+        if linked_sessions:
+            placeholders = ", ".join(["?"] * len(linked_sessions))
+            lconn.execute(
+                f"DELETE FROM usage_entries WHERE source_type = 'session' AND source_id IN ({placeholders})",
+                tuple(linked_sessions),
+            )
+
         # Also materialize raw sessions that were not attributable to a board.
         for row in sconn.execute("SELECT * FROM sessions ORDER BY started_at"):
             if row["id"] in linked_sessions:

--- a/hermes_cli/project_usage_ledger.py
+++ b/hermes_cli/project_usage_ledger.py
@@ -226,7 +226,7 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
     session_entries = 0
     run_entries = 0
     linked_sessions: set[str] = set()
-    counted_session_usage: set[str] = set()
+    counted_task_session_usage: set[tuple[str, str]] = set()
 
     if not state_path.exists():
         lconn.execute("INSERT OR REPLACE INTO ledger_meta(key, value) VALUES ('last_backfill_error', ?)", (f"missing state db: {state_path}",))
@@ -280,11 +280,11 @@ def backfill(*, ledger_conn: Optional[sqlite3.Connection] = None) -> dict[str, A
                     session_row = _get_state_session(sconn, session_id)
                     values = _session_values(session_row)
                     if session_id:
-                        session_key = str(session_id)
-                        if session_key in counted_session_usage:
+                        session_key = (str(row["task_id"]), str(session_id))
+                        if session_key in counted_task_session_usage:
                             values = _zero_usage_values(values)
                         else:
-                            counted_session_usage.add(session_key)
+                            counted_task_session_usage.add(session_key)
                     _upsert_entry(lconn, {
                         **values,
                         "source_type": "task_run",

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -151,6 +151,19 @@
     return tx(t, key, FALLBACK_DIAGNOSTIC_EVENT_LABELS[kind]);
   }
 
+  function formatCompactNumber(n) {
+    n = Number(n || 0);
+    if (n >= 1000000) return (n / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
+    if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+    return String(Math.round(n));
+  }
+
+  function taskUsageTokens(t) {
+    const u = t && t.usage ? t.usage : null;
+    if (!u) return 0;
+    return Number(u.input_tokens || 0) + Number(u.output_tokens || 0) + Number(u.reasoning_tokens || 0);
+  }
+
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
@@ -2573,6 +2586,11 @@
               ? h("span", { className: "hermes-kanban-count",
                             title: `${t.link_counts.parents} parent${t.link_counts.parents === 1 ? "" : "s"}, ${t.link_counts.children} child${t.link_counts.children === 1 ? "" : "ren"}. Children stay blocked until their parent is done.` },
                   "↔ ", t.link_counts.parents + t.link_counts.children)
+              : null,
+            taskUsageTokens(t) > 0
+              ? h("span", { className: "hermes-kanban-count hermes-kanban-usage",
+                            title: `Usage: ${taskUsageTokens(t)} tokens, estimated cost $${Number((t.usage && t.usage.estimated_cost_usd) || 0).toFixed(4)}` },
+                  "◈ ", formatCompactNumber(taskUsageTokens(t)))
               : null,
             h("span", { className: "hermes-kanban-ago",
                         title: t.created_at ? `Created ${t.created_at}` : "" },

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -186,6 +186,32 @@ def _comment_dict(c: kanban_db.Comment) -> dict[str, Any]:
     }
 
 
+def _usage_by_task(board_slug: Optional[str], task_ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not task_ids:
+        return {}
+    try:
+        from hermes_cli import project_usage_ledger as usage
+        summary = usage.get_summary(board=board_slug, refresh=True)
+    except Exception as exc:
+        log.debug("kanban usage rollup unavailable: %s", exc)
+        return {}
+    wanted = set(task_ids)
+    out: dict[str, dict[str, Any]] = {}
+    for row in summary.get("tasks") or []:
+        tid = row.get("task_id")
+        if tid in wanted:
+            out[str(tid)] = {
+                "runs": row.get("runs", 0),
+                "sessions": row.get("sessions", 0),
+                "input_tokens": row.get("input_tokens", 0),
+                "output_tokens": row.get("output_tokens", 0),
+                "reasoning_tokens": row.get("reasoning_tokens", 0),
+                "estimated_cost_usd": row.get("estimated_cost_usd", 0.0),
+                "actual_cost_usd": row.get("actual_cost_usd", 0.0),
+            }
+    return out
+
+
 def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
     """Serialise a Run for the drawer's Run history section."""
     return {
@@ -431,7 +457,9 @@ def get_board(
         # window-function query (avoids N+1 ``latest_summary`` calls
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
-        summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        task_ids = [t.id for t in tasks]
+        summary_map = kanban_db.latest_summaries(conn, task_ids)
+        usage_map = _usage_by_task(board or kanban_db.get_current_board(), task_ids)
 
         for t in tasks:
             full = summary_map.get(t.id)
@@ -442,6 +470,10 @@ def get_board(
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
+            d["usage"] = usage_map.get(t.id, {
+                "runs": 0, "sessions": 0, "input_tokens": 0, "output_tokens": 0,
+                "reasoning_tokens": 0, "estimated_cost_usd": 0.0, "actual_cost_usd": 0.0,
+            })
             diags = diagnostics_per_task.get(t.id)
             if diags:
                 # Full list goes into the payload so the drawer can render
@@ -1629,6 +1661,24 @@ def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(N
         return {"ok": True, "task_id": task_id, "home_channel": home}
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Usage (token/cost rollups from the project usage ledger)
+# ---------------------------------------------------------------------------
+
+@router.get("/usage")
+def get_usage(
+    board: Optional[str] = Query(None),
+    task_id: Optional[str] = Query(None),
+    refresh: bool = Query(True),
+):
+    board = _resolve_board(board)
+    try:
+        from hermes_cli import project_usage_ledger as usage
+        return usage.get_summary(board=board, task_id=task_id, refresh=refresh)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"usage summary failed: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1285,21 +1285,29 @@ except ImportError:
     _psutil = None  # type: ignore[assignment]
 
 
-@router.get("/workers/active")
-def list_active_workers(
-    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
-):
-    """Return every currently-running worker on the board.
+def _pid_liveness(pid: Optional[int]) -> dict[str, Any]:
+    """Best-effort OS liveness for an already-recorded worker PID."""
+    if pid is None:
+        return {"alive": False, "reason": "no worker_pid recorded"}
+    if _psutil is None:
+        return {"alive": None, "reason": "psutil not available"}
+    try:
+        proc = _psutil.Process(int(pid))
+        status = proc.status()
+        return {
+            "alive": proc.is_running() and status != getattr(_psutil, "STATUS_ZOMBIE", "zombie"),
+            "pid_status": status,
+            "create_time": proc.create_time(),
+        }
+    except _psutil.NoSuchProcess:
+        return {"alive": False, "reason": "process not found"}
+    except _psutil.AccessDenied:
+        return {"alive": True, "error": "access denied"}
 
-    A worker is a ``task_runs`` row whose ``ended_at`` is NULL and whose
-    ``worker_pid`` is non-NULL, belonging to a task with ``status='running'``.
 
-    Returns ``{workers: [...], count: N, checked_at: <epoch>}``.  Each
-    worker entry carries enough context for the dashboard to link back to
-    its task without a second round-trip.
-    """
-    board = _resolve_board(board)
-    conn = _conn(board=board)
+def _active_worker_snapshot_for_board(board_slug: str) -> dict[str, Any]:
+    """Return active workers plus not-counted diagnostics for one board."""
+    conn = _conn(board=board_slug)
     try:
         rows = conn.execute(
             """
@@ -1310,40 +1318,214 @@ def list_active_workers(
                 t.status      AS task_status,
                 t.assignee    AS task_assignee,
                 r.profile,
-                r.worker_pid,
+                COALESCE(r.worker_pid, t.worker_pid) AS worker_pid,
+                CASE
+                    WHEN r.worker_pid IS NOT NULL THEN 'run'
+                    WHEN t.worker_pid IS NOT NULL THEN 'task'
+                    ELSE NULL
+                END AS pid_source,
+                r.worker_pid AS run_worker_pid,
+                t.worker_pid AS task_worker_pid,
                 r.started_at,
                 r.claim_lock,
                 r.claim_expires,
                 r.last_heartbeat_at,
                 r.max_runtime_seconds
-            FROM task_runs r
-            JOIN tasks t ON t.id = r.task_id
-            WHERE r.ended_at IS NULL
-              AND r.worker_pid IS NOT NULL
-              AND t.status = 'running'
+            FROM tasks t
+            JOIN task_runs r ON r.id = t.current_run_id
+            WHERE t.status = 'running'
+              AND r.ended_at IS NULL
+              AND COALESCE(r.worker_pid, t.worker_pid) IS NOT NULL
             ORDER BY r.started_at ASC
             """,
         ).fetchall()
-        workers = [
-            {
+        workers: list[dict[str, Any]] = []
+        counted_keys: set[tuple[Optional[int], str, int]] = set()
+        for row in rows:
+            pid = row["worker_pid"]
+            entry = {
+                "board": board_slug,
                 "run_id": row["run_id"],
                 "task_id": row["task_id"],
                 "task_title": row["task_title"],
                 "task_status": row["task_status"],
                 "task_assignee": row["task_assignee"],
                 "profile": row["profile"],
-                "worker_pid": row["worker_pid"],
+                "worker_pid": pid,
+                "pid_source": row["pid_source"],
                 "started_at": row["started_at"],
                 "claim_lock": row["claim_lock"],
                 "claim_expires": row["claim_expires"],
                 "last_heartbeat_at": row["last_heartbeat_at"],
                 "max_runtime_seconds": row["max_runtime_seconds"],
             }
-            for row in rows
-        ]
-        return {"workers": workers, "count": len(workers), "checked_at": int(time.time())}
+            if row["pid_source"] == "task":
+                entry["diagnostic"] = "run worker_pid missing; using task.worker_pid fallback"
+            entry.update(_pid_liveness(pid))
+            workers.append(entry)
+            counted_keys.add((row["run_id"], row["task_id"], int(pid)))
+
+        diagnostics: list[dict[str, Any]] = []
+
+        # Running tasks with claim/run state that do not satisfy the canonical
+        # active-worker predicate. These are the rows that make "PID exists but
+        # count=0" confusing unless the dashboard explains why they were not
+        # included.
+        for row in conn.execute(
+            """
+            SELECT
+                t.id AS task_id,
+                t.title AS task_title,
+                t.status AS task_status,
+                t.assignee AS task_assignee,
+                t.current_run_id,
+                t.worker_pid AS task_worker_pid,
+                r.id AS run_id,
+                r.worker_pid AS run_worker_pid,
+                r.ended_at AS run_ended_at,
+                r.status AS run_status,
+                r.outcome AS run_outcome
+            FROM tasks t
+            LEFT JOIN task_runs r ON r.id = t.current_run_id
+            WHERE t.status = 'running'
+              AND (t.current_run_id IS NOT NULL OR t.worker_pid IS NOT NULL)
+            ORDER BY COALESCE(r.started_at, t.started_at, t.created_at) ASC
+            """,
+        ).fetchall():
+            pid = row["run_worker_pid"] or row["task_worker_pid"]
+            if pid is not None and (row["run_id"], row["task_id"], int(pid)) in counted_keys:
+                continue
+            reason = "unknown"
+            if row["current_run_id"] is None:
+                reason = "running task has no current_run_id"
+            elif row["run_id"] is None:
+                reason = "current_run_id does not resolve to a task_runs row"
+            elif row["run_ended_at"] is not None:
+                reason = "current run is already ended"
+            elif pid is None:
+                reason = "no worker_pid recorded on task or current run"
+            diag = {
+                "board": board_slug,
+                "task_id": row["task_id"],
+                "task_title": row["task_title"],
+                "task_status": row["task_status"],
+                "task_assignee": row["task_assignee"],
+                "run_id": row["run_id"] or row["current_run_id"],
+                "worker_pid": pid,
+                "reason": reason,
+                "run_status": row["run_status"],
+                "run_outcome": row["run_outcome"],
+            }
+            diag.update(_pid_liveness(pid))
+            diagnostics.append(diag)
+
+        # Active run rows with PIDs that are not the task's current running
+        # claim. These can be genuine stale/orphan rows; surface them with the
+        # board/task/run identifiers instead of silently dropping live PIDs.
+        for row in conn.execute(
+            """
+            SELECT
+                r.id AS run_id,
+                r.task_id,
+                t.title AS task_title,
+                t.status AS task_status,
+                t.assignee AS task_assignee,
+                t.current_run_id,
+                r.worker_pid,
+                r.status AS run_status,
+                r.outcome AS run_outcome
+            FROM task_runs r
+            LEFT JOIN tasks t ON t.id = r.task_id
+            WHERE r.ended_at IS NULL
+              AND r.worker_pid IS NOT NULL
+              AND (t.id IS NULL OR t.status != 'running' OR t.current_run_id != r.id)
+            ORDER BY r.started_at ASC
+            """,
+        ).fetchall():
+            pid = row["worker_pid"]
+            key = (row["run_id"], row["task_id"], int(pid))
+            if key in counted_keys:
+                continue
+            reason = "task row missing"
+            if row["task_status"] and row["task_status"] != "running":
+                reason = f"task status is {row['task_status']!r}, not 'running'"
+            elif row["task_status"] == "running" and row["current_run_id"] != row["run_id"]:
+                reason = "run is not the task current_run_id"
+            diag = {
+                "board": board_slug,
+                "task_id": row["task_id"],
+                "task_title": row["task_title"],
+                "task_status": row["task_status"],
+                "task_assignee": row["task_assignee"],
+                "run_id": row["run_id"],
+                "worker_pid": pid,
+                "reason": reason,
+                "run_status": row["run_status"],
+                "run_outcome": row["run_outcome"],
+            }
+            diag.update(_pid_liveness(pid))
+            diagnostics.append(diag)
+
+        return {"board": board_slug, "workers": workers, "diagnostics": diagnostics}
     finally:
         conn.close()
+
+
+@router.get("/workers/active")
+def list_active_workers(
+    board: Optional[str] = Query(
+        None,
+        description="Kanban board slug; omit to scan all boards for live workers",
+    ),
+):
+    """Return currently-running workers and active-worker diagnostics.
+
+    When ``board`` is omitted, this scans every board on disk. That matches
+    gateway-embedded dispatch, which ticks all boards, and prevents the global
+    dashboard status from reporting ``count=0`` just because the selected/current
+    board differs from the board where workers were spawned.
+
+    A counted worker is the task's current active run with either
+    ``task_runs.worker_pid`` or (for legacy/racy rows) ``tasks.worker_pid`` set.
+    Rows with live-looking PIDs that are not counted are returned under
+    ``diagnostics`` with the board slug and task/run identifiers so operators
+    can see exactly why a process was excluded.
+    """
+    if board is None:
+        scope = "all"
+        board_slugs = [
+            str(meta.get("slug") or kanban_db.DEFAULT_BOARD)
+            for meta in kanban_db.list_boards(include_archived=False)
+        ]
+    else:
+        scope = "board"
+        resolved = _resolve_board(board)
+        board_slugs = [resolved or kanban_db.get_current_board()]
+
+    workers: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+    board_summaries: list[dict[str, Any]] = []
+    for board_slug in board_slugs:
+        snapshot = _active_worker_snapshot_for_board(board_slug)
+        board_workers = snapshot["workers"]
+        board_diagnostics = snapshot["diagnostics"]
+        workers.extend(board_workers)
+        diagnostics.extend(board_diagnostics)
+        board_summaries.append({
+            "board": board_slug,
+            "count": len(board_workers),
+            "diagnostics_count": len(board_diagnostics),
+        })
+
+    return {
+        "workers": workers,
+        "count": len(workers),
+        "checked_at": int(time.time()),
+        "scope": scope,
+        "board": board_slugs[0] if scope == "board" else None,
+        "boards": board_summaries,
+        "diagnostics": diagnostics,
+    }
 
 
 @router.get("/runs/{run_id}")

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -191,7 +191,9 @@ def _usage_by_task(board_slug: Optional[str], task_ids: list[str]) -> dict[str, 
         return {}
     try:
         from hermes_cli import project_usage_ledger as usage
-        summary = usage.get_summary(board=board_slug, refresh=True)
+        summary = usage.get_summary(board=board_slug, refresh=False)
+        if summary.get("last_backfill_at") is None:
+            summary = usage.get_summary(board=board_slug, refresh=True)
     except Exception as exc:
         log.debug("kanban usage rollup unavailable: %s", exc)
         return {}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -257,8 +257,8 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
         for key in ("estimated_cost_usd", "actual_cost_usd"):
             agg[key] += float(snapshot.get(key) or 0.0)
     for agg in out.values():
-        agg["sessions"] = len(agg.pop("_session_ids"))
-        agg.pop("_sessionless_seen", None)
+        sessionless_seen = bool(agg.pop("_sessionless_seen", False))
+        agg["sessions"] = len(agg.pop("_session_ids")) + (1 if sessionless_seen else 0)
     return out
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -210,6 +210,7 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
             SELECT task_id, metadata
             FROM task_runs
             WHERE task_id IN ({placeholders})
+            ORDER BY COALESCE(ended_at, started_at, 0) DESC, id DESC
             """,
             list(task_ids),
         ).fetchall()

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -239,6 +239,7 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
             "estimated_cost_usd": 0.0,
             "actual_cost_usd": 0.0,
             "_session_ids": set(),
+            "_sessionless_seen": False,
         })
         agg["runs"] += 1
         sid = snapshot.get("session_id") or meta.get("worker_session_id")
@@ -247,12 +248,17 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
             if session_key in agg["_session_ids"]:
                 continue
             agg["_session_ids"].add(session_key)
+        elif agg["_sessionless_seen"]:
+            continue
+        else:
+            agg["_sessionless_seen"] = True
         for key in ("input_tokens", "output_tokens", "reasoning_tokens"):
             agg[key] += int(snapshot.get(key) or 0)
         for key in ("estimated_cost_usd", "actual_cost_usd"):
             agg[key] += float(snapshot.get(key) or 0.0)
     for agg in out.values():
         agg["sessions"] = len(agg.pop("_session_ids"))
+        agg.pop("_sessionless_seen", None)
     return out
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -198,7 +198,7 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
         return {}
     wanted = set(task_ids)
     placeholders = ", ".join(["?"] * len(task_ids))
-    out: dict[str, dict[str, Any]] = {}
+    latest_by_task: dict[str, dict[str, Any]] = {}
     try:
         conn = kanban_db.connect(board=board_slug)
     except Exception as exc:
@@ -230,35 +230,46 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
         snapshot = meta.get("usage_snapshot") if isinstance(meta, dict) else None
         if not isinstance(snapshot, dict):
             continue
-        agg = out.setdefault(tid, {
+        bucket = latest_by_task.setdefault(tid, {
             "runs": 0,
-            "sessions": 0,
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "reasoning_tokens": 0,
-            "estimated_cost_usd": 0.0,
-            "actual_cost_usd": 0.0,
-            "_session_ids": set(),
-            "_sessionless_seen": False,
+            "by_session": {},
+            "sessionless": None,
         })
-        agg["runs"] += 1
+        bucket["runs"] += 1
         sid = snapshot.get("session_id") or meta.get("worker_session_id")
         if sid:
-            session_key = str(sid)
-            if session_key in agg["_session_ids"]:
-                continue
-            agg["_session_ids"].add(session_key)
-        elif agg["_sessionless_seen"]:
+            # Rows are newest-first, so the first snapshot per session is the
+            # safest board-local estimate for that cumulative session total.
+            bucket["by_session"].setdefault(str(sid), snapshot)
+        elif bucket["sessionless"] is None:
+            bucket["sessionless"] = snapshot
+
+    out: dict[str, dict[str, Any]] = {}
+    for tid, bucket in latest_by_task.items():
+        by_session = bucket["by_session"]
+        if len(by_session) > 1:
+            # usage_snapshot values are cumulative per session, not per-run
+            # deltas. Summing multiple sessions can charge unrelated work from
+            # reused agent sessions to this card, so let _usage_by_task fall
+            # back to the project ledger, which correlates each session once.
             continue
+        if by_session:
+            snapshot = next(iter(by_session.values()))
+            sessions = 1
         else:
-            agg["_sessionless_seen"] = True
-        for key in ("input_tokens", "output_tokens", "reasoning_tokens"):
-            agg[key] += int(snapshot.get(key) or 0)
-        for key in ("estimated_cost_usd", "actual_cost_usd"):
-            agg[key] += float(snapshot.get(key) or 0.0)
-    for agg in out.values():
-        sessionless_seen = bool(agg.pop("_sessionless_seen", False))
-        agg["sessions"] = len(agg.pop("_session_ids")) + (1 if sessionless_seen else 0)
+            snapshot = bucket["sessionless"]
+            sessions = 1 if snapshot is not None else 0
+        if not isinstance(snapshot, dict):
+            continue
+        out[tid] = {
+            "runs": int(bucket["runs"]),
+            "sessions": sessions,
+            "input_tokens": int(snapshot.get("input_tokens") or 0),
+            "output_tokens": int(snapshot.get("output_tokens") or 0),
+            "reasoning_tokens": int(snapshot.get("reasoning_tokens") or 0),
+            "estimated_cost_usd": float(snapshot.get("estimated_cost_usd") or 0.0),
+            "actual_cost_usd": float(snapshot.get("actual_cost_usd") or 0.0),
+        }
     return out
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -186,19 +186,90 @@ def _comment_dict(c: kanban_db.Comment) -> dict[str, Any]:
     }
 
 
+def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) -> dict[str, dict[str, Any]]:
+    """Build per-task card usage from task_run metadata snapshots.
+
+    Worker terminal events stamp a usage_snapshot when they complete/block.
+    Reading those rows is board-local and cheap, so card badges can update for
+    newly completed tasks without running a full cross-board project ledger
+    backfill on every board poll.
+    """
+    if not task_ids:
+        return {}
+    wanted = set(task_ids)
+    placeholders = ", ".join(["?"] * len(task_ids))
+    out: dict[str, dict[str, Any]] = {}
+    try:
+        conn = kanban_db.connect(board=board_slug)
+    except Exception as exc:
+        log.debug("kanban usage snapshot lookup unavailable: %s", exc)
+        return {}
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT task_id, metadata
+            FROM task_runs
+            WHERE task_id IN ({placeholders})
+            """,
+            list(task_ids),
+        ).fetchall()
+    except Exception as exc:
+        log.debug("kanban usage snapshot lookup failed: %s", exc)
+        return {}
+    finally:
+        conn.close()
+    for row in rows:
+        tid = str(row["task_id"])
+        if tid not in wanted:
+            continue
+        try:
+            meta = json.loads(row["metadata"] or "{}")
+        except Exception:
+            continue
+        snapshot = meta.get("usage_snapshot") if isinstance(meta, dict) else None
+        if not isinstance(snapshot, dict):
+            continue
+        agg = out.setdefault(tid, {
+            "runs": 0,
+            "sessions": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "reasoning_tokens": 0,
+            "estimated_cost_usd": 0.0,
+            "actual_cost_usd": 0.0,
+            "_session_ids": set(),
+        })
+        agg["runs"] += 1
+        sid = snapshot.get("session_id") or meta.get("worker_session_id")
+        if sid:
+            agg["_session_ids"].add(str(sid))
+        for key in ("input_tokens", "output_tokens", "reasoning_tokens"):
+            agg[key] += int(snapshot.get(key) or 0)
+        for key in ("estimated_cost_usd", "actual_cost_usd"):
+            agg[key] += float(snapshot.get(key) or 0.0)
+    for agg in out.values():
+        agg["sessions"] = len(agg.pop("_session_ids"))
+    return out
+
+
 def _usage_by_task(board_slug: Optional[str], task_ids: list[str]) -> dict[str, dict[str, Any]]:
     if not task_ids:
         return {}
+    out = _usage_from_run_snapshots(board_slug, task_ids)
+    missing = [tid for tid in task_ids if tid not in out]
+    if not missing:
+        return out
     try:
         from hermes_cli import project_usage_ledger as usage
-        rows = usage.get_task_rollups(board=board_slug, task_ids=task_ids, refresh=False)
+        rows = usage.get_task_rollups(board=board_slug, task_ids=missing, refresh=False)
         if not rows:
-            rows = usage.get_task_rollups(board=board_slug, task_ids=task_ids, refresh=True)
+            summary = usage.get_summary(board=board_slug, refresh=False)
+            if summary.get("last_backfill_at") is None:
+                rows = usage.get_task_rollups(board=board_slug, task_ids=missing, refresh=True)
     except Exception as exc:
         log.debug("kanban usage rollup unavailable: %s", exc)
-        return {}
-    wanted = set(task_ids)
-    out: dict[str, dict[str, Any]] = {}
+        return out
+    wanted = set(missing)
     for row in rows:
         tid = row.get("task_id")
         if tid in wanted:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1758,24 +1758,6 @@ def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(N
 
 
 # ---------------------------------------------------------------------------
-# Usage (token/cost rollups from the project usage ledger)
-# ---------------------------------------------------------------------------
-
-@router.get("/usage")
-def get_usage(
-    board: Optional[str] = Query(None),
-    task_id: Optional[str] = Query(None),
-    refresh: bool = Query(True),
-):
-    board = _resolve_board(board)
-    try:
-        from hermes_cli import project_usage_ledger as usage
-        return usage.get_summary(board=board, task_id=task_id, refresh=refresh)
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"usage summary failed: {exc}")
-
-
-# ---------------------------------------------------------------------------
 # Stats (per-profile / per-status counts + oldest-ready age)
 # ---------------------------------------------------------------------------
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -242,7 +242,10 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
         agg["runs"] += 1
         sid = snapshot.get("session_id") or meta.get("worker_session_id")
         if sid:
-            agg["_session_ids"].add(str(sid))
+            session_key = str(sid)
+            if session_key in agg["_session_ids"]:
+                continue
+            agg["_session_ids"].add(session_key)
         for key in ("input_tokens", "output_tokens", "reasoning_tokens"):
             agg[key] += int(snapshot.get(key) or 0)
         for key in ("estimated_cost_usd", "actual_cost_usd"):

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -223,6 +223,12 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
         tid = str(row["task_id"])
         if tid not in wanted:
             continue
+        bucket = latest_by_task.setdefault(tid, {
+            "runs": 0,
+            "by_session": {},
+            "sessionless": None,
+        })
+        bucket["runs"] += 1
         try:
             meta = json.loads(row["metadata"] or "{}")
         except Exception:
@@ -230,12 +236,6 @@ def _usage_from_run_snapshots(board_slug: Optional[str], task_ids: list[str]) ->
         snapshot = meta.get("usage_snapshot") if isinstance(meta, dict) else None
         if not isinstance(snapshot, dict):
             continue
-        bucket = latest_by_task.setdefault(tid, {
-            "runs": 0,
-            "by_session": {},
-            "sessionless": None,
-        })
-        bucket["runs"] += 1
         sid = snapshot.get("session_id") or meta.get("worker_session_id")
         if sid:
             # Rows are newest-first, so the first snapshot per session is the

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -191,15 +191,15 @@ def _usage_by_task(board_slug: Optional[str], task_ids: list[str]) -> dict[str, 
         return {}
     try:
         from hermes_cli import project_usage_ledger as usage
-        summary = usage.get_summary(board=board_slug, refresh=False)
-        if summary.get("last_backfill_at") is None:
-            summary = usage.get_summary(board=board_slug, refresh=True)
+        rows = usage.get_task_rollups(board=board_slug, task_ids=task_ids, refresh=False)
+        if not rows:
+            rows = usage.get_task_rollups(board=board_slug, task_ids=task_ids, refresh=True)
     except Exception as exc:
         log.debug("kanban usage rollup unavailable: %s", exc)
         return {}
     wanted = set(task_ids)
     out: dict[str, dict[str, Any]] = {}
-    for row in summary.get("tasks") or []:
+    for row in rows:
         tid = row.get("task_id")
         if tid in wanted:
             out[str(tid)] = {

--- a/plugins/project_usage/dashboard/dist/index.js
+++ b/plugins/project_usage/dashboard/dist/index.js
@@ -1,0 +1,225 @@
+(function () {
+  var sdk = window.__HERMES_PLUGIN_SDK__;
+  var registry = window.__HERMES_PLUGINS__;
+  if (!sdk || !registry) return;
+
+  var React = sdk.React;
+  var hooks = sdk.hooks;
+  var fetchJSON = sdk.fetchJSON;
+  var Card = sdk.components.Card;
+  var CardHeader = sdk.components.CardHeader;
+  var CardTitle = sdk.components.CardTitle;
+  var CardContent = sdk.components.CardContent;
+  var Button = sdk.components.Button;
+  var Badge = sdk.components.Badge;
+  var Input = sdk.components.Input;
+  var Select = sdk.components.Select;
+  var SelectOption = sdk.components.SelectOption;
+
+  function h(type, props) {
+    var children = Array.prototype.slice.call(arguments, 2);
+    return React.createElement.apply(React, [type, props || {}].concat(children));
+  }
+
+  function fmtInt(v) {
+    return Number(v || 0).toLocaleString();
+  }
+
+  function fmtUsd(v) {
+    var n = Number(v || 0);
+    if (!Number.isFinite(n)) n = 0;
+    return "$" + n.toFixed(n >= 1 ? 2 : 4);
+  }
+
+  function fmtTs(v) {
+    if (!v) return "—";
+    var ms = Number(v) * 1000;
+    if (!Number.isFinite(ms)) return "—";
+    return new Date(ms).toLocaleString();
+  }
+
+  function tokenTotal(row) {
+    return Number(row.input_tokens || 0) + Number(row.output_tokens || 0) + Number(row.reasoning_tokens || 0);
+  }
+
+  function SummaryCard(props) {
+    return h(Card, { className: "project-usage-card" },
+      h(CardHeader, null, h(CardTitle, null, props.label)),
+      h(CardContent, null,
+        h("div", { className: "project-usage-metric" }, props.value),
+        props.sub ? h("div", { className: "project-usage-muted" }, props.sub) : null
+      )
+    );
+  }
+
+  function ProjectUsagePage() {
+    var _useState = hooks.useState(null), data = _useState[0], setData = _useState[1];
+    var _useState2 = hooks.useState(""), error = _useState2[0], setError = _useState2[1];
+    var _useState3 = hooks.useState(true), loading = _useState3[0], setLoading = _useState3[1];
+    var _useState4 = hooks.useState(""), board = _useState4[0], setBoard = _useState4[1];
+    var _useState5 = hooks.useState(""), taskId = _useState5[0], setTaskId = _useState5[1];
+    var _useState6 = hooks.useState(""), search = _useState6[0], setSearch = _useState6[1];
+
+    var load = hooks.useCallback(function (opts) {
+      opts = opts || {};
+      setLoading(true);
+      setError("");
+      var params = new URLSearchParams();
+      if (board) params.set("board", board);
+      if (taskId) params.set("task_id", taskId);
+      params.set("refresh", opts.refresh === false ? "false" : "true");
+      fetchJSON("/api/plugins/project_usage/summary?" + params.toString())
+        .then(function (json) { setData(json); })
+        .catch(function (err) { setError(String(err && err.message ? err.message : err)); })
+        .finally(function () { setLoading(false); });
+    }, [board, taskId]);
+
+    hooks.useEffect(function () { load({ refresh: true }); }, [load]);
+
+    var boards = data && data.boards ? data.boards : [];
+    var tasks = data && data.tasks ? data.tasks : [];
+    var runs = data && data.runs ? data.runs : [];
+    var totals = data && data.totals ? data.totals : {};
+    var query = search.trim().toLowerCase();
+    var visibleTasks = tasks.filter(function (t) {
+      if (!query) return true;
+      return String(t.task_id || "").toLowerCase().includes(query) ||
+        String(t.task_title || "").toLowerCase().includes(query) ||
+        String(t.board_slug || "").toLowerCase().includes(query);
+    });
+
+    return h("div", { className: "project-usage" },
+      h("div", { className: "project-usage-header" },
+        h("div", null,
+          h("h1", null, "Project Usage"),
+          h("p", null, "Usage ledger under Hermes home, backfilled from state.db and Kanban board metadata.")
+        ),
+        h("div", { className: "project-usage-actions" },
+          h(Button, { onClick: function () { load({ refresh: true }); }, disabled: loading }, loading ? "Refreshing…" : "Refresh ledger")
+        )
+      ),
+
+      error ? h("div", { className: "project-usage-error" }, error) : null,
+
+      h("div", { className: "project-usage-grid" },
+        h(SummaryCard, { label: "Estimated cost", value: fmtUsd(totals.estimated_cost_usd), sub: "actual " + fmtUsd(totals.actual_cost_usd) }),
+        h(SummaryCard, { label: "Input tokens", value: fmtInt(totals.input_tokens), sub: "cache read " + fmtInt(totals.cache_read_tokens) }),
+        h(SummaryCard, { label: "Output tokens", value: fmtInt(totals.output_tokens), sub: "reasoning " + fmtInt(totals.reasoning_tokens) }),
+        h(SummaryCard, { label: "Coverage", value: fmtInt(totals.tasks) + " tasks", sub: fmtInt(totals.sessions) + " sessions / " + fmtInt(totals.entries) + " entries" })
+      ),
+
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Filters")),
+        h(CardContent, null,
+          h("div", { className: "project-usage-filters" },
+            h("label", null, "Board",
+              h(Select, {
+                value: board || "__all__",
+                onValueChange: function (v) { setTaskId(""); setBoard(v === "__all__" ? "" : v); },
+                onChange: function (e) { var v = e.target.value; setTaskId(""); setBoard(v === "__all__" ? "" : v); }
+              },
+                h(SelectOption, { value: "__all__" }, "All boards"),
+                boards.filter(function (b) { return b.board_slug !== "__unassigned__"; }).map(function (b) {
+                  return h(SelectOption, { key: b.board_slug, value: b.board_slug }, b.board_name + " (" + b.board_slug + ")");
+                })
+              )
+            ),
+            h("label", null, "Search tasks",
+              h(Input, { value: search, placeholder: "task id/title/board", onChange: function (e) { setSearch(e.target.value); } })
+            ),
+            taskId ? h("div", { className: "project-usage-selected" },
+              h(Badge, null, "Drilldown: " + taskId),
+              h(Button, { onClick: function () { setTaskId(""); } }, "Clear")
+            ) : null
+          )
+        )
+      ),
+
+      h("div", { className: "project-usage-columns" },
+        h(Card, null,
+          h(CardHeader, null, h(CardTitle, null, "Per-board totals")),
+          h(CardContent, null,
+            h("div", { className: "project-usage-table-wrap" },
+              h("table", { className: "project-usage-table" },
+                h("thead", null, h("tr", null,
+                  h("th", null, "Board"), h("th", null, "Tasks"), h("th", null, "Sessions"),
+                  h("th", null, "Tokens"), h("th", null, "Est. cost"), h("th", null, "Latest")
+                )),
+                h("tbody", null,
+                  boards.map(function (b) {
+                    return h("tr", { key: b.board_slug, onClick: function () { if (b.board_slug !== "__unassigned__") { setTaskId(""); setBoard(b.board_slug); } } },
+                      h("td", null, h("strong", null, b.board_name), h("div", { className: "project-usage-muted" }, b.board_slug)),
+                      h("td", null, fmtInt(b.tasks)),
+                      h("td", null, fmtInt(b.sessions)),
+                      h("td", null, fmtInt(tokenTotal(b))),
+                      h("td", null, fmtUsd(b.estimated_cost_usd)),
+                      h("td", null, fmtTs(b.latest_started_at))
+                    );
+                  })
+                )
+              )
+            )
+          )
+        ),
+
+        h(Card, null,
+          h(CardHeader, null, h(CardTitle, null, "Per-task drilldown")),
+          h(CardContent, null,
+            h("div", { className: "project-usage-table-wrap" },
+              h("table", { className: "project-usage-table" },
+                h("thead", null, h("tr", null,
+                  h("th", null, "Task"), h("th", null, "Board"), h("th", null, "Runs"),
+                  h("th", null, "Tokens"), h("th", null, "Est. cost"), h("th", null, "Last ended")
+                )),
+                h("tbody", null,
+                  visibleTasks.map(function (t) {
+                    return h("tr", { key: t.board_slug + ":" + t.task_id, onClick: function () { setBoard(t.board_slug || ""); setTaskId(t.task_id); } },
+                      h("td", null, h("strong", null, t.task_title || t.task_id), h("div", { className: "project-usage-muted" }, t.task_id + " · " + (t.task_status || "unknown"))),
+                      h("td", null, t.board_name || t.board_slug || "—"),
+                      h("td", null, fmtInt(t.runs)),
+                      h("td", null, fmtInt(tokenTotal(t))),
+                      h("td", null, fmtUsd(t.estimated_cost_usd)),
+                      h("td", null, fmtTs(t.last_ended_at))
+                    );
+                  })
+                )
+              )
+            )
+          )
+        )
+      ),
+
+      taskId ? h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Run/session rows for " + taskId)),
+        h(CardContent, null,
+          h("div", { className: "project-usage-table-wrap" },
+            h("table", { className: "project-usage-table" },
+              h("thead", null, h("tr", null,
+                h("th", null, "Run"), h("th", null, "Session"), h("th", null, "Model"),
+                h("th", null, "Tokens"), h("th", null, "Est. cost"), h("th", null, "Status")
+              )),
+              h("tbody", null,
+                runs.map(function (r) {
+                  return h("tr", { key: r.source_id },
+                    h("td", null, r.run_id || "—"),
+                    h("td", null, h("div", null, r.session_title || r.session_id || "unlinked"), h("div", { className: "project-usage-muted" }, r.session_id || "—")),
+                    h("td", null, r.model || "—"),
+                    h("td", null, fmtInt(tokenTotal(r))),
+                    h("td", null, fmtUsd(r.estimated_cost_usd)),
+                    h("td", null, (r.run_status || "—") + (r.run_outcome ? " / " + r.run_outcome : ""))
+                  );
+                })
+              )
+            )
+          )
+        )
+      ) : null,
+
+      data ? h("div", { className: "project-usage-footer" },
+        "Ledger: " + data.ledger_path + " · Last backfill: " + fmtTs(data.last_backfill_at)
+      ) : null
+    );
+  }
+
+  registry.register("project_usage", ProjectUsagePage);
+})();

--- a/plugins/project_usage/dashboard/dist/style.css
+++ b/plugins/project_usage/dashboard/dist/style.css
@@ -1,0 +1,116 @@
+.project-usage {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.project-usage-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.project-usage-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.project-usage-header p,
+.project-usage-muted,
+.project-usage-footer {
+  color: hsl(var(--muted-foreground, 240 3.8% 46.1%));
+  font-size: 0.85rem;
+}
+
+.project-usage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.75rem;
+}
+
+.project-usage-metric {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.project-usage-filters {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(220px, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.project-usage-filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.project-usage-selected,
+.project-usage-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.project-usage-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 1rem;
+}
+
+.project-usage-table-wrap {
+  overflow-x: auto;
+}
+
+.project-usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.project-usage-table th,
+.project-usage-table td {
+  padding: 0.55rem 0.6rem;
+  border-bottom: 1px solid hsl(var(--border, 240 5.9% 90%));
+  text-align: left;
+  vertical-align: top;
+}
+
+.project-usage-table th {
+  color: hsl(var(--muted-foreground, 240 3.8% 46.1%));
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.project-usage-table tbody tr {
+  cursor: pointer;
+}
+
+.project-usage-table tbody tr:hover {
+  background: hsl(var(--muted, 240 4.8% 95.9%) / 0.45);
+}
+
+.project-usage-error {
+  border: 1px solid hsl(var(--destructive, 0 84.2% 60.2%));
+  color: hsl(var(--destructive, 0 84.2% 60.2%));
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+}
+
+.project-usage-footer {
+  word-break: break-all;
+}
+
+@media (max-width: 760px) {
+  .project-usage-header,
+  .project-usage-filters {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+}

--- a/plugins/project_usage/dashboard/manifest.json
+++ b/plugins/project_usage/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "project_usage",
+  "label": "Project Usage",
+  "description": "Per-board and per-task token/cost usage ledger for Kanban projects",
+  "icon": "BarChart3",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/project-usage",
+    "position": "after:kanban"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/project_usage/dashboard/plugin_api.py
+++ b/plugins/project_usage/dashboard/plugin_api.py
@@ -1,0 +1,30 @@
+"""Project Usage dashboard plugin backend.
+
+Mounted at /api/plugins/project_usage/ by the dashboard plugin loader.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from hermes_cli import project_usage_ledger
+
+router = APIRouter()
+
+
+@router.get("/summary")
+def get_project_usage_summary(
+    board: Optional[str] = Query(None, description="Optional board slug filter"),
+    task_id: Optional[str] = Query(None, description="Optional task id drilldown"),
+    refresh: bool = Query(True, description="Refresh ledger from source DBs before reading"),
+):
+    """Return per-board totals and per-task drilldown usage rows."""
+    return project_usage_ledger.get_summary(board=board, task_id=task_id, refresh=refresh)
+
+
+@router.post("/backfill")
+def backfill_project_usage():
+    """Force an idempotent ledger backfill."""
+    return project_usage_ledger.backfill()

--- a/scripts/update_local_fork.sh
+++ b/scripts/update_local_fork.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rebase the user's local/fork-retained Hermes Agent customization branch on top
+# of upstream NousResearch/hermes-agent main, then push the rebased branch to the
+# user's fork. This keeps local-only changes reapplied after Hermes updates
+# without ad hoc cherry-picking.
+
+BRANCH="${1:-openclaw/local-main}"
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-origin}"
+UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-main}"
+FORK_REMOTE="${FORK_REMOTE:-fork}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Refusing to update with uncommitted changes in $repo_root" >&2
+  git status --short
+  exit 2
+fi
+
+git fetch "$UPSTREAM_REMOTE" "$UPSTREAM_BRANCH"
+git fetch "$FORK_REMOTE" "$BRANCH" || true
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git switch "$BRANCH"
+elif git show-ref --verify --quiet "refs/remotes/$FORK_REMOTE/$BRANCH"; then
+  git switch -c "$BRANCH" --track "$FORK_REMOTE/$BRANCH"
+else
+  echo "Branch $BRANCH not found locally or on $FORK_REMOTE" >&2
+  exit 3
+fi
+
+git rebase "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH"
+
+# Lightweight smoke check from the local checkout's virtualenv when present.
+if [ -x ./venv/bin/python ]; then
+  ./venv/bin/python - <<'PY'
+from hermes_cli.main import main
+print('hermes_cli import ok')
+PY
+fi
+
+# Keep the fork branch updated so future machines/workers can recover it.
+git push --force-with-lease "$FORK_REMOTE" "$BRANCH"
+
+echo "Updated $BRANCH on top of $UPSTREAM_REMOTE/$UPSTREAM_BRANCH and pushed to $FORK_REMOTE/$BRANCH"

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -519,3 +519,30 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+
+def test_usage_refresh_flag_defaults_false_and_respects_explicit_refresh(monkeypatch, capsys):
+    from hermes_cli import project_usage_ledger as usage
+
+    calls = []
+
+    def fake_get_summary(**kwargs):
+        calls.append(kwargs)
+        return {
+            "ledger_path": "/tmp/project_usage.db",
+            "totals": {},
+            "boards": [],
+            "tasks": [],
+            "last_backfill_at": None,
+        }
+
+    monkeypatch.setattr(usage, "get_summary", fake_get_summary)
+
+    assert kc._cmd_usage(argparse.Namespace(refresh=None, board=None, task_id=None, json=True)) == 0
+    assert kc._cmd_usage(argparse.Namespace(refresh=True, board="default", task_id="t1", json=True)) == 0
+    assert kc._cmd_usage(argparse.Namespace(refresh=False, board=None, task_id=None, json=True)) == 0
+
+    assert [c["refresh"] for c in calls] == [False, True, False]
+    assert calls[1]["board"] == "default"
+    assert calls[1]["task_id"] == "t1"
+    capsys.readouterr()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -345,7 +345,11 @@ def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
         t = kb.create_task(conn, title="delayed recheck", assignee="ops")
         assert kb.schedule_task(conn, t, reason="run next week") is True
         task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
         assert task.status == "scheduled"
+        assert run is not None
+        assert run.status == "scheduled"
+        assert run.outcome == "scheduled"
         assert kb.claim_task(conn, t) is None
 
         events = kb.list_events(conn, t)
@@ -3253,6 +3257,24 @@ def test_required_review_gate_routes_implementation_completion_to_merge_captain(
     assert run.status == "review"
     assert run.outcome == "completed"
     assert any(e.kind == "submitted_for_review" for e in events)
+
+
+def test_ready_completion_synthesizes_review_status_run(kanban_home, monkeypatch):
+    """Synthetic completion runs should preserve the destination lane."""
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="manual impl completion", assignee="worker-a")
+        assert kb.complete_task(conn, t, summary="PR ready without active claim")
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+
+    assert task is not None
+    assert run is not None
+    assert task.status == "review"
+    assert task.assignee == "merge-captain"
+    assert run.status == "review"
+    assert run.outcome == "completed"
 
 
 def test_required_review_gate_allows_review_run_to_complete_done(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -639,6 +639,35 @@ def test_resolve_crash_grace_seconds_handles_bad_env(monkeypatch):
             f"expected default for {bad_val!r}, got {result}"
         )
 
+def test_detect_crashed_review_worker_returns_to_review(
+    kanban_home, monkeypatch,
+):
+    """A crashed merge-captain attempt must stay in Review, not ready."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="review crash", assignee="mergecaptain")
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (tid,))
+        host = _kb._claimer_id().split(":", 1)[0]
+        claimed = kb.claim_review_task(conn, tid, claimer=f"{host}:reviewer")
+        assert claimed is not None
+        conn.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (81000, tid))
+        conn.execute(
+            "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
+            (81000, claimed.current_run_id),
+        )
+        conn.commit()
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert crashed == [tid]
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "review"
+        assert task.assignee == "mergecaptain"
+        assert task.claim_lock is None
+
 
 def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch):
     """A retry should get a fresh max-runtime window.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1383,6 +1383,39 @@ def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     assert reason is None
 
 
+def test_respawn_guard_recent_success_older_than_unblock_not_guarded(kanban_home):
+    """Review/manual handoff after a successful run must allow re-spawn."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="needs-followup", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'completed', ?, ?)",
+            (t, now - 300, now - 120),
+        )
+        assert kb.block_task(conn, t, reason="review found follow-up")
+        assert kb.unblock_task(conn, t)
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_pr_comment_older_than_unblock_not_guarded(kanban_home):
+    """A PR URL from the previous handoff must not pin a requeued task."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="fix-pr-followup", assignee="alice")
+        old_ts = int(time.time()) - 120
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', "
+            "'PR: https://github.com/totemx-AI/subsidysmart/pull/11', ?)",
+            (t, old_ts),
+        )
+        assert kb.block_task(conn, t, reason="review found follow-up")
+        assert kb.unblock_task(conn, t)
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
 def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
     kanban_home, all_assignees_spawnable
 ):
@@ -2973,6 +3006,49 @@ def test_dispatch_review_spawn_failure_blocks_intentionally_at_threshold(
     assert (run.metadata or {}).get("restore_status") == "review"
     gave_up = [event for event in events if event.kind == "gave_up"][-1]
     assert (gave_up.payload or {}).get("restore_status") == "review"
+
+
+def test_review_origin_crash_breaker_keeps_restore_status_metadata(
+    kanban_home, all_assignees_spawnable,
+):
+    """Breaker metadata keeps review origin even after _end_run clears current_run_id."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review crash", assignee="alice", max_retries=1)
+        _set_task_status(conn, t, "review")
+        assert kb.claim_review_task(conn, t) is not None
+        conn.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (99999999, t))
+
+        crashed = kb.detect_crashed_workers(conn)
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert crashed == [t]
+    assert task is not None
+    assert task.status == "blocked"
+    gave_up = [event for event in events if event.kind == "gave_up"][-1]
+    assert (gave_up.payload or {}).get("restore_status") == "review"
+
+
+def test_review_origin_stale_claim_restores_to_review(kanban_home):
+    """Expired review claims should return to Review, not Ready."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review stale", assignee="alice")
+        _set_task_status(conn, t, "review")
+        claimed = kb.claim_review_task(conn, t, ttl_seconds=1)
+        assert claimed is not None
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, worker_pid = ? WHERE id = ?",
+            (int(time.time()) - 10, 99999999, t),
+        )
+
+        assert kb.release_stale_claims(conn) == 1
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert task is not None
+    assert task.status == "review"
+    reclaimed = [event for event in events if event.kind == "reclaimed"][-1]
+    assert (reclaimed.payload or {}).get("restore_status") == "review"
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3059,6 +3059,53 @@ def test_review_origin_stale_claim_restores_to_review(kanban_home):
     assert (reclaimed.payload or {}).get("restore_status") == "review"
 
 
+def test_review_origin_manual_reclaim_restores_to_review(kanban_home):
+    """Manual reclaim should preserve the lane that produced the active run."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="manual review reclaim", assignee="alice")
+        _set_task_status(conn, t, "review")
+        claimed = kb.claim_review_task(conn, t, ttl_seconds=60)
+        assert claimed is not None
+
+        assert kb.reclaim_task(conn, t, reason="operator retry")
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert task is not None
+    assert task.status == "review"
+    assert run is not None
+    assert run.status == "review"
+    assert run.outcome == "reclaimed"
+    reclaimed = [event for event in events if event.kind == "reclaimed"][-1]
+    assert (reclaimed.payload or {}).get("restore_status") == "review"
+
+
+def test_spawn_breaker_blocks_even_after_review_status_restore(kanban_home):
+    """Breaker UPDATE accepts review if spawn bookkeeping sees a restored task."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review breaker", assignee="alice")
+        _set_task_status(conn, t, "review")
+
+        tripped = kb._record_task_failure(
+            conn,
+            t,
+            "synthetic spawn failure",
+            outcome="spawn_failed",
+            failure_limit=1,
+            release_claim=True,
+            end_run=False,
+            restore_status="review",
+        )
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert tripped is True
+    assert task is not None
+    assert task.status == "blocked"
+    assert any(e.kind == "gave_up" for e in events)
+
+
 def test_dispatch_review_skips_unassigned(kanban_home):
     """Unassigned review tasks go to skipped_unassigned, not spawned."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import time
@@ -3222,6 +3223,20 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
             f"Expected 'stale' event in task_events; got {kinds!r}"
         )
 
+
+def test_block_ready_task_with_metadata_synthesizes_run(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="metadata-only block")
+        assert kb.block_task(conn, tid, metadata={"worker_session_id": "sess-block"})
+        rows = conn.execute(
+            "SELECT status, outcome, metadata FROM task_runs WHERE task_id = ?",
+            (tid,),
+        ).fetchall()
+
+    assert len(rows) == 1
+    assert rows[0]["status"] == "blocked"
+    assert rows[0]["outcome"] == "blocked"
+    assert json.loads(rows[0]["metadata"])["worker_session_id"] == "sess-block"
 
 # ---------------------------------------------------------------------------
 # Corruption guard (issue #30687)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3149,6 +3149,44 @@ def test_required_review_gate_block_returns_to_original_worker(kanban_home, monk
     assert any(e.kind == "review_rejected" for e in events)
 
 
+def test_required_review_gate_block_without_implementation_assignee_is_explicit(
+    kanban_home, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="unassigned impl", assignee=None)
+        impl = kb.claim_task(conn, t)
+        assert impl is not None
+        assert kb.complete_task(conn, t, summary="PR ready", expected_run_id=impl.current_run_id)
+        review = kb.claim_review_task(conn, t)
+        assert review is not None
+        assert kb.block_task(
+            conn,
+            t,
+            reason="review rejected",
+            expected_run_id=review.current_run_id,
+        )
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+        event = kb.list_events(conn, t)[-1]
+
+    assert task is not None
+    assert run is not None
+    assert task.status == "blocked"
+    assert task.assignee == "merge-captain"
+    assert run.outcome == "blocked"
+    assert run.status == "blocked"
+    assert (run.metadata or {}).get("review_rejection") is True
+    assert (run.metadata or {}).get("missing_implementation_assignee") is True
+    assert "implementation assignee" in (run.metadata or {}).get(
+        "review_rejection_reason", ""
+    )
+    assert event.kind == "blocked"
+    assert (event.payload or {}).get("review_rejection") is True
+    assert (event.payload or {}).get("missing_implementation_assignee") is True
+
+
 def test_dispatch_review_does_not_claim_ready_tasks(
     kanban_home, all_assignees_spawnable,
 ):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3106,6 +3106,31 @@ def test_spawn_breaker_blocks_even_after_review_status_restore(kanban_home):
     assert any(e.kind == "gave_up" for e in events)
 
 
+def test_spawn_failure_below_threshold_updates_review_restored_task(kanban_home):
+    """Below-threshold spawn bookkeeping also accepts review-restored tasks."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review below threshold", assignee="alice")
+        _set_task_status(conn, t, "review")
+
+        tripped = kb._record_task_failure(
+            conn,
+            t,
+            "synthetic spawn failure",
+            outcome="spawn_failed",
+            failure_limit=2,
+            release_claim=True,
+            end_run=False,
+            restore_status="review",
+        )
+        task = kb.get_task(conn, t)
+
+    assert tripped is False
+    assert task is not None
+    assert task.status == "review"
+    assert task.consecutive_failures == 1
+    assert task.last_failure_error == "synthetic spawn failure"
+
+
 def test_dispatch_review_skips_unassigned(kanban_home):
     """Unassigned review tasks go to skipped_unassigned, not spawned."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2155,6 +2155,12 @@ class TestSharedBoardPaths:
         # `-p <profile>` flag rewrites HERMES_HOME.
         default_home = tmp_path / ".hermes"
         default_home.mkdir()
+        (default_home / "config.yaml").write_text(
+            "kanban:\n"
+            "  require_review_before_done: true\n"
+            "  merge_captain_profile: merge-captain\n",
+            encoding="utf-8",
+        )
         self._set_home(monkeypatch, tmp_path, default_home)
 
         captured = {}
@@ -2194,6 +2200,8 @@ class TestSharedBoardPaths:
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
+        assert env["HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE"] == "1"
+        assert env["HERMES_KANBAN_MERGE_CAPTAIN_PROFILE"] == "merge-captain"
 
 
 # ---------------------------------------------------------------------------
@@ -3368,7 +3376,7 @@ def test_required_review_gate_block_returns_to_original_worker(kanban_home, monk
         assert kb.block_task(
             conn,
             t,
-            reason="Bugbot found issue; rebase after recent merge and fix failing test.",
+            reason="Bugbot found issue; fix failing test and update the PR body.",
             expected_run_id=review.current_run_id,
         )
         task = kb.get_task(conn, t)
@@ -3382,6 +3390,70 @@ def test_required_review_gate_block_returns_to_original_worker(kanban_home, monk
     assert run.outcome == "blocked"
     assert run.status == "ready"
     assert any(e.kind == "review_rejected" for e in events)
+
+
+def test_required_review_gate_rebase_block_stays_blocked_for_recovery(
+    kanban_home, monkeypatch
+):
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="stale PR", assignee="worker-a")
+        impl = kb.claim_task(conn, t)
+        assert impl is not None
+        assert kb.complete_task(conn, t, summary="PR ready", expected_run_id=impl.current_run_id)
+        review = kb.claim_review_task(conn, t)
+        assert review is not None
+        assert kb.block_task(
+            conn,
+            t,
+            reason=(
+                "rebase-required: PR is exact-head clean, but origin/main "
+                "advanced and GitHub reports mergeable_state=dirty."
+            ),
+            expected_run_id=review.current_run_id,
+        )
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+        run = kb.latest_run(conn, t)
+
+    assert task is not None
+    assert run is not None
+    assert task.status == "blocked"
+    assert task.assignee == "merge-captain"
+    assert run.outcome == "blocked"
+    assert run.status == "blocked"
+    assert (run.metadata or {}).get("review_rebase_blocker") is True
+    assert events[-1].kind == "blocked"
+    assert (events[-1].payload or {}).get("review_rebase_blocker") is True
+
+
+def test_review_origin_block_routes_even_when_profile_config_lacks_gate(
+    kanban_home, monkeypatch
+):
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="profile gap", assignee="worker-a")
+        impl = kb.claim_task(conn, t)
+        assert impl is not None
+        assert kb.complete_task(conn, t, summary="PR ready", expected_run_id=impl.current_run_id)
+        review = kb.claim_review_task(conn, t)
+        assert review is not None
+        monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "0")
+        assert kb.block_task(
+            conn,
+            t,
+            reason="Bugbot found an issue; fix it and resubmit.",
+            expected_run_id=review.current_run_id,
+        )
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert task is not None
+    assert task.status == "ready"
+    assert task.assignee == "worker-a"
+    assert events[-1].kind == "review_rejected"
 
 
 def test_required_review_gate_block_without_implementation_assignee_is_explicit(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3316,6 +3316,24 @@ def test_ready_completion_synthesizes_review_status_run(kanban_home, monkeypatch
     assert run.outcome == "completed"
 
 
+def test_complete_task_preserves_zero_expected_run_id_for_review_gate(kanban_home, monkeypatch):
+    """Only None means no run id; numeric zero should still be passed through."""
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    seen = []
+
+    def fake_run_started_from_review(conn, task_id, run_id):
+        _ = conn, task_id
+        seen.append(run_id)
+        return False
+
+    monkeypatch.setattr(kb, "_run_started_from_review", fake_run_started_from_review)
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="zero run id", assignee="worker-a")
+        assert not kb.complete_task(conn, t, summary="mismatched run", expected_run_id=0)
+
+    assert seen == [0]
+
+
 def test_required_review_gate_allows_review_run_to_complete_done(kanban_home, monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
     monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2916,7 +2916,7 @@ def test_dispatch_review_spawns_with_correct_skills(
         res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
-    assert spawned_tasks[0].skills == ["cursor-bugbot-sweep", "github-pr-workflow"]
+    assert spawned_tasks[0].skills == ["github/cursor-bugbot-sweep", "github/github-pr-workflow"]
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2854,10 +2854,27 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
         assert kb.get_task(conn, t).status == "review"
 
 
+def test_skill_available_accepts_qualified_and_unqualified_names(kanban_home):
+    """Worker skill preflight accepts category-qualified skill names safely."""
+    (kanban_home / "skills" / "github" / "cursor-bugbot-sweep").mkdir(parents=True)
+    (kanban_home / "skills" / "github" / "cursor-bugbot-sweep" / "SKILL.md").write_text(
+        "---\nname: cursor-bugbot-sweep\n---\n# Skill\n"
+    )
+    (kanban_home / "skills" / "devops" / "kanban-worker").mkdir(parents=True)
+    (kanban_home / "skills" / "devops" / "kanban-worker" / "SKILL.md").write_text(
+        "---\nname: kanban-worker\n---\n# Skill\n"
+    )
+
+    assert kb._skill_available(str(kanban_home), "github/cursor-bugbot-sweep")
+    assert kb._skill_available(str(kanban_home), "kanban-worker")
+    assert not kb._skill_available(str(kanban_home), "../cursor-bugbot-sweep")
+    assert not kb._skill_available(str(kanban_home), "/tmp/cursor-bugbot-sweep")
+
+
 def test_dispatch_review_spawns_with_correct_skills(
     kanban_home, all_assignees_spawnable,
 ):
-    """Review tasks get sdlc-review skill set before spawning."""
+    """Review tasks get merge-train skills set before spawning."""
     spawned_tasks = []
 
     def capture_spawn(task, workspace, board=None):
@@ -2870,7 +2887,7 @@ def test_dispatch_review_spawns_with_correct_skills(
         res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
-    assert spawned_tasks[0].skills == ["sdlc-review"]
+    assert spawned_tasks[0].skills == ["cursor-bugbot-sweep", "github-pr-workflow"]
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):
@@ -2965,6 +2982,86 @@ def test_dispatch_review_skips_nonspawnable(kanban_home, monkeypatch):
 def test_review_status_in_valid_statuses():
     """'review' is a valid task status."""
     assert "review" in kb.VALID_STATUSES
+
+
+def test_required_review_gate_routes_implementation_completion_to_merge_captain(
+    kanban_home, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="implement feature", assignee="worker-a")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="PR ready for review",
+            metadata={"pr": 123},
+            expected_run_id=claimed.current_run_id,
+        )
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+        run = kb.latest_run(conn, t)
+
+    assert task is not None
+    assert run is not None
+    assert task.status == "review"
+    assert task.assignee == "merge-captain"
+    assert task.completed_at is None
+    assert run.status == "review"
+    assert run.outcome == "completed"
+    assert any(e.kind == "submitted_for_review" for e in events)
+
+
+def test_required_review_gate_allows_review_run_to_complete_done(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="merge approved", assignee="worker-a")
+        impl = kb.claim_task(conn, t)
+        assert impl is not None
+        assert kb.complete_task(conn, t, summary="PR ready", expected_run_id=impl.current_run_id)
+        review = kb.claim_review_task(conn, t)
+        assert review is not None
+        assert review.assignee == "merge-captain"
+        assert kb.complete_task(conn, t, summary="merged", expected_run_id=review.current_run_id)
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert task is not None
+    assert task.status == "done"
+    assert task.completed_at is not None
+    assert any(e.kind == "completed" for e in events)
+
+
+def test_required_review_gate_block_returns_to_original_worker(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE", "1")
+    monkeypatch.setenv("HERMES_KANBAN_MERGE_CAPTAIN_PROFILE", "merge-captain")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="bugbot found issue", assignee="worker-a")
+        impl = kb.claim_task(conn, t)
+        assert impl is not None
+        assert kb.complete_task(conn, t, summary="PR ready", expected_run_id=impl.current_run_id)
+        review = kb.claim_review_task(conn, t)
+        assert review is not None
+        assert kb.block_task(
+            conn,
+            t,
+            reason="Bugbot found issue; rebase after recent merge and fix failing test.",
+            expected_run_id=review.current_run_id,
+        )
+        task = kb.get_task(conn, t)
+        events = kb.list_events(conn, t)
+        run = kb.latest_run(conn, t)
+
+    assert task is not None
+    assert run is not None
+    assert task.status == "ready"
+    assert task.assignee == "worker-a"
+    assert run.outcome == "blocked"
+    assert run.status == "ready"
+    assert any(e.kind == "review_rejected" for e in events)
 
 
 def test_dispatch_review_does_not_claim_ready_tasks(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2974,7 +2974,7 @@ def test_dispatch_review_spawn_failure_returns_to_review_below_threshold(
     assert task.assignee == "alice"
     assert task.claim_lock is None
     assert run is not None
-    assert run.status == "spawn_failed"
+    assert run.status == "review"
     assert run.outcome == "spawn_failed"
     assert (run.metadata or {}).get("restore_status") == "review"
 
@@ -3001,7 +3001,7 @@ def test_dispatch_review_spawn_failure_blocks_intentionally_at_threshold(
     assert task.assignee == "alice"
     assert task.claim_lock is None
     assert run is not None
-    assert run.status == "gave_up"
+    assert run.status == "blocked"
     assert run.outcome == "gave_up"
     assert (run.metadata or {}).get("restore_status") == "review"
     gave_up = [event for event in events if event.kind == "gave_up"][-1]
@@ -3020,11 +3020,15 @@ def test_review_origin_crash_breaker_keeps_restore_status_metadata(
 
         crashed = kb.detect_crashed_workers(conn)
         task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
         events = kb.list_events(conn, t)
 
     assert crashed == [t]
     assert task is not None
     assert task.status == "blocked"
+    assert run is not None
+    assert run.status == "review"
+    assert run.outcome == "crashed"
     gave_up = [event for event in events if event.kind == "gave_up"][-1]
     assert (gave_up.payload or {}).get("restore_status") == "review"
 
@@ -3043,10 +3047,14 @@ def test_review_origin_stale_claim_restores_to_review(kanban_home):
 
         assert kb.release_stale_claims(conn) == 1
         task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
         events = kb.list_events(conn, t)
 
     assert task is not None
     assert task.status == "review"
+    assert run is not None
+    assert run.status == "review"
+    assert run.outcome == "reclaimed"
     reclaimed = [event for event in events if event.kind == "reclaimed"][-1]
     assert (reclaimed.payload or {}).get("restore_status") == "review"
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1420,6 +1420,45 @@ def test_respawn_guard_pr_comment_older_than_unblock_not_guarded(kanban_home):
     assert reason is None
 
 
+def test_respawn_guard_failure_event_does_not_supersede_recent_success(kanban_home):
+    """Failure events should not erase recent-success duplicate-work guardrails."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="failed-after-success", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'completed', ?, ?)",
+            (t, now - 300, now - 120),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'spawn_failed', '{}', ?)",
+            (t, now - 30),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "recent_success"
+
+
+def test_respawn_guard_failure_event_does_not_supersede_active_pr(kanban_home):
+    """Failure events should not make an existing PR comment look stale."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="failed-after-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', "
+            "'PR: https://github.com/totemx-AI/subsidysmart/pull/12', ?)",
+            (t, now - 120),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'timed_out', '{}', ?)",
+            (t, now - 30),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "active_pr"
+
+
 def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
     kanban_home, all_assignees_spawnable
 ):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2919,6 +2919,62 @@ def test_dispatch_review_spawns_with_correct_skills(
     assert spawned_tasks[0].skills == ["github/cursor-bugbot-sweep", "github/github-pr-workflow"]
 
 
+def test_dispatch_review_spawn_failure_returns_to_review_below_threshold(
+    kanban_home, all_assignees_spawnable,
+):
+    """Review-origin spawn failures below breaker threshold stay in Review."""
+
+    def bad_spawn(task, workspace, board=None):
+        raise RuntimeError("synthetic spawn failure")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review spawn fail", assignee="alice")
+        _set_task_status(conn, t, "review")
+        res = kb.dispatch_once(conn, spawn_fn=bad_spawn, failure_limit=3)
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+
+    assert not res.spawned
+    assert not res.auto_blocked
+    assert task is not None
+    assert task.status == "review"
+    assert task.assignee == "alice"
+    assert task.claim_lock is None
+    assert run is not None
+    assert run.status == "spawn_failed"
+    assert run.outcome == "spawn_failed"
+    assert (run.metadata or {}).get("restore_status") == "review"
+
+
+def test_dispatch_review_spawn_failure_blocks_intentionally_at_threshold(
+    kanban_home, all_assignees_spawnable,
+):
+    """Breaker-tripped review spawn failures block intentionally, never ready."""
+
+    def bad_spawn(task, workspace, board=None):
+        raise RuntimeError("synthetic spawn failure")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review spawn fail", assignee="alice")
+        _set_task_status(conn, t, "review")
+        res = kb.dispatch_once(conn, spawn_fn=bad_spawn, failure_limit=1)
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+        events = kb.list_events(conn, t)
+
+    assert t in res.auto_blocked
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.assignee == "alice"
+    assert task.claim_lock is None
+    assert run is not None
+    assert run.status == "gave_up"
+    assert run.outcome == "gave_up"
+    assert (run.metadata or {}).get("restore_status") == "review"
+    gave_up = [event for event in events if event.kind == "gave_up"][-1]
+    assert (gave_up.payload or {}).get("restore_status") == "review"
+
+
 def test_dispatch_review_skips_unassigned(kanban_home):
     """Unassigned review tasks go to skipped_unassigned, not spawned."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -74,6 +74,41 @@ def test_project_usage_backfill_correlates_kanban_run_to_session(usage_home):
     assert data["runs"][0]["session_id"] == "sess-usage-1"
 
 
+def test_project_usage_backfill_counts_session_usage_once_across_runs(usage_home):
+    _seed_session(usage_home, "sess-retry", in_tok=100, out_tok=50, cost=0.0123)
+    tid = _seed_completed_run("sess-retry")
+    with kb.connect(board="default") as conn:
+        conn.execute(
+            """
+            INSERT INTO task_runs(
+                task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tid,
+                "worker",
+                "completed",
+                10,
+                20,
+                "done",
+                "retry terminal row",
+                json.dumps({"worker_session_id": "sess-retry"}),
+            ),
+        )
+
+    data = usage.get_summary(board="default", task_id=tid, refresh=True)
+
+    assert data["totals"]["entries"] == 2
+    assert data["totals"]["sessions"] == 1
+    assert data["totals"]["input_tokens"] == 100
+    assert data["totals"]["output_tokens"] == 50
+    assert data["totals"]["estimated_cost_usd"] == pytest.approx(0.0123)
+    assert data["tasks"][0]["runs"] == 2
+    assert data["tasks"][0]["sessions"] == 1
+    assert data["tasks"][0]["input_tokens"] == 100
+
+
 def test_project_usage_summary_keeps_unassigned_sessions_visible(usage_home):
     _seed_session(usage_home, "sess-unassigned", in_tok=11, out_tok=22, cost=0.003)
 

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -1,0 +1,112 @@
+"""Tests for the derived project usage ledger and Kanban usage CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli import project_usage_ledger as usage
+
+
+@pytest.fixture
+def usage_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db(board="default")
+    return home
+
+
+def _seed_session(home: Path, session_id: str, *, in_tok: int, out_tok: int, cost: float) -> None:
+    db = SessionDB(home / "state.db")
+    try:
+        db.create_session(session_id, "kanban", model="gpt-test", user_id="u-test")
+        db.update_token_counts(
+            session_id,
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+            reasoning_tokens=7,
+            estimated_cost_usd=cost,
+            billing_provider="test-provider",
+            billing_mode="api",
+            api_call_count=2,
+            absolute=True,
+        )
+        db.end_session(session_id, "done")
+    finally:
+        db.close()
+
+
+def _seed_completed_run(session_id: str, *, title: str = "usage task") -> str:
+    with kb.connect(board="default") as conn:
+        tid = kb.create_task(conn, title=title, assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.complete_task(
+            conn,
+            tid,
+            summary="finished",
+            metadata={"worker_session_id": session_id},
+        )
+        return tid
+
+
+def test_project_usage_backfill_correlates_kanban_run_to_session(usage_home):
+    _seed_session(usage_home, "sess-usage-1", in_tok=100, out_tok=50, cost=0.0123)
+    tid = _seed_completed_run("sess-usage-1")
+
+    data = usage.get_summary(board="default", task_id=tid, refresh=True)
+
+    assert data["ledger_path"].endswith("usage/project_usage.db")
+    assert data["totals"]["input_tokens"] == 100
+    assert data["totals"]["output_tokens"] == 50
+    assert data["totals"]["reasoning_tokens"] == 7
+    assert data["totals"]["estimated_cost_usd"] == pytest.approx(0.0123)
+    assert [b["board_slug"] for b in data["boards"]] == ["default"]
+    assert data["tasks"][0]["task_id"] == tid
+    assert data["tasks"][0]["sessions"] == 1
+    assert data["runs"][0]["session_id"] == "sess-usage-1"
+
+
+def test_project_usage_summary_keeps_unassigned_sessions_visible(usage_home):
+    _seed_session(usage_home, "sess-unassigned", in_tok=11, out_tok=22, cost=0.003)
+
+    data = usage.get_summary(refresh=True)
+
+    unassigned = next(b for b in data["boards"] if b["board_slug"] == "__unassigned__")
+    assert unassigned["board_name"] == "Unassigned sessions"
+    assert unassigned["sessions"] == 1
+    assert data["totals"]["input_tokens"] == 11
+    assert data["totals"]["output_tokens"] == 22
+
+
+def test_stamp_usage_metadata_embeds_worker_session_snapshot(usage_home):
+    _seed_session(usage_home, "sess-snapshot", in_tok=5, out_tok=6, cost=0.0009)
+
+    stamped = usage.stamp_usage_metadata({"keep": True}, "sess-snapshot")
+
+    assert stamped["keep"] is True
+    assert stamped["worker_session_id"] == "sess-snapshot"
+    assert stamped["usage_snapshot"]["input_tokens"] == 5
+    assert stamped["usage_snapshot"]["output_tokens"] == 6
+    assert stamped["usage_snapshot"]["estimated_cost_usd"] == pytest.approx(0.0009)
+
+
+def test_kanban_usage_cli_outputs_json_summary(usage_home):
+    _seed_session(usage_home, "sess-cli", in_tok=13, out_tok=17, cost=0.0042)
+    tid = _seed_completed_run("sess-cli", title="cli usage task")
+
+    out = kc.run_slash("usage --json")
+    data = json.loads(out)
+
+    assert data["totals"]["input_tokens"] == 13
+    assert data["totals"]["output_tokens"] == 17
+    row = next(t for t in data["tasks"] if t["task_id"] == tid)
+    assert row["task_title"] == "cli usage task"
+    assert row["estimated_cost_usd"] == pytest.approx(0.0042)

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -229,7 +229,7 @@ def test_kanban_usage_cli_outputs_json_summary(usage_home):
     _seed_session(usage_home, "sess-cli", in_tok=13, out_tok=17, cost=0.0042)
     tid = _seed_completed_run("sess-cli", title="cli usage task")
 
-    out = kc.run_slash("usage --json")
+    out = kc.run_slash("usage --refresh --json")
     data = json.loads(out)
 
     assert data["totals"]["input_tokens"] == 13

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -169,6 +170,40 @@ def test_get_task_rollups_finds_specific_task_beyond_summary_limit(usage_home):
     assert rows[0]["task_id"] == "t-0"
     assert rows[0]["input_tokens"] == 1
 
+
+
+def test_backfill_records_board_query_error_without_aborting(usage_home, monkeypatch):
+    _seed_session(usage_home, "sess-board-error", in_tok=21, out_tok=8, cost=0.004)
+    _seed_completed_run("sess-board-error")
+    real_connect = kb.connect
+
+    class FlakyConn:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args, **kwargs):
+            if "FROM task_runs" in sql:
+                raise sqlite3.OperationalError("synthetic task_runs failure")
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def close(self):
+            self._conn.close()
+
+    def fake_connect(*args, board=None, **kwargs):
+        conn = real_connect(*args, board=board, **kwargs)
+        if board == "default":
+            return FlakyConn(conn)
+        return conn
+
+    monkeypatch.setattr(usage.kanban_db, "connect", fake_connect)
+
+    data = usage.get_summary(refresh=True)
+
+    assert data["last_backfill_error"]
+    assert "default: synthetic task_runs failure" in data["last_backfill_error"]
+    # The skipped board should not abort the whole backfill; raw sessions remain visible.
+    assert data["totals"]["input_tokens"] == 21
+    assert any(b["board_slug"] == "__unassigned__" for b in data["boards"])
 
 def test_project_usage_summary_keeps_unassigned_sessions_visible(usage_home):
     _seed_session(usage_home, "sess-unassigned", in_tok=11, out_tok=22, cost=0.003)

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -75,6 +75,25 @@ def test_project_usage_backfill_correlates_kanban_run_to_session(usage_home):
     assert data["runs"][0]["session_id"] == "sess-usage-1"
 
 
+def test_project_usage_backfill_batches_upserts_in_transaction(usage_home, monkeypatch):
+    _seed_session(usage_home, "sess-txn", in_tok=100, out_tok=50, cost=0.0123)
+    _seed_completed_run("sess-txn")
+    real_upsert = usage._upsert_entry
+    saw_upsert = False
+
+    def assert_transaction(conn, entry):
+        nonlocal saw_upsert
+        saw_upsert = True
+        assert conn.in_transaction is True
+        return real_upsert(conn, entry)
+
+    monkeypatch.setattr(usage, "_upsert_entry", assert_transaction)
+
+    usage.backfill()
+
+    assert saw_upsert is True
+
+
 def test_project_usage_backfill_counts_session_usage_once_across_runs(usage_home):
     _seed_session(usage_home, "sess-retry", in_tok=100, out_tok=50, cost=0.0123)
     tid = _seed_completed_run("sess-retry")

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -182,6 +182,20 @@ def test_project_usage_summary_keeps_unassigned_sessions_visible(usage_home):
     assert data["totals"]["output_tokens"] == 22
 
 
+def test_backfill_removes_stale_unassigned_row_after_session_links_to_task(usage_home):
+    _seed_session(usage_home, "sess-later-linked", in_tok=11, out_tok=22, cost=0.003)
+    first = usage.get_summary(refresh=True)
+    assert any(b["board_slug"] == "__unassigned__" for b in first["boards"])
+
+    tid = _seed_completed_run("sess-later-linked")
+    linked = usage.get_summary(board="default", task_id=tid, refresh=True)
+    all_data = usage.get_summary(refresh=False)
+
+    assert linked["totals"]["input_tokens"] == 11
+    assert not any(b["board_slug"] == "__unassigned__" for b in all_data["boards"])
+    assert all_data["totals"]["input_tokens"] == 11
+
+
 def test_stamp_usage_metadata_embeds_worker_session_snapshot(usage_home):
     _seed_session(usage_home, "sess-snapshot", in_tok=5, out_tok=6, cost=0.0009)
 

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -109,6 +109,55 @@ def test_project_usage_backfill_counts_session_usage_once_across_runs(usage_home
     assert data["tasks"][0]["input_tokens"] == 100
 
 
+def test_get_task_rollups_finds_specific_task_beyond_summary_limit(usage_home):
+    conn = usage.connect()
+    try:
+        now = 123.0
+        for idx in range(501):
+            usage._upsert_entry(conn, {
+                "source_type": "task_run",
+                "source_id": f"default:{idx}",
+                "board_slug": "default",
+                "board_name": "Default",
+                "task_id": f"t-{idx}",
+                "task_title": f"task {idx}",
+                "task_status": "done",
+                "run_id": idx,
+                "run_status": "completed",
+                "run_outcome": "done",
+                "session_id": f"sess-{idx}",
+                "session_title": None,
+                "session_source": "kanban",
+                "user_id": None,
+                "model": "gpt-test",
+                "billing_provider": "test",
+                "billing_mode": "api",
+                "input_tokens": idx + 1,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "api_call_count": 0,
+                "tool_call_count": 0,
+                "estimated_cost_usd": float(idx + 1),
+                "actual_cost_usd": 0.0,
+                "cost_status": None,
+                "started_at": now + idx,
+                "ended_at": now + idx,
+                "metadata": None,
+                "backfilled_at": now,
+            })
+    finally:
+        conn.close()
+
+    summary = usage.get_summary(board="default", refresh=False)
+    assert "t-0" not in {row["task_id"] for row in summary["tasks"]}
+
+    rows = usage.get_task_rollups(board="default", task_ids=["t-0"], refresh=False)
+    assert rows[0]["task_id"] == "t-0"
+    assert rows[0]["input_tokens"] == 1
+
+
 def test_project_usage_summary_keeps_unassigned_sessions_visible(usage_home):
     _seed_session(usage_home, "sess-unassigned", in_tok=11, out_tok=22, cost=0.003)
 
@@ -131,6 +180,20 @@ def test_stamp_usage_metadata_embeds_worker_session_snapshot(usage_home):
     assert stamped["usage_snapshot"]["input_tokens"] == 5
     assert stamped["usage_snapshot"]["output_tokens"] == 6
     assert stamped["usage_snapshot"]["estimated_cost_usd"] == pytest.approx(0.0009)
+
+
+def test_cli_worker_usage_metadata_stamping_is_best_effort(usage_home, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t-safe")
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess-safe")
+
+    def boom(metadata, session_id):
+        raise sqlite3.OperationalError("database is locked")
+
+    import sqlite3
+    monkeypatch.setattr(usage, "stamp_usage_metadata", boom)
+
+    assert kc._stamp_worker_usage_metadata("t-safe", {"keep": True}) == {"keep": True}
+    assert "usage metadata unavailable" in capsys.readouterr().err
 
 
 def test_kanban_usage_cli_outputs_json_summary(usage_home):

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -172,6 +172,32 @@ def test_get_task_rollups_finds_specific_task_beyond_summary_limit(usage_home):
 
 
 
+
+def test_backfill_closes_owned_ledger_when_state_open_fails(usage_home, monkeypatch):
+    class FakeLedgerConn:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    fake_ledger = FakeLedgerConn()
+    usage.state_db_path().touch()
+    real_sqlite_connect = usage.sqlite3.connect
+
+    def fake_sqlite_connect(path, *args, **kwargs):
+        if str(path).endswith("state.db"):
+            raise sqlite3.OperationalError("state open failed")
+        return real_sqlite_connect(path, *args, **kwargs)
+
+    monkeypatch.setattr(usage, "connect", lambda: fake_ledger)
+    monkeypatch.setattr(usage.sqlite3, "connect", fake_sqlite_connect)
+
+    with pytest.raises(sqlite3.OperationalError, match="state open failed"):
+        usage.backfill()
+
+    assert fake_ledger.closed is True
+
 def test_backfill_records_board_query_error_without_aborting(usage_home, monkeypatch):
     _seed_session(usage_home, "sess-board-error", in_tok=21, out_tok=8, cost=0.004)
     _seed_completed_run("sess-board-error")

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -192,7 +192,10 @@ def test_cli_worker_usage_metadata_stamping_is_best_effort(usage_home, monkeypat
     import sqlite3
     monkeypatch.setattr(usage, "stamp_usage_metadata", boom)
 
-    assert kc._stamp_worker_usage_metadata("t-safe", {"keep": True}) == {"keep": True}
+    assert kc._stamp_worker_usage_metadata("t-safe", {"keep": True}) == {
+        "keep": True,
+        "worker_session_id": "sess-safe",
+    }
     assert "usage metadata unavailable" in capsys.readouterr().err
 
 

--- a/tests/hermes_cli/test_project_usage_ledger.py
+++ b/tests/hermes_cli/test_project_usage_ledger.py
@@ -109,6 +109,18 @@ def test_project_usage_backfill_counts_session_usage_once_across_runs(usage_home
     assert data["tasks"][0]["input_tokens"] == 100
 
 
+def test_project_usage_backfill_dedupes_per_task_not_globally(usage_home):
+    _seed_session(usage_home, "sess-shared", in_tok=100, out_tok=50, cost=0.0123)
+    tid1 = _seed_completed_run("sess-shared", title="first shared task")
+    tid2 = _seed_completed_run("sess-shared", title="second shared task")
+
+    data1 = usage.get_summary(board="default", task_id=tid1, refresh=True)
+    data2 = usage.get_summary(board="default", task_id=tid2, refresh=False)
+
+    assert data1["totals"]["input_tokens"] == 100
+    assert data2["totals"]["input_tokens"] == 100
+
+
 def test_get_task_rollups_finds_specific_task_beyond_summary_limit(usage_home):
     conn = usage.connect()
     try:

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -192,6 +192,61 @@ def test_board_query_param_default_overrides_current_board_pointer(client):
     assert pinned_ids == {default_task["id"]}
 
 
+def test_active_workers_scans_all_boards_when_board_omitted(client):
+    """Gateway-embedded dispatch ticks all boards, so the active-worker API must too.
+
+    Regression: a SuperOptions worker could be alive while ``/workers/active``
+    returned count=0 because the endpoint only read the current/default board.
+    """
+    kb.create_board("superoptions")
+    conn = kb.connect(board="superoptions")
+    try:
+        task_id = kb.create_task(conn, title="superoptions worker", assignee="default")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        kb._set_worker_pid(conn, task_id, os.getpid())
+    finally:
+        conn.close()
+
+    data = client.get("/api/plugins/kanban/workers/active").json()
+    assert data["scope"] == "all"
+    assert data["count"] == 1
+    assert data["workers"][0]["board"] == "superoptions"
+    assert data["workers"][0]["task_id"] == task_id
+    assert data["workers"][0]["worker_pid"] == os.getpid()
+    assert {b["board"]: b["count"] for b in data["boards"]}["superoptions"] == 1
+
+    default_only = client.get("/api/plugins/kanban/workers/active?board=default").json()
+    assert default_only["scope"] == "board"
+    assert default_only["board"] == "default"
+    assert default_only["count"] == 0
+
+
+def test_active_workers_falls_back_to_task_worker_pid(client):
+    """Expose legacy/racy rows where the task PID was set but run PID is blank."""
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="pid fallback", assignee="default")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (os.getpid(), task_id))
+            conn.execute(
+                "UPDATE task_runs SET worker_pid = NULL WHERE task_id = ?",
+                (task_id,),
+            )
+    finally:
+        conn.close()
+
+    data = client.get("/api/plugins/kanban/workers/active?board=default").json()
+    assert data["count"] == 1
+    worker = data["workers"][0]
+    assert worker["task_id"] == task_id
+    assert worker["worker_pid"] == os.getpid()
+    assert worker["pid_source"] == "task"
+    assert "task.worker_pid fallback" in worker["diagnostic"]
+
+
 def test_dashboard_select_filters_use_sdk_value_change_handler():
     """Tenant/assignee filters must work with the dashboard SDK Select API.
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2236,6 +2236,45 @@ def test_board_cards_include_usage_rollup(client, kanban_home):
     assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.007)
 
 
+def test_board_usage_rollup_does_not_refresh_when_ledger_exists(monkeypatch):
+    """Board loads should not trigger full cross-board usage backfills repeatedly."""
+    import hermes_cli
+
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_usage_refresh_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    refresh_calls: list[bool] = []
+
+    class FakeUsage:
+        def get_summary(self, *, board=None, refresh=True):
+            refresh_calls.append(refresh)
+            return {
+                "last_backfill_at": 123.0,
+                "tasks": [{
+                    "task_id": "t1",
+                    "runs": 1,
+                    "sessions": 1,
+                    "input_tokens": 3,
+                    "output_tokens": 5,
+                    "reasoning_tokens": 0,
+                    "estimated_cost_usd": 0.01,
+                    "actual_cost_usd": 0.0,
+                }],
+            }
+
+    monkeypatch.setattr(hermes_cli, "project_usage_ledger", FakeUsage(), raising=False)
+
+    assert mod._usage_by_task("default", ["t1"])["t1"]["input_tokens"] == 3
+    assert refresh_calls == [False]
+
+
 def test_usage_route_returns_board_filtered_summary(client, kanban_home):
     from hermes_state import SessionDB
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2367,3 +2367,46 @@ def test_dashboard_bundle_renders_usage_badge():
     assert "function taskUsageTokens(t)" in js
     assert "hermes-kanban-usage" in js
     assert "estimated cost" in js
+
+
+def test_board_usage_rollup_dedupes_sessionless_snapshots_by_latest(client, kanban_home):
+    """Session-less cumulative snapshots should not double count older rows."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="sessionless usage snapshot", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        now = int(time.time())
+        for ended_at, tokens in ((now, 7), (now + 1000, 11)):
+            conn.execute(
+                """
+                INSERT INTO task_runs(
+                    task_id, profile, status, started_at, ended_at, outcome,
+                    summary, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    tid,
+                    "worker",
+                    "completed",
+                    ended_at - 10,
+                    ended_at,
+                    "done",
+                    "sessionless snapshot",
+                    json.dumps({
+                        "usage_snapshot": {
+                            "input_tokens": tokens,
+                            "output_tokens": 1,
+                            "reasoning_tokens": 0,
+                            "estimated_cost_usd": 0.001 * tokens,
+                        },
+                    }),
+                ),
+            )
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (tid,))
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200, r.text
+    tasks = [task for col in r.json()["columns"] for task in col["tasks"]]
+    card = next(t for t in tasks if t["id"] == tid)
+    assert card["usage"]["input_tokens"] == 11
+    assert card["usage"]["output_tokens"] == 1
+    assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.011)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2301,17 +2301,17 @@ def test_board_usage_rollup_reads_fresh_task_run_snapshots(client, kanban_home):
                 "worker",
                 "completed",
                 10,
-                20,
+                int(time.time()) + 1000,
                 "retry",
-                "duplicate cumulative snapshot",
+                "newer cumulative snapshot",
                 json.dumps({
                     "worker_session_id": "sess-snapshot-card",
                     "usage_snapshot": {
                         "session_id": "sess-snapshot-card",
-                        "input_tokens": 55,
-                        "output_tokens": 89,
-                        "reasoning_tokens": 13,
-                        "estimated_cost_usd": 0.015,
+                        "input_tokens": 60,
+                        "output_tokens": 90,
+                        "reasoning_tokens": 14,
+                        "estimated_cost_usd": 0.016,
                     },
                 }),
             ),
@@ -2321,10 +2321,10 @@ def test_board_usage_rollup_reads_fresh_task_run_snapshots(client, kanban_home):
     assert r.status_code == 200, r.text
     tasks = [task for col in r.json()["columns"] for task in col["tasks"]]
     card = next(t for t in tasks if t["id"] == tid)
-    assert card["usage"]["input_tokens"] == 55
-    assert card["usage"]["output_tokens"] == 89
-    assert card["usage"]["reasoning_tokens"] == 13
-    assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.015)
+    assert card["usage"]["input_tokens"] == 60
+    assert card["usage"]["output_tokens"] == 90
+    assert card["usage"]["reasoning_tokens"] == 14
+    assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.016)
 
 
 def test_usage_route_returns_board_filtered_summary(client, kanban_home):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2195,3 +2195,84 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_board_cards_include_usage_rollup(client, kanban_home):
+    """Board cards expose per-task token/cost rollups from the usage ledger."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(kanban_home / "state.db")
+    try:
+        db.create_session("sess-card-usage", "kanban", model="gpt-test")
+        db.update_token_counts(
+            "sess-card-usage",
+            input_tokens=21,
+            output_tokens=34,
+            reasoning_tokens=5,
+            estimated_cost_usd=0.007,
+            absolute=True,
+        )
+    finally:
+        db.close()
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="usage badge", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.complete_task(
+            conn,
+            tid,
+            summary="done",
+            metadata={"worker_session_id": "sess-card-usage"},
+        )
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200, r.text
+    tasks = [task for col in r.json()["columns"] for task in col["tasks"]]
+    card = next(t for t in tasks if t["id"] == tid)
+
+    assert card["usage"]["input_tokens"] == 21
+    assert card["usage"]["output_tokens"] == 34
+    assert card["usage"]["reasoning_tokens"] == 5
+    assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.007)
+
+
+def test_usage_route_returns_board_filtered_summary(client, kanban_home):
+    from hermes_state import SessionDB
+
+    db = SessionDB(kanban_home / "state.db")
+    try:
+        db.create_session("sess-route", "kanban", model="gpt-test")
+        db.update_token_counts(
+            "sess-route",
+            input_tokens=8,
+            output_tokens=9,
+            estimated_cost_usd=0.002,
+            absolute=True,
+        )
+    finally:
+        db.close()
+
+    with kb.connect(board="default") as conn:
+        tid = kb.create_task(conn, title="route usage", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.complete_task(
+            conn, tid, summary="done", metadata={"worker_session_id": "sess-route"}
+        )
+
+    r = client.get(f"/api/plugins/kanban/usage?board=default&task_id={tid}")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["totals"]["input_tokens"] == 8
+    assert [b["board_slug"] for b in data["boards"]] == ["default"]
+    assert data["tasks"][0]["task_id"] == tid
+    assert data["runs"][0]["session_id"] == "sess-route"
+
+
+def test_dashboard_bundle_renders_usage_badge():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "function taskUsageTokens(t)" in js
+    assert "hermes-kanban-usage" in js
+    assert "estimated cost" in js

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2409,4 +2409,5 @@ def test_board_usage_rollup_dedupes_sessionless_snapshots_by_latest(client, kanb
     card = next(t for t in tasks if t["id"] == tid)
     assert card["usage"]["input_tokens"] == 11
     assert card["usage"]["output_tokens"] == 1
+    assert card["usage"]["sessions"] == 1
     assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.011)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2415,36 +2415,11 @@ def test_board_usage_rollup_falls_back_for_multiple_snapshot_sessions(monkeypatc
     assert rollup["estimated_cost_usd"] == pytest.approx(0.017)
 
 
-def test_usage_route_returns_board_filtered_summary(client, kanban_home):
-    from hermes_state import SessionDB
-
-    db = SessionDB(kanban_home / "state.db")
-    try:
-        db.create_session("sess-route", "kanban", model="gpt-test")
-        db.update_token_counts(
-            "sess-route",
-            input_tokens=8,
-            output_tokens=9,
-            estimated_cost_usd=0.002,
-            absolute=True,
-        )
-    finally:
-        db.close()
-
-    with kb.connect(board="default") as conn:
-        tid = kb.create_task(conn, title="route usage", assignee="worker")
-        assert kb.claim_task(conn, tid)
-        assert kb.complete_task(
-            conn, tid, summary="done", metadata={"worker_session_id": "sess-route"}
-        )
-
-    r = client.get(f"/api/plugins/kanban/usage?board=default&task_id={tid}")
-    assert r.status_code == 200, r.text
-    data = r.json()
-    assert data["totals"]["input_tokens"] == 8
-    assert [b["board_slug"] for b in data["boards"]] == ["default"]
-    assert data["tasks"][0]["task_id"] == tid
-    assert data["runs"][0]["session_id"] == "sess-route"
+def test_kanban_usage_route_removed_in_favor_of_project_usage_plugin(client, kanban_home):
+    """Project usage is exposed by the dedicated project_usage dashboard plugin."""
+    _ = kanban_home
+    r = client.get("/api/plugins/kanban/usage?board=default")
+    assert r.status_code == 404
 
 
 def test_dashboard_bundle_renders_usage_badge():

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2255,21 +2255,48 @@ def test_board_usage_rollup_does_not_refresh_when_ledger_exists(monkeypatch):
     class FakeUsage:
         def get_task_rollups(self, *, board=None, task_ids=None, refresh=True):
             refresh_calls.append(refresh)
-            return [{
-                "task_id": "t1",
-                "runs": 1,
-                "sessions": 1,
-                "input_tokens": 3,
-                "output_tokens": 5,
-                "reasoning_tokens": 0,
-                "estimated_cost_usd": 0.01,
-                "actual_cost_usd": 0.0,
-            }]
+            return []
+
+        def get_summary(self, *, board=None, refresh=True):
+            refresh_calls.append(refresh)
+            return {"last_backfill_at": 123.0}
 
     monkeypatch.setattr(hermes_cli, "project_usage_ledger", FakeUsage(), raising=False)
+    monkeypatch.setattr(mod, "_usage_from_run_snapshots", lambda board, ids: {})
 
-    assert mod._usage_by_task("default", ["t1"])["t1"]["input_tokens"] == 3
-    assert refresh_calls == [False]
+    assert mod._usage_by_task("default", ["t1"]) == {}
+    assert refresh_calls == [False, False]
+
+
+def test_board_usage_rollup_reads_fresh_task_run_snapshots(client, kanban_home):
+    """Newly completed cards can show stamped usage without a ledger backfill."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="usage snapshot badge", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.complete_task(
+            conn,
+            tid,
+            summary="done",
+            metadata={
+                "worker_session_id": "sess-snapshot-card",
+                "usage_snapshot": {
+                    "session_id": "sess-snapshot-card",
+                    "input_tokens": 55,
+                    "output_tokens": 89,
+                    "reasoning_tokens": 13,
+                    "estimated_cost_usd": 0.015,
+                },
+            },
+        )
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200, r.text
+    tasks = [task for col in r.json()["columns"] for task in col["tasks"]]
+    card = next(t for t in tasks if t["id"] == tid)
+    assert card["usage"]["input_tokens"] == 55
+    assert card["usage"]["output_tokens"] == 89
+    assert card["usage"]["reasoning_tokens"] == 13
+    assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.015)
 
 
 def test_usage_route_returns_board_filtered_summary(client, kanban_home):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2327,6 +2327,75 @@ def test_board_usage_rollup_reads_fresh_task_run_snapshots(client, kanban_home):
     assert card["usage"]["estimated_cost_usd"] == pytest.approx(0.016)
 
 
+def test_board_usage_rollup_falls_back_for_multiple_snapshot_sessions(monkeypatch, kanban_home):
+    """Do not add cumulative usage_snapshot totals from distinct sessions."""
+    import hermes_cli
+
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_usage_multisession_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="multi-session snapshots", assignee="worker")
+        now = int(time.time())
+        for session_id, ended_at, tokens in (
+            ("sess-a", now, 100),
+            ("sess-b", now + 60, 200),
+        ):
+            conn.execute(
+                """
+                INSERT INTO task_runs(
+                    task_id, profile, status, started_at, ended_at, outcome,
+                    summary, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    tid,
+                    "worker",
+                    "done",
+                    ended_at - 10,
+                    ended_at,
+                    "completed",
+                    "cumulative snapshot",
+                    json.dumps({
+                        "worker_session_id": session_id,
+                        "usage_snapshot": {
+                            "session_id": session_id,
+                            "input_tokens": tokens,
+                            "output_tokens": 1,
+                            "estimated_cost_usd": 0.001 * tokens,
+                        },
+                    }),
+                ),
+            )
+
+    class FakeUsage:
+        def get_task_rollups(self, *, board=None, task_ids=None, refresh=True):
+            return [{
+                "task_id": tid,
+                "runs": 2,
+                "sessions": 2,
+                "input_tokens": 17,
+                "output_tokens": 3,
+                "reasoning_tokens": 0,
+                "estimated_cost_usd": 0.017,
+                "actual_cost_usd": 0.0,
+            }]
+
+    monkeypatch.setattr(hermes_cli, "project_usage_ledger", FakeUsage(), raising=False)
+
+    assert mod._usage_from_run_snapshots("default", [tid]) == {}
+    rollup = mod._usage_by_task("default", [tid])[tid]
+    assert rollup["input_tokens"] == 17
+    assert rollup["estimated_cost_usd"] == pytest.approx(0.017)
+
+
 def test_usage_route_returns_board_filtered_summary(client, kanban_home):
     from hermes_state import SessionDB
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -8,6 +8,7 @@ REST surface without spinning up the whole dashboard.
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import sys
 import time
@@ -2287,6 +2288,33 @@ def test_board_usage_rollup_reads_fresh_task_run_snapshots(client, kanban_home):
                     "estimated_cost_usd": 0.015,
                 },
             },
+        )
+        conn.execute(
+            """
+            INSERT INTO task_runs(
+                task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tid,
+                "worker",
+                "completed",
+                10,
+                20,
+                "retry",
+                "duplicate cumulative snapshot",
+                json.dumps({
+                    "worker_session_id": "sess-snapshot-card",
+                    "usage_snapshot": {
+                        "session_id": "sess-snapshot-card",
+                        "input_tokens": 55,
+                        "output_tokens": 89,
+                        "reasoning_tokens": 13,
+                        "estimated_cost_usd": 0.015,
+                    },
+                }),
+            ),
         )
 
     r = client.get("/api/plugins/kanban/board")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2316,11 +2316,30 @@ def test_board_usage_rollup_reads_fresh_task_run_snapshots(client, kanban_home):
                 }),
             ),
         )
+        conn.execute(
+            """
+            INSERT INTO task_runs(
+                task_id, profile, status, started_at, ended_at, outcome,
+                summary, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tid,
+                "worker",
+                "done",
+                20,
+                int(time.time()) + 2000,
+                "completed",
+                "run without usage metadata",
+                None,
+            ),
+        )
 
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200, r.text
     tasks = [task for col in r.json()["columns"] for task in col["tasks"]]
     card = next(t for t in tasks if t["id"] == tid)
+    assert card["usage"]["runs"] == 3
     assert card["usage"]["input_tokens"] == 60
     assert card["usage"]["output_tokens"] == 90
     assert card["usage"]["reasoning_tokens"] == 14

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2253,21 +2253,18 @@ def test_board_usage_rollup_does_not_refresh_when_ledger_exists(monkeypatch):
     refresh_calls: list[bool] = []
 
     class FakeUsage:
-        def get_summary(self, *, board=None, refresh=True):
+        def get_task_rollups(self, *, board=None, task_ids=None, refresh=True):
             refresh_calls.append(refresh)
-            return {
-                "last_backfill_at": 123.0,
-                "tasks": [{
-                    "task_id": "t1",
-                    "runs": 1,
-                    "sessions": 1,
-                    "input_tokens": 3,
-                    "output_tokens": 5,
-                    "reasoning_tokens": 0,
-                    "estimated_cost_usd": 0.01,
-                    "actual_cost_usd": 0.0,
-                }],
-            }
+            return [{
+                "task_id": "t1",
+                "runs": 1,
+                "sessions": 1,
+                "input_tokens": 3,
+                "output_tokens": 5,
+                "reasoning_tokens": 0,
+                "estimated_cost_usd": 0.01,
+                "actual_cost_usd": 0.0,
+            }]
 
     monkeypatch.setattr(hermes_cli, "project_usage_ledger", FakeUsage(), raising=False)
 

--- a/tests/plugins/test_project_usage_dashboard_plugin.py
+++ b/tests/plugins/test_project_usage_dashboard_plugin.py
@@ -1,0 +1,183 @@
+"""Tests for the Project Usage dashboard plugin and ledger backfill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import project_usage_ledger as ledger
+
+
+SESSION_COLUMNS_SQL = """
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    user_id TEXT,
+    model TEXT,
+    model_config TEXT,
+    system_prompt TEXT,
+    parent_session_id TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    end_reason TEXT,
+    message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    billing_provider TEXT,
+    billing_base_url TEXT,
+    billing_mode TEXT,
+    estimated_cost_usd REAL,
+    actual_cost_usd REAL,
+    cost_status TEXT,
+    cost_source TEXT,
+    pricing_version TEXT,
+    title TEXT,
+    api_call_count INTEGER DEFAULT 0,
+    handoff_state TEXT,
+    handoff_platform TEXT,
+    handoff_error TEXT
+);
+"""
+
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "project_usage" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_project_usage_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod.router
+
+
+@pytest.fixture
+def usage_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Avoid module-level kanban init cache carrying paths across tests.
+    kb._INITIALIZED_PATHS.clear()
+    yield home
+    kb._INITIALIZED_PATHS.clear()
+
+
+def _seed_state_db(home: Path):
+    conn = sqlite3.connect(home / "state.db")
+    conn.execute(SESSION_COLUMNS_SQL)
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id, source, user_id, model, started_at, ended_at, title,
+            input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+            reasoning_tokens, billing_provider, billing_mode,
+            estimated_cost_usd, actual_cost_usd, cost_status,
+            api_call_count, tool_call_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "sess-worker-1", "kanban", "u1", "test/model", 1000.0, 1060.0,
+            "Worker session", 120, 45, 10, 5, 7, "openrouter", "estimated",
+            0.0123, None, "estimated", 2, 3,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id, source, user_id, model, started_at, ended_at, title,
+            input_tokens, output_tokens, estimated_cost_usd, api_call_count, tool_call_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "sess-unassigned", "cli", "u1", "test/model", 900.0, 930.0,
+            "Loose session", 10, 4, 0.001, 1, 0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_board():
+    kb.create_board("proj", name="Project One")
+    conn = kb.connect(board="proj")
+    try:
+        task_id = kb.create_task(conn, title="Implement thing", assignee="default")
+        conn.execute(
+            """
+            INSERT INTO task_runs (
+                task_id, profile, status, started_at, ended_at, outcome, metadata
+            ) VALUES (?, 'default', 'done', 1000, 1060, 'completed', ?)
+            """,
+            (task_id, '{"worker_session_id":"sess-worker-1"}'),
+        )
+        return task_id
+    finally:
+        conn.close()
+
+
+def test_backfill_creates_ledger_and_correlates_board_task_usage(usage_home):
+    _seed_state_db(usage_home)
+    task_id = _seed_board()
+
+    summary = ledger.get_summary(refresh=True)
+
+    assert Path(summary["ledger_path"]).exists()
+    project = next(b for b in summary["boards"] if b["board_slug"] == "proj")
+    assert project["board_name"] == "Project One"
+    assert project["tasks"] == 1
+    assert project["sessions"] == 1
+    assert project["input_tokens"] == 120
+    assert project["output_tokens"] == 45
+    assert project["estimated_cost_usd"] == pytest.approx(0.0123)
+
+    unassigned = next(b for b in summary["boards"] if b["board_slug"] == "__unassigned__")
+    assert unassigned["sessions"] == 1
+
+    drilldown = ledger.get_summary(board="proj", task_id=task_id, refresh=False)
+    assert drilldown["totals"]["tasks"] == 1
+    assert drilldown["runs"][0]["session_id"] == "sess-worker-1"
+
+
+def test_project_usage_plugin_summary_endpoint(usage_home):
+    _seed_state_db(usage_home)
+    task_id = _seed_board()
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/project_usage")
+    client = TestClient(app)
+
+    r = client.get(f"/api/plugins/project_usage/summary?board=proj&task_id={task_id}")
+
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["totals"]["input_tokens"] == 120
+    assert payload["tasks"][0]["task_id"] == task_id
+    assert payload["runs"][0]["session_id"] == "sess-worker-1"
+
+
+def test_project_usage_dashboard_bundle_registers_plugin():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "project_usage" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert 'registry.register("project_usage", ProjectUsagePage)' in js
+    assert "/api/plugins/project_usage/summary" in js
+    assert "Per-board totals" in js
+    assert "Per-task drilldown" in js

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -354,10 +354,9 @@ def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata == {
-            "files": 2,
-            "worker_session_id": "session-trusted",
-        }
+        assert run.metadata["files"] == 2
+        assert run.metadata["worker_session_id"] == "session-trusted"
+        assert run.metadata["usage_snapshot"]["session_id"] == "session-trusted"
     finally:
         conn.close()
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -388,6 +388,26 @@ def test_complete_does_not_stamp_worker_session_id_without_scoped_task(
         conn.close()
 
 
+def test_stamp_worker_session_metadata_delegates_scope_check(monkeypatch):
+    """The usage ledger helper owns worker-task scope validation."""
+    from hermes_cli import project_usage_ledger
+    from tools import kanban_tools as kt
+
+    calls = []
+
+    def fake_stamp(task_id, metadata):
+        calls.append((task_id, metadata))
+        return metadata
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-trusted")
+    monkeypatch.setattr(project_usage_ledger, "stamp_worker_usage_metadata", fake_stamp)
+
+    metadata = {"files": 2}
+    assert kt._stamp_worker_session_metadata("t-other", metadata) is metadata
+    assert calls == [("t-other", metadata)]
+
+
 def test_complete_with_result_only(worker_env):
     """`result` alone (without summary) is accepted for legacy compat."""
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -118,15 +118,19 @@ def _worker_run_id(task_id: str) -> Optional[int]:
 def _stamp_worker_session_metadata(
     task_id: str, metadata: Optional[dict]
 ) -> Optional[dict]:
-    """Add trusted worker session id metadata for this worker's own task."""
+    """Add trusted worker session id + token usage metadata for this worker."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return metadata
     session_id = os.environ.get("HERMES_SESSION_ID")
     if not session_id:
         return metadata
-    stamped = dict(metadata or {})
-    stamped["worker_session_id"] = session_id
-    return stamped
+    try:
+        from hermes_cli.project_usage_ledger import stamp_usage_metadata
+        return stamp_usage_metadata(metadata, session_id)
+    except Exception:
+        stamped = dict(metadata or {})
+        stamped["worker_session_id"] = session_id
+        return stamped
 
 
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
@@ -528,10 +532,12 @@ def _handle_block(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            metadata = _stamp_worker_session_metadata(tid, None)
             ok = kb.block_task(
                 conn, tid,
                 reason=reason,
                 expected_run_id=_worker_run_id(tid),
+                metadata=metadata,
             )
             if not ok:
                 return tool_error(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -125,8 +125,8 @@ def _stamp_worker_session_metadata(
     if not session_id:
         return metadata
     try:
-        from hermes_cli.project_usage_ledger import stamp_usage_metadata
-        return stamp_usage_metadata(metadata, session_id)
+        from hermes_cli.project_usage_ledger import stamp_worker_usage_metadata
+        return stamp_worker_usage_metadata(task_id, metadata)
     except Exception:
         stamped = dict(metadata or {})
         stamped["worker_session_id"] = session_id

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -119,15 +119,15 @@ def _stamp_worker_session_metadata(
     task_id: str, metadata: Optional[dict]
 ) -> Optional[dict]:
     """Add trusted worker session id + token usage metadata for this worker."""
-    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
-        return metadata
-    session_id = os.environ.get("HERMES_SESSION_ID")
-    if not session_id:
-        return metadata
     try:
         from hermes_cli.project_usage_ledger import stamp_worker_usage_metadata
         return stamp_worker_usage_metadata(task_id, metadata)
     except Exception:
+        if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+            return metadata
+        session_id = os.environ.get("HERMES_SESSION_ID")
+        if not session_id:
+            return metadata
         stamped = dict(metadata or {})
         stamped["worker_session_id"] = session_id
         return stamped

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -505,7 +505,13 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            task = kb.get_task(conn, tid)
+            return _ok(
+                task_id=tid,
+                run_id=run.id if run else None,
+                status=task.status if task else None,
+                assignee=task.assignee if task else None,
+            )
         finally:
             conn.close()
     except ValueError as e:
@@ -545,7 +551,13 @@ def _handle_block(args: dict, **kw) -> str:
                     f"running/ready)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            task = kb.get_task(conn, tid)
+            return _ok(
+                task_id=tid,
+                run_id=run.id if run else None,
+                status=task.status if task else None,
+                assignee=task.assignee if task else None,
+            )
         finally:
             conn.close()
     except ValueError as e:
@@ -875,7 +887,11 @@ KANBAN_COMPLETE_SCHEMA = {
     "name": "kanban_complete",
     "description": (
         "Mark your current task done with a structured handoff for "
-        "downstream workers and humans. Prefer ``summary`` for a "
+        "downstream workers and humans. On boards with the required Review "
+        "gate enabled, implementation-worker calls do not go straight to Done: "
+        "the kernel moves the card to Review and assigns the configured merge "
+        "captain, who is the only actor allowed to complete the card after "
+        "Bugbot/review and merge-train checks. Prefer ``summary`` for a "
         "human-readable 1-3 sentence description of what you did; put "
         "machine-readable facts in ``metadata`` (changed_files, "
         "tests_run, decisions, findings, etc). At least one of "


### PR DESCRIPTION
## Summary
- Make /api/plugins/kanban/workers/active scan all boards when board is omitted, matching gateway-embedded dispatch behavior.
- Include board slugs on worker rows plus per-board summaries and not-counted diagnostics for stale/orphan PID states.
- Fall back to tasks.worker_pid when task_runs.worker_pid is missing and annotate the PID source.

## Test Plan
- python -m pytest tests/plugins/test_kanban_dashboard_plugin.py::test_active_workers_scans_all_boards_when_board_omitted tests/plugins/test_kanban_dashboard_plugin.py::test_active_workers_falls_back_to_task_worker_pid -q
- env -u HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q

Note: Running the full file without unsetting HERMES_KANBAN_REQUIRE_REVIEW_BEFORE_DONE in this Kanban worker environment fails existing dashboard tests that assume direct done completion instead of the Review gate.