### PR TITLE
fix(context): per-model context_length override wins over global default

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1437,7 +1437,9 @@ def get_model_context_length(
     """Get the context length for a model.
 
     Resolution order:
-    0. Explicit config override (model.context_length or custom_providers per-model)
+    0a. custom_providers per-model override (most specific — wins over the
+        global ``model.context_length`` default which applies to *all* models).
+    0b. Explicit global config override (``model.context_length``)
     1. Persistent cache (previously discovered via probing).  Nous URLs
        bypass the cache here so step 5b can always reconcile against
        the authoritative portal /v1/models response.
@@ -1458,14 +1460,11 @@ def get_model_context_length(
     7. Hardcoded defaults (broad family patterns, longest-key-first)
     8. Local server query (last resort)
     9. Default fallback (256K)"""
-    # 0. Explicit config override — user knows best
-    if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
-        return config_context_length
-
-    # 0b. custom_providers per-model override — check before any probe.
-    # This closes the gap where /model switch and display paths used to fall
-    # back to 128K despite the user having a per-model context_length set.
-    # See #15779.
+    # 0a. custom_providers per-model override — most specific signal, wins over
+    # the global ``model.context_length`` default which applies to *all* models.
+    # Without this precedence, a user who sets ``model.context_length: 200000``
+    # for an Anthropic daily-driver would see /model display 200K for their
+    # local Ollama models too, even with an explicit per-model 64K override.
     if custom_providers and base_url and model:
         try:
             from hermes_cli.config import get_custom_provider_context_length
@@ -1477,7 +1476,11 @@ def get_model_context_length(
             if cp_ctx:
                 return cp_ctx
         except Exception:
-            pass  # fall through to probing
+            pass
+
+    # 0b. Explicit global config override — user knows best (model.context_length)
+    if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
+        return config_context_length
 
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -183,27 +183,32 @@ class TestGetModelContextLengthHonorsOverride:
                 p.stop()
         assert ctx == 1_050_000
 
-    def test_explicit_config_context_length_still_wins(self):
-        """Top-level model.context_length (step 0) outranks custom_providers (step 0b).
+    def test_per_model_override_wins_over_global_config_default(self):
+        """Per-model custom_providers override (step 0a) outranks the
+        top-level ``model.context_length`` default (step 0b).
 
-        Users who set both should see the top-level value — that's the
-        documented precedence and matches the long-standing step-0 behavior.
+        Rationale: ``model.context_length`` is a *global* default that applies
+        to every model; ``custom_providers[].models.<id>.context_length`` is
+        explicitly per-model and therefore strictly more specific. Without
+        this precedence, a user who sets a high global default for their
+        cloud daily-driver would see the wrong number for a local Ollama
+        model with a baked-in lower ``num_ctx``.
         """
         from agent.model_metadata import get_model_context_length
         custom = [
             {
                 "base_url": "https://example.invalid/v1",
-                "models": {"m": {"context_length": 1_050_000}},
+                "models": {"m": {"context_length": 65_536}},
             }
         ]
         ctx = get_model_context_length(
             "m",
             base_url="https://example.invalid/v1",
             provider="custom",
-            config_context_length=500_000,  # explicit top-level wins
+            config_context_length=200_000,  # global default, less specific
             custom_providers=custom,
         )
-        assert ctx == 500_000
+        assert ctx == 65_536
 
     def test_no_override_falls_through_to_default(self):
         """With custom_providers=None and all probes disabled, resolver


### PR DESCRIPTION
## Problem

`agent/model_metadata.get_model_context_length()` checks the global `model.context_length` config **before** the per-model `custom_providers[].models.<id>.context_length` override.

**User-visible bug:** Set `model.context_length: 200000` for your Anthropic daily-driver, configure a local Ollama model with a baked-in 64K `num_ctx` and an explicit per-model override:

```yaml
model:
  context_length: 200000        # for Opus / Sonnet
providers:
  ollama:
    base_url: http://localhost:11434/v1
    models:
      gemma4:26b-a4b-it-q4_K_M-64k:
        context_length: 65536   # explicit per-model
```

`/model gemma` displays **200K** instead of 64K. The global default leaks through and shadows the explicit per-model override.

## Fix

Swap the precedence — the per-model override is strictly more specific than the global default, so it should win:

- **0a.** `custom_providers` per-model override (most specific)
- **0b.** Global `model.context_length` (broad default)

All other resolution steps unchanged.

## Tests

Updated `tests/hermes_cli/test_custom_provider_context_length.py`:
- Renamed `test_explicit_config_context_length_still_wins` →  `test_per_model_override_wins_over_global_config_default` to assert the new (correct) precedence.
- All 12 tests pass.

## Verification

Reproduced and confirmed fix locally on macOS with Ollama:

```
Before: /model gemma → 200K context (wrong)
After:  /model gemma → 64K context  (correct)
```