### PR TITLE
Project Autopilot V0

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -25,6 +25,17 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = float(raw)
+    except Exception:
+        return default
+    return value if value > 0 else default
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -65,8 +76,17 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    turn_timeout = _env_float("HERMES_CODEX_TURN_TIMEOUT_SEC", 600.0)
+    post_tool_quiet_timeout = _env_float(
+        "HERMES_CODEX_POST_TOOL_QUIET_TIMEOUT_SEC", 90.0
+    )
+
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            turn_timeout=turn_timeout,
+            post_tool_quiet_timeout=post_tool_quiet_timeout,
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -30,6 +30,52 @@ from typing import Any, Callable, Optional
 MIN_CODEX_VERSION = (0, 125, 0)
 
 
+def _codex_workspace_write_roots(spawn_env: dict[str, str]) -> list[str]:
+    """Return narrow extra writable roots for kanban Codex workers.
+
+    The default Codex workspace-write sandbox only allows writes inside the
+    current task workspace. Hermes kanban workers also need access to a few
+    carefully-scoped external paths:
+
+    - the board root that contains the shared kanban SQLite DB/logs
+    - the linked Project Autopilot project home, when the dispatcher knows it
+
+    Keep this list narrow; if a task needs some *other* external path (for
+    example creating a new git worktree off a repo outside the board root), the
+    task should block for human intervention rather than silently widening the
+    sandbox or inventing a fallback clone.
+    """
+
+    roots: list[str] = []
+
+    kanban_db = spawn_env.get("HERMES_KANBAN_DB")
+    kanban_root = (
+        os.path.dirname(kanban_db)
+        if kanban_db
+        else spawn_env.get(
+            "HERMES_KANBAN_ROOT",
+            os.path.join(
+                spawn_env.get("HERMES_HOME", os.path.expanduser("~/.hermes")),
+                "kanban",
+            ),
+        )
+    )
+    if kanban_root:
+        roots.append(os.path.abspath(os.path.expanduser(kanban_root)))
+
+    project_home = (spawn_env.get("HERMES_KANBAN_PROJECT_HOME") or "").strip()
+    if project_home:
+        roots.append(os.path.abspath(os.path.expanduser(project_home)))
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for root in roots:
+        if root not in seen:
+            seen.add(root)
+            deduped.append(root)
+    return deduped
+
+
 @dataclass
 class CodexAppServerError(RuntimeError):
     """Raised on JSON-RPC errors from the app-server."""
@@ -82,29 +128,19 @@ class CodexAppServerClient:
 
         app_server_args = list(extra_args or [])
         # Kanban workers must be able to write their handoff/status back to
-        # the board DB, which lives outside the per-task workspace. Keep the
-        # Codex sandbox on, but add the Kanban root as the only extra writable
-        # root. Without this, codex-runtime workers finish their actual work
-        # but crash/block when kanban_complete/kanban_block writes SQLite.
+        # the board DB, and Project Autopilot tasks may also need the linked
+        # project home outside the per-task workspace. Keep the Codex sandbox
+        # on and add only these narrow extra writable roots. If a task needs
+        # some other external root, it should block for human intervention
+        # instead of creating fallback clones or widening permissions.
         if spawn_env.get("HERMES_KANBAN_TASK"):
-            kanban_db = spawn_env.get("HERMES_KANBAN_DB")
-            kanban_root = (
-                os.path.dirname(kanban_db)
-                if kanban_db
-                else spawn_env.get(
-                    "HERMES_KANBAN_ROOT",
-                    os.path.join(
-                        spawn_env.get("HERMES_HOME", os.path.expanduser("~/.hermes")),
-                        "kanban",
-                    ),
-                )
-            )
+            writable_roots_json = json.dumps(_codex_workspace_write_roots(spawn_env))
             app_server_args.extend(
                 [
                     "-c",
                     'sandbox_mode="workspace-write"',
                     "-c",
-                    f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
+                    f"sandbox_workspace_write.writable_roots={writable_roots_json}",
                     "-c",
                     "sandbox_workspace_write.network_access=false",
                 ]

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -24,6 +24,7 @@ call is synchronous and behaves like AIAgent's existing chat_completions loop.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import threading
@@ -58,6 +59,50 @@ _HERMES_TO_CODEX_PERMISSION_PROFILE = {
     # Backstop alias used by some skills/tests.
     "yolo": "full-access",
 }
+
+
+def _build_dynamic_tools() -> list[dict[str, Any]]:
+    """Return Hermes tool schemas in Codex dynamicTools format.
+
+    Kanban workers need a reliable model-visible path to kanban_complete /
+    kanban_block / kanban_comment. In practice some codex app-server sessions
+    come up with an empty MCP surface, which leaves workers with only Codex's
+    built-in shell/apply_patch tools and no dependable way to hand results back
+    to Hermes. Register the Hermes callback tools directly as dynamicTools on
+    thread/start so the worker can always complete or block itself.
+    """
+
+    try:
+        from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+        from model_tools import get_tool_definitions
+    except Exception:
+        logger.exception("failed to build codex dynamicTools from Hermes tool registry")
+        return []
+
+    tool_defs = {
+        td["function"]["name"]: td["function"]
+        for td in (get_tool_definitions(quiet_mode=True) or [])
+        if isinstance(td, dict)
+        and td.get("type") == "function"
+        and isinstance(td.get("function"), dict)
+    }
+
+    out: list[dict[str, Any]] = []
+    for name in EXPOSED_TOOLS:
+        spec = tool_defs.get(name)
+        if not spec:
+            continue
+        out.append(
+            {
+                "name": name,
+                "description": spec.get("description") or f"Hermes {name} tool",
+                "inputSchema": spec.get("parameters") or {
+                    "type": "object",
+                    "properties": {},
+                },
+            }
+        )
+    return out
 
 
 @dataclass
@@ -115,6 +160,37 @@ _OAUTH_REFRESH_FAILURE_HINTS = (
     "no auth profile",
     "oauth",
 )
+
+
+def _auto_accept_via_hermes_approval_policy() -> bool:
+    """Return True when Hermes' own approval policy says prompts should be bypassed.
+
+    Codex app-server server-side approval requests (exec/apply_patch) need to
+    honor the same top-level approval semantics as Hermes' native tools. In
+    particular, unattended worker profiles often run with ``approvals.mode:
+    off`` (or YOLO) specifically to avoid interactive approval prompts.
+
+    Before this helper existed, the codex app-server bridge invoked the CLI
+    approval callback directly whenever one was installed, bypassing
+    ``approvals.mode=off`` and session YOLO. In non-interactive kanban runs that
+    callback timed out after 60s, denied the request, and then left the codex
+    app-server session silent / wedged after the tool result.
+    """
+    try:
+        from tools.approval import _get_approval_mode, is_current_session_yolo_enabled
+
+        if _get_approval_mode() == "off":
+            return True
+        if is_current_session_yolo_enabled():
+            return True
+    except Exception:
+        logger.debug(
+            "Failed to read Hermes approval policy for codex request",
+            exc_info=True,
+        )
+
+    raw = str(os.getenv("HERMES_YOLO_MODE", "")).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 def _classify_oauth_failure(*parts: str) -> Optional[str]:
@@ -185,6 +261,7 @@ class CodexAppServerSession:
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
+        self._dynamic_tools = _build_dynamic_tools()
 
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
@@ -213,6 +290,7 @@ class CodexAppServerSession:
             client_name="hermes",
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
+            capabilities={"experimentalApi": True},
         )
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
@@ -230,6 +308,8 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
+        if self._dynamic_tools:
+            params["dynamicTools"] = self._dynamic_tools
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
@@ -595,8 +675,7 @@ class CodexAppServerSession:
             logger.warning("turn/interrupt timed out")
 
     def _handle_server_request(self, req: dict) -> None:
-        """Translate a codex server request (approval) into Hermes' approval
-        flow, then send the response.
+        """Translate a codex server request into Hermes callbacks.
 
         Method names verified live against codex 0.130.0 (Apr 2026):
           item/commandExecution/requestApproval — exec approvals
@@ -605,6 +684,7 @@ class CodexAppServerSession:
                                                   (we decline; user controls
                                                   permission profile in
                                                   ~/.codex/config.toml).
+          item/tool/call                        — dynamicTools callback
         """
         if self._client is None:
             return
@@ -624,6 +704,8 @@ class CodexAppServerSession:
             # profile in ~/.codex/config.toml and surprise escalations
             # shouldn't be silently accepted.
             self._client.respond(rid, {"decision": "decline"})
+        elif method == "item/tool/call":
+            self._handle_dynamic_tool_call(rid, params)
         elif method == "mcpServer/elicitation/request":
             # Codex's MCP layer asks the user for structured input on
             # behalf of an MCP server (e.g. tool-call confirmation,
@@ -652,8 +734,60 @@ class CodexAppServerSession:
                 rid, code=-32601, message=f"Unsupported method: {method}"
             )
 
+    def _handle_dynamic_tool_call(self, request_id: Any, params: dict) -> None:
+        """Dispatch a Codex dynamic tool call through Hermes' tool registry."""
+        if self._client is None:
+            return
+
+        tool_name = str(params.get("tool") or "").strip()
+        arguments = params.get("arguments") or {}
+        if not isinstance(arguments, dict):
+            arguments = {"arguments": arguments}
+        if not tool_name:
+            self._client.respond(
+                request_id,
+                {
+                    "contentItems": [
+                        {"type": "inputText", "text": "Missing dynamic tool name."}
+                    ],
+                    "success": False,
+                },
+            )
+            return
+
+        try:
+            from model_tools import handle_function_call
+
+            tool_result = handle_function_call(tool_name, arguments)
+            self._client.respond(
+                request_id,
+                {
+                    "contentItems": [
+                        {"type": "inputText", "text": str(tool_result or "")}
+                    ],
+                    "success": True,
+                },
+            )
+        except Exception as exc:
+            logger.exception("dynamic tool %s raised", tool_name)
+            self._client.respond(
+                request_id,
+                {
+                    "contentItems": [
+                        {
+                            "type": "inputText",
+                            "text": json.dumps(
+                                {"error": str(exc), "tool": tool_name},
+                                ensure_ascii=False,
+                            ),
+                        }
+                    ],
+                    "success": False,
+                },
+            )
+
     def _decide_exec_approval(self, params: dict) -> str:
-        if self._routing.auto_approve_exec:
+        if self._routing.auto_approve_exec or _auto_accept_via_hermes_approval_policy():
             return "accept"
         command = params.get("command") or ""
         # Codex's CommandExecutionRequestApprovalParams has cwd as Optional —
@@ -676,7 +810,7 @@ class CodexAppServerSession:
         return "decline"  # fail-closed when no callback wired
 
     def _decide_apply_patch_approval(self, params: dict) -> str:
-        if self._routing.auto_approve_apply_patch:
+        if self._routing.auto_approve_apply_patch or _auto_accept_via_hermes_approval_policy():
             return "accept"
         if self._approval_callback is not None:
             # FileChangeRequestApprovalParams gives us reason + grantRoot.

--- a/cli.py
+++ b/cli.py
@@ -2277,6 +2277,34 @@ def _bind_prompt_submit_keys(kb, handler) -> None:
         kb.add("c-j")(handler)
 
 
+def _consume_backslash_submit_newline(buffer) -> bool:
+    r"""On macOS, treat a trailing backslash + Enter as a literal newline.
+
+    This gives Terminal.app/iTerm users a terminal-agnostic multiline fallback
+    even when Option/Shift/Ctrl/Cmd+Enter are intercepted or collapsed before
+    prompt_toolkit sees them. It also matches the `\\` + Enter sequence the
+    Hermes TUI installs in VS Code/Cursor/Windsurf terminals.
+
+    Only a *single* trailing backslash immediately before the cursor is
+    consumed. Double-backslash stays literal so users can still submit text
+    ending in `\\` by typing two backslashes.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        before = buffer.document.current_line_before_cursor
+    except Exception:
+        return False
+    if not before.endswith("\\") or before.endswith("\\\\"):
+        return False
+    try:
+        buffer.delete_before_cursor(count=1)
+        buffer.insert_text("\n")
+        return True
+    except Exception:
+        return False
+
+
 def _disable_prompt_toolkit_cpr_warning(app) -> None:
     """Let prompt_toolkit fall back from CPR without printing into the prompt."""
     try:
@@ -12154,6 +12182,10 @@ class HermesCLI:
                 return
 
             # --- Normal input routing ---
+            if _consume_backslash_submit_newline(event.current_buffer):
+                event.app.invalidate()
+                return
+
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3475,9 +3475,11 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
       resolves against the dispatcher's CWD instead of a meaningful
       root.  Users who want a kanban-root-relative workspace should
       compute the absolute path themselves.
-    - ``worktree``: a git worktree at ``workspace_path``.  Not created
-      automatically in v1 -- the kanban-worker skill documents
-      ``git worktree add`` as a worker-side step.  Returns the intended path.
+    - ``worktree``: a pre-existing git worktree at ``workspace_path``.
+      ``workspace_path`` and ``branch_name`` are required.  The dispatcher
+      validates that the path exists, is a git worktree, and is already on
+      the declared branch before spawning a worker.  Workers must never be
+      the first process to discover a missing declared worktree.
 
     Persist the resolved path back to the task row via ``set_workspace_path``
     so subsequent runs reuse the same directory.
@@ -3514,13 +3516,58 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         return p
     if kind == "worktree":
         if not task.workspace_path:
-            # Default: .worktrees/<id>/ under CWD.  Worker skill creates it.
-            return Path.cwd() / ".worktrees" / task.id
+            raise ValueError(
+                f"task {task.id} has workspace_kind=worktree but no workspace_path; "
+                "create the git worktree before dispatch and store its absolute path"
+            )
         p = Path(task.workspace_path).expanduser()
         if not p.is_absolute():
             raise ValueError(
                 f"task {task.id} has non-absolute worktree path "
                 f"{task.workspace_path!r}; use an absolute path"
+            )
+        if not task.branch_name:
+            raise ValueError(
+                f"task {task.id} has workspace_kind=worktree but no branch_name; "
+                "worktree tasks must declare the expected branch before dispatch"
+            )
+        if not p.exists():
+            raise ValueError(
+                f"task {task.id} declares worktree path {str(p)!r}, but it does not exist; "
+                f"create it with `git worktree add -b {task.branch_name} {p} <base-ref>` "
+                "before dispatch"
+            )
+        try:
+            proc = subprocess.run(
+                ["git", "-C", str(p), "rev-parse", "--is-inside-work-tree"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception as exc:
+            raise ValueError(
+                f"task {task.id} declares worktree path {str(p)!r}, but git validation failed: {exc}"
+            ) from exc
+        if proc.returncode != 0 or (proc.stdout or "").strip() != "true":
+            detail = (proc.stderr or proc.stdout or "not a git worktree").strip()
+            raise ValueError(
+                f"task {task.id} declares worktree path {str(p)!r}, but it is not a git worktree: {detail}"
+            )
+        branch_proc = subprocess.run(
+            ["git", "-C", str(p), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        actual_branch = (branch_proc.stdout or "").strip()
+        if branch_proc.returncode != 0 or actual_branch != task.branch_name:
+            detail = (branch_proc.stderr or "").strip()
+            suffix = f": {detail}" if detail else ""
+            raise ValueError(
+                f"task {task.id} declares branch {task.branch_name!r} at {str(p)!r}, "
+                f"but actual branch is {actual_branch!r}{suffix}"
             )
         return p
     raise ValueError(f"unknown workspace_kind: {kind}")
@@ -4999,8 +5046,21 @@ def dispatch_once(
                         {"reason": guard_reason},
                     )
             continue
+        preflight_workspace: Optional[Path] = None
+        preflight_task = get_task(conn, row["id"])
+        if preflight_task is not None and (preflight_task.workspace_kind or "scratch") == "worktree":
+            try:
+                preflight_workspace = resolve_workspace(preflight_task, board=board)
+            except Exception as exc:
+                reason = f"workspace-preflight: {exc}"
+                if dry_run:
+                    result.respawn_guarded.append((row["id"], reason))
+                else:
+                    if block_task(conn, row["id"], reason=reason):
+                        result.auto_blocked.append(row["id"])
+                continue
         if dry_run:
-            result.spawned.append((row["id"], row["assignee"], ""))
+            result.spawned.append((row["id"], row["assignee"], str(preflight_workspace or "")))
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -5077,8 +5137,21 @@ def dispatch_once(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        preflight_workspace: Optional[Path] = None
+        preflight_task = get_task(conn, row["id"])
+        if preflight_task is not None and (preflight_task.workspace_kind or "scratch") == "worktree":
+            try:
+                preflight_workspace = resolve_workspace(preflight_task, board=board)
+            except Exception as exc:
+                reason = f"workspace-preflight: {exc}"
+                if dry_run:
+                    result.respawn_guarded.append((row["id"], reason))
+                else:
+                    if block_task(conn, row["id"], reason=reason):
+                        result.auto_blocked.append(row["id"])
+                continue
         if dry_run:
-            result.spawned.append((row["id"], row["assignee"], ""))
+            result.spawned.append((row["id"], row["assignee"], str(preflight_workspace or "")))
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3401,6 +3401,11 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
     recompute_ready(conn)
+    task = get_task(conn, task_id)
+    cleanup = cleanup_archived_workspace(task)
+    if cleanup.get("status") not in {"none", "missing_task"}:
+        with write_txn(conn):
+            _append_event(conn, task_id, "workspace_cleanup", cleanup)
     return True
 
 
@@ -3519,6 +3524,179 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
             )
         return p
     raise ValueError(f"unknown workspace_kind: {kind}")
+
+
+def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 15) -> str:
+    """Run a git command and return stripped stdout or raise RuntimeError."""
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(stderr or f"git {' '.join(args)} failed")
+    return (proc.stdout or "").strip()
+
+
+def _git_has_unpushed_commits(worktree: Path) -> bool:
+    """Return True if HEAD has commits not reachable from any remote ref."""
+    try:
+        out = _git_stdout(
+            ["log", "--oneline", "HEAD", "--not", "--remotes"],
+            cwd=worktree,
+            timeout=10,
+        )
+    except Exception:
+        # On inspection failure, keep the worktree instead of risking deletion.
+        return True
+    return bool(out)
+
+
+def _git_common_repo_root(worktree: Path) -> Path:
+    """Resolve the owning repository root for a git worktree path."""
+    common_dir_raw = _git_stdout(["rev-parse", "--git-common-dir"], cwd=worktree)
+    common_dir = Path(common_dir_raw).expanduser()
+    if not common_dir.is_absolute():
+        common_dir = (worktree / common_dir).resolve()
+    return common_dir.parent
+
+
+def cleanup_archived_workspace(task: Optional[Task], *, board: Optional[str] = None) -> dict[str, Any]:
+    """Best-effort cleanup for an archived task's workspace.
+
+    Policy:
+    - ``scratch``: remove immediately once archived.
+    - ``worktree``: remove only when there are no unpushed commits.
+    - ``dir``: never auto-delete; it's treated as shared persistent state.
+    """
+    if task is None:
+        return {"status": "missing_task"}
+    kind = task.workspace_kind or "scratch"
+    raw_path = task.workspace_path
+    if kind == "dir":
+        return {
+            "status": "kept",
+            "kind": kind,
+            "reason": "persistent_dir",
+            "path": raw_path,
+        }
+    if kind == "scratch":
+        scratch_root = workspaces_root(board=board)
+        path = Path(raw_path or (scratch_root / task.id))
+        try:
+            resolved_root = scratch_root.resolve()
+            resolved_path = path.resolve()
+        except OSError as exc:
+            return {
+                "status": "error",
+                "kind": kind,
+                "path": str(path),
+                "reason": f"resolve_failed: {exc}",
+            }
+        try:
+            resolved_path.relative_to(resolved_root)
+        except ValueError:
+            return {
+                "status": "kept",
+                "kind": kind,
+                "path": str(path),
+                "reason": "outside_scratch_root",
+            }
+        if not resolved_path.exists():
+            return {
+                "status": "none",
+                "kind": kind,
+                "path": str(resolved_path),
+                "reason": "already_missing",
+            }
+        try:
+            import shutil
+            shutil.rmtree(resolved_path, ignore_errors=False)
+        except Exception as exc:
+            return {
+                "status": "error",
+                "kind": kind,
+                "path": str(resolved_path),
+                "reason": f"remove_failed: {exc}",
+            }
+        return {
+            "status": "removed",
+            "kind": kind,
+            "path": str(resolved_path),
+        }
+    if kind == "worktree":
+        if not raw_path:
+            return {
+                "status": "kept",
+                "kind": kind,
+                "reason": "missing_workspace_path",
+            }
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute():
+            return {
+                "status": "kept",
+                "kind": kind,
+                "path": str(path),
+                "reason": "non_absolute_path",
+            }
+        if not path.exists():
+            return {
+                "status": "none",
+                "kind": kind,
+                "path": str(path),
+                "reason": "already_missing",
+            }
+        try:
+            _git_stdout(["rev-parse", "--is-inside-work-tree"], cwd=path, timeout=10)
+        except Exception as exc:
+            return {
+                "status": "kept",
+                "kind": kind,
+                "path": str(path),
+                "reason": f"not_git_worktree: {exc}",
+            }
+        if _git_has_unpushed_commits(path):
+            return {
+                "status": "kept",
+                "kind": kind,
+                "path": str(path),
+                "reason": "unpushed_commits",
+            }
+        branch = ""
+        try:
+            branch = _git_stdout(["branch", "--show-current"], cwd=path, timeout=10)
+        except Exception:
+            branch = ""
+        try:
+            repo_root = _git_common_repo_root(path)
+            _git_stdout(["worktree", "remove", str(path), "--force"], cwd=repo_root, timeout=20)
+            with contextlib.suppress(Exception):
+                _git_stdout(["worktree", "prune"], cwd=repo_root, timeout=15)
+            if branch:
+                with contextlib.suppress(Exception):
+                    _git_stdout(["branch", "-D", branch], cwd=repo_root, timeout=10)
+        except Exception as exc:
+            return {
+                "status": "error",
+                "kind": kind,
+                "path": str(path),
+                "reason": f"worktree_remove_failed: {exc}",
+            }
+        return {
+            "status": "removed",
+            "kind": kind,
+            "path": str(path),
+            "branch": branch or None,
+        }
+    return {
+        "status": "kept",
+        "kind": kind,
+        "path": raw_path,
+        "reason": "unknown_workspace_kind",
+    }
 
 
 def set_workspace_path(
@@ -5286,12 +5464,26 @@ def _default_spawn(
     # dispatcher's. Belt-and-braces with the `get_default_hermes_root()`
     # resolution in `kanban_home()` — symmetric resolution is the norm,
     # but unusual symlink / Docker layouts are caught here too.
+    resolved_board = _normalize_board_slug(board) or get_current_board()
     env["HERMES_KANBAN_DB"] = str(kanban_db_path(board=board))
     env["HERMES_KANBAN_WORKSPACES_ROOT"] = str(workspaces_root(board=board))
+    project_home = (
+        os.environ.get("HERMES_KANBAN_PROJECT_HOME")
+        or os.environ.get("HERMES_PROJECT_HOME")
+        or os.path.join(
+            os.path.expanduser(
+                os.environ.get("HERMES_PROJECTS_ROOT", "~/Documents/hermes-projects")
+            ),
+            "active",
+            resolved_board,
+        )
+    )
+    project_home = os.path.abspath(os.path.expanduser(project_home))
+    if os.path.exists(project_home):
+        env["HERMES_KANBAN_PROJECT_HOME"] = project_home
     # Board slug — the final defense-in-depth pin. If the worker ever
     # resolves kanban paths without the DB / workspaces env vars, the
     # board slug still forces it to the right directory.
-    resolved_board = _normalize_board_slug(board) or get_current_board()
     env["HERMES_KANBAN_BOARD"] = resolved_board
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5801,6 +5801,13 @@ def cmd_kanban(args):
     return kanban_command(args)
 
 
+def cmd_project(args):
+    """Filesystem-backed Project Autopilot projects."""
+    from hermes_cli.project import project_command
+
+    return project_command(args)
+
+
 def cmd_hooks(args):
     """Shell-hook inspection and management."""
     from hermes_cli.hooks import hooks_command
@@ -10296,7 +10303,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
-        "model", "pairing", "plugins", "postinstall", "profile", "proxy",
+        "model", "pairing", "plugins", "postinstall", "profile", "project", "proxy",
         "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat",
@@ -11258,6 +11265,11 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    from hermes_cli.project import build_parser as _build_project_parser
+
+    project_parser = _build_project_parser(subparsers)
+    project_parser.set_defaults(func=cmd_project)
 
     # =========================================================================
     # hooks command — shell-hook inspection and management

--- a/hermes_cli/project.py
+++ b/hermes_cli/project.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from hermes_cli.project_autopilot import bootstrap_project_home, verify_project_home
+
+
+def build_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(
+        "project",
+        help="Filesystem-backed Project Autopilot projects",
+        description="Create and verify deterministic Project Autopilot homes.",
+    )
+    sub = parser.add_subparsers(dest="project_action")
+
+    init = sub.add_parser("init", help="Bootstrap a Project Autopilot home")
+    init.add_argument("--slug", required=True)
+    init.add_argument("--title", required=True)
+    init.add_argument("--goal", required=True)
+    init.add_argument("--board", required=True, dest="board_slug")
+    init.add_argument("--root-task", required=True, dest="root_task_id")
+    init.add_argument("--project-home", required=True)
+    init.add_argument("--repo-org", required=True)
+    init.add_argument("--repo-name", required=True)
+    init.add_argument("--canonical-repo", required=True)
+    init.add_argument("--final-branch", required=True)
+    init.add_argument("--source-plan")
+
+    verify = sub.add_parser("verify", help="Verify project-home invariants")
+    verify.add_argument("project_home")
+    parser.set_defaults(func=project_command)
+    return parser
+
+
+def project_command(args: argparse.Namespace) -> int:
+    action = getattr(args, "project_action", None)
+    if action == "init":
+        doc = bootstrap_project_home(
+            slug=args.slug,
+            title=args.title,
+            goal=args.goal,
+            board_slug=args.board_slug,
+            root_task_id=args.root_task_id,
+            project_home=Path(args.project_home).expanduser(),
+            repo_org=args.repo_org,
+            repo_name=args.repo_name,
+            canonical_checkout=Path(args.canonical_repo).expanduser(),
+            final_branch=args.final_branch,
+            source_plan=Path(args.source_plan).expanduser()
+            if args.source_plan
+            else None,
+        )
+        print(f"BOOTSTRAPPED {doc['slug']} at {doc['project_home']}")
+        return 0
+    if action == "verify":
+        doc = verify_project_home(Path(args.project_home).expanduser())
+        print(f"OK {doc['slug']} state={doc['state']}")
+        return 0
+    print("usage: hermes project <init|verify>")
+    return 1

--- a/hermes_cli/project.py
+++ b/hermes_cli/project.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from hermes_cli.project_autopilot import (
     bootstrap_project_home,
+    generate_cleanup_inventory,
     sync_project_home,
     verify_project_home,
 )
@@ -36,6 +37,11 @@ def build_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentPar
     sync = sub.add_parser("sync", help="Sync a Project Autopilot home from kanban")
     sync.add_argument("project_home")
     sync.add_argument("--kanban-db")
+    cleanup_inventory = sub.add_parser(
+        "cleanup-inventory",
+        help="Write an auditable cleanup inventory without deleting anything",
+    )
+    cleanup_inventory.add_argument("project_home")
     parser.set_defaults(func=project_command)
     return parser
 
@@ -71,5 +77,9 @@ def project_command(args: argparse.Namespace) -> int:
         )
         print(f"SYNCED {doc['slug']} from board {doc['board_slug']}")
         return 0
-    print("usage: hermes project <init|sync|verify>")
+    if action == "cleanup-inventory":
+        inventory = generate_cleanup_inventory(Path(args.project_home).expanduser())
+        print(f"CLEANUP_INVENTORY {inventory['inventory_path']}")
+        return 0
+    print("usage: hermes project <init|sync|verify|cleanup-inventory>")
     return 1

--- a/hermes_cli/project.py
+++ b/hermes_cli/project.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from hermes_cli.project_autopilot import bootstrap_project_home, verify_project_home
+from hermes_cli.project_autopilot import (
+    bootstrap_project_home,
+    sync_project_home,
+    verify_project_home,
+)
 
 
 def build_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
     parser = subparsers.add_parser(
         "project",
         help="Filesystem-backed Project Autopilot projects",
-        description="Create and verify deterministic Project Autopilot homes.",
+        description="Create, sync, and verify deterministic Project Autopilot homes.",
     )
     sub = parser.add_subparsers(dest="project_action")
 
@@ -29,6 +33,9 @@ def build_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentPar
 
     verify = sub.add_parser("verify", help="Verify project-home invariants")
     verify.add_argument("project_home")
+    sync = sub.add_parser("sync", help="Sync a Project Autopilot home from kanban")
+    sync.add_argument("project_home")
+    sync.add_argument("--kanban-db")
     parser.set_defaults(func=project_command)
     return parser
 
@@ -57,5 +64,12 @@ def project_command(args: argparse.Namespace) -> int:
         doc = verify_project_home(Path(args.project_home).expanduser())
         print(f"OK {doc['slug']} state={doc['state']}")
         return 0
-    print("usage: hermes project <init|verify>")
+    if action == "sync":
+        doc = sync_project_home(
+            Path(args.project_home).expanduser(),
+            db_path=Path(args.kanban_db).expanduser() if args.kanban_db else None,
+        )
+        print(f"SYNCED {doc['slug']} from board {doc['board_slug']}")
+        return 0
+    print("usage: hermes project <init|sync|verify>")
     return 1

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -394,6 +394,11 @@ def render_status_md(
         f"Tasks: {total_tasks} total"
         + (f" ({count_bits})" if count_bits else "")
     )
+    task_lines = [
+        f"- `{node['id']}` [{node['status']}] {node['title']}"
+        for node in graph.get("nodes", [])
+    ]
+    task_snapshot = "\n".join(task_lines) if task_lines else "- no tasks cached"
     return f"""# Status: {doc["title"]}
 
 State: {doc["state"]}
@@ -407,6 +412,10 @@ Blocker: {blocker_text}
 ## Next action
 
 {action}
+
+## Board tasks
+
+{task_snapshot}
 """
 
 
@@ -471,6 +480,7 @@ def derive_task_graph(conn: Any, root_task_id: str) -> dict[str, Any]:
 
     ordered_ids: list[str] = []
     seen: set[str] = set()
+
     queue = [root_task_id]
     while queue:
         task_id = queue.pop(0)
@@ -483,6 +493,11 @@ def derive_task_graph(conn: Any, root_task_id: str) -> dict[str, Any]:
             for child_id in kanban_db.child_ids(conn, task_id)
             if child_id not in seen
         )
+
+    for task in kanban_db.list_tasks(conn, include_archived=False):
+        if task.id not in seen:
+            seen.add(task.id)
+            ordered_ids.append(task.id)
 
     nodes: list[dict[str, Any]] = []
     edges: list[dict[str, str]] = []

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -9,6 +9,7 @@ V0 is intentionally boring:
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from pathlib import Path
@@ -213,3 +214,152 @@ def validate_project_doc(doc: dict[str, Any]) -> None:
         raise ProjectAutopilotError(
             "V0 requires execution_policy parallelism=none max_active_workers=1"
         )
+
+
+def project_home_for_slug(slug: str) -> Path:
+    if not _SLUG_RE.match(slug):
+        raise ProjectAutopilotError(f"invalid project slug: {slug!r}")
+    return ACTIVE_PROJECTS_ROOT / slug
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_project_doc(project_home: Path) -> dict[str, Any]:
+    doc = json.loads((project_home / "project.json").read_text(encoding="utf-8"))
+    validate_project_doc(doc)
+    return doc
+
+
+def render_project_md(doc: dict[str, Any]) -> str:
+    return f"""# {doc["title"]}
+
+Goal: {doc["goal"]}
+
+Board: `{doc["board_slug"]}`
+Root task: `{doc["root_task_id"]}`
+Project mode: `{doc["project_mode"]}`
+Canonical repo: `{doc["repo"]["canonical_checkout"]}`
+Final branch: `{doc["branch_strategy"]["final_branch"]}`
+Final worktree: `{doc["final_worktree_path"]}`
+"""
+
+
+def render_status_md(
+    doc: dict[str, Any],
+    *,
+    next_action: str | None = None,
+    blocker: str | None = None,
+) -> str:
+    action = next_action or "Plan the first executable task graph."
+    blocker_text = blocker or "none"
+    return f"""# Status: {doc["title"]}
+
+State: {doc["state"]}
+Project home: `{doc["project_home"]}`
+Board: `{doc["board_slug"]}`
+Root task: `{doc["root_task_id"]}`
+PR: {doc.get("pr_url") or "not open"}
+Blocker: {blocker_text}
+
+## Next action
+
+{action}
+"""
+
+
+def render_handoff_md(doc: dict[str, Any]) -> str:
+    return f"""# Session Handoff: {doc["title"]}
+
+State: {doc["state"]}
+
+Restart checklist:
+1. Verify this project home exists and `project.json` validates.
+2. Inspect board `{doc["board_slug"]}` and root task `{doc["root_task_id"]}`.
+3. Reconcile `TASKS.md` and `STATUS.md` from board truth before dispatching work.
+"""
+
+
+def bootstrap_project_home(
+    *,
+    slug: str,
+    title: str,
+    goal: str,
+    board_slug: str,
+    root_task_id: str,
+    project_home: Path | None,
+    repo_org: str,
+    repo_name: str,
+    canonical_checkout: Path,
+    final_branch: str,
+    source_plan: Path | None = None,
+) -> dict[str, Any]:
+    project_home = project_home or project_home_for_slug(slug)
+    project_home.mkdir(parents=True, exist_ok=True)
+    for dirname in REQUIRED_DIRS:
+        (project_home / dirname).mkdir(parents=True, exist_ok=True)
+
+    doc = normalize_project_doc(
+        slug=slug,
+        title=title,
+        goal=goal,
+        board_slug=board_slug,
+        root_task_id=root_task_id,
+        project_home=project_home,
+        repo_org=repo_org,
+        repo_name=repo_name,
+        canonical_checkout=canonical_checkout,
+        final_branch=final_branch,
+    )
+    validate_project_doc(doc)
+
+    (project_home / "PROJECT.md").write_text(
+        render_project_md(doc),
+        encoding="utf-8",
+    )
+    (project_home / "STATUS.md").write_text(
+        render_status_md(doc),
+        encoding="utf-8",
+    )
+    (project_home / "SESSION-HANDOFF.md").write_text(
+        render_handoff_md(doc),
+        encoding="utf-8",
+    )
+    (project_home / "SESSION-LOG.md").write_text(
+        f"# Session Log: {title}\n\n- bootstrapped project home\n",
+        encoding="utf-8",
+    )
+    (project_home / "PARKING-LOT.md").write_text(
+        f"# Parking Lot: {title}\n\n",
+        encoding="utf-8",
+    )
+    (project_home / "TASKS.md").write_text(
+        f"# Tasks: {title}\n\nRoot task: `{root_task_id}`\n",
+        encoding="utf-8",
+    )
+    if source_plan:
+        target = project_home / "refs" / source_plan.name
+        target.write_text(source_plan.read_text(encoding="utf-8"), encoding="utf-8")
+    write_json(project_home / "project.json", doc)
+    verify_project_home(project_home)
+    return doc
+
+
+def verify_project_home(project_home: Path) -> dict[str, Any]:
+    missing = [rel for rel in REQUIRED_FILES if not (project_home / rel).exists()]
+    missing_dirs = [rel for rel in REQUIRED_DIRS if not (project_home / rel).is_dir()]
+    if missing or missing_dirs:
+        raise InvariantError(
+            f"missing project artifacts: files={missing} dirs={missing_dirs}"
+        )
+    doc = load_project_doc(project_home)
+    status = (project_home / "STATUS.md").read_text(encoding="utf-8")
+    if status.count("## Next action") != 1:
+        raise InvariantError("STATUS.md must contain exactly one ## Next action")
+    if str(project_home) != doc["project_home"]:
+        raise InvariantError("project.json project_home does not match actual path")
+    return doc

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -724,10 +724,15 @@ def sync_project_home(
         task_graph["nodes"],
         root_task_id=doc["root_task_id"],
     )
+    doc["invariant_failures"] = [
+        failure
+        for failure in doc.get("invariant_failures", [])
+        if failure.get("type") != "terminal_tasks_missing_reports"
+    ]
     blocker = None
     if missing_reports:
         doc["state"] = "BLOCKED_PROCESS"
-        doc.setdefault("invariant_failures", []).append(
+        doc["invariant_failures"].append(
             {
                 "type": "terminal_tasks_missing_reports",
                 "task_ids": missing_reports,
@@ -735,6 +740,8 @@ def sync_project_home(
         )
         task_list = ", ".join(f"`{task_id}`" for task_id in missing_reports)
         blocker = f"missing terminal task status reports: {task_list}"
+    elif doc["state"] == "BLOCKED_PROCESS" and not doc["invariant_failures"]:
+        doc["state"] = "PLANNED"
     validate_project_doc(doc)
 
     (project_home / "TASKS.md").write_text(

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -420,12 +420,12 @@ def render_status_md(
     task_snapshot = "\n".join(task_lines) if task_lines else "- no tasks cached"
     return f"""# Status: {doc["title"]}
 
+Blocker: {blocker_text}
 State: {doc["state"]}
 Project home: `{doc["project_home"]}`
 Board: `{doc["board_slug"]}`
 Root task: `{doc["root_task_id"]}`
 PR: {doc.get("pr_url") or "not open"}
-Blocker: {blocker_text}
 {task_summary}
 
 ## Next action
@@ -568,6 +568,36 @@ def render_tasks_md(doc: dict[str, Any], task_graph: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _terminal_tasks_missing_reports_for_root(
+    project_home: Path,
+    nodes: list[dict[str, Any]],
+    *,
+    root_task_id: str,
+) -> list[str]:
+    missing: list[str] = []
+    for node in nodes:
+        task_id = node["id"]
+        if task_id == root_task_id:
+            continue
+        if node["status"] not in TERMINAL_TASK_STATES:
+            continue
+        report = project_home / "status" / f"{task_id}.md"
+        if not report.exists() or not report.read_text(encoding="utf-8").strip():
+            missing.append(task_id)
+    return missing
+
+
+def terminal_tasks_missing_reports(
+    project_home: Path,
+    nodes: list[dict[str, Any]],
+) -> list[str]:
+    return _terminal_tasks_missing_reports_for_root(
+        project_home,
+        nodes,
+        root_task_id=load_project_doc(project_home)["root_task_id"],
+    )
+
+
 def sync_project_home(
     project_home: Path,
     *,
@@ -590,6 +620,22 @@ def sync_project_home(
     doc["task_graph"] = task_graph
     doc["workspace_contracts"] = graph_with_contracts["workspace_contracts"]
     doc["updated_at"] = now_ts()
+    missing_reports = _terminal_tasks_missing_reports_for_root(
+        project_home,
+        task_graph["nodes"],
+        root_task_id=doc["root_task_id"],
+    )
+    blocker = None
+    if missing_reports:
+        doc["state"] = "BLOCKED_PROCESS"
+        doc.setdefault("invariant_failures", []).append(
+            {
+                "type": "terminal_tasks_missing_reports",
+                "task_ids": missing_reports,
+            }
+        )
+        task_list = ", ".join(f"`{task_id}`" for task_id in missing_reports)
+        blocker = f"missing terminal task status reports: {task_list}"
     validate_project_doc(doc)
 
     (project_home / "TASKS.md").write_text(
@@ -597,7 +643,7 @@ def sync_project_home(
         encoding="utf-8",
     )
     (project_home / "STATUS.md").write_text(
-        render_status_md(doc, task_graph=task_graph),
+        render_status_md(doc, blocker=blocker, task_graph=task_graph),
         encoding="utf-8",
     )
     (project_home / "SESSION-HANDOFF.md").write_text(

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -743,7 +743,12 @@ def sync_project_home(
         task_list = ", ".join(f"`{task_id}`" for task_id in missing_reports)
         blocker = f"missing terminal task status reports: {task_list}"
     elif doc["state"] == "BLOCKED_PROCESS" and not doc["invariant_failures"]:
-        doc["state"] = "PLANNED"
+        if doc.get("pr_url") and all(
+            node["status"] in TERMINAL_TASK_STATES for node in task_graph["nodes"]
+        ):
+            doc["state"] = "DONE"
+        else:
+            doc["state"] = "PLANNED"
     validate_project_doc(doc)
 
     (project_home / "TASKS.md").write_text(

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -83,6 +83,22 @@ def validate_workspace_contract(contract: dict[str, Any], *, repo: dict[str, Any
         )
 
 
+def parse_patch_id_output(output: str) -> set[str]:
+    ids: set[str] = set()
+    for line in output.splitlines():
+        parts = line.split()
+        if parts:
+            ids.add(parts[0])
+    return ids
+
+
+def missing_patch_ids(
+    task_patch_ids: set[str],
+    final_patch_ids: set[str],
+) -> set[str]:
+    return task_patch_ids - final_patch_ids
+
+
 def _canonical_worktree_namespace(repo_org: str, repo_name: str) -> Path:
     return Path("/Users/vsletten/src") / repo_org / repo_name
 

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -614,6 +614,79 @@ def terminal_tasks_missing_reports(
     )
 
 
+def _path_under(parent: Path, child: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _cleanup_inventory_target(node: dict[str, Any], workspace_path: Path) -> dict[str, Any]:
+    return {
+        "task_id": node["id"],
+        "title": node.get("title") or "",
+        "status": node.get("status") or "",
+        "workspace_kind": node.get("workspace_kind") or "",
+        "workspace_path": str(workspace_path),
+        "branch_name": node.get("branch_name"),
+        "exists": workspace_path.exists(),
+    }
+
+
+def generate_cleanup_inventory(project_home: Path) -> dict[str, Any]:
+    doc = verify_project_home(project_home)
+    repo = doc["repo"]
+    worktree_namespace = Path(repo["worktree_namespace"]).expanduser()
+    canonical_checkout = Path(repo["canonical_checkout"]).expanduser()
+    final_worktree_path = Path(doc["final_worktree_path"]).expanduser()
+
+    targets: list[dict[str, Any]] = []
+    for node in doc.get("task_graph", {}).get("nodes", []):
+        if node.get("status") not in TERMINAL_TASK_STATES:
+            continue
+        if node.get("workspace_kind") != "worktree":
+            continue
+        if not node.get("workspace_path"):
+            continue
+
+        workspace_path = Path(node["workspace_path"]).expanduser()
+        if workspace_path == canonical_checkout or workspace_path == final_worktree_path:
+            continue
+        if not _path_under(worktree_namespace, workspace_path):
+            raise InvariantError(
+                "cleanup inventory target outside repo.worktree_namespace: "
+                f"{workspace_path}"
+            )
+        targets.append(_cleanup_inventory_target(node, workspace_path))
+
+    generated_at = now_ts()
+    cleanup_dir = project_home / "artifacts" / "cleanup"
+    cleanup_dir.mkdir(parents=True, exist_ok=True)
+    inventory_path = cleanup_dir / f"cleanup-inventory-{generated_at}.json"
+    inventory = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "project_slug": doc["slug"],
+        "project_home": str(project_home),
+        "cleanup_policy": doc["cleanup_policy"],
+        "exclusions": {
+            "canonical_checkout": str(canonical_checkout),
+            "final_worktree_path": str(final_worktree_path),
+        },
+        "targets": targets,
+        "inventory_path": str(inventory_path),
+    }
+    write_json(inventory_path, inventory)
+
+    doc["cleanup"]["state"] = "inventory_ready"
+    doc["cleanup"]["inventory_path"] = str(inventory_path)
+    doc["cleanup"]["targets"] = targets
+    doc["updated_at"] = generated_at
+    write_json(project_home / "project.json", doc)
+    return inventory
+
+
 def sync_project_home(
     project_home: Path,
     *,

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import time
 from pathlib import Path
 from typing import Any
@@ -235,6 +236,105 @@ def load_project_doc(project_home: Path) -> dict[str, Any]:
     return doc
 
 
+def _git_output(args: list[str], *, cwd: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _infer_current_repo_context() -> dict[str, Any]:
+    cwd = Path.cwd().resolve()
+    git_root = _git_output(["rev-parse", "--show-toplevel"], cwd=cwd)
+    checkout = Path(git_root).resolve() if git_root else cwd
+    try:
+        rel_parts = checkout.relative_to(Path("/Users/vsletten/src")).parts
+    except ValueError as exc:
+        raise ProjectAutopilotError(
+            "cannot adopt legacy project.json outside /Users/vsletten/src"
+        ) from exc
+    if len(rel_parts) < 2:
+        raise ProjectAutopilotError(
+            "cannot infer repo org/name for legacy project.json adoption"
+        )
+    branch = _git_output(["rev-parse", "--abbrev-ref", "HEAD"], cwd=checkout)
+    if not branch or branch == "HEAD":
+        branch_parts = rel_parts[2:]
+        branch = "/".join(branch_parts) if branch_parts else None
+    if not branch:
+        raise ProjectAutopilotError(
+            "cannot infer current branch for legacy project.json adoption"
+        )
+    return {
+        "repo_org": rel_parts[0],
+        "repo_name": rel_parts[1],
+        "canonical_checkout": checkout,
+        "final_branch": branch,
+    }
+
+
+def _normalize_legacy_project_doc(
+    doc: dict[str, Any],
+    *,
+    project_home: Path,
+) -> dict[str, Any]:
+    missing = [
+        key
+        for key in (
+            "slug",
+            "title",
+            "goal",
+            "board_slug",
+            "root_task_id",
+            "project_home",
+        )
+        if not doc.get(key)
+    ]
+    if missing:
+        raise ProjectAutopilotError(
+            f"cannot adopt legacy project.json missing fields: {', '.join(missing)}"
+        )
+    if str(project_home) != doc["project_home"]:
+        raise InvariantError("legacy project.json project_home does not match actual path")
+
+    repo_context = _infer_current_repo_context()
+    adopted = normalize_project_doc(
+        slug=doc["slug"],
+        title=doc["title"],
+        goal=doc["goal"],
+        board_slug=doc["board_slug"],
+        root_task_id=doc["root_task_id"],
+        project_home=project_home,
+        **repo_context,
+    )
+    adopted["state"] = doc.get("state") or adopted["state"]
+    if isinstance(doc.get("created_at"), int):
+        adopted["created_at"] = doc["created_at"]
+    if isinstance(doc.get("pr_url"), str):
+        adopted["pr_url"] = doc["pr_url"]
+    validate_project_doc(adopted)
+    return adopted
+
+
+def load_project_doc_for_sync(project_home: Path) -> dict[str, Any]:
+    doc = json.loads((project_home / "project.json").read_text(encoding="utf-8"))
+    if doc.get("schema_version") == SCHEMA_VERSION:
+        validate_project_doc(doc)
+        return doc
+    return _normalize_legacy_project_doc(doc, project_home=project_home)
+
+
 def render_project_md(doc: dict[str, Any]) -> str:
     return f"""# {doc["title"]}
 
@@ -442,7 +542,7 @@ def sync_project_home(
 ) -> dict[str, Any]:
     from hermes_cli import kanban_db
 
-    doc = load_project_doc(project_home)
+    doc = load_project_doc_for_sync(project_home)
     conn = kanban_db.connect(db_path, board=board or doc["board_slug"])
     try:
         graph_with_contracts = derive_task_graph(conn, doc["root_task_id"])

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -1,0 +1,215 @@
+"""Deterministic filesystem-backed Project Autopilot V0.
+
+V0 is intentionally boring:
+- file-backed project homes
+- kanban board remains execution truth
+- project.json owns lifecycle/continuity metadata
+- only project_mode=stacked-slices-one-pr is supported
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "project-autopilot/v0"
+PROJECT_MODE_V0 = "stacked-slices-one-pr"
+SUPPORTED_PROJECT_MODES = {PROJECT_MODE_V0}
+PROJECTS_ROOT = Path.home() / "Documents" / "hermes-projects"
+ACTIVE_PROJECTS_ROOT = PROJECTS_ROOT / "active"
+
+REQUIRED_FILES = (
+    "PROJECT.md",
+    "STATUS.md",
+    "SESSION-HANDOFF.md",
+    "SESSION-LOG.md",
+    "PARKING-LOT.md",
+    "TASKS.md",
+    "project.json",
+)
+REQUIRED_DIRS = ("status", "refs", "scratch", "artifacts")
+TERMINAL_TASK_STATES = {"done", "archived", "superseded", "canceled"}
+DEPENDENCY_SATISFYING_STATES = {"done"}
+
+_BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-_]{0,63}$")
+
+
+class ProjectAutopilotError(RuntimeError):
+    """Base error for deterministic Project Autopilot failures."""
+
+
+class InvariantError(ProjectAutopilotError):
+    """Raised when a project lifecycle invariant fails."""
+
+
+def now_ts() -> int:
+    return int(time.time())
+
+
+def branch_to_worktree_path(*, worktree_namespace: Path, branch_name: str) -> Path:
+    branch = branch_name.strip().strip("/")
+    if not branch or branch.startswith("-") or ".." in branch.split("/"):
+        raise ProjectAutopilotError(
+            f"invalid branch name for worktree path: {branch_name!r}"
+        )
+    if not _BRANCH_RE.match(branch):
+        raise ProjectAutopilotError(
+            f"invalid branch name for worktree path: {branch_name!r}"
+        )
+    return worktree_namespace / Path(*branch.split("/"))
+
+
+def _canonical_worktree_namespace(repo_org: str, repo_name: str) -> Path:
+    return Path("/Users/vsletten/src") / repo_org / repo_name
+
+
+def normalize_project_doc(
+    *,
+    slug: str,
+    title: str,
+    goal: str,
+    board_slug: str,
+    root_task_id: str,
+    project_home: Path,
+    repo_org: str,
+    repo_name: str,
+    canonical_checkout: Path,
+    final_branch: str,
+    default_worker: str = "codexapp",
+) -> dict[str, Any]:
+    if not _SLUG_RE.match(slug):
+        raise ProjectAutopilotError(f"invalid project slug: {slug!r}")
+    worktree_namespace = _canonical_worktree_namespace(repo_org, repo_name)
+    final_worktree_path = branch_to_worktree_path(
+        worktree_namespace=worktree_namespace,
+        branch_name=final_branch,
+    )
+    ts = now_ts()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "slug": slug,
+        "title": title,
+        "goal": goal,
+        "project_type": "coding",
+        "project_mode": PROJECT_MODE_V0,
+        "state": "BOOTSTRAPPED",
+        "board_slug": board_slug,
+        "root_task_id": root_task_id,
+        "project_home": str(project_home),
+        "default_worker": default_worker,
+        "repo": {
+            "org": repo_org,
+            "name": repo_name,
+            "canonical_checkout": str(canonical_checkout),
+            "worktree_namespace": str(worktree_namespace),
+            "remote_name": "origin",
+            "remote_url": None,
+            "default_branch": "main",
+            "pr_base_ref": "main",
+            "provider": "github",
+        },
+        "branch_strategy": {
+            "mode": PROJECT_MODE_V0,
+            "base_ref": "origin/main",
+            "final_branch": final_branch,
+        },
+        "final_worktree_path": str(final_worktree_path),
+        "pr_url": None,
+        "pr_requirement": {
+            "required": True,
+            "waived": False,
+            "waived_by": None,
+            "waived_at": None,
+            "reason": None,
+            "approval_evidence": None,
+        },
+        "execution_policy": {"parallelism": "none", "max_active_workers": 1},
+        "cleanup_policy": {
+            "mode": "manual-approval-required",
+            "keep_final_pr_worktree": True,
+            "remove_intermediate_worktrees_after_pr_open": False,
+        },
+        "cleanup": {
+            "state": "not_started",
+            "inventory_path": None,
+            "approved_by": None,
+            "approved_at": None,
+            "completed_at": None,
+            "targets": [],
+        },
+        "completion": {
+            "done_by": None,
+            "done_at": None,
+            "done_basis": None,
+            "evidence": [],
+        },
+        "created_at": ts,
+        "updated_at": ts,
+        "last_verified_at": None,
+        "last_transition": None,
+        "transition_log": [],
+        "invariant_failures": [],
+        "workspace_contracts": {},
+        "task_graph": {"nodes": [], "edges": []},
+    }
+
+
+def validate_project_doc(doc: dict[str, Any]) -> None:
+    if doc.get("schema_version") != SCHEMA_VERSION:
+        raise ProjectAutopilotError("unsupported schema_version")
+    if doc.get("project_mode") not in SUPPORTED_PROJECT_MODES:
+        raise ProjectAutopilotError(
+            f"unsupported project_mode: {doc.get('project_mode')!r}"
+        )
+    branch_strategy = doc.get("branch_strategy") or {}
+    if branch_strategy.get("mode") not in SUPPORTED_PROJECT_MODES:
+        raise ProjectAutopilotError(
+            f"unsupported branch_strategy.mode: {branch_strategy.get('mode')!r}"
+        )
+    if "final_branch" in doc:
+        raise ProjectAutopilotError(
+            "top-level final_branch is not authoritative in V0"
+        )
+
+    required_top = [
+        "slug",
+        "title",
+        "goal",
+        "state",
+        "board_slug",
+        "root_task_id",
+        "project_home",
+        "repo",
+        "branch_strategy",
+        "final_worktree_path",
+        "pr_requirement",
+        "execution_policy",
+        "cleanup",
+        "transition_log",
+    ]
+    missing = [key for key in required_top if key not in doc]
+    if missing:
+        raise ProjectAutopilotError(f"missing project fields: {', '.join(missing)}")
+
+    repo = doc["repo"]
+    for key in (
+        "org",
+        "name",
+        "canonical_checkout",
+        "worktree_namespace",
+        "remote_name",
+        "default_branch",
+        "pr_base_ref",
+        "provider",
+    ):
+        if not repo.get(key):
+            raise ProjectAutopilotError(f"missing repo.{key}")
+
+    expected_policy = {"parallelism": "none", "max_active_workers": 1}
+    if doc["execution_policy"] != expected_policy:
+        raise ProjectAutopilotError(
+            "V0 requires execution_policy parallelism=none max_active_workers=1"
+        )

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -422,6 +422,8 @@ def render_status_md(
     next_task = _find_next_executable(graph)
     if next_action:
         action = next_action
+    elif doc["state"] == "DONE" and doc.get("pr_url"):
+        action = f"Review draft PR: {doc['pr_url']}"
     elif next_task:
         action = (
             f"Next executable task: `{next_task['id']}` {next_task['title']} "

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -249,14 +249,51 @@ Final worktree: `{doc["final_worktree_path"]}`
 """
 
 
+def _status_counts(task_graph: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for node in task_graph.get("nodes", []):
+        status = str(node.get("status") or "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def _find_next_executable(task_graph: dict[str, Any]) -> dict[str, Any] | None:
+    nodes = list(task_graph.get("nodes", []))
+    for desired_status in ("running", "ready"):
+        for node in nodes:
+            if node.get("status") == desired_status:
+                return node
+    return None
+
+
 def render_status_md(
     doc: dict[str, Any],
     *,
     next_action: str | None = None,
     blocker: str | None = None,
+    task_graph: dict[str, Any] | None = None,
 ) -> str:
-    action = next_action or "Plan the first executable task graph."
+    graph = task_graph or doc.get("task_graph") or {"nodes": [], "edges": []}
+    next_task = _find_next_executable(graph)
+    if next_action:
+        action = next_action
+    elif next_task:
+        action = (
+            f"Next executable task: `{next_task['id']}` {next_task['title']} "
+            f"({next_task['status']})."
+        )
+    else:
+        action = "No ready or running task found; inspect the board for blockers."
     blocker_text = blocker or "none"
+    counts = _status_counts(graph)
+    count_bits = ", ".join(
+        f"{status}: {count}" for status, count in sorted(counts.items())
+    )
+    total_tasks = len(graph.get("nodes", []))
+    task_summary = (
+        f"Tasks: {total_tasks} total"
+        + (f" ({count_bits})" if count_bits else "")
+    )
     return f"""# Status: {doc["title"]}
 
 State: {doc["state"]}
@@ -265,6 +302,7 @@ Board: `{doc["board_slug"]}`
 Root task: `{doc["root_task_id"]}`
 PR: {doc.get("pr_url") or "not open"}
 Blocker: {blocker_text}
+{task_summary}
 
 ## Next action
 
@@ -272,7 +310,22 @@ Blocker: {blocker_text}
 """
 
 
-def render_handoff_md(doc: dict[str, Any]) -> str:
+def render_handoff_md(
+    doc: dict[str, Any],
+    task_graph: dict[str, Any] | None = None,
+) -> str:
+    graph = task_graph or doc.get("task_graph") or {"nodes": [], "edges": []}
+    next_task = _find_next_executable(graph)
+    next_line = (
+        f"- Next executable task: `{next_task['id']}` {next_task['title']}"
+        if next_task
+        else "- Next executable task: none"
+    )
+    task_lines = [
+        f"- `{node['id']}` [{node['status']}] {node['title']}"
+        for node in graph.get("nodes", [])
+    ]
+    task_snapshot = "\n".join(task_lines) if task_lines else "- no tasks cached"
     return f"""# Session Handoff: {doc["title"]}
 
 State: {doc["state"]}
@@ -281,7 +334,145 @@ Restart checklist:
 1. Verify this project home exists and `project.json` validates.
 2. Inspect board `{doc["board_slug"]}` and root task `{doc["root_task_id"]}`.
 3. Reconcile `TASKS.md` and `STATUS.md` from board truth before dispatching work.
+
+## Task graph snapshot
+
+{next_line}
+
+{task_snapshot}
 """
+
+
+def _task_to_node(task: Any, parents: list[str], children: list[str]) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "title": task.title,
+        "body": task.body,
+        "assignee": task.assignee,
+        "status": task.status,
+        "priority": task.priority,
+        "created_at": task.created_at,
+        "started_at": task.started_at,
+        "completed_at": task.completed_at,
+        "workspace_kind": task.workspace_kind,
+        "workspace_path": task.workspace_path,
+        "branch_name": task.branch_name,
+        "parents": parents,
+        "children": children,
+    }
+
+
+def derive_task_graph(conn: Any, root_task_id: str) -> dict[str, Any]:
+    from hermes_cli import kanban_db
+
+    root = kanban_db.get_task(conn, root_task_id)
+    if root is None:
+        raise InvariantError(f"root task not found on kanban board: {root_task_id}")
+
+    ordered_ids: list[str] = []
+    seen: set[str] = set()
+    queue = [root_task_id]
+    while queue:
+        task_id = queue.pop(0)
+        if task_id in seen:
+            continue
+        seen.add(task_id)
+        ordered_ids.append(task_id)
+        queue.extend(
+            child_id
+            for child_id in kanban_db.child_ids(conn, task_id)
+            if child_id not in seen
+        )
+
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, str]] = []
+    workspace_contracts: dict[str, dict[str, str | None]] = {}
+    for task_id in ordered_ids:
+        task = kanban_db.get_task(conn, task_id)
+        if task is None:
+            continue
+        parents = [pid for pid in kanban_db.parent_ids(conn, task_id) if pid in seen]
+        children = [cid for cid in kanban_db.child_ids(conn, task_id) if cid in seen]
+        nodes.append(_task_to_node(task, parents, children))
+        edges.extend({"parent": pid, "child": task_id} for pid in parents)
+        if task.workspace_kind == "worktree":
+            workspace_contracts[task_id] = {
+                "workspace_kind": task.workspace_kind,
+                "workspace_path": task.workspace_path,
+                "branch_name": task.branch_name,
+            }
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "workspace_contracts": workspace_contracts,
+    }
+
+
+def render_tasks_md(doc: dict[str, Any], task_graph: dict[str, Any]) -> str:
+    lines = [
+        f"# Tasks: {doc['title']}",
+        "",
+        f"Root task: `{doc['root_task_id']}`",
+        "",
+        "| Task | Status | Assignee | Workspace |",
+        "| --- | --- | --- | --- |",
+    ]
+    for node in task_graph.get("nodes", []):
+        workspace = node.get("workspace_path") or node.get("workspace_kind") or ""
+        lines.append(
+            "| "
+            f"`{node['id']}` {node['title']} | "
+            f"{node['status']} | "
+            f"{node.get('assignee') or ''} | "
+            f"{workspace} |"
+        )
+    if task_graph.get("edges"):
+        lines.extend(["", "## Dependencies", ""])
+        for edge in task_graph["edges"]:
+            lines.append(f"- `{edge['parent']}` blocks `{edge['child']}`")
+    return "\n".join(lines) + "\n"
+
+
+def sync_project_home(
+    project_home: Path,
+    *,
+    db_path: Path | None = None,
+    board: str | None = None,
+) -> dict[str, Any]:
+    from hermes_cli import kanban_db
+
+    doc = load_project_doc(project_home)
+    conn = kanban_db.connect(db_path, board=board or doc["board_slug"])
+    try:
+        graph_with_contracts = derive_task_graph(conn, doc["root_task_id"])
+    finally:
+        conn.close()
+
+    task_graph = {
+        "nodes": graph_with_contracts["nodes"],
+        "edges": graph_with_contracts["edges"],
+    }
+    doc["task_graph"] = task_graph
+    doc["workspace_contracts"] = graph_with_contracts["workspace_contracts"]
+    doc["updated_at"] = now_ts()
+    validate_project_doc(doc)
+
+    (project_home / "TASKS.md").write_text(
+        render_tasks_md(doc, task_graph),
+        encoding="utf-8",
+    )
+    (project_home / "STATUS.md").write_text(
+        render_status_md(doc, task_graph=task_graph),
+        encoding="utf-8",
+    )
+    (project_home / "SESSION-HANDOFF.md").write_text(
+        render_handoff_md(doc, task_graph),
+        encoding="utf-8",
+    )
+    write_json(project_home / "project.json", doc)
+    verify_project_home(project_home)
+    return doc
 
 
 def bootstrap_project_home(

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -250,6 +250,16 @@ def validate_project_doc(doc: dict[str, Any]) -> None:
         raise ProjectAutopilotError(
             "V0 requires execution_policy parallelism=none max_active_workers=1"
         )
+    if doc["state"] == "DONE":
+        assert_done_preconditions(doc)
+
+
+def assert_done_preconditions(doc: dict[str, Any]) -> None:
+    pr_req = doc.get("pr_requirement") or {}
+    if pr_req.get("required", True) and not pr_req.get("waived") and not doc.get("pr_url"):
+        raise InvariantError(
+            "coding project cannot be DONE without pr_url or Victor PR waiver"
+        )
 
 
 def project_home_for_slug(slug: str) -> Path:

--- a/hermes_cli/project_autopilot.py
+++ b/hermes_cli/project_autopilot.py
@@ -64,6 +64,25 @@ def branch_to_worktree_path(*, worktree_namespace: Path, branch_name: str) -> Pa
     return worktree_namespace / Path(*branch.split("/"))
 
 
+def validate_workspace_contract(contract: dict[str, Any], *, repo: dict[str, Any]) -> None:
+    for key in ("task_id", "workspace_path", "branch_name", "base_ref"):
+        if not contract.get(key):
+            raise ProjectAutopilotError(f"workspace contract missing {key}")
+    if not repo.get("worktree_namespace"):
+        raise ProjectAutopilotError("workspace contract missing repo.worktree_namespace")
+
+    expected = branch_to_worktree_path(
+        worktree_namespace=Path(repo["worktree_namespace"]),
+        branch_name=contract["branch_name"],
+    )
+    actual = Path(contract["workspace_path"]).expanduser()
+    if actual != expected:
+        raise ProjectAutopilotError(
+            "workspace_path must equal branch-derived path: "
+            f"expected {expected}, got {actual}"
+        )
+
+
 def _canonical_worktree_namespace(repo_org: str, repo_name: str) -> Path:
     return Path("/Users/vsletten/src") / repo_org / repo_name
 

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -242,11 +242,10 @@ class TestSpawnEnvIsolation:
         # And HOME still passes through unchanged
         assert captured["env"].get("HOME") == "/users/alice"
 
-    def test_kanban_worker_adds_only_kanban_writable_root(self, monkeypatch):
-        """Codex-runtime Kanban workers need to write board state outside
-        their scratch/worktree workspace, but should not fall back to
-        danger-full-access. Hermes passes a narrow app-server config override
-        for the Kanban root only.
+    def test_kanban_worker_adds_board_and_project_home_writable_roots(self, monkeypatch):
+        """Codex-runtime Kanban workers need narrow extra writable roots for
+        the board DB and, when present, the linked Project Autopilot home.
+        Hermes must not widen the sandbox beyond those explicit paths.
         """
         import subprocess
         from agent.transports import codex_app_server as cas
@@ -283,6 +282,10 @@ class TestSpawnEnvIsolation:
             "HERMES_KANBAN_DB",
             "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
         )
+        monkeypatch.setenv(
+            "HERMES_KANBAN_PROJECT_HOME",
+            "/users/alice/Documents/hermes-projects/active/smoke",
+        )
 
         client = cas.CodexAppServerClient(codex_bin="codex")
         client._closed = True
@@ -291,7 +294,8 @@ class TestSpawnEnvIsolation:
         assert cmd[:2] == ["codex", "app-server"]
         assert 'sandbox_mode="workspace-write"' in cmd
         assert (
-            'sandbox_workspace_write.writable_roots=["/users/alice/.hermes/kanban/boards/smoke"]'
+            'sandbox_workspace_write.writable_roots=["/users/alice/.hermes/kanban/boards/smoke", '
+            '"/users/alice/Documents/hermes-projects/active/smoke"]'
             in cmd
         )
         assert "sandbox_workspace_write.network_access=false" in cmd

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -30,6 +30,7 @@ class FakeClient:
     def __init__(self, *, codex_bin: str = "codex", codex_home=None) -> None:
         self.codex_bin = codex_bin
         self.codex_home = codex_home
+        self.initialize_kwargs: dict[str, Any] | None = None
         self.requests: list[tuple[str, dict]] = []
         self.notifications_responses: list[dict] = []
         self.responses: list[tuple[Any, dict]] = []
@@ -42,6 +43,7 @@ class FakeClient:
 
     # API matching CodexAppServerClient
     def initialize(self, **kwargs):
+        self.initialize_kwargs = dict(kwargs)
         self._initialized = True
         return {"userAgent": "fake/0.0.0", "codexHome": "/tmp",
                 "platformOs": "linux", "platformFamily": "unix"}
@@ -140,6 +142,24 @@ class TestLifecycle:
         # thread/start should be called exactly once
         method_calls = [m for (m, _) in client.requests if m == "thread/start"]
         assert len(method_calls) == 1
+
+    def test_initialize_enables_experimental_api_and_registers_dynamic_tools(self, monkeypatch):
+        client = FakeClient()
+        monkeypatch.setattr(
+            session_mod,
+            "_build_dynamic_tools",
+            lambda: [{"name": "kanban_complete", "description": "Complete a kanban task", "inputSchema": {"type": "object"}}],
+        )
+        s = make_session(client)
+        s.ensure_started()
+        assert client.initialize_kwargs == {
+            "client_name": "hermes",
+            "client_title": "Hermes Agent",
+            "client_version": session_mod._get_hermes_version(),
+            "capabilities": {"experimentalApi": True},
+        }
+        _method, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert params["dynamicTools"][0]["name"] == "kanban_complete"
 
     def test_thread_start_passes_cwd_only(self):
         """thread/start carries cwd. We intentionally do NOT pass `permissions`
@@ -413,6 +433,129 @@ class TestServerRequestRouting:
         s = make_session(client)  # no approval_callback wired
         s.run_turn("hi", turn_timeout=1.0)
         assert ("req-1", {"decision": "decline"}) in client.responses
+
+    def test_dynamic_tool_call_dispatches_via_handle_function_call(self, monkeypatch):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/tool/call",
+            request_id="tool-1",
+            threadId="t",
+            turnId="tu1",
+            callId="call-1",
+            tool="kanban_complete",
+            arguments={"task_id": "t_123", "summary": "done"},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        captured: dict[str, Any] = {}
+
+        def fake_handle(tool_name, tool_args):
+            captured["tool_name"] = tool_name
+            captured["tool_args"] = tool_args
+            return '{"ok":true}'
+
+        monkeypatch.setattr("model_tools.handle_function_call", fake_handle)
+        s = make_session(client)
+        s.run_turn("hi", turn_timeout=1.0)
+        assert captured == {
+            "tool_name": "kanban_complete",
+            "tool_args": {"task_id": "t_123", "summary": "done"},
+        }
+        assert (
+            "tool-1",
+            {
+                "contentItems": [{"type": "inputText", "text": '{"ok":true}'}],
+                "success": True,
+            },
+        ) in client.responses
+
+    def test_dynamic_tool_call_failure_returns_unsuccessful_result(self, monkeypatch):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/tool/call",
+            request_id="tool-err",
+            threadId="t",
+            turnId="tu1",
+            callId="call-1",
+            tool="kanban_block",
+            arguments={"task_id": "t_123", "reason": "oops"},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        def boom(_tool_name, _tool_args):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr("model_tools.handle_function_call", boom)
+        s = make_session(client)
+        s.run_turn("hi", turn_timeout=1.0)
+        assert any(
+            rid == "tool-err"
+            and payload.get("success") is False
+            and "kaboom" in payload.get("contentItems", [{}])[0].get("text", "")
+            for (rid, payload) in client.responses
+        )
+
+    def test_exec_approval_mode_off_auto_accepts_without_callback(self, monkeypatch):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval", request_id="req-off",
+            command="rm -rf /tmp/safe-scratch", cwd="/tmp",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        seen = {"called": False}
+
+        def cb(*_a, **_kw):
+            seen["called"] = True
+            return "deny"
+
+        monkeypatch.setattr(
+            session_mod,
+            "_auto_accept_via_hermes_approval_policy",
+            lambda: True,
+        )
+        s = make_session(client, approval_callback=cb)
+        s.run_turn("hi", turn_timeout=1.0)
+        assert ("req-off", {"decision": "accept"}) in client.responses
+        assert seen["called"] is False
+
+    def test_apply_patch_approval_mode_off_auto_accepts_without_callback(self, monkeypatch):
+        client = FakeClient()
+        client.queue_server_request(
+            "item/fileChange/requestApproval", request_id="req-patch-off",
+            itemId="fc-off", turnId="t1", threadId="th",
+            startedAtMs=1234567890,
+            reason="write generated file",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        seen = {"called": False}
+
+        def cb(*_a, **_kw):
+            seen["called"] = True
+            return "deny"
+
+        monkeypatch.setattr(
+            session_mod,
+            "_auto_accept_via_hermes_approval_policy",
+            lambda: True,
+        )
+        s = make_session(client, approval_callback=cb)
+        s.run_turn("hi", turn_timeout=1.0)
+        assert ("req-patch-off", {"decision": "accept"}) in client.responses
+        assert seen["called"] is False
 
     def test_apply_patch_approval_session_maps_to_session_decision(self):
         client = FakeClient()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -192,6 +192,91 @@ def test_branch_name_requires_worktree_workspace(kanban_home):
         )
 
 
+def _init_git_repo_with_commit(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    subprocess.run(["git", "config", "user.email", "tests@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Hermes Tests"], cwd=path, check=True)
+    (path / "README.md").write_text("test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    return path
+
+
+def test_resolve_workspace_rejects_missing_declared_worktree(kanban_home, tmp_path):
+    missing = tmp_path / "worktrees" / "missing"
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="missing worktree",
+            workspace_kind="worktree",
+            workspace_path=str(missing),
+            branch_name="feature/missing",
+        )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    with pytest.raises(ValueError, match="does not exist"):
+        kb.resolve_workspace(task)
+
+
+def test_resolve_workspace_accepts_existing_declared_worktree(kanban_home, tmp_path):
+    repo = _init_git_repo_with_commit(tmp_path / "repo")
+    wt = tmp_path / "worktrees" / "feature"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/ok", str(wt), "HEAD"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="existing worktree",
+            workspace_kind="worktree",
+            workspace_path=str(wt),
+            branch_name="feature/ok",
+        )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    assert kb.resolve_workspace(task) == wt
+
+
+def test_dispatch_blocks_missing_declared_worktree_before_spawn(
+    kanban_home, tmp_path, all_assignees_spawnable
+):
+    missing = tmp_path / "worktrees" / "missing"
+    spawned = []
+
+    def fake_spawn(task, workspace):
+        spawned.append((task.id, workspace))
+        return 123
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="missing worktree",
+            assignee="alice",
+            workspace_kind="worktree",
+            workspace_path=str(missing),
+            branch_name="feature/missing",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, tid)
+        runs = kb.list_runs(conn, task_id=tid)
+
+    assert task is not None
+    assert spawned == []
+    assert tid in res.auto_blocked
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+    assert runs[-1].outcome == "blocked"
+    assert "workspace-preflight" in (runs[-1].summary or "")
+
+
 # ---------------------------------------------------------------------------
 # Links + dependency resolution
 # ---------------------------------------------------------------------------
@@ -1530,16 +1615,16 @@ def test_dir_workspace_honors_given_path(kanban_home, tmp_path):
     assert ws.exists()
 
 
-def test_worktree_workspace_returns_intended_path(kanban_home, tmp_path):
+def test_worktree_workspace_requires_declared_existing_git_worktree(kanban_home, tmp_path):
     target = str(tmp_path / ".worktrees" / "my-task")
     with kb.connect() as conn:
         t = kb.create_task(
             conn, title="ship", workspace_kind="worktree", workspace_path=target
         )
         task = kb.get_task(conn, t)
-        ws = kb.resolve_workspace(task)
-    # We do NOT auto-create worktrees; the worker's skill handles that.
-    assert str(ws) == target
+    assert task is not None
+    with pytest.raises(ValueError, match="branch_name"):
+        kb.resolve_workspace(task)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import sqlite3
+import subprocess
 import time
 from pathlib import Path
 
@@ -1190,6 +1191,98 @@ def test_respawn_guard_blocker_auth_on_authentication_error(kanban_home):
     assert reason == "blocker_auth"
 
 
+def _init_git_repo(repo: Path) -> None:
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, capture_output=True, check=True)
+    (repo / "README.md").write_text("# Test Repo\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=repo, capture_output=True, check=True)
+
+
+def test_archive_task_removes_scratch_workspace(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="scratch cleanup")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        ws = kb.resolve_workspace(task)
+        (ws / "artifact.txt").write_text("leftover")
+        assert ws.exists()
+        assert kb.archive_task(conn, tid) is True
+    assert not ws.exists()
+
+
+def test_archive_task_keeps_worktree_with_unpushed_commits(kanban_home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    wt_path = tmp_path / "repo-worktree"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt_path), "-b", "feat/test-cleanup", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    (wt_path / "feature.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "feature.txt"], cwd=wt_path, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "feature work"], cwd=wt_path, capture_output=True, check=True)
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="worktree cleanup",
+            workspace_kind="worktree",
+            workspace_path=str(wt_path),
+        )
+        assert kb.archive_task(conn, tid) is True
+    assert wt_path.exists()
+
+
+def test_archive_task_removes_worktree_when_no_unpushed_commits(kanban_home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    wt_path = tmp_path / "repo-worktree"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt_path), "-b", "feat/test-cleanup", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="worktree cleanup",
+            workspace_kind="worktree",
+            workspace_path=str(wt_path),
+        )
+        assert kb.archive_task(conn, tid) is True
+    assert not wt_path.exists()
+    branches = subprocess.run(
+        ["git", "branch", "--list", "feat/test-cleanup"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert not branches.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Tenancy
+# ---------------------------------------------------------------------------
+
+def test_tenant_column_filters_listings(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="authn-task", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("Authentication failed: invalid credentials", t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
 def test_respawn_guard_blocker_auth_on_authorization_error(kanban_home):
     """Full word 'authorization' triggers blocker_auth (regex covers auth\\w*)."""
     with kb.connect() as conn:
@@ -1815,12 +1908,20 @@ class TestSharedBoardPaths:
     def test_dispatcher_spawn_injects_kanban_db_and_workspaces_root(
         self, tmp_path, monkeypatch
     ):
-        # The dispatcher's `_default_spawn` must inject HERMES_KANBAN_DB
-        # and HERMES_KANBAN_WORKSPACES_ROOT into the worker env so the
-        # worker converges on the dispatcher's paths even when the
+        # The dispatcher's `_default_spawn` must inject HERMES_KANBAN_DB,
+        # HERMES_KANBAN_WORKSPACES_ROOT, and when present the linked project
+        # home, so the worker converges on the dispatcher's paths even when the
         # `-p <profile>` flag rewrites HERMES_HOME.
         default_home = tmp_path / ".hermes"
         default_home.mkdir()
+        linked_project_home = (
+            tmp_path / "Documents" / "hermes-projects" / "active" / "default"
+        )
+        linked_project_home.mkdir(parents=True)
+        monkeypatch.setenv(
+            "HERMES_PROJECTS_ROOT",
+            str(tmp_path / "Documents" / "hermes-projects"),
+        )
         self._set_home(monkeypatch, tmp_path, default_home)
 
         captured = {}
@@ -1858,6 +1959,7 @@ class TestSharedBoardPaths:
         assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(
             default_home / "kanban" / "workspaces"
         )
+        assert env["HERMES_KANBAN_PROJECT_HOME"] == str(linked_project_home)
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
 

--- a/tests/hermes_cli/test_project_autopilot_init.py
+++ b/tests/hermes_cli/test_project_autopilot_init.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+from hermes_cli.project_autopilot import bootstrap_project_home, verify_project_home
+
+
+def test_bootstrap_project_home_writes_required_files(tmp_path):
+    project_home = tmp_path / "active" / "demo"
+
+    doc = bootstrap_project_home(
+        slug="demo",
+        title="Demo",
+        goal="Make demo restartable",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=project_home,
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+        source_plan=None,
+    )
+
+    for rel in [
+        "PROJECT.md",
+        "STATUS.md",
+        "SESSION-HANDOFF.md",
+        "SESSION-LOG.md",
+        "PARKING-LOT.md",
+        "TASKS.md",
+        "project.json",
+        "status",
+        "refs",
+        "scratch",
+        "artifacts",
+    ]:
+        assert (project_home / rel).exists(), rel
+
+    saved = json.loads((project_home / "project.json").read_text())
+    assert saved["slug"] == "demo"
+    assert saved["root_task_id"] == "t_root"
+    assert "## Next action" in (project_home / "STATUS.md").read_text()
+    verify_project_home(project_home)

--- a/tests/hermes_cli/test_project_autopilot_schema.py
+++ b/tests/hermes_cli/test_project_autopilot_schema.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.project_autopilot import (
+    PROJECT_MODE_V0,
+    SUPPORTED_PROJECT_MODES,
+    ProjectAutopilotError,
+    branch_to_worktree_path,
+    normalize_project_doc,
+    validate_project_doc,
+)
+
+
+def test_v0_rejects_unsupported_project_modes(tmp_path):
+    doc = normalize_project_doc(
+        slug="demo",
+        title="Demo",
+        goal="Demo goal",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=tmp_path / "demo",
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+    )
+    doc["project_mode"] = "many-independent-prs"
+
+    with pytest.raises(ProjectAutopilotError, match="unsupported project_mode"):
+        validate_project_doc(doc)
+
+
+def test_v0_schema_has_required_repo_and_policy_fields(tmp_path):
+    doc = normalize_project_doc(
+        slug="demo",
+        title="Demo",
+        goal="Demo goal",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=tmp_path / "demo",
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+    )
+
+    validate_project_doc(doc)
+
+    assert doc["schema_version"] == "project-autopilot/v0"
+    assert doc["project_mode"] == PROJECT_MODE_V0
+    assert SUPPORTED_PROJECT_MODES == {PROJECT_MODE_V0}
+    assert doc["repo"]["worktree_namespace"] == "/Users/vsletten/src/summation/Code"
+    assert doc["branch_strategy"]["final_branch"] == "feat/demo-pr"
+    assert "final_branch" not in doc
+    assert doc["execution_policy"] == {"parallelism": "none", "max_active_workers": 1}
+    assert doc["pr_requirement"]["required"] is True
+    assert doc["cleanup"]["state"] == "not_started"
+    assert isinstance(doc["transition_log"], list)
+
+
+def test_branch_to_worktree_path_uses_victor_convention():
+    assert branch_to_worktree_path(
+        worktree_namespace=Path("/Users/vsletten/src/summation/Code"),
+        branch_name="kanban/fix-this-shit",
+    ) == Path("/Users/vsletten/src/summation/Code/kanban/fix-this-shit")

--- a/tests/hermes_cli/test_project_autopilot_schema.py
+++ b/tests/hermes_cli/test_project_autopilot_schema.py
@@ -9,6 +9,7 @@ from hermes_cli.project_autopilot import (
     ProjectAutopilotError,
     branch_to_worktree_path,
     normalize_project_doc,
+    render_status_md,
     validate_project_doc,
 )
 
@@ -106,6 +107,28 @@ def test_done_state_accepts_pr_url(tmp_path):
     doc["pr_url"] = "https://github.com/NousResearch/hermes-agent/pull/123"
 
     validate_project_doc(doc)
+
+
+def test_done_status_points_at_pr_review(tmp_path):
+    doc = normalize_project_doc(
+        slug="demo",
+        title="Demo",
+        goal="Demo goal",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=tmp_path / "demo",
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+    )
+    doc["state"] = "DONE"
+    doc["pr_url"] = "https://github.com/NousResearch/hermes-agent/pull/123"
+
+    status_md = render_status_md(doc, task_graph={"nodes": [], "edges": []})
+
+    assert "Review draft PR: https://github.com/NousResearch/hermes-agent/pull/123" in status_md
+    assert "No ready or running task found" not in status_md
 
 
 def test_done_state_accepts_victor_pr_waiver(tmp_path):

--- a/tests/hermes_cli/test_project_autopilot_schema.py
+++ b/tests/hermes_cli/test_project_autopilot_schema.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli.project_autopilot import (
+    InvariantError,
     PROJECT_MODE_V0,
     SUPPORTED_PROJECT_MODES,
     ProjectAutopilotError,
@@ -64,3 +65,65 @@ def test_branch_to_worktree_path_uses_victor_convention():
         worktree_namespace=Path("/Users/vsletten/src/summation/Code"),
         branch_name="kanban/fix-this-shit",
     ) == Path("/Users/vsletten/src/summation/Code/kanban/fix-this-shit")
+
+
+def test_done_state_requires_pr_url_or_victor_waiver(tmp_path):
+    doc = normalize_project_doc(
+        slug="demo",
+        title="Demo",
+        goal="Demo goal",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=tmp_path / "demo",
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+    )
+    doc["state"] = "DONE"
+
+    with pytest.raises(
+        InvariantError,
+        match="coding project cannot be DONE without pr_url or Victor PR waiver",
+    ):
+        validate_project_doc(doc)
+
+
+def test_done_state_accepts_pr_url(tmp_path):
+    doc = normalize_project_doc(
+        slug="demo",
+        title="Demo",
+        goal="Demo goal",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=tmp_path / "demo",
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+    )
+    doc["state"] = "DONE"
+    doc["pr_url"] = "https://github.com/NousResearch/hermes-agent/pull/123"
+
+    validate_project_doc(doc)
+
+
+def test_done_state_accepts_victor_pr_waiver(tmp_path):
+    doc = normalize_project_doc(
+        slug="demo",
+        title="Demo",
+        goal="Demo goal",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=tmp_path / "demo",
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+    )
+    doc["state"] = "DONE"
+    doc["pr_requirement"]["waived"] = True
+    doc["pr_requirement"]["waived_by"] = "Victor"
+    doc["pr_requirement"]["reason"] = "Manual approval"
+
+    validate_project_doc(doc)

--- a/tests/hermes_cli/test_project_autopilot_sync.py
+++ b/tests/hermes_cli/test_project_autopilot_sync.py
@@ -117,6 +117,77 @@ def test_sync_project_home_rewrites_project_files_from_board_truth(tmp_path):
         conn.close()
 
 
+def test_sync_project_home_includes_unlinked_live_board_tasks(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                "Project root body",
+                "codexapp",
+                "done",
+                0,
+                "tester",
+                1,
+                "scratch",
+            ),
+        )
+        implementation_id = kanban_db.create_task(
+            conn,
+            title="Implement board execution slice",
+            body="Implementation body",
+            assignee="codexapp",
+            created_by="tester",
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'done' WHERE id = ?",
+            (implementation_id,),
+        )
+        review_id = kanban_db.create_task(
+            conn,
+            title="Review board execution slice",
+            body="Review body",
+            assignee="reviewer",
+            created_by="tester",
+            parents=[implementation_id],
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'review' WHERE id = ?",
+            (review_id,),
+        )
+
+        project_home = _bootstrap_demo_project(tmp_path)
+
+        sync_project_home(project_home, db_path=db_path)
+
+        saved = json.loads((project_home / "project.json").read_text())
+        node_ids = {node["id"] for node in saved["task_graph"]["nodes"]}
+        assert {"t_root", implementation_id, review_id} <= node_ids
+        assert {"parent": implementation_id, "child": review_id} in saved[
+            "task_graph"
+        ]["edges"]
+
+        tasks_md = (project_home / "TASKS.md").read_text(encoding="utf-8")
+        assert implementation_id in tasks_md
+        assert review_id in tasks_md
+        assert "Implement board execution slice" in tasks_md
+        assert "Review board execution slice" in tasks_md
+
+        status_md = (project_home / "STATUS.md").read_text(encoding="utf-8")
+        assert "Tasks: 3 total" in status_md
+        assert review_id in status_md
+    finally:
+        conn.close()
+
+
 @pytest.mark.parametrize("schema_version", [None, "legacy-project/v0"])
 def test_sync_project_home_upgrades_legacy_project_json_before_validation(
     tmp_path, schema_version

--- a/tests/hermes_cli/test_project_autopilot_sync.py
+++ b/tests/hermes_cli/test_project_autopilot_sync.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from hermes_cli import project_autopilot
 from hermes_cli import kanban_db
 from hermes_cli.project_autopilot import bootstrap_project_home, sync_project_home
 
@@ -184,6 +185,112 @@ def test_sync_project_home_includes_unlinked_live_board_tasks(tmp_path):
         status_md = (project_home / "STATUS.md").read_text(encoding="utf-8")
         assert "Tasks: 3 total" in status_md
         assert review_id in status_md
+    finally:
+        conn.close()
+
+
+def test_sync_project_home_blocks_when_terminal_non_root_task_missing_report(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                "Project root body",
+                "codexapp",
+                "done",
+                0,
+                "tester",
+                1,
+                "scratch",
+            ),
+        )
+        child_id = kanban_db.create_task(
+            conn,
+            title="Completed implementation",
+            body="Implementation body",
+            assignee="codexapp",
+            created_by="tester",
+            parents=["t_root"],
+        )
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (child_id,))
+
+        project_home = _bootstrap_demo_project(tmp_path)
+
+        doc = sync_project_home(project_home, db_path=db_path)
+
+        assert doc["state"] == "BLOCKED_PROCESS"
+        assert project_autopilot.terminal_tasks_missing_reports(
+            project_home, doc["task_graph"]["nodes"]
+        ) == [child_id]
+        assert doc["invariant_failures"][-1] == {
+            "type": "terminal_tasks_missing_reports",
+            "task_ids": [child_id],
+        }
+
+        status_md = (project_home / "STATUS.md").read_text(encoding="utf-8")
+        assert f"Blocker: missing terminal task status reports: `{child_id}`" in status_md
+        assert status_md.index("Blocker:") < status_md.index("## Next action")
+    finally:
+        conn.close()
+
+
+def test_sync_project_home_accepts_non_empty_terminal_task_report(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                "Project root body",
+                "codexapp",
+                "done",
+                0,
+                "tester",
+                1,
+                "scratch",
+            ),
+        )
+        child_id = kanban_db.create_task(
+            conn,
+            title="Completed implementation",
+            body="Implementation body",
+            assignee="codexapp",
+            created_by="tester",
+            parents=["t_root"],
+        )
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (child_id,))
+
+        project_home = _bootstrap_demo_project(tmp_path)
+        (project_home / "status" / f"{child_id}.md").write_text(
+            "# Completed implementation\n\nVerified and pushed.\n",
+            encoding="utf-8",
+        )
+
+        doc = sync_project_home(project_home, db_path=db_path)
+
+        assert project_autopilot.terminal_tasks_missing_reports(
+            project_home, doc["task_graph"]["nodes"]
+        ) == []
+        assert doc["state"] != "BLOCKED_PROCESS"
+        assert doc["invariant_failures"] == []
+        assert "Blocker: none" in (project_home / "STATUS.md").read_text(
+            encoding="utf-8"
+        )
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_project_autopilot_sync.py
+++ b/tests/hermes_cli/test_project_autopilot_sync.py
@@ -351,6 +351,65 @@ def test_sync_project_home_clears_stale_terminal_task_report_failure(tmp_path):
         conn.close()
 
 
+def test_sync_project_home_restores_done_after_repaired_report_failure(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                "Project root body",
+                "codexapp",
+                "done",
+                0,
+                "tester",
+                1,
+                "scratch",
+            ),
+        )
+        child_id = kanban_db.create_task(
+            conn,
+            title="Completed implementation",
+            body="Implementation body",
+            assignee="codexapp",
+            created_by="tester",
+            parents=["t_root"],
+        )
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (child_id,))
+
+        project_home = _bootstrap_demo_project(tmp_path)
+        project_json = project_home / "project.json"
+        doc = json.loads(project_json.read_text())
+        doc["state"] = "DONE"
+        doc["pr_url"] = "https://github.com/NousResearch/hermes-agent/pull/123"
+        project_json.write_text(json.dumps(doc), encoding="utf-8")
+
+        first_doc = sync_project_home(project_home, db_path=db_path)
+        assert first_doc["state"] == "BLOCKED_PROCESS"
+
+        (project_home / "status" / f"{child_id}.md").write_text(
+            "# Completed implementation\n\nVerified and pushed.\n",
+            encoding="utf-8",
+        )
+
+        repaired_doc = sync_project_home(project_home, db_path=db_path)
+
+        assert repaired_doc["state"] == "DONE"
+        assert repaired_doc["invariant_failures"] == []
+        assert "Review draft PR: https://github.com/NousResearch/hermes-agent/pull/123" in (
+            project_home / "STATUS.md"
+        ).read_text(encoding="utf-8")
+    finally:
+        conn.close()
+
+
 @pytest.mark.parametrize("schema_version", [None, "legacy-project/v0"])
 def test_sync_project_home_upgrades_legacy_project_json_before_validation(
     tmp_path, schema_version

--- a/tests/hermes_cli/test_project_autopilot_sync.py
+++ b/tests/hermes_cli/test_project_autopilot_sync.py
@@ -1,0 +1,171 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from hermes_cli import kanban_db
+from hermes_cli.project_autopilot import bootstrap_project_home, sync_project_home
+
+
+def _bootstrap_demo_project(tmp_path, *, board_slug="demo-board"):
+    project_home = tmp_path / "projects" / "demo"
+    bootstrap_project_home(
+        slug="demo",
+        title="Demo",
+        goal="Make demo restartable",
+        board_slug=board_slug,
+        root_task_id="t_root",
+        project_home=project_home,
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=Path("/Users/vsletten/src/summation/Code/main"),
+        final_branch="feat/demo-pr",
+        source_plan=None,
+    )
+    return project_home
+
+
+def test_sync_project_home_rewrites_project_files_from_board_truth(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind, workspace_path, branch_name
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                "Project root body",
+                "codexapp",
+                "done",
+                0,
+                "tester",
+                1,
+                "scratch",
+                None,
+                None,
+            ),
+        )
+        first_child = kanban_db.create_task(
+            conn,
+            title="Implement slice",
+            body="Slice body",
+            assignee="codexapp",
+            created_by="tester",
+            workspace_kind="worktree",
+            workspace_path="/Users/vsletten/src/summation/Code/feat/demo-pr",
+            branch_name="feat/demo-pr",
+            parents=["t_root"],
+        )
+        second_child = kanban_db.create_task(
+            conn,
+            title="Review slice",
+            body="Review body",
+            assignee="reviewer",
+            created_by="tester",
+            parents=[first_child],
+        )
+
+        project_home = _bootstrap_demo_project(tmp_path)
+        (project_home / "TASKS.md").write_text("stale task cache\n", encoding="utf-8")
+        (project_home / "STATUS.md").write_text(
+            "# Status: stale\n\n## Next action\n\nstale\n",
+            encoding="utf-8",
+        )
+
+        doc = sync_project_home(project_home, db_path=db_path)
+
+        saved = json.loads((project_home / "project.json").read_text())
+        assert saved["task_graph"]["nodes"][0]["id"] == "t_root"
+        assert {edge["parent"] for edge in saved["task_graph"]["edges"]} == {
+            "t_root",
+            first_child,
+        }
+        assert saved["workspace_contracts"][first_child] == {
+            "workspace_kind": "worktree",
+            "workspace_path": "/Users/vsletten/src/summation/Code/feat/demo-pr",
+            "branch_name": "feat/demo-pr",
+        }
+        assert doc["updated_at"] >= doc["created_at"]
+
+        tasks_md = (project_home / "TASKS.md").read_text(encoding="utf-8")
+        assert "Root project" in tasks_md
+        assert "Implement slice" in tasks_md
+        assert "Review slice" in tasks_md
+        assert f"`{first_child}`" in tasks_md
+        assert "stale task cache" not in tasks_md
+
+        status_md = (project_home / "STATUS.md").read_text(encoding="utf-8")
+        assert "Tasks: 3 total" in status_md
+        assert "Next executable task" in status_md
+        assert f"`{first_child}`" in status_md
+        assert "stale" not in status_md
+
+        handoff_md = (project_home / "SESSION-HANDOFF.md").read_text(
+            encoding="utf-8"
+        )
+        assert "Reconcile `TASKS.md` and `STATUS.md` from board truth" in handoff_md
+        assert "Task graph snapshot" in handoff_md
+    finally:
+        conn.close()
+
+
+def test_project_sync_cli_reconciles_home_from_kanban_db(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                None,
+                "codexapp",
+                "done",
+                0,
+                "tester",
+                1,
+                "scratch",
+            ),
+        )
+        child_id = kanban_db.create_task(
+            conn,
+            title="CLI synced task",
+            assignee="codexapp",
+            created_by="tester",
+            parents=["t_root"],
+        )
+    finally:
+        conn.close()
+
+    project_home = _bootstrap_demo_project(tmp_path)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HERMES_HOME": str(tmp_path / ".hermes"),
+            "HERMES_KANBAN_DB": str(db_path),
+            "PYTHONPATH": str(Path.cwd()),
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "project", "sync", str(project_home)],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SYNCED demo" in result.stdout
+    assert child_id in (project_home / "TASKS.md").read_text(encoding="utf-8")

--- a/tests/hermes_cli/test_project_autopilot_sync.py
+++ b/tests/hermes_cli/test_project_autopilot_sync.py
@@ -295,6 +295,62 @@ def test_sync_project_home_accepts_non_empty_terminal_task_report(tmp_path):
         conn.close()
 
 
+def test_sync_project_home_clears_stale_terminal_task_report_failure(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                "Project root body",
+                "codexapp",
+                "done",
+                0,
+                "tester",
+                1,
+                "scratch",
+            ),
+        )
+        child_id = kanban_db.create_task(
+            conn,
+            title="Completed implementation",
+            body="Implementation body",
+            assignee="codexapp",
+            created_by="tester",
+            parents=["t_root"],
+        )
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (child_id,))
+
+        project_home = _bootstrap_demo_project(tmp_path)
+        first_doc = sync_project_home(project_home, db_path=db_path)
+        assert first_doc["state"] == "BLOCKED_PROCESS"
+        assert first_doc["invariant_failures"] == [
+            {"type": "terminal_tasks_missing_reports", "task_ids": [child_id]}
+        ]
+
+        (project_home / "status" / f"{child_id}.md").write_text(
+            "# Completed implementation\n\nVerified and pushed.\n",
+            encoding="utf-8",
+        )
+
+        repaired_doc = sync_project_home(project_home, db_path=db_path)
+
+        assert repaired_doc["state"] == "PLANNED"
+        assert repaired_doc["invariant_failures"] == []
+        assert "Blocker: none" in (project_home / "STATUS.md").read_text(
+            encoding="utf-8"
+        )
+    finally:
+        conn.close()
+
+
 @pytest.mark.parametrize("schema_version", [None, "legacy-project/v0"])
 def test_sync_project_home_upgrades_legacy_project_json_before_validation(
     tmp_path, schema_version

--- a/tests/hermes_cli/test_project_autopilot_sync.py
+++ b/tests/hermes_cli/test_project_autopilot_sync.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from hermes_cli import kanban_db
 from hermes_cli.project_autopilot import bootstrap_project_home, sync_project_home
 
@@ -111,6 +113,70 @@ def test_sync_project_home_rewrites_project_files_from_board_truth(tmp_path):
         )
         assert "Reconcile `TASKS.md` and `STATUS.md` from board truth" in handoff_md
         assert "Task graph snapshot" in handoff_md
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("schema_version", [None, "legacy-project/v0"])
+def test_sync_project_home_upgrades_legacy_project_json_before_validation(
+    tmp_path, schema_version
+):
+    db_path = tmp_path / "kanban.db"
+    conn = kanban_db.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO tasks (
+                id, title, body, assignee, status, priority, created_by,
+                created_at, workspace_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "t_root",
+                "Root project",
+                "Project root body",
+                "codexapp",
+                "ready",
+                0,
+                "tester",
+                1,
+                "scratch",
+            ),
+        )
+
+        project_home = _bootstrap_demo_project(tmp_path)
+        legacy_doc = {
+            "slug": "demo",
+            "title": "Demo",
+            "goal": "Make demo restartable",
+            "board_slug": "demo-board",
+            "root_task_id": "t_root",
+            "project_home": str(project_home),
+            "project_type": "Hermes feature project",
+            "state": "PLANNED",
+            "created_at": 123,
+            "updated_at": 456,
+        }
+        if schema_version is not None:
+            legacy_doc["schema_version"] = schema_version
+        (project_home / "project.json").write_text(
+            json.dumps(legacy_doc, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        doc = sync_project_home(project_home, db_path=db_path)
+
+        saved = json.loads((project_home / "project.json").read_text())
+        assert saved["schema_version"] == "project-autopilot/v0"
+        assert saved["project_mode"] == "stacked-slices-one-pr"
+        assert saved["slug"] == "demo"
+        assert saved["state"] == "PLANNED"
+        assert saved["root_task_id"] == "t_root"
+        assert saved["task_graph"]["nodes"][0]["id"] == "t_root"
+        assert saved["branch_strategy"]["final_branch"]
+        assert saved["repo"]["org"]
+        assert saved["repo"]["name"]
+        assert doc == saved
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_project_autopilot_worktrees.py
+++ b/tests/hermes_cli/test_project_autopilot_worktrees.py
@@ -1,9 +1,16 @@
+import json
+from pathlib import Path
+
 import pytest
 
 from hermes_cli.project_autopilot import (
+    InvariantError,
     ProjectAutopilotError,
+    generate_cleanup_inventory,
     missing_patch_ids,
+    normalize_project_doc,
     parse_patch_id_output,
+    write_json,
     validate_workspace_contract,
 )
 
@@ -61,3 +68,155 @@ def test_missing_patch_ids_returns_task_ids_absent_from_final_branch():
     final_patch_ids = {"def456", "zzz000"}
 
     assert missing_patch_ids(task_patch_ids, final_patch_ids) == {"abc123", "fed999"}
+
+
+def _write_project_with_task_graph(
+    project_home: Path,
+    *,
+    worktree_namespace: Path,
+    nodes: list[dict],
+    final_worktree_path: Path | None = None,
+    canonical_checkout: Path | None = None,
+) -> dict:
+    for dirname in ("status", "refs", "scratch", "artifacts"):
+        (project_home / dirname).mkdir(parents=True, exist_ok=True)
+    for filename in (
+        "PROJECT.md",
+        "SESSION-HANDOFF.md",
+        "SESSION-LOG.md",
+        "PARKING-LOT.md",
+        "TASKS.md",
+    ):
+        (project_home / filename).write_text(f"# {filename}\n", encoding="utf-8")
+    (project_home / "STATUS.md").write_text(
+        "# Status\n\n## Next action\n\nInspect cleanup inventory.\n",
+        encoding="utf-8",
+    )
+    doc = normalize_project_doc(
+        slug="demo",
+        title="Demo",
+        goal="Demo goal",
+        board_slug="demo",
+        root_task_id="t_root",
+        project_home=project_home,
+        repo_org="summation",
+        repo_name="Code",
+        canonical_checkout=canonical_checkout or worktree_namespace / "main",
+        final_branch="feat/demo-pr",
+    )
+    doc["repo"]["worktree_namespace"] = str(worktree_namespace)
+    doc["repo"]["canonical_checkout"] = str(
+        canonical_checkout or worktree_namespace / "main"
+    )
+    doc["final_worktree_path"] = str(
+        final_worktree_path or worktree_namespace / "feat" / "demo-pr"
+    )
+    doc["task_graph"] = {"nodes": nodes, "edges": []}
+    write_json(project_home / "project.json", doc)
+    return doc
+
+
+def test_generate_cleanup_inventory_writes_audit_json_and_updates_cleanup_state(
+    tmp_path,
+):
+    project_home = tmp_path / "project"
+    namespace = tmp_path / "src" / "summation" / "Code"
+    stale_worktree = namespace / "feat" / "slice-one"
+    final_worktree = namespace / "feat" / "demo-pr"
+    canonical_checkout = namespace / "main"
+    sentinel = stale_worktree / "keep.txt"
+    sentinel.parent.mkdir(parents=True)
+    sentinel.write_text("do not delete", encoding="utf-8")
+
+    _write_project_with_task_graph(
+        project_home,
+        worktree_namespace=namespace,
+        final_worktree_path=final_worktree,
+        canonical_checkout=canonical_checkout,
+        nodes=[
+            {
+                "id": "t_done",
+                "title": "slice one",
+                "status": "done",
+                "workspace_kind": "worktree",
+                "workspace_path": str(stale_worktree),
+                "branch_name": "feat/slice-one",
+            },
+            {
+                "id": "t_running",
+                "title": "running slice",
+                "status": "running",
+                "workspace_kind": "worktree",
+                "workspace_path": str(namespace / "feat" / "slice-two"),
+                "branch_name": "feat/slice-two",
+            },
+            {
+                "id": "t_final",
+                "title": "final branch",
+                "status": "done",
+                "workspace_kind": "worktree",
+                "workspace_path": str(final_worktree),
+                "branch_name": "feat/demo-pr",
+            },
+            {
+                "id": "t_main",
+                "title": "canonical checkout",
+                "status": "done",
+                "workspace_kind": "worktree",
+                "workspace_path": str(canonical_checkout),
+                "branch_name": "main",
+            },
+            {
+                "id": "t_docs",
+                "title": "docs only",
+                "status": "done",
+                "workspace_kind": "scratch",
+                "workspace_path": str(tmp_path / "scratch"),
+            },
+        ],
+    )
+
+    inventory = generate_cleanup_inventory(project_home)
+
+    inventory_path = Path(inventory["inventory_path"])
+    assert inventory_path == project_home / "artifacts" / "cleanup" / inventory_path.name
+    assert inventory_path.exists()
+    saved_inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
+    assert saved_inventory["project_home"] == str(project_home)
+    assert [target["task_id"] for target in saved_inventory["targets"]] == ["t_done"]
+    assert saved_inventory["targets"][0]["workspace_path"] == str(stale_worktree)
+    assert saved_inventory["exclusions"]["final_worktree_path"] == str(final_worktree)
+    assert saved_inventory["exclusions"]["canonical_checkout"] == str(
+        canonical_checkout
+    )
+    assert sentinel.exists()
+
+    saved_doc = json.loads((project_home / "project.json").read_text(encoding="utf-8"))
+    assert saved_doc["cleanup"]["state"] == "inventory_ready"
+    assert saved_doc["cleanup"]["inventory_path"] == str(inventory_path)
+    assert saved_doc["cleanup"]["targets"] == saved_inventory["targets"]
+
+
+def test_generate_cleanup_inventory_rejects_terminal_worktree_outside_namespace(
+    tmp_path,
+):
+    project_home = tmp_path / "project"
+    namespace = tmp_path / "src" / "summation" / "Code"
+    outside_worktree = tmp_path / "elsewhere" / "feat" / "slice-one"
+    _write_project_with_task_graph(
+        project_home,
+        worktree_namespace=namespace,
+        nodes=[
+            {
+                "id": "t_done",
+                "title": "slice one",
+                "status": "done",
+                "workspace_kind": "worktree",
+                "workspace_path": str(outside_worktree),
+                "branch_name": "feat/slice-one",
+            }
+        ],
+    )
+
+    with pytest.raises(InvariantError, match="outside repo.worktree_namespace"):
+        generate_cleanup_inventory(project_home)

--- a/tests/hermes_cli/test_project_autopilot_worktrees.py
+++ b/tests/hermes_cli/test_project_autopilot_worktrees.py
@@ -2,6 +2,8 @@ import pytest
 
 from hermes_cli.project_autopilot import (
     ProjectAutopilotError,
+    missing_patch_ids,
+    parse_patch_id_output,
     validate_workspace_contract,
 )
 
@@ -41,3 +43,21 @@ def test_workspace_contract_requires_metadata_fields():
 
     with pytest.raises(ProjectAutopilotError, match="workspace contract missing base_ref"):
         validate_workspace_contract(contract, repo=repo)
+
+
+def test_parse_patch_id_output_returns_first_column_ids():
+    output = """
+    abc123 commit-one
+    def456 commit-two
+
+    abc123 duplicate-commit
+    """
+
+    assert parse_patch_id_output(output) == {"abc123", "def456"}
+
+
+def test_missing_patch_ids_returns_task_ids_absent_from_final_branch():
+    task_patch_ids = {"abc123", "def456", "fed999"}
+    final_patch_ids = {"def456", "zzz000"}
+
+    assert missing_patch_ids(task_patch_ids, final_patch_ids) == {"abc123", "fed999"}

--- a/tests/hermes_cli/test_project_autopilot_worktrees.py
+++ b/tests/hermes_cli/test_project_autopilot_worktrees.py
@@ -1,0 +1,43 @@
+import pytest
+
+from hermes_cli.project_autopilot import (
+    ProjectAutopilotError,
+    validate_workspace_contract,
+)
+
+
+def test_workspace_contract_rejects_wrong_path():
+    contract = {
+        "task_id": "t_1",
+        "workspace_path": "/tmp/demo",
+        "branch_name": "kanban/fix-this-shit",
+        "base_ref": "origin/main",
+    }
+    repo = {"worktree_namespace": "/Users/vsletten/src/summation/Code"}
+
+    with pytest.raises(ProjectAutopilotError, match="branch-derived path"):
+        validate_workspace_contract(contract, repo=repo)
+
+
+def test_workspace_contract_accepts_branch_derived_path():
+    contract = {
+        "task_id": "t_1",
+        "workspace_path": "/Users/vsletten/src/summation/Code/kanban/fix-this-shit",
+        "branch_name": "kanban/fix-this-shit",
+        "base_ref": "origin/main",
+    }
+    repo = {"worktree_namespace": "/Users/vsletten/src/summation/Code"}
+
+    validate_workspace_contract(contract, repo=repo)
+
+
+def test_workspace_contract_requires_metadata_fields():
+    contract = {
+        "task_id": "t_1",
+        "workspace_path": "/Users/vsletten/src/summation/Code/kanban/fix-this-shit",
+        "branch_name": "kanban/fix-this-shit",
+    }
+    repo = {"worktree_namespace": "/Users/vsletten/src/summation/Code"}
+
+    with pytest.raises(ProjectAutopilotError, match="workspace contract missing base_ref"):
+        validate_workspace_contract(contract, repo=repo)

--- a/tests/hermes_cli/test_project_cli.py
+++ b/tests/hermes_cli/test_project_cli.py
@@ -50,3 +50,63 @@ def test_project_init_cli_bootstraps_home(tmp_path):
     assert "BOOTSTRAPPED" in result.stdout
     doc = json.loads((project_home / "project.json").read_text())
     assert doc["slug"] == "demo"
+
+
+def test_project_cleanup_inventory_cli_writes_inventory(tmp_path):
+    project_home = tmp_path / "projects" / "demo"
+    init_result = run_hermes(
+        tmp_path,
+        "project",
+        "init",
+        "--slug",
+        "demo",
+        "--title",
+        "Demo",
+        "--goal",
+        "Make demo restartable",
+        "--board",
+        "demo",
+        "--root-task",
+        "t_root",
+        "--project-home",
+        str(project_home),
+        "--repo-org",
+        "summation",
+        "--repo-name",
+        "Code",
+        "--canonical-repo",
+        "/Users/vsletten/src/summation/Code/main",
+        "--final-branch",
+        "feat/demo-pr",
+    )
+    assert init_result.returncode == 0, init_result.stderr
+
+    doc = json.loads((project_home / "project.json").read_text())
+    doc["repo"]["worktree_namespace"] = str(tmp_path / "src" / "summation" / "Code")
+    doc["final_worktree_path"] = str(
+        tmp_path / "src" / "summation" / "Code" / "feat" / "demo-pr"
+    )
+    doc["task_graph"] = {
+        "nodes": [
+            {
+                "id": "t_done",
+                "title": "slice one",
+                "status": "done",
+                "workspace_kind": "worktree",
+                "workspace_path": str(
+                    tmp_path / "src" / "summation" / "Code" / "feat" / "slice-one"
+                ),
+                "branch_name": "feat/slice-one",
+            }
+        ],
+        "edges": [],
+    }
+    (project_home / "project.json").write_text(json.dumps(doc), encoding="utf-8")
+
+    result = run_hermes(tmp_path, "project", "cleanup-inventory", str(project_home))
+
+    assert result.returncode == 0, result.stderr
+    assert "CLEANUP_INVENTORY" in result.stdout
+    saved = json.loads((project_home / "project.json").read_text())
+    assert saved["cleanup"]["state"] == "inventory_ready"
+    assert Path(saved["cleanup"]["inventory_path"]).exists()

--- a/tests/hermes_cli/test_project_cli.py
+++ b/tests/hermes_cli/test_project_cli.py
@@ -1,0 +1,52 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_hermes(tmp_path, *args):
+    env = os.environ.copy()
+    env.update({"HERMES_HOME": str(tmp_path / ".hermes"), "PYTHONPATH": str(Path.cwd())})
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_project_init_cli_bootstraps_home(tmp_path):
+    project_home = tmp_path / "projects" / "demo"
+    result = run_hermes(
+        tmp_path,
+        "project",
+        "init",
+        "--slug",
+        "demo",
+        "--title",
+        "Demo",
+        "--goal",
+        "Make demo restartable",
+        "--board",
+        "demo",
+        "--root-task",
+        "t_root",
+        "--project-home",
+        str(project_home),
+        "--repo-org",
+        "summation",
+        "--repo-name",
+        "Code",
+        "--canonical-repo",
+        "/Users/vsletten/src/summation/Code/main",
+        "--final-branch",
+        "feat/demo-pr",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "BOOTSTRAPPED" in result.stdout
+    doc = json.loads((project_home / "project.json").read_text())
+    assert doc["slug"] == "demo"

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -71,6 +71,38 @@ class TestApiModeAccepted:
 
 
 class TestRunConversationCodexPath:
+    def test_run_conversation_passes_env_timeouts(self, monkeypatch):
+        captured = {}
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured["user_input"] = user_input
+            captured["kwargs"] = kwargs
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-timeout-1",
+                thread_id="thread-timeout-1",
+            )
+
+        monkeypatch.setenv("HERMES_CODEX_TURN_TIMEOUT_SEC", "1800")
+        monkeypatch.setenv("HERMES_CODEX_POST_TOOL_QUIET_TIMEOUT_SEC", "240")
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-timeout-1"
+        )
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "ok"
+        assert captured["user_input"] == "hello"
+        assert captured["kwargs"]["turn_timeout"] == 1800.0
+        assert captured["kwargs"]["post_tool_quiet_timeout"] == 240.0
+
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
         # No background review fork during tests

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1132,8 +1132,9 @@ def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     assert "kanban_complete" in prompt
     assert "kanban_block" in prompt
     assert "kanban_create" in prompt
-    # Anti-shell guidance
+    # Anti-shell / workspace guidance
     assert "Do not shell out" in prompt or "tools — they work" in prompt
+    assert "Don't modify files outside it unless the task explicitly asks." in prompt
 
 
 def test_kanban_guidance_prompt_size_bounded(monkeypatch, tmp_path):

--- a/tests/website/test_project_autopilot_docs.py
+++ b/tests/website/test_project_autopilot_docs.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_AUTOPILOT_DOC = (
+    REPO_ROOT / "website" / "docs" / "user-guide" / "features" / "project-autopilot.md"
+)
+CLI_COMMANDS_DOC = REPO_ROOT / "website" / "docs" / "reference" / "cli-commands.md"
+SIDEBARS = REPO_ROOT / "website" / "sidebars.ts"
+
+
+def test_project_autopilot_feature_doc_covers_v0_workflow():
+    body = PROJECT_AUTOPILOT_DOC.read_text(encoding="utf-8")
+
+    for command in (
+        "hermes project init",
+        "hermes project verify <project_home>",
+        "hermes project sync <project_home>",
+        "hermes project cleanup-inventory <project_home>",
+    ):
+        assert command in body
+
+    for required_phrase in (
+        "stacked-slices-one-pr",
+        "Kanban remains the execution truth",
+        "/Users/vsletten/src/<org>/<repo>/<branch-name-as-path>",
+        "draft or open PR",
+        "No cleanup command deletes files",
+    ):
+        assert required_phrase in body
+
+
+def test_project_autopilot_doc_is_discoverable_from_docs_nav_and_cli_reference():
+    cli_reference = CLI_COMMANDS_DOC.read_text(encoding="utf-8")
+    sidebar = SIDEBARS.read_text(encoding="utf-8")
+
+    assert "| `hermes project` |" in cli_reference
+    assert "## `hermes project`" in cli_reference
+    assert "user-guide/features/project-autopilot" in sidebar

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -50,6 +50,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes status` | Show agent, auth, and platform status. |
 | `hermes cron` | Inspect and tick the cron scheduler. |
 | `hermes kanban` | Multi-profile collaboration board (tasks, links, dispatcher). |
+| `hermes project` | Filesystem-backed Project Autopilot homes for long-running Kanban projects. |
 | `hermes webhook` | Manage dynamic webhook subscriptions for event-driven activation. |
 | `hermes hooks` | Inspect, approve, or remove shell-script hooks declared in `config.yaml`. |
 | `hermes doctor` | Diagnose config and dependency issues. |
@@ -438,6 +439,55 @@ Board resolution order (highest precedence first): `--board <slug>` flag → `HE
 All actions are also available as a slash command in the gateway (`/kanban …`), with the same argument surface — including `boards` subcommands and the `--board` flag.
 
 For the full design — comparison with Cline Kanban / Paperclip / NanoClaw / Gemini Enterprise, eight collaboration patterns, four user stories, concurrency correctness proof — see `docs/hermes-kanban-v1-spec.pdf` in the repository or the [Kanban user guide](/docs/user-guide/features/kanban).
+
+## `hermes project`
+
+```bash
+hermes project <init|sync|verify|cleanup-inventory>
+```
+
+Manage deterministic Project Autopilot V0 project homes for long-running Kanban
+engineering projects. The project home stores lifecycle state and continuity
+files, while Kanban remains canonical for task execution.
+
+| Subcommand | Description |
+|------------|-------------|
+| `init` | Bootstrap a Project Autopilot home and seed `project.json` plus continuity docs. |
+| `verify <project_home>` | Validate schema, required files, lifecycle invariants, PR gating, and worktree path policy. |
+| `sync <project_home>` | Refresh `TASKS.md`, `STATUS.md`, `SESSION-HANDOFF.md`, and cached task graph state from Kanban. |
+| `cleanup-inventory <project_home>` | Write a dry-run cleanup inventory under `artifacts/cleanup/` without deleting files. |
+
+### `hermes project init`
+
+```bash
+hermes project init \
+  --slug <slug> \
+  --title "<title>" \
+  --goal "<goal>" \
+  --board <board_slug> \
+  --root-task <task_id> \
+  --project-home <project_home> \
+  --repo-org <org> \
+  --repo-name <repo> \
+  --canonical-repo <path> \
+  --final-branch <branch> \
+  [--source-plan <path>]
+```
+
+Project Autopilot V0 supports only `stacked-slices-one-pr`. Code worktrees must
+map branch names to paths under `/Users/vsletten/src/<org>/<repo>/<branch-name-as-path>`;
+the project home itself stays under `~/Documents/hermes-projects/active/<slug>/`.
+
+Examples:
+
+```bash
+hermes project verify ~/Documents/hermes-projects/active/project-autopilot
+hermes project sync ~/Documents/hermes-projects/active/project-autopilot
+hermes project cleanup-inventory ~/Documents/hermes-projects/active/project-autopilot
+```
+
+See [Project Autopilot](/docs/user-guide/features/project-autopilot) for the
+full workflow and guardrails.
 
 ## `hermes webhook`
 

--- a/website/docs/user-guide/features/project-autopilot.md
+++ b/website/docs/user-guide/features/project-autopilot.md
@@ -1,0 +1,134 @@
+---
+sidebar_position: 16
+title: "Project Autopilot"
+description: "Filesystem-backed project lifecycle automation for Kanban work"
+---
+
+# Project Autopilot
+
+Project Autopilot V0 gives long-running Hermes engineering projects a durable
+project home on disk. The project home stores lifecycle state, continuity docs,
+task status reports, and dry-run cleanup inventories. Kanban remains the execution truth for task dispatch and worker handoff.
+
+V0 is intentionally narrow. It supports only `stacked-slices-one-pr`, one active
+executable task at a time, deterministic worktree contracts, and a final
+completion gate that requires a draft or open PR unless the project owner
+explicitly waives it.
+
+## Project Home
+
+Each project lives under:
+
+```text
+~/Documents/hermes-projects/active/<slug>/
+```
+
+The home contains the files workers and reviewers use to resume safely:
+
+```text
+PROJECT.md
+STATUS.md
+SESSION-HANDOFF.md
+SESSION-LOG.md
+PARKING-LOT.md
+TASKS.md
+project.json
+status/
+refs/
+scratch/
+artifacts/
+```
+
+Code worktrees do not live in the project home. A task worktree must use the
+deterministic branch-to-path rule:
+
+```text
+/Users/vsletten/src/<org>/<repo>/<branch-name-as-path>
+```
+
+For example, branch `feat/project-autopilot-v0` in `vsletten/hermes-agent`
+maps to:
+
+```text
+/Users/vsletten/src/vsletten/hermes-agent/feat/project-autopilot-v0
+```
+
+## Commands
+
+### Initialize a Project
+
+```bash
+hermes project init \
+  --slug project-autopilot \
+  --title "Project Autopilot V0" \
+  --goal "Ship deterministic project lifecycle automation" \
+  --board project-autopilot \
+  --root-task t_root \
+  --project-home ~/Documents/hermes-projects/active/project-autopilot \
+  --repo-org vsletten \
+  --repo-name hermes-agent \
+  --canonical-repo ~/src/vsletten/hermes-agent/main \
+  --final-branch feat/project-autopilot-v0 \
+  --source-plan ~/Documents/hermes-projects/active/project-autopilot/refs/project-autopilot-implementation-plan-v0.md
+```
+
+`init` creates the project home, writes `project.json`, and seeds the continuity
+docs. It does not create or switch git branches.
+
+### Verify Invariants
+
+```bash
+hermes project verify <project_home>
+```
+
+Use `verify` before dispatching or reviewing work. It validates the project
+schema, required files, supported mode, PR requirement, worktree path policy, and
+task lifecycle invariants.
+
+### Sync From Kanban
+
+```bash
+hermes project sync <project_home>
+```
+
+`sync` refreshes `TASKS.md`, `STATUS.md`, `SESSION-HANDOFF.md`, and the cached
+task graph from the Kanban board. The board remains canonical for task status,
+parent links, comments, runs, and worker handoffs.
+
+If you need to read from a specific board database:
+
+```bash
+hermes project sync <project_home> --kanban-db ~/.hermes/kanban/boards/<slug>/kanban.db
+```
+
+### Prepare Cleanup Inventory
+
+```bash
+hermes project cleanup-inventory <project_home>
+```
+
+This writes an auditable inventory under `artifacts/cleanup/` and updates
+`project.json` to `cleanup.state=inventory_ready`. No cleanup command deletes files.
+Destructive cleanup remains a separate human-approved operation outside
+Project Autopilot V0.
+
+## Workflow
+
+1. Create or update the project home with `hermes project init`.
+2. Create planned Kanban tasks with explicit workspace contracts.
+3. Let the dispatcher run the next ready task.
+4. Require every worker to write a report under `status/<task_id>.md`.
+5. Run `hermes project sync <project_home>` after task completion.
+6. Run `hermes project verify <project_home>` before promoting the next task or
+   reviewing completion.
+7. Before marking the project done, confirm the final branch has a draft or open
+   PR, unless the owner recorded an explicit waiver in `project.json`.
+
+## Guardrails
+
+- Do not use Project Autopilot V0 for independent multi-PR projects.
+- Do not create code worktrees under `~/Documents/hermes-projects/...`.
+- Do not switch an existing local worktree branch.
+- Do not treat `project.json` as the execution source of truth. Kanban owns
+  dispatch, task state, comments, dependencies, and worker runs.
+- Do not delete files from cleanup inventory output.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -68,6 +68,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/cron',
             'user-guide/features/delegation',
             'user-guide/features/kanban',
+            'user-guide/features/project-autopilot',
             'user-guide/features/codex-app-server-runtime',
             'user-guide/features/kanban-tutorial',
             'user-guide/features/kanban-worker-lanes',


### PR DESCRIPTION
## Summary

Implements Project Autopilot V0 for filesystem-backed Hermes projects:

- adds V0 schema primitives and project-home bootstrap
- adds `hermes project init`, `verify`, `sync`, and cleanup inventory workflow
- syncs project homes from kanban board truth, including legacy project-home adoption
- validates deterministic workspace contracts
- enforces terminal per-task status reports under `status/<task_id>.md`
- clears repaired process-invariant failures once reports are restored
- surfaces PR review as the canonical next action for DONE coding projects
- adds patch proof helpers for final integration audits
- generates cleanup inventories without destructive removal
- guards done-state on required PR evidence
- documents the V0 command workflow

## Verification

- `python -m pytest tests/hermes_cli/test_project_autopilot_schema.py tests/hermes_cli/test_project_autopilot_sync.py tests/hermes_cli/test_project_autopilot_init.py tests/hermes_cli/test_project_cli.py tests/hermes_cli/test_project_autopilot_worktrees.py -q -o 'addopts='`
- Result: `26 passed in 1.57s`
- Final review gate `t_d6d18350` also reported: `27 passed` including docs test, ruff passed, `git diff --check` passed, branch head matches `origin/feat/project-autopilot-v0`.

## Kanban evidence

Project board: `project-autopilot`

V0 planned implementation/review chain completed:

- Task 1 schema primitives and review
- Task 2 project-home bootstrap and review
- Task 3 project CLI init/verify and review
- Task 4 project sync and review/remediation
- Task 5 workspace contracts and review
- Task 6 task status report enforcement and review
- Task 7 patch proof helpers and review
- Task 8 cleanup inventories and review
- Task 9 PR done-state guard and review
- Task 10 docs/process references and review
- Final close-out review gate: `t_d6d18350`, passed with no findings

Final board audit: `50 done`, `0 active`, `0 blocked`, `0 ready`.
