### PR TITLE
fix(cron,gateway): activate fallback when api-key provider has no key (#33936)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1543,6 +1543,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         from hermes_cli.runtime_provider import (
             resolve_runtime_provider,
             format_runtime_provider_error,
+            ensure_runtime_credentials_or_raise,
         )
         from hermes_cli.auth import AuthError
         try:
@@ -1557,6 +1558,18 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
+            # api-key providers (DeepSeek, Z.AI/GLM, Kimi, Mistral, …)
+            # silently return an empty ``api_key`` when their env var is
+            # unset rather than raising. Without this check the cron
+            # scheduler skipped the fallback chain entirely and the job
+            # eventually crashed at the API call with a generic 401,
+            # leaving operators chasing the wrong tail (#33936). Promote
+            # the empty-key case to AuthError so the existing
+            # ``except AuthError`` branch below can try each configured
+            # fallback provider.
+            ensure_runtime_credentials_or_raise(
+                runtime, requested_provider=job.get("provider"),
+            )
         except AuthError as auth_exc:
             # Primary provider auth failed — try fallback chain before giving up.
             logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1077,11 +1077,18 @@ def _resolve_runtime_agent_kwargs() -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
+        ensure_runtime_credentials_or_raise,
     )
     from hermes_cli.auth import AuthError, is_rate_limited_auth_error
 
     try:
         runtime = resolve_runtime_provider()
+        # api-key providers (DeepSeek, Z.AI, Kimi, Mistral, …) silently
+        # return ``api_key=""`` when their env var is unset. Without
+        # this promotion the gateway constructs an agent with empty
+        # credentials and the request eventually fails with a 401
+        # instead of fal­ling through to ``fallback_providers`` (#33936).
+        ensure_runtime_credentials_or_raise(runtime)
     except AuthError as auth_exc:
         # Distinguish a transient rate-limit/quota cap (credentials are fine,
         # re-auth cannot help) from a genuine auth failure (expired/revoked

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1666,3 +1666,150 @@ def format_runtime_provider_error(error: Exception) -> str:
     if isinstance(error, AuthError):
         return format_auth_error(error)
     return str(error)
+
+
+# ---------------------------------------------------------------------------
+# Post-resolution credential sanity check (#33936)
+# ---------------------------------------------------------------------------
+# ``resolve_runtime_provider()`` for an api-key provider (PROVIDER_REGISTRY
+# entry with ``auth_type='api_key'`` — DeepSeek, Z.AI/GLM, Kimi, Mistral,
+# Groq, NVIDIA NIM, ...) silently returns ``{"api_key": "", ...}`` when the
+# expected env var is unset or empty. Long-lived callers (cron scheduler,
+# gateway request handler, CLI one-shot) wrap the call in ``try/except
+# AuthError`` to trigger their ``fallback_providers`` chain — but the
+# missing-key case never raised, so the agent was constructed with an
+# empty api_key and the API call eventually failed with a confusing 401
+# instead of falling back. #33936 reported this as "DEEPSEEK_API_KEY blocked
+# by env blocklist" but the real root cause was the silent fall-through.
+# The helper below classifies a resolved runtime and lets the caller raise
+# ``AuthError`` so the existing fallback wiring kicks in.
+# ---------------------------------------------------------------------------
+
+
+# Placeholder api_key values that pass our string-truthiness check but
+# represent "no real credential" — used by local LLM providers that
+# expose an OpenAI-compatible endpoint without auth. Keep in sync with
+# ``hermes_cli.auth.LMSTUDIO_NOAUTH_PLACEHOLDER`` and the ``no-key-required``
+# sentinel produced by ``_resolve_named_custom_runtime`` for localhost-
+# only custom providers.
+_RUNTIME_NOAUTH_API_KEY_PLACEHOLDERS = frozenset({
+    "no-key-required",
+    "dummy-lm-api-key",
+    "aws-sdk",
+    "copilot-acp",
+})
+
+
+def _runtime_is_registry_api_key_provider(runtime: dict[str, Any]) -> bool:
+    """True when ``runtime['provider']`` is a registry entry whose
+    ``auth_type`` is ``api_key``.
+
+    Used to scope the empty-key check to providers that genuinely
+    require an api_key in ``os.environ`` / ``~/.hermes/.env`` —
+    DeepSeek, Z.AI/GLM, Kimi, Mistral, Groq, NVIDIA NIM, etc.
+    OAuth providers (Nous, Codex, xAI OAuth, Qwen, Gemini OAuth),
+    OpenRouter, AWS Bedrock, Copilot ACP and bare ``custom`` /
+    localhost runtimes all carry their auth in other fields and are
+    intentionally allowed to flow through with empty/placeholder
+    api_key values.
+    """
+    provider = str(runtime.get("provider") or "").strip().lower()
+    if not provider:
+        return False
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    return bool(pconfig and pconfig.auth_type == "api_key")
+
+
+def runtime_credentials_are_usable(runtime: dict[str, Any] | None) -> bool:
+    """Return True when ``runtime`` carries credentials we can actually use.
+
+    The check is intentionally scoped to api-key providers from
+    :data:`PROVIDER_REGISTRY` (DeepSeek, Z.AI/GLM, Kimi, Mistral, …).
+    Those are the providers that 1) silently returned ``api_key=""``
+    in #33936 when their env var was unset, and 2) cannot possibly
+    succeed without a real bearer token at the API call.
+
+    A runtime is *usable* when:
+
+    * it's a dict, AND either:
+        - the provider is NOT a registry api-key provider (OAuth,
+          OpenRouter, Bedrock, custom, … carry auth in other fields,
+          we trust the per-provider resolver); OR
+        - its ``api_key`` is a callable (dynamic-token resolvers
+          refresh at API call time); OR
+        - its ``api_key`` is a known no-auth placeholder
+          (``no-key-required`` / ``dummy-lm-api-key`` / …); OR
+        - its ``api_key`` is a non-empty string that passes
+          :func:`has_usable_secret`.
+
+    Returns False for the silent-failure case described in #33936: an
+    api-key provider (DeepSeek, Z.AI, Kimi, …) resolved with an empty
+    ``api_key`` because the env var wasn't set. Callers should raise
+    :class:`AuthError` in that case so their fallback chain activates.
+    """
+    if not isinstance(runtime, dict):
+        return False
+
+    api_key = runtime.get("api_key")
+    if callable(api_key):
+        return True
+
+    # Off-registry / OAuth / Bedrock / OpenRouter / custom — trust the
+    # per-provider resolver's idea of "usable". The check below would
+    # otherwise reject test mocks with ``api_key='***'`` and break a
+    # large swath of tests that don't care about credentials.
+    if not _runtime_is_registry_api_key_provider(runtime):
+        return True
+
+    if isinstance(api_key, str):
+        cleaned = api_key.strip()
+        if not cleaned:
+            return False
+        # Known placeholders for local/no-auth providers are fine —
+        # the API call won't try to send them as bearer tokens.
+        if cleaned.lower() in _RUNTIME_NOAUTH_API_KEY_PLACEHOLDERS:
+            return True
+        return has_usable_secret(cleaned)
+
+    return False
+
+
+def ensure_runtime_credentials_or_raise(
+    runtime: dict[str, Any] | None,
+    *,
+    requested_provider: Optional[str] = None,
+) -> None:
+    """Raise :class:`AuthError` when ``runtime`` lacks usable credentials.
+
+    Companion to :func:`runtime_credentials_are_usable`. The error
+    message names the provider and the env var(s) the resolver tried to
+    read, so operators reading gateway / cron logs can fix their
+    ``~/.hermes/.env`` without digging through code.
+
+    No-op when the runtime is usable — keeps the happy path cost
+    negligible for callers that wrap every primary-provider resolution.
+    """
+    if runtime_credentials_are_usable(runtime):
+        return
+
+    runtime = runtime or {}
+    provider_id = (
+        str(runtime.get("provider") or "").strip()
+        or str(requested_provider or "").strip()
+        or "?"
+    )
+
+    env_hint = ""
+    pconfig = PROVIDER_REGISTRY.get(provider_id.lower())
+    if pconfig and pconfig.auth_type == "api_key" and pconfig.api_key_env_vars:
+        env_hint = (
+            f" Set one of: {', '.join(pconfig.api_key_env_vars)} "
+            f"(in ~/.hermes/.env or the process environment)."
+        )
+
+    raise AuthError(
+        f"Provider '{provider_id}' resolved with no usable api_key — "
+        f"the configured credential source is empty or missing.{env_hint}",
+        provider=provider_id,
+        code="missing_api_key",
+    )

--- a/tests/cron/test_cron_fallback_on_missing_api_key.py
+++ b/tests/cron/test_cron_fallback_on_missing_api_key.py
@@ -1,0 +1,169 @@
+"""Cron-level regression for the empty-api-key → fallback promotion (#33936).
+
+Before this fix, ``resolve_runtime_provider("deepseek")`` returned
+``{"api_key": "", ...}`` when ``DEEPSEEK_API_KEY`` was missing rather
+than raising :class:`AuthError`. The cron scheduler's ``except AuthError``
+branch therefore never fired and the configured ``fallback_providers``
+chain was skipped — the job was built with empty credentials and then
+crashed at API-call time with a generic 401, leaving operators to
+debug a credential leak instead of a missing-key configuration.
+
+The cron path now wraps the primary resolution with
+:func:`hermes_cli.runtime_provider.ensure_runtime_credentials_or_raise`,
+so the registry api-key providers (DeepSeek, Z.AI/GLM, Kimi, …) flip
+empty-key into AuthError. This test pins that wiring end-to-end.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCronFallbackOnMissingPrimaryApiKey:
+    """Empty primary api_key should trigger the configured fallback chain."""
+
+    def test_deepseek_empty_key_falls_through_to_openrouter(self, tmp_path):
+        """Mirror the reporter's setup in #33936: ``provider: deepseek``
+        as primary, ``openrouter`` configured as fallback. With
+        ``DEEPSEEK_API_KEY`` unset the cron scheduler must try the
+        openrouter fallback instead of failing the job outright.
+        """
+        from cron.scheduler import run_job
+
+        # config.yaml: deepseek primary, openrouter fallback.
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  provider: deepseek\n"
+            "  default: deepseek-chat\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: meta-llama/llama-4-maverick\n"
+            "    api_key: or-fallback-real-key-12345\n"
+        )
+
+        fake_db = MagicMock()
+
+        # First call (primary) returns empty key for deepseek (silent
+        # failure mode that #33936 reported). Second call (fallback)
+        # returns a fully-resolved openrouter runtime.
+        call_log: list[dict] = []
+
+        def _mock_resolve(**kwargs):
+            call_log.append(dict(kwargs))
+            if (kwargs.get("requested") or "").lower() == "deepseek":
+                return {
+                    "api_key": "",
+                    "base_url": "https://api.deepseek.com/v1",
+                    "provider": "deepseek",
+                    "api_mode": "chat_completions",
+                }
+            return {
+                "api_key": "or-fallback-real-key-12345",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+            }
+
+        job = {
+            "id": "test-fallback",
+            "name": "fallback",
+            "prompt": "hello",
+            "provider": "deepseek",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=_mock_resolve,
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True, f"job should have succeeded via fallback, got error={error!r}"
+        assert final_response == "ok"
+
+        # The resolver was called at least twice: once for the primary
+        # (deepseek, returned empty key, promoted to AuthError) and once
+        # for the openrouter fallback.
+        primary_calls = [c for c in call_log if (c.get("requested") or "").lower() == "deepseek"]
+        fallback_calls = [c for c in call_log if (c.get("requested") or "").lower() == "openrouter"]
+        assert primary_calls, "primary deepseek call was never attempted"
+        assert fallback_calls, (
+            "openrouter fallback was never attempted — empty primary "
+            "api_key did not promote to AuthError so the fallback "
+            "chain in cron/scheduler.py stayed dormant (#33936 regression)."
+        )
+
+        # AIAgent received the fallback runtime's credentials, not the
+        # empty primary ones.
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["provider"] == "openrouter"
+        assert kwargs["api_key"] == "or-fallback-real-key-12345"
+
+    def test_realistic_primary_key_skips_fallback(self, tmp_path):
+        """Sanity: when the primary api-key provider has a usable key
+        the fallback chain is not consulted."""
+        from cron.scheduler import run_job
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  provider: deepseek\n"
+            "  default: deepseek-chat\n"
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: meta-llama/llama-4-maverick\n"
+            "    api_key: or-fallback-real-key-12345\n"
+        )
+
+        fake_db = MagicMock()
+
+        call_log: list[dict] = []
+
+        def _mock_resolve(**kwargs):
+            call_log.append(dict(kwargs))
+            return {
+                "api_key": "sk-deepseek-real-key-test-12345",
+                "base_url": "https://api.deepseek.com/v1",
+                "provider": "deepseek",
+                "api_mode": "chat_completions",
+            }
+
+        job = {
+            "id": "happy",
+            "name": "happy",
+            "prompt": "hello",
+            "provider": "deepseek",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=_mock_resolve,
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, error = run_job(job)
+
+        assert success is True, f"job should have succeeded, got error={error!r}"
+        # Only one resolver call — primary succeeded, no fallback needed.
+        assert len(call_log) == 1
+        assert (call_log[0].get("requested") or "").lower() == "deepseek"
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["provider"] == "deepseek"
+        assert kwargs["api_key"] == "sk-deepseek-real-key-test-12345"

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -72,6 +72,65 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
             with pytest.raises(RuntimeError):
                 _resolve_runtime_agent_kwargs()
 
+    def test_empty_api_key_for_api_key_provider_activates_fallback(
+        self, tmp_path, monkeypatch,
+    ):
+        """``resolve_runtime_provider`` for an api-key provider (DeepSeek,
+        Z.AI, Kimi, …) silently returns ``api_key=""`` when its env var
+        is unset. Without the post-resolution credential check the
+        gateway would build an agent with no key and fail at the API
+        call with a generic 401 instead of trying the fallback chain
+        (#33936). Pin the new behavior: empty key on primary should
+        flip into AuthError and fall through to the fallback.
+        """
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "model:\n  provider: deepseek\n  default: deepseek-chat\n"
+            "fallback_model:\n  provider: openrouter\n"
+            "  model: meta-llama/llama-4-maverick\n"
+        )
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        calls = []
+
+        def _mock_resolve(**kwargs):
+            calls.append(kwargs.get("requested"))
+            if len(calls) == 1:
+                # Primary path — simulate the silent empty-key return
+                # that the api-key provider branch produces when the
+                # env var is unset.
+                return {
+                    "api_key": "",
+                    "base_url": "https://api.deepseek.com/v1",
+                    "provider": "deepseek",
+                    "api_mode": "chat_completions",
+                }
+            # Fallback path — fully resolved openrouter runtime.
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _resolve_runtime_agent_kwargs
+            result = _resolve_runtime_agent_kwargs()
+
+        assert result["provider"] == "openrouter"
+        assert result["api_key"] == "fallback-key"
+        # Primary was called, returned silently with empty key, then
+        # the credential check raised AuthError and the fallback path
+        # took over.
+        assert len(calls) >= 2
+
     def test_legacy_fallback_is_appended_after_fallback_providers(self, tmp_path, monkeypatch):
         """When both keys exist, the legacy entry still participates in resolution."""
         config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_runtime_credentials_check.py
+++ b/tests/hermes_cli/test_runtime_credentials_check.py
@@ -1,0 +1,137 @@
+"""Unit tests for the runtime credentials sanity check (#33936).
+
+The api-key providers in ``PROVIDER_REGISTRY`` (DeepSeek, Z.AI, Kimi,
+Mistral, NVIDIA NIM, …) silently return ``api_key=""`` when their env
+var is unset rather than raising. Cron, gateway, and CLI all wrap the
+resolver in ``try/except AuthError`` to trigger their ``fallback_providers``
+chain — but the missing-key case never raised, so the agent was built
+with empty credentials and crashed later at the API call with a 401
+instead of falling back to the configured next provider.
+
+These tests pin the new ``ensure_runtime_credentials_or_raise()`` /
+``runtime_credentials_are_usable()`` helpers that promote the empty-key
+case to ``AuthError`` so the existing fallback wiring activates.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.auth import AuthError
+from hermes_cli.runtime_provider import (
+    ensure_runtime_credentials_or_raise,
+    runtime_credentials_are_usable,
+)
+
+
+class TestRuntimeCredentialsAreUsable:
+    def test_non_dict_runtime_is_unusable(self):
+        assert runtime_credentials_are_usable(None) is False
+        assert runtime_credentials_are_usable("not-a-dict") is False
+        assert runtime_credentials_are_usable(42) is False
+
+    def test_empty_string_api_key_for_registry_api_key_provider_is_unusable(self):
+        # deepseek is a registry api-key provider; empty key must fail.
+        runtime = {"provider": "deepseek", "api_key": ""}
+        assert runtime_credentials_are_usable(runtime) is False
+
+    def test_whitespace_only_api_key_for_registry_provider_is_unusable(self):
+        runtime = {"provider": "deepseek", "api_key": "   \n\t"}
+        assert runtime_credentials_are_usable(runtime) is False
+
+    def test_real_api_key_is_usable(self):
+        runtime = {
+            "provider": "deepseek",
+            "api_key": "sk-deepseek-realistic-test-key-12345",
+        }
+        assert runtime_credentials_are_usable(runtime) is True
+
+    def test_callable_api_key_is_usable(self):
+        """Entra ID / dynamic token resolvers expose api_key as a callable;
+        the actual token is fetched at API call time, so we cannot
+        inspect it now. Trust the callable."""
+        runtime = {"provider": "azure-foundry", "api_key": lambda: "token"}
+        assert runtime_credentials_are_usable(runtime) is True
+
+    def test_no_key_required_placeholder_for_custom_provider_is_usable(self):
+        """Localhost / custom-provider runtime sets api_key='no-key-required'.
+        ``custom`` isn't a registry api-key provider so the scoped check
+        lets it pass without inspecting the api_key further."""
+        runtime = {"provider": "custom", "api_key": "no-key-required"}
+        assert runtime_credentials_are_usable(runtime) is True
+
+    def test_lmstudio_dummy_key_is_usable(self):
+        # lmstudio is a registry api-key provider but uses a documented
+        # no-auth placeholder; the placeholder allowlist must cover it.
+        runtime = {"provider": "lmstudio", "api_key": "dummy-lm-api-key"}
+        assert runtime_credentials_are_usable(runtime) is True
+
+    def test_off_registry_providers_pass_through(self):
+        """Non-api-key providers (openrouter, nous, bedrock, openai-codex,
+        custom) are not subject to the empty-key check — they carry auth
+        in other fields and have their own per-provider validation."""
+        for provider, key in [
+            ("openrouter", ""),
+            ("openrouter", "***"),
+            ("nous", ""),
+            ("bedrock", "aws-sdk"),
+            ("openai-codex", ""),
+            ("custom", ""),
+        ]:
+            runtime = {"provider": provider, "api_key": key}
+            assert runtime_credentials_are_usable(runtime) is True, (
+                f"{provider!r} runtime should not be subject to the "
+                f"registry api-key empty-check, got rejected with "
+                f"api_key={key!r}"
+            )
+
+    def test_placeholder_string_for_registry_provider_is_unusable(self):
+        """``has_usable_secret`` rejects obvious placeholders for api-key
+        providers (``***``, ``changeme``, …) so empty-config test fakes
+        also flip into the fallback path."""
+        for placeholder in ("***", "changeme", "your_api_key", "placeholder", "example"):
+            runtime = {"provider": "deepseek", "api_key": placeholder}
+            assert runtime_credentials_are_usable(runtime) is False, placeholder
+
+
+class TestEnsureRuntimeCredentialsOrRaise:
+    def test_returns_silently_on_usable_runtime(self):
+        runtime = {
+            "provider": "deepseek",
+            "api_key": "sk-deepseek-realistic-test-key-12345",
+        }
+        # No exception expected.
+        ensure_runtime_credentials_or_raise(runtime)
+
+    def test_raises_auth_error_on_empty_key(self):
+        runtime = {"provider": "deepseek", "api_key": ""}
+        with pytest.raises(AuthError) as excinfo:
+            ensure_runtime_credentials_or_raise(runtime)
+        assert "deepseek" in str(excinfo.value).lower()
+        assert getattr(excinfo.value, "code", None) == "missing_api_key"
+
+    def test_auth_error_names_expected_env_var(self):
+        """For api-key providers in ``PROVIDER_REGISTRY``, the AuthError
+        message must list the env var the resolver tried to read so
+        operators can fix ``~/.hermes/.env`` without reading source code."""
+        runtime = {"provider": "deepseek", "api_key": ""}
+        with pytest.raises(AuthError) as excinfo:
+            ensure_runtime_credentials_or_raise(runtime)
+        msg = str(excinfo.value)
+        assert "DEEPSEEK_API_KEY" in msg, (
+            f"AuthError message should hint at the expected env var "
+            f"to make the fix obvious; got: {msg!r}"
+        )
+
+    def test_off_registry_runtime_passes_through(self):
+        """Openrouter / nous / codex / custom runtimes don't trip the
+        check even with empty api_key — their per-provider resolvers
+        are the source of truth for their respective auth shapes."""
+        for provider in ("openrouter", "nous", "openai-codex", "custom"):
+            runtime = {"provider": provider, "api_key": ""}
+            # No exception expected.
+            ensure_runtime_credentials_or_raise(runtime)
+
+    def test_none_runtime_raises(self):
+        with pytest.raises(AuthError):
+            ensure_runtime_credentials_or_raise(None, requested_provider="deepseek")

--- a/tests/tools/test_blocklist_does_not_mutate_gateway_env.py
+++ b/tests/tools/test_blocklist_does_not_mutate_gateway_env.py
@@ -1,0 +1,141 @@
+"""Regression tests for the gateway-process scope of the env blocklist (#33936).
+
+``_HERMES_PROVIDER_ENV_BLOCKLIST`` is a *subprocess sanitization* filter.
+It must never pop or otherwise mutate provider credential env vars on the
+calling Hermes process (gateway, CLI, cron worker). Users in #33936
+mis-diagnosed cron-job failures as "the blocklist is removing
+``DEEPSEEK_API_KEY`` from the gateway process" because their only
+diagnostic surface (``env | grep ...`` invoked through the agent's
+terminal tool) routed through ``_sanitize_subprocess_env`` and returned
+empty. Pin the actual contract here so a future refactor cannot
+silently break it.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+class TestBlocklistImportDoesNotMutateOsEnviron:
+    """Importing the local environment module must not pop blocked vars."""
+
+    def test_provider_credentials_still_in_os_environ_after_import(self):
+        """Sanity: provider creds set in os.environ remain after blocklist import.
+
+        Mirrors the bug report in #33936: users set ``DEEPSEEK_API_KEY``
+        (or any other blocked provider env var) in ``/opt/data/.env`` /
+        ``~/.hermes/.env`` and expect the gateway's provider resolver
+        to see it. The blocklist must not interfere with that
+        in-process visibility.
+        """
+        provider_creds = {
+            "DEEPSEEK_API_KEY": "sk-deepseek-fake",
+            "ANTHROPIC_API_KEY": "sk-ant-fake",
+            "OPENAI_API_KEY": "sk-openai-fake",
+            "ZAI_API_KEY": "zai-fake",
+            "GROQ_API_KEY": "groq-fake",
+        }
+        with patch.dict(os.environ, provider_creds, clear=False):
+            # Force a fresh import path — the build_provider_env_blocklist
+            # call inside the module imports several other modules that
+            # could in principle scrub os.environ as a side effect.
+            from tools.environments import local as local_mod
+            from importlib import reload
+
+            reload(local_mod)
+
+            for var, expected in provider_creds.items():
+                assert os.environ.get(var) == expected, (
+                    f"{var} disappeared from os.environ after importing "
+                    f"the blocklist module — the subprocess sanitization "
+                    f"contract leaked into gateway-process state (#33936)."
+                )
+
+    def test_blocklist_is_a_frozenset_not_a_mutator(self):
+        """The blocklist itself must be an inert frozenset of names."""
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+        assert isinstance(_HERMES_PROVIDER_ENV_BLOCKLIST, frozenset)
+        # Cannot be coerced into modifying os.environ — it's just names.
+        for name in _HERMES_PROVIDER_ENV_BLOCKLIST:
+            assert isinstance(name, str)
+
+
+class TestSanitizeSubprocessEnvDoesNotMutateBaseEnv:
+    """Calling ``_sanitize_subprocess_env(os.environ)`` must not pop keys."""
+
+    def test_passing_os_environ_directly_does_not_modify_it(self):
+        """If a caller passes ``os.environ`` (not a copy), the function
+        must still leave ``os.environ`` untouched. Mirrors the cron
+        scheduler / terminal tool patterns that may pass live env
+        references.
+        """
+        from tools.environments.local import _sanitize_subprocess_env
+
+        with patch.dict(
+            os.environ,
+            {
+                "DEEPSEEK_API_KEY": "sk-deepseek-fake",
+                "ANTHROPIC_API_KEY": "sk-ant-fake",
+            },
+            clear=False,
+        ):
+            before = dict(os.environ)
+            _ = _sanitize_subprocess_env(os.environ)
+            after = dict(os.environ)
+
+            assert before == after, (
+                "_sanitize_subprocess_env mutated os.environ in place — "
+                "blocked vars must only be stripped from the *returned* "
+                "subprocess env dict, never from the caller's live "
+                "environment (#33936)."
+            )
+            assert os.environ.get("DEEPSEEK_API_KEY") == "sk-deepseek-fake"
+            assert os.environ.get("ANTHROPIC_API_KEY") == "sk-ant-fake"
+
+    def test_return_value_strips_blocked_vars_only(self):
+        """Spot-check: the *returned* dict drops blocked vars but
+        leaves everything else (PATH, HOME, custom user vars).
+        """
+        from tools.environments.local import _sanitize_subprocess_env
+
+        base = {
+            "DEEPSEEK_API_KEY": "sk-deepseek-fake",
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "MY_CUSTOM_VAR": "keep-me",
+        }
+        result = _sanitize_subprocess_env(base)
+
+        assert "DEEPSEEK_API_KEY" not in result
+        assert result.get("PATH") == "/usr/bin:/bin"
+        assert result.get("HOME") == "/home/user"
+        assert result.get("MY_CUSTOM_VAR") == "keep-me"
+        # The input dict is left intact — no in-place mutation.
+        assert base.get("DEEPSEEK_API_KEY") == "sk-deepseek-fake"
+
+
+class TestRuntimeProviderStillSeesBlockedCredentials:
+    """Cross-check: the in-process runtime provider resolver reads
+    the same env vars that the subprocess blocklist scrubs."""
+
+    def test_resolve_api_key_provider_reads_blocked_var(self):
+        """``DEEPSEEK_API_KEY`` is in the blocklist, but
+        :func:`resolve_api_key_provider_credentials` must still
+        return it for the gateway's own use. This is the property
+        the cron scheduler depends on.
+        """
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        with patch.dict(
+            os.environ,
+            {"DEEPSEEK_API_KEY": "sk-deepseek-fake-for-test-only-1234"},
+            clear=False,
+        ):
+            creds = resolve_api_key_provider_credentials("deepseek")
+            assert creds.get("api_key") == "sk-deepseek-fake-for-test-only-1234", (
+                "Provider resolver could not see DEEPSEEK_API_KEY despite "
+                "it being in os.environ — the subprocess blocklist must "
+                "not affect in-process credential reads (#33936)."
+            )

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -76,8 +76,38 @@ def _resolve_safe_cwd(cwd: str) -> str:
 _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
 
 
+# ---------------------------------------------------------------------------
+# Blocklist scope contract (#33936)
+# ---------------------------------------------------------------------------
+# ``_HERMES_PROVIDER_ENV_BLOCKLIST`` exists for *subprocess* sanitization only.
+# It is consumed by :func:`_sanitize_subprocess_env` and a small number of
+# call-sites that build child-process environments (terminal tool, Docker
+# environment, background process registry, gateway quick-command exec).
+#
+# Importing this module is a pure-Python operation that builds a
+# ``frozenset`` of names — it does **not** mutate ``os.environ`` and does
+# **not** remove any keys from the long-lived gateway / CLI / cron process.
+# The provider resolver in :mod:`hermes_cli.runtime_provider` still reads
+# every var on this list (``DEEPSEEK_API_KEY``, ``ANTHROPIC_API_KEY``, etc.)
+# from ``os.environ`` / ``~/.hermes/.env`` to populate runtime credentials.
+#
+# UX corollary: running ``env | grep DEEPSEEK_API_KEY`` from the agent's
+# terminal tool (or any other Hermes-managed subprocess) will return
+# empty by design — that's the sanitization in action. To verify that a
+# credential is actually visible to the *gateway* process, use
+# ``hermes doctor`` or import :mod:`os` from a Python repl attached to
+# the gateway and check ``os.environ`` directly.
+# ---------------------------------------------------------------------------
+
+
 def _build_provider_env_blocklist() -> frozenset:
-    """Derive the blocklist from provider, tool, and gateway config."""
+    """Derive the blocklist from provider, tool, and gateway config.
+
+    Used **only** by :func:`_sanitize_subprocess_env` to scrub secrets
+    out of child-process environments. Never mutates ``os.environ`` of
+    the calling Hermes process (gateway, CLI, cron). See the scope
+    contract block above for the full UX implications (#33936).
+    """
     blocked: set[str] = set()
 
     try:
@@ -180,7 +210,20 @@ def _inject_context_hermes_home(env: dict) -> None:
 
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
-    """Filter Hermes-managed secrets from a subprocess environment."""
+    """Filter Hermes-managed secrets from a subprocess environment.
+
+    Builds a fresh dict by copying ``base_env`` (typically
+    ``os.environ.copy()``) and dropping any key listed in
+    :data:`_HERMES_PROVIDER_ENV_BLOCKLIST` unless it is explicitly
+    opted in (skill-declared / config-listed passthrough, or the
+    ``_HERMES_FORCE_<name>`` override prefix in ``extra_env``).
+
+    This function never mutates ``base_env`` and never touches the
+    caller's ``os.environ``. The blocklist is a subprocess-scoped
+    filter; the gateway / CLI / cron process still reads provider
+    credentials directly from ``os.environ`` for its own provider
+    resolution (see #33936 and the scope contract block above).
+    """
     try:
         from tools.env_passthrough import is_env_passthrough as _is_passthrough
     except Exception:


### PR DESCRIPTION
## What does this PR do?

Fixes the silent fall-through that #33936 reported as "DEEPSEEK_API_KEY blocked by env blocklist in gateway process":

1. **`resolve_runtime_provider("deepseek")`** (and every other api-key provider in `PROVIDER_REGISTRY`: Z.AI/GLM, Kimi, Mistral, Groq, NVIDIA NIM, DashScope, …) silently returned `{api_key: "", ...}` when its env var was unset. Cron + gateway wrapped the call in `try/except AuthError` to trigger the configured `fallback_providers` chain — but the missing-key case never raised, so the agent was constructed with empty credentials and the request later 401-d. Operators chased a "blocklist" red herring instead of a "missing api-key" configuration.

2. **The blocklist itself was fine.** `_HERMES_PROVIDER_ENV_BLOCKLIST` is strictly a *subprocess* sanitization filter — it never mutates the gateway / cron / CLI `os.environ`. The reporter's diagnostic (``env | grep DEEPSEEK_API_KEY`` from the agent's terminal tool) routed through the same sanitization and returned empty, which is what made the blocklist look like the culprit. Documented the scope contract in code so the next operator doesn't fall into the same trap.

Three small additions wired together:

1. **Scope contract docs** (`tools/environments/local.py`) — explicit block above `_HERMES_PROVIDER_ENV_BLOCKLIST` and `_sanitize_subprocess_env` spelling out: blocklist is subprocess-only, never mutates `os.environ`, `env | grep KEY` via the terminal tool returning empty is BY DESIGN, and how to actually verify gateway-side credential visibility.

2. **`ensure_runtime_credentials_or_raise()` helper** (`hermes_cli/runtime_provider.py`) — scoped classifier + AuthError thrower. Only flags registry api-key providers; OAuth / OpenRouter / Bedrock / Copilot ACP / `custom` / localhost runtimes pass through unchanged (they carry auth in other fields). Recognizes known no-auth placeholders (`no-key-required`, `dummy-lm-api-key`, `aws-sdk`, `copilot-acp`) and callable api_keys (Entra ID dynamic resolvers). Error message names the provider AND the expected env vars so operators can fix `~/.hermes/.env` straight from the log.

3. **Cron + gateway wiring** (`cron/scheduler.py`, `gateway/run.py`) — call the helper after primary `resolve_runtime_provider`. The empty-key case now flips into `AuthError`, the existing `except AuthError` branch activates, and the configured `fallback_providers` chain runs as designed.

## Related Issue

Fixes #33936

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update (clarifies the blocklist's subprocess-only scope)

## Changes Made

- `tools/environments/local.py` — explicit scope contract above `_HERMES_PROVIDER_ENV_BLOCKLIST` and on `_sanitize_subprocess_env`; reference #33936.
- `hermes_cli/runtime_provider.py` — new `runtime_credentials_are_usable()` + `ensure_runtime_credentials_or_raise()` helpers, scoped to registry api-key providers; new `_RUNTIME_NOAUTH_API_KEY_PLACEHOLDERS` allowlist.
- `cron/scheduler.py` — call `ensure_runtime_credentials_or_raise()` after the primary resolution so the existing `AuthError` → `fallback_providers` chain triggers.
- `gateway/run.py` — same wiring in `_resolve_runtime_agent_kwargs()` for parity with cron.
- `tests/tools/test_blocklist_does_not_mutate_gateway_env.py` — **5 new tests** pinning the gateway-process visibility contract.
- `tests/hermes_cli/test_runtime_credentials_check.py` — **14 new tests** for the helper (registry vs off-registry, placeholders, callable api_keys, env-var hint in the AuthError message).
- `tests/cron/test_cron_fallback_on_missing_api_key.py` — **2 new tests** mirroring the reporter's deepseek → openrouter fallback setup end-to-end.
- `tests/gateway/test_auth_fallback.py` — **1 new test** pinning the same wiring on the gateway side.

Backwards compatible:
- Off-registry providers (OpenRouter, Nous, Codex, custom, Bedrock, …) pass through unchanged.
- Existing tests using mock `api_key=\"***\"` for openrouter / custom keep working — those providers are not subject to the check.
- The helper is a pure additive function; no existing callers behave differently unless they opt in.

## How to Test

```bash
# New regression tests (22 tests, ~1.5s total)
pytest tests/tools/test_blocklist_does_not_mutate_gateway_env.py \
       tests/hermes_cli/test_runtime_credentials_check.py \
       tests/cron/test_cron_fallback_on_missing_api_key.py \
       tests/gateway/test_auth_fallback.py -q

# Broader regression across the touched modules
pytest tests/cron/ tests/tools/test_local_env_blocklist.py \
       tests/tools/test_env_passthrough.py tests/hermes_cli/test_runtime_provider_resolution.py \
       tests/hermes_cli/test_api_key_providers.py tests/gateway/test_auth_fallback.py \
       tests/cli/test_cli_provider_resolution.py -q
# expected: passes (2 unrelated pre-existing failures in
# tests/cron/test_cron_script.py::test_script_timeout and
# tests/cron/test_jobs.py::test_broken_cron_without_next_run_is_recovered
# — confirmed unchanged on upstream/main).
```

End-to-end behaviour after the fix (the reporter's setup):

```yaml
# ~/.hermes/config.yaml
model:
  provider: deepseek
  default: deepseek/deepseek-v4-flash
fallback_providers:
  - provider: zai
    model: glm-5-turbo
```

```
# DEEPSEEK_API_KEY is unset (or empty) in os.environ / ~/.hermes/.env

# Cron tick fires the deepseek job:
WARNING  cron.scheduler  Job 'digest': primary auth failed
         (Provider 'deepseek' resolved with no usable api_key —
          the configured credential source is empty or missing.
          Set one of: DEEPSEEK_API_KEY (in ~/.hermes/.env or the
          process environment).), trying fallback
INFO     cron.scheduler  Job 'digest': fallback resolved to zai
INFO     cron.scheduler  Job 'digest' completed
```

Before this PR the same job logged no fallback attempt, built `AIAgent(api_key=\"\")`, and surfaced as a generic 401 — the failure mode #33936 reported.

## Checklist

- [x] Conventional Commits (`docs(env):`, `feat(runtime):`, `fix(cron,gateway):`)
- [x] 3 focused commits, single author
- [x] 22 new tests pass; existing cron / gateway / runtime-provider suites pass
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12
- [x] No new config keys, no schema migration, no breaking change to public API
- [x] Issue #33936 explicitly referenced in code comments at every wiring point
