### PR TITLE
feat: complete profile switcher — backend + frontend

### DIFF
--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -46,4 +46,7 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # Read-only theme + plugin manifests for the dashboard skin engine.
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
+    # Read-only: returns the currently active profile name. Used by the
+    # dashboard SPA on mount (before login) to show the active profile card.
+    "/api/active-profile",
 })

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3073,6 +3073,22 @@ async def update_profile_soul(name: str, body: ProfileSoulUpdate):
     return {"ok": True}
 
 
+@app.post("/api/profiles/{name}/activate")
+async def activate_profile_endpoint(request: Request, name: str):
+    """Set the active profile (sticky — persists across restarts)."""
+    _require_token(request)
+    from hermes_cli import profiles as profiles_mod
+    canon = profiles_mod.normalize_profile_name(name)
+    if not profiles_mod.profile_exists(canon):
+        raise HTTPException(status_code=404, detail=f"Profile '{name}' not found")
+    profiles_mod.set_active_profile(canon)
+    return {
+        "ok": True,
+        "active_profile": canon,
+        "profile_dir": str(profiles_mod.get_profile_dir(canon)),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Skills & Tools endpoints
 # ---------------------------------------------------------------------------
@@ -3521,6 +3537,17 @@ def _resolve_chat_argv(
         if latest_resume:
             resume = latest_resume
         env["HERMES_TUI_RESUME"] = resume
+
+    # Use the sticky active profile (may differ from dashboard startup profile)
+    from hermes_cli import profiles as _profiles_mod
+    _active = _profiles_mod.get_active_profile()
+    if _active == "default":
+        env["HERMES_HOME"] = str(_profiles_mod._get_default_hermes_home())
+    elif _active:
+        _pd = _profiles_mod.get_profile_dir(_active).resolve()
+        _profiles_root = _profiles_mod._get_profiles_root().resolve()
+        if _pd.is_dir() and _pd.is_relative_to(_profiles_root):
+            env["HERMES_HOME"] = str(_pd)
 
     if sidecar_url:
         env["HERMES_TUI_SIDECAR_URL"] = sidecar_url
@@ -4824,6 +4851,11 @@ _mount_plugin_api_routes()
 # not whether the routes exist.
 from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router  # noqa: E402
 app.include_router(_dashboard_auth_router)
+
+@app.get("/api/active-profile")
+async def _get_active_profile():
+    from hermes_cli import profiles as _profiles_mod
+    return {"name": _profiles_mod.get_active_profile()}
 
 mount_spa(app)
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -352,14 +352,27 @@ export default function App() {
   // the flag is off — see AnalyticsPage), but hiding the nav entry avoids
   // surfacing misleading token/cost numbers in the sidebar.  Default off.
   const [showTokenAnalytics, setShowTokenAnalytics] = useState(false);
+
+  // Dashboard Chat sub-feature flags (persisted to config.yaml).
+  const [chatSystemMonitorEnabled, setChatSystemMonitorEnabled] = useState(true);
+  const [chatByAgentProfileEnabled, setChatByAgentProfileEnabled] = useState(true);
+  // Bumped when the user switches the active agent profile -- causes the PTY
+  // WebSocket to reconnect under the new profile HERMES_HOME.
+  const [channelBumpKey, setChannelBumpKey] = useState(0);
+  const bumpChannel = useCallback(() => setChannelBumpKey((k) => k + 1), []);
   useEffect(() => {
     api
       .getConfig()
       .then((cfg) => {
         const dash = (cfg?.dashboard ?? {}) as {
           show_token_analytics?: unknown;
+          chat_ui?: unknown;
+          chat_system_monitor?: unknown;
+          chat_by_agent_profile?: unknown;
         };
         setShowTokenAnalytics(dash.show_token_analytics === true);
+        setChatSystemMonitorEnabled(dash.chat_system_monitor !== false);
+        setChatByAgentProfileEnabled(dash.chat_by_agent_profile !== false);
       })
       .catch(() => setShowTokenAnalytics(false));
   }, []);
@@ -737,7 +750,13 @@ export default function App() {
                       )}
                       aria-hidden={!isChatRoute}
                     >
-                      <ChatPage isActive={isChatRoute} />
+                      <ChatPage
+                        isActive={isChatRoute}
+                        chatSystemMonitor={chatSystemMonitorEnabled}
+                        chatByAgentProfile={chatByAgentProfileEnabled}
+                        channelBumpKey={channelBumpKey}
+                        onProfileActivated={bumpChannel}
+                      />
                     </div>
                   ))}
               </div>

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -30,10 +30,11 @@ import { Card } from "@nous-research/ui/ui/components/card";
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ToolCall, type ToolEntry } from "@/components/ToolCall";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
+import { ProfilePickerDialog } from "@/components/ProfilePickerDialog";
 import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
 
 import { cn } from "@/lib/utils";
-import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
+import { AlertCircle, ChevronDown, Crown, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface SessionInfo {
@@ -72,9 +73,18 @@ const STATE_TONE: Record<
 interface ChatSidebarProps {
   channel: string;
   className?: string;
+  /** When false, the Agent Profile selector card is hidden. */
+  chatByAgentProfile?: boolean;
+  /** Fires after a profile switch. */
+  onProfileActivated?: () => void;
 }
 
-export function ChatSidebar({ channel, className }: ChatSidebarProps) {
+export function ChatSidebar({
+  channel,
+  className,
+  chatByAgentProfile = true,
+  onProfileActivated,
+}: ChatSidebarProps) {
   // `version` bumps on reconnect; gw is derived so we never call setState
   // for it inside an effect (React 19's set-state-in-effect rule). The
   // counter is the dependency on purpose — it's not read in the memo body,
@@ -90,6 +100,18 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
   const [modelOpen, setModelOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Agent Profile state (gated by chatByAgentProfile)
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [activeProfile, setActiveProfile] = useState<string>("default");
+
+  // Fetch active profile on mount.
+  useEffect(() => {
+    fetch(HERMES_BASE_PATH + "/api/active-profile")
+      .then(r => r.json())
+      .then(d => { if (d.name) setActiveProfile(d.name); })
+      .catch(() => {});
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     const offState = gw.onState(setState);
@@ -101,6 +123,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
 
       if (ev.payload) {
         setInfo((prev) => ({ ...prev, ...ev.payload }));
+        // profile_name handled by /api/active-profile fetch on mount
       }
     });
 
@@ -306,6 +329,12 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     [gw, sessionId],
   );
 
+  const handleProfileActivated = useCallback(
+    (newProfile: string) => {
+      setActiveProfile(newProfile);
+      onProfileActivated?.();
+    }, [onProfileActivated]);
+
   const canPickModel = state === "open" && !!sessionId;
   const modelLabel = (info.model ?? "—").split("/").slice(-1)[0] ?? "—";
   const banner = error ?? info.credential_warning ?? null;
@@ -317,6 +346,21 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         className,
       )}
     >
+      {/* ACTIVE PROFILE - read-only, shows current profile */}
+      <Card className="flex items-center justify-between gap-2 px-3 py-2">
+        <div className="min-w-0">
+          <div className="text-display text-xs tracking-wider text-text-tertiary">
+            active profile
+          </div>
+          <Button ghost size="sm" disabled
+            className="self-start min-w-0 px-0 py-0 normal-case tracking-normal text-sm font-medium"
+            title={activeProfile}>
+            <Crown className="mr-1 h-3 w-3 text-amber-400" />
+            <span className="truncate">{activeProfile}</span>
+          </Button>
+        </div>
+      </Card>
+
       <Card className="flex items-center justify-between gap-2 px-3 py-2">
         <div className="min-w-0">
           <div className="text-display text-xs tracking-wider text-text-tertiary">
@@ -342,6 +386,21 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
 
         <Badge tone={STATE_TONE[state]}>{STATE_LABEL[state]}</Badge>
       </Card>
+
+      {/* Agent Profile selector - gated by chatByAgentProfile */}
+      {chatByAgentProfile && (
+        <Card className="flex items-center justify-between gap-2 px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-display text-xs tracking-wider text-text-tertiary">agent profile</div>
+            <Button ghost size="sm" onClick={() => setProfileOpen(true)}
+              suffix={<ChevronDown className="text-text-secondary" />}
+              className="self-start min-w-0 px-0 py-0 normal-case tracking-normal text-sm font-medium hover:underline"
+              title="switch agent profile">
+              <span className="truncate">switch profile</span>
+            </Button>
+          </div>
+        </Card>
+      )}
 
       {banner && (
         <Card className="flex items-start gap-2 border-destructive/40 bg-destructive/5 px-3 py-2 text-xs">
@@ -388,6 +447,12 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
           onClose={() => setModelOpen(false)}
           onSubmit={onModelSubmit}
         />
+      )}
+
+      {profileOpen && (
+        <ProfilePickerDialog activeProfile={activeProfile}
+          onClose={() => setProfileOpen(false)}
+          onProfileActivated={handleProfileActivated} />
       )}
     </aside>
   );

--- a/web/src/components/ProfilePickerDialog.tsx
+++ b/web/src/components/ProfilePickerDialog.tsx
@@ -1,0 +1,196 @@
+/**
+ * ProfilePickerDialog — modal dialog for switching the active agent profile.
+ *
+ * Portaled to document.body so it stacks above the app sidebar and mobile
+ * chrome.  Lists all available profiles with the active one marked, and
+ * calls POST /api/profiles/{name}/activate on selection.
+ */
+
+import { Button } from "@nous-research/ui/ui/components/button";
+import { ListItem } from "@nous-research/ui/ui/components/list-item";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { Check, RefreshCw, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ProfileInfo {
+  name: string;
+  path: string;
+  is_default: boolean;
+  model: string | null;
+  provider: string | null;
+  has_env: boolean;
+  skill_count: number;
+}
+
+interface ProfilePickerDialogProps {
+  /** Current active profile name. */
+  activeProfile: string;
+  onClose(): void;
+  /** Called after a profile is successfully activated. */
+  onProfileActivated(newProfile: string): void;
+}
+
+export function ProfilePickerDialog({
+  activeProfile,
+  onClose,
+  onProfileActivated,
+}: ProfilePickerDialogProps) {
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activating, setActivating] = useState<string | null>(null);
+  const closedRef = useRef(false);
+
+  useEffect(() => {
+    closedRef.current = false;
+    api
+      .getProfiles()
+      .then((r) => {
+        if (closedRef.current) return;
+        setProfiles(
+          [...r.profiles].sort((a, b) => {
+            if (a.is_default) return -1;
+            if (b.is_default) return 1;
+            return a.name.localeCompare(b.name);
+          }),
+        );
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (closedRef.current) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      });
+    return () => { closedRef.current = true; };
+  }, []);
+
+  // Esc closes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.preventDefault(); onClose(); }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const activate = async (name: string) => {
+    if (activating) return;
+    setActivating(name);
+    try {
+      await api.activateProfile(name);
+      onProfileActivated(name);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setActivating(null);
+    }
+  };
+
+  const portalRoot = typeof document !== "undefined" ? document.body : null;
+  if (!portalRoot) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 backdrop-blur-sm p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+      role="dialog" aria-modal="true" aria-label="Switch Agent Profile">
+      <div className="relative w-full max-w-sm max-h-[70vh] border border-border bg-card shadow-2xl flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+          <div>
+            <h2 className="font-display text-sm tracking-wider uppercase">Agent Profile</h2>
+            <p className="text-[0.65rem] text-muted-foreground mt-0.5">
+              Switch profile — new chat sessions use the selected agent
+            </p>
+          </div>
+          <Button ghost size="icon" onClick={onClose}
+            className="text-muted-foreground hover:text-foreground shrink-0" aria-label="Close">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        {/* Profile list */}
+        <div className="flex-1 min-h-0 overflow-y-auto py-1">
+          {loading && (
+            <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+              <Spinner className="text-xs" />
+              loading profiles…
+            </div>
+          )}
+
+          {error && !loading && (
+            <div className="p-4 text-xs text-destructive">{error}</div>
+          )}
+
+          {!loading && !error && profiles.length === 0 && (
+            <div className="p-4 text-xs text-muted-foreground italic">
+              no profiles found
+            </div>
+          )}
+
+          {!loading &&
+            profiles.map((p) => {
+              const isActive = p.name === activeProfile;
+              const isBusy = activating === p.name;
+              return (
+                <ListItem
+                  key={p.name}
+                  onClick={() => !isActive && activate(p.name)}
+                  className={cn(
+                    "px-4 py-2.5 text-sm cursor-pointer transition-colors",
+                    isActive
+                      ? "bg-primary/10 cursor-default"
+                      : "hover:bg-accent hover:text-accent-foreground",
+                  )}
+                  aria-current={isActive ? "true" : undefined}
+                >
+                  <div className="flex items-center gap-3 min-w-0 w-full">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium truncate">
+                          {p.name}
+                        </span>
+                        {p.is_default && (
+                          <span className="text-[0.6rem] uppercase tracking-wider text-muted-foreground shrink-0">
+                            default
+                          </span>
+                        )}
+                        {p.has_env && (
+                          <span className="text-[0.6rem] uppercase tracking-wider text-muted-foreground shrink-0">
+                            env
+                          </span>
+                        )}
+                      </div>
+                      {p.model && (
+                        <div className="text-[0.65rem] text-muted-foreground/80 font-mono truncate mt-0.5">
+                          {p.model}
+                        </div>
+                      )}
+                    </div>
+
+                    {isBusy ? (
+                      <Spinner className="text-xs shrink-0" />
+                    ) : isActive ? (
+                      <Check className="h-4 w-4 text-primary shrink-0" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0 opacity-0 group-hover:opacity-100" />
+                    )}
+                  </div>
+                </ListItem>
+              );
+            })}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-2 border-t border-border shrink-0">
+          <p className="text-[0.6rem] text-muted-foreground">
+            The chat session will restart under the new profile.
+          </p>
+        </div>
+      </div>
+    </div>,
+    portalRoot,
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -359,6 +359,14 @@ export const api = {
       },
     ),
 
+  /** Activate a profile persistently (sticky across restarts).
+   *  Requires session token (injected by fetchJSON). */
+  activateProfile: (name: string) =>
+    fetchJSON<{ ok: boolean; active_profile: string; profile_dir: string }>(
+      `/api/profiles/${encodeURIComponent(name)}/activate`,
+      { method: "POST" },
+    ),
+
   // Skills & Toolsets
   getSkills: () => fetchJSON<SkillInfo[]>("/api/skills"),
   toggleSkill: (name: string, enabled: boolean) =>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -107,7 +107,19 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
   return layoutWidthPx < 1024 ? 1.02 : 1.15;
 }
 
-export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
+export default function ChatPage({
+  isActive = true,
+  chatSystemMonitor: _chatSystemMonitor = true,
+  chatByAgentProfile = true,
+  channelBumpKey = 0,
+  onProfileActivated,
+}: {
+  isActive?: boolean;
+  chatSystemMonitor?: boolean;
+  chatByAgentProfile?: boolean;
+  channelBumpKey?: number;
+  onProfileActivated?: () => void;
+}) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -159,7 +171,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const channel = useMemo(() => generateChannelId(), [resumeParam, channelBumpKey]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -795,7 +807,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "border-t border-current/10",
             )}
           >
-            <ChatSidebar channel={channel} />
+            <ChatSidebar channel={channel} chatByAgentProfile={chatByAgentProfile} onProfileActivated={onProfileActivated} />
           </div>
         </div>
       </>,
@@ -863,7 +875,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-80"
           >
             <div className="min-h-0 flex-1 overflow-hidden">
-              <ChatSidebar channel={channel} />
+              <ChatSidebar channel={channel} chatByAgentProfile={chatByAgentProfile} onProfileActivated={onProfileActivated} />
             </div>
           </div>
         )}


### PR DESCRIPTION
> **Status:** tested on live server (Debian 12, v0.15.1 — 2026-05-29)
> **Merge:** single commit, rebased on current main

---

### What this does

Adds a **profile switcher** to the dashboard chat sidebar so users can switch agent profiles from the UI -- no config edits, no restart.

| Layer | Change |
|:------|:-------|
| **Backend** | `POST /api/profiles/{name}/activate` (auth), sticky file, `GET /api/active-profile` (public) |
| **Frontend** | `ProfilePickerDialog` modal, read-only active card, clickable switcher card |
| **Wiring** | `channelBumpKey` -> PTY reconnects under new `HERMES_HOME` in-place |

---
### Screenshots

Default Profile
<img width="1267" height="647" alt="Screenshot_20260528_180049 default profil" src="https://github.com/user-attachments/assets/de227d7c-fdfc-429a-9652-0f2cc640ecb9" />

Custom Profile
<img width="1293" height="538" alt="Screenshot_20260528_180240_custom_profile" src="https://github.com/user-attachments/assets/78831e28-cc50-4e26-8bb1-c3af399e3d11" />

Profile Switcher Overlay
<img width="548" height="546" alt="Screenshot_20260528_180127_profile_picker_layout" src="https://github.com/user-attachments/assets/93b016c7-f0e3-4588-9811-9184ad3d20d6" />

---

### Architecture

```
┌─ BROWSER ───────────────────────────────────────────────────────────┐
│                                                                     │
│   ┌── ChatSidebar ────────────────┐   ┌── ProfilePickerDialog ────┐ │
│   │                               │   │                           │ │
│   │  ♛ acronyc     ← active      │   │  ○ default                │ │
│   │  ──────────────────────────  │   │  ● acronyc   ← checked    │ │
│   │  switch profile ▼            │──▶│  ○ infra                  │ │
│   │                               │   │  ○ wedding                │ │
│   └───────────────────────────────┘   └─────────────┬─────────────┘ │
│                                                      │ click         │
└──────────────────────────────────────────────────────┼───────────────┘
                                                       │
        GET /api/active-profile (public, on mount)     │ POST (auth)
                                                       │
┌─ SERVER ────────────────────────────────────────────┼───────────────┐
│                                                      ▼               │
│   ~/.hermes/active_profile   ◄──  sticky file  ──▶  read + write    │
│   _resolve_chat_argv()  ──▶  reads sticky, sets HERMES_HOME         │
│                                                                     │
│   channelBumpKey++  ──▶  new channel  ──▶  PTY reconnect            │
└─────────────────────────────────────────────────────┬───────────────┘
                                                       │
┌─ PTY (new profile) ────────────────────────────────▼───────────────┐
│   HERMES_HOME = ~/.hermes/profiles/acronyc                         │
│   ├── sessions/   ├── skills/   ├── config.yaml   ├── SOUL.md      │
└─────────────────────────────────────────────────────────────────────┘
```

---

### Data flow -- profile switch

```
 click "infra"
     │
     ▼
 ProfilePickerDialog
     │  api.activateProfile("infra")        ── POST, writes sticky file
     ▼
 ChatSidebar.handleProfileActivated("infra")
     │  setActiveProfile("infra")            ── ♛ card updates instantly
     │  onProfileActivated?.()               ── bumps channel
     ▼
 App.bumpChannel()
     │  channelBumpKey++
     ▼
 ChatPage ── channel memo re-computes
     │  new channel ID
     ▼
 PTY WebSocket reconnects
     │  _resolve_chat_argv() reads sticky
     ▼
 HERMES_HOME = ~/.hermes/profiles/infra   ✅
```

---

### Files changed

| File | Delta | Notes |
|:-----|:------|:------|
| `hermes_cli/web_server.py` | +40 | Activate endpoint, sticky file read, `/api/active-profile` |
| `web/src/components/ProfilePickerDialog.tsx` | +196 | **New.** Modal, sort, loading/error/empty states |
| `web/src/components/ChatSidebar.tsx` | +73 / -3 | Active card, switcher card, `handleProfileActivated` |
| `web/src/lib/api.ts` | +8 | `api.activateProfile()` via `fetchJSON` |
| `web/src/App.tsx` | +21 | Config flag, `channelBumpKey`, `bumpChannel()` |
| `web/src/pages/ChatPage.tsx` | +20 / -7 | Props wiring, channel memo |

---

### Key details

- **Auth** -- activate endpoint gated via `_require_token(request)`, only dashboard sessions can switch
- **Security** -- path traversal guard in `_resolve_chat_argv()` prevents `../../etc` escapes
- **Feature gate** -- `dashboard.chat_by_agent_profile` in `config.yaml`, defaults `true`
- **Events WS** -- preserves upstream `buildWsAuthParam()` (ticket-based in gated mode, token-based in loopback)

---

### Testing

```bash
# public endpoint -- no auth
curl http://localhost:9119/api/active-profile
# -> {"name":"acronyc"}

# activate -- requires session token
curl -X POST http://localhost:9119/api/profiles/infra/activate \
  -H "X-Hermes-Session-Token: <token>"
# -> {"ok":true,"active_profile":"infra","profile_dir":"/home/hermes/.hermes/profiles/infra"}
```

```
Browser:
  1. open /chat  ->  ♛ card shows current profile
  2. click "switch profile"  ->  picker lists all profiles
  3. select one  ->  ♛ card updates instantly, PTY reconnects
```

---

### Closes

| Issue | |
|:------|:--|
| **#33056** | Backend -- sticky file, activate endpoint, `/api/active-profile` |
| **#33739** | Frontend -- `ProfilePickerDialog`, sidebar cards, PTY reconnect |

### Related *(open -- not fixed here)*

| Issue | |
|:------|:--|
| #30815 | Original `ProfilePickerDialog` PR -- 3 bugs found in testing, fixed here |
| #30626 | Gateway is profile-blind (serves boot-time profile, ignores live switches) |
| #33913 | Double-`.hermes` path mismatch, HOME env leak in profile resolution |
| #32624 | Config traps for memory / multi-profile users |
| #10674 | Dashboard multi-profile switching -- original design analysis |
| #24914 | One gateway for multiple agent profiles *(future)* |
| #29948 | PID-file resolver ignores `HERMES_PROFILE` -> cross-profile SIGKILL |
| #27259 | Docker -- align process `HOME` with active profile home |