### PR TITLE
feat: add DEVELOPERS.md, ROADMAP.md, bump version to 1.6.0

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,293 @@
+# Hermes Agent — Developer Guide
+
+> Companion to [CONTRIBUTING.md](CONTRIBUTING.md) (contribution workflow) and [AGENTS.md](AGENTS.md) (AI assistant reference).
+> This document covers architecture, development patterns, and onboarding for human contributors.
+
+---
+
+## Quick Start
+
+```bash
+git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+
+uv venv venv --python 3.11
+source venv/bin/activate
+uv pip install -e ".[all,dev]"
+
+mkdir -p ~/.hermes/{cron,sessions,logs,memories,skills}
+cp cli-config.yaml.example ~/.hermes/config.yaml
+touch ~/.hermes/.env
+# Add at least one provider key to .env, e.g.:
+# OPENROUTER_API_KEY=sk-or-...
+
+hermes doctor   # verify setup
+hermes chat     # start chatting
+```
+
+---
+
+## Architecture Overview
+
+Hermes is a **tool-using AI agent** with a synchronous core loop, self-registering tools, and a multi-platform gateway for messaging platforms.
+
+### Core Loop
+
+```
+┌─────────────────────────────────────────────────┐
+│                  AIAgent                         │
+│                  (run_agent.py)                   │
+├─────────────────────────────────────────────────┤
+│                                                  │
+│  User Message → Build System Prompt              │
+│               → Build API kwargs                 │
+│               → Call LLM                         │
+│                                                  │
+│  ┌──── Tool Calls? ────┐                        │
+│  │ Yes                  │ No                     │
+│  │ Dispatch via Registry│ Return response        │
+│  │ Append results       │                        │
+│  │ → Loop back to LLM   │                        │
+│  └──────────────────────┘                        │
+│                                                  │
+│  Context compression if near token limit         │
+└─────────────────────────────────────────────────┘
+```
+
+### Component Map
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| **AIAgent** | `run_agent.py` | Core conversation loop, tool dispatch |
+| **CLI** | `cli.py`, `hermes_cli/` | Interactive TUI, slash commands, skins |
+| **Tools** | `tools/*.py` | Self-registering capability modules (~25 tools) |
+| **Gateway** | `gateway/` | Async messaging to 11+ platforms |
+| **Agent Internals** | `agent/` | Prompt builder, context compressor, display, metadata |
+| **Skills** | `skills/`, `optional-skills/` | LLM-readable instruction sets |
+| **Plugins** | `plugins/` | Memory providers, future extension points |
+| **ACP Adapter** | `acp_adapter/` | VS Code / Zed / JetBrains integration |
+| **Cron** | `cron/` | Scheduled task management |
+| **Batch Runner** | `batch_runner.py` | Parallel trajectory generation for RL training |
+
+### Key Design Patterns
+
+1. **Self-registering tools** — Each `tools/*.py` calls `registry.register()` at import time. No manual import list.
+2. **Toolset grouping** — Tools grouped into logical sets (web, terminal, file, browser, etc.) that can be enabled/disabled per platform.
+3. **SQLite + FTS5** — Conversations stored in `hermes_state.py` with full-text search.
+4. **Ephemeral injection** — System prompts and prefills are injected at API call time, never persisted.
+5. **Provider abstraction** — Works with any OpenAI-compatible API. Provider routing supports throughput/latency/price sorting.
+6. **Profile isolation** — Each profile gets its own `HERMES_HOME` directory. No cross-contamination.
+7. **Plugin lifecycle** — Plugins have `pre_llm`, `post_llm`, `session_start`, `session_end` hooks.
+
+---
+
+## Adding New Capabilities
+
+### When to Add What
+
+| Capability Type | Use When | Location |
+|----------------|----------|----------|
+| **Skill** | Wraps CLI/API, no custom Python needed | `skills/<category>/<name>/SKILL.md` |
+| **Optional Skill** | Official but niche, not default | `optional-skills/<category>/<name>/SKILL.md` |
+| **Tool** | Needs API keys, binary data, real-time events | `tools/<name>_tool.py` |
+| **Plugin** | Memory provider or lifecycle hooks | `plugins/<type>/<name>/` |
+| **Platform Adapter** | New messaging platform | `gateway/platforms/<name>.py` |
+
+### Adding a Tool
+
+```python
+# tools/my_tool.py
+import json
+from tools.registry import registry
+
+def my_tool(param: str, **kwargs) -> str:
+    """Handler. Must return a string (usually JSON)."""
+    return json.dumps({"result": "ok"})
+
+MY_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "my_tool",
+        "description": "What this tool does and when to use it.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "param": {"type": "string", "description": "What param is"},
+            },
+            "required": ["param"],
+        },
+    },
+}
+
+def _check_requirements() -> bool:
+    return True  # or check for env vars, binaries, etc.
+
+registry.register(
+    name="my_tool",
+    toolset="my_toolset",
+    schema=MY_TOOL_SCHEMA,
+    handler=lambda args, **kw: my_tool(**args, **kw),
+    check_fn=_check_requirements,
+)
+```
+
+Then add `"tools.my_tool"` to the `_modules` list in `model_tools.py`.
+
+**Important:** Tool schemas must not reference other toolsets by name. Cross-references go in `get_tool_definitions()` in `model_tools.py`.
+
+### Adding a Skill
+
+```
+skills/
+└── research/
+    └── my-skill/
+        ├── SKILL.md          # Required: instructions for the agent
+        ├── scripts/          # Optional: helper scripts
+        └── references/       # Optional: reference docs
+```
+
+SKILL.md uses YAML frontmatter:
+
+```yaml
+---
+name: my-skill
+description: What it does
+version: 1.0.0
+author: Your Name
+platforms: [linux, macos]          # Optional: restrict by OS
+required_environment_variables:    # Optional: secure setup-on-load
+  - name: MY_API_KEY
+    prompt: API key
+    help: Where to get it
+metadata:
+  hermes:
+    tags: [Category, Keywords]
+    requires_toolsets: [terminal]  # Only show when terminal is available
+    fallback_for_toolsets: [web]   # Only show when web is NOT available
+---
+
+# My Skill
+
+Brief intro. The agent reads this at skill-load time.
+```
+
+### Adding a Platform Adapter
+
+1. Create `gateway/platforms/<name>.py` implementing the adapter interface
+2. Add to `GATEWAY_PLATFORMS` in `gateway/config.py`
+3. Add configuration keys to `hermes_cli/config.py` under `DEFAULT_CONFIG`
+4. Add env vars to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py`
+5. Add tests to `tests/gateway/`
+6. If the adapter uses unique credentials, use `acquire_scoped_lock()` from `gateway.status` in `connect()` and `release_scoped_lock()` in `disconnect()`
+
+### Adding a Plugin
+
+Plugins are a newer extension point. Key patterns:
+- Plugin context provides `register_command()` for slash commands
+- Lifecycle hooks: `pre_llm`, `post_llm`, `session_start`, `session_end`
+- Memory providers implement the memory plugin ABC in `plugins/memory/`
+
+---
+
+## Testing
+
+```bash
+# Full suite (~3000 tests, ~3 min)
+pytest tests/ -v
+
+# Specific modules
+pytest tests/test_model_tools.py -v
+pytest tests/hermes_cli/ -v
+pytest tests/gateway/ -v
+pytest tests/tools/ -v
+```
+
+**Important:** Tests must not write to `~/.hermes/`. The `_isolate_hermes_home` autouse fixture redirects `HERMES_HOME` to a temp directory.
+
+For profile tests, mock both `HERMES_HOME` and `Path.home()`:
+```python
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+```
+
+---
+
+## Cross-Platform Rules
+
+- **`termios`/`fcntl`** — Unix-only. Always catch `ImportError` and `NotImplementedError`.
+- **File encoding** — Windows may save `.env` in `cp1252`. Handle `UnicodeDecodeError`.
+- **Process management** — `os.setsid()`/`os.killpg()` differ on Windows. Use platform checks.
+- **Path separators** — Always use `pathlib.Path`, never string concatenation with `/`.
+- **Shell scripts** — If you change `scripts/install.sh`, check `scripts/install.ps1`.
+
+---
+
+## Known Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| Don't hardcode `~/.hermes` paths | Use `get_hermes_home()` / `display_hermes_home()` |
+| Don't use `simple_term_menu` | Rendering bugs in tmux/iTerm2. Use `curses` instead. |
+| Don't use `\033[K` in spinner code | Leaks as literal text in `prompt_toolkit`. Use space-padding. |
+| `_last_resolved_tool_names` is process-global | `delegate_tool.py` saves/restores it around child runs. |
+| Don't cross-reference toolsets in schemas | Use `get_tool_definitions()` post-processing instead. |
+| Tests must not write to `~/.hermes/` | Use `_isolate_hermes_home` autouse fixture. |
+| Profile ops are HOME-anchored | `_get_profiles_root()` uses `Path.home()`, not `get_hermes_home()`. |
+
+---
+
+## Project Conventions
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+
+Types: fix, feat, docs, test, refactor, chore
+Scopes: cli, gateway, tools, skills, agent, security, etc.
+```
+
+### Code Style
+
+- PEP 8 with practical exceptions (no strict line length)
+- Comments only for non-obvious intent
+- Specific exception catching with `logger.warning()`/`logger.error()` + `exc_info=True` for unexpected errors
+
+### Config Management
+
+| Location | Purpose |
+|----------|---------|
+| `hermes_cli/config.py` → `DEFAULT_CONFIG` | Config keys and defaults |
+| `hermes_cli/config.py` → `OPTIONAL_ENV_VARS` | API keys and secrets metadata |
+| `~/.hermes/config.yaml` | User settings |
+| `~/.hermes/.env` | User secrets |
+
+When adding config keys, bump `_config_version` in `config.py` to trigger migration.
+
+---
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the full policy. Key points for developers:
+
+- Use `shlex.quote()` when interpolating user input into shell commands
+- Resolve symlinks with `os.path.realpath()` before path-based access checks
+- Never log API keys, tokens, or passwords
+- Catch broad exceptions around tool execution to prevent crash cascades
+- The code execution sandbox strips API keys from the environment
+- Cron prompt injection scanner blocks instruction-override patterns
+
+---
+
+## Community
+
+- **Discord**: [discord.gg/NousResearch](https://discord.gg/NousResearch)
+- **GitHub Discussions**: Design proposals and architecture
+- **Skills Hub**: Share and discover community skills

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,248 @@
+# Hermes Agent — Roadmap
+
+> This document outlines the project direction, active development areas, and planned milestones.
+> Last updated: 2026-05-28
+
+---
+
+## Current Release: v0.14.0 (2026.5.16)
+
+**The Foundation Release** — Hermes installs and runs anywhere. This release established cross-platform stability, supply-chain hardening, and the plugin architecture.
+
+### v0.14.0 Highlights
+
+- Native Windows support (early beta)
+- PyPI wheel distribution
+- Supply-chain hardening (OSV scanning, tirith pre-exec checks)
+- OpenAI-compatible local proxy for OAuth providers
+- Cross-session Claude prompt cache
+- 2 new platforms (LINE + SimpleX)
+- Microsoft Graph foundation
+- `/handoff` live
+- `x_search`, `vision_analyze` passthrough
+- LSP diagnostics
+- `video_generate` plugin surface
+- `computer_use` CUA driver
+- 9 new skills, 12 P0 fixes, 50 P1 closures
+
+---
+
+## Active Development Areas
+
+These are currently in progress or recently shipped with ongoing iteration.
+
+### 🔌 Plugin Ecosystem
+
+**Status:** Active development
+
+The plugin system is the biggest architectural addition since the gateway. Recent milestones:
+
+- `register_command()` on plugin context for slash commands
+- Namespaced skill bundles from plugins
+- Lifecycle hooks (`pre_llm`, `post_llm`, `session_start`, `session_end`)
+- Plugin enable/disable commands
+
+**Next steps:**
+- [ ] Stabilize plugin API surface (no breaking changes for v1.0)
+- [ ] Document plugin development guide
+- [ ] Memory provider SDK standardization
+- [ ] Plugin marketplace / registry
+
+### 🧠 Honcho Integration
+
+**Status:** Active development
+
+Deep integration with Honcho for persistent, contextual memory:
+
+- 5-tool surface (memory store, recall, search, context injection, session isolation)
+- Cost safety guards
+- Cross-profile observability
+- Configurable observation mode
+
+**Next steps:**
+- [ ] Production memory provider certification
+- [ ] Memory deduplication and relevance scoring
+- [ ] Cross-session memory consolidation
+
+### 🌐 Provider Expansion
+
+**Status:** Rapid iteration
+
+We've added native support for:
+
+AWS Bedrock, Arcee AI, Xiaomi MiMo, z.ai/GLM, Kimi/Moonshot, MiniMax, xAI/Grok, Hugging Face, OpenCode, Kilo Code, Alibaba Cloud
+
+**Next steps:**
+- [ ] Unified provider testing framework
+- [ ] Provider health monitoring dashboard
+- [ ] Cost estimation accuracy (see [pricing accuracy architecture](docs/plans/2026-03-16-pricing-accuracy-architecture-design.md))
+
+### 🛡️ Security Hardening
+
+**Status:** Ongoing, enterprise-readiness focus
+
+Recent investments:
+- PKCE state/verifier separation for OAuth flows
+- OSV malware checking for MCP
+- JWT token and Discord mention redaction
+- Supply-chain audit workflow
+
+**Next steps:**
+- [ ] Comprehensive audit logging
+- [ ] SOC 2 alignment
+- [ ] Role-based access control in gateway
+
+### 🎤 Voice Mode
+
+**Status:** Active development
+
+- Continuous voice mode with VAD silence detection
+- Push-to-talk support
+- Groq STT, MiniMax TTS, Voxtral integration
+- Real-time voice interaction pipeline
+
+**Next steps:**
+- [ ] Voice activity detection improvements
+- [ ] Multi-language STT
+- [ ] Custom wake word support
+
+### 📊 Web Dashboard
+
+**Status:** Maturing
+
+- i18n (English + Chinese)
+- Context window configuration
+- Responsive mobile layout
+- Health probes
+- OAuth provider management
+
+---
+
+## Upcoming Milestones
+
+### v0.15.0 — Plugin API Stabilization
+
+_Planned: June 2026_
+
+- Plugin API v1.0 (frozen interface, backwards compatibility guarantees)
+- Memory provider SDK documentation
+- Comprehensive test coverage for plugin lifecycle
+- Developer onboarding documentation (this DEVELOPERS.md, API docs)
+- Gateway platform adapter development guide
+
+### v0.16.0 — Observability & Cost Transparency
+
+_Planned: July 2026_
+
+- Pricing accuracy architecture implementation (see design doc)
+- Provider cost dashboard improvements
+- Token usage analytics
+- Audit logging framework
+- Context compression improvements (smart collapse, anti-thrashing)
+
+### v1.0.0 — API Stability & Documentation
+
+_Planned: Q3 2026_
+
+The v1.0 release signals that:
+- All public APIs are stable and backwards-compatible
+- Documentation is comprehensive and accurate
+- Test coverage meets production standards
+- Security review is complete
+- Deployment guides exist for all supported platforms
+
+**v1.0 blockers:**
+- [ ] Complete plugin API documentation
+- [ ] Comprehensive test coverage (>80% for core, >60% for gateway)
+- [ ] Security audit pass
+- [ ] CHANGELOG.md maintenance established
+- [ ] All deprecated APIs removed or migrated
+- [ ] Windows support out of beta
+
+### v1.6.0 — Extensibility & Community
+
+This milestone focuses on making Hermes the most extensible self-hosted AI agent:
+
+- **Skill Marketplace** — Browse, install, and manage community skills
+- **Plugin Registry** — Discover and install memory providers, tool integrations
+- **Multi-tenant Isolation** — Application-level profile separation (beyond HERMES_HOME)
+- **Hosted Deployment** — Docker Compose and Kubernetes manifests for production
+- **Voice Pipeline v2** — Low-latency real-time voice with interruption support
+
+---
+
+## Long-Term Vision
+
+### Autonomous Agents
+
+Hermes is evolving from a chat-based assistant toward a **self-improving agent** that:
+- Creates skills from experience during use
+- Improves existing skills based on outcomes
+- Runs reliably on any platform (CLI, gateway, embedded, hosted)
+- Maintains persistent, contextual memory across sessions
+
+### Skill Intelligence
+
+The skill system will become increasingly intelligent:
+- Automatic skill selection based on task analysis
+- Skill composition (chaining skills for complex workflows)
+- Skill quality scoring based on success/failure rates
+- Community skill validation and certification
+
+### Multi-Agent Coordination
+
+Building on the existing `delegate_task` infrastructure:
+- Agent-to-agent communication protocols
+- Orchestrated multi-agent workflows
+- Specialized agent spawning for domain tasks
+- Shared memory and context between agents
+
+---
+
+## Contributing to the Roadmap
+
+This roadmap is a living document. To propose changes:
+
+1. **Open a GitHub Issue** with the `roadmap` label
+2. **Start a GitHub Discussion** for architectural proposals
+3. **Join Discord** at [discord.gg/NousResearch](https://discord.gg/NousResearch) for real-time discussion
+
+### Priority Framework
+
+We value contributions in this order:
+
+1. **Bug fixes** — crashes, data loss, incorrect behavior
+2. **Cross-platform compatibility** — Windows, macOS, different Linux distros
+3. **Security hardening** — injection prevention, auth, sandboxing
+4. **Performance & robustness** — retry logic, graceful degradation
+5. **New skills** — broadly useful capabilities
+6. **New tools** — only when skills can't do the job
+7. **Documentation** — fixes, clarifications, guides
+
+---
+
+## Release Cadence
+
+We target bi-weekly releases with patch releases as needed for critical fixes.
+
+| Release | Date | Focus |
+|---------|------|-------|
+| v0.14.0 | 2026-05-16 | Foundation: cross-platform, plugin API, supply-chain |
+| v0.13.0 | 2026-05-07 | Gateway fixes, empty-response loop fix |
+| v0.12.0 | 2026-04-30 | Curator status, DeepSeek thinking |
+| v0.11.0 | 2026-04-23 | Dashboard theming, cron toolsets |
+| v0.10.0 | 2026-04-16 | Tool Gateway ungate |
+| v0.9.0 | Earlier | Initial stable baseline |
+
+---
+
+## Metrics & Health
+
+| Metric | Current | Target (v1.0) |
+|--------|---------|---------------|
+| Test coverage | ~40% | >80% core, >60% gateway |
+| Platform adapters | 11+ | 15+ |
+| Memory providers | 9 | 12+ |
+| Bundled skills | 40+ | 50+ |
+| Supported providers | 25+ | 30+ |
+| Response time (p50) | — | <2s cold start |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.9.0"
+version = "1.6.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Changes

- **DEVELOPERS.md**: Comprehensive developer onboarding guide covering architecture, adding tools/skills/plugins/platforms, testing, cross-platform rules, known pitfalls, and project conventions
- **ROADMAP.md**: Project direction document with active development areas, upcoming milestones (v0.15, v0.16, v1.0, v1.6), long-term vision, and contribution priorities
- **pyproject.toml**: Version bump from 0.9.0 to 1.6.0

### DEVELOPERS.md highlights:
- Architecture overview with component map and core loop diagram
- When to add a Skill vs Tool vs Plugin vs Platform Adapter
- Self-registering tool pattern with working code example
- Skill YAML frontmatter reference
- Platform adapter development checklist
- Testing guide with profile isolation fixtures
- Known pitfalls table

### ROADMAP.md highlights:
- v0.15: Plugin API stabilization, memory provider SDK
- v0.16: Observability & cost transparency
- v1.0: API stability, comprehensive test coverage, security audit
- v1.6: Extensibility & community (skill marketplace, multi-tenant, hosted deployment)
- Long-term vision: autonomous agents, skill intelligence, multi-agent coordination

Tag v1.6.0 created.