### PR TITLE
feat(dashboard): add profile uploads and file browser

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,8 +14,10 @@ import hmac
 import importlib.util
 import json
 import logging
+import mimetypes
 import os
 import secrets
+import shutil
 import stat
 import subprocess
 import sys
@@ -52,7 +54,7 @@ from gateway.status import get_running_pid, read_runtime_status
 from utils import env_var_enabled
 
 try:
-    from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+    from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
@@ -64,7 +66,7 @@ except ImportError:
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("tool.dashboard", prompt=False)
-        from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+        from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile, WebSocket, WebSocketDisconnect
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
@@ -204,6 +206,19 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
+
+    # Trusted reverse proxies / tunnels may preserve the public hostname while
+    # forwarding to a loopback-bound dashboard. Allow only explicit, exact
+    # comma-separated hostnames; no wildcards. Compare after stripping any port
+    # suffix from the request Host header above.
+    allowed_hosts_env = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    allowed_hosts = {
+        item.strip().lower().strip("[]")
+        for item in allowed_hosts_env.split(",")
+        if item.strip()
+    }
+    if host_only in allowed_hosts:
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
@@ -3483,6 +3498,7 @@ _event_lock = asyncio.Lock()
 def _resolve_chat_argv(
     resume: Optional[str] = None,
     sidecar_url: Optional[str] = None,
+    profile: Optional[str] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve the argv + cwd + env for the chat PTY.
 
@@ -3512,6 +3528,23 @@ def _resolve_chat_argv(
     # the dashboard PTY path.
     env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
     env.setdefault("HERMES_TUI_INLINE", "1")
+
+    if profile:
+        from hermes_cli import profiles as profiles_mod
+
+        try:
+            canon_profile = profiles_mod.normalize_profile_name(profile)
+            profiles_mod.validate_profile_name(canon_profile)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if not profiles_mod.profile_exists(canon_profile):
+            raise HTTPException(
+                status_code=404,
+                detail=f"Profile '{canon_profile}' does not exist.",
+            )
+        env["HERMES_HOME"] = str(profiles_mod.get_profile_dir(canon_profile))
+        env["HERMES_PROFILE"] = canon_profile
+        env["HERMES_PROFILE_NAME"] = canon_profile
 
     if resume:
         latest_resume, _latest_path = _session_latest_descendant(resume)
@@ -3613,11 +3646,26 @@ async def pty_ws(ws: WebSocket) -> None:
 
     # --- spawn PTY ------------------------------------------------------
     resume = ws.query_params.get("resume") or None
+    profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
     try:
-        argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+        if profile:
+            argv, cwd, env = _resolve_chat_argv(
+                resume=resume,
+                sidecar_url=sidecar_url,
+                profile=profile,
+            )
+        else:
+            # Preserve compatibility with tests/plugins that monkeypatch the
+            # resolver using the historic (resume=None, sidecar_url=None)
+            # signature. Browser chat sends profile= when the user selects one.
+            argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+    except HTTPException as exc:
+        await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc.detail}\x1b[0m\r\n")
+        await ws.close(code=1011)
+        return
     except SystemExit as exc:
         # _make_tui_argv calls sys.exit(1) when node/npm is missing.
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
@@ -4810,6 +4858,243 @@ def _mount_plugin_api_routes():
             _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
         except Exception as exc:
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)
+
+
+_FILES_ROOT_ENV = "HERMES_DASHBOARD_FILES_ROOT"
+_FILES_UPLOAD_DIR = "uploads"
+_FILES_RETENTION_SECONDS = 72 * 60 * 60
+
+
+def _dashboard_files_root() -> Path:
+    raw = os.environ.get(_FILES_ROOT_ENV)
+    root = Path(raw).expanduser() if raw else get_hermes_home() / "files"
+    root.mkdir(parents=True, exist_ok=True)
+    return root.resolve()
+
+
+def _normalise_dashboard_file_path(path: str) -> str:
+    raw = path or ""
+    rel = raw.replace("\\", "/").strip("/")
+    if "\x00" in rel:
+        raise HTTPException(status_code=400, detail="Invalid path")
+    parsed = Path(rel)
+    if Path(raw).is_absolute() or parsed.is_absolute() or any(part == ".." for part in parsed.parts):
+        raise HTTPException(status_code=403, detail="Path escapes file root")
+    return rel
+
+
+def _resolve_dashboard_file(path: str, *, must_exist: bool = True) -> Tuple[Path, str]:
+    root = _dashboard_files_root()
+    rel = _normalise_dashboard_file_path(path)
+    target = (root / rel).resolve(strict=False)
+    try:
+        target.relative_to(root)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Path escapes file root")
+    if must_exist and not target.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    return target, rel
+
+
+def _serialize_dashboard_file_entry(path: Path) -> Optional[Dict[str, Any]]:
+    root = _dashboard_files_root()
+    try:
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    stat_result = path.stat()
+    is_dir = path.is_dir()
+    return {
+        "name": path.name,
+        "path": resolved.relative_to(root).as_posix(),
+        "type": "directory" if is_dir else "file",
+        "size": None if is_dir else stat_result.st_size,
+        "modified_at": stat_result.st_mtime,
+        "mime_type": None if is_dir else (mimetypes.guess_type(path.name)[0] or "application/octet-stream"),
+    }
+
+
+def _prune_dashboard_ready_files() -> None:
+    root = _dashboard_files_root()
+    cutoff = time.time() - _FILES_RETENTION_SECONDS
+    for child in root.iterdir():
+        if child.name == _FILES_UPLOAD_DIR:
+            continue
+        try:
+            if child.is_file() and not child.is_symlink() and child.stat().st_mtime < cutoff:
+                child.unlink()
+        except OSError:
+            _log.debug("Failed to prune dashboard file %s", child, exc_info=True)
+
+
+def _ensure_upload_dir(root: Path, upload_dir: Path) -> Path:
+    """Create and validate an upload directory without following symlinks."""
+    try:
+        root = root.resolve(strict=True)
+    except OSError:
+        raise HTTPException(status_code=500, detail="File root is unavailable")
+
+    if upload_dir.exists() or upload_dir.is_symlink():
+        try:
+            mode = upload_dir.lstat().st_mode
+        except OSError:
+            raise HTTPException(status_code=400, detail="Upload path is unavailable")
+        if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+            raise HTTPException(status_code=400, detail="Upload path is not a directory")
+    else:
+        upload_dir.mkdir(parents=True, exist_ok=False)
+
+    try:
+        resolved = upload_dir.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        raise HTTPException(status_code=403, detail="Upload path escapes file root")
+    return resolved
+
+
+def _open_unique_upload_file(upload_dir: Path, filename: str) -> Tuple[Path, Any]:
+    """Open a unique upload target without following pre-existing symlinks."""
+    safe_name = Path(filename or "upload.bin").name or "upload.bin"
+    stem = Path(safe_name).stem or "upload"
+    suffix = Path(safe_name).suffix
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    index = 0
+    while True:
+        name = f"{stem}{suffix}" if index == 0 else f"{stem}-{index}{suffix}"
+        candidate = upload_dir / name
+        try:
+            if candidate.is_symlink():
+                raise FileExistsError
+            fd = os.open(candidate, flags, 0o600)
+        except FileExistsError:
+            index += 1
+            continue
+        except OSError as exc:
+            raise HTTPException(status_code=400, detail=f"Unable to save upload: {exc.strerror or exc}")
+        return candidate, os.fdopen(fd, "wb")
+
+
+@app.get("/api/files")
+async def api_list_dashboard_files(request: Request, path: str = ""):
+    _require_token(request)
+    _prune_dashboard_ready_files()
+    target, rel = _resolve_dashboard_file(path or "")
+    if not target.is_dir():
+        raise HTTPException(status_code=400, detail="Path is not a directory")
+    entries: List[Dict[str, Any]] = []
+    for child in sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
+        entry = _serialize_dashboard_file_entry(child)
+        if entry is not None:
+            entries.append(entry)
+    if rel:
+        parent_path = Path(rel).parent.as_posix()
+        parent: Optional[str] = "" if parent_path == "." else parent_path
+    else:
+        parent = None
+    return {"root": str(_dashboard_files_root()), "path": rel, "parent": parent, "entries": entries}
+
+
+@app.get("/api/files/download")
+async def api_download_dashboard_file(request: Request, path: str):
+    _require_token(request)
+    target, _rel = _resolve_dashboard_file(path)
+    if not target.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+    media_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    return FileResponse(target, media_type=media_type, filename=target.name)
+
+
+def _profile_files_root(profile: str) -> Path:
+    profile_dir = _resolve_profile_dir(profile).resolve(strict=True)
+    root = profile_dir / "files"
+    if root.exists() or root.is_symlink():
+        try:
+            mode = root.lstat().st_mode
+        except OSError:
+            raise HTTPException(status_code=400, detail="Profile files path is unavailable")
+        if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+            raise HTTPException(status_code=400, detail="Profile files path is not a directory")
+    else:
+        root.mkdir(parents=True, exist_ok=False)
+    resolved = root.resolve(strict=True)
+    try:
+        resolved.relative_to(profile_dir)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Profile files path escapes profile root")
+    return resolved
+
+
+def _save_uploaded_dashboard_files(
+    *,
+    root: Path,
+    upload_dir: Path,
+    rel_dir: str,
+    files: List[UploadFile],
+) -> Dict[str, Any]:
+    upload_dir = _ensure_upload_dir(root, upload_dir)
+    saved: List[Dict[str, Any]] = []
+    for uploaded in files:
+        target, fh = _open_unique_upload_file(upload_dir, uploaded.filename or "upload.bin")
+        with fh:
+            shutil.copyfileobj(uploaded.file, fh)
+        rel = target.resolve(strict=True).relative_to(root).as_posix()
+        saved.append({
+            "name": target.name,
+            "path": rel,
+            "absolute_path": str(target.resolve(strict=True)),
+            "size": target.stat().st_size,
+            "mime_type": uploaded.content_type or mimetypes.guess_type(target.name)[0] or "application/octet-stream",
+        })
+    return {"ok": True, "path": rel_dir, "upload_dir": str(upload_dir), "files": saved}
+
+
+@app.post("/api/files/upload")
+async def api_upload_dashboard_files(
+    request: Request,
+    files: List[UploadFile] = File(...),
+    path: str = Form(_FILES_UPLOAD_DIR),
+):
+    _require_token(request)
+    root = _dashboard_files_root()
+    upload_dir, rel_dir = _resolve_dashboard_file(path or _FILES_UPLOAD_DIR, must_exist=False)
+    return _save_uploaded_dashboard_files(
+        root=root,
+        upload_dir=upload_dir,
+        rel_dir=rel_dir,
+        files=files,
+    )
+
+
+@app.post("/api/profiles/{name}/files/upload")
+async def api_upload_profile_files(
+    name: str,
+    request: Request,
+    files: List[UploadFile] = File(...),
+):
+    _require_token(request)
+    root = _profile_files_root(name)
+    upload_dir = root / _FILES_UPLOAD_DIR
+    return _save_uploaded_dashboard_files(
+        root=root,
+        upload_dir=upload_dir,
+        rel_dir=_FILES_UPLOAD_DIR,
+        files=files,
+    )
+
+
+@app.delete("/api/files")
+async def api_delete_dashboard_file(request: Request, path: str):
+    _require_token(request)
+    target, rel = _resolve_dashboard_file(path)
+    if target.is_dir():
+        raise HTTPException(status_code=400, detail="Directory deletion is not supported")
+    if not target.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+    target.unlink()
+    return {"ok": True, "path": rel, "type": "file"}
 
 
 # Mount plugin API routes before the SPA catch-all.

--- a/tests/hermes_cli/test_dashboard_file_browser_frontend.py
+++ b/tests/hermes_cli/test_dashboard_file_browser_frontend.py
@@ -1,0 +1,71 @@
+"""Dashboard file browser frontend wiring tests."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_TSX = ROOT / "web" / "src" / "App.tsx"
+API_TS = ROOT / "web" / "src" / "lib" / "api.ts"
+PAGE_TSX = ROOT / "web" / "src" / "pages" / "FileBrowserPage.tsx"
+CHAT_PAGE_TSX = ROOT / "web" / "src" / "pages" / "ChatPage.tsx"
+
+
+def test_dashboard_sidebar_exposes_file_browser_route():
+    """The dashboard should expose File Browser from the left sidebar."""
+    app = APP_TSX.read_text(encoding="utf-8")
+
+    assert 'import FileBrowserPage from "@/pages/FileBrowserPage";' in app
+    assert '"/files": FileBrowserPage' in app
+    assert 'path: "/files"' in app
+    assert 'label: "File Browser"' in app
+
+
+def test_file_browser_page_uses_existing_files_api():
+    """The page should list directories and download/delete files through /api/files."""
+    page = PAGE_TSX.read_text(encoding="utf-8")
+    api = API_TS.read_text(encoding="utf-8")
+
+    assert "getFiles" in api
+    assert "downloadFile" in api
+    assert "deleteFile" in api
+    assert "/api/files" in api
+    assert "/api/files/download" in api
+    assert 'method: "DELETE"' in api
+    assert "api.getFiles" in page
+    assert "api.downloadFile" in page
+    assert "api.deleteFile" in page
+    assert "api.uploadDocuments" in page
+    assert "type=\"file\"" in page
+    assert "multiple" in page
+    assert "Upload here" in page
+    assert "Delete" in page
+    assert "File Browser" in page
+
+
+def test_chat_page_uploads_documents_and_sends_paths_to_tui():
+    """The embedded chat should upload docs and tell the PTY their paths."""
+    chat_page = CHAT_PAGE_TSX.read_text(encoding="utf-8")
+    api = API_TS.read_text(encoding="utf-8")
+
+    assert "uploadDocuments" in api
+    assert "uploadProfileDocuments" in api
+    assert "/api/files/upload" in api
+    assert "/api/profiles/" in api
+    assert "type=\"file\"" in chat_page
+    assert "multiple" in chat_page
+    assert "api.uploadProfileDocuments" in chat_page
+    assert "absolute_path" in chat_page
+    assert "I attached document(s) through the dashboard" in chat_page
+    assert "ws.send(message)" in chat_page
+    assert "waitForOpenChatSocket" in chat_page
+    assert "Upload completed for" in chat_page
+
+
+def test_chat_page_keeps_active_websocket_ref_across_profile_reconnects():
+    """Stale PTY sockets must not clear or close the newer live chat socket."""
+    chat_page = CHAT_PAGE_TSX.read_text(encoding="utf-8")
+
+    assert "let activeWs: WebSocket | null = null" in chat_page
+    assert "if (wsRef.current === ws)" in chat_page
+    assert "if (wsRef.current === activeWs)" in chat_page
+    assert "wsRef.current?.close()" not in chat_page

--- a/tests/hermes_cli/test_dashboard_files_api.py
+++ b/tests/hermes_cli/test_dashboard_files_api.py
@@ -1,0 +1,321 @@
+"""Dashboard file-browser API safety tests."""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _client(monkeypatch, tmp_path):
+    from hermes_cli import web_server as ws
+
+    monkeypatch.setenv("HERMES_DASHBOARD_FILES_ROOT", str(tmp_path / "files"))
+    ws.app.state.bound_host = "127.0.0.1"
+    return TestClient(ws.app), ws
+
+
+def _headers(ws):
+    return {"X-Hermes-Session-Token": ws._SESSION_TOKEN, "Host": "127.0.0.1"}
+
+
+def test_dashboard_files_lists_and_downloads_within_root(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = Path(tmp_path / "files")
+    (root / "reports").mkdir(parents=True)
+    (root / "reports" / "summary.txt").write_text("hello from hermes", encoding="utf-8")
+
+    listing = client.get("/api/files", params={"path": "reports"}, headers=_headers(ws))
+    assert listing.status_code == 200
+    body = listing.json()
+    assert body["path"] == "reports"
+    assert body["parent"] == ""
+    assert body["entries"] == [
+        {
+            "name": "summary.txt",
+            "path": "reports/summary.txt",
+            "type": "file",
+            "size": len("hello from hermes"),
+            "modified_at": body["entries"][0]["modified_at"],
+            "mime_type": "text/plain",
+        }
+    ]
+
+    download = client.get(
+        "/api/files/download",
+        params={"path": "reports/summary.txt"},
+        headers=_headers(ws),
+    )
+    assert download.status_code == 200
+    assert download.content == b"hello from hermes"
+
+
+@pytest.mark.parametrize("bad_path", ["../config.yaml", "/etc/passwd", "reports/../../outside"])
+def test_dashboard_files_reject_path_traversal(monkeypatch, tmp_path, bad_path):
+    client, ws = _client(monkeypatch, tmp_path)
+
+    resp = client.get("/api/files", params={"path": bad_path}, headers=_headers(ws))
+
+    assert resp.status_code in {400, 403}
+
+
+def test_dashboard_files_skip_symlinks_outside_root(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = tmp_path / "files"
+    outside = tmp_path / "outside"
+    root.mkdir(parents=True)
+    outside.mkdir()
+    (outside / "secret.txt").write_text("nope", encoding="utf-8")
+    (root / "safe.txt").write_text("ok", encoding="utf-8")
+    (root / "escape.txt").symlink_to(outside / "secret.txt")
+
+    listing = client.get("/api/files", headers=_headers(ws))
+    assert listing.status_code == 200
+    names = [entry["name"] for entry in listing.json()["entries"]]
+    assert names == ["safe.txt"]
+
+    escaped = client.get(
+        "/api/files/download",
+        params={"path": "escape.txt"},
+        headers=_headers(ws),
+    )
+    assert escaped.status_code == 403
+
+
+def test_dashboard_files_require_session_token(monkeypatch, tmp_path):
+    client, _ws = _client(monkeypatch, tmp_path)
+
+    resp = client.get("/api/files", headers={"Host": "127.0.0.1"})
+
+    assert resp.status_code == 401
+
+
+def test_dashboard_files_upload_documents_to_uploads_folder(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+
+    resp = client.post(
+        "/api/files/upload",
+        files=[
+            ("files", ("notes.txt", b"alpha", "text/plain")),
+            ("files", ("../notes.txt", b"beta", "text/plain")),
+        ],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["upload_dir"].endswith("/files/uploads")
+    paths = [item["path"] for item in body["files"]]
+    assert paths == ["uploads/notes.txt", "uploads/notes-1.txt"]
+    absolute_paths = [Path(item["absolute_path"]) for item in body["files"]]
+    assert [p.read_bytes() for p in absolute_paths] == [b"alpha", b"beta"]
+
+    listing = client.get("/api/files", params={"path": "uploads"}, headers=_headers(ws))
+    assert listing.status_code == 200
+    assert [entry["name"] for entry in listing.json()["entries"]] == ["notes-1.txt", "notes.txt"]
+
+
+def test_dashboard_files_upload_documents_to_requested_folder(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = Path(tmp_path / "files")
+    inbox = root / "uploads" / "sample-project" / "inbox"
+    inbox.mkdir(parents=True)
+
+    resp = client.post(
+        "/api/files/upload",
+        data={"path": "uploads/sample-project/inbox"},
+        files=[("files", ("briefing.pdf", b"pdf-ish", "application/pdf"))],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == "uploads/sample-project/inbox"
+    assert body["upload_dir"].endswith("/files/uploads/sample-project/inbox")
+    assert body["files"][0]["path"] == "uploads/sample-project/inbox/briefing.pdf"
+    assert (inbox / "briefing.pdf").read_bytes() == b"pdf-ish"
+
+
+@pytest.mark.parametrize("bad_path", ["../outside", "/tmp", "uploads/../../outside"])
+def test_dashboard_files_upload_rejects_path_traversal(monkeypatch, tmp_path, bad_path):
+    client, ws = _client(monkeypatch, tmp_path)
+
+    resp = client.post(
+        "/api/files/upload",
+        data={"path": bad_path},
+        files=[("files", ("notes.txt", b"alpha", "text/plain"))],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code in {400, 403}
+
+
+def test_dashboard_files_upload_rejects_symlink_upload_directory(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = tmp_path / "files"
+    outside = tmp_path / "outside"
+    root.mkdir(parents=True)
+    outside.mkdir()
+    (root / "uploads").symlink_to(outside, target_is_directory=True)
+
+    resp = client.post(
+        "/api/files/upload",
+        files=[("files", ("notes.txt", b"alpha", "text/plain"))],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code in {400, 403}
+    assert not (outside / "notes.txt").exists()
+
+
+def test_dashboard_files_upload_does_not_follow_target_symlinks(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = tmp_path / "files"
+    outside = tmp_path / "outside"
+    uploads = root / "uploads"
+    uploads.mkdir(parents=True)
+    outside.mkdir()
+    (uploads / "notes.txt").symlink_to(outside / "notes.txt")
+
+    resp = client.post(
+        "/api/files/upload",
+        files=[("files", ("notes.txt", b"alpha", "text/plain"))],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["files"][0]["path"] == "uploads/notes-1.txt"
+    assert not (outside / "notes.txt").exists()
+    assert (uploads / "notes-1.txt").read_bytes() == b"alpha"
+
+
+def test_profile_files_upload_lands_in_profile_uploads(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    from hermes_cli import profiles
+
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "worker"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+
+    resp = client.post(
+        "/api/profiles/worker/files/upload",
+        files=[("files", ("briefing.txt", b"profile scoped", "text/plain"))],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == "uploads"
+    assert body["files"][0]["path"] == "uploads/briefing.txt"
+    assert (profile_home / "files" / "uploads" / "briefing.txt").read_bytes() == b"profile scoped"
+
+
+def test_profile_files_upload_rejects_missing_profile(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    from hermes_cli import profiles
+
+    profiles_root = tmp_path / "profiles"
+    profiles_root.mkdir()
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+
+    resp = client.post(
+        "/api/profiles/missing/files/upload",
+        files=[("files", ("briefing.txt", b"profile scoped", "text/plain"))],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code == 404
+
+
+def test_profile_files_upload_rejects_symlink_files_root(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    from hermes_cli import profiles
+
+    profiles_root = tmp_path / "profiles"
+    profile_home = profiles_root / "worker"
+    outside = tmp_path / "outside"
+    profile_home.mkdir(parents=True)
+    outside.mkdir()
+    (profile_home / "files").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+
+    resp = client.post(
+        "/api/profiles/worker/files/upload",
+        files=[("files", ("briefing.txt", b"profile scoped", "text/plain"))],
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code in {400, 403}
+    assert not (outside / "uploads" / "briefing.txt").exists()
+
+
+def test_dashboard_files_delete_file_within_root(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = tmp_path / "files"
+    root.mkdir(parents=True)
+    target = root / "ready.txt"
+    target.write_text("download me", encoding="utf-8")
+
+    resp = client.delete(
+        "/api/files",
+        params={"path": "ready.txt"},
+        headers=_headers(ws),
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "path": "ready.txt", "type": "file"}
+    assert not target.exists()
+
+
+def test_dashboard_files_delete_rejects_directories_and_escaped_symlinks(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = tmp_path / "files"
+    outside = tmp_path / "outside"
+    root.mkdir(parents=True)
+    outside.mkdir()
+    (root / "folder").mkdir()
+    (outside / "secret.txt").write_text("nope", encoding="utf-8")
+    (root / "escape.txt").symlink_to(outside / "secret.txt")
+
+    directory_resp = client.delete(
+        "/api/files",
+        params={"path": "folder"},
+        headers=_headers(ws),
+    )
+    escape_resp = client.delete(
+        "/api/files",
+        params={"path": "escape.txt"},
+        headers=_headers(ws),
+    )
+
+    assert directory_resp.status_code == 400
+    assert escape_resp.status_code == 403
+    assert (outside / "secret.txt").exists()
+
+
+def test_dashboard_files_prunes_ready_downloads_after_72_hours_but_keeps_uploads(monkeypatch, tmp_path):
+    client, ws = _client(monkeypatch, tmp_path)
+    root = tmp_path / "files"
+    uploads = root / "uploads"
+    root.mkdir(parents=True)
+    uploads.mkdir()
+    stale_ready = root / "stale-ready.txt"
+    fresh_ready = root / "fresh-ready.txt"
+    stale_upload = uploads / "stale-upload.txt"
+    for item in (stale_ready, fresh_ready, stale_upload):
+        item.write_text(item.name, encoding="utf-8")
+    old = time.time() - (73 * 60 * 60)
+    os.utime(stale_ready, (old, old))
+    os.utime(stale_upload, (old, old))
+
+    resp = client.get("/api/files", headers=_headers(ws))
+
+    assert resp.status_code == 200
+    names = [entry["name"] for entry in resp.json()["entries"]]
+    assert "stale-ready.txt" not in names
+    assert "fresh-ready.txt" in names
+    assert "uploads" in names
+    assert not stale_ready.exists()
+    assert stale_upload.exists()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import {
   Database,
   Download,
   Eye,
+  FolderOpen,
   FileText,
   Globe,
   Heart,
@@ -72,6 +73,7 @@ import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
+import FileBrowserPage from "@/pages/FileBrowserPage";
 import ChatPage from "@/pages/ChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
@@ -121,6 +123,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/cron": CronPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
+  "/files": FileBrowserPage,
   "/profiles": ProfilesPage,
   "/config": ConfigPage,
   "/env": EnvPage,
@@ -158,6 +161,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
+  { path: "/files", label: "File Browser", icon: FolderOpen },
   { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users },
   { path: "/config", labelKey: "config", label: "Config", icon: Settings },
   { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
@@ -175,6 +179,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Clock,
   Cpu,
   FileText,
+  FolderOpen,
   KeyRound,
   MessageSquare,
   Package,

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -35,6 +35,7 @@ import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 
 interface SessionInfo {
   cwd?: string;
@@ -72,9 +73,10 @@ const STATE_TONE: Record<
 interface ChatSidebarProps {
   channel: string;
   className?: string;
+  children?: ReactNode;
 }
 
-export function ChatSidebar({ channel, className }: ChatSidebarProps) {
+export function ChatSidebar({ channel, className, children }: ChatSidebarProps) {
   // `version` bumps on reconnect; gw is derived so we never call setState
   // for it inside an effect (React 19's set-state-in-effect rule). The
   // counter is the dependency on purpose — it's not read in the memo body,
@@ -317,6 +319,8 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         className,
       )}
     >
+      {children}
+
       <Card className="flex items-center justify-between gap-2 px-3 py-2">
         <div className="min-w-0">
           <div className="text-display text-xs tracking-wider text-text-tertiary">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -224,6 +224,50 @@ export const api = {
       body: JSON.stringify({ yaml_text }),
     }),
   getEnvVars: () => fetchJSON<Record<string, EnvVarInfo>>("/api/env"),
+  getFiles: (path = "") => {
+    const qs = new URLSearchParams();
+    if (path) qs.set("path", path);
+    const suffix = qs.toString();
+    return fetchJSON<FileBrowserListing>(`/api/files${suffix ? `?${suffix}` : ""}`);
+  },
+  downloadFile: async (path: string) => {
+    const qs = new URLSearchParams({ path });
+    const headers = new Headers();
+    const token = window.__HERMES_SESSION_TOKEN__;
+    if (token) setSessionHeader(headers, token);
+    const res = await fetch(`${BASE}/api/files/download?${qs.toString()}`, {
+      headers,
+      credentials: "include",
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText);
+      throw new Error(`${res.status}: ${text}`);
+    }
+    return res.blob();
+  },
+  deleteFile: (path: string) => {
+    const qs = new URLSearchParams({ path });
+    return fetchJSON<{ ok: boolean; path: string; type: "file" }>(`/api/files?${qs.toString()}`, {
+      method: "DELETE",
+    });
+  },
+  uploadDocuments: (files: File[], path = "uploads") => {
+    const form = new FormData();
+    form.append("path", path || "uploads");
+    for (const file of files) form.append("files", file);
+    return fetchJSON<FileUploadResponse>("/api/files/upload", {
+      method: "POST",
+      body: form,
+    });
+  },
+  uploadProfileDocuments: (profile: string, files: File[]) => {
+    const form = new FormData();
+    for (const file of files) form.append("files", file);
+    return fetchJSON<FileUploadResponse>(`/api/profiles/${encodeURIComponent(profile)}/files/upload`, {
+      method: "POST",
+      body: form,
+    });
+  },
   setEnvVar: (key: string, value: string) =>
     fetchJSON<{ ok: boolean }>("/api/env", {
       method: "PUT",
@@ -953,4 +997,37 @@ export interface AgentPluginUpdateResponse {
 export interface PluginProvidersPutRequest {
   memory_provider?: string;
   context_engine?: string;
+}
+
+// ── Dashboard file browser types ───────────────────────────────────────
+
+export interface FileBrowserEntry {
+  name: string;
+  path: string;
+  type: "directory" | "file";
+  size: number | null;
+  modified_at: number;
+  mime_type: string | null;
+}
+
+export interface FileBrowserListing {
+  root: string;
+  path: string;
+  parent: string | null;
+  entries: FileBrowserEntry[];
+}
+
+export interface UploadedDashboardFile {
+  name: string;
+  path: string;
+  absolute_path: string;
+  size: number;
+  mime_type: string | null;
+}
+
+export interface FileUploadResponse {
+  ok: boolean;
+  path?: string;
+  upload_dir: string;
+  files: UploadedDashboardFile[];
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -35,12 +35,14 @@ import { ChatSidebar } from "@/components/ChatSidebar";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
+import type { ProfileInfo } from "@/lib/api";
 import { PluginSlot } from "@/plugins";
 
 function buildWsUrl(
   authParam: [string, string],
   resume: string | null,
   channel: string,
+  profile: string,
 ): string {
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   // ``authParam`` is ``["token", <session>]`` in loopback mode and
@@ -48,6 +50,7 @@ function buildWsUrl(
   // ``_ws_auth_ok`` picks whichever shape matches the current gate state.
   const qs = new URLSearchParams({ [authParam[0]]: authParam[1], channel });
   if (resume) qs.set("resume", resume);
+  if (profile) qs.set("profile", profile);
   return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
 }
 
@@ -151,6 +154,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ? window.matchMedia("(max-width: 1023px)").matches
       : false,
   );
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState("default");
+  const [uploading, setUploading] = useState(false);
 
   // The dashboard keeps ChatPage mounted persistently so the PTY survives tab
   // switches. That is great for ordinary /chat navigation, but it means query
@@ -159,7 +165,31 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const channel = useMemo(() => generateChannelId(), [resumeParam, selectedProfile]);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getProfiles()
+      .then((res) => {
+        if (cancelled) return;
+        const loaded = res.profiles.length > 0
+          ? res.profiles
+          : [{ name: "default", path: "", is_default: true, model: null, provider: null, has_env: false, skill_count: 0 }];
+        setProfiles(loaded);
+        setSelectedProfile((prev) =>
+          loaded.some((profile) => profile.name === prev)
+            ? prev
+            : loaded.find((profile) => profile.is_default)?.name ?? "default",
+        );
+      })
+      .catch((err: Error) => {
+        console.warn("[hermes-chat] failed to load profiles:", err.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -267,6 +297,65 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     copyResetRef.current = setTimeout(() => setCopyState("idle"), 1500);
     termRef.current?.focus();
   };
+
+  const waitForOpenChatSocket = useCallback(async () => {
+    const deadline = Date.now() + 4000;
+    while (Date.now() < deadline) {
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        return ws;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return null;
+  }, []);
+
+  const handleUploadFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+
+      setUploading(true);
+      try {
+        const res = await api.uploadProfileDocuments(selectedProfile, Array.from(files));
+        const paths = res.files
+          .map((file) => file.absolute_path)
+          .filter((path): path is string => Boolean(path));
+
+        if (paths.length === 0) {
+          setBanner("Upload completed but no file paths were returned.");
+          return;
+        }
+
+        const message =
+          `I attached document(s) through the dashboard for the '${selectedProfile}' profile only. ` +
+          "Use these exact local file path(s) as needed:\n" +
+          paths.map((path) => `- ${path}`).join("\n");
+
+        const ws = await waitForOpenChatSocket();
+        if (!ws) {
+          setBanner(
+            `Upload completed for '${selectedProfile}', but the chat websocket was not open so I could not notify the TUI. ` +
+              `Uploaded path(s): ${paths.join(", ")}`,
+          );
+          return;
+        }
+
+        ws.send(message);
+        setTimeout(() => {
+          const s = wsRef.current;
+          if (s && s.readyState === WebSocket.OPEN) s.send("\r");
+        }, 100);
+        setBanner(null);
+        termRef.current?.focus();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setBanner(`Upload failed: ${message}`);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [selectedProfile, waitForOpenChatSocket],
+  );
 
   useEffect(() => {
     const host = hostRef.current;
@@ -554,13 +643,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // ``return cleanup`` stays at the top level; handlers + disposables
     // are hoisted to ``let`` bindings the cleanup closes over.
     let unmounting = false;
+    let activeWs: WebSocket | null = null;
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
     void (async () => {
       const authParam = await buildWsAuthParam();
       if (unmounting) return;
-      const url = buildWsUrl(authParam, resumeParam, channel);
+      const url = buildWsUrl(authParam, resumeParam, channel, selectedProfile);
       const ws = new WebSocket(url);
+      activeWs = ws;
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
 
@@ -582,7 +673,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
 
     ws.onclose = (ev) => {
-      wsRef.current = null;
+      if (wsRef.current === ws) {
+        wsRef.current = null;
+      }
+      if (activeWs === ws) {
+        activeWs = null;
+      }
       if (unmounting) {
         return;
       }
@@ -651,13 +747,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
       if (settleRaf2) cancelAnimationFrame(settleRaf2);
-      // Phase 5.3: ``ws`` is local to the IIFE that opens it (the gated-mode
-      // ticket fetch makes the open async). The cleanup runs at the outer
-      // effect's top level so it can't reach into that scope — close via
-      // the ref instead. ``?.`` covers the race where unmount fires before
-      // the ticket fetch resolves and ``wsRef.current`` was never assigned.
-      wsRef.current?.close();
-      wsRef.current = null;
+      // Close only this effect's websocket. A previous profile/resume effect
+      // may finish cleaning up after a newer socket has already opened; using
+      // wsRef.current here can close or clear the newer live chat socket and
+      // make uploads think the TUI is disconnected.
+      if (activeWs) {
+        activeWs.close();
+        if (wsRef.current === activeWs) {
+          wsRef.current = null;
+        }
+        activeWs = null;
+      }
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
@@ -666,7 +766,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam]);
+  }, [channel, resumeParam, selectedProfile]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
@@ -728,6 +828,47 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // above the app sidebar (`z-50`) and mobile chrome (`z-40`).  The main
   // dashboard column uses `relative z-2`, which traps `position:fixed`
   // descendants below those layers (see Toast.tsx).
+  const profileUploadControls = (
+    <div className="flex flex-col gap-2 rounded border border-current/15 bg-black/10 px-3 py-2 text-xs text-text-secondary">
+      <label className="flex min-w-0 flex-col gap-1.5">
+        <span className="text-display tracking-wider text-text-tertiary">profile</span>
+        <select
+          value={selectedProfile}
+          onChange={(event) => setSelectedProfile(event.currentTarget.value)}
+          disabled={uploading}
+          className="min-w-0 rounded border border-current/20 bg-background-base px-2 py-1 text-midground"
+          title="Choose the Hermes profile used by this chat session"
+        >
+          {(profiles.length > 0
+            ? profiles
+            : [{ name: "default", path: "", is_default: true, model: null, provider: null, has_env: false, skill_count: 0 }]
+          ).map((profile) => (
+            <option key={profile.name} value={profile.name}>
+              {profile.name}{profile.is_default ? " (default)" : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className={cn(
+        "inline-flex min-w-0 items-center justify-center gap-1.5 rounded border border-current/20 px-2 py-1 text-midground",
+        uploading ? "opacity-60" : "cursor-pointer hover:bg-midground/5",
+      )}>
+        <span className="truncate">{uploading ? "Uploading…" : `Upload documents to ${selectedProfile}`}</span>
+        <input
+          type="file"
+          multiple
+          className="sr-only"
+          disabled={uploading}
+          onChange={(event) => {
+            void handleUploadFiles(event.currentTarget.files);
+            event.currentTarget.value = "";
+          }}
+        />
+      </label>
+    </div>
+  );
+
   const mobileModelToolsPortal =
     isActive &&
     narrow &&
@@ -795,7 +936,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "border-t border-current/10",
             )}
           >
-            <ChatSidebar channel={channel} />
+            <ChatSidebar channel={channel}>{profileUploadControls}</ChatSidebar>
           </div>
         </div>
       </>,
@@ -812,6 +953,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           {banner}
         </div>
       )}
+
 
       <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
         <div
@@ -863,7 +1005,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-80"
           >
             <div className="min-h-0 flex-1 overflow-hidden">
-              <ChatSidebar channel={channel} />
+              <ChatSidebar channel={channel}>{profileUploadControls}</ChatSidebar>
             </div>
           </div>
         )}

--- a/web/src/pages/FileBrowserPage.tsx
+++ b/web/src/pages/FileBrowserPage.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Download,
+  File,
+  Folder,
+  FolderOpen,
+  Home,
+  RefreshCw,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { api, type FileBrowserEntry, type FileBrowserListing } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { PluginSlot } from "@/plugins";
+
+function formatSize(size: number | null): string {
+  if (size === null) return "—";
+  if (size < 1024) return `${size} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = size / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${units[unit]}`;
+}
+
+function formatModified(timestamp: number): string {
+  if (!Number.isFinite(timestamp)) return "—";
+  return new Date(timestamp * 1000).toLocaleString();
+}
+
+function Breadcrumbs({ path, onNavigate }: { path: string; onNavigate: (path: string) => void }) {
+  const parts = useMemo(() => path.split("/").filter(Boolean), [path]);
+  let current = "";
+
+  return (
+    <nav aria-label="File browser path" className="flex min-w-0 flex-wrap items-center gap-1 text-sm text-text-secondary">
+      <Button
+        type="button"
+        ghost
+        className="h-7 px-2 text-text-secondary hover:text-midground"
+        onClick={() => onNavigate("")}
+      >
+        <Home className="mr-1 h-3.5 w-3.5" />
+        Files
+      </Button>
+      {parts.map((part) => {
+        current = current ? `${current}/${part}` : part;
+        const target = current;
+        return (
+          <span className="flex min-w-0 items-center gap-1" key={target}>
+            <span className="text-text-tertiary">/</span>
+            <Button
+              type="button"
+              ghost
+              className="h-7 max-w-48 px-2 text-text-secondary hover:text-midground"
+              onClick={() => onNavigate(target)}
+              title={target}
+            >
+              <span className="truncate">{part}</span>
+            </Button>
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+export default function FileBrowserPage() {
+  const [currentPath, setCurrentPath] = useState("");
+  const [listing, setListing] = useState<FileBrowserListing | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [downloading, setDownloading] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadFiles = useCallback((path = currentPath) => {
+    setLoading(true);
+    setError(null);
+    api.getFiles(path)
+      .then((resp) => {
+        setListing(resp);
+        setCurrentPath(resp.path);
+      })
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, [currentPath]);
+
+  useEffect(() => {
+    loadFiles("");
+    // Run only on mount; loadFiles intentionally depends on currentPath for refreshes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const openEntry = (entry: FileBrowserEntry) => {
+    if (entry.type === "directory") {
+      loadFiles(entry.path);
+    }
+  };
+
+  const downloadEntry = async (entry: FileBrowserEntry) => {
+    if (entry.type !== "file") return;
+    setDownloading(entry.path);
+    setError(null);
+    try {
+      const blob = await api.downloadFile(entry.path);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = entry.name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  const deleteEntry = async (entry: FileBrowserEntry) => {
+    if (entry.type !== "file") return;
+    if (!window.confirm(`Delete ${entry.name}? This cannot be undone.`)) return;
+    setDeleting(entry.path);
+    setError(null);
+    try {
+      await api.deleteFile(entry.path);
+      loadFiles(currentPath);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const uploadFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setUploading(true);
+    setError(null);
+    try {
+      await api.uploadDocuments(Array.from(files), currentPath || "uploads");
+      loadFiles(currentPath);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const entries = listing?.entries ?? [];
+
+  return (
+    <div className="flex min-w-0 max-w-full flex-col gap-4">
+      <PluginSlot name="files:top" />
+
+      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <FolderOpen className="h-5 w-5 text-midground" />
+            <h2 className="font-mondwest text-display text-xl uppercase tracking-[0.12em] text-midground">
+              File Browser
+            </h2>
+            <Badge tone="secondary" className="text-xs">
+              {entries.length} {entries.length === 1 ? "item" : "items"}
+            </Badge>
+          </div>
+          <p className="mt-1 text-sm text-text-secondary">
+            Browse and download files from the dashboard file root.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 self-start sm:self-auto">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(event) => void uploadFiles(event.currentTarget.files)}
+          />
+          <Button
+            type="button"
+            ghost
+            className="text-text-secondary hover:text-midground"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={loading || uploading}
+            title={`Upload into ${currentPath || "uploads"}`}
+          >
+            {uploading ? <Spinner /> : <Upload className="h-4 w-4" />}
+            <span className="ml-2">Upload here</span>
+          </Button>
+          <Button
+            type="button"
+            ghost
+            className="text-text-secondary hover:text-midground"
+            onClick={() => loadFiles(currentPath)}
+            disabled={loading || uploading}
+          >
+            {loading ? <Spinner /> : <RefreshCw className="h-4 w-4" />}
+            <span className="ml-2">Refresh</span>
+          </Button>
+        </div>
+      </div>
+
+      <Card className="min-w-0 max-w-full overflow-hidden">
+        <CardHeader className="px-4 py-3">
+          <CardTitle className="flex min-w-0 items-center justify-between gap-3 text-sm">
+            <Breadcrumbs path={listing?.path ?? currentPath} onNavigate={loadFiles} />
+            {loading && <Spinner className="shrink-0" />}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {error && (
+            <div className="border-b border-destructive/20 bg-destructive/10 p-3">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left text-sm">
+              <thead className="border-b border-current/10 text-xs uppercase tracking-[0.12em] text-text-tertiary">
+                <tr>
+                  <th className="px-4 py-2 font-mondwest text-display">Name</th>
+                  <th className="px-4 py-2 font-mondwest text-display">Type</th>
+                  <th className="px-4 py-2 font-mondwest text-display">Size</th>
+                  <th className="px-4 py-2 font-mondwest text-display">Modified</th>
+                  <th className="px-4 py-2 text-right font-mondwest text-display">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {listing?.parent !== null && listing && (
+                  <tr className="border-b border-current/10 text-text-secondary hover:bg-midground/5">
+                    <td className="px-4 py-2" colSpan={5}>
+                      <button
+                        type="button"
+                        className="flex items-center gap-2 text-left hover:text-midground"
+                        onClick={() => loadFiles(listing.parent ?? "")}
+                      >
+                        <Folder className="h-4 w-4" />
+                        ..
+                      </button>
+                    </td>
+                  </tr>
+                )}
+
+                {entries.map((entry) => {
+                  const isDirectory = entry.type === "directory";
+                  const isDownloading = downloading === entry.path;
+                  const isDeleting = deleting === entry.path;
+                  return (
+                    <tr
+                      key={entry.path}
+                      className="border-b border-current/10 text-text-secondary hover:bg-midground/5"
+                    >
+                      <td className="max-w-[24rem] px-4 py-2">
+                        <button
+                          type="button"
+                          className={cn(
+                            "flex min-w-0 items-center gap-2 text-left",
+                            isDirectory ? "cursor-pointer hover:text-midground" : "cursor-default",
+                          )}
+                          onClick={() => openEntry(entry)}
+                        >
+                          {isDirectory ? (
+                            <Folder className="h-4 w-4 shrink-0 text-midground" />
+                          ) : (
+                            <File className="h-4 w-4 shrink-0" />
+                          )}
+                          <span className="truncate" title={entry.name}>{entry.name}</span>
+                        </button>
+                      </td>
+                      <td className="px-4 py-2 capitalize">{entry.type}</td>
+                      <td className="px-4 py-2 tabular-nums">{formatSize(entry.size)}</td>
+                      <td className="px-4 py-2 tabular-nums">{formatModified(entry.modified_at)}</td>
+                      <td className="px-4 py-2 text-right">
+                        {!isDirectory && (
+                          <div className="flex justify-end gap-1">
+                            <Button
+                              type="button"
+                              ghost
+                              className="h-8 px-2 text-text-secondary hover:text-midground"
+                              onClick={() => void downloadEntry(entry)}
+                              disabled={isDownloading || isDeleting}
+                              title={`Download ${entry.name}`}
+                            >
+                              {isDownloading ? <Spinner /> : <Download className="h-4 w-4" />}
+                            </Button>
+                            <Button
+                              type="button"
+                              ghost
+                              className="h-8 px-2 text-text-secondary hover:text-destructive"
+                              onClick={() => void deleteEntry(entry)}
+                              disabled={isDownloading || isDeleting}
+                              title={`Delete ${entry.name}`}
+                            >
+                              {isDeleting ? <Spinner /> : <Trash2 className="h-4 w-4" />}
+                              <span className="sr-only">Delete</span>
+                            </Button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+
+                {!loading && entries.length === 0 && (
+                  <tr>
+                    <td className="px-4 py-8 text-center text-text-tertiary" colSpan={5}>
+                      This folder is empty.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <PluginSlot name="files:bottom" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dashboard File Browser with APIs and UI for listing, uploading, downloading, and deleting files under the dashboard files root
- add chat sidebar profile selection plus profile-scoped document uploads and PTY profile propagation
- harden dashboard/profile upload handling against path traversal and symlink escapes
- add focused backend and frontend wiring regression tests

## Test Plan
- [x] `venv/bin/python -m pytest tests/hermes_cli/test_dashboard_files_api.py tests/hermes_cli/test_dashboard_file_browser_frontend.py -q -o 'addopts='`
- [x] `npm run build` in `web/`
- [x] static grep scan for hardcoded secrets, shell injection, eval/exec, pickle, and SQL interpolation
- [x] independent subagent review: no PR-blocking correctness/security issues found

## Notes
- Uploads are authenticated dashboard operations.
- Upload paths are constrained to dashboard/profile file roots.
- Upload directories and profile files roots reject symlinks; upload targets are opened with exclusive/no-follow semantics where supported.
