### PR TITLE
fix(cron): add schedule to required array in CRONJOB_SCHEMA

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -801,7 +801,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "description": "Optional Hermes profile name to run the job under. When set, the scheduler resolves that profile, applies a context-local Hermes home override, loads that profile's config/.env for the run, and bridges HERMES_HOME into subprocesses. Any temporary process-environment changes from profile .env loading are restored after the job exits. Use 'default' for the root Hermes profile. Named profiles must already exist. When unset (default), preserves the scheduler's existing profile. On update, pass an empty string to clear. Jobs with profile run sequentially (not parallel) to keep profile-scoped runtime state isolated."
             },
         },
-        "required": ["action"]
+        "required": ["action", "schedule"],
     }
 }
 


### PR DESCRIPTION
Grok models ignore prose descriptions and only respect the machine-readable required field in JSON Schema. The prior fix (51013268c) clarified the description text but did not add schedule to required[], so grok-4.3 still omits it on action=create, causing an infinite loop of "schedule is required for create" errors.

**Fix:** Add "schedule" to the required array. Safe because the handler only checks schedule for action=create and ignores it for other actions.

Fixes #32427