### PR TITLE
fix(discord): log when require_mention silently drops messages

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4577,6 +4577,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions and not mention_prefix:
+                    logger.info(
+                        "[%s] Dropping message in #%s (require_mention=true, no @mention). "
+                        "Set discord.require_mention: false or add channel to "
+                        "discord.free_response_channels to override.",
+                        self.name,
+                        getattr(message.channel, "name", message.channel.id),
+                    )
                     return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
@@ -6109,6 +6116,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     update.  Returns ``None`` because no extras are seeded into
     ``PlatformConfig.extra`` directly (everything flows through env).
     """
+    if not discord_cfg:
+        logger.warning(
+            "Discord profile has no explicit 'discord:' config block — using "
+            "plugin defaults (require_mention=true, auto_thread=true). "
+            "Add a 'discord:' section to config.yaml to override. "
+            "See https://docs.hermes.agent/platforms/discord for options."
+        )
     if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
     if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -927,3 +927,32 @@ async def test_discord_auto_thread_skips_backfill(adapter, monkeypatch):
     adapter._fetch_channel_context.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_discord_require_mention_logs_info_on_drop(adapter, monkeypatch, caplog):
+    """When require_mention drops a message, log at INFO level with actionable guidance."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(channel=FakeTextChannel(channel_id=123, name="general"), content="hello")
+
+    import logging
+    with caplog.at_level(logging.INFO, logger="plugins.platforms.discord.adapter"):
+        await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    assert any("Dropping message" in r.message and "require_mention=true" in r.message for r in caplog.records), \
+        f"Expected INFO log about require_mention drop, got: {[r.message for r in caplog.records]}"
+
+
+def test_apply_yaml_config_warns_on_empty_discord_cfg(caplog):
+    """When discord_cfg is empty (no explicit discord: block), warn at startup."""
+    import logging
+    from plugins.platforms.discord.adapter import _apply_yaml_config
+
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.discord.adapter"):
+        _apply_yaml_config({}, {})
+
+    assert any("no explicit 'discord:' config block" in r.message for r in caplog.records), \
+        f"Expected WARNING about missing discord config, got: {[r.message for r in caplog.records]}"
+
+


### PR DESCRIPTION
## What does this PR do?

When a Discord profile's `config.yaml` has no explicit `discord:` block, the bundled Discord plugin silently applies plugin-internal defaults (`require_mention=true`, `auto_thread=true`). Messages that don't @mention the bot are silently dropped with no log output at default log level, making this behavior nearly impossible to diagnose without source-patching.

This PR adds two targeted logging improvements (no behavior change):

1. **`logger.info` when `require_mention` drops a message** — includes the channel name and actionable guidance to override via `discord.require_mention: false` or `discord.free_response_channels`.

2. **`logger.warning` at startup when `_apply_yaml_config` receives an empty `discord_cfg`** — alerts operators that plugin defaults are in effect and a `discord:` config section is missing.
## Related Issue

Fixes #33947

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

| File | Change |
|------|--------|
| `plugins/platforms/discord/adapter.py` | Add `logger.info` in `_handle_message` when `require_mention` silently drops a non-mentioned message; add `logger.warning` in `_apply_yaml_config` when `discord_cfg` is empty |
| `tests/gateway/test_discord_free_response.py` | Add 2 regression tests: `test_discord_require_mention_logs_info_on_drop` and `test_apply_yaml_config_warns_on_empty_discord_cfg` |

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `_apply_yaml_config` (1 caller: line 6230 in `register()`), `_discord_require_mention` (2 callers: lines 4555, 4832), `require_mention` filter (line 4578)
- Blast radius: LOW — logging-only changes in `plugins/platforms/discord/adapter.py`, no behavioral change
- Related patterns: `_discord_thread_require_mention` at line 3700 uses the same config-extra → env-var → default resolution chain

## Checklist

- [x] One root cause (silent drops without logging)
- [x] Small diff (43 insertions, 0 deletions)
- [x] Regression tests added
- [x] No unrelated changes
- [x] Existing tests pass