### PR TITLE
fix(kanban): add connection pooling to prevent FD exhaustion

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -983,6 +983,8 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
+_CONNECTION_POOL: dict[str, sqlite3.Connection] = {}
+_POOL_MAX_SIZE = 4
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
 
 
@@ -1277,6 +1279,17 @@ def connect(
         path = db_path
     else:
         path = kanban_db_path(board=board)
+    
+    resolved_str = str(path.resolve())
+    with _INIT_LOCK:
+        if resolved_str in _CONNECTION_POOL:
+            conn = _CONNECTION_POOL[resolved_str]
+            try:
+                conn.execute("SELECT 1")
+                return conn
+            except sqlite3.DatabaseError:
+                del _CONNECTION_POOL[resolved_str]
+    
     path.parent.mkdir(parents=True, exist_ok=True)
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
@@ -1324,7 +1337,29 @@ def connect(
         except Exception:
             conn.close()
             raise
+    
+    with _INIT_LOCK:
+        if len(_CONNECTION_POOL) >= _POOL_MAX_SIZE:
+            oldest_path = next(iter(_CONNECTION_POOL))
+            old_conn = _CONNECTION_POOL.pop(oldest_path)
+            try:
+                old_conn.close()
+            except Exception:
+                pass
+        _CONNECTION_POOL[resolved] = conn
+    
     return conn
+
+
+def close_all_connections():
+    """Close all connections in the pool. Called on shutdown."""
+    with _INIT_LOCK:
+        for conn in _CONNECTION_POOL.values():
+            try:
+                conn.close()
+            except Exception:
+                pass
+        _CONNECTION_POOL.clear()
 
 
 @contextlib.contextmanager

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3945,3 +3945,81 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Connection pooling tests (#33580)
+# ---------------------------------------------------------------------------
+
+def test_connect_reuses_pooled_connections(tmp_path):
+    """Multiple connect() calls return the same connection from pool."""
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.close_all_connections()
+    
+    conn1 = kb.connect(db_path=db_path)
+    conn1_id = id(conn1)
+    
+    conn2 = kb.connect(db_path=db_path)
+    conn2_id = id(conn2)
+    
+    assert conn1_id == conn2_id, "Should return same connection from pool"
+    
+    kb.close_all_connections()
+
+
+def test_connection_pool_size_limit(tmp_path):
+    """Pool evicts oldest connection when reaching max size."""
+    kb.close_all_connections()
+    
+    paths = []
+    
+    for i in range(kb._POOL_MAX_SIZE):
+        db_path = tmp_path / f"kanban_{i}.db"
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+        paths.append(db_path)
+        kb.connect(db_path=db_path)
+    
+    assert len(kb._CONNECTION_POOL) == kb._POOL_MAX_SIZE
+    
+    first_conn = kb._CONNECTION_POOL.get(str(paths[0].resolve()))
+    first_conn_id = id(first_conn) if first_conn else None
+    
+    extra_path = tmp_path / f"kanban_extra.db"
+    kb._INITIALIZED_PATHS.discard(str(extra_path.resolve()))
+    kb.connect(db_path=extra_path)
+    
+    assert len(kb._CONNECTION_POOL) == kb._POOL_MAX_SIZE
+    assert str(paths[0].resolve()) not in kb._CONNECTION_POOL, "Oldest path should be evicted"
+    
+    kb.close_all_connections()
+
+
+def test_connection_pool_handles_closed_connections(tmp_path):
+    """Pool detects and replaces closed connections."""
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.close_all_connections()
+    
+    conn1 = kb.connect(db_path=db_path)
+    conn1_id = id(conn1)
+    conn1.close()
+    
+    conn2 = kb.connect(db_path=db_path)
+    conn2_id = id(conn2)
+    
+    assert conn1_id != conn2_id, "Should create new connection when pooled one is closed"
+    
+    kb.close_all_connections()
+
+
+def test_close_all_connections_clears_pool(tmp_path):
+    """close_all_connections() empties the pool."""
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    
+    kb.connect(db_path=db_path)
+    assert len(kb._CONNECTION_POOL) == 1
+    
+    kb.close_all_connections()
+    assert len(kb._CONNECTION_POOL) == 0


### PR DESCRIPTION
## Summary
Fixes #33580

Prevents 'Too many open files' errors on macOS by adding connection pooling to kanban_db.

## Problem
Each kanban_db.connect() call creates a new SQLite connection that opens 3 file descriptors (db, wal, shm). The gateway dispatcher and notifier watchers call connect() repeatedly without reusing connections, quickly exhausting the macOS default limit of 256 FDs.

## Solution
Added a connection pool with max size of 4 connections:
- Reuses existing connections when available
- Validates connections are still alive before returning
- Evicts oldest connection when pool is full
- Provides close_all_connections() for cleanup

## Testing
- Added comprehensive tests for connection pooling behavior
- All existing tests pass
- Verified pool reuses connections and respects size limit

## Platform
Tested on macOS