### PR TITLE
docs(providers): document OpenRouter session-pinned sticky routing for prompt cache reuse

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1455,6 +1455,14 @@ Notes:
 - See OpenRouter's [Pareto Router docs](https://openrouter.ai/docs/guides/routing/routers/pareto-router) for the full router behavior.
 - To use the Pareto Code router for a specific **auxiliary task** (compression, vision, etc.) instead of the main agent, set `extra_body.plugins` under that task — see [Auxiliary Models → OpenRouter routing & Pareto Code for auxiliary tasks](/user-guide/configuration#openrouter-routing--pareto-code-for-auxiliary-tasks).
 
+## OpenRouter — Session-Pinned Prompt Caching
+
+When using OpenRouter as a provider, Hermes automatically passes the active session ID as `session_id` in the request's `extra_body`. OpenRouter pins subsequent requests in the same session to the same upstream provider endpoint, so prompt caches (e.g., Anthropic's 5-minute TTL cache and similar caches on other upstreams) actually hit across turns instead of routing to a different server and missing the cache.
+
+No configuration is needed — the session ID is added automatically when one is available, and OpenRouter ignores it for providers that don't honor sticky routing. This reduces latency and cost for multi-turn conversations without changing how you write your config.
+
+This is the OpenRouter counterpart to the `x-grok-conv-id` mechanism for xAI Grok above; together they cover prompt cache reuse on the two providers Hermes routes through most frequently.
+
 ## Fallback Providers
 
 Configure a chain of backup providers Hermes tries in order when the primary model fails (rate limits, server errors, auth failures). The canonical format is a top-level `fallback_providers:` list:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -1379,6 +1379,14 @@ openrouter:
 - 参见 OpenRouter 的 [Pareto Router 文档](https://openrouter.ai/docs/guides/routing/routers/pareto-router) 了解完整路由器行为。
 - 要将 Pareto Code 路由器用于特定**辅助任务**（压缩、视觉等）而非主智能体，在该任务下设置 `extra_body.plugins`——参见[辅助模型 → OpenRouter 路由与辅助任务的 Pareto Code](/user-guide/configuration#openrouter-routing--pareto-code-for-auxiliary-tasks)。
 
+## OpenRouter — 会话固定的 Prompt 缓存
+
+使用 OpenRouter 作为提供商时，Hermes 会自动在请求的 `extra_body` 中传入当前会话 ID 作为 `session_id`。OpenRouter 会将同一会话的后续请求固定路由到同一个上游 provider 端点，使 prompt 缓存（如 Anthropic 5 分钟 TTL 缓存以及其他上游的类似缓存）能在多轮对话间真正命中，而不是被路由到另一台服务器后错过缓存。
+
+无需任何配置——只要会话 ID 可用就会自动加入，OpenRouter 对不支持粘性路由的上游 provider 也会安全地忽略它。这能降低多轮对话的延迟和成本，且无需修改配置写法。
+
+这是 OpenRouter 端对应于上文 xAI Grok 的 `x-grok-conv-id` 机制；二者共同覆盖了 Hermes 最常路由的两大提供商的 prompt 缓存复用。
+
 ## 故障转移提供商
 
 配置一个备用提供商链，当主模型失败时（速率限制、服务器错误、认证失败）Hermes 按顺序尝试。规范格式是顶级 `fallback_providers:` 列表：


### PR DESCRIPTION
## Summary

Document OpenRouter's already-shipped session-pinned routing behavior in both
provider guides.

Hermes passes the active session ID as `extra_body.session_id` on normal
OpenRouter chat-completions requests. OpenRouter can then keep successive turns
on the same upstream endpoint, allowing prompt caches to remain useful across a
multi-turn conversation. This is automatic and requires no configuration.

The English and zh-Hans sections are placed between the existing Pareto Code
Router and fallback-provider documentation, mirroring the xAI Grok cache-affinity
explanation earlier in the same guide.

## Source verification

- `plugins/model-providers/openrouter/__init__.py:76-82` adds `session_id` to
  `extra_body` when available.
- `agent/transports/chat_completions.py:598-605` supplies the active session ID.
- `tests/providers/test_provider_profiles.py:105-108` covers the provider body.

## Validation

- `git diff --check`
- Documentation-only: 8 lines in English plus the 8-line zh-Hans mirror.
