### PR TITLE
fix(tools): preserve core tools when disabling platform bundles in disabled_toolsets

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -370,8 +370,31 @@ def _compute_tool_definitions(
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
-                resolved = resolve_toolset(toolset_name)
-                tools_to_include.difference_update(resolved)
+                # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS in
+                # their definition.  Subtracting them blindly removes core
+                # tools (terminal, read_file, …) from *other* enabled
+                # toolsets that also include those core tools (see #33924).
+                # For platform bundles, only subtract the platform-specific
+                # tools — leave core tools intact.
+                if toolset_name.startswith("hermes-"):
+                    from toolsets import get_toolset as _get_ts, _HERMES_CORE_TOOLS as _core_tools
+                    ts_def = _get_ts(toolset_name)
+                    to_remove: set = set()
+                    if ts_def and "tools" in ts_def:
+                        to_remove = set(ts_def["tools"]) - set(_core_tools)
+                        for _inc in ts_def.get("includes", []):
+                            _inc_def = _get_ts(_inc)
+                            if _inc_def and "tools" in _inc_def:
+                                to_remove.update(
+                                    set(_inc_def["tools"]) - set(_core_tools)
+                                )
+                    else:
+                        to_remove = set(resolve_toolset(toolset_name))
+                    tools_to_include.difference_update(to_remove)
+                    resolved = sorted(to_remove)
+                else:
+                    resolved = resolve_toolset(toolset_name)
+                    tools_to_include.difference_update(resolved)
                 if not quiet_mode:
                     print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -358,3 +358,65 @@ class TestCoerceNumberInfNan:
         assert _coerce_number("42") == 42
         assert _coerce_number("3.14") == 3.14
         assert _coerce_number("1e3") == 1000
+
+class TestDisabledToolsetsPlatformBundle:
+    """Regression test for #33924: disabling a platform bundle (hermes-*)
+    must not remove core tools from other enabled toolsets."""
+
+    def test_disabling_platform_bundle_preserves_core_tools(self):
+        """Disabling hermes-yuanbao should not strip core tools from hermes-telegram."""
+        from model_tools import get_tool_definitions
+
+        tools_telegram = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            quiet_mode=True,
+        )
+        tools_telegram_no_yuanbao = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            disabled_toolsets=["hermes-yuanbao"],
+            quiet_mode=True,
+        )
+        names_telegram = {t["function"]["name"] for t in tools_telegram}
+        names_no_yuanbao = {t["function"]["name"] for t in tools_telegram_no_yuanbao}
+
+        # Disabling a *different* platform bundle must not remove any tools
+        assert names_telegram == names_no_yuanbao, (
+            f"Tools lost after disabling hermes-yuanbao: "
+            f"{names_telegram - names_no_yuanbao}"
+        )
+
+    def test_disabling_platform_bundle_removes_own_tools(self):
+        """Disabling hermes-discord should remove discord-specific tools."""
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["hermes-discord"],
+            disabled_toolsets=["hermes-discord"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert "discord" not in names
+
+    def test_disabling_non_platform_toolset_still_works(self):
+        """Disabling a regular (non-hermes-) toolset still subtracts all tools."""
+        from model_tools import get_tool_definitions
+
+        tools_normal = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            quiet_mode=True,
+        )
+        tools_no_web = get_tool_definitions(
+            enabled_toolsets=["hermes-telegram"],
+            disabled_toolsets=["web"],
+            quiet_mode=True,
+        )
+        names_normal = {t["function"]["name"] for t in tools_normal}
+        names_no_web = {t["function"]["name"] for t in tools_no_web}
+
+        web_tools = {"web_search", "web_extract"}
+        removed = names_normal - names_no_web
+        # web tools should be removed (if they were present)
+        present_web = web_tools & names_normal
+        assert present_web <= removed, (
+            f"Web tools not removed: {present_web - removed}"
+        )


### PR DESCRIPTION
## What does this PR do?

When a platform bundle name (e.g. `hermes-yuanbao`) appears in `agent.disabled_toolsets`, the toolset subtraction step in `_compute_tool_definitions()` resolves the bundle to **all** its tools — including the shared `_HERMES_CORE_TOOLS` (terminal, read_file, web_search, etc.) — and removes them from every other enabled toolset.

This means disabling any single platform bundle silently strips **all** core tools from the gateway path, making the agent unable to use any tools at all. The CLI path is unaffected because it uses a different toolset configuration.

**Fix**: For platform bundles (`hermes-*`), only subtract the platform-specific tools (the delta over `_HERMES_CORE_TOOLS`), preserving core tools that are shared across all bundles.
## Related Issue

Fixes #33924

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`model_tools.py`** — In `_compute_tool_definitions()`, when a disabled toolset starts with `hermes-`, compute the platform-specific delta (toolset tools minus `_HERMES_CORE_TOOLS`) instead of subtracting the full resolved set.
- **`tests/test_model_tools.py`** — Added `TestDisabledToolsetsPlatformBundle` with 3 regression tests:
  - Disabling a platform bundle preserves core tools in other enabled toolsets
  - Disabling a platform bundle removes its own platform-specific tools
  - Disabling a non-platform toolset still works as before

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- **Analyzed**: `model_tools.py:_compute_tool_definitions()` (called by `get_tool_definitions()`, used by `run_agent.py`, `cli.py`, `gateway/run.py`)
- **Blast radius**: LOW — the change only affects the disabled-toolset subtraction path; enabled-toolset resolution is unchanged
- **Related patterns**: Every platform bundle (`hermes-telegram`, `hermes-discord`, `hermes-whatsapp`, etc.) includes `_HERMES_CORE_TOOLS` in its definition. The fix applies to all of them uniformly.