### PR TITLE
feat(slack): SLACK_REACTIONS_SKIP_USERS to suppress reactions per poster

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1323,6 +1323,25 @@ class SlackAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("SLACK_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
+    def _reactions_skip_user_ids(self) -> set:
+        """Slack user IDs whose messages should not receive bot reactions.
+
+        Configured via the comma-separated ``SLACK_REACTIONS_SKIP_USERS`` env
+        var or the ``reactions_skip_users`` adapter config key. Intended for
+        suppressing the :eyes:/:white_check_mark:/:x: reaction cycle on
+        messages posted by forwarder / escalation bots whose own triage
+        workflow relies on those emojis (e.g. the "Just a Chill Guy"
+        Need-Developers-Help bot used by Kaching CS).
+        """
+        raw = self.config.extra.get("reactions_skip_users", "")
+        if not raw:
+            raw = os.getenv("SLACK_REACTIONS_SKIP_USERS", "")
+        if not raw:
+            return set()
+        if isinstance(raw, (list, tuple, set)):
+            return {str(x).strip() for x in raw if str(x).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():
@@ -2231,7 +2250,17 @@ class SlackAdapter(BasePlatformAdapter):
         # Only react when bot is directly addressed (DM or @mention).
         # In listen-all channels (require_mention=false), reacting to every
         # casual message would be noisy.
-        _should_react = (is_dm or is_mentioned) and self._reactions_enabled()
+        # Also skip reactions when the message is posted by a Slack user/bot
+        # listed in ``SLACK_REACTIONS_SKIP_USERS`` — used to keep our reactions
+        # off forwarder/escalation bot messages whose own triage workflow owns
+        # the ✅/❌ markers.
+        _skip_user_ids = self._reactions_skip_user_ids()
+        _poster_id = event.get("user") or ""
+        _should_react = (
+            (is_dm or is_mentioned)
+            and self._reactions_enabled()
+            and _poster_id not in _skip_user_ids
+        )
         if _should_react:
             self._reacting_message_ids.add(ts)
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1967,6 +1967,41 @@ class TestReactions:
         adapter._app.client.reactions_remove.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_reactions_skipped_for_listed_user(self, adapter, monkeypatch):
+        """SLACK_REACTIONS_SKIP_USERS should suppress reactions on listed posters."""
+        monkeypatch.setenv("SLACK_REACTIONS_SKIP_USERS", "U_FORWARDER,U_OTHER")
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+        adapter._app.client.users_info = AsyncMock(return_value={
+            "user": {"profile": {"display_name": "Forwarder Bot"}}
+        })
+
+        event = {
+            "text": "escalation",
+            "user": "U_FORWARDER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000005",
+        }
+        await adapter._handle_slack_message(event)
+
+        # Should NOT register for reactions when poster is in the skip list
+        assert "1234567890.000005" not in adapter._reacting_message_ids
+        adapter._app.client.reactions_add.assert_not_called()
+
+        # Other users in the same DM still get reactions
+        event2 = {
+            "text": "hello",
+            "user": "U_HUMAN",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000006",
+        }
+        await adapter._handle_slack_message(event2)
+        assert "1234567890.000006" in adapter._reacting_message_ids
+
+    @pytest.mark.asyncio
     async def test_reactions_enabled_by_default(self, adapter):
         """SLACK_REACTIONS defaults to true (matches existing behavior)."""
         assert adapter._reactions_enabled() is True


### PR DESCRIPTION
## Problem

The Slack adapter brackets every addressed message with a reaction lifecycle: :eyes: on processing start, :white_check_mark: on success, :x: on failure (`gateway/platforms/slack.py:1326-1352`).

Some Slack apps run their own triage workflow on those same emojis. When Hermes is mentioned in a message posted by such an app, our reactions interfere with the app's routing.

Concrete case: Kaching CS uses a forwarder bot ('Just a Chill Guy', `U09N71810JE`) which posts 'Need Developers Help' escalations and uses :white_check_mark: / :x: as triage markers. Hermes auto-:white_check_mark: on investigation completion was tripping the workflow.

`SLACK_REACTIONS=false` already exists but disables reactions globally — too blunt when reactions are useful on human-authored pings.

## Fix

Add a per-poster skip list:

- Env: `SLACK_REACTIONS_SKIP_USERS=U09N71810JE,U_OTHER`
- YAML: `platforms.slack.reactions_skip_users: [U09N71810JE]`

New helper `_reactions_skip_user_ids()` parses the comma-separated list (or YAML list/set). In `_handle_slack_message`, the `_should_react` gate now also checks that `event['user']` is not in the skip set. When skipped, the message ts is never added to `_reacting_message_ids`, so both `on_processing_start` and `on_processing_complete` no-op for that message (existing membership check at lines 1331/1342).

Default behavior unchanged — skip set is empty when neither env var nor config key is set.

## Test plan

- New test `test_reactions_skipped_for_listed_user` — verifies listed user gets no reactions, unlisted user in same DM still gets them
- All 9 `TestReactions` tests pass:

```
$ python -m pytest tests/gateway/test_slack.py::TestReactions -x -q
......... 9 passed in 0.27s
```