### PR TITLE
fix: substitute quick command args placeholder

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8656,8 +8656,16 @@ class HermesCLI:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            user_args = cmd_original[len(base_cmd):].strip()
+                            if "{args}" in exec_cmd:
+                                import shlex
+                                exec_cmd = exec_cmd.replace(
+                                    "{args}", shlex.quote(user_args) if user_args else ""
+                                )
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.
+                            # User-provided slash-command arguments are shell-quoted before
+                            # replacing the optional {args} placeholder.
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
                                 text=True, timeout=30

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7691,9 +7691,17 @@ class GatewayRunner:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            user_args = event.get_command_args().strip()
+                            if "{args}" in exec_cmd:
+                                import shlex
+                                exec_cmd = exec_cmd.replace(
+                                    "{args}", shlex.quote(user_args) if user_args else ""
+                                )
                             # Sanitize env to prevent credential leakage —
                             # quick commands run in the gateway process which
-                            # has all API keys in os.environ.
+                            # has all API keys in os.environ. User-provided
+                            # slash-command args are shell-quoted before
+                            # replacing the optional {args} placeholder.
                             from tools.environments.local import _sanitize_subprocess_env
                             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
                             proc = await asyncio.create_subprocess_shell(

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -60,6 +60,24 @@ class TestCLIQuickCommands:
         # stderr fallback — should print something
         cli.console.print.assert_called_once()
 
+    def test_exec_command_replaces_args_placeholder(self):
+        """Exec quick commands can safely receive slash-command arguments."""
+        cli = self._make_cli({"say": {"type": "exec", "command": "printf '%s' {args}"}})
+        result = cli.process_command("/say hello world")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "hello world"
+
+    def test_exec_command_quotes_args_placeholder(self):
+        """Arguments inserted into shell commands must not become shell syntax."""
+        cli = self._make_cli({"say": {"type": "exec", "command": "printf '%s' {args}"}})
+        result = cli.process_command("/say hello; echo hacked")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "hello; echo hacked"
+
     def test_exec_command_no_output_shows_fallback(self):
         cli = self._make_cli({"empty": {"type": "exec", "command": "true"}})
         cli.process_command("/empty")
@@ -159,6 +177,34 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_replaces_args_placeholder(self):
+        """Gateway quick command exec can receive slash-command arguments."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"say": {"type": "exec", "command": "printf '%s' {args}"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("say", "hello world")
+        result = await runner._handle_message(event)
+        assert result == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_quotes_args_placeholder(self):
+        """Gateway args replacement must quote shell metacharacters."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"say": {"type": "exec", "command": "printf '%s' {args}"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("say", "hello; echo hacked")
+        result = await runner._handle_message(event)
+        assert result == "hello; echo hacked"
 
     @pytest.mark.asyncio
     async def test_exec_command_does_not_leak_credentials(self):


### PR DESCRIPTION
## Summary
- substitutes `{args}` in exec quick commands for CLI and gateway handlers
- shell-quotes user-provided args before replacement
- adds CLI and gateway regression tests for placeholder substitution and shell metacharacter safety

## Test Plan
- [x] `venv/bin/python -m pytest tests/cli/test_quick_commands.py -q -o 'addopts='`
