### PR TITLE
fix(discord): log silent require_mention drops at INFO + read auto_thread from config

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4577,6 +4577,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions and not mention_prefix:
+                    logger.info(
+                        "[Discord] require_mention: dropped message from %s in #%s "
+                        "(no mention; set discord.require_mention: false to allow)",
+                        getattr(message.author, "name", "unknown"),
+                        getattr(message.channel, "name", str(getattr(message.channel, "id", "?"))),
+                    )
                     return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
@@ -4587,7 +4593,14 @@ class DiscordAdapter(BasePlatformAdapter):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
             skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
+            _auto_thread_cfg = self.config.extra.get("auto_thread")
+            if _auto_thread_cfg is not None:
+                if isinstance(_auto_thread_cfg, str):
+                    auto_thread = _auto_thread_cfg.lower() not in {"false", "0", "no", "off"}
+                else:
+                    auto_thread = bool(_auto_thread_cfg)
+            else:
+                auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4577,7 +4577,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions and not mention_prefix:
-                    logger.info(
+                    logger.debug(
                         "[Discord] require_mention: dropped message from %s in #%s "
                         "(no mention; set discord.require_mention: false to allow)",
                         getattr(message.author, "name", "unknown"),


### PR DESCRIPTION
## Problem

Regression in cc8e5ec2a: profiles without explicit discord: block silently get require_mention=true + auto_thread=true. Silent drops logged at DEBUG (issue #33947).

## Fix

1. INFO log when require_mention drops a message
2. auto_thread reads from config.extra first like require_mention does

Fixes #33947 (partial)