### PR TITLE
feat(provider): add Codex ACP model provider support

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -357,8 +357,8 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider not in {"copilot-acp", "codex-acp"}
+        and not str(agent.base_url or "").lower().startswith(("acp://copilot", "acp://codex"))
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -711,7 +711,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "codex-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1262,12 +1262,13 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
-        from agent.copilot_acp_client import CopilotACPClient
+    if agent.provider in {"copilot-acp", "codex-acp"} or str(client_kwargs.get("base_url", "")).startswith(("acp://copilot", "acp://codex")):
+        from agent.copilot_acp_client import CodexACPClient, CopilotACPClient
 
-        client = CopilotACPClient(**client_kwargs)
+        client_cls = CodexACPClient if str(client_kwargs.get("base_url", "")).startswith("acp://codex") or agent.provider == "codex-acp" else CopilotACPClient
+        client = client_cls(**client_kwargs)
         _ra().logger.info(
-            "Copilot ACP client created (%s, shared=%s) %s",
+            "ACP client created (%s, shared=%s) %s",
             reason,
             shared,
             agent._client_log_context(),

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3666,26 +3666,27 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "codex-acp"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
+                    "resolve_provider_client: ACP provider requested but no model "
                     "was provided or configured"
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
+                    "resolve_provider_client: ACP provider requested but external "
                     "process credentials are incomplete"
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            from agent.copilot_acp_client import CodexACPClient, CopilotACPClient
 
-            client = CopilotACPClient(
+            client_cls = CodexACPClient if provider == "codex-acp" or base_url.startswith("acp://codex") else CopilotACPClient
+            client = client_cls(
                 api_key=api_key,
                 base_url=base_url,
                 command=command,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1261,13 +1261,13 @@ def run_conversation(
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
-                # CopilotACPClient communicates via subprocess stdio and
+                # ACP clients communicate via subprocess stdio and
                 # returns a plain SimpleNamespace — not an iterable
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider == "copilot-acp"
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    agent.provider in {"copilot-acp", "codex-acp"}
+                    or str(agent.base_url or "").lower().startswith(("acp://copilot", "acp://codex"))
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -1,9 +1,10 @@
 """OpenAI-compatible shim that forwards Hermes requests to `copilot --acp`.
 
-This adapter lets Hermes treat the GitHub Copilot ACP server as a chat-style
-backend. Each request starts a short-lived ACP session, sends the formatted
-conversation as a single prompt, collects text chunks, and converts the result
-back into the minimal shape Hermes expects from an OpenAI client.
+This adapter lets Hermes treat GitHub Copilot ACP and Codex ACP servers as
+chat-style backends. It serializes each Hermes request into a text-only ACP
+prompt, collects text chunks, and converts the result back into the minimal
+shape Hermes expects from an OpenAI client. Native ACP media blocks are not
+forwarded by this shim yet, even when the underlying ACP agent supports them.
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
 
 ACP_MARKER_BASE_URL = "acp://copilot"
+CODEX_ACP_MARKER_BASE_URL = "acp://codex"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
@@ -53,7 +55,38 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
     return any(marker in lower for marker in _DEPRECATION_MARKERS)
 
 
-def _resolve_command() -> str:
+def _is_codex_base_url(base_url: str | None) -> bool:
+    return str(base_url or "").lower().startswith("acp://codex")
+
+
+def _repo_local_node_bin(binary_name: str) -> str:
+    suffix = ".cmd" if os.name == "nt" else ""
+    return str(Path(__file__).resolve().parent.parent / "node_modules" / ".bin" / f"{binary_name}{suffix}")
+
+
+_CODEX_ACP_REASONING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
+
+
+def _codex_acp_config_args() -> list[str]:
+    args = ["-c", "features.fast_mode=true"]
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+        effort = ""
+        if isinstance(agent_cfg, dict):
+            effort = str(agent_cfg.get("reasoning_effort") or "").strip().lower()
+        if effort in _CODEX_ACP_REASONING_EFFORTS:
+            args.extend(["-c", f'model_reasoning_effort="{effort}"'])
+    except Exception:
+        pass
+    return args
+
+
+def _resolve_command(base_url: str | None = None) -> str:
+    if _is_codex_base_url(base_url):
+        return _repo_local_node_bin("codex-acp")
     return (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
         or os.getenv("COPILOT_CLI_PATH", "").strip()
@@ -61,7 +94,10 @@ def _resolve_command() -> str:
     )
 
 
-def _resolve_args() -> list[str]:
+def _resolve_args(base_url: str | None = None) -> list[str]:
+    if _is_codex_base_url(base_url):
+        raw = os.getenv("HERMES_CODEX_ACP_ARGS", "").strip()
+        return shlex.split(raw) if raw else _codex_acp_config_args()
     raw = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     if not raw:
         return ["--acp", "--stdio"]
@@ -107,6 +143,16 @@ def _build_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
     env["HOME"] = _resolve_home_dir()
     return env
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
 
 
 def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
@@ -332,7 +378,7 @@ class _ACPChatNamespace:
 
 
 class CopilotACPClient:
-    """Minimal OpenAI-client-compatible facade for Copilot ACP."""
+    """Minimal OpenAI-client-compatible facade for ACP subprocesses."""
 
     def __init__(
         self,
@@ -350,19 +396,34 @@ class CopilotACPClient:
         self.api_key = api_key or "copilot-acp"
         self.base_url = base_url or ACP_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
-        self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_command = acp_command or command or _resolve_command(self.base_url)
+        self._acp_args = list(acp_args or args or _resolve_args(self.base_url))
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
         self._active_process: subprocess.Popen[str] | None = None
         self._active_process_lock = threading.Lock()
+        self._request_lock = threading.Lock()
+        self._inbox: queue.Queue[dict[str, Any]] | None = None
+        self._stderr_tail: deque[str] | None = None
+        self._session_id: str | None = None
+        self._next_id = 0
+        self._uses = 0
+        self._max_uses = (
+            0
+            if _is_codex_base_url(self.base_url)
+            else _env_int("HERMES_COPILOT_ACP_MAX_USES", 1)
+        )
 
     def close(self) -> None:
         proc: subprocess.Popen[str] | None
         with self._active_process_lock:
             proc = self._active_process
             self._active_process = None
+        self._inbox = None
+        self._stderr_tail = None
+        self._session_id = None
+        self._uses = 0
         self.is_closed = True
         if proc is None:
             return
@@ -407,10 +468,11 @@ class CopilotACPClient:
             _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
             _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
 
-        response_text, reasoning_text = self._run_prompt(
-            prompt_text,
-            timeout_seconds=_effective_timeout,
-        )
+        with self._request_lock:
+            response_text, reasoning_text = self._run_prompt(
+                prompt_text,
+                timeout_seconds=_effective_timeout,
+            )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
 
@@ -436,6 +498,47 @@ class CopilotACPClient:
         )
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        proc = self._ensure_process(timeout_seconds=timeout_seconds)
+        if proc.stdin is None:
+            self.close()
+            raise RuntimeError("ACP process did not expose stdin.")
+
+        session_id = self._session_id or ""
+        if not session_id:
+            self.close()
+            raise RuntimeError("ACP process did not initialize a sessionId.")
+
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        try:
+            self._request(
+                "session/prompt",
+                {
+                    "sessionId": session_id,
+                    "prompt": [
+                        {
+                            "type": "text",
+                            "text": prompt_text,
+                        }
+                    ],
+                },
+                timeout_seconds=timeout_seconds,
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+            )
+            self._uses += 1
+            return "".join(text_parts), "".join(reasoning_parts)
+        finally:
+            if self._max_uses > 0 and self._uses >= self._max_uses:
+                self.close()
+
+    def _ensure_process(self, *, timeout_seconds: float) -> subprocess.Popen[str]:
+        with self._active_process_lock:
+            proc = self._active_process
+        if proc is not None and proc.poll() is None and self._session_id:
+            return proc
+
+        self.close()
         try:
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
@@ -448,14 +551,19 @@ class CopilotACPClient:
                 env=_build_subprocess_env(),
             )
         except FileNotFoundError as exc:
+            label = "Codex ACP" if _is_codex_base_url(self.base_url) else "Copilot ACP"
+            if _is_codex_base_url(self.base_url):
+                hint = "Run `npm install` from the Hermes repo so the bundled @zed-industries/codex-acp binary is available."
+            else:
+                hint = "Install the matching ACP CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
             raise RuntimeError(
-                f"Could not start Copilot ACP command '{self._acp_command}'. "
-                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+                f"Could not start {label} command '{self._acp_command}'. "
+                f"{hint}"
             ) from exc
 
         if proc.stdin is None or proc.stdout is None:
             proc.kill()
-            raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
+            raise RuntimeError("ACP process did not expose stdin/stdout pipes.")
 
         self.is_closed = False
         with self._active_process_lock:
@@ -463,6 +571,8 @@ class CopilotACPClient:
 
         inbox: queue.Queue[dict[str, Any]] = queue.Queue()
         stderr_tail: deque[str] = deque(maxlen=40)
+        self._inbox = inbox
+        self._stderr_tail = stderr_tail
 
         def _stdout_reader() -> None:
             if proc.stdout is None:
@@ -484,70 +594,8 @@ class CopilotACPClient:
         out_thread.start()
         err_thread.start()
 
-        next_id = 0
-
-        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
-            nonlocal next_id
-            next_id += 1
-            request_id = next_id
-            payload = {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "method": method,
-                "params": params,
-            }
-            proc.stdin.write(json.dumps(payload) + "\n")
-            proc.stdin.flush()
-
-            deadline = time.monotonic() + timeout_seconds
-            while time.monotonic() < deadline:
-                if proc.poll() is not None:
-                    break
-                try:
-                    msg = inbox.get(timeout=0.1)
-                except queue.Empty:
-                    continue
-
-                if self._handle_server_message(
-                    msg,
-                    process=proc,
-                    cwd=self._acp_cwd,
-                    text_parts=text_parts,
-                    reasoning_parts=reasoning_parts,
-                ):
-                    continue
-
-                if msg.get("id") != request_id:
-                    continue
-                if "error" in msg:
-                    err = msg.get("error") or {}
-                    raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
-                    )
-                return msg.get("result")
-
-            stderr_text = "\n".join(stderr_tail).strip()
-            if proc.poll() is not None and stderr_text:
-                if _is_gh_copilot_deprecation_message(stderr_text):
-                    raise RuntimeError(
-                        "Hermes ACP mode requires the NEW GitHub Copilot CLI "
-                        "(github.com/github/copilot-cli), but the binary it just "
-                        "spawned is the deprecated `gh copilot` extension.\n\n"
-                        "Install the new CLI:\n"
-                        "  npm install -g @github/copilot\n"
-                        "  # then verify with: copilot --help\n\n"
-                        "If `copilot` already resolves to the new CLI but you still see this,\n"
-                        "point Hermes at it explicitly:\n"
-                        "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
-                        "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
-                        "directly with a Copilot subscription token) via `hermes setup`.\n\n"
-                        f"Original error:\n{stderr_text}"
-                    )
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
-
         try:
-            _request(
+            self._request(
                 "initialize",
                 {
                     "protocolVersion": 1,
@@ -563,37 +611,102 @@ class CopilotACPClient:
                         "version": "0.0.0",
                     },
                 },
+                timeout_seconds=timeout_seconds,
             )
-            session = _request(
+            session = self._request(
                 "session/new",
                 {
                     "cwd": self._acp_cwd,
                     "mcpServers": [],
                 },
+                timeout_seconds=timeout_seconds,
             ) or {}
             session_id = str(session.get("sessionId") or "").strip()
             if not session_id:
-                raise RuntimeError("Copilot ACP did not return a sessionId.")
+                raise RuntimeError("ACP did not return a sessionId.")
+            self._session_id = session_id
+            self._uses = 0
+            return proc
+        except Exception:
+            self.close()
+            raise
 
-            text_parts: list[str] = []
-            reasoning_parts: list[str] = []
-            _request(
-                "session/prompt",
-                {
-                    "sessionId": session_id,
-                    "prompt": [
-                        {
-                            "type": "text",
-                            "text": prompt_text,
-                        }
-                    ],
-                },
+    def _request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout_seconds: float,
+        text_parts: list[str] | None = None,
+        reasoning_parts: list[str] | None = None,
+    ) -> Any:
+        proc = self._active_process
+        inbox = self._inbox
+        stderr_tail = self._stderr_tail
+        if proc is None or proc.stdin is None or inbox is None or stderr_tail is None:
+            raise RuntimeError("ACP process is not running.")
+
+        self._next_id += 1
+        request_id = self._next_id
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                break
+            try:
+                msg = inbox.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            if self._handle_server_message(
+                msg,
+                process=proc,
+                cwd=self._acp_cwd,
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
+            ):
+                continue
+
+            if msg.get("id") != request_id:
+                continue
+            if "error" in msg:
+                err = msg.get("error") or {}
+                raise RuntimeError(
+                    f"ACP {method} failed: {err.get('message') or err}"
+                )
+            return msg.get("result")
+
+        stderr_text = "\n".join(stderr_tail).strip()
+        if proc.poll() is not None and stderr_text:
+            if _is_gh_copilot_deprecation_message(stderr_text):
+                raise RuntimeError(
+                    "Hermes ACP mode requires the NEW GitHub Copilot CLI "
+                    "(github.com/github/copilot-cli), but the binary it just "
+                    "spawned is the deprecated `gh copilot` extension.\n\n"
+                    "Install the new CLI:\n"
+                    "  npm install -g @github/copilot\n"
+                    "  # then verify with: copilot --help\n\n"
+                    "If `copilot` already resolves to the new CLI but you still see this,\n"
+                    "point Hermes at it explicitly:\n"
+                    "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
+                    "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
+                    "directly with a Copilot subscription token) via `hermes setup`.\n\n"
+                    f"Original error:\n{stderr_text}"
+                )
+            raise RuntimeError(f"ACP process exited early: {stderr_text}")
+        if stderr_text:
+            raise TimeoutError(
+                f"Timed out waiting for ACP response to {method}. Stderr tail: {stderr_text}"
             )
-            return "".join(text_parts), "".join(reasoning_parts)
-        finally:
-            self.close()
+        raise TimeoutError(f"Timed out waiting for ACP response to {method}.")
 
     def _handle_server_message(
         self,
@@ -684,3 +797,8 @@ class CopilotACPClient:
         process.stdin.write(json.dumps(response) + "\n")
         process.stdin.flush()
         return True
+
+
+class CodexACPClient(CopilotACPClient):
+    """Named facade for Codex ACP; behavior is selected by acp://codex."""
+

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -107,6 +107,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CODEX_ACP_BASE_URL = "acp://codex"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -245,6 +246,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "codex-acp": ProviderConfig(
+        id="codex-acp",
+        name="OpenAI Codex ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CODEX_ACP_BASE_URL,
+        base_url_env_var="CODEX_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1516,6 +1524,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "openai-codex-acp": "codex-acp", "acp-codex": "codex-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
@@ -6173,6 +6182,31 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _repo_local_node_bin(binary_name: str) -> str:
+    suffix = ".cmd" if os.name == "nt" else ""
+    return str(Path(__file__).resolve().parent.parent / "node_modules" / ".bin" / f"{binary_name}{suffix}")
+
+
+_CODEX_ACP_REASONING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
+
+
+def _codex_acp_config_args() -> list[str]:
+    args = ["-c", "features.fast_mode=true"]
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+        effort = ""
+        if isinstance(agent_cfg, dict):
+            effort = str(agent_cfg.get("reasoning_effort") or "").strip().lower()
+        if effort in _CODEX_ACP_REASONING_EFFORTS:
+            args.extend(["-c", f'model_reasoning_effort="{effort}"'])
+    except Exception:
+        pass
+    return args
+
+
 def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str, Any]:
     """Resolve runtime details for local subprocess-backed providers."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
@@ -6187,25 +6221,42 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "codex-acp":
+        command = _repo_local_node_bin("codex-acp")
+        raw_args = os.getenv("HERMES_CODEX_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else _codex_acp_config_args()
+        api_key = "codex-acp"
+        missing_code = "missing_codex_acp_cli"
+        missing_message = (
+            f"Could not find the bundled Codex ACP command '{command}'. "
+            "Run `npm install` from the Hermes repo so @zed-industries/codex-acp is available."
+        )
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+        api_key = "copilot-acp"
+        missing_code = "missing_copilot_cli"
+        missing_message = (
+            f"Could not find the Copilot CLI command '{command}'. "
+            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        )
+
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            missing_message,
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=missing_code,
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": api_key,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -79,6 +79,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "codex-acp",
     "openai-codex",
 })
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -95,6 +95,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "codex-acp": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://codex",
+        base_url_env_var="CODEX_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -285,6 +291,8 @@ ALIASES: Dict[str, str] = {
     "copilot": "github-copilot",
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
+    "openai-codex-acp": "codex-acp",
+    "acp-codex": "codex-acp",
 
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
@@ -369,6 +377,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "codex-acp": "OpenAI Codex ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1363,7 +1363,11 @@ def resolve_runtime_provider(
             creds = resolve_codex_runtime_credentials()
             return {
                 "provider": "openai-codex",
-                "api_mode": "codex_responses",
+                "api_mode": _maybe_apply_codex_app_server_runtime(
+                    provider="openai-codex",
+                    api_mode="codex_responses",
+                    model_cfg=model_cfg,
+                ),
                 "base_url": creds.get("base_url", "").rstrip("/"),
                 "api_key": creds.get("api_key", ""),
                 "source": creds.get("source", "hermes-auth-store"),
@@ -1448,10 +1452,10 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "codex-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,124 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@zed-industries/codex-acp": "0.15.0",
         "agent-browser": "^0.26.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp/-/codex-acp-0.15.0.tgz",
+      "integrity": "sha512-eAv7sGBeiYrYkOulF729nrM51szS7WIhBtugRj5wWq6csRKZUhAZfoUZlF8xUWdHPtOIzd/eT6MNG6gMHu6z0w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex-acp": "bin/codex-acp.js"
+      },
+      "optionalDependencies": {
+        "@zed-industries/codex-acp-darwin-arm64": "0.15.0",
+        "@zed-industries/codex-acp-darwin-x64": "0.15.0",
+        "@zed-industries/codex-acp-linux-arm64": "0.15.0",
+        "@zed-industries/codex-acp-linux-x64": "0.15.0",
+        "@zed-industries/codex-acp-win32-arm64": "0.15.0",
+        "@zed-industries/codex-acp-win32-x64": "0.15.0"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-darwin-arm64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-arm64/-/codex-acp-darwin-arm64-0.15.0.tgz",
+      "integrity": "sha512-9/tnj1fXeXIONgr+5FGwr3bkqd4jaORdr3X9/k++rzHW+UIzvgIeXrJKv43403gtuKp0BoxdzsFxe2qsAQhhkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "codex-acp-darwin-arm64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-darwin-x64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-x64/-/codex-acp-darwin-x64-0.15.0.tgz",
+      "integrity": "sha512-2cmflnVYM5yzvNu4ldff6OsfLzQThFToPszCT3t7jytWuG28V+W1cUEGsvFJGNkGC1Wo29Z4w5LZ3wyfOkvPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "codex-acp-darwin-x64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-linux-arm64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-arm64/-/codex-acp-linux-arm64-0.15.0.tgz",
+      "integrity": "sha512-ioCXCiZMd4v7Eqyed9Iz4xcPKsZbSH157wOitsWQKxUiX43c1Ti5fykZcrh9cNSLOgiGmI3V2nbYp0aTf66grQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "codex-acp-linux-arm64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-linux-x64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-x64/-/codex-acp-linux-x64-0.15.0.tgz",
+      "integrity": "sha512-WtqI8KGX9z7XvdkazumYraoDwpip5lFBRtFXoIwYCSBoDZdOqQsfNQndIfTDttfQ1BdZYKczDnrfbRaiIFU9UA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "codex-acp-linux-x64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-win32-arm64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-arm64/-/codex-acp-win32-arm64-0.15.0.tgz",
+      "integrity": "sha512-L+OFIPOzAuxsImlq8E227MZxgujMLMEJSqiR9QjZq8fiIFCKh/HnxmvyXvjWaHbJdb1pZ09WKe3MNwV9ln/+GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "codex-acp-win32-arm64": "bin/codex-acp.exe"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-win32-x64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-x64/-/codex-acp-win32-x64-0.15.0.tgz",
+      "integrity": "sha512-LDnADpCg1Rzbkyxs4hMaOvRwNa68KLp8CoNVom8ZE/sChSvcDrj/RCoMsZWrARJGWs7EQ9zYeLoeVk5VcVQoPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "codex-acp-win32-x64": "bin/codex-acp.exe"
       }
     },
     "node_modules/agent-browser": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
   "dependencies": {
+    "@zed-industries/codex-acp": "0.15.0",
     "agent-browser": "^0.26.0"
   },
   "overrides": {

--- a/plugins/model-providers/codex-acp/__init__.py
+++ b/plugins/model-providers/codex-acp/__init__.py
@@ -1,0 +1,34 @@
+"""OpenAI Codex ACP provider profile.
+
+codex-acp uses a local ACP subprocess, typically Zed's
+@zed-industries/codex-acp adapter. It is routed through Hermes'
+OpenAI-compatible ACP facade rather than the OpenAI Responses API.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CodexACPProfile(ProviderProfile):
+    """OpenAI Codex ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+codex_acp = CodexACPProfile(
+    name="codex-acp",
+    aliases=("openai-codex-acp", "acp-codex"),
+    api_mode="chat_completions",
+    env_vars=(),
+    base_url="acp://codex",
+    auth_type="external_process",
+)
+
+register_provider(codex_acp)

--- a/plugins/model-providers/codex-acp/plugin.yaml
+++ b/plugins/model-providers/codex-acp/plugin.yaml
@@ -1,0 +1,4 @@
+name: codex-acp-provider
+kind: model-provider
+version: 0.1.0
+description: OpenAI Codex via ACP subprocess

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -10,7 +10,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.copilot_acp_client import CopilotACPClient
+from agent.copilot_acp_client import CodexACPClient, CopilotACPClient
 
 
 class _FakeProcess:
@@ -205,3 +205,24 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+class CodexACPClientArgsTests(unittest.TestCase):
+    def test_codex_client_default_args_include_fast_mode_and_reasoning(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("hermes_cli.config.load_config", return_value={"agent": {"reasoning_effort": "high"}}),
+        ):
+            os.environ.pop("HERMES_CODEX_ACP_ARGS", None)
+            client = CodexACPClient(base_url="acp://codex", command="/tmp/codex-acp")
+
+        self.assertEqual(
+            client._acp_args,
+            ["-c", "features.fast_mode=true", "-c", 'model_reasoning_effort="high"'],
+        )
+
+    def test_codex_client_env_args_override_config_args(self) -> None:
+        with patch.dict(os.environ, {"HERMES_CODEX_ACP_ARGS": '-c model="gpt-5.5"'}, clear=False):
+            client = CodexACPClient(base_url="acp://codex", command="/tmp/codex-acp")
+
+        self.assertEqual(client._acp_args, ["-c", "model=gpt-5.5"])

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2657,3 +2657,77 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+def test_resolve_runtime_provider_codex_acp(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "codex-acp")
+    monkeypatch.setattr(
+        rp,
+        "resolve_external_process_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "codex-acp",
+            "base_url": "acp://codex",
+            "command": "/usr/local/bin/codex-acp",
+            "args": [],
+            "source": "process",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="codex-acp")
+
+    assert resolved["provider"] == "codex-acp"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "acp://codex"
+    assert resolved["api_key"] == "codex-acp"
+    assert resolved["command"] == "/usr/local/bin/codex-acp"
+    assert resolved["args"] == []
+
+
+def test_resolve_codex_acp_args_include_fast_mode_and_reasoning(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.delenv("HERMES_CODEX_ACP_ARGS", raising=False)
+    monkeypatch.setattr(auth_mod, "_repo_local_node_bin", lambda name: f"/tmp/{name}")
+    monkeypatch.setattr(auth_mod.shutil, "which", lambda command: command)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"agent": {"reasoning_effort": "xhigh"}},
+    )
+
+    creds = auth_mod.resolve_external_process_provider_credentials("codex-acp")
+
+    assert creds["args"] == [
+        "-c",
+        "features.fast_mode=true",
+        "-c",
+        'model_reasoning_effort="xhigh"',
+    ]
+
+
+def test_resolve_codex_acp_args_ignore_invalid_reasoning(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.delenv("HERMES_CODEX_ACP_ARGS", raising=False)
+    monkeypatch.setattr(auth_mod, "_repo_local_node_bin", lambda name: f"/tmp/{name}")
+    monkeypatch.setattr(auth_mod.shutil, "which", lambda command: command)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"agent": {"reasoning_effort": "none"}},
+    )
+
+    creds = auth_mod.resolve_external_process_provider_credentials("codex-acp")
+
+    assert creds["args"] == ["-c", "features.fast_mode=true"]
+
+
+def test_resolve_codex_acp_args_env_override_wins(monkeypatch):
+    from hermes_cli import auth as auth_mod
+
+    monkeypatch.setenv("HERMES_CODEX_ACP_ARGS", '-c model="gpt-5.5"')
+    monkeypatch.setattr(auth_mod, "_repo_local_node_bin", lambda name: f"/tmp/{name}")
+    monkeypatch.setattr(auth_mod.shutil, "which", lambda command: command)
+
+    creds = auth_mod.resolve_external_process_provider_credentials("codex-acp")
+
+    assert creds["args"] == ["-c", "model=gpt-5.5"]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4665,6 +4665,37 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+
+
+def test_aiagent_uses_codex_acp_client():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.copilot_acp_client.CodexACPClient") as mock_acp_client,
+    ):
+        acp_client = MagicMock()
+        mock_acp_client.return_value = acp_client
+
+        agent = AIAgent(
+            api_key="codex-acp",
+            base_url="acp://codex",
+            provider="codex-acp",
+            acp_command="/usr/local/bin/codex-acp",
+            acp_args=[],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is acp_client
+    mock_openai.assert_not_called()
+    mock_acp_client.assert_called_once()
+    assert mock_acp_client.call_args.kwargs["base_url"] == "acp://codex"
+    assert mock_acp_client.call_args.kwargs["api_key"] == "codex-acp"
+    assert mock_acp_client.call_args.kwargs["command"] == "/usr/local/bin/codex-acp"
+    assert mock_acp_client.call_args.kwargs["args"] == []
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -16,6 +16,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 |----------|-------|
 | **Nous Portal** | `hermes model` (OAuth, subscription-based) |
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
+| **OpenAI Codex ACP** | `hermes model` (spawns local `codex-acp`) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
@@ -81,15 +82,27 @@ Don't have a subscription yet? Get one at [portal.nousresearch.com/manage-subscr
 :::info Codex Note
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
 
-If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add codex-oauth` (or `hermes model` → OpenAI Codex) to start a fresh device-code login; the quarantine clears on the next successful exchange.
+If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add codex-oauth` (or `hermes model` -> OpenAI Codex) to start a fresh device-code login; the quarantine clears on the next successful exchange.
 :::
 
+### OpenAI Codex ACP
+
+`codex-acp` runs Codex through the local `@zed-industries/codex-acp` adapter over ACP stdio. Use it when you want a process-backed Codex agent backend instead of the API-backed OpenAI Codex provider.
+
+```bash
+hermes chat --provider codex-acp --model codex-acp
+```
+
+Hermes uses the bundled `codex-acp` binary from `node_modules/.bin`. Override adapter arguments with `HERMES_CODEX_ACP_ARGS` when needed. Codex ACP subprocesses are reused across turns. When args are not overridden, Hermes enables Codex ACP fast mode and forwards supported `agent.reasoning_effort` values.
+
+Current capability boundary: Hermes sends text-only ACP prompts through this shim. Text chat and Hermes tool-call bridging are supported; native image blocks are not forwarded yet, even though upstream Codex ACP advertises image support. Native video input and OpenAI-style token usage accounting are not supported in this path. Use the API-backed Codex/OpenAI providers when you need native multimodal parity.
+
 :::warning
-Even when using Nous Portal, Codex, or a custom endpoint, some tools (vision, web summarization, MoA) use a separate "auxiliary" model. By default (`auxiliary.*.provider: "auto"`), Hermes routes these tasks to your **main chat model** — the same model you picked in `hermes model`. You can override each task individually to route it to a cheaper/faster model (e.g. Gemini Flash on OpenRouter) — see [Auxiliary Models](/user-guide/configuration#auxiliary-models).
+Even when using Nous Portal, Codex, or a custom endpoint, some tools (vision, web summarization, MoA) use a separate "auxiliary" model. By default (`auxiliary.*.provider: "auto"`), Hermes routes these tasks to your **main chat model** - the same model you picked in `hermes model`. You can override each task individually to route it to a cheaper/faster model (e.g. Gemini Flash on OpenRouter) - see [Auxiliary Models](/user-guide/configuration#auxiliary-models).
 :::
 
 :::tip Nous Tool Gateway
-Paid Nous Portal subscribers also get access to the **[Tool Gateway](/user-guide/features/tool-gateway)** — web search, image generation, TTS, and browser automation routed through your subscription. No extra API keys needed. On a fresh install, `hermes setup --portal` logs you in, sets Nous as your provider, and turns the gateway on in one command. Existing users can enable it from `hermes model` or per-tool from `hermes tools`. Inspect routing at any time with `hermes portal status`.
+Paid Nous Portal subscribers also get access to the **[Tool Gateway](/user-guide/features/tool-gateway)** - web search, image generation, TTS, and browser automation routed through your subscription. No extra API keys needed. On a fresh install, `hermes setup --portal` logs you in, sets Nous as your provider, and turns the gateway on in one command. Existing users can enable it from `hermes model` or per-tool from `hermes tools`. Inspect routing at any time with `hermes portal status`.
 :::
 
 ### Two Commands for Model Management
@@ -98,7 +111,7 @@ Hermes has **two** model commands that serve different purposes:
 
 | Command | Where to run | What it does |
 |---------|-------------|--------------|
-| **`hermes model`** | Your terminal (outside any session) | Full setup wizard — add providers, run OAuth, enter API keys, configure endpoints |
+| **`hermes model`** | Your terminal (outside any session) | Full setup wizard - add providers, run OAuth, enter API keys, configure endpoints |
 | **`/model`** | Inside a Hermes chat session | Quick switch between **already-configured** providers and models |
 
 If you're trying to switch to a provider you haven't set up yet (e.g. you only have OpenRouter configured and want to use Anthropic), you need `hermes model`, not `/model`. Exit your session first (`Ctrl+C` or `/quit`), run `hermes model`, complete the provider setup, then start a new session.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -26,6 +26,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `HERMES_COPILOT_ACP_COMMAND` | Override Copilot ACP CLI binary path (default: `copilot`) |
 | `COPILOT_CLI_PATH` | Alias for `HERMES_COPILOT_ACP_COMMAND` |
 | `HERMES_COPILOT_ACP_ARGS` | Override Copilot ACP arguments (default: `--acp --stdio`) |
+| `HERMES_CODEX_ACP_ARGS` | Override Codex ACP arguments. When unset, Hermes enables fast mode and forwards supported reasoning effort config. |
 | `COPILOT_ACP_BASE_URL` | Override Copilot ACP base URL |
 | `GLM_API_KEY` | z.ai / ZhipuAI GLM API key ([z.ai](https://z.ai)) |
 | `ZAI_API_KEY` | Alias for `GLM_API_KEY` |


### PR DESCRIPTION
## What does this PR do?

Adds a `codex-acp` **model provider** so Hermes can use Codex through the `@zed-industries/codex-acp` adapter over ACP stdio for normal chat/model turns.

Motivation: this provides an alternate Codex model-provider path for users who run into reliability or performance issues with the API-backed Codex/OpenAI route. In local testing, routing through Codex ACP has avoided some of those API-path issues and improved turn reliability, while still letting Hermes use the normal provider selection flow.

This is for selecting Codex ACP as the active Hermes inference provider, similar to selecting `openai-codex`, `copilot`, or another model backend. The implementation reuses the ACP client shim, adds Codex-specific command/argument resolution, registers a bundled model-provider plugin, and wires runtime/provider resolution so `codex-acp` can be selected through the normal Hermes provider flow.

### Codex ACP vs API-backed Codex/OpenAI

This provider is a process-backed ACP bridge for model usage, not a full replacement for the API-backed Codex/OpenAI providers.

What works in this PR:

- Text chat/model turns through the local `codex-acp` subprocess.
- Hermes tool/function-call bridging via prompted `<tool_call>{...}</tool_call>` blocks.
- Subprocess reuse across turns for the Codex ACP model provider.
- Optional argument overrides for local Codex ACP launches.

Current differences from the API-backed path:

- Hermes sends ACP prompts as text-only `session/prompt` content. It does not forward native ACP image blocks yet.
- Upstream Codex ACP advertises image support, but Hermes does not expose that support through this shim in this PR.
- Native video input is not supported.
- Tool calling is prompt-convention based, not first-class API tool-call transport.
- Token usage accounting is stubbed because this shim does not receive OpenAI-style usage data from ACP.
- Richer ACP client features available in clients like Zed are not all exposed; this PR supports the subset Hermes needs for chat/model turns, text streaming, basic filesystem callbacks, and provider selection.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the bundled `codex-acp` model-provider plugin under `plugins/model-providers/codex-acp/`.
- Added `@zed-industries/codex-acp` to npm dependencies.
- Extended `agent/copilot_acp_client.py` for `acp://codex`, Codex ACP defaults, subprocess reuse, and text-only media-boundary documentation.
- Added the optional Codex ACP args override: `HERMES_CODEX_ACP_ARGS`.
- Documented Codex ACP setup and current capability limits in provider/env docs.
- Added/updated tests for ACP client behavior, runtime provider resolution, and agent client construction.

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh tests/agent/test_copilot_acp_client.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_run_agent.py
   ```

2. Verify:

   ```text
   485 tests passed, 0 failed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests:

```text
=== Summary: 3 files, 485 tests passed, 0 failed (100% complete) in 70.6s (8 workers) ===
```

