### PR TITLE
fix(cli): use renderer.erase() in _recover_after_resize to clear ghost paint on SIGWINCH

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3349,7 +3349,7 @@ class HermesCLI:
         """
         self._status_bar_suppressed_after_resize = True
         try:
-            app.renderer.reset(leave_alternate_screen=False)
+            app.renderer.erase(leave_alternate_screen=False)
         except Exception:
             pass
         try:


### PR DESCRIPTION
## Summary
One-character change. `_recover_after_resize` calls `app.renderer.reset(leave_alternate_screen=False)`, but prompt_toolkit's `renderer.reset()` only clears internal state (`_cursor_pos`, `_last_screen`, etc.) without writing any erase sequences. On SIGWINCH-heavy environments — mobile SSH with a soft keyboard, screen/tmux reflows, anywhere the terminal area changes frequently — this leaves the previous prompt+input paint visible while pt redraws below it, producing additive duplicates of the prompt: `> text> text> text...`. Each focus/resize cycle adds another copy.

Swapping to `renderer.erase()` (which does `cursor_backward + cursor_up + erase_down + reset` per prompt_toolkit/renderer.py:734) properly clears pt's tracked paint area before resetting state. The startup banner above pt's tracked region is preserved because it was printed before pt took over.

## Reproduction
1. SSH from Termux on Android (or any mobile terminal with a soft keyboard that triggers TIOCWINCH on show/hide)
2. Run `hermes`
3. Type a distinctive line into the input area; do NOT press Enter
4. Hide the soft keyboard, then show it (or swipe to home then back)
5. Observe the input line duplicates: each show/hide cycle adds another visible copy
6. Buffer.text remains a single copy — only the last is editable

## Why renderer.erase()
- `renderer.reset()` at prompt_toolkit/renderer.py:382 resets `_cursor_pos = Point(0,0)`, `_last_screen = None`, `_min_available_height = 0` — and does NOT emit any erase output to the terminal
- `renderer.erase()` at prompt_toolkit/renderer.py:734 does the required terminal-side cleanup: moves cursor back to the start of pt's tracked paint area and emits `erase_down()` before calling `reset()`
- The intent of `_recover_after_resize` was to clear pt's stale screen-diff state before letting `original_on_resize` recompute layout; that intent is preserved
- The `_status_bar_suppressed_after_resize` flag and subsequent `invalidate()` + `original_on_resize()` calls are unchanged

## Risk
If pt's tracked cursor position is stale at the moment `erase()` is called (e.g., row reflow during the SIGWINCH), the `cursor_backward`/`cursor_up` may overshoot or undershoot the actual previous paint position by a row. Practical impact is minimal — the subsequent paint covers it. The 120ms debounce in `_schedule_resize_recovery` already coalesces rapid resizes, reducing this risk.

## Test Plan
- [x] mobile SSH (Termux + soft keyboard show/hide) — confirms primary fix (verified locally)
- [ ] tmux pane resize within a desktop terminal — secondary case
- [ ] desktop terminal window resize — regression check, no new artifacts
- [ ] verify startup banner remains visible after resize — confirms erase() doesn't reach above pt's tracked region
