### PR TITLE
fix(constants): guard against double-nested .hermes path in Docker (#33913)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, _is_hermes_config
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -541,6 +541,17 @@ def run_doctor(args):
             check_warn(name, "(optional, not installed)")
     
     _section("Configuration Files")
+
+    # Check for double-nested HERMES_HOME (#33913)
+    if HERMES_HOME.name == ".hermes" and _is_hermes_config(HERMES_HOME.parent / "config.yaml"):
+        check_warn(
+            "Double-nested Hermes home detected",
+            f"{HERMES_HOME} — parent {HERMES_HOME.parent} already has config.yaml",
+        )
+        issues.append(
+            f"Set HERMES_HOME={HERMES_HOME.parent} instead of {HERMES_HOME}"
+        )
+
     # Check ~/.hermes/.env (primary location for user config)
     env_path = HERMES_HOME / '.env'
     if env_path.exists():

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -604,6 +604,22 @@ def _print_setup_summary(config: dict, hermes_home):
     )
     print()
 
+    # Warn if wizard path differs from what the runtime will use (#33913)
+    # get_hermes_home() is safe here — its stderr warnings are once-cached.
+    from hermes_constants import get_hermes_home as _ghh
+    _runtime_home = _ghh()
+    _config_parent = get_config_path().parent
+    if _config_parent != _runtime_home:
+        print(
+            color(
+                f"   ⚠️  WARNING: Setup wrote to {_config_parent}\n"
+                f"      but runtime will read from {_runtime_home}\n"
+                f"      Fix: export HERMES_HOME={_config_parent}",
+                Colors.RED,
+            )
+        )
+        print()
+
     print(color("─" * 60, Colors.DIM))
     print()
     print(color("📝 To edit your configuration:", Colors.CYAN, Colors.BOLD))

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -40,6 +40,31 @@ def get_hermes_home_override() -> str | None:
     return str(override)
 
 
+def _is_hermes_config(path: "Path") -> bool:
+    """Check if a config.yaml looks like a Hermes config (not Ansible, Helm, etc.).
+
+    Hermes configs always have a top-level ``model:`` key with nested
+    ``default:`` or ``provider:``.  Checking for ``model:`` alone is
+    insufficient — we also require either ``terminal:`` or ``gateway:``
+    to avoid false-positives with other ML tools.
+    """
+    import re
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")[:2048]
+    except OSError:
+        return False
+    # Fast heuristic: look for distinctive top-level keys (anchored to start-of-line)
+    has_model = bool(re.search(r"^model:", text, re.MULTILINE))
+    has_hermes_specific = bool(re.search(r"^(terminal|gateway|skills):", text, re.MULTILINE))
+    return has_model and has_hermes_specific
+
+
+# Module-level cache for the Docker guard correction
+_docker_guard_checked: bool = False
+_docker_home_override: "Path | None" = None
+_explicit_hh_warned: bool = False
+
+
 def get_hermes_home() -> Path:
     """Return the Hermes home directory (default: ~/.hermes).
 
@@ -62,7 +87,24 @@ def get_hermes_home() -> Path:
 
     val = os.environ.get("HERMES_HOME", "").strip()
     if val:
-        return Path(val)
+        resolved = Path(val)
+        # Warn once if HERMES_HOME points to a double-nested .hermes path
+        # (e.g. HERMES_HOME=/opt/data/.hermes when /opt/data has a Hermes config)
+        global _explicit_hh_warned
+        if not _explicit_hh_warned and resolved.name == ".hermes" and _is_hermes_config(resolved.parent / "config.yaml"):
+            _explicit_hh_warned = True
+            import sys
+            msg = (
+                f"[HERMES_HOME warning] HERMES_HOME={val} looks double-nested — "
+                f"{resolved.parent} already contains a Hermes config. "
+                f"Did you mean HERMES_HOME={resolved.parent}?"
+            )
+            try:
+                sys.stderr.write(msg + "\n")
+                sys.stderr.flush()
+            except Exception:
+                pass
+        return resolved
 
     # Guard: if a non-default profile is sticky-active, warn once that
     # the fallback to the default profile is almost certainly wrong.
@@ -98,7 +140,35 @@ def get_hermes_home() -> Path:
             except Exception:
                 pass
 
-    return Path.home() / ".hermes"
+    default_path = Path.home() / ".hermes"
+
+    # Guard: if the fallback would produce a double-nested .hermes path
+    # (e.g. /opt/data/.hermes when HOME=/opt/data in Docker), detect it.
+    # This happens when the user's home directory already IS a Hermes home
+    # (contains a Hermes config) — appending .hermes would be wrong.
+    global _docker_guard_checked, _docker_home_override
+    if _docker_home_override is not None:
+        return _docker_home_override
+    if not _docker_guard_checked:
+        _docker_guard_checked = True
+        parent = Path.home()
+        if _is_hermes_config(parent / "config.yaml"):
+            _docker_home_override = parent
+            import sys
+            msg = (
+                f"[HERMES_HOME guard] ~/.hermes resolves to {default_path}, but "
+                f"{parent} already contains a Hermes config — this looks like a "
+                f"double-nested Hermes home. Using {parent} instead. "
+                f"Set HERMES_HOME={parent} explicitly to silence this warning."
+            )
+            try:
+                sys.stderr.write(msg + "\n")
+                sys.stderr.flush()
+            except Exception:
+                pass
+            return parent
+
+    return default_path
 
 
 def get_default_hermes_root() -> Path:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -174,6 +174,128 @@ class TestParseReasoningEffort:
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
 
 
+class TestDoubleNestingGuard:
+    """Tests for double-.hermes path guard (#33913)."""
+
+    # Minimal content that _is_hermes_config() recognizes
+    _HERMES_CONFIG = "model:\n  default: test\n  provider: custom\nterminal:\n  backend: local\n"
+
+    def test_fallback_no_double_nesting_when_parent_has_hermes_config(self, tmp_path, monkeypatch):
+        """When HOME contains a Hermes config, fallback returns HOME, not HOME/.hermes."""
+        fake_home = tmp_path / "opt" / "data"
+        fake_home.mkdir(parents=True)
+        (fake_home / "config.yaml").write_text(self._HERMES_CONFIG)
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        from hermes_constants import set_hermes_home_override, get_hermes_home
+        import hermes_constants
+        hermes_constants._docker_guard_checked = False
+        hermes_constants._docker_home_override = None
+        set_hermes_home_override(None)
+
+        result = get_hermes_home()
+        assert result == fake_home, f"Expected {fake_home}, got {result}"
+        assert result.name != ".hermes"
+
+    def test_fallback_normal_when_parent_has_no_config(self, tmp_path, monkeypatch):
+        """When HOME has no config.yaml, fallback returns HOME/.hermes as usual."""
+        fake_home = tmp_path / "home" / "user"
+        fake_home.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        from hermes_constants import set_hermes_home_override, get_hermes_home
+        import hermes_constants
+        hermes_constants._docker_guard_checked = False
+        hermes_constants._docker_home_override = None
+        set_hermes_home_override(None)
+
+        result = get_hermes_home()
+        assert result == fake_home / ".hermes"
+
+    def test_fallback_ignores_non_hermes_config(self, tmp_path, monkeypatch):
+        """When HOME has a config.yaml from another tool (Ansible, Helm), guard does NOT fire."""
+        fake_home = tmp_path / "home" / "user"
+        fake_home.mkdir(parents=True)
+        # Non-Hermes config — no model:/terminal:/gateway: keys
+        (fake_home / "config.yaml").write_text("inventory:\n  hosts:\n    - localhost\n")
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        from hermes_constants import set_hermes_home_override, get_hermes_home
+        import hermes_constants
+        hermes_constants._docker_guard_checked = False
+        hermes_constants._docker_home_override = None
+        set_hermes_home_override(None)
+
+        result = get_hermes_home()
+        # Should return the normal fallback, not the parent
+        assert result == fake_home / ".hermes"
+
+    def test_explicit_hermes_home_warns_on_double_nesting(self, tmp_path, monkeypatch, capsys):
+        """When HERMES_HOME=/opt/data/.hermes and parent has Hermes config, warn."""
+        nested = tmp_path / "opt" / "data" / ".hermes"
+        nested.mkdir(parents=True)
+        (nested.parent / "config.yaml").write_text(self._HERMES_CONFIG)
+
+        monkeypatch.setenv("HERMES_HOME", str(nested))
+
+        from hermes_constants import set_hermes_home_override, get_hermes_home
+        import hermes_constants
+        hermes_constants._explicit_hh_warned = False
+        set_hermes_home_override(None)
+
+        result = get_hermes_home()
+        assert result == nested  # Still returns the explicit value
+        captured = capsys.readouterr()
+        assert "did you mean" in captured.err.lower()
+
+    def test_explicit_hermes_home_no_warning_when_clean(self, tmp_path, monkeypatch, capsys):
+        """When HERMES_HOME=/opt/data (clean), no warning."""
+        clean = tmp_path / "opt" / "data"
+        clean.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(clean))
+
+        from hermes_constants import set_hermes_home_override, get_hermes_home
+        import hermes_constants
+        hermes_constants._explicit_hh_warned = False
+        set_hermes_home_override(None)
+
+        result = get_hermes_home()
+        assert result == clean
+        captured = capsys.readouterr()
+        assert "double-nested" not in captured.err.lower()
+
+    def test_guard_warns_only_once_and_returns_consistent_path(self, tmp_path, monkeypatch, capsys):
+        """Guard caches and only warns once per process. Return value is consistent."""
+        fake_home = tmp_path / "opt" / "data"
+        fake_home.mkdir(parents=True)
+        (fake_home / "config.yaml").write_text(self._HERMES_CONFIG)
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        from hermes_constants import set_hermes_home_override, get_hermes_home
+        import hermes_constants
+        hermes_constants._docker_guard_checked = False
+        hermes_constants._docker_home_override = None
+        set_hermes_home_override(None)
+
+        first_result = get_hermes_home()
+        first_err = capsys.readouterr().err
+        second_result = get_hermes_home()
+        second_err = capsys.readouterr().err
+
+        assert "guard" in first_err.lower()
+        assert second_err == ""  # No second warning
+        assert first_result == second_result == fake_home  # Consistent path
+
+
 class TestSecureParentDir:
     """Tests for secure_parent_dir() — prevents chmod on / or top-level dirs."""
 


### PR DESCRIPTION
## What does this PR do?

Guards against a double-nested `.hermes` path in Docker environments where `HERMES_HOME` is misconfigured or unset. When the user's home directory (e.g. `/opt/data`) already contains a Hermes config, the fallback `Path.home() / ".hermes"` would produce `/opt/data/.hermes` — a path the runtime never reads. This caused the setup wizard to write config to one location while the runtime read from another.

Adds `_is_hermes_config()` — a lightweight validator that checks for Hermes-specific top-level keys (`model:`, `terminal:`, `gateway:`, `skills:`) before triggering the guard. This prevents false positives from non-Hermes `config.yaml` files (Ansible, Helm, Go apps, etc.) in the user's home directory.

## Related Issue

Fixes #33913

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py` — Added `_is_hermes_config()` validator with regex-anchored top-level key detection. Fallback path in `get_hermes_home()` now returns `HOME` instead of `HOME/.hermes` when the home directory already contains a Hermes config. Explicit `HERMES_HOME` values ending in `/.hermes` emit a one-shot warning when the parent has a Hermes config. Both branches use module-level caching (`_docker_home_override`, `_explicit_hh_warned`) to avoid repeated work.
- `hermes_cli/doctor.py` — Added diagnostic check in "Configuration Files" section that detects double-nested `HERMES_HOME` using `_is_hermes_config()`.
- `hermes_cli/setup.py` — Added path mismatch warning in the setup summary when the wizard's config path differs from what the runtime will resolve.
- `tests/test_hermes_constants.py` — Added 6 tests covering: fallback with Hermes config in HOME, normal fallback, non-Hermes config ignored, explicit double-nested warning, clean explicit path, and once-caching with return value consistency.

## How to Test

1. Simulate Docker: `HOME=/opt/data HERMES_HOME= python -c "from hermes_constants import get_hermes_home; print(get_hermes_home())"` — should return `/opt/data`, not `/opt/data/.hermes`
2. With non-Hermes config: place a non-Hermes `config.yaml` in `$HOME` — guard should NOT fire
3. Run tests: `pytest tests/test_hermes_constants.py::TestDoubleNestingGuard -v` — all 6 should pass
4. Run `hermes doctor` in a Docker container with `HERMES_HOME=/opt/data/.hermes` — should warn about double-nesting

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.17.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
