### PR TITLE
fix(gateway, matrix): macOS gateway-process detection + dead-invite cleanup

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2072,6 +2072,18 @@ class MatrixAdapter(BasePlatformAdapter):
             return True
         except Exception as exc:
             logger.warning("Matrix: error joining %s: %s", room_id, exc)
+            # Abandoned rooms (no current members) surface as "no servers
+            # in the room have been provided" or "room not found". The
+            # pending invite keeps retrying every startup unless we
+            # explicitly leave it. Match is narrow enough that transient
+            # failures still leave the invite untouched for the next try.
+            msg = str(exc).lower()
+            if ("no servers" in msg) or ("room not found" in msg):
+                try:
+                    await self._client.leave_room(RoomID(room_id))
+                    logger.info("Matrix: declined dead invite to %s", room_id)
+                except Exception:
+                    pass
             return False
 
     async def _join_pending_invites(self, sync_data: Dict[str, Any]) -> None:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -164,6 +164,19 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     return None
 
 
+# CLI wrappers that match the broad "hermes gateway" prefix but are
+# short-lived helper commands, not the long-lived daemon. A hung
+# wrapper (e.g. a `hermes gateway restart` parent that never exits)
+# would otherwise satisfy the gateway-identity check and squat on
+# gateway.pid/gateway.lock, blocking every subsequent `gateway run`.
+_GATEWAY_WRAPPER_SUBCOMMANDS = (
+    "gateway restart",
+    "gateway stop",
+    "gateway status",
+    "gateway kill",
+)
+
+
 def _looks_like_gateway_process(pid: int) -> bool:
     """Return True when the live PID still looks like the Hermes gateway."""
     cmdline = _read_process_cmdline(pid)
@@ -177,7 +190,9 @@ def _looks_like_gateway_process(pid: int) -> bool:
         "hermes-gateway",
         "gateway/run.py",
     )
-    return any(pattern in cmdline for pattern in patterns)
+    if not any(pattern in cmdline for pattern in patterns):
+        return False
+    return not any(sub in cmdline for sub in _GATEWAY_WRAPPER_SUBCOMMANDS)
 
 
 def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
@@ -197,7 +212,9 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
         "hermes gateway",
         "gateway/run.py",
     )
-    return any(pattern in cmdline for pattern in patterns)
+    if not any(pattern in cmdline for pattern in patterns):
+        return False
+    return not any(sub in cmdline for sub in _GATEWAY_WRAPPER_SUBCOMMANDS)
 
 
 def _build_pid_record() -> dict:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -109,12 +109,25 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
 
 
 def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
+    """Return the kernel start time for a process when available.
+
+    On Linux, reads /proc/<pid>/stat field 22 (clock ticks since boot).
+    On macOS and other platforms without /proc, falls back to psutil,
+    which returns a Unix timestamp. The exact unit does not matter for
+    the same-PID equality check the caller performs — only that the
+    value is stable for a given (host, PID) pair, which both sources
+    provide.
+    """
     stat_path = Path(f"/proc/{pid}/stat")
     try:
-        # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text(encoding="utf-8").split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+
+    try:
+        import psutil  # type: ignore
+        return int(psutil.Process(pid).create_time())
+    except Exception:
         return None
 
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2670,3 +2670,107 @@ class TestCreateMatrixSession:
                     assert session.connector is fake_connector
                 finally:
                     await session.close()
+
+class TestMatrixDeadInviteHandling:
+    """Tests for _join_room_by_id auto-leaving dead/abandoned rooms.
+
+    Regression: when a room had no current members, ``join_room`` raised
+    ``MUnknown: Can't join remote room because no servers that are in
+    the room have been provided``. The pending invite stayed in the
+    bot's view of the world, so every gateway restart re-attempted the
+    join and re-emitted the warning indefinitely. There was no path
+    that ever cleared the invite.
+    """
+
+    def _make_adapter(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@user:example.org")
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            from gateway.platforms.matrix import MatrixAdapter
+            return MatrixAdapter(PlatformConfig(
+                enabled=True, token="tok",
+                extra={"homeserver": "https://matrix.example.org"},
+            ))
+
+    @pytest.mark.asyncio
+    async def test_no_servers_error_triggers_leave(self, monkeypatch):
+        adapter = self._make_adapter(monkeypatch)
+        adapter._refresh_dm_cache = AsyncMock()
+
+        join_err = Exception(
+            "Can't join remote room because no servers that are in the "
+            "room have been provided."
+        )
+        adapter._client = types.SimpleNamespace(
+            join_room=AsyncMock(side_effect=join_err),
+            leave_room=AsyncMock(),
+        )
+
+        result = await adapter._join_room_by_id("!dead:example.org")
+
+        assert result is False
+        adapter._client.leave_room.assert_awaited_once()
+        # leave_room receives a RoomID-wrapped value; verify the underlying str.
+        leave_arg = adapter._client.leave_room.await_args.args[0]
+        assert str(leave_arg) == "!dead:example.org"
+
+    @pytest.mark.asyncio
+    async def test_room_not_found_error_triggers_leave(self, monkeypatch):
+        adapter = self._make_adapter(monkeypatch)
+        adapter._refresh_dm_cache = AsyncMock()
+
+        join_err = Exception("M_NOT_FOUND: Room not found")
+        adapter._client = types.SimpleNamespace(
+            join_room=AsyncMock(side_effect=join_err),
+            leave_room=AsyncMock(),
+        )
+
+        await adapter._join_room_by_id("!gone:example.org")
+        adapter._client.leave_room.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_transient_error_does_not_trigger_leave(self, monkeypatch):
+        """A network blip or 5xx must NOT decline the invite — the bot
+        should retry on the next sync cycle."""
+        adapter = self._make_adapter(monkeypatch)
+        adapter._refresh_dm_cache = AsyncMock()
+
+        join_err = Exception("Connection reset by peer")
+        adapter._client = types.SimpleNamespace(
+            join_room=AsyncMock(side_effect=join_err),
+            leave_room=AsyncMock(),
+        )
+
+        result = await adapter._join_room_by_id("!transient:example.org")
+        assert result is False
+        adapter._client.leave_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_successful_join_does_not_attempt_leave(self, monkeypatch):
+        adapter = self._make_adapter(monkeypatch)
+        adapter._refresh_dm_cache = AsyncMock()
+
+        adapter._client = types.SimpleNamespace(
+            join_room=AsyncMock(return_value=None),
+            leave_room=AsyncMock(),
+        )
+
+        result = await adapter._join_room_by_id("!alive:example.org")
+        assert result is True
+        assert "!alive:example.org" in adapter._joined_rooms
+        adapter._client.leave_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_leave_room_failure_is_swallowed(self, monkeypatch):
+        """If leave_room itself fails (e.g. server returns 500), the
+        helper must still return False cleanly rather than re-raise."""
+        adapter = self._make_adapter(monkeypatch)
+        adapter._refresh_dm_cache = AsyncMock()
+
+        adapter._client = types.SimpleNamespace(
+            join_room=AsyncMock(side_effect=Exception("no servers in the room")),
+            leave_room=AsyncMock(side_effect=Exception("500 internal")),
+        )
+
+        result = await adapter._join_room_by_id("!brokenleave:example.org")
+        assert result is False
+

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -941,3 +941,84 @@ class TestReadProcessCmdlinePsFallback:
         )
         result = status._read_process_cmdline(12345)
         assert "hermes_cli/main.py" in result
+
+class TestGatewayWrapperSubcommandRejection:
+    """Wrapper CLI commands (gateway restart/stop/status/kill) must not
+    be mistaken for the long-lived daemon. A hung wrapper would otherwise
+    hold gateway.pid + gateway.lock and block every subsequent
+    ``gateway run`` with "Another gateway instance is already running"
+    until the wrapper is killed by hand.
+    """
+
+    def test_record_with_restart_subcommand_is_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["/usr/local/bin/hermes", "gateway", "restart"],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
+    def test_record_with_stop_subcommand_is_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["/usr/local/bin/hermes", "gateway", "stop"],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert status.get_running_pid() is None
+
+    def test_live_cmdline_with_restart_subcommand_is_rejected(self, monkeypatch):
+        """Live-process path: even if /proc/<pid>/cmdline reads back the
+        wrapper command, the helper must decline to claim it as the
+        daemon. Mirrors the production failure where ``ps -p`` showed
+        ``hermes gateway restart`` for the hung parent.
+        """
+        monkeypatch.setattr(
+            status, "_read_process_cmdline",
+            lambda pid: "/usr/local/bin/hermes gateway restart",
+        )
+        assert status._looks_like_gateway_process(os.getpid()) is False
+
+    def test_live_cmdline_with_run_subcommand_is_accepted(self, monkeypatch):
+        monkeypatch.setattr(
+            status, "_read_process_cmdline",
+            lambda pid: "/path/to/venv/bin/python /path/hermes_cli/main.py gateway run",
+        )
+        assert status._looks_like_gateway_process(os.getpid()) is True
+
+    def test_record_with_run_subcommand_is_accepted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["/path/hermes_cli/main.py", "gateway", "run"],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert status.acquire_gateway_runtime_lock() is True
+        try:
+            assert status.get_running_pid() == os.getpid()
+        finally:
+            status.release_gateway_runtime_lock()
+

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1022,3 +1022,46 @@ class TestGatewayWrapperSubcommandRejection:
         finally:
             status.release_gateway_runtime_lock()
 
+class TestGetProcessStartTimeFallback:
+    """Tests for _get_process_start_time falling back to psutil on non-Linux."""
+
+    def test_psutil_fallback_when_proc_unavailable(self, monkeypatch):
+        """macOS / Windows have no /proc — must fall back to psutil so the
+        same-PID equality check in get_running_pid stays meaningful."""
+        monkeypatch.setattr(
+            status.Path, "read_text",
+            lambda self, **kwargs: (_ for _ in ()).throw(FileNotFoundError),
+        )
+
+        fake_psutil = SimpleNamespace(
+            Process=lambda pid: SimpleNamespace(create_time=lambda: 1779982521.123),
+        )
+        monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
+
+        result = status._get_process_start_time(os.getpid())
+        assert result == 1779982521
+        assert isinstance(result, int)
+
+    def test_returns_none_when_both_proc_and_psutil_fail(self, monkeypatch):
+        monkeypatch.setattr(
+            status.Path, "read_text",
+            lambda self, **kwargs: (_ for _ in ()).throw(FileNotFoundError),
+        )
+
+        def fake_proc_init(pid):
+            raise RuntimeError("no such process")
+
+        fake_psutil = SimpleNamespace(Process=fake_proc_init)
+        monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
+
+        assert status._get_process_start_time(99999) is None
+
+    def test_proc_is_used_when_available(self, monkeypatch):
+        """Linux behavior unchanged: /proc/<pid>/stat is the first source."""
+        monkeypatch.setattr(
+            status.Path, "read_text",
+            # Synthetic /proc/<pid>/stat — field 22 = 4242 clock ticks.
+            lambda self, **kwargs: "1 (proc) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 4242 rest",
+        )
+        assert status._get_process_start_time(1234) == 4242
+


### PR DESCRIPTION
## Summary

Three closely-related robustness fixes uncovered while debugging a multi-hour gateway crash-loop on macOS Tahoe:

1. **`gateway/status.py`** — add a wrapper-subcommand blacklist (`gateway restart` / `stop` / `status` / `kill`) applied after the broad `"hermes gateway"` pattern match. A hung `hermes gateway restart` wrapper otherwise matches as a live daemon, holds `gateway.pid` + `gateway.lock`, and every subsequent `gateway run` fails with `"Another gateway instance is already running"`. Health-check `pgrep` for the daemon correctly sees nothing — a standoff with no auto-recovery (observed: **27 hours** in our case). Existing daemon detection (`gateway run`, bare `"gateway"` from script-style invocations, `gateway/run.py`) is preserved unchanged, so the existing test corpus continues to pass.

2. **`gateway/status.py`** — `_get_process_start_time` only reads `/proc/<pid>/stat`, so every macOS/Windows gateway records `start_time: null` in `gateway.pid`. The same-start-time equality guard in `get_running_pid` is therefore inert on non-Linux hosts — a recycled PID can be mistaken for the original daemon. Add a `psutil` fallback (already a dependency, used by `_pid_exists` and `_read_process_cmdline`). Linux behavior unchanged.

3. **`gateway/platforms/matrix.py`** — `_join_room_by_id` retries a dead/abandoned room (no remaining members) on every startup, since there is no path that clears the pending invite. Detect the specific `"no servers in the room"` / `"room not found"` failure mode by error-message match and call `leave_room` to decline the invite. Match is narrow enough that transient/network errors still leave the invite untouched.

## How this was discovered

- Gateway crash-loop on macOS Tahoe — `pgrep` reported no daemon while `gateway.pid` referenced a 27-hour-old `hermes gateway restart` parent that had hung.
- Killing the parent + clearing the lock fixed the immediate symptom, but the same standoff would have recurred — wrappers will keep getting written into `gateway.pid` and matching the broad `"hermes gateway"` prefix.
- `start_time: null` in the pid file pointed to the missing macOS fallback.
- The recurring `Can't join remote room` warning in `errors.log` was an abandoned room with 0 joined members. Synapse refuses joins to rooms with no current members.

## Test coverage

**13 new tests, 0 regressions in the 200 existing `test_status.py` + `test_matrix.py` tests** (full pytest output: 213 passed, 1 warning).

`tests/gateway/test_status.py::TestGatewayWrapperSubcommandRejection` (5 tests):
- `test_record_with_restart_subcommand_is_rejected` — record-path: argv ending in `gateway restart` → `get_running_pid()` returns None and cleans up.
- `test_record_with_stop_subcommand_is_rejected` — same for `stop`.
- `test_live_cmdline_with_restart_subcommand_is_rejected` — live-process path: `/proc`/`ps` cmdline showing the wrapper command is rejected.
- `test_live_cmdline_with_run_subcommand_is_accepted` — regression guard: real daemon still detected.
- `test_record_with_run_subcommand_is_accepted` — record-path: argv with `run` subcommand still detected when cmdline unavailable.

`tests/gateway/test_status.py::TestGetProcessStartTimeFallback` (3 tests):
- `test_psutil_fallback_when_proc_unavailable` — mocks `/proc` read as `FileNotFoundError`, verifies psutil path returns the expected int Unix timestamp.
- `test_returns_none_when_both_proc_and_psutil_fail` — both sources fail → `None`.
- `test_proc_is_used_when_available` — Linux unchanged: `/proc/<pid>/stat` field 22 still wins when readable.

`tests/gateway/test_matrix.py::TestMatrixDeadInviteHandling` (5 tests):
- `test_no_servers_error_triggers_leave` — `"no servers in the room"` exception triggers `leave_room` exactly once.
- `test_room_not_found_error_triggers_leave` — `"Room not found"` likewise.
- `test_transient_error_does_not_trigger_leave` — `"Connection reset by peer"` must NOT decline the invite.
- `test_successful_join_does_not_attempt_leave` — happy path stays happy.
- `test_leave_room_failure_is_swallowed` — if `leave_room` itself raises, the helper still returns `False` cleanly.

## Verified locally
- Full `tests/gateway/test_status.py` (58 tests, including 8 new) — pass.
- Full `tests/gateway/test_matrix.py` (155 tests, including 5 new) — pass.
- End-to-end on macOS Tahoe with the live runtime: `start_time` populates with a Unix timestamp; the dead invite triggered `Matrix: declined dead invite to ...` and `pending invites: []` on next sync; the gateway recovers cleanly from a synthesised wrapper-hold of `gateway.pid`.