### PR TITLE
feat(openrouter): pass session_id in extra_body for sticky routing

### DIFF
--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -43,6 +43,8 @@ class OpenRouterProfile(ProviderProfile):
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
         body: dict[str, Any] = {}
+        if session_id:
+            body["session_id"] = session_id
         prefs = context.get("provider_preferences")
         if prefs:
             body["provider"] = prefs

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -98,6 +98,11 @@ class TestOpenRouterProfile:
         body = p.build_extra_body(provider_preferences={"allow": ["anthropic"]})
         assert body["provider"] == {"allow": ["anthropic"]}
 
+    def test_extra_body_session_id(self):
+        p = get_provider_profile("openrouter")
+        body = p.build_extra_body(session_id="test-session-123")
+        assert body["session_id"] == "test-session-123"
+
     def test_extra_body_no_prefs(self):
         p = get_provider_profile("openrouter")
         body = p.build_extra_body()


### PR DESCRIPTION
## Summary

- Pass `session_id` through to OpenRouter's `extra_body` in `build_extra_body()`, enabling sticky session routing that pins multi-turn conversations to the same provider endpoint for prompt cache reuse across turns.
- The `session_id` parameter was already threaded through from the transport layer but was never included in the returned dict — this is a one-line fix.
- Adds a unit test for the new behavior.

## Context

OpenRouter supports a `session_id` field in `extra_body` that tells the router to pin subsequent requests to the same upstream provider. This enables prompt caching (e.g., Anthropic's 5-minute TTL cache) to actually hit across turns in a multi-turn conversation. Without this, each request could be routed to a different endpoint, missing the cache entirely.

The `session_id` was already:
1. Generated per session (`gateway/session.py`, `cron/scheduler.py`)
2. Passed through to `build_extra_body()` via the transport layer (`chat_completions.py:508`)
3. Accepted as a keyword argument in the OpenRouter override

It just wasn't being added to the returned body dict.

## Test plan

- [x] Unit test: `test_extra_body_session_id` verifies `session_id` appears in the dict
- [x] All 15 existing `TestOpenRouterProfile` tests still pass
- [x] Manual verification: ran `hermes chat` with `--pass-session-id` against OpenRouter, confirmed `cache_write_tokens` in the response usage data

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)