### PR TITLE
feat: add common code/text file extensions to MEDIA: tag support

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|py|js|ts|sh|yaml|yml|toml|md|html?|css|json|xml|sql|rb|go|rs|java|c|cpp|h)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## What

Added 20 new file extensions to the `media_pattern` regex in `BasePlatformAdapter.extract_media()`.

## Extensions Added

**Code:** py, js, ts, sh, rb, go, rs, java, c, cpp, h
**Config/Data:** yaml, yml, toml, json, xml, sql
**Markup:** md, html, htm, css

## Why

Previously only media/document formats were supported (png, jpg, pdf, zip, docx, etc.). Users often want to send code snippets, config files, and scripts via messaging platforms. Now they can use `MEDIA:/path/to/file.py` to send these files natively.

## Testing

Verified on WeChat (weixin platform) — .py file was successfully delivered as a native file attachment.