### PR TITLE
fix: pass reference images to Codex image generation

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -139,7 +139,9 @@ class ImageGenProvider(abc.ABC):
         Implementations should return the dict from :func:`success_response`
         or :func:`error_response`. ``kwargs`` may contain forward-compat
         parameters future versions of the schema will expose — implementations
-        should ignore unknown keys.
+        should ignore unknown keys. Known optional kwargs include
+        ``reference_image_paths`` (list[str]) for backends that support
+        image-conditioned generation.
         """
 
 

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 
 import json
 import logging
+import base64
+import mimetypes
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -143,8 +146,47 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
-def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[str, Any]:
+def _coerce_reference_image_paths(value: Any) -> List[str]:
+    """Normalize optional reference image paths/URLs from tool kwargs."""
+    if not isinstance(value, list):
+        return []
+    paths: List[str] = []
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            paths.append(item.strip())
+    return paths
+
+
+def _reference_image_content_item(reference: str) -> Dict[str, str]:
+    """Convert a local reference image path or URL into a Responses input item."""
+    lowered = reference.lower()
+    if lowered.startswith("http://") or lowered.startswith("https://") or lowered.startswith("data:image/"):
+        return {"type": "input_image", "image_url": reference}
+
+    path = Path(reference).expanduser()
+    if not path.is_file():
+        raise ValueError(f"Reference image is not readable: {reference}")
+
+    mime_type, _encoding = mimetypes.guess_type(str(path))
+    if not mime_type or not mime_type.startswith("image/"):
+        raise ValueError(f"Reference file is not a supported image: {reference}")
+
+    image_b64 = base64.b64encode(path.read_bytes()).decode("ascii")
+    return {"type": "input_image", "image_url": f"data:{mime_type};base64,{image_b64}"}
+
+
+def _build_responses_payload(
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    reference_image_paths: Optional[List[str]] = None,
+) -> Dict[str, Any]:
     """Build the Codex Responses request body for an image_generation call."""
+    content: List[Dict[str, str]] = [{"type": "input_text", "text": prompt}]
+    for reference in _coerce_reference_image_paths(reference_image_paths):
+        content.append(_reference_image_content_item(reference))
+
     return {
         "model": _CODEX_CHAT_MODEL,
         "store": False,
@@ -152,7 +194,7 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
         "input": [{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": content,
         }],
         "tools": [{
             "type": "image_generation",
@@ -242,7 +284,14 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
-def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _collect_image_b64(
+    token: str,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    reference_image_paths: Optional[List[str]] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
@@ -253,7 +302,12 @@ def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> O
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     })
-    payload = _build_responses_payload(prompt=prompt, size=size, quality=quality)
+    payload = _build_responses_payload(
+        prompt=prompt,
+        size=size,
+        quality=quality,
+        reference_image_paths=reference_image_paths,
+    )
     timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
 
     image_b64: Optional[str] = None
@@ -367,6 +421,19 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
+        reference_image_paths = _coerce_reference_image_paths(kwargs.get("reference_image_paths"))
+        try:
+            for reference in reference_image_paths:
+                _reference_image_content_item(reference)
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_reference_image",
+                provider="openai-codex",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
 
         token = _read_codex_access_token()
         if not token:
@@ -383,12 +450,14 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             )
 
         try:
-            b64 = _collect_image_b64(
-                token,
-                prompt=prompt,
-                size=size,
-                quality=meta["quality"],
-            )
+            collect_kwargs: Dict[str, Any] = {
+                "prompt": prompt,
+                "size": size,
+                "quality": meta["quality"],
+            }
+            if reference_image_paths:
+                collect_kwargs["reference_image_paths"] = reference_image_paths
+            b64 = _collect_image_b64(token, **collect_kwargs)
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
             return error_response(

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -160,6 +160,23 @@ class TestGenerate:
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
 
+    def test_codex_payload_includes_reference_images_as_input_images(self, tmp_path):
+        reference = tmp_path / "dominik-reference.png"
+        reference.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        payload = codex_plugin._build_responses_payload(
+            prompt="portrait of Dominik",
+            size="1024x1536",
+            quality="medium",
+            reference_image_paths=[str(reference)],
+        )
+
+        content = payload["input"][0]["content"]
+        assert content[0] == {"type": "input_text", "text": "portrait of Dominik"}
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+        assert str(reference) not in content[0]["text"]
+
     def test_partial_image_event_used_when_done_missing(self):
         """If output_item.done is missing, partial_image_b64 is accepted."""
         payload = {

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,13 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
+    def test_schema_exposes_prompt_aspect_ratio_and_reference_paths_to_agent(self, image_tool):
         """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+        user-level config choice, while reference paths are needed for
+        image-conditioned generation."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "reference_image_paths"}
+        assert "model" not in props
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -27,6 +27,7 @@ class _FakeCodexProvider(ImageGenProvider):
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
             "provider": "codex",
+            "kwargs": kwargs,
         }
 
 
@@ -51,6 +52,27 @@ class TestPluginDispatch:
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+
+    def test_dispatch_forwards_reference_image_paths(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        reference_paths = [str(tmp_path / "reference.png")]
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "draw Dominik",
+            "portrait",
+            reference_image_paths=reference_paths,
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert payload["kwargs"]["reference_image_paths"] == reference_paths
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -842,10 +842,32 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "reference_image_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional local image file paths or image URLs to pass as "
+                    "input/reference images when the configured backend supports "
+                    "image-conditioned generation. Do not include these paths in "
+                    "the text prompt."
+                ),
+                "default": [],
+            },
         },
         "required": ["prompt"],
     },
 }
+
+
+def _coerce_reference_image_paths(value: Any) -> list[str]:
+    """Return a clean list of reference image path strings from tool args."""
+    if not isinstance(value, list):
+        return []
+    paths: list[str] = []
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            paths.append(item.strip())
+    return paths
 
 
 def _read_configured_image_model():
@@ -887,7 +909,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, reference_image_paths=None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -941,9 +963,12 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        clean_reference_image_paths = _coerce_reference_image_paths(reference_image_paths)
+        if clean_reference_image_paths:
+            kwargs["reference_image_paths"] = clean_reference_image_paths
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -971,12 +996,32 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_image_paths = _coerce_reference_image_paths(args.get("reference_image_paths"))
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(
+        prompt,
+        aspect_ratio,
+        reference_image_paths=reference_image_paths,
+    )
     if dispatched is not None:
         return dispatched
+
+    if reference_image_paths:
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                "reference_image_paths were provided, but no image_gen.provider "
+                "plugin is configured to accept image references. Configure a "
+                "reference-capable provider such as openai-codex."
+            ),
+            "error_type": "unsupported_reference_images",
+            "provider": "fal",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+        })
 
     return image_generate_tool(
         prompt=prompt,


### PR DESCRIPTION
## Summary
- expose optional `reference_image_paths` on the Hermes `image_generate` tool schema
- forward reference images through image plugin dispatch into the provider kwargs
- teach the OpenAI Codex image generation plugin to send local/URL reference images as `input_image` items
- return a clear unsupported-reference error when references are provided without a reference-capable plugin

## Test Plan
- `python -m pytest tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/plugins/image_gen/test_openai_codex_provider.py -q -o 'addopts='`
