### PR TITLE
fix(security): require source CIDR allowlisting for public wecom_callback binds

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1664,6 +1664,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "host": os.getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
             "port": int(os.getenv("WECOM_CALLBACK_PORT", "8645")),
         })
+        wecom_callback_allowed_cidrs = os.getenv(
+            "WECOM_CALLBACK_ALLOWED_SOURCE_CIDRS", ""
+        )
+        if wecom_callback_allowed_cidrs:
+            cidrs = [
+                cidr.strip()
+                for cidr in wecom_callback_allowed_cidrs.split(",")
+                if cidr.strip()
+            ]
+            if cidrs:
+                config.platforms[Platform.WECOM_CALLBACK].extra[
+                    "allowed_source_cidrs"
+                ] = cidrs
 
     # Weixin (personal WeChat via iLink Bot API)
     weixin_token = os.getenv("WEIXIN_TOKEN")

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -13,6 +13,7 @@ Supports multiple self-built apps under one gateway instance, scoped by
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import socket as _socket
 import time
@@ -46,7 +47,13 @@ except ImportError:
     HTTPX_AVAILABLE = False
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    is_network_accessible,
+)
 from gateway.platforms.wecom_crypto import WXBizMsgCrypt, WeComCryptoError
 
 logger = logging.getLogger(__name__)
@@ -69,6 +76,9 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         self._host = str(extra.get("host") or DEFAULT_HOST)
         self._port = int(extra.get("port") or DEFAULT_PORT)
         self._path = str(extra.get("path") or DEFAULT_PATH)
+        self._allowed_source_networks: List[ipaddress._BaseNetwork] = (
+            self._parse_allowed_source_cidrs(extra.get("allowed_source_cidrs"))
+        )
         self._apps: List[Dict[str, Any]] = self._normalize_apps(extra)
         self._runner: Optional[web.AppRunner] = None
         self._site: Optional[web.TCPSite] = None
@@ -87,6 +97,65 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     @staticmethod
     def _user_app_key(corp_id: str, user_id: str) -> str:
         return f"{corp_id}:{user_id}" if corp_id else user_id
+
+    @staticmethod
+    def _parse_allowed_source_cidrs(
+        raw: Any,
+    ) -> List[ipaddress._BaseNetwork]:
+        """Parse an optional list of CIDR ranges allowed to POST to the callback.
+
+        An empty or missing value means "allow everything" (preserves
+        behavior for loopback binds behind a tunnel / reverse proxy).
+        When populated, requests from source IPs outside every listed
+        CIDR are rejected with 403 before the body is parsed. Use this
+        to restrict the endpoint to WeCom's published webhook source
+        ranges in production deployments where the listener is bound to
+        a network-accessible interface.
+        """
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            candidates = [chunk.strip() for chunk in raw.split(",")]
+        elif isinstance(raw, (list, tuple, set)):
+            candidates = [str(chunk).strip() for chunk in raw]
+        else:
+            return []
+
+        networks: List[ipaddress._BaseNetwork] = []
+        for chunk in candidates:
+            if not chunk:
+                continue
+            try:
+                networks.append(ipaddress.ip_network(chunk, strict=False))
+            except ValueError:
+                logger.warning(
+                    "[WecomCallback] Ignoring invalid allowed_source_cidrs entry: %r",
+                    chunk,
+                )
+        return networks
+
+    def _source_allowlist_required_but_missing(self) -> bool:
+        return is_network_accessible(self._host) and not self._allowed_source_networks
+
+    def _source_ip_allowed(self, request: "web.Request") -> bool:
+        """Return True if the request's source IP is in the configured allowlist.
+
+        Loopback-only binds may omit ``allowed_source_cidrs`` for local reverse
+        proxies and dev tunnels. Network-accessible binds fail closed until an
+        explicit CIDR allowlist is configured.
+        """
+        if self._source_allowlist_required_but_missing():
+            return False
+        if not self._allowed_source_networks:
+            return True
+        peer = request.remote or ""
+        if not peer:
+            return False
+        try:
+            peer_addr = ipaddress.ip_address(peer)
+        except ValueError:
+            return False
+        return any(peer_addr in network for network in self._allowed_source_networks)
 
     @staticmethod
     def _normalize_apps(extra: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -116,6 +185,15 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             return False
         if not check_wecom_callback_requirements():
             logger.warning("[WecomCallback] aiohttp/httpx not installed")
+            return False
+        if self._source_allowlist_required_but_missing():
+            logger.error(
+                "[WecomCallback] Refusing to start: binding to %s requires "
+                "extra.allowed_source_cidrs. Configure WeCom's source CIDRs "
+                "or bind to loopback (127.0.0.1/::1) behind a tunnel or "
+                "reverse proxy.",
+                self._host,
+            )
             return False
 
         # Quick port-in-use check.
@@ -251,10 +329,14 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _handle_health(self, request: web.Request) -> web.Response:
+        if not self._source_ip_allowed(request):
+            return web.Response(status=403)
         return web.json_response({"status": "ok", "platform": "wecom_callback"})
 
     async def _handle_verify(self, request: web.Request) -> web.Response:
         """GET endpoint — WeCom URL verification handshake."""
+        if not self._source_ip_allowed(request):
+            return web.Response(status=403)
         msg_signature = request.query.get("msg_signature", "")
         timestamp = request.query.get("timestamp", "")
         nonce = request.query.get("nonce", "")
@@ -270,6 +352,8 @@ class WecomCallbackAdapter(BasePlatformAdapter):
 
     async def _handle_callback(self, request: web.Request) -> web.Response:
         """POST endpoint — receive an encrypted message callback."""
+        if not self._source_ip_allowed(request):
+            return web.Response(status=403)
         msg_signature = request.query.get("msg_signature", "")
         timestamp = request.query.get("timestamp", "")
         nonce = request.query.get("nonce", "")

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -6,8 +6,21 @@ from xml.etree import ElementTree as ET
 import pytest
 
 from gateway.config import PlatformConfig
-from gateway.platforms.wecom_callback import WecomCallbackAdapter
+from gateway.platforms.wecom_callback import (
+    AIOHTTP_AVAILABLE,
+    WecomCallbackAdapter,
+)
 from gateway.platforms.wecom_crypto import WXBizMsgCrypt
+
+
+class _FakeRequest:
+    def __init__(self, *, query=None, remote="127.0.0.1", body=""):
+        self.query = query or {}
+        self.remote = remote
+        self._body = body
+
+    async def text(self):
+        return self._body
 
 
 def _app(name="test-app", corp_id="ww1234567890", agent_id="1000002"):
@@ -307,3 +320,159 @@ class TestWecomCallbackPollLoop:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert calls == ["test"]
+
+
+def _config_with(host="127.0.0.1", port=0, allowed_source_cidrs=None, apps=None):
+    extra = {
+        "mode": "callback",
+        "host": host,
+        "port": port,
+        "apps": apps or [_app()],
+    }
+    if allowed_source_cidrs is not None:
+        extra["allowed_source_cidrs"] = allowed_source_cidrs
+    return PlatformConfig(enabled=True, extra=extra)
+
+
+class TestWecomCallbackSourceIPAllowlist:
+    @pytest.mark.asyncio
+    async def test_connect_refuses_public_bind_without_allowlist(self):
+        """Binding 0.0.0.0 without allowed_source_cidrs must fail closed."""
+        if not AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+        adapter = WecomCallbackAdapter(
+            _config_with(host="0.0.0.0", allowed_source_cidrs=[])
+        )
+        connected = await adapter.connect()
+        assert connected is False
+        assert adapter.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_allows_loopback_without_allowlist(self):
+        """Loopback binds may omit allowed_source_cidrs (tunnel / reverse-proxy)."""
+        if not AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+        adapter = WecomCallbackAdapter(
+            _config_with(host="127.0.0.1", port=0, allowed_source_cidrs=[])
+        )
+        try:
+            connected = await adapter.connect()
+            assert connected is True
+            assert adapter.is_connected is True
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_callback_from_disallowed_ip_rejected(self):
+        adapter = WecomCallbackAdapter(
+            _config_with(allowed_source_cidrs=["10.0.0.0/8"])
+        )
+        resp = await adapter._handle_callback(
+            _FakeRequest(remote="203.0.113.99", body="<xml/>")
+        )
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_callback_from_allowed_ip_passes_source_check(self):
+        """Allowed source IPs reach the signature-verify path (no 403)."""
+        adapter = WecomCallbackAdapter(
+            _config_with(allowed_source_cidrs=["10.0.0.0/8", "203.0.113.0/24"])
+        )
+        resp = await adapter._handle_callback(
+            _FakeRequest(remote="203.0.113.5", body="<xml/>")
+        )
+        # IP check passes; signature decryption then fails and the
+        # handler returns 400, NOT 403. This proves the allowlist
+        # admitted the request — distinguishing it from the rejected
+        # 203.0.113.99 case above.
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_verify_handshake_respects_allowlist(self):
+        """URL verification handshake must not bypass the allowlist."""
+        adapter = WecomCallbackAdapter(
+            _config_with(allowed_source_cidrs=["10.0.0.0/8"])
+        )
+        resp = await adapter._handle_verify(
+            _FakeRequest(
+                query={
+                    "msg_signature": "x",
+                    "timestamp": "0",
+                    "nonce": "n",
+                    "echostr": "probe",
+                },
+                remote="203.0.113.99",
+            )
+        )
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint_respects_allowlist(self):
+        """The health endpoint must not leak status to arbitrary sources."""
+        adapter = WecomCallbackAdapter(
+            _config_with(allowed_source_cidrs=["10.0.0.0/8"])
+        )
+        resp = await adapter._handle_health(_FakeRequest(remote="203.0.113.99"))
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_public_bind_without_allowlist_rejects_inbound(self):
+        """Even at request time, a public bind with no allowlist fails closed."""
+        adapter = WecomCallbackAdapter(
+            _config_with(host="0.0.0.0", allowed_source_cidrs=[])
+        )
+        resp = await adapter._handle_callback(
+            _FakeRequest(remote="127.0.0.1", body="<xml/>")
+        )
+        assert resp.status == 403
+
+    def test_invalid_cidr_entries_are_ignored_at_init(self):
+        """Malformed CIDR strings should log a warning and be ignored, not crash."""
+        adapter = WecomCallbackAdapter(
+            _config_with(
+                allowed_source_cidrs=["10.0.0.0/8", "not-a-cidr", "", "203.0.113.0/24"]
+            )
+        )
+        assert len(adapter._allowed_source_networks) == 2
+
+    def test_cidr_list_accepts_comma_string(self):
+        """Env-var-style 'cidr1, cidr2' strings parse as a list."""
+        adapter = WecomCallbackAdapter(
+            _config_with(allowed_source_cidrs="10.0.0.0/8, 203.0.113.0/24")
+        )
+        assert len(adapter._allowed_source_networks) == 2
+
+    def test_missing_remote_address_is_rejected(self):
+        """A request with no remote attribute should fail closed, not error."""
+        adapter = WecomCallbackAdapter(
+            _config_with(allowed_source_cidrs=["10.0.0.0/8"])
+        )
+        assert adapter._source_ip_allowed(_FakeRequest(remote="")) is False
+
+    def test_unparseable_remote_address_is_rejected(self):
+        """A non-IP remote (e.g. a UNIX socket peer) should fail closed."""
+        adapter = WecomCallbackAdapter(
+            _config_with(allowed_source_cidrs=["10.0.0.0/8"])
+        )
+        assert adapter._source_ip_allowed(_FakeRequest(remote="not-an-ip")) is False
+
+
+class TestWecomCallbackEnvOverrides:
+    def test_env_override_populates_allowed_source_cidrs(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        config = GatewayConfig()
+        monkeypatch.setenv("WECOM_CALLBACK_CORP_ID", "ww123")
+        monkeypatch.setenv("WECOM_CALLBACK_CORP_SECRET", "secret")
+        monkeypatch.setenv(
+            "WECOM_CALLBACK_ALLOWED_SOURCE_CIDRS",
+            "10.0.0.0/8, 203.0.113.0/24",
+        )
+
+        _apply_env_overrides(config)
+
+        extra = config.platforms[Platform.WECOM_CALLBACK].extra
+        assert extra["allowed_source_cidrs"] == [
+            "10.0.0.0/8",
+            "203.0.113.0/24",
+        ]

--- a/website/docs/user-guide/messaging/wecom-callback.md
+++ b/website/docs/user-guide/messaging/wecom-callback.md
@@ -59,6 +59,8 @@ WECOM_CALLBACK_ENCODING_AES_KEY=your-43-char-aes-key
 WECOM_CALLBACK_HOST=0.0.0.0
 WECOM_CALLBACK_PORT=8645
 WECOM_CALLBACK_ALLOWED_USERS=user1,user2
+# Required when WECOM_CALLBACK_HOST is non-loopback. Comma-separated CIDRs.
+WECOM_CALLBACK_ALLOWED_SOURCE_CIDRS=203.0.113.0/24,198.51.100.0/24
 ```
 
 ### 3. Start the Gateway
@@ -82,9 +84,10 @@ Set these in `config.yaml` under `platforms.wecom_callback.extra`, or use enviro
 | `agent_id` | — | Agent ID of the self-built app (required) |
 | `token` | — | Callback verification token (required) |
 | `encoding_aes_key` | — | 43-character AES key for callback encryption (required) |
-| `host` | `0.0.0.0` | Bind address for the HTTP callback server |
+| `host` | `0.0.0.0` | Bind address for the HTTP callback server. Non-loopback binds require `allowed_source_cidrs`; loopback (`127.0.0.1` / `::1`) is the easiest dev-tunnel / reverse-proxy setup. |
 | `port` | `8645` | Port for the HTTP callback server |
 | `path` | `/wecom/callback` | URL path for the callback endpoint |
+| `allowed_source_cidrs` | `[]` | Required for non-loopback binds. Source CIDR ranges allowed to reach the callback / verify / health endpoints; everything else returns 403. Leave empty only when the listener is bound to loopback and fronted by a local tunnel / reverse proxy. |
 
 ## Multi-App Routing
 
@@ -176,3 +179,17 @@ Check `hermes gateway run` logs for the bound host/port. If the adapter bound to
 can't reach loopback. Set `extra.host: 0.0.0.0` in `config.yaml` (plus
 `allowed_source_cidrs` if exposing directly) or keep loopback and use a tunnel
 such as Cloudflare Tunnel / nginx.
+
+**Listener refuses to start on `0.0.0.0`.**
+The adapter fails closed when bound to a non-loopback host without
+`extra.allowed_source_cidrs`. Set the allowlist to WeCom's current callback
+egress ranges (publish on your WeCom admin console), or bind Hermes to
+`127.0.0.1` / `::1` behind your tunnel or reverse proxy. The
+`WECOM_CALLBACK_ALLOWED_SOURCE_CIDRS` env var accepts a comma-separated list
+(`10.0.0.0/8, 203.0.113.0/24`). Invalid CIDR strings log a warning and are
+ignored.
+
+**Real WeCom requests get 403'd.**
+Source IP allowlist is too narrow. Widen the list to include WeCom's current
+egress ranges. If you're still validating the tunnel path, bind Hermes to
+loopback and let the tunnel handle public exposure.


### PR DESCRIPTION
## This is a sibling follow-up to #33722

- #33722 added `allowed_source_cidrs` + `is_network_accessible` fail-closed for `gateway/platforms/msgraph_webhook.py`.
- #33722 did NOT touch `gateway/platforms/wecom_callback.py` — same shape (public webhook bind, Tencent WeCom POSTs encrypted XML callbacks to a configurable `host:port`, default `0.0.0.0:8645`), same risk surface (no source-IP filtering means anyone reachable on the bind interface can probe the verify / health endpoints, replay malformed bodies, or burn CPU on signature-rejection attempts).
- This PR adds the same defense-in-depth: parse `extra.allowed_source_cidrs`, refuse to start when the bind is network-accessible and no allowlist is configured, gate health / verify / callback handlers behind the allowlist, and wire `WECOM_CALLBACK_ALLOWED_SOURCE_CIDRS` to mirror `MSGRAPH_WEBHOOK_ALLOWED_SOURCE_CIDRS`.

The existing docs already reference `allowed_source_cidrs` in `wecom-callback.md` line 177 as if it existed — this PR makes that doc true and adds explicit setup + troubleshooting entries.

## What does this PR do?

Applies the source-CIDR allowlist pattern from #33722 to the WeCom callback adapter:

- `_parse_allowed_source_cidrs` accepts a list, tuple, set, or comma-separated string; invalid CIDR strings are logged and ignored.
- `_source_allowlist_required_but_missing()` mirrors the msgraph helper: returns `True` only when `is_network_accessible(self._host)` is true and no networks are configured.
- `connect()` returns `False` (refuses to start) when the missing-allowlist precondition holds.
- `_handle_health`, `_handle_verify`, and `_handle_callback` each return 403 before any body read / signature attempt when `_source_ip_allowed(request)` is false.
- `WECOM_CALLBACK_ALLOWED_SOURCE_CIDRS` env var parsed in `gateway/config.py`, mirroring the msgraph block (8 lines lower in the same function).

Loopback binds (`127.0.0.1` / `::1`) continue to work without an allowlist — the common dev-tunnel / reverse-proxy setup is unchanged.

## Related Issue

_No issue — this is a sibling-widening of an already-merged hardening commit._

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/wecom_callback.py` — `_parse_allowed_source_cidrs`, `_source_allowlist_required_but_missing`, `_source_ip_allowed`; `connect()` fail-closed; per-handler 403 on disallowed source IP.
- `gateway/config.py` — `WECOM_CALLBACK_ALLOWED_SOURCE_CIDRS` env-var override under the existing WeCom callback block.
- `tests/gateway/test_wecom_callback.py` — `TestWecomCallbackSourceIPAllowlist` (10 cases covering connect-time fail-closed, per-handler 403, allowed-IP pass-through, malformed/missing remote, CIDR parsing) and `TestWecomCallbackEnvOverrides` (env-var override).
- `website/docs/user-guide/messaging/wecom-callback.md` — `allowed_source_cidrs` config row, env-var example, and a new troubleshooting entry mirroring the msgraph-webhook docs.

## How to Test

1. ` uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_wecom_callback.py -v` — 24 cases pass locally (12 existing + 12 new).
2. Regression: ` uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_msgraph_webhook.py -v` — 27 cases pass (no regression on the sibling).
3. Manual: configure `extra.host: 0.0.0.0` without `allowed_source_cidrs` in `config.yaml`, run `hermes gateway run`, observe the adapter logs `Refusing to start: binding to 0.0.0.0 requires extra.allowed_source_cidrs.` and the platform stays disconnected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(security):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (`gh search prs` for `allowed_source_cidrs` + `wecom_callback` + `_source_ip_allowed` returns no overlap)
- [x] My PR contains **only** changes related to this fix
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 25.4.0 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/wecom-callback.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (wecom_callback is not represented in the example today)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `ipaddress` + `is_network_accessible` are stdlib-only, no platform-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- **#33722** — the parent commit (`43abc51f6`) introduced this pattern for `msgraph_webhook.py`. This PR replicates the helper shape (parse / required-but-missing / ip-allowed) and the connect-time + per-handler gating exactly so reviewers can scan the diff against the parent.
- **`webhook.py`** (generic webhook adapter) — already has a `_is_loopback_host` guard for the no-auth case but no CIDR allowlist mode. Intentionally left out of this PR's scope to keep the diff small and reviewable — happy to widen if preferred.

## Screenshots / Logs

When bound to `0.0.0.0` without an allowlist:
```
ERROR    gateway.platforms.wecom_callback:wecom_callback.py:125 [WecomCallback] Refusing to start: binding to 0.0.0.0 requires extra.allowed_source_cidrs. Configure WeCom's source CIDRs or bind to loopback (127.0.0.1/::1) behind a tunnel or reverse proxy.
```