### PR TITLE
feat(discord): interactive buttons on cron reminders

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3,6 +3,22 @@ Cron job storage and management.
 
 Jobs are stored in ~/.hermes/cron/jobs.json
 Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
+
+Discord reminder buttons sentinel
+---------------------------------
+Cron prompts that should produce interactive Discord reminder buttons must
+instruct the agent to emit a sentinel block of the form::
+
+    <<<REMINDER_BUTTONS reminder_id="abc123" text_b64="<base64 of reminder text>">>>
+    ✅ Done | ⏰ +15min | ⏰ +1h | ⏰ Tomorrow 9am
+    <<</REMINDER_BUTTONS>>>
+
+The Discord adapter strips this block from the displayed text and attaches a
+four-button view ( done / +15min / +1h / Tomorrow 9am ).  Snooze buttons
+create a new cron job here via :func:`create_job` that re-delivers the same
+reminder text after the chosen delay.  See
+``plugins/platforms/discord/reminder_buttons.py`` for the full implementation
+and persistence layout under ``~/.hermes/reminders/``.
 """
 
 import copy

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -710,6 +710,24 @@ class DiscordAdapter(BasePlatformAdapter):
                 await adapter_self._resolve_allowed_usernames()
                 adapter_self._ready_event.set()
 
+                # Re-register persistent reminder-button views so reminders
+                # delivered before the last restart still respond to clicks.
+                try:
+                    from plugins.platforms.discord.reminder_buttons import (
+                        register_persistent_views as _register_reminder_views,
+                    )
+                    count = _register_reminder_views(adapter_self._client)
+                    if count:
+                        logger.info(
+                            "[%s] Restored %d reminder-button view(s)",
+                            adapter_self.name, count,
+                        )
+                except Exception:
+                    logger.debug(
+                        "[%s] Failed to restore reminder-button views",
+                        adapter_self.name, exc_info=True,
+                    )
+
                 if adapter_self._post_connect_task and not adapter_self._post_connect_task.done():
                     adapter_self._post_connect_task.cancel()
                 adapter_self._post_connect_task = asyncio.create_task(
@@ -1411,6 +1429,21 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._is_forum_parent(channel):
                 return await self._send_to_forum(channel, content)
 
+            # Extract reminder-button sentinel BEFORE chunking so the cleaned
+            # text gets formatted/split normally and the buttons attach to the
+            # final chunk only.
+            from plugins.platforms.discord.reminder_buttons import (
+                extract as _extract_reminder_buttons,
+            )
+            reminder_origin = {
+                "platform": "discord",
+                "chat_id": str(chat_id),
+                "thread_id": str(thread_id) if thread_id else None,
+            }
+            content, reminder_view = _extract_reminder_buttons(
+                content, origin=reminder_origin,
+            )
+
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -1433,11 +1466,16 @@ class DiscordAdapter(BasePlatformAdapter):
                     chunk_reference = reference
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
+                # Attach the reminder-button view to the FINAL chunk only —
+                # the buttons live on the message that ends the reminder.
+                send_kwargs: Dict[str, Any] = {
+                    "content": chunk,
+                    "reference": chunk_reference,
+                }
+                if reminder_view is not None and i == len(chunks) - 1:
+                    send_kwargs["view"] = reminder_view
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -1456,10 +1494,9 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        retry_kwargs = dict(send_kwargs)
+                        retry_kwargs["reference"] = None
+                        msg = await channel.send(**retry_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))

--- a/plugins/platforms/discord/reminder_buttons.py
+++ b/plugins/platforms/discord/reminder_buttons.py
@@ -1,0 +1,491 @@
+"""
+Discord reminder-button view + persistence + sentinel parsing.
+
+When a cron reminder's outbound text contains a sentinel block::
+
+    <<<REMINDER_BUTTONS reminder_id="abc123" text_b64="<b64 of reminder text>">>>
+    ✅ Done | ⏰ +15min | ⏰ +1h | ⏰ Tomorrow 9am
+    <<</REMINDER_BUTTONS>>>
+
+the Discord adapter calls :func:`extract` to (a) strip the block from the
+displayed message and (b) attach a :class:`ReminderButtonsView` carrying
+four persistent buttons.  The base64-encoded reminder text is also written
+to ``~/.hermes/reminders/{reminder_id}.json`` so button callbacks (including
+those that fire after the bot restarts) can re-deliver the same reminder
+text on snooze.
+
+Discord caps button ``custom_id`` at 100 chars, so the reminder text cannot
+ride on the custom_id itself — that's why we persist a per-reminder JSON
+file keyed by ``reminder_id`` alongside the platform-agnostic Hermes home.
+
+Buttons
+-------
+* **Done** — edits the message ("✓ done"), disables all buttons,
+  removes the persisted JSON, and reacts ✅.
+* **+15min** / **+1h** — schedules a new cron job firing after the chosen
+  delay that re-delivers the same reminder text (with a fresh sentinel
+  block).  Edits the message and disables the buttons.
+* **Tomorrow 9am** — schedules a cron job to fire at the next 09:00 in
+  ``Europe/Oslo`` (today's 9am if not yet past; otherwise tomorrow's).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from zoneinfo import ZoneInfo
+
+from hermes_constants import get_hermes_home
+
+try:
+    import discord  # type: ignore
+    DISCORD_AVAILABLE = True
+except ImportError:  # pragma: no cover - lazy install path covered elsewhere
+    DISCORD_AVAILABLE = False
+    discord = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel parsing
+# ---------------------------------------------------------------------------
+
+# Reminder ids are short hex/url-safe slugs.  Restrict to what we generate
+# (and what cleanly fits inside the 100-char Discord custom_id cap with the
+# `reminder:` prefix and `:tomorrow9` suffix).
+_ID_PATTERN = r"[A-Za-z0-9_-]{1,40}"
+
+_SENTINEL_RE = re.compile(
+    r"<<<REMINDER_BUTTONS\s+"
+    r'reminder_id="(?P<reminder_id>' + _ID_PATTERN + r')"\s+'
+    r'text_b64="(?P<text_b64>[A-Za-z0-9+/=_-]+)"\s*>>>'
+    r".*?<<</REMINDER_BUTTONS>>>",
+    re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+def _reminders_dir() -> Path:
+    base = Path(get_hermes_home()) / "reminders"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _sanitize_id(reminder_id: str) -> str:
+    if not reminder_id or not re.fullmatch(_ID_PATTERN, reminder_id):
+        raise ValueError(f"Invalid reminder id: {reminder_id!r}")
+    return reminder_id
+
+
+def _reminder_path(reminder_id: str) -> Path:
+    return _reminders_dir() / f"{_sanitize_id(reminder_id)}.json"
+
+
+def save_reminder(
+    reminder_id: str,
+    text: str,
+    *,
+    origin: Optional[Dict[str, Any]] = None,
+    deliver: str = "origin",
+) -> Path:
+    """Persist a reminder's text + delivery target so buttons survive restart."""
+    path = _reminder_path(reminder_id)
+    payload = {
+        "reminder_id": reminder_id,
+        "text": text,
+        "origin": origin,
+        "deliver": deliver,
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def load_reminder(reminder_id: str) -> Optional[Dict[str, Any]]:
+    """Return persisted reminder state, or None when the file is missing/corrupt."""
+    try:
+        path = _reminder_path(reminder_id)
+    except ValueError:
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        logger.warning("Failed to load reminder %s", reminder_id, exc_info=True)
+        return None
+
+
+def delete_reminder(reminder_id: str) -> bool:
+    """Remove the persisted JSON for a reminder.  Returns True on delete."""
+    try:
+        path = _reminder_path(reminder_id)
+    except ValueError:
+        return False
+    try:
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        logger.warning("Failed to delete reminder %s", reminder_id, exc_info=True)
+        return False
+
+
+def list_active_reminder_ids() -> list[str]:
+    """Return ids of all reminders currently persisted on disk."""
+    try:
+        return sorted(p.stem for p in _reminders_dir().glob("*.json"))
+    except OSError:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Snooze scheduling
+# ---------------------------------------------------------------------------
+
+OSLO_TZ = ZoneInfo("Europe/Oslo")
+
+
+def _new_reminder_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def _build_sentinel_block(reminder_id: str, text: str) -> str:
+    text_b64 = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    return (
+        f'<<<REMINDER_BUTTONS reminder_id="{reminder_id}" text_b64="{text_b64}">>>\n'
+        "✅ Done | ⏰ +15min | ⏰ +1h | ⏰ Tomorrow 9am\n"
+        "<<</REMINDER_BUTTONS>>>"
+    )
+
+
+_SNOOZE_PROMPT_TEMPLATE = (
+    "This is an automatic re-fire of a snoozed reminder.\n\n"
+    "Send the user this reminder verbatim:\n\n"
+    "{text}\n\n"
+    "End your reply with EXACTLY the following block, on its own lines, with\n"
+    "no modifications:\n\n"
+    "{sentinel}\n"
+)
+
+
+def _next_tomorrow_9am(now: Optional[datetime] = None) -> datetime:
+    """Return the next 09:00 Europe/Oslo.
+
+    Today's 9am when it hasn't passed yet; otherwise tomorrow's 9am.
+    """
+    current = now.astimezone(OSLO_TZ) if now else datetime.now(OSLO_TZ)
+    target = current.replace(hour=9, minute=0, second=0, microsecond=0)
+    if target <= current:
+        target = target + timedelta(days=1)
+    return target
+
+
+def schedule_snooze(
+    reminder_id: str,
+    *,
+    delay_minutes: Optional[int] = None,
+    run_at: Optional[datetime] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create a fresh cron job that re-delivers the reminder later.
+
+    Returns the new cron job dict, or None when the persisted reminder is
+    missing.  Exactly one of ``delay_minutes`` / ``run_at`` must be set.
+    """
+    record = load_reminder(reminder_id)
+    if not record or not record.get("text"):
+        logger.warning(
+            "schedule_snooze: no persisted state for reminder %s", reminder_id,
+        )
+        return None
+
+    new_id = _new_reminder_id()
+    text = record["text"]
+    sentinel = _build_sentinel_block(new_id, text)
+    prompt = _SNOOZE_PROMPT_TEMPLATE.format(text=text, sentinel=sentinel)
+
+    if run_at is not None:
+        schedule = run_at.isoformat()
+    elif delay_minutes is not None:
+        schedule = f"{int(delay_minutes)}m"
+    else:
+        raise ValueError("schedule_snooze requires delay_minutes or run_at")
+
+    # Persist the new reminder state up-front so the snooze chain works even
+    # if the cron run starts before extract() re-saves it from its own
+    # outbound text.
+    save_reminder(
+        new_id,
+        text,
+        origin=record.get("origin"),
+        deliver=record.get("deliver") or "origin",
+    )
+
+    # Imported lazily — cron has its own heavy imports we don't want at
+    # adapter-load time.
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt=prompt,
+        schedule=schedule,
+        name=f"reminder snooze {new_id}",
+        repeat=1,
+        deliver=record.get("deliver") or "origin",
+        origin=record.get("origin"),
+    )
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Sentinel extraction + view construction
+# ---------------------------------------------------------------------------
+
+def extract(
+    text: str,
+    *,
+    origin: Optional[Dict[str, Any]] = None,
+    deliver: str = "origin",
+) -> Tuple[str, Optional[Any]]:
+    """Strip the sentinel block from ``text`` and return a button view.
+
+    Returns ``(cleaned_text, view_or_None)``.  When a sentinel is found:
+      · the block is removed from the displayed text,
+      · the (base64-decoded) reminder text + origin is persisted to
+        ``~/.hermes/reminders/{id}.json`` so buttons survive bot restart,
+      · a :class:`ReminderButtonsView` is returned, ready to be passed as
+        ``view=`` to ``channel.send``.
+
+    When ``discord`` is not installed (or no sentinel is present), returns
+    the original text and ``None``.
+    """
+    if not text:
+        return text, None
+    match = _SENTINEL_RE.search(text)
+    if not match:
+        return text, None
+    if not DISCORD_AVAILABLE:
+        # Strip the sentinel even when we can't attach buttons — the
+        # raw block would otherwise leak into the user's display.
+        cleaned = (text[: match.start()] + text[match.end():]).strip()
+        return cleaned, None
+
+    reminder_id = match.group("reminder_id")
+    text_b64 = match.group("text_b64")
+    try:
+        reminder_text = base64.b64decode(text_b64).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        logger.warning(
+            "extract: bad text_b64 for reminder %s — leaving sentinel in place",
+            reminder_id,
+            exc_info=True,
+        )
+        return text, None
+
+    try:
+        save_reminder(
+            reminder_id, reminder_text, origin=origin, deliver=deliver,
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.warning(
+            "extract: failed to persist reminder %s",
+            reminder_id,
+            exc_info=True,
+        )
+
+    cleaned = (text[: match.start()] + text[match.end():]).strip()
+    return cleaned, ReminderButtonsView(reminder_id)
+
+
+# ---------------------------------------------------------------------------
+# View class
+# ---------------------------------------------------------------------------
+
+if DISCORD_AVAILABLE:
+    _ACTION_LABELS = {
+        "done": "✅ Done",
+        "snooze15": "⏰ +15min",
+        "snooze60": "⏰ +1h",
+        "tomorrow9": "⏰ Tomorrow 9am",
+    }
+    _ACTIONS = ("done", "snooze15", "snooze60", "tomorrow9")
+
+    class ReminderButtonsView(discord.ui.View):
+        """Four-button view attached to cron reminder messages.
+
+        Persistence: ``timeout=None`` plus stable ``custom_id``s on every
+        child make this a persistent view in discord.py terms.  The adapter
+        re-registers one view per active ``~/.hermes/reminders/*.json`` on
+        bot startup via :func:`register_persistent_views`, so button
+        callbacks fire correctly after the bot has restarted.
+        """
+
+        def __init__(self, reminder_id: str):
+            super().__init__(timeout=None)
+            self.reminder_id = _sanitize_id(reminder_id)
+            for action in _ACTIONS:
+                self._add_button(action)
+
+        def _add_button(self, action: str) -> None:
+            label = _ACTION_LABELS[action]
+            style = (
+                discord.ButtonStyle.success if action == "done"
+                else discord.ButtonStyle.secondary
+            )
+            btn = discord.ui.Button(
+                label=label,
+                style=style,
+                custom_id=f"reminder:{self.reminder_id}:{action}",
+            )
+            btn.callback = self._make_callback(action)
+            self.add_item(btn)
+
+        def _make_callback(self, action: str):
+            async def _callback(interaction: "discord.Interaction") -> None:
+                await self._dispatch(interaction, action)
+            return _callback
+
+        def _disable_buttons(self) -> None:
+            for child in self.children:
+                child.disabled = True
+
+        async def _dispatch(
+            self, interaction: "discord.Interaction", action: str,
+        ) -> None:
+            if action == "done":
+                await self._on_done(interaction)
+            elif action == "snooze15":
+                await self._on_snooze(interaction, delay_minutes=15, label="+15min")
+            elif action == "snooze60":
+                await self._on_snooze(interaction, delay_minutes=60, label="+1h")
+            elif action == "tomorrow9":
+                await self._on_tomorrow9(interaction)
+            else:  # pragma: no cover - defensive
+                logger.warning("Unknown reminder action: %s", action)
+
+        async def _edit_with_suffix(
+            self,
+            interaction: "discord.Interaction",
+            suffix: str,
+        ) -> None:
+            self._disable_buttons()
+            message = getattr(interaction, "message", None)
+            new_content: Optional[str] = None
+            if message is not None:
+                existing = getattr(message, "content", "") or ""
+                new_content = f"{existing}\n\n{suffix}" if existing else suffix
+            try:
+                if new_content is None:
+                    await interaction.response.edit_message(view=self)
+                else:
+                    await interaction.response.edit_message(
+                        content=new_content, view=self,
+                    )
+            except Exception:
+                logger.debug(
+                    "Reminder edit_message failed (rid=%s)",
+                    self.reminder_id,
+                    exc_info=True,
+                )
+                try:
+                    await interaction.response.defer()
+                except Exception:
+                    pass
+
+        async def _on_done(self, interaction: "discord.Interaction") -> None:
+            await self._edit_with_suffix(interaction, "✓ done")
+            delete_reminder(self.reminder_id)
+            message = getattr(interaction, "message", None)
+            if message is not None and hasattr(message, "add_reaction"):
+                try:
+                    await message.add_reaction("✅")
+                except Exception:
+                    logger.debug(
+                        "Reminder add_reaction failed (rid=%s)",
+                        self.reminder_id,
+                        exc_info=True,
+                    )
+
+        async def _on_snooze(
+            self,
+            interaction: "discord.Interaction",
+            *,
+            delay_minutes: int,
+            label: str,
+        ) -> None:
+            job = None
+            try:
+                job = schedule_snooze(
+                    self.reminder_id, delay_minutes=delay_minutes,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Reminder snooze failed (rid=%s, +%dm): %s",
+                    self.reminder_id, delay_minutes, exc, exc_info=True,
+                )
+            if job is None:
+                await self._edit_with_suffix(
+                    interaction,
+                    f"⚠ couldn't snooze ({label}) — reminder state not found",
+                )
+                return
+            await self._edit_with_suffix(interaction, f"⏰ snoozed {label}")
+
+        async def _on_tomorrow9(
+            self, interaction: "discord.Interaction",
+        ) -> None:
+            target = _next_tomorrow_9am()
+            job = None
+            try:
+                job = schedule_snooze(self.reminder_id, run_at=target)
+            except Exception as exc:
+                logger.error(
+                    "Reminder tomorrow-9 snooze failed (rid=%s): %s",
+                    self.reminder_id, exc, exc_info=True,
+                )
+            if job is None:
+                await self._edit_with_suffix(
+                    interaction,
+                    "⚠ couldn't snooze (Tomorrow 9am) — reminder state not found",
+                )
+                return
+            stamp = target.strftime("%Y-%m-%d %H:%M %Z")
+            await self._edit_with_suffix(
+                interaction, f"⏰ snoozed → {stamp}",
+            )
+
+else:  # pragma: no cover - shim when discord isn't installed
+    class ReminderButtonsView:  # type: ignore[no-redef]
+        def __init__(self, reminder_id: str):
+            self.reminder_id = reminder_id
+
+
+def register_persistent_views(bot: Any) -> int:
+    """Re-register one persistent view per active reminder on bot startup.
+
+    Returns the number of views registered.  Safe to call multiple times —
+    discord.py de-duplicates by custom_id.
+    """
+    if not DISCORD_AVAILABLE or bot is None or not hasattr(bot, "add_view"):
+        return 0
+    count = 0
+    for reminder_id in list_active_reminder_ids():
+        try:
+            bot.add_view(ReminderButtonsView(reminder_id))
+            count += 1
+        except Exception:
+            logger.debug(
+                "register_persistent_views: failed for %s",
+                reminder_id,
+                exc_info=True,
+            )
+    return count

--- a/tests/gateway/test_discord_reminder_buttons.py
+++ b/tests/gateway/test_discord_reminder_buttons.py
@@ -1,0 +1,480 @@
+"""Tests for the Discord reminder-buttons sentinel extractor + view.
+
+Covers:
+
+  * :func:`extract` — sentinel parsing, base64 decoding, persistence, and
+    cleaned-text output.
+  * :class:`ReminderButtonsView` — button custom_ids, done/snooze/tomorrow9
+    callbacks, and the message-edit + add_reaction side-effects.
+  * :func:`schedule_snooze` — cron job creation via ``cron.jobs.create_job``.
+  * :func:`register_persistent_views` — view re-registration on bot startup.
+
+Discord is mocked via the shared :mod:`tests.gateway.conftest` fixtures.
+``cron.jobs.create_job`` is patched per-test so we don't write real cron
+jobs to ``~/.hermes/cron/jobs.json``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+# Repo root importable
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+# Trigger the shared discord mock from tests/gateway/conftest.py before
+# importing the production modules.
+from plugins.platforms.discord import reminder_buttons as rb  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.reminder_buttons import (  # noqa: E402
+    ReminderButtonsView,
+    delete_reminder,
+    extract,
+    list_active_reminder_ids,
+    load_reminder,
+    register_persistent_views,
+    save_reminder,
+    schedule_snooze,
+    _next_tomorrow_9am,
+)
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+OSLO = ZoneInfo("Europe/Oslo")
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a tmp dir so persistence stays test-local."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _b64(text: str) -> str:
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _sentinel_block(reminder_id: str, text: str) -> str:
+    return (
+        f'<<<REMINDER_BUTTONS reminder_id="{reminder_id}" text_b64="{_b64(text)}">>>\n'
+        "✅ Done | ⏰ +15min | ⏰ +1h | ⏰ Tomorrow 9am\n"
+        "<<</REMINDER_BUTTONS>>>"
+    )
+
+
+def _make_interaction(*, message_content: str = "the reminder body"):
+    response = SimpleNamespace(
+        edit_message=AsyncMock(),
+        send_message=AsyncMock(),
+        defer=AsyncMock(),
+    )
+    message = SimpleNamespace(
+        content=message_content,
+        add_reaction=AsyncMock(),
+    )
+    return SimpleNamespace(response=response, message=message)
+
+
+# ---------------------------------------------------------------------------
+# extract()
+# ---------------------------------------------------------------------------
+
+class TestExtract:
+    def test_no_sentinel_returns_unchanged(self, hermes_home):
+        cleaned, view = extract("hello world")
+        assert cleaned == "hello world"
+        assert view is None
+
+    def test_empty_input(self, hermes_home):
+        cleaned, view = extract("")
+        assert cleaned == ""
+        assert view is None
+
+    def test_strips_sentinel_block(self, hermes_home):
+        body = "Time to drink water!"
+        text = f"{body}\n\n{_sentinel_block('abc123', body)}"
+        cleaned, view = extract(text)
+        # Sentinel block removed
+        assert "<<<REMINDER_BUTTONS" not in cleaned
+        assert "<<</REMINDER_BUTTONS>>>" not in cleaned
+        # Body preserved
+        assert "Time to drink water!" in cleaned
+        assert view is not None
+
+    def test_view_has_four_buttons_with_correct_custom_ids(self, hermes_home):
+        text = _sentinel_block("rid42", "stand up")
+        _, view = extract(text)
+        assert view is not None
+        assert len(view.children) == 4
+        custom_ids = [b.custom_id for b in view.children]
+        assert custom_ids == [
+            "reminder:rid42:done",
+            "reminder:rid42:snooze15",
+            "reminder:rid42:snooze60",
+            "reminder:rid42:tomorrow9",
+        ]
+
+    def test_persists_reminder_json(self, hermes_home):
+        body = "Take a break"
+        text = _sentinel_block("ridP1", body)
+        origin = {"platform": "discord", "chat_id": "9001", "thread_id": None}
+        extract(text, origin=origin, deliver="origin")
+
+        record = load_reminder("ridP1")
+        assert record is not None
+        assert record["text"] == body
+        assert record["origin"] == origin
+        assert record["deliver"] == "origin"
+
+    def test_bad_base64_leaves_sentinel_in_place(self, hermes_home):
+        text = (
+            '<<<REMINDER_BUTTONS reminder_id="ridBad" '
+            'text_b64="!!!notbase64!!!">>>\n'
+            "x\n"
+            "<<</REMINDER_BUTTONS>>>"
+        )
+        cleaned, view = extract(text)
+        # Regex requires base64 chars in text_b64, so the sentinel never
+        # matches — text is returned untouched.
+        assert cleaned == text
+        assert view is None
+
+    def test_invalid_base64_payload_leaves_text_unchanged(self, hermes_home):
+        # Construct a sentinel whose text_b64 is regex-valid base64 chars but
+        # decodes to bytes that are not valid UTF-8.  This forces the
+        # decode-side exception branch.
+        bad_payload = "////"  # decodes to bytes 0xff 0xff 0xff
+        text = (
+            f'<<<REMINDER_BUTTONS reminder_id="ridUE" '
+            f'text_b64="{bad_payload}">>>\n'
+            "<<</REMINDER_BUTTONS>>>"
+        )
+        cleaned, view = extract(text)
+        assert cleaned == text
+        assert view is None
+
+    def test_only_first_sentinel_block_is_consumed(self, hermes_home):
+        first = _sentinel_block("rid1", "one")
+        second = _sentinel_block("rid2", "two")
+        text = f"intro\n{first}\nmid\n{second}"
+        cleaned, view = extract(text)
+        assert view is not None
+        # First sentinel removed, second remains
+        assert "intro" in cleaned
+        assert "<<<REMINDER_BUTTONS" in cleaned
+        assert 'reminder_id="rid2"' in cleaned
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_save_and_load_round_trip(self, hermes_home):
+        save_reminder("ridS", "hello", origin={"platform": "discord", "chat_id": "1"})
+        record = load_reminder("ridS")
+        assert record["reminder_id"] == "ridS"
+        assert record["text"] == "hello"
+        assert record["origin"]["chat_id"] == "1"
+
+    def test_load_returns_none_for_missing(self, hermes_home):
+        assert load_reminder("does-not-exist") is None
+
+    def test_delete_reminder_removes_file(self, hermes_home):
+        save_reminder("ridD", "x")
+        assert load_reminder("ridD") is not None
+        assert delete_reminder("ridD") is True
+        assert load_reminder("ridD") is None
+        # Idempotent
+        assert delete_reminder("ridD") is False
+
+    def test_list_active_returns_all_ids(self, hermes_home):
+        save_reminder("ridA", "a")
+        save_reminder("ridB", "b")
+        ids = list_active_reminder_ids()
+        assert "ridA" in ids
+        assert "ridB" in ids
+
+    def test_rejects_invalid_id(self, hermes_home):
+        with pytest.raises(ValueError):
+            save_reminder("../escape", "x")
+
+
+# ---------------------------------------------------------------------------
+# _next_tomorrow_9am
+# ---------------------------------------------------------------------------
+
+class TestNextTomorrow9am:
+    def test_returns_today_9am_when_before_9am(self):
+        now = datetime(2026, 5, 28, 7, 30, tzinfo=OSLO)
+        target = _next_tomorrow_9am(now)
+        assert target.year == 2026
+        assert target.month == 5
+        assert target.day == 28
+        assert target.hour == 9
+        assert target.minute == 0
+        assert target.tzinfo == OSLO
+
+    def test_returns_tomorrow_9am_when_after_9am(self):
+        now = datetime(2026, 5, 28, 10, 0, tzinfo=OSLO)
+        target = _next_tomorrow_9am(now)
+        assert target.day == 29
+        assert target.hour == 9
+
+    def test_returns_tomorrow_when_exactly_9am(self):
+        # Exact 9am is already "passed" — should target tomorrow.
+        now = datetime(2026, 5, 28, 9, 0, tzinfo=OSLO)
+        target = _next_tomorrow_9am(now)
+        assert target.day == 29
+
+    def test_handles_non_oslo_input_via_conversion(self):
+        # UTC 06:00 on a non-DST day == 07:00 Oslo (CET / CEST drift handled
+        # by ZoneInfo).  Either way: target must be today's 9am Oslo.
+        now = datetime(2026, 1, 15, 6, 0, tzinfo=timezone.utc)
+        target = _next_tomorrow_9am(now)
+        # Today in Oslo is still 2026-01-15
+        assert target.day == 15
+        assert target.hour == 9
+        assert target.tzinfo == OSLO
+
+
+# ---------------------------------------------------------------------------
+# schedule_snooze
+# ---------------------------------------------------------------------------
+
+class TestScheduleSnooze:
+    def test_returns_none_when_state_missing(self, hermes_home):
+        with patch("cron.jobs.create_job") as cj:
+            assert schedule_snooze("missing") is None
+            cj.assert_not_called()
+
+    def test_delay_minutes_invokes_create_job_with_minute_schedule(
+        self, hermes_home,
+    ):
+        save_reminder(
+            "ridS15", "drink water",
+            origin={"platform": "discord", "chat_id": "9001"},
+            deliver="origin",
+        )
+        fake_job = {"id": "jobxyz", "name": "x"}
+        with patch("cron.jobs.create_job", return_value=fake_job) as cj:
+            job = schedule_snooze("ridS15", delay_minutes=15)
+        assert job is fake_job
+        cj.assert_called_once()
+        kwargs = cj.call_args.kwargs
+        assert kwargs["schedule"] == "15m"
+        assert kwargs["repeat"] == 1
+        assert kwargs["deliver"] == "origin"
+        assert kwargs["origin"] == {"platform": "discord", "chat_id": "9001"}
+        # Prompt must contain the reminder text + a fresh sentinel block
+        assert "drink water" in kwargs["prompt"]
+        assert "<<<REMINDER_BUTTONS" in kwargs["prompt"]
+        assert "<<</REMINDER_BUTTONS>>>" in kwargs["prompt"]
+        # Fresh sentinel: new reminder_id, not the original
+        assert 'reminder_id="ridS15"' not in kwargs["prompt"]
+
+    def test_run_at_invokes_create_job_with_iso_schedule(self, hermes_home):
+        save_reminder("ridT9", "stand up")
+        target = datetime(2026, 5, 29, 9, 0, tzinfo=OSLO)
+        with patch("cron.jobs.create_job", return_value={"id": "j"}) as cj:
+            schedule_snooze("ridT9", run_at=target)
+        kwargs = cj.call_args.kwargs
+        # Schedule is the ISO timestamp string
+        assert kwargs["schedule"] == target.isoformat()
+
+    def test_persists_new_reminder_for_chained_buttons(self, hermes_home):
+        save_reminder(
+            "ridChain", "do the thing",
+            origin={"platform": "discord", "chat_id": "42"},
+            deliver="origin",
+        )
+        with patch("cron.jobs.create_job", return_value={"id": "j"}):
+            schedule_snooze("ridChain", delay_minutes=15)
+        # A new reminder JSON must exist with the same text + origin so the
+        # next reminder's buttons work too.
+        ids = list_active_reminder_ids()
+        new_ids = [rid for rid in ids if rid != "ridChain"]
+        assert len(new_ids) == 1
+        new_record = load_reminder(new_ids[0])
+        assert new_record["text"] == "do the thing"
+        assert new_record["origin"] == {"platform": "discord", "chat_id": "42"}
+
+    def test_requires_delay_or_run_at(self, hermes_home):
+        save_reminder("ridX", "x")
+        with patch("cron.jobs.create_job"):
+            with pytest.raises(ValueError):
+                schedule_snooze("ridX")
+
+
+# ---------------------------------------------------------------------------
+# ReminderButtonsView callbacks
+# ---------------------------------------------------------------------------
+
+class TestReminderButtonsView:
+    @pytest.mark.asyncio
+    async def test_done_edits_message_and_reacts(self, hermes_home):
+        save_reminder("ridDone", "x")
+        view = ReminderButtonsView("ridDone")
+        interaction = _make_interaction(message_content="Drink water")
+        await view._on_done(interaction)
+        # Buttons disabled
+        assert all(c.disabled for c in view.children)
+        # edit_message called with new content suffixed
+        interaction.response.edit_message.assert_called_once()
+        kwargs = interaction.response.edit_message.call_args.kwargs
+        assert "✓ done" in kwargs["content"]
+        # ✅ reaction added
+        interaction.message.add_reaction.assert_called_once_with("✅")
+        # Persisted state removed
+        assert load_reminder("ridDone") is None
+
+    @pytest.mark.asyncio
+    async def test_snooze15_schedules_cron_and_edits(self, hermes_home):
+        save_reminder(
+            "ridSn15", "remember",
+            origin={"platform": "discord", "chat_id": "1"},
+        )
+        view = ReminderButtonsView("ridSn15")
+        interaction = _make_interaction(message_content="Remember!")
+        with patch("cron.jobs.create_job", return_value={"id": "j15"}) as cj:
+            await view._on_snooze(interaction, delay_minutes=15, label="+15min")
+        # Cron job created
+        cj.assert_called_once()
+        assert cj.call_args.kwargs["schedule"] == "15m"
+        # Buttons disabled + message edited
+        assert all(c.disabled for c in view.children)
+        kwargs = interaction.response.edit_message.call_args.kwargs
+        assert "snoozed +15min" in kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_snooze60_uses_60_minute_schedule(self, hermes_home):
+        save_reminder("ridSn60", "remember")
+        view = ReminderButtonsView("ridSn60")
+        interaction = _make_interaction()
+        with patch("cron.jobs.create_job", return_value={"id": "j60"}) as cj:
+            await view._on_snooze(interaction, delay_minutes=60, label="+1h")
+        assert cj.call_args.kwargs["schedule"] == "60m"
+
+    @pytest.mark.asyncio
+    async def test_tomorrow9_schedules_at_oslo_9am(self, hermes_home):
+        save_reminder("ridT9", "wake up")
+        view = ReminderButtonsView("ridT9")
+        interaction = _make_interaction()
+        with patch("cron.jobs.create_job", return_value={"id": "jT9"}) as cj:
+            await view._on_tomorrow9(interaction)
+        schedule = cj.call_args.kwargs["schedule"]
+        # ISO timestamp of next 9am Oslo — must parse and be in Oslo tz.
+        dt = datetime.fromisoformat(schedule)
+        # Confirm hour/min in Oslo time
+        dt_oslo = dt.astimezone(OSLO)
+        assert dt_oslo.hour == 9
+        assert dt_oslo.minute == 0
+
+    @pytest.mark.asyncio
+    async def test_snooze_without_persisted_state_warns_user(self, hermes_home):
+        # No save_reminder — state is missing
+        view = ReminderButtonsView("ridGone")
+        interaction = _make_interaction()
+        with patch("cron.jobs.create_job") as cj:
+            await view._on_snooze(interaction, delay_minutes=15, label="+15min")
+        cj.assert_not_called()
+        # Buttons still disabled + edit indicates the failure
+        assert all(c.disabled for c in view.children)
+        kwargs = interaction.response.edit_message.call_args.kwargs
+        assert "couldn't snooze" in kwargs["content"]
+
+
+# ---------------------------------------------------------------------------
+# register_persistent_views
+# ---------------------------------------------------------------------------
+
+class TestRegisterPersistentViews:
+    def test_registers_one_view_per_active_reminder(self, hermes_home):
+        save_reminder("r1", "a")
+        save_reminder("r2", "b")
+        save_reminder("r3", "c")
+        bot = MagicMock()
+        count = register_persistent_views(bot)
+        assert count == 3
+        # All three views passed to bot.add_view
+        assert bot.add_view.call_count == 3
+        registered_ids = [
+            call.args[0].reminder_id for call in bot.add_view.call_args_list
+        ]
+        assert set(registered_ids) == {"r1", "r2", "r3"}
+
+    def test_returns_zero_when_no_reminders(self, hermes_home):
+        bot = MagicMock()
+        count = register_persistent_views(bot)
+        assert count == 0
+        bot.add_view.assert_not_called()
+
+    def test_none_bot_returns_zero(self, hermes_home):
+        save_reminder("r1", "x")
+        assert register_persistent_views(None) == 0
+
+
+# ---------------------------------------------------------------------------
+# Adapter wiring — send() should call extract() and attach the view
+# ---------------------------------------------------------------------------
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="t", extra={})
+    adapter = DiscordAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+class TestAdapterSendIntegration:
+    @pytest.mark.asyncio
+    async def test_send_strips_sentinel_and_attaches_view(self, hermes_home):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 555
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+        # Treat as non-forum
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        body = "Drink water"
+        content = f"{body}\n\n{_sentinel_block('ridSend', body)}"
+
+        result = await adapter.send(chat_id="9001", content=content)
+        assert result.success is True
+        # channel.send called with view kwarg + cleaned content
+        channel.send.assert_called()
+        kwargs = channel.send.call_args.kwargs
+        assert "view" in kwargs
+        assert isinstance(kwargs["view"], ReminderButtonsView)
+        # Sentinel block stripped from outgoing content
+        assert "<<<REMINDER_BUTTONS" not in kwargs["content"]
+        assert body in kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_send_without_sentinel_does_not_attach_view(self, hermes_home):
+        adapter = _make_adapter()
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 1
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        await adapter.send(chat_id="9001", content="just a normal message")
+        kwargs = channel.send.call_args.kwargs
+        assert "view" not in kwargs


### PR DESCRIPTION
## Summary

Adds an interactive four-button view on Discord-delivered cron reminders.

When a cron reminder's outbound text contains a sentinel block, the Discord adapter strips it from the displayed text and attaches a persistent button view:

\`\`\`
<<<REMINDER_BUTTONS reminder_id=\"abc123\" text_b64=\"<base64 reminder text>\">>>
✅ Done | ⏰ +15min | ⏰ +1h | ⏰ Tomorrow 9am
<<</REMINDER_BUTTONS>>>
\`\`\`

Buttons:
- **Done** — edits the message, disables buttons, adds a ✅ reaction, removes persisted state
- **+15min / +1h** — schedules a new cron job that re-delivers the same reminder (with a fresh sentinel for chained snoozes)
- **Tomorrow 9am** — schedules at the next 09:00 \`Europe/Oslo\` (today if before 9am, else tomorrow)

Persistence: reminder text + origin saved to \`~/.hermes/reminders/{reminder_id}.json\` so buttons survive bot restart. On \`on_ready\`, one persistent view per active reminder JSON is re-registered with \`bot.add_view\`.

## Implementation notes / smallest-reasonable choices

- **Reminder text not in custom_id.** Discord caps custom_id at 100 chars, so the reminder text is persisted to a per-id JSON file and read back on click.
- **Snoozed reminder re-fires via cron.** A new \`cron.jobs.create_job\` schedules an LLM-driven re-delivery with a prompt that instructs the agent to repeat the reminder text and emit a fresh sentinel block. This is a deliberate trade-off: it relies on the agent reproducing the sentinel verbatim, but avoids requiring a writable scripts file or new \`no_agent\` plumbing for arbitrary text payloads.
- **Per-reminder view registration.** \`discord.ui.DynamicItem\` would handle wildcard custom_ids in one shot, but is discord.py 2.4+. The repo's existing views don't use it, so this PR sticks with one persistent view per active reminder — re-registered on startup by walking \`~/.hermes/reminders/*.json\`.
- **First sentinel only.** \`extract()\` consumes the first sentinel block in a message; any additional blocks are left in place. The cron prompt template only emits one.

## Test plan

- [x] \`tests/gateway/test_discord_reminder_buttons.py\` (32 new tests) covers parse, persistence, callbacks, Oslo-timezone math, cron-job scheduling, view re-registration, and adapter wiring
- [x] Existing \`test_discord_clarify_buttons.py\` + \`test_discord_lazy_install_views.py\` still pass (no ClarifyChoiceView regression)
- [x] Broader \`test_discord_send.py\` / \`test_discord_connect.py\` / \`test_discord_imports.py\` still pass
- [ ] Manual end-to-end click test against a live Discord channel (not exercised in this environment)