### PR TITLE
fix(memory/mem0): thread memory.mem0.* from config.yaml into the plugin

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1109,6 +1109,22 @@ def init_agent(
                         "hermes_home": str(get_hermes_home()),
                         "agent_context": "primary",
                     }
+                    # Thread per-provider subconfig from config.yaml so that
+                    # `memory.<provider_name>.*` keys (e.g.
+                    # `memory.mem0.user_id` / `memory.mem0.agent_id`) actually
+                    # reach the plugin.  Without this, the only path into a
+                    # plugin's `_load_config()` is env vars + its own
+                    # $HERMES_HOME/<provider>.json — config.yaml is silently
+                    # ignored, so users who set `memory.mem0.user_id: jereme`
+                    # still get writes scoped to the env default
+                    # ("hermes-user"), which defeats per-profile memory
+                    # scoping in multi-profile setups.
+                    try:
+                        _provider_subconf = mem_config.get(_mem_provider_name)
+                        if isinstance(_provider_subconf, dict) and _provider_subconf:
+                            _init_kwargs["provider_config"] = dict(_provider_subconf)
+                    except Exception:
+                        pass
                     # Thread session title for memory provider scoping
                     # (e.g. honcho uses this to derive chat-scoped session keys)
                     if agent._session_db:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -79,6 +79,13 @@ class MemoryProvider(ABC):
           - parent_session_id (str): For subagents, the parent's session_id.
           - user_id (str): Platform user identifier (gateway sessions).
           - user_id_alt (str): Optional alternate stable platform user identifier.
+          - provider_config (dict): Per-provider subconfig from config.yaml's
+            ``memory.<provider_name>.*`` block (e.g. ``memory.mem0.user_id``
+            / ``memory.mem0.agent_id``). Plugins should merge this over their
+            own env/JSON-file defaults so users can configure provider
+            scoping in the same file that holds the rest of their Hermes
+            config. Missing/empty values should be ignored so an unset YAML
+            key doesn't silently wipe out an env / JSON sidecar value.
         """
 
     def system_prompt_block(self) -> str:

--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -21,12 +21,28 @@ echo "MEM0_API_KEY=your-key" >> ~/.hermes/.env
 
 ## Config
 
-Config file: `$HERMES_HOME/mem0.json`
+Mem0 reads its config from three sources, in order of increasing precedence:
+
+1. **Environment variables** — `MEM0_API_KEY`, `MEM0_USER_ID`, `MEM0_AGENT_ID`.
+2. **`$HERMES_HOME/mem0.json`** — a JSON sidecar for the keys below.
+3. **`config.yaml > memory.mem0.*`** — the same key/value pairs in
+   the main Hermes config. Useful for per-profile setups so the
+   profile's `config.yaml` is the single source of truth.
+
+```yaml
+# config.yaml
+memory:
+  provider: mem0
+  mem0:
+    user_id: jereme
+    agent_id: stack
+    rerank: true
+```
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `user_id` | `hermes-user` | User identifier on Mem0 |
-| `agent_id` | `hermes` | Agent identifier |
+| `user_id` | `hermes-user` | User identifier on Mem0. Gateway-supplied `user_id` (e.g. a Telegram chat id) wins over config. |
+| `agent_id` | `hermes` | Agent identifier. If left unset everywhere, defaults to the active Hermes profile name (so multi-profile users get per-profile write attribution automatically). |
 | `rerank` | `true` | Enable reranking for recall |
 
 ## Tools

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -66,6 +66,46 @@ def _load_config() -> dict:
     return config
 
 
+def _explicit_source_keys() -> set:
+    """Return the set of config keys that came from an explicit user source.
+
+    A key is "explicit" if it was set via an environment variable
+    (``MEM0_API_KEY`` / ``MEM0_USER_ID`` / ``MEM0_AGENT_ID``) OR appeared
+    with a non-empty value in ``$HERMES_HOME/mem0.json``.
+
+    Used by ``initialize()`` to decide whether a runtime override
+    (e.g. profile name → ``agent_id``) should win over a value present in
+    the loaded config dict.  Without this, the env-var defaults for
+    ``user_id`` and ``agent_id`` would always look "set" and runtime
+    overrides could never take effect.
+    """
+    from hermes_constants import get_hermes_home
+
+    explicit: set = set()
+    _env_keys = {
+        "api_key": "MEM0_API_KEY",
+        "user_id": "MEM0_USER_ID",
+        "agent_id": "MEM0_AGENT_ID",
+    }
+    for _k, _env in _env_keys.items():
+        _v = os.environ.get(_env)
+        if _v not in (None, ""):
+            explicit.add(_k)
+
+    config_path = get_hermes_home() / "mem0.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            for _k, _v in file_cfg.items():
+                if _v is None or _v == "":
+                    continue
+                explicit.add(_k)
+        except Exception:
+            pass
+
+    return explicit
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -202,11 +242,41 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs) -> None:
         self._config = _load_config()
+        explicit_keys = _explicit_source_keys()
+        # Merge in per-provider config from config.yaml's `memory.mem0.*`
+        # subsection — threaded by agent_init as the `provider_config` kwarg.
+        # Source precedence (lowest → highest):
+        #   hardcoded defaults → env vars → mem0.json → config.yaml memory.mem0.*
+        # `explicit_keys` tracks keys that came from a user-supplied source
+        # (env / mem0.json / yaml) rather than a hardcoded default — so a
+        # runtime override (e.g. profile name → agent_id) won't silently
+        # clobber an explicit user setting.
+        # Skip empty values so that an unset YAML key (e.g. `user_id: ""`)
+        # doesn't silently wipe out a non-empty env / mem0.json value.
+        prov_cfg = kwargs.get("provider_config") or {}
+        if isinstance(prov_cfg, dict):
+            for _k, _v in prov_cfg.items():
+                if _v is None or _v == "":
+                    continue
+                self._config[_k] = _v
+                explicit_keys.add(_k)
         self._api_key = self._config.get("api_key", "")
         # Prefer gateway-provided user_id for per-user memory scoping;
-        # fall back to config/env default for CLI (single-user) sessions.
+        # fall back to config (yaml/json/env) for CLI (single-user) sessions.
         self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
-        self._agent_id = self._config.get("agent_id", "hermes")
+        # agent_id precedence: explicit config (env / mem0.json / yaml) >
+        # runtime profile name (agent_identity, set by agent_init) >
+        # hardcoded "hermes" default. This way, multi-profile users get
+        # per-profile attribution automatically while a user who explicitly
+        # pinned `MEM0_AGENT_ID`, `mem0.json`'s `agent_id`, or
+        # `memory.mem0.agent_id` is still honoured.
+        if "agent_id" in explicit_keys:
+            self._agent_id = self._config["agent_id"]
+        else:
+            self._agent_id = (
+                kwargs.get("agent_identity")
+                or self._config.get("agent_id", "hermes")
+            )
         self._rerank = self._config.get("rerank", True)
 
     def _read_filters(self) -> Dict[str, Any]:

--- a/tests/plugins/memory/test_mem0_config_yaml_threading.py
+++ b/tests/plugins/memory/test_mem0_config_yaml_threading.py
@@ -1,0 +1,288 @@
+"""Tests for Mem0 config.yaml threading + runtime profile -> agent_id mapping.
+
+Covers the gap where ``memory.mem0.{user_id,agent_id}`` in ``config.yaml``
+was silently dropped on the floor: agent_init never passed the subconfig
+through to the plugin, and the plugin's ``_load_config`` only read env vars
+plus ``$HERMES_HOME/mem0.json``.  After the fix:
+
+1. ``initialize(provider_config=...)`` is the new threading hop.
+2. Precedence for ``agent_id``:
+       explicit config (env / mem0.json / yaml) > runtime profile
+       (``agent_identity`` kwarg) > hardcoded ``"hermes"`` default.
+3. ``user_id`` keeps existing precedence:
+       runtime kwarg > explicit config > default.
+"""
+
+import json
+
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+# ---------------------------------------------------------------------------
+# provider_config threading from config.yaml
+# ---------------------------------------------------------------------------
+
+
+class TestProviderConfigThreading:
+    """`provider_config` kwarg carries memory.mem0.* from config.yaml."""
+
+    def test_provider_config_sets_user_id_and_agent_id(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            provider_config={"user_id": "jereme", "agent_id": "stack"},
+        )
+
+        assert provider._user_id == "jereme"
+        assert provider._agent_id == "stack"
+
+    def test_provider_config_carries_rerank(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            provider_config={"rerank": False},
+        )
+
+        assert provider._rerank is False
+
+    def test_missing_provider_config_falls_back_to_env_and_json(self, monkeypatch, tmp_path):
+        """No provider_config kwarg: pre-fix behaviour is preserved."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("MEM0_USER_ID", "env-user")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+
+        assert provider._user_id == "env-user"
+        # No agent_id env / yaml / runtime override -> hermes default.
+        assert provider._agent_id == "hermes"
+
+    def test_empty_provider_config_keys_dont_clobber_env(self, monkeypatch, tmp_path):
+        """``user_id: ""`` in yaml must not wipe out an MEM0_USER_ID env value."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("MEM0_USER_ID", "env-user")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            provider_config={"user_id": "", "agent_id": None},
+        )
+
+        assert provider._user_id == "env-user"
+        # agent_id had no explicit source (env unset, yaml empty) ->
+        # falls through to default since no agent_identity either.
+        assert provider._agent_id == "hermes"
+
+    def test_provider_config_non_dict_is_ignored(self, monkeypatch, tmp_path):
+        """Hostile / mistyped provider_config (e.g. a string) shouldn't crash."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session", provider_config="not-a-dict")
+
+        assert provider._user_id == "hermes-user"
+        assert provider._agent_id == "hermes"
+
+
+# ---------------------------------------------------------------------------
+# agent_identity (profile name) -> agent_id mapping
+# ---------------------------------------------------------------------------
+
+
+class TestAgentIdentityMapping:
+    """`agent_identity` kwarg (profile name) becomes the default agent_id."""
+
+    def test_agent_identity_sets_agent_id_when_no_explicit_config(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session", agent_identity="seo-expert")
+
+        assert provider._agent_id == "seo-expert"
+
+    def test_explicit_env_agent_id_wins_over_agent_identity(self, monkeypatch, tmp_path):
+        """A user who pinned MEM0_AGENT_ID expects it to win."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("MEM0_AGENT_ID", "pinned-by-env")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session", agent_identity="seo-expert")
+
+        assert provider._agent_id == "pinned-by-env"
+
+    def test_explicit_json_agent_id_wins_over_agent_identity(self, monkeypatch, tmp_path):
+        """mem0.json's agent_id is an explicit user choice — outranks profile."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(json.dumps({"agent_id": "pinned-by-json"}))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session", agent_identity="seo-expert")
+
+        assert provider._agent_id == "pinned-by-json"
+
+    def test_explicit_yaml_agent_id_wins_over_agent_identity(self, monkeypatch, tmp_path):
+        """`memory.mem0.agent_id` in config.yaml outranks runtime profile."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            agent_identity="seo-expert",
+            provider_config={"agent_id": "pinned-by-yaml"},
+        )
+
+        assert provider._agent_id == "pinned-by-yaml"
+
+    def test_no_explicit_no_identity_falls_back_to_hermes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+
+        assert provider._agent_id == "hermes"
+
+
+# ---------------------------------------------------------------------------
+# user_id precedence (runtime kwarg always wins)
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdPrecedence:
+    """user_id keeps existing precedence: runtime kwarg > config > default."""
+
+    def test_runtime_user_id_wins_over_yaml(self, monkeypatch, tmp_path):
+        """Gateway-supplied user_id (e.g. Telegram chat id) outranks yaml."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            user_id="tg_user_42",
+            provider_config={"user_id": "jereme"},
+        )
+
+        assert provider._user_id == "tg_user_42"
+
+    def test_yaml_user_id_wins_over_env(self, monkeypatch, tmp_path):
+        """config.yaml is a stronger signal than env defaults."""
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("MEM0_USER_ID", "env-user")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            provider_config={"user_id": "yaml-user"},
+        )
+
+        assert provider._user_id == "yaml-user"
+
+    def test_json_user_id_wins_over_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("MEM0_USER_ID", "env-user")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(json.dumps({"user_id": "json-user"}))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+
+        assert provider._user_id == "json-user"
+
+
+# ---------------------------------------------------------------------------
+# Filter outputs reflect threaded values
+# ---------------------------------------------------------------------------
+
+
+class TestFilterOutputsAfterThreading:
+    """Once provider_config sets user_id/agent_id, downstream filters reflect them.
+
+    This is the end-to-end guarantee: a profile that sets
+    ``memory.mem0.user_id: jereme`` actually writes under that user.
+    """
+
+    def test_write_filters_use_yaml_threaded_ids(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            provider_config={"user_id": "jereme", "agent_id": "stack"},
+        )
+
+        wf = provider._write_filters()
+        assert wf == {"user_id": "jereme", "agent_id": "stack"}
+
+    def test_read_filters_use_yaml_threaded_user(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        provider = Mem0MemoryProvider()
+        provider.initialize(
+            "test-session",
+            provider_config={"user_id": "jereme"},
+        )
+
+        rf = provider._read_filters()
+        assert rf == {"user_id": "jereme"}
+
+    def test_profile_only_yaml_agent_id_yields_per_profile_attribution(
+        self, monkeypatch, tmp_path
+    ):
+        """End-to-end multi-profile scenario:
+
+        Three Hermes profiles share user_id=jereme but each writes under its
+        own agent_id (= profile name) via the agent_identity runtime kwarg.
+        """
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        monkeypatch.delenv("MEM0_AGENT_ID", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        common_yaml = {"user_id": "jereme"}
+
+        stack = Mem0MemoryProvider()
+        stack.initialize("s", provider_config=common_yaml, agent_identity="stack")
+
+        seo = Mem0MemoryProvider()
+        seo.initialize("s", provider_config=common_yaml, agent_identity="seo-expert")
+
+        staff = Mem0MemoryProvider()
+        staff.initialize("s", provider_config=common_yaml, agent_identity="staff-agent")
+
+        assert stack._write_filters() == {"user_id": "jereme", "agent_id": "stack"}
+        assert seo._write_filters() == {"user_id": "jereme", "agent_id": "seo-expert"}
+        assert staff._write_filters() == {"user_id": "jereme", "agent_id": "staff-agent"}
+
+        # Read filters share the user but ignore agent_id — so cross-profile
+        # recall sees everything under user_id=jereme, regardless of which
+        # profile wrote it.
+        for p in (stack, seo, staff):
+            assert p._read_filters() == {"user_id": "jereme"}

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -90,3 +90,144 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert provider.init_kwargs["user_id"] == "open-id"
     assert provider.init_kwargs["user_id_alt"] == "union-id"
     assert provider.init_kwargs["platform"] == "feishu"
+
+
+def test_aiagent_threads_provider_subconfig_to_memory_provider():
+    """`memory.<provider_name>.*` from config.yaml is threaded as provider_config kwarg.
+
+    Without this hop, every key under (e.g.) `memory.mem0.*` would be
+    silently dropped on the floor — the plugin only sees env vars and its
+    own JSON sidecar, so config.yaml user_id / agent_id would be dead config.
+    """
+    provider = RecordingMemoryProvider()
+    cfg = {
+        "memory": {
+            "provider": "recording",
+            "recording": {
+                "user_id": "jereme",
+                "agent_id": "stack",
+                "rerank": True,
+            },
+        },
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    assert agent._memory_manager is not None
+    threaded = provider.init_kwargs.get("provider_config")
+    assert threaded == {
+        "user_id": "jereme",
+        "agent_id": "stack",
+        "rerank": True,
+    }
+
+
+def test_aiagent_omits_provider_config_when_subconfig_missing():
+    """No `memory.<provider_name>` block in config.yaml -> no provider_config kwarg."""
+    provider = RecordingMemoryProvider()
+    cfg = {"memory": {"provider": "recording"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    assert "provider_config" not in provider.init_kwargs
+
+
+def test_aiagent_skips_non_dict_provider_subconfig():
+    """Malformed `memory.<provider_name>` (e.g. a string) is gracefully skipped."""
+    provider = RecordingMemoryProvider()
+    cfg = {
+        "memory": {
+            "provider": "recording",
+            "recording": "not-a-dict",
+        },
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    assert "provider_config" not in provider.init_kwargs
+
+
+def test_aiagent_skips_empty_provider_subconfig():
+    """Empty dict in `memory.<provider_name>` -> no provider_config kwarg.
+
+    Avoids attaching a meaningless ``{}`` that plugins would have to
+    defensively handle.
+    """
+    provider = RecordingMemoryProvider()
+    cfg = {
+        "memory": {
+            "provider": "recording",
+            "recording": {},
+        },
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    assert "provider_config" not in provider.init_kwargs


### PR DESCRIPTION
## Summary

Plumb `memory.<provider_name>.*` from `config.yaml` through to memory provider plugins (concrete first user: Mem0). Without this fix, that subconfig was silently dropped — users who set, e.g.

```yaml
memory:
  provider: mem0
  mem0:
    user_id: jereme
    agent_id: stack
```

still had writes scoped to the env defaults (`hermes-user`, `hermes`) because the only paths into the Mem0 plugin's `_load_config()` were env vars and `$HERMES_HOME/mem0.json`. `config.yaml` itself was unreachable.

This defeated per-profile memory scoping in multi-profile setups: running three Hermes profiles (e.g. `stack` / `seo-expert` / `staff-agent`), each with its own `memory.mem0.agent_id`, still caused all three to write under `(hermes-user, hermes)` instead of getting per-profile attribution.

## Fix

1. **`agent/agent_init.py`** now extracts `mem_config.get(<provider_name>)` and threads it through `MemoryManager.initialize_all` as a `provider_config` kwarg. The dict is only attached when it's a non-empty dict — empty / wrong-type subconfigs are skipped silently so plugins don't have to defensively handle them.

2. **`plugins/memory/mem0/__init__.py`** merges `provider_config` over its existing env-vars-plus-`mem0.json` defaults. A new `_explicit_source_keys()` helper tracks which keys came from a real user source (env / json / yaml) vs the hardcoded fallback, so the runtime profile-name kwarg (`agent_identity`, already threaded by `agent_init`) can become the default `agent_id` without clobbering a value the user explicitly pinned. New precedence (low → high):

   ```
   hardcoded defaults → env vars → mem0.json → config.yaml
                     → runtime kwargs (user_id, agent_identity)
   ```

   with explicit user-supplied config always beating runtime defaults.

3. **`agent_identity`** (the active Hermes profile name) now becomes the fallback `agent_id` when nothing else is set. Multi-profile users get per-profile write attribution automatically — no need to repeat the profile name in every profile's `config.yaml`.

4. **`agent/memory_provider.py`** docstring documents `provider_config` as a standard kwarg so future plugins can opt into the same threading without re-deriving the convention.

## Tests

New file `tests/plugins/memory/test_mem0_config_yaml_threading.py` — 15 cases:

- `provider_config` threading from yaml sets `user_id`, `agent_id`, `rerank`
- Missing / empty / non-dict `provider_config` falls back gracefully
- Precedence: explicit env / json / yaml `agent_id` all win over `agent_identity` runtime kwarg
- Precedence: runtime `user_id` (gateway) > yaml > json > env > default
- End-to-end multi-profile scenario verifying `_write_filters()` outputs differ per profile while `_read_filters()` shares the user (cross-profile recall preserved)

Extended `tests/run_agent/test_memory_provider_init.py` — 4 new cases verifying `agent_init` builds the `provider_config` kwarg correctly (or skips it gracefully when missing/malformed/empty).

All 125 tests in the surrounding memory-provider test surface pass. Existing Mem0 tests (23) and memory-provider tests unaffected.

## Backward compatibility

- `_load_config()` keeps its `dict` return signature (a private helper but it's monkeypatched in tests).
- Users with only env vars or only `mem0.json` configured see identical behaviour.
- Users who already have `memory.mem0.user_id` / `agent_id` in their `config.yaml` (dead config before) now get the scoping they expected.
- Users who don't set `agent_id` anywhere get the active profile name (instead of the literal `"hermes"`); this is the new useful default. Anyone relying on the old literal `"hermes"` can pin it explicitly via `MEM0_AGENT_ID=hermes` or `memory.mem0.agent_id: hermes`.
