### PR TITLE
fix(cli): display full session IDs in hermes sessions browse

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -661,11 +661,11 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
             preview = (s.get("preview") or "").strip()
             source = s.get("source", "")[:6]
             last_active = _relative_time(s.get("last_active"))
-            sid = s["id"][:18]
+            sid = s["id"]
 
             # Adaptive column widths based on terminal width
-            # Layout: [arrow 3] [title/preview flexible] [active 12] [src 6] [id 18]
-            fixed_cols = 3 + 12 + 6 + 18 + 6  # arrow + active + src + id + padding
+            # Layout: [arrow 3] [title/preview flexible] [active 12] [src 6] [id 32]
+            fixed_cols = 3 + 12 + 6 + 32 + 6  # arrow + active + src + id + padding
             name_width = max(20, max_x - fixed_cols)
 
             if title:
@@ -732,7 +732,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                     pass
 
                 # Column header line
-                fixed_cols = 3 + 12 + 6 + 18 + 6
+                fixed_cols = 3 + 12 + 6 + 32 + 6
                 name_width = max(20, max_x - fixed_cols)
                 col_header = f"   {'Title / Preview':<{name_width}}  {'Active':<10}  {'Src':<5} {'ID'}"
                 try:


### PR DESCRIPTION
## What does this PR do?

Removes the arbitrary 18-character truncation of session IDs in the interactive session browser (`hermes sessions browse`). The longest session IDs (cron scheduler format: `f"cron_{job_id}_{timestamp}"`) can be up to 32 characters, so the ID column budget was expanded accordingly.

## Related Issue

Fixes none (this is a standalone UI fix)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Remove `[:18]` truncation on `sid` in `_format_row()` and `_format_row` in `_curses_browse()`
- `hermes_cli/main.py`: Increase ID column budget from 18 to 32 characters in both `_format_row()` and the column header line
- `hermes_cli/main.py`: Update column header to match the new ID column width

## How to Test

1. Run `hermes sessions browse` with a long-running cron job session or any session with a >18 character ID
2. Verify that the session ID column displays the full ID (e.g. `cron_86b7fcdf06b0_20260528_090000`) instead of a truncated version
3. Verify the title/preview column shrinks proportionally to accommodate the wider ID column, eliminating the large empty gap

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): display full session IDs in hermes sessions browse`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_session_browse.py -q` and all 33 tests pass
- [x] I've tested on my platform: Linux (Ubuntu 24.04)

### Documentation & Housekeeping

- [ ] N/A (no documentation changes needed for a UI fix)
- [ ] N/A (no config key changes)
- [ ] N/A (no architecture changes)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (curses rendering is already platform-limited to terminal environments)
- [ ] N/A (no tool descriptions/schemas changed)

## Screenshots / Logs
### Screenshots of `hermes sessions browse`

Before (truncated IDs):

<img width="1897" height="91" alt="image" src="https://github.com/user-attachments/assets/28f9cb7e-94f3-4b8d-84b7-cbecdd4f1471" />


After (full IDs visible):
<img width="1897" height="91" alt="image" src="https://github.com/user-attachments/assets/8e00ba35-615f-41da-ab03-f7e971f9a8f0" />

