### PR TITLE
fix(gateway): surface provider auth reauth guidance

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3205,7 +3205,16 @@ def run_conversation(
                             "failed": True,
                             "error": f"content_policy_blocked: {_summary}",
                         }
-                    return {
+                    _auth_error = None
+                    if classified.is_auth:
+                        _auth_error = {
+                            "provider": _provider,
+                            "model": _model,
+                            "status_code": status_code,
+                            "is_auth": True,
+                            "relogin_required": status_code == 401,
+                        }
+                    _failed_result = {
                         "final_response": None,
                         "messages": messages,
                         "api_calls": api_call_count,
@@ -3213,6 +3222,9 @@ def run_conversation(
                         "failed": True,
                         "error": str(api_error),
                     }
+                    if _auth_error is not None:
+                        _failed_result["auth_error"] = _auth_error
+                    return _failed_result
 
                 if retry_count >= max_retries:
                     # Before falling back, try rebuilding the primary

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1468,6 +1468,65 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _resolve_gateway_provider(config: dict | None = None) -> str:
+    """Read provider from config.yaml for user-facing diagnostics."""
+    cfg = config if config is not None else _load_gateway_config()
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        return model_cfg.get("provider") or ""
+    return ""
+
+
+def _gateway_reauth_command(provider: str) -> str:
+    """Return the most direct re-auth command for a gateway provider."""
+    if provider:
+        return f"hermes auth add {provider}"
+    return "hermes model"
+
+
+def _format_gateway_provider_auth_failure(
+    *,
+    provider: str = "",
+    model: str = "",
+    raw_error: object = "",
+) -> str:
+    """Render a concise gateway-safe message for provider auth failures."""
+    provider_label = provider or "configured provider"
+    model_label = f" / {model}" if model else ""
+    command = _gateway_reauth_command(provider)
+    message = (
+        "⚠️ Model provider login expired or was rejected.\n"
+        f"Provider: {provider_label}{model_label}\n"
+        f"Run `{command}` to re-authenticate, then restart the gateway or retry."
+    )
+    if raw_error:
+        message += f"\nRaw error: {str(raw_error)[:200]}"
+    return message
+
+
+def _agent_result_auth_failure(agent_result: dict, error_str: str) -> dict | None:
+    """Extract structured auth failure metadata from an agent result.
+
+    ``agent.run_conversation`` may return provider-auth metadata without a final
+    response when all fallback providers are exhausted.  Keep a conservative
+    legacy fallback for the known opaque Codex auth failure shape so gateways do
+    not leak a Python ``NoneType`` error to chat users.
+    """
+    auth_error = agent_result.get("auth_error")
+    if isinstance(auth_error, dict):
+        if auth_error.get("relogin_required") or auth_error.get("is_auth"):
+            return auth_error
+
+    provider = _resolve_gateway_provider()
+    if (
+        provider == "openai-codex"
+        and "nonetype" in error_str
+        and "not iterable" in error_str
+    ):
+        return {"provider": provider, "relogin_required": True}
+    return None
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -1583,6 +1642,17 @@ def _normalize_empty_agent_response(
                 "Use /compact to compress the conversation, or "
                 "/reset to start fresh."
             )
+
+        auth_error = _agent_result_auth_failure(agent_result, error_str)
+        if auth_error is not None:
+            provider = str(auth_error.get("provider") or _resolve_gateway_provider() or "")
+            model = str(auth_error.get("model") or _resolve_gateway_model() or "")
+            return _format_gateway_provider_auth_failure(
+                provider=provider,
+                model=model,
+                raw_error=error_detail,
+            )
+
         return (
             f"The request failed: {str(error_detail)[:300]}\n"
             "Try again or use /reset to start a fresh session."

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -405,6 +405,64 @@ class TestGatewaySurfacesNullResponse:
         assert "500 Internal Server Error" in response
         assert "/reset" in response
 
+    def test_failed_auth_error_surfaces_reauth_guidance(self):
+        """Structured provider auth failures should tell gateway users to re-auth."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": None,
+            "api_calls": 1,
+            "failed": True,
+            "error": "401 Unauthorized",
+            "auth_error": {
+                "provider": "openai-codex",
+                "model": "gpt-5.5",
+                "status_code": 401,
+                "is_auth": True,
+                "relogin_required": True,
+            },
+        }
+
+        response = _normalize_empty_agent_response(
+            agent_result, "", history_len=5,
+        )
+
+        assert "Model provider login expired" in response
+        assert "openai-codex / gpt-5.5" in response
+        assert "hermes auth add openai-codex" in response
+        assert "401 Unauthorized" in response
+        assert "/reset" not in response
+
+    def test_failed_codex_nonetype_error_uses_auth_guidance(self, monkeypatch):
+        """Known opaque Codex auth failures should not leak as Python errors."""
+        import gateway.run as gateway_run
+
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {
+                "model": {
+                    "provider": "openai-codex",
+                    "default": "gpt-5.5",
+                }
+            },
+        )
+        agent_result = {
+            "final_response": None,
+            "api_calls": 1,
+            "failed": True,
+            "error": "'NoneType' object is not iterable",
+        }
+
+        response = gateway_run._normalize_empty_agent_response(
+            agent_result, "", history_len=5,
+        )
+
+        assert "Model provider login expired" in response
+        assert "openai-codex / gpt-5.5" in response
+        assert "hermes auth add openai-codex" in response
+        assert "Raw error: 'NoneType' object is not iterable" in response
+
     def test_nonempty_response_passes_through(self):
         """Non-empty response is returned unchanged."""
         from gateway.run import _normalize_empty_agent_response


### PR DESCRIPTION
## Summary
- attach structured `auth_error` metadata when provider auth failures surface through terminal tool results
- render provider re-auth guidance in the gateway instead of leaking opaque Codex `NoneType` failures
- keep a generic fallback for Codex auth crashes that do not include structured metadata

## Test Plan
- `python -m pytest tests/test_lazy_session_regressions.py -o 'addopts=' -q`
- `python -m py_compile agent/conversation_loop.py gateway/run.py tests/test_lazy_session_regressions.py`
