### PR TITLE
feat(tui): add expandable tool visibility helpers

### DIFF
--- a/ui-tui/src/__tests__/toolVisibility.test.ts
+++ b/ui-tui/src/__tests__/toolVisibility.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseToolTrailEntry,
+  shouldToolEntryAutoOpen,
+  summarizeDelegationControls
+} from '../lib/toolVisibility.js'
+
+describe('parseToolTrailEntry', () => {
+  it('turns verbose completed tool lines into expandable sections', () => {
+    const entry = parseToolTrailEntry(
+      'Terminal("npm test") (1.3s) :: Args:\n{ "cmd": "npm test" }\nResult:\npassed ✓'
+    )
+
+    expect(entry).toEqual({
+      call: 'Terminal("npm test")',
+      detail: 'Args:\n{ "cmd": "npm test" }\nResult:\npassed',
+      duration: ' (1.3s)',
+      mark: '✓',
+      sections: [
+        { label: 'Args', text: '{ "cmd": "npm test" }' },
+        { label: 'Result', text: 'passed' }
+      ],
+      status: 'done'
+    })
+  })
+
+  it('auto-opens error rows but keeps successful rows collapsed by default', () => {
+    const failed = parseToolTrailEntry('Terminal("npm test") (0.5s) :: Error:\nfailed ✗')
+    const ok = parseToolTrailEntry('Read File("x") (0.1s) ✓')
+
+    expect(shouldToolEntryAutoOpen(failed)).toBe(true)
+    expect(shouldToolEntryAutoOpen(ok)).toBe(false)
+  })
+})
+
+describe('summarizeDelegationControls', () => {
+  it('shows pause/capacity controls for live delegation', () => {
+    expect(
+      summarizeDelegationControls({ maxConcurrentChildren: 3, maxSpawnDepth: 2, paused: false }, false)
+    ).toEqual({
+      capsLabel: 'caps d2/3',
+      controlsHint: ' · x kill · X subtree · p pause',
+      titleSuffix: ''
+    })
+  })
+
+  it('locks destructive controls during replay while preserving capacity context', () => {
+    expect(
+      summarizeDelegationControls({ maxConcurrentChildren: 5, maxSpawnDepth: 1, paused: true }, true)
+    ).toEqual({
+      capsLabel: 'caps d1/5',
+      controlsHint: ' · controls locked',
+      titleSuffix: ' · ⏸ paused'
+    })
+  })
+})

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -30,6 +30,7 @@ import {
   widthByDepth
 } from '../lib/subagentTree.js'
 import { compactPreview } from '../lib/text.js'
+import { summarizeDelegationControls } from '../lib/toolVisibility.js'
 import type { Theme } from '../theme.js'
 import type { SubagentNode, SubagentProgress } from '../types.js'
 
@@ -967,22 +968,23 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
     .map(([k, v]) => `${k}×${v}`)
     .join(' · ')
 
-  const capsLabel = delegation.maxSpawnDepth
-    ? `caps d${delegation.maxSpawnDepth}/${delegation.maxConcurrentChildren ?? '?'}`
-    : ''
+  const { capsLabel, controlsHint, titleSuffix } = summarizeDelegationControls(
+    {
+      maxConcurrentChildren: delegation.maxConcurrentChildren ?? undefined,
+      maxSpawnDepth: delegation.maxSpawnDepth ?? undefined,
+      paused: delegation.paused
+    },
+    replayMode
+  )
 
   const title =
     replayMode && effectiveSnapshot
       ? `${historyIndex > 0 ? `Replay ${historyIndex}/${history.length}` : 'Last turn'} · finished ${new Date(
           effectiveSnapshot.finishedAt
-        ).toLocaleTimeString()}`
-      : `Spawn tree${delegation.paused ? ' · ⏸ paused' : ''}`
+        ).toLocaleTimeString()}${titleSuffix}`
+      : `Spawn tree${titleSuffix}`
 
   const metaLine = [formatSummary(totals), spark, capsLabel, mix ? `· ${mix}` : ''].filter(Boolean).join('  ')
-
-  const controlsHint = replayMode
-    ? ' · controls locked'
-    : ` · x kill · X subtree · p ${delegation.paused ? 'resume' : 'pause'}`
 
   // ── Rendering ──────────────────────────────────────────────────────
 

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -21,12 +21,15 @@ import {
   estimateTokensRough,
   fmtK,
   formatToolCall,
-  parseToolTrailResultLine,
   pick,
-  splitToolDuration,
   thinkingPreview,
   toolTrailLabel
 } from '../lib/text.js'
+import {
+  type ParsedToolTrailEntry,
+  parseToolTrailEntry,
+  shouldToolEntryAutoOpen
+} from '../lib/toolVisibility.js'
 import type { Theme } from '../theme.js'
 import type {
   ActiveTool,
@@ -93,6 +96,7 @@ function TreeTextRow({
   color,
   content,
   dimColor,
+  onClick,
   rails = [],
   t,
   wrap = 'wrap-trim'
@@ -101,6 +105,7 @@ function TreeTextRow({
   color: string
   content: ReactNode
   dimColor?: boolean
+  onClick?: () => void
   rails?: TreeRails
   t: Theme
   wrap?: 'truncate-end' | 'wrap' | 'wrap-trim'
@@ -117,7 +122,7 @@ function TreeTextRow({
 
   return (
     <TreeRow branch={branch} rails={rails} t={t}>
-      {text}
+      {onClick ? <Box onClick={onClick}>{text}</Box> : text}
     </TreeRow>
   )
 }
@@ -679,11 +684,70 @@ export const Thinking = memo(function Thinking({
 // ── ToolTrail ────────────────────────────────────────────────────────
 
 interface Group {
+  autoOpen?: boolean
   color: string
   content: ReactNode
   details: DetailRow[]
+  entry?: ParsedToolTrailEntry
   key: string
   label: string
+}
+
+function ToolGroupRows({
+  branch,
+  children,
+  group,
+  rails,
+  t
+}: {
+  branch: TreeBranch
+  children?: ReactNode
+  group: Group
+  rails: TreeRails
+  t: Theme
+}) {
+  const expandable = group.details.length > 0 || Boolean(children)
+  const [open, setOpen] = useState(Boolean(group.autoOpen || children))
+
+  useEffect(() => {
+    if (group.autoOpen) {
+      setOpen(true)
+    }
+  }, [group.autoOpen])
+
+  const childRails = nextTreeRails(rails, branch)
+  const icon = expandable ? (open ? '▾ ' : '▸ ') : '  '
+
+  return (
+    <Box flexDirection="column">
+      <TreeTextRow
+        branch={branch}
+        color={group.color}
+        content={
+          <>
+            <Text color={expandable ? t.color.accent : t.color.muted}>{icon}</Text>
+            <Text color={t.color.accent}>● </Text>
+            {group.content}
+          </>
+        }
+        onClick={expandable ? () => setOpen(v => !v) : undefined}
+        rails={rails}
+        t={t}
+      />
+      {open
+        ? group.details.map((detail, detailIndex) => (
+            <Detail
+              {...detail}
+              branch={detailIndex === group.details.length - 1 && !children ? 'last' : 'mid'}
+              key={detail.key}
+              rails={childRails}
+              t={t}
+            />
+          ))
+        : null}
+      {open ? children : null}
+    </Box>
+  )
 }
 
 export const ToolTrail = memo(function ToolTrail({
@@ -792,25 +856,35 @@ export const ToolTrail = memo(function ToolTrail({
   const pushDetail = (row: DetailRow) => (groups.at(-1)?.details ?? meta).push(row)
 
   for (const [i, line] of trail.entries()) {
-    const parsed = parseToolTrailResultLine(line)
+    const entry = parseToolTrailEntry(line)
 
-    if (parsed) {
+    if (entry) {
       groups.push({
-        color: parsed.mark === '✗' ? t.color.error : t.color.text,
-        content: parsed.call,
-        details: [],
+        autoOpen: shouldToolEntryAutoOpen(entry),
+        color: entry.status === 'error' ? t.color.error : t.color.text,
+        content: `${entry.call}${entry.duration}`,
+        details:
+          entry.sections.length > 0
+            ? entry.sections.map((section, sectionIndex) => ({
+                color: section.label === 'Error' ? t.color.error : t.color.muted,
+                content: `${section.label}:\n${section.text}`,
+                dimColor: section.label !== 'Error',
+                key: `tr-${i}-s-${sectionIndex}`
+              }))
+            : entry.detail
+              ? [
+                  {
+                    color: entry.status === 'error' ? t.color.error : t.color.muted,
+                    content: entry.detail,
+                    dimColor: entry.status !== 'error',
+                    key: `tr-${i}-d`
+                  }
+                ]
+              : [],
+        entry,
         key: `tr-${i}`,
-        label: parsed.call
+        label: `${entry.call}${entry.duration}`
       })
-
-      if (parsed.detail) {
-        pushDetail({
-          color: parsed.mark === '✗' ? t.color.error : t.color.muted,
-          content: parsed.detail,
-          dimColor: parsed.mark !== '✗',
-          key: `tr-${i}-d`
-        })
-      }
 
       continue
     }
@@ -901,21 +975,6 @@ export const ToolTrail = memo(function ToolTrail({
   const totalTokensLabel = tokenCount > 0 && toolTokenCount > 0 ? `~${fmtK(totalTokenCount)} total` : null
   const delegateGroups = groups.filter(g => g.label.startsWith('Delegate Task'))
   const inlineDelegateKey = hasSubagents && delegateGroups.length === 1 ? delegateGroups[0]!.key : null
-
-  const toolLabel = (group: Group) => {
-    const { duration, label } = splitToolDuration(String(group.content))
-
-    return duration ? (
-      <>
-        {label}
-        <Text color={t.color.statusFg} dim>
-          {duration}
-        </Text>
-      </>
-    ) : (
-      group.content
-    )
-  }
 
   // ── Backstop: floating alerts when every panel is hidden ─────────
   //
@@ -1075,30 +1134,9 @@ export const ToolTrail = memo(function ToolTrail({
             const hasInlineSubagents = inlineDelegateKey === group.key
 
             return (
-              <Box flexDirection="column" key={group.key}>
-                <TreeTextRow
-                  branch={branch}
-                  color={group.color}
-                  content={
-                    <>
-                      <Text color={t.color.accent}>● </Text>
-                      {toolLabel(group)}
-                    </>
-                  }
-                  rails={rails}
-                  t={t}
-                />
-                {group.details.map((detail, detailIndex) => (
-                  <Detail
-                    {...detail}
-                    branch={detailIndex === group.details.length - 1 && !hasInlineSubagents ? 'last' : 'mid'}
-                    key={detail.key}
-                    rails={childRails}
-                    t={t}
-                  />
-                ))}
+              <ToolGroupRows branch={branch} group={group} key={group.key} rails={rails} t={t}>
                 {hasInlineSubagents ? renderSubagentList(childRails) : null}
-              </Box>
+              </ToolGroupRows>
             )
           })}
         </Box>

--- a/ui-tui/src/lib/toolVisibility.ts
+++ b/ui-tui/src/lib/toolVisibility.ts
@@ -1,0 +1,92 @@
+import { parseToolTrailResultLine, splitToolDuration } from './text.js'
+
+export type ToolEntryStatus = 'done' | 'error' | 'running'
+
+export interface ToolTrailSection {
+  label: string
+  text: string
+}
+
+export interface ParsedToolTrailEntry {
+  call: string
+  detail: string
+  duration: string
+  mark: '✓' | '✗'
+  sections: ToolTrailSection[]
+  status: Exclude<ToolEntryStatus, 'running'>
+}
+
+export interface DelegationControlState {
+  maxConcurrentChildren?: number | null
+  maxSpawnDepth?: number | null
+  paused: boolean
+}
+
+export interface DelegationControlSummary {
+  capsLabel: string
+  controlsHint: string
+  titleSuffix: string
+}
+
+const SECTION_HEADER = /^(Args|Result|Error):$/
+
+export const parseToolSections = (detail: string): ToolTrailSection[] => {
+  const lines = detail.split('\n')
+  const sections: ToolTrailSection[] = []
+  let current: null | ToolTrailSection = null
+
+  for (const line of lines) {
+    const header = line.match(SECTION_HEADER)?.[1]
+
+    if (header) {
+      current = { label: header, text: '' }
+      sections.push(current)
+
+      continue
+    }
+
+    if (current) {
+      current.text = current.text ? `${current.text}\n${line}` : line
+    }
+  }
+
+  return sections.map(section => ({ ...section, text: section.text.trim() })).filter(section => section.text)
+}
+
+export const parseToolTrailEntry = (line: string): ParsedToolTrailEntry | null => {
+  const parsed = parseToolTrailResultLine(line)
+
+  if (!parsed) {
+    return null
+  }
+
+  const { duration, label } = splitToolDuration(parsed.call)
+
+  const mark = parsed.mark as '✓' | '✗'
+
+  return {
+    call: label,
+    detail: parsed.detail,
+    duration,
+    mark,
+    sections: parseToolSections(parsed.detail),
+    status: mark === '✗' ? 'error' : 'done'
+  }
+}
+
+export const shouldToolEntryAutoOpen = (entry: null | ParsedToolTrailEntry): boolean => entry?.status === 'error'
+
+export const summarizeDelegationControls = (
+  delegation: DelegationControlState,
+  replayMode: boolean
+): DelegationControlSummary => {
+  const capsLabel = delegation.maxSpawnDepth
+    ? `caps d${delegation.maxSpawnDepth}/${delegation.maxConcurrentChildren ?? '?'}`
+    : ''
+
+  return {
+    capsLabel,
+    controlsHint: replayMode ? ' · controls locked' : ` · x kill · X subtree · p ${delegation.paused ? 'resume' : 'pause'}`,
+    titleSuffix: delegation.paused ? ' · ⏸ paused' : ''
+  }
+}


### PR DESCRIPTION
## Summary
- Add TUI tool-trail parsing helpers for compact/verbose completed tool rows.
- Render completed tool calls as clickable expandable/collapsible rows; successful verbose rows collapse by default, failed rows auto-open.
- Reuse delegation status summary logic for `/agents` caps, pause state, and replay control hints.

## Test Plan
- `cd ui-tui && npm ci`
- `cd ui-tui && npm run build --prefix packages/hermes-ink`
- `cd ui-tui && npm test -- --run src/__tests__/toolVisibility.test.ts src/__tests__/text.test.ts src/__tests__/details.test.ts`
- `cd ui-tui && npx eslint src/lib/toolVisibility.ts src/__tests__/toolVisibility.test.ts src/components/thinking.tsx src/components/agentsOverlay.tsx`
- `git diff --check`

## Known baseline issues observed
- `cd ui-tui && npm run type-check` still fails in existing `packages/hermes-ink/src/utils/execFileNoThrow.ts` overload/type errors, unrelated to this patch.
- Full `cd ui-tui && npm test` needs `packages/hermes-ink` built first; after building, one existing `src/__tests__/virtualHeights.test.ts` assertion fails. This patch does not touch virtual-height code/tests.
