### PR TITLE
feat: add Claude Code ACP integration (claude-code-acp provider)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ RELEASE_v*.md
 # Desktop demo-run scratch output (hermes writes demo/*.txt during recorded
 # walkthroughs). Throwaway artifacts, never part of the app.
 apps/desktop/demo/
+
+# Claude Code working directory
+.claude/

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -748,9 +748,13 @@ def init_agent(
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             elif agent.provider == "claude-code-acp":
-                # Inject sandbox/session context so the ACP client can
-                # build per-session sandboxes with the agent's persona,
-                # memory, platform, and available tools.
+                # Inject transport overrides, sandbox/session context so
+                # the ACP client honours user-supplied acp_command/acp_args
+                # (e.g. /custom/npx, --debug, --model opus) and can build
+                # per-session sandboxes with the agent's persona, memory,
+                # platform, and available tools.
+                client_kwargs["acp_command"] = agent.acp_command
+                client_kwargs["acp_args"] = agent.acp_args
                 client_kwargs["agent"] = agent
                 client_kwargs["hermes_home"] = get_hermes_home()
                 client_kwargs["hermes_session_id"] = getattr(agent, "session_id", None)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -747,6 +747,14 @@ def init_agent(
             if agent.provider == "copilot-acp":
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
+            elif agent.provider == "claude-code-acp":
+                # Inject sandbox/session context so the ACP client can
+                # build per-session sandboxes with the agent's persona,
+                # memory, platform, and available tools.
+                client_kwargs["agent"] = agent
+                client_kwargs["hermes_home"] = get_hermes_home()
+                client_kwargs["hermes_session_id"] = getattr(agent, "session_id", None)
+                client_kwargs["platform"] = getattr(agent, "platform", None)
             effective_base = base_url
             if base_url_host_matches(effective_base, "openrouter.ai"):
                 from agent.auxiliary_client import build_or_headers

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -302,6 +302,7 @@ def init_agent(
     agent.memory_notifications = "on"  # Memory update notifications: "off", "on", "verbose"
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
+    agent.skip_memory = skip_memory            # Root-cause fix: was missing, broke fast-path detection
     agent.pass_session_id = pass_session_id
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -302,7 +302,7 @@ def init_agent(
     agent.memory_notifications = "on"  # Memory update notifications: "off", "on", "verbose"
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
-    agent.skip_memory = skip_memory            # Root-cause fix: was missing, broke fast-path detection
+    agent.skip_memory = skip_memory            # was missing: getattr default kept fast-path dead
     agent.pass_session_id = pass_session_id
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1373,6 +1373,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "claude-code-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://claude-code"):
+        from agent.claude_code_acp_client import ClaudeCodeACPClient
+
+        client = ClaudeCodeACPClient(**client_kwargs)
+        _ra().logger.info(
+            "Claude Code ACP client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -496,6 +496,7 @@ class ClaudeCodeACPClient:
         self.is_closed = False
         self._active_process: subprocess.Popen[str] | None = None
         self._active_process_lock = threading.Lock()
+        self._reader_threads: list[threading.Thread] = []
         self._next_request_id = 0
         self._stderr_log_path: Optional[Path] = None
 
@@ -578,6 +579,15 @@ class ClaudeCodeACPClient:
                 proc.kill()
             except (OSError, ProcessLookupError):
                 pass
+        # Reader threads may still be mid-readline on the now-closed pipes.
+        # Join with a short timeout so they can drain/EOF cleanly before close()
+        # returns; daemon=True ensures the process can't hang on shutdown.
+        for t in self._reader_threads:
+            try:
+                t.join(timeout=1.0)
+            except Exception:
+                pass
+        self._reader_threads = []
         self.is_closed = True
 
     def _start_subprocess(self) -> tuple[subprocess.Popen[str], "queue.Queue[dict[str, Any]]", deque[str]]:
@@ -644,8 +654,11 @@ class ClaudeCodeACPClient:
                     except OSError:
                         pass
 
-        threading.Thread(target=_stdout_reader, daemon=True).start()
-        threading.Thread(target=_stderr_reader, daemon=True).start()
+        t_out = threading.Thread(target=_stdout_reader, daemon=True)
+        t_err = threading.Thread(target=_stderr_reader, daemon=True)
+        t_out.start()
+        t_err.start()
+        self._reader_threads = [t_out, t_err]
         return proc, inbox, stderr_tail
 
     # ------------------------------------------------------------------

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -464,6 +464,17 @@ class ClaudeCodeACPClient:
         self._sandbox_path: Path | None = None
         self._pending_model: str | None = None
 
+        # Seed _pending_model from --model flag in acp_args so the subprocess
+        # uses the requested model even when the calling LLM doesn't pass a
+        # per-call model parameter. The session/new → session/set_config_option
+        # flow in _ensure_session() will route this to claude-agent-acp's
+        # query.setModel() on the first _create_chat_completion call. This is
+        # necessary because the underlying @agentclientprotocol/claude-agent-acp
+        # subprocess silently ignores all CLI args except --cli/--version/
+        # --help/--debug, so the model flag has to flow through ACP's
+        # set_config_option channel rather than argv.
+        self._seed_pending_model_from_acp_args()
+
         self._trace_lock = threading.Lock()
         self._tool_trace: list[ToolCallRecord] = []
         self._tool_records_by_id: dict[str, ToolCallRecord] = {}
@@ -1172,6 +1183,43 @@ class ClaudeCodeACPClient:
         if re.match(r"^claude-(haiku|sonnet|opus)(?:-\d+(?:-\d+)*)?$", normalized):
             return True
         return False
+
+    def _seed_pending_model_from_acp_args(self) -> None:
+        """Seed ``_pending_model`` from a ``--model`` flag in ``self._acp_args``.
+
+        Allows callers to pin the Claude model via the CLI-level ``--model``
+        flag in ``acp_args`` (e.g. ``["--acp", "--stdio", "--model",
+        "claude-sonnet-4-6"]``) even when the calling LLM skips the per-call
+        ``model`` tool parameter. The model is consumed by the existing
+        ``_ensure_session()`` flow which calls
+        ``session/set_config_option({"configId": "model", ...})`` after
+        ``session/new`` — claude-agent-acp routes that to
+        ``query.setModel(resolvedValue)`` on the live SDK query.
+
+        The ``--model`` token is left in ``self._acp_args`` because the
+        underlying ``@agentclientprotocol/claude-agent-acp`` subprocess
+        silently ignores all unknown CLI args, so there's no benefit (and
+        some debugging value) in stripping it.
+        """
+        for i, arg in enumerate(self._acp_args):
+            if arg == "--model" and i + 1 < len(self._acp_args):
+                candidate = self._acp_args[i + 1]
+                if self._is_valid_claude_alias(candidate):
+                    self._pending_model = candidate
+                    logger.info(
+                        "ClaudeCodeACPClient: seeded _pending_model=%r from "
+                        "acp_args --model flag",
+                        candidate,
+                    )
+                else:
+                    logger.warning(
+                        "ClaudeCodeACPClient: ignoring --model=%r from "
+                        "acp_args: not a valid Claude alias (expected "
+                        "opus/sonnet/haiku or claude-{opus,sonnet,haiku}-*)",
+                        candidate,
+                    )
+                # Only honor the first --model flag
+                return
 
     def _create_chat_completion(
         self,

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -522,7 +522,6 @@ class ClaudeCodeACPClient:
         self._session_stderr: deque[str] | None = None
         self._session_id: str | None = None
         self._sandbox_path: Path | None = None
-        self._pending_model: str | None = None
         self._pending_session_configs: dict[str, str] = {}
 
         # Scan _acp_args (runtime directives from caller) for recognized
@@ -912,7 +911,7 @@ class ClaudeCodeACPClient:
             platform=self._platform,
             available_tools=self._available_tools,
             available_toolsets=self._available_toolsets,
-            model=model or self._pending_model,
+            model=model or self._pending_session_configs.get("model"),
         )
         # ACP subprocess must cd into the sandbox so .mcp.json and CLAUDE.md
         # are picked up.
@@ -1327,14 +1326,6 @@ class ClaudeCodeACPClient:
             if channel == "session_config":
                 config_id = directive["config_id"]
                 self._pending_session_configs[config_id] = value
-                # Backward compat: also set _pending_model for --model
-                if config_id == "model":
-                    self._pending_model = value
-                    logger.info(
-                        "ClaudeCodeACPClient: seeded _pending_model=%r from "
-                        "acp_args --model flag",
-                        value,
-                    )
             elif channel == "init":
                 attr = directive["attr"]
                 setattr(self, attr, value)
@@ -1370,7 +1361,6 @@ class ClaudeCodeACPClient:
         )
 
         if raw_model and self._is_valid_claude_alias(raw_model):
-            self._pending_model = raw_model
             self._pending_session_configs["model"] = raw_model
 
         proc, inbox, stderr_tail, session_id = self._ensure_session()

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -34,7 +34,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, Iterable, Iterator, List, Optional
+from typing import Any, Callable, ClassVar, Iterable, Iterator, List, Optional
 
 from agent.file_safety import get_read_block_error, is_write_denied
 from gateway.session_context import get_session_env
@@ -393,6 +393,18 @@ class ClaudeCodeACPClient:
     issues ``initialize`` + ``session/new``, and caches the ``sessionId``.
     Subsequent calls reuse the same subprocess and session — mirroring the
     Claude Code editor lifetime.
+
+    Supported ``acp_args`` directives (queued during ``__init__``, flushed
+    via ``session/set_config_option`` after ``session/new``):
+
+    * ``--model <name>`` — set Claude model (opus/sonnet/haiku or full name)
+    * ``--permission-mode <mode>`` — set permission mode (auto/default/
+      acceptEdits/plan/dontAsk/bypassPermissions)
+    * ``--effort <level>`` — set reasoning effort (default/low/medium/high/
+      xhigh/max)
+
+    Unrecognised flags are left in ``acp_args`` and passed through to the
+    ACP subprocess (which silently ignores unknown CLI arguments).
     """
 
     _provider_label = "claude-code-acp"
@@ -403,6 +415,42 @@ class ClaudeCodeACPClient:
     _marker_base_url = ACP_MARKER_BASE_URL
     _default_timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
     _client_name = "hermes-agent"
+
+    # Declarative dispatch table: maps recognized CLI flags from acp_args
+    # to their ACP session config actions. Each entry defines:
+    #   flag: the CLI flag to match (e.g. "--model")
+    #   channel: "session_config" (via session/set_config_option) or "init"
+    #   config_id: the ACP configId for session_config channel entries
+    #   attr: the instance attribute to set for init channel entries
+    #   takes_value: True if the flag consumes the next token as its value
+    #   validate: optional method name (str) for value validation; None = trust caller
+    #   repeatable: if False, only the first occurrence is honoured
+    _ACP_ARG_DIRECTIVES: ClassVar[tuple[dict[str, Any], ...]] = (
+        {
+            "flag": "--model",
+            "channel": "session_config",
+            "config_id": "model",
+            "takes_value": True,
+            "validate": "_is_valid_claude_alias",
+            "repeatable": False,
+        },
+        {
+            "flag": "--permission-mode",
+            "channel": "session_config",
+            "config_id": "mode",
+            "takes_value": True,
+            "validate": None,  # ACP server validates: auto/default/acceptEdits/plan/dontAsk/bypassPermissions
+            "repeatable": False,
+        },
+        {
+            "flag": "--effort",
+            "channel": "session_config",
+            "config_id": "effort",
+            "takes_value": True,
+            "validate": "_is_valid_effort_level",
+            "repeatable": False,
+        },
+    )
 
     def __init__(
         self,
@@ -463,17 +511,14 @@ class ClaudeCodeACPClient:
         self._session_id: str | None = None
         self._sandbox_path: Path | None = None
         self._pending_model: str | None = None
+        self._pending_session_configs: dict[str, str] = {}
 
-        # Seed _pending_model from --model flag in acp_args so the subprocess
-        # uses the requested model even when the calling LLM doesn't pass a
-        # per-call model parameter. The session/new → session/set_config_option
-        # flow in _ensure_session() will route this to claude-agent-acp's
-        # query.setModel() on the first _create_chat_completion call. This is
-        # necessary because the underlying @agentclientprotocol/claude-agent-acp
-        # subprocess silently ignores all CLI args except --cli/--version/
-        # --help/--debug, so the model flag has to flow through ACP's
-        # set_config_option channel rather than argv.
-        self._seed_pending_model_from_acp_args()
+        # Scan acp_args for recognized directive flags (--model, --permission-mode,
+        # --effort) and queue them into _pending_session_configs.  These are
+        # flushed via session/set_config_option after session/new in
+        # _ensure_session().  Unrecognised flags remain in acp_args and are
+        # passed to the subprocess (which silently ignores them).
+        self._apply_acp_arg_directives()
 
         self._trace_lock = threading.Lock()
         self._tool_trace: list[ToolCallRecord] = []
@@ -929,23 +974,30 @@ class ClaudeCodeACPClient:
                     raise RuntimeError(
                         "claude-agent-acp did not return a sessionId from session/new."
                     )
-                if self._pending_model:
+                # Flush all pending session configs from directive scanner.
+                # Order matters: model MUST be flushed first because switching
+                # models can invalidate subsequent mode/effort settings
+                # (e.g. Haiku does not support auto mode).
+                _FLUSH_ORDER = ("model", "mode", "effort")
+                for config_id in _FLUSH_ORDER:
+                    if config_id not in self._pending_session_configs:
+                        continue
                     try:
                         self._request(
                             proc, inbox, stderr_tail,
                             "session/set_config_option",
                             {
                                 "sessionId": session_id,
-                                "configId": "model",
-                                "value": self._pending_model,
+                                "configId": config_id,
+                                "value": self._pending_session_configs[config_id],
                             },
                             timeout_seconds=self._default_timeout_seconds,
                         )
                     except Exception as exc:
                         logger.warning(
-                            "Failed to set model via session/set_config_option (%s: %r); "
-                            "falling back to user default",
-                            type(exc).__name__, exc,
+                            "Failed to set %s via session/set_config_option "
+                            "(%s: %r); continuing",
+                            config_id, type(exc).__name__, exc,
                         )
             except Exception:
                 try:
@@ -1184,42 +1236,83 @@ class ClaudeCodeACPClient:
             return True
         return False
 
-    def _seed_pending_model_from_acp_args(self) -> None:
-        """Seed ``_pending_model`` from a ``--model`` flag in ``self._acp_args``.
+    def _is_valid_effort_level(self, value: str) -> bool:
+        """Return True if *value* is a valid ACP effort level.
 
-        Allows callers to pin the Claude model via the CLI-level ``--model``
-        flag in ``acp_args`` (e.g. ``["--acp", "--stdio", "--model",
-        "claude-sonnet-4-6"]``) even when the calling LLM skips the per-call
-        ``model`` tool parameter. The model is consumed by the existing
-        ``_ensure_session()`` flow which calls
-        ``session/set_config_option({"configId": "model", ...})`` after
-        ``session/new`` — claude-agent-acp routes that to
-        ``query.setModel(resolvedValue)`` on the live SDK query.
-
-        The ``--model`` token is left in ``self._acp_args`` because the
-        underlying ``@agentclientprotocol/claude-agent-acp`` subprocess
-        silently ignores all unknown CLI args, so there's no benefit (and
-        some debugging value) in stripping it.
+        Valid values (from @agentclientprotocol/claude-agent-acp buildConfigOptions):
+        default, low, medium, high, xhigh, max
         """
-        for i, arg in enumerate(self._acp_args):
-            if arg == "--model" and i + 1 < len(self._acp_args):
-                candidate = self._acp_args[i + 1]
-                if self._is_valid_claude_alias(candidate):
-                    self._pending_model = candidate
+        return value.lower() in ("default", "low", "medium", "high", "xhigh", "max")
+
+    def _apply_acp_arg_directives(self) -> None:
+        """Scan ``self._acp_args`` for recognized flags and queue them.
+
+        Each matched flag is queued into ``_pending_session_configs`` (for
+        ``session_config`` channel directives).  Unrecognised flags are
+        left in ``self._acp_args`` — the ACP subprocess silently ignores
+        unknown CLI arguments.
+
+        Only the first occurrence of each non-repeatable flag is honoured.
+        """
+        recognized_flags = {d["flag"]: d for d in self._ACP_ARG_DIRECTIVES}
+        seen: set[str] = set()
+        i = 0
+        while i < len(self._acp_args):
+            arg = self._acp_args[i]
+            if arg not in recognized_flags:
+                i += 1
+                continue
+            directive = recognized_flags[arg]
+
+            # Skip duplicate non-repeatable flags
+            if not directive.get("repeatable", False) and arg in seen:
+                i += (2 if directive["takes_value"] else 1)
+                continue
+            seen.add(arg)
+
+            if directive["takes_value"]:
+                if i + 1 >= len(self._acp_args):
+                    logger.warning(
+                        "ClaudeCodeACPClient: %s flag has no value, skipping",
+                        arg,
+                    )
+                    i += 1
+                    continue
+                value = self._acp_args[i + 1]
+            else:
+                value = "true"  # boolean flag
+
+            # Validate if a validator is specified
+            validator_name = directive.get("validate")
+            if validator_name:
+                validator = getattr(self, validator_name, None)
+                if validator and not validator(value):
+                    logger.warning(
+                        "ClaudeCodeACPClient: ignoring %s=%r — validation failed",
+                        arg,
+                        value,
+                    )
+                    i += (2 if directive["takes_value"] else 1)
+                    continue
+
+            # Dispatch to the appropriate channel
+            channel = directive["channel"]
+            if channel == "session_config":
+                config_id = directive["config_id"]
+                self._pending_session_configs[config_id] = value
+                # Backward compat: also set _pending_model for --model
+                if config_id == "model":
+                    self._pending_model = value
                     logger.info(
                         "ClaudeCodeACPClient: seeded _pending_model=%r from "
                         "acp_args --model flag",
-                        candidate,
+                        value,
                     )
-                else:
-                    logger.warning(
-                        "ClaudeCodeACPClient: ignoring --model=%r from "
-                        "acp_args: not a valid Claude alias (expected "
-                        "opus/sonnet/haiku or claude-{opus,sonnet,haiku}-*)",
-                        candidate,
-                    )
-                # Only honor the first --model flag
-                return
+            elif channel == "init":
+                attr = directive["attr"]
+                setattr(self, attr, value)
+
+            i += (2 if directive["takes_value"] else 1)
 
     def _create_chat_completion(
         self,
@@ -1251,6 +1344,7 @@ class ClaudeCodeACPClient:
 
         if raw_model and self._is_valid_claude_alias(raw_model):
             self._pending_model = raw_model
+            self._pending_session_configs["model"] = raw_model
 
         proc, inbox, stderr_tail, session_id = self._ensure_session()
 

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -529,6 +529,7 @@ class ClaudeCodeACPClient:
         self._session_id: str | None = None
         self._sandbox_path: Path | None = None
         self._pending_session_configs: dict[str, str] = {}
+        self._acp_config_options: list[dict[str, Any]] = []
 
         # Scan _acp_args (runtime directives from caller) for recognized
         # flags (--model, --permission-mode, --effort) and queue them into
@@ -967,6 +968,19 @@ class ClaudeCodeACPClient:
             out.append(entry)
         return out
 
+    def _get_acp_model(self) -> str | None:
+        """Return the current ACP session model from cached configOptions.
+
+        The value comes from the ``session/new`` response (initial default)
+        or the most recent ``session/set_config_option`` response (after a
+        model switch).  Returns *None* when no configOptions have been
+        recorded yet (e.g. session not created).
+        """
+        for opt in self._acp_config_options:
+            if opt.get("id") == "model":
+                return opt.get("currentValue")
+        return None
+
     def _flush_pending_configs(
         self, proc, inbox, stderr_tail, session_id: str
     ) -> None:
@@ -975,13 +989,17 @@ class ClaudeCodeACPClient:
         Order matters: model MUST be flushed first because switching
         models can invalidate subsequent mode/effort settings
         (e.g. Haiku does not support auto mode).
+
+        After each successful flush, updates ``_acp_config_options`` with
+        the response's ``configOptions`` so hermes always knows the actual
+        ACP session config (including defaults).
         """
         _FLUSH_ORDER = ("model", "mode", "effort")
         for config_id in _FLUSH_ORDER:
             if config_id not in self._pending_session_configs:
                 continue
             try:
-                self._request(
+                result = self._request(
                     proc, inbox, stderr_tail,
                     "session/set_config_option",
                     {
@@ -991,6 +1009,9 @@ class ClaudeCodeACPClient:
                     },
                     timeout_seconds=self._default_timeout_seconds,
                 )
+                # Update cached configOptions from response
+                if result and isinstance(result.get("configOptions"), list):
+                    self._acp_config_options = result["configOptions"]
             except Exception as exc:
                 logger.warning(
                     "Failed to set %s via session/set_config_option "
@@ -1017,6 +1038,12 @@ class ClaudeCodeACPClient:
                     self._session_proc, self._session_inbox,
                     self._session_stderr, self._session_id,
                 )
+                acp_model = self._get_acp_model()
+                logger.info(
+                    "ACP session model: %s (session=%s, alive=True)",
+                    acp_model or "(claude-agent-acp default)",
+                    self._session_id,
+                )
                 return (
                     self._session_proc,
                     self._session_inbox,
@@ -1042,7 +1069,16 @@ class ClaudeCodeACPClient:
                     raise RuntimeError(
                         "claude-agent-acp did not return a sessionId from session/new."
                     )
+                # Cache configOptions from session/new response (includes default model)
+                if isinstance(session.get("configOptions"), list):
+                    self._acp_config_options = session["configOptions"]
                 self._flush_pending_configs(proc, inbox, stderr_tail, session_id)
+                acp_model = self._get_acp_model()
+                logger.info(
+                    "ACP session model: %s (session=%s, alive=False)",
+                    acp_model or "(claude-agent-acp default)",
+                    session_id,
+                )
             except Exception:
                 try:
                     proc.terminate()

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -565,11 +565,12 @@ class ClaudeCodeACPClient:
             self._session_id = None
             self._session_inbox = None
             self._session_stderr = None
+            self._session_proc = None
         with self._active_process_lock:
             proc = self._active_process
             self._active_process = None
-        self.is_closed = True
         if proc is None:
+            self.is_closed = True
             return
         try:
             proc.terminate()
@@ -579,7 +580,7 @@ class ClaudeCodeACPClient:
                 proc.kill()
             except (OSError, ProcessLookupError):
                 pass
-        self._session_proc = None
+        self.is_closed = True
 
     def _start_subprocess(self) -> tuple[subprocess.Popen[str], "queue.Queue[dict[str, Any]]", deque[str]]:
         """Launch the ACP subprocess and start reader threads.

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -950,6 +950,37 @@ class ClaudeCodeACPClient:
             out.append(entry)
         return out
 
+    def _flush_pending_configs(
+        self, proc, inbox, stderr_tail, session_id: str
+    ) -> None:
+        """Flush pending session configs via session/set_config_option.
+
+        Order matters: model MUST be flushed first because switching
+        models can invalidate subsequent mode/effort settings
+        (e.g. Haiku does not support auto mode).
+        """
+        _FLUSH_ORDER = ("model", "mode", "effort")
+        for config_id in _FLUSH_ORDER:
+            if config_id not in self._pending_session_configs:
+                continue
+            try:
+                self._request(
+                    proc, inbox, stderr_tail,
+                    "session/set_config_option",
+                    {
+                        "sessionId": session_id,
+                        "configId": config_id,
+                        "value": self._pending_session_configs[config_id],
+                    },
+                    timeout_seconds=self._default_timeout_seconds,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to set %s via session/set_config_option "
+                    "(%s: %r); continuing",
+                    config_id, type(exc).__name__, exc,
+                )
+
     def _ensure_session(self) -> tuple[
         subprocess.Popen[str],
         "queue.Queue[dict[str, Any]]",
@@ -964,6 +995,11 @@ class ClaudeCodeACPClient:
                 and self._session_inbox is not None
                 and self._session_stderr is not None
             ):
+                # Flush any pending config changes before reusing the live session
+                self._flush_pending_configs(
+                    self._session_proc, self._session_inbox,
+                    self._session_stderr, self._session_id,
+                )
                 return (
                     self._session_proc,
                     self._session_inbox,
@@ -989,31 +1025,7 @@ class ClaudeCodeACPClient:
                     raise RuntimeError(
                         "claude-agent-acp did not return a sessionId from session/new."
                     )
-                # Flush all pending session configs from directive scanner.
-                # Order matters: model MUST be flushed first because switching
-                # models can invalidate subsequent mode/effort settings
-                # (e.g. Haiku does not support auto mode).
-                _FLUSH_ORDER = ("model", "mode", "effort")
-                for config_id in _FLUSH_ORDER:
-                    if config_id not in self._pending_session_configs:
-                        continue
-                    try:
-                        self._request(
-                            proc, inbox, stderr_tail,
-                            "session/set_config_option",
-                            {
-                                "sessionId": session_id,
-                                "configId": config_id,
-                                "value": self._pending_session_configs[config_id],
-                            },
-                            timeout_seconds=self._default_timeout_seconds,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "Failed to set %s via session/set_config_option "
-                            "(%s: %r); continuing",
-                            config_id, type(exc).__name__, exc,
-                        )
+                self._flush_pending_configs(proc, inbox, stderr_tail, session_id)
             except Exception:
                 try:
                     proc.terminate()

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -1,0 +1,1363 @@
+"""OpenAI-compatible shim that forwards Hermes requests to Claude Code over ACP.
+
+Unlike :mod:`agent.copilot_acp_client`, which scrapes ``<tool_call>`` blocks
+from flat text output, this client consumes the **native** ACP events emitted
+by ``@agentclientprotocol/claude-agent-acp`` — Claude Code runs its own tool loop
+autonomously, so tool-call facts arrive as first-class ``session/update``
+messages of kind ``tool_call_start`` and ``tool_call_update``.
+
+The client:
+
+* Builds a per-session Claude Code sandbox (``CLAUDE.md``, skills,
+  ``.mcp.json``) via :mod:`agent.claude_code_sandbox` so hermes's persona,
+  memory, skills, and tools are available inside the subprocess.
+* Keeps one ACP subprocess + one ``sessionId`` alive across turns, matching
+  the Claude Code editor lifetime. Subsequent calls reuse the session.
+* Routes streamed text → ``stream_delta_callback``, thought chunks →
+  ``thinking_callback``, and tool events → ``tool_progress_callback``.
+* Accumulates a :class:`ToolCallRecord` list and attaches it to the
+  response as ``hermes_tool_trace`` so the AIAgent loop can feed it into
+  auto-skill-creation and background review without re-running the tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import shlex
+import subprocess
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Iterable, Iterator, List, Optional
+
+from agent.file_safety import get_read_block_error, is_write_denied
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (inlined from former _acp_client_base.py)
+# ---------------------------------------------------------------------------
+
+def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+class AcpCancelled(RuntimeError):
+    """Raised when an in-flight ACP request is cancelled by the caller.
+
+    Subclass of :class:`RuntimeError` on purpose: the run_agent retry loop
+    catches broad ``Exception`` for transient transport errors, and
+    cancellation should unwind the same way without being mistaken for a
+    retryable failure. Callers that need to distinguish (e.g. to suppress
+    the usual error surfacing) should catch ``AcpCancelled`` explicitly.
+    """
+
+
+def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        raise PermissionError("ACP file-system paths must be absolute.")
+    resolved = candidate.resolve()
+    root = Path(cwd).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(
+            f"Path '{resolved}' is outside the session cwd '{root}'."
+        ) from exc
+    return resolved
+
+
+def _walk_text_blocks(obj: Any) -> Iterator[str]:
+    """Yield text fragments from any nested OpenAI/ACP content shape.
+
+    Handles the union of shapes we see in the wild:
+      - ``str`` → yield as-is
+      - ``{"text": "..."}`` → yield the text value
+      - ``{"content": ...}`` → recurse into the inner content
+      - ``list`` → recurse into each item
+    Anything else (e.g. image/tool blocks) is skipped silently. Callers
+    decide how to frame the output (strip/join separator, etc.).
+    """
+    if obj is None:
+        return
+    if isinstance(obj, str):
+        if obj:
+            yield obj
+        return
+    if isinstance(obj, dict):
+        text = obj.get("text")
+        if isinstance(text, str) and text:
+            yield text
+            return
+        inner = obj.get("content")
+        if inner is not None and inner is not obj:
+            yield from _walk_text_blocks(inner)
+        return
+    if isinstance(obj, list):
+        for item in obj:
+            yield from _walk_text_blocks(item)
+
+
+_NON_TEXT_BLOCK_TYPES = {"image", "image_url", "input_audio", "audio", "file"}
+_MULTIMODAL_WARNED = False
+
+
+def _warn_once_multimodal_stripped(block_types: set[str]) -> None:
+    """Log once per process when non-text content (image/audio/…) is dropped."""
+    global _MULTIMODAL_WARNED
+    if _MULTIMODAL_WARNED or not block_types:
+        return
+    _MULTIMODAL_WARNED = True
+    logger.warning(
+        "ACP prompt path is text-only; dropped content block(s): %s. "
+        "Attach the image via an on-disk path the model can read, or use "
+        "a provider that supports multimodal prompts.",
+        ", ".join(sorted(block_types)),
+    )
+
+
+def _render_message_content(content: Any) -> str:
+    """Flatten a message ``content`` field to a single stripped string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        stripped_types: set[str] = set()
+        for item in content:
+            if isinstance(item, dict):
+                block_type = str(item.get("type") or "")
+                if block_type in _NON_TEXT_BLOCK_TYPES:
+                    stripped_types.add(block_type)
+        if stripped_types:
+            _warn_once_multimodal_stripped(stripped_types)
+        parts = [t.strip() for t in _walk_text_blocks(content) if t.strip()]
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    *,
+    preamble: list[str] | None = None,
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+    tool_call_instructions: str | None = None,
+    closing: str | None = "Continue the conversation from the latest user request.",
+) -> str:
+    """Flatten an OpenAI-style ``messages`` list into one ACP prompt string."""
+    sections: list[str] = list(preamble or [])
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            fn = t.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            header = tool_call_instructions or (
+                "Available tools (OpenAI function schema)."
+            )
+            sections.append(f"{header}\n{json.dumps(tool_specs, ensure_ascii=False)}")
+
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            role = "tool"
+        elif role not in {"system", "user", "assistant"}:
+            role = "context"
+
+        content = message.get("content")
+        rendered = _render_message_content(content)
+        if not rendered:
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    if closing:
+        sections.append(closing)
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def resolve_effective_timeout(timeout: Any, *, default: float) -> float:
+    """Translate run_agent's ``timeout`` kwarg (plain number or httpx.Timeout) to seconds."""
+    if timeout is None:
+        return default
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+    candidates = [
+        getattr(timeout, attr, None)
+        for attr in ("read", "write", "connect", "pool", "timeout")
+    ]
+    numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+    return max(numeric) if numeric else default
+
+
+# ---------------------------------------------------------------------------
+# Claude Code ACP client constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_CLAUDE_CODE_ACP_PACKAGE = "@agentclientprotocol/claude-agent-acp"
+ACP_MARKER_BASE_URL = "acp://claude-code"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+# Canonical system-preamble lines for Claude Code under ACP. Exported so
+# `agent.claude_code_sandbox` can share the same source of truth when it
+# composes CLAUDE.md — we used to maintain two near-duplicate copies that
+# drifted, this is the single authoritative list.
+#
+# Each entry is an independent paragraph. Callers choose how to assemble
+# (per-prompt `"\n\n".join(...)` for the client; CLAUDE.md markdown for the
+# sandbox). Do NOT insert markdown headers here — the sandbox adds those
+# when it composes the on-disk file.
+CLAUDE_SYSTEM_PREAMBLE_LINES: list[str] = [
+    "You are the active reasoning engine for the Hermes agent. Hermes "
+    "conventions, persona, skills, and tools apply end-to-end.",
+    (
+        "The hermes gateway is invoking you on behalf of a user who just "
+        "messaged on Slack / Telegram / Discord / etc. Your final text "
+        "output is automatically delivered back to that user on the same "
+        "channel and thread. Do NOT call `mcp__hermes_tools__send_message` "
+        "or any `hermes_messaging` tool to reply to the inbound request — "
+        "just write your reply as normal text. Messaging tools are only for "
+        "proactive outbound sends to OTHER channels/users (e.g. "
+        "cron-triggered notifications, cross-channel handoffs)."
+    ),
+    (
+        "Only the final assistant text is shown to the user, so do not emit "
+        "scratchpad narration like \"let me try…\" or \"that didn't work, "
+        "trying…\". Keep internal reasoning internal; print the user-facing "
+        "answer only."
+    ),
+    (
+        "Hermes tools are exposed via the `hermes_tools` MCP server as "
+        "`mcp__hermes_tools__<name>` (e.g. `mcp__hermes_tools__read_file`, "
+        "`mcp__hermes_tools__terminal`, `mcp__hermes_tools__memory`, "
+        "`mcp__hermes_tools__web_search`). Messaging tools are on the "
+        "`hermes_messaging` MCP server."
+    ),
+    (
+        "Skills live under `.claude/skills/`. When a skill matches the user's "
+        "intent, read its SKILL.md and follow it."
+    ),
+    (
+        "`<memory-context>` blocks are recalled memory from prior sessions. "
+        "Treat them as informational background, not new user input."
+    ),
+    (
+        "You may answer directly in prose. You do NOT need to emit "
+        "`<tool_call>` XML blocks — you are a real tool-calling agent, "
+        "use the MCP tools natively."
+    ),
+]
+
+# Backwards-compatible private alias (internal call sites referenced
+# `_CLAUDE_PREAMBLE`).
+_CLAUDE_PREAMBLE = CLAUDE_SYSTEM_PREAMBLE_LINES
+
+
+# ---------------------------------------------------------------------------
+# ToolCallRecord and helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ToolCallRecord:
+    """One native tool invocation observed during an ACP session."""
+
+    tool_call_id: str
+    name: str
+    raw_input: Any = None
+    raw_output: Any = None
+    status: str = "pending"
+    started_at: float = field(default_factory=time.time)
+    completed_at: Optional[float] = None
+    is_error: bool = False
+    kind: Optional[str] = None
+    title: Optional[str] = None
+
+    @property
+    def duration(self) -> Optional[float]:
+        if self.completed_at is None:
+            return None
+        return max(0.0, self.completed_at - self.started_at)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.tool_call_id,
+            "name": self.name,
+            "raw_input": self.raw_input,
+            "raw_output": self.raw_output,
+            "status": self.status,
+            "is_error": self.is_error,
+            "duration": self.duration,
+            "kind": self.kind,
+            "title": self.title,
+        }
+
+
+def _coerce_str(val: Any) -> str:
+    if val is None:
+        return ""
+    if isinstance(val, str):
+        return val
+    try:
+        return json.dumps(val, ensure_ascii=False)
+    except Exception:
+        return str(val)
+
+
+def _extract_text_from_content_blocks(content: Any) -> str:
+    """Pull ``text`` fields out of ACP ``content`` list/dict shapes.
+
+    Unlike :func:`_render_message_content` (which strips
+    whitespace and joins with ``"\\n"`` for human display), this one keeps
+    raw whitespace and joins with ``"\\n"`` for streaming accumulation —
+    downstream tool-output concatenation expects to append chunks with
+    their original newlines preserved.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    parts = list(_walk_text_blocks(content))
+    return "\n".join(parts) if parts else ""
+
+
+def _short_preview(text: str, limit: int = 160) -> str:
+    if not isinstance(text, str):
+        text = _coerce_str(text)
+    text = " ".join(text.split())
+    if len(text) > limit:
+        return text[: limit - 1] + "…"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCodeACPClient — self-contained ACP client
+# ---------------------------------------------------------------------------
+
+class ClaudeCodeACPClient:
+    """Persistent-session ACP client targeting Claude Code.
+
+    The first :meth:`_create_chat_completion` call spawns the ACP subprocess,
+    issues ``initialize`` + ``session/new``, and caches the ``sessionId``.
+    Subsequent calls reuse the same subprocess and session — mirroring the
+    Claude Code editor lifetime.
+    """
+
+    _provider_label = "claude-code-acp"
+    _default_command = "npx"
+    _default_args = ("-y", DEFAULT_CLAUDE_CODE_ACP_PACKAGE)
+    _env_command_vars = ("HERMES_CLAUDE_CODE_ACP_COMMAND", "CLAUDE_ACP_PATH")
+    _env_args_var = "HERMES_CLAUDE_CODE_ACP_ARGS"
+    _marker_base_url = ACP_MARKER_BASE_URL
+    _default_timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+    _client_name = "hermes-agent"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        agent: Any | None = None,
+        hermes_home: Path | None = None,
+        hermes_session_id: str | None = None,
+        platform: str | None = None,
+        stream_delta_callback: Callable[[str], Any] | None = None,
+        thinking_callback: Callable[[str], Any] | None = None,
+        tool_progress_callback: Callable[..., Any] | None = None,
+        available_tools: Optional[set[str]] = None,
+        available_toolsets: Optional[set[str]] = None,
+        **_: Any,
+    ) -> None:
+        # ACP transport state (formerly from _AcpClientBase.__init__)
+        self.api_key = api_key or self._provider_label
+        self.base_url = base_url or self._marker_base_url
+        self._default_headers = dict(default_headers or {})
+        self._acp_command = acp_command or command or self._resolve_command()
+        self._acp_args = list(acp_args or args or self._resolve_args())
+        self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+        self._next_request_id = 0
+        self._stderr_log_path: Optional[Path] = None
+
+        # ClaudeCode-specific state
+        self._agent = agent
+        self._hermes_home = Path(hermes_home) if hermes_home else None
+        self._hermes_session_id = (
+            hermes_session_id
+            or os.environ.get("HERMES_SESSION_ID", "").strip()
+            or f"hermes-{int(time.time())}"
+        )
+        self._platform = platform or os.environ.get("HERMES_SESSION_PLATFORM") or None
+        self._available_tools = set(available_tools) if available_tools else None
+        self._available_toolsets = set(available_toolsets) if available_toolsets else None
+
+        self.stream_delta_callback = stream_delta_callback
+        self.thinking_callback = thinking_callback
+        self.tool_progress_callback = tool_progress_callback
+
+        self._session_lock = threading.Lock()
+        self._session_proc: subprocess.Popen[str] | None = None
+        self._session_inbox: "queue.Queue[dict[str, Any]]" | None = None
+        self._session_stderr: deque[str] | None = None
+        self._session_id: str | None = None
+        self._sandbox_path: Path | None = None
+        self._pending_model: str | None = None
+
+        self._trace_lock = threading.Lock()
+        self._tool_trace: list[ToolCallRecord] = []
+        self._tool_records_by_id: dict[str, ToolCallRecord] = {}
+
+    # ------------------------------------------------------------------
+    # Env-driven resolution of the launcher path + args
+    # ------------------------------------------------------------------
+
+    def _resolve_command(self) -> str:
+        for env_var in self._env_command_vars:
+            val = os.getenv(env_var, "").strip()
+            if val:
+                return val
+        return self._default_command
+
+    def _resolve_args(self) -> list[str]:
+        if self._env_args_var:
+            raw = os.getenv(self._env_args_var, "").strip()
+            if raw:
+                return shlex.split(raw)
+        return list(self._default_args)
+
+    # ------------------------------------------------------------------
+    # Subprocess lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        with self._session_lock:
+            self._session_id = None
+            self._session_inbox = None
+            self._session_stderr = None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except (subprocess.TimeoutExpired, OSError, ProcessLookupError):
+            try:
+                proc.kill()
+            except (OSError, ProcessLookupError):
+                pass
+        self._session_proc = None
+
+    def _start_subprocess(self) -> tuple[subprocess.Popen[str], "queue.Queue[dict[str, Any]]", deque[str]]:
+        """Launch the ACP subprocess and start reader threads.
+
+        Returns ``(proc, inbox, stderr_tail)``. The caller owns the process
+        lifetime: persistent clients keep the reference; one-shot clients
+        terminate via :meth:`close` after the request completes.
+        """
+        try:
+            proc = subprocess.Popen(
+                [self._acp_command] + self._acp_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                cwd=self._acp_cwd,
+            )
+        except FileNotFoundError as exc:
+            envs = "/".join(self._env_command_vars) if self._env_command_vars else "the launcher path"
+            raise RuntimeError(
+                f"Could not start {self._provider_label} command '{self._acp_command}'. "
+                f"Install it or set {envs}."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError(f"{self._provider_label} process did not expose stdin/stdout.")
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        inbox: "queue.Queue[dict[str, Any]]" = queue.Queue()
+        stderr_tail: deque[str] = deque(maxlen=40)
+
+        log_file = self._open_stderr_log_file(proc.pid)
+
+        def _stdout_reader() -> None:
+            for line in proc.stdout:
+                try:
+                    inbox.put(json.loads(line))
+                except Exception:
+                    inbox.put({"raw": line.rstrip("\n")})
+
+        def _stderr_reader() -> None:
+            if proc.stderr is None:
+                return
+            try:
+                for line in proc.stderr:
+                    stripped = line.rstrip("\n")
+                    stderr_tail.append(stripped)
+                    if log_file is not None:
+                        try:
+                            log_file.write(line if line.endswith("\n") else line + "\n")
+                            log_file.flush()
+                        except OSError:
+                            pass
+            finally:
+                if log_file is not None:
+                    try:
+                        log_file.close()
+                    except OSError:
+                        pass
+
+        threading.Thread(target=_stdout_reader, daemon=True).start()
+        threading.Thread(target=_stderr_reader, daemon=True).start()
+        return proc, inbox, stderr_tail
+
+    # ------------------------------------------------------------------
+    # Stderr logging to disk
+    # ------------------------------------------------------------------
+
+    def _open_stderr_log_file(self, pid: int):
+        """Open a per-subprocess stderr log under ``<hermes_home>/logs/acp/``."""
+        try:
+            try:
+                from hermes_constants import get_hermes_home
+                home = Path(get_hermes_home())
+            except Exception:
+                home = Path.home() / ".hermes"
+            log_dir = home / "logs" / "acp"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            ts = time.strftime("%Y%m%d-%H%M%S")
+            provider = self._provider_label.replace("/", "_")
+            path = log_dir / f"{provider}-{pid}-{ts}.log"
+            self._stderr_log_path = path
+            return path.open("w", encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.debug("Unable to open ACP stderr log: %s", exc)
+            self._stderr_log_path = None
+            return None
+
+    # ------------------------------------------------------------------
+    # JSON-RPC request/response
+    # ------------------------------------------------------------------
+
+    def _next_id(self) -> int:
+        self._next_request_id += 1
+        return self._next_request_id
+
+    def _request(
+        self,
+        proc: subprocess.Popen[str],
+        inbox: "queue.Queue[dict[str, Any]]",
+        stderr_tail: deque[str],
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout_seconds: float | None = None,
+        dispatch_ctx: Optional[dict[str, Any]] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
+    ) -> Any:
+        """Send a JSON-RPC request and block for the matching response."""
+        timeout_seconds = (
+            timeout_seconds if timeout_seconds is not None else self._default_timeout_seconds
+        )
+        request_id = self._next_id()
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
+
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                break
+            if cancel_check is not None and cancel_check():
+                raise AcpCancelled(
+                    f"{self._provider_label} {method} cancelled by caller"
+                )
+            try:
+                msg = inbox.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            if self._handle_server_message(msg, process=proc, dispatch_ctx=dispatch_ctx or {}):
+                continue
+
+            if msg.get("id") != request_id:
+                continue
+            if "error" in msg:
+                err = msg.get("error") or {}
+                raise RuntimeError(
+                    f"{self._provider_label} {method} failed: {err.get('message') or err}"
+                )
+            return msg.get("result")
+
+        stderr_text = "\n".join(stderr_tail).strip()
+        if proc.poll() is not None and stderr_text:
+            log_hint = (
+                f"\nFull stderr: {self._stderr_log_path}"
+                if self._stderr_log_path is not None
+                else ""
+            )
+            raise RuntimeError(
+                f"{self._provider_label} process exited early: {stderr_text}{log_hint}"
+            )
+        raise TimeoutError(
+            f"Timed out waiting for {self._provider_label} response to {method}."
+        )
+
+    def _notify(
+        self,
+        proc: subprocess.Popen[str],
+        method: str,
+        params: dict[str, Any] | None = None,
+    ) -> None:
+        """Send a JSON-RPC notification (no response expected)."""
+        payload = {"jsonrpc": "2.0", "method": method, "params": params or {}}
+        try:
+            proc.stdin.write(json.dumps(payload) + "\n")
+            proc.stdin.flush()
+        except Exception:
+            logger.debug("Failed to write notification %s", method, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Server-initiated message dispatch
+    # ------------------------------------------------------------------
+
+    def _handle_server_message(
+        self,
+        msg: dict[str, Any],
+        *,
+        process: subprocess.Popen[str],
+        dispatch_ctx: dict[str, Any],
+    ) -> bool:
+        """Return True if this message was a server-initiated notification /
+        request and was handled here; False if it is a response the caller
+        must correlate by id."""
+        method = msg.get("method")
+        if not isinstance(method, str):
+            return False
+
+        if method == "session/update":
+            params = msg.get("params") or {}
+            update = params.get("update") or {}
+            self._handle_session_update(update, dispatch_ctx=dispatch_ctx, params=params)
+            return True
+
+        if process.stdin is None:
+            return True
+
+        message_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if method == "session/request_permission":
+            response = self._handle_permission_request(message_id, params)
+        elif method == "fs/read_text_file":
+            response = self._handle_fs_read(message_id, params)
+        elif method == "fs/write_text_file":
+            response = self._handle_fs_write(message_id, params)
+        else:
+            response = _jsonrpc_error(
+                message_id,
+                -32601,
+                f"ACP client method '{method}' is not supported by Hermes yet.",
+            )
+
+        try:
+            process.stdin.write(json.dumps(response) + "\n")
+            process.stdin.flush()
+        except Exception:
+            logger.debug("Failed to send response for %s", method, exc_info=True)
+        return True
+
+    # ------------------------------------------------------------------
+    # Default fs / permission handlers
+    # ------------------------------------------------------------------
+
+    def _handle_permission_request(self, message_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "result": {"outcome": {"outcome": "allow_once"}},
+        }
+
+    def _handle_fs_read(self, message_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+        try:
+            path = _ensure_path_within_cwd(str(params.get("path") or ""), self._acp_cwd)
+            block_error = get_read_block_error(str(path))
+            if block_error:
+                raise PermissionError(block_error)
+            content = path.read_text() if path.exists() else ""
+            line = params.get("line")
+            limit = params.get("limit")
+            if isinstance(line, int) and line > 1:
+                lines = content.splitlines(keepends=True)
+                start = line - 1
+                end = start + limit if isinstance(limit, int) and limit > 0 else None
+                content = "".join(lines[start:end])
+            return {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {"content": content},
+            }
+        except Exception as exc:
+            return _jsonrpc_error(message_id, -32602, str(exc))
+
+    def _handle_fs_write(self, message_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+        try:
+            path = _ensure_path_within_cwd(str(params.get("path") or ""), self._acp_cwd)
+            if is_write_denied(str(path)):
+                raise PermissionError(f"Write denied: '{path}' is protected by safety policy")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(str(params.get("content") or ""))
+            return {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": None,
+            }
+        except Exception as exc:
+            return _jsonrpc_error(message_id, -32602, str(exc))
+
+    # ------------------------------------------------------------------
+    # Initialize / session/new params
+    # ------------------------------------------------------------------
+
+    def _build_initialize_params(self) -> dict[str, Any]:
+        return {
+            "protocolVersion": 1,
+            "clientCapabilities": {
+                "fs": {"readTextFile": True, "writeTextFile": True},
+            },
+            "clientInfo": {
+                "name": self._client_name,
+                "title": "Hermes Agent",
+                "version": "0.0.0",
+            },
+        }
+
+    def _build_session_new_params(self) -> dict[str, Any]:
+        sandbox = self._ensure_sandbox()
+        mcp_servers = self._load_mcp_servers(sandbox)
+        params: dict[str, Any] = {
+            "cwd": str(sandbox),
+            "mcpServers": mcp_servers,
+        }
+        return params
+
+    # ------------------------------------------------------------------
+    # Sandbox + session lifecycle
+    # ------------------------------------------------------------------
+
+    def _resolve_hermes_home(self) -> Path:
+        if self._hermes_home is not None:
+            return self._hermes_home
+        try:
+            from hermes_constants import get_hermes_home
+
+            return get_hermes_home()
+        except Exception:
+            return Path.home() / ".hermes"
+
+    def _ensure_sandbox(self, *, model: str | None = None) -> Path:
+        if self._sandbox_path is not None:
+            return self._sandbox_path
+        from agent.claude_code_sandbox import build_session_sandbox
+
+        hermes_home = self._resolve_hermes_home()
+        self._sandbox_path = build_session_sandbox(
+            self._hermes_session_id,
+            self._agent,
+            hermes_home=hermes_home,
+            platform=self._platform,
+            available_tools=self._available_tools,
+            available_toolsets=self._available_toolsets,
+            model=model or self._pending_model,
+        )
+        # ACP subprocess must cd into the sandbox so .mcp.json and CLAUDE.md
+        # are picked up.
+        self._acp_cwd = str(self._sandbox_path)
+        return self._sandbox_path
+
+    def _load_mcp_servers(self, sandbox: Path) -> list[dict[str, Any]]:
+        """Translate the sandbox's .mcp.json into ACP's mcpServers array shape."""
+        mcp_path = sandbox / ".mcp.json"
+        if not mcp_path.exists():
+            return []
+        try:
+            cfg = json.loads(mcp_path.read_text(encoding="utf-8"))
+        except Exception:
+            return []
+        servers = cfg.get("mcpServers") or {}
+        out: list[dict[str, Any]] = []
+        for name, spec in servers.items():
+            if not isinstance(spec, dict):
+                continue
+            cmd = spec.get("command")
+            if not isinstance(cmd, str) or not cmd.strip():
+                continue
+            entry: dict[str, Any] = {
+                "name": name,
+                "command": cmd,
+                "args": list(spec.get("args") or []),
+            }
+            env = spec.get("env") or {}
+            if isinstance(env, dict) and env:
+                entry["env"] = [
+                    {"name": str(k), "value": str(v)}
+                    for k, v in env.items()
+                ]
+            out.append(entry)
+        return out
+
+    def _ensure_session(self) -> tuple[
+        subprocess.Popen[str],
+        "queue.Queue[dict[str, Any]]",
+        deque[str],
+        str,
+    ]:
+        with self._session_lock:
+            if (
+                self._session_proc is not None
+                and self._session_proc.poll() is None
+                and self._session_id is not None
+                and self._session_inbox is not None
+                and self._session_stderr is not None
+            ):
+                return (
+                    self._session_proc,
+                    self._session_inbox,
+                    self._session_stderr,
+                    self._session_id,
+                )
+
+            self._ensure_sandbox()
+            proc, inbox, stderr_tail = self._start_subprocess()
+            try:
+                self._request(
+                    proc, inbox, stderr_tail,
+                    "initialize", self._build_initialize_params(),
+                    timeout_seconds=self._default_timeout_seconds,
+                )
+                session = self._request(
+                    proc, inbox, stderr_tail,
+                    "session/new", self._build_session_new_params(),
+                    timeout_seconds=self._default_timeout_seconds,
+                ) or {}
+                session_id = str(session.get("sessionId") or "").strip()
+                if not session_id:
+                    raise RuntimeError(
+                        "claude-agent-acp did not return a sessionId from session/new."
+                    )
+                if self._pending_model:
+                    try:
+                        self._request(
+                            proc, inbox, stderr_tail,
+                            "session/set_config_option",
+                            {
+                                "sessionId": session_id,
+                                "configId": "model",
+                                "value": self._pending_model,
+                            },
+                            timeout_seconds=self._default_timeout_seconds,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to set model via session/set_config_option (%s: %r); "
+                            "falling back to user default",
+                            type(exc).__name__, exc,
+                        )
+            except Exception:
+                try:
+                    proc.terminate()
+                except Exception:
+                    pass
+                raise
+
+            self._session_proc = proc
+            self._session_inbox = inbox
+            self._session_stderr = stderr_tail
+            self._session_id = session_id
+            return proc, inbox, stderr_tail, session_id
+
+    # ------------------------------------------------------------------
+    # session/update routing (native tool events)
+    # ------------------------------------------------------------------
+
+    def _handle_session_update(
+        self,
+        update: dict[str, Any],
+        *,
+        dispatch_ctx: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> None:
+        ctx = dispatch_ctx or {}
+        kind = str(update.get("sessionUpdate") or "").strip()
+
+        if kind == "agent_message_chunk":
+            text = _extract_text_from_content_blocks(update.get("content"))
+            if text:
+                text_parts = ctx.get("text_parts")
+                if isinstance(text_parts, list):
+                    text_parts.append(text)
+                cb = self.stream_delta_callback
+                if callable(cb):
+                    try:
+                        cb(text)
+                    except Exception as exc:
+                        logger.debug("stream_delta_callback raised: %s", exc)
+            return
+
+        if kind == "agent_thought_chunk":
+            text = _extract_text_from_content_blocks(update.get("content"))
+            if text:
+                reasoning_parts = ctx.get("reasoning_parts")
+                if isinstance(reasoning_parts, list):
+                    reasoning_parts.append(text)
+                cb = self.thinking_callback
+                if callable(cb):
+                    try:
+                        cb(text)
+                    except Exception as exc:
+                        logger.debug("thinking_callback raised: %s", exc)
+            return
+
+        if kind == "tool_call_start":
+            self._handle_tool_call_start(update)
+            return
+
+        if kind == "tool_call_update":
+            self._handle_tool_call_update(update)
+            return
+
+        if kind == "plan":
+            self._handle_plan_update(update)
+            return
+
+        if kind == "available_commands_update":
+            return
+
+        logger.debug("Unhandled ACP session/update kind: %s", kind)
+
+    def _handle_tool_call_start(self, update: dict[str, Any]) -> None:
+        raw_input = update.get("rawInput")
+        if raw_input is None:
+            raw_input = update.get("input")
+        kind = update.get("kind")
+        tool_id_raw = str(update.get("toolCallId") or update.get("id") or "").strip()
+        name = str(update.get("title") or update.get("name") or "").strip() or "unknown_tool"
+
+        with self._trace_lock:
+            tool_id = tool_id_raw or f"tool-{len(self._tool_trace) + 1}"
+            record = ToolCallRecord(
+                tool_call_id=tool_id,
+                name=name,
+                raw_input=raw_input,
+                status="in_progress",
+                kind=str(kind) if kind else None,
+                title=update.get("title"),
+            )
+            self._tool_trace.append(record)
+            self._tool_records_by_id[tool_id] = record
+
+        cb = self.tool_progress_callback
+        if callable(cb):
+            preview = _short_preview(_coerce_str(raw_input))
+            try:
+                cb("tool.started", name, preview, raw_input)
+            except Exception as exc:
+                logger.debug("tool_progress_callback(started) raised: %s", exc)
+
+    def _handle_tool_call_update(self, update: dict[str, Any]) -> None:
+        tool_id = str(update.get("toolCallId") or update.get("id") or "").strip()
+        raw_output = update.get("rawOutput")
+        if raw_output is None:
+            raw_output = update.get("output")
+        if raw_output is None:
+            raw_output = _extract_text_from_content_blocks(update.get("content"))
+        status = update.get("status")
+        is_error_flag = bool(update.get("isError"))
+
+        with self._trace_lock:
+            record = self._tool_records_by_id.get(tool_id)
+            if record is None:
+                record = ToolCallRecord(
+                    tool_call_id=tool_id or f"tool-{len(self._tool_trace) + 1}",
+                    name=str(update.get("title") or "unknown_tool"),
+                    status="in_progress",
+                )
+                self._tool_trace.append(record)
+                if tool_id:
+                    self._tool_records_by_id[tool_id] = record
+
+            if raw_output:
+                if record.raw_output is None:
+                    record.raw_output = raw_output
+                elif isinstance(record.raw_output, str) and isinstance(raw_output, str):
+                    record.raw_output = record.raw_output + raw_output
+                else:
+                    record.raw_output = raw_output
+
+            if isinstance(status, str):
+                record.status = status
+
+            if is_error_flag:
+                record.is_error = True
+
+            is_terminal = (
+                record.status in {"completed", "failed", "cancelled", "success"}
+                or update.get("isComplete") is True
+                or update.get("complete") is True
+            )
+            if is_terminal:
+                record.completed_at = time.time()
+                cb_snapshot = (
+                    record.name,
+                    _short_preview(_coerce_str(record.raw_output)),
+                    record.raw_input,
+                    record.duration or 0.0,
+                    record.is_error,
+                )
+            else:
+                cb_snapshot = None
+
+        if cb_snapshot is not None:
+            cb = self.tool_progress_callback
+            if callable(cb):
+                name, preview, raw_input_val, duration, is_error_val = cb_snapshot
+                try:
+                    cb(
+                        "tool.completed",
+                        name,
+                        preview,
+                        raw_input_val,
+                        duration=duration,
+                        is_error=is_error_val,
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "tool_progress_callback(completed) raised: %s", exc
+                    )
+
+    def _handle_plan_update(self, update: dict[str, Any]) -> None:
+        cb = self.thinking_callback
+        if not callable(cb):
+            return
+        entries = update.get("entries") or update.get("plan") or []
+        if not isinstance(entries, list):
+            return
+        summary_parts: list[str] = []
+        for item in entries:
+            if isinstance(item, dict):
+                content = item.get("content") or item.get("text") or ""
+                if isinstance(content, str) and content.strip():
+                    summary_parts.append(content.strip())
+            elif isinstance(item, str) and item.strip():
+                summary_parts.append(item.strip())
+        if not summary_parts:
+            return
+        try:
+            cb("\U0001f4dd plan: " + "; ".join(summary_parts[:3]))
+        except Exception as exc:
+            logger.debug("thinking_callback(plan) raised: %s", exc)
+
+    # ------------------------------------------------------------------
+    # create() entrypoint
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_model_name(raw: str) -> str:
+        """Normalise Anthropic model names for Claude Code ACP.
+
+        Strips optional context-window suffixes like ``[1m]``, ``[200k]``
+        before alias resolution so that ``opus[1m]`` and ``sonnet[200k]``
+        are recognised as valid Claude Code model identifiers.
+        """
+        if not raw:
+            return raw
+        import re
+        lower = raw.lower()
+        # Strip optional context-window suffix, e.g. "opus[1m]" → "opus"
+        lower = re.sub(r"\[\w+\]$", "", lower)
+        if lower in ("haiku", "sonnet", "opus", "claude", "default"):
+            return lower
+        m = re.match(r"^claude-(haiku|sonnet|opus)(?:-\d+(?:-\d+)*)?$", lower)
+        if m:
+            return m.group(1)
+        return raw
+
+    def _is_valid_claude_alias(self, name: str) -> bool:
+        """Return True if *name* is a Claude Code-recognizable model identifier."""
+        normalized = self._normalize_model_name(name)
+        return normalized.lower() in ("haiku", "sonnet", "opus", "claude", "default")
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: Any = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        raw_model = model
+        model = self._normalize_model_name(model) if model else model
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            preamble=_CLAUDE_PREAMBLE,
+            model=model,
+            tools=None,
+            tool_choice=None,
+            tool_call_instructions=None,
+            closing=(
+                "Continue the conversation from the latest user request. "
+                "Use the hermes MCP tools natively."
+            ),
+        )
+        effective_timeout = resolve_effective_timeout(
+            timeout, default=self._default_timeout_seconds
+        )
+
+        if raw_model and self._is_valid_claude_alias(raw_model):
+            self._pending_model = raw_model
+
+        proc, inbox, stderr_tail, session_id = self._ensure_session()
+
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        with self._trace_lock:
+            pre_trace_len = len(self._tool_trace)
+
+        def _cancel_check() -> bool:
+            return bool(getattr(self._agent, "_interrupt_requested", False))
+
+        try:
+            result = self._request(
+                proc, inbox, stderr_tail,
+                "session/prompt",
+                {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": prompt_text}],
+                },
+                timeout_seconds=effective_timeout,
+                dispatch_ctx={
+                    "text_parts": text_parts,
+                    "reasoning_parts": reasoning_parts,
+                },
+                cancel_check=_cancel_check if self._agent is not None else None,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Claude Code ACP prompt failed (%s: %r); closing session",
+                type(exc).__name__,
+                exc,
+            )
+            self.close()
+            raise
+
+        response_text = "".join(text_parts).strip()
+        reasoning_text = "".join(reasoning_parts).strip()
+
+        if isinstance(result, dict):
+            tail = _extract_text_from_content_blocks(
+                result.get("content") or result.get("message")
+            )
+            if tail and tail not in response_text:
+                response_text = (response_text + "\n" + tail).strip() if response_text else tail
+
+        with self._trace_lock:
+            turn_trace_dicts = [r.to_dict() for r in self._tool_trace[pre_trace_len:]]
+
+        usage = self._extract_usage(result if isinstance(result, dict) else None)
+
+        assistant_message = SimpleNamespace(
+            content=response_text,
+            tool_calls=[],
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=assistant_message, finish_reason="stop")
+        response = SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "claude-code-acp",
+            hermes_tool_trace=turn_trace_dicts,
+        )
+        return response
+
+    def _extract_usage(self, result: Optional[dict[str, Any]]) -> Any:
+        """Best-effort extraction of token usage from a session/prompt result."""
+        prompt_tokens = 0
+        completion_tokens = 0
+        if isinstance(result, dict):
+            usage = result.get("usage") or {}
+            if isinstance(usage, dict):
+                prompt_tokens = int(
+                    usage.get("inputTokens")
+                    or usage.get("prompt_tokens")
+                    or 0
+                )
+                completion_tokens = int(
+                    usage.get("outputTokens")
+                    or usage.get("completion_tokens")
+                    or 0
+                )
+        return SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers exposed for tests / run_agent integration
+    # ------------------------------------------------------------------
+
+    @property
+    def tool_trace(self) -> list[ToolCallRecord]:
+        """Full list of tool records observed in this client's lifetime."""
+        with self._trace_lock:
+            return list(self._tool_trace)
+
+    def reset_tool_trace(self) -> None:
+        with self._trace_lock:
+            self._tool_trace.clear()
+            self._tool_records_by_id.clear()
+
+
+# ---------------------------------------------------------------------------
+# _ACPChatNamespace / _ACPChatCompletions — OpenAI-shaped .chat shim
+# ---------------------------------------------------------------------------
+
+class _ACPChatCompletions:
+    def __init__(self, client: "ClaudeCodeACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "ClaudeCodeACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+def trace_to_messages_snapshot(
+    trace: Iterable[Any],
+    *,
+    fallback_name: str = "claude_code_tool",
+) -> list[dict[str, Any]]:
+    """Reconstruct a hermes-shape ``messages_snapshot`` from a tool trace.
+
+    ``trace`` may be an iterable of :class:`ToolCallRecord` instances OR of
+    dict records (as produced by :attr:`ToolCallRecord.to_dict`) — both are
+    accepted so auto-skill-creation can consume the serialized form.
+    Each record becomes an ``assistant`` message containing a ``tool_use``
+    block, followed by a ``tool`` message with the ``tool_result`` block.
+    """
+    messages: list[dict[str, Any]] = []
+    for record in trace:
+        if hasattr(record, "to_dict"):
+            data = record.to_dict()
+        elif isinstance(record, dict):
+            data = record
+        else:
+            continue
+        call_id = str(data.get("id") or data.get("tool_call_id") or "").strip()
+        if not call_id:
+            call_id = f"tool-{len(messages) + 1}"
+        name = str(data.get("name") or fallback_name).strip() or fallback_name
+        raw_input = data.get("raw_input")
+        raw_output = data.get("raw_output")
+
+        messages.append(
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": call_id,
+                        "name": name,
+                        "input": raw_input if raw_input is not None else {},
+                    }
+                ],
+            }
+        )
+        messages.append(
+            {
+                "role": "tool",
+                "tool_use_id": call_id,
+                "content": _coerce_str(raw_output) if raw_output is not None else "",
+            }
+        )
+    return messages

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -479,17 +479,23 @@ class ClaudeCodeACPClient:
         self.api_key = api_key or self._provider_label
         self.base_url = base_url or self._marker_base_url
         self._default_headers = dict(default_headers or {})
-        # Fixed subprocess launch argv — always npx + npm package, never user-configurable.
-        # The acp_command parameter passed by delegate_task is a routing placeholder
-        # (e.g. "claude-code-acp") to distinguish Claude vs Copilot providers — it is
-        # NOT used for subprocess argv. The real launch command comes from
-        # _resolve_command() (env var / default "npx"); the launch args come from
-        # _resolve_args() (env var / default ["-y", "<npm package>"]).
+        # Subprocess launch argv (consumed by subprocess.Popen at L602):
+        # [_launch_command] + _launch_args, resolved from _resolve_command()
+        # (env / "npx") and _resolve_args() (env / ["-y", "<npm>"]). Not
+        # influenced by any __init__ kwarg.
+        #
+        # Routing placeholders (NOT argv): acp_command / command are
+        # caller-compat kwargs — delegate_task passes e.g. "claude-code-acp"
+        # to pick Claude vs Copilot provider. Never read by this class.
+        # Kept to avoid breaking the delegate_task routing layer.
+        # See B4/B5 review (2026-06-16).
+        #
+        # Runtime ACP config directives (NOT argv): acp_args / args carry
+        # --model, --effort, --permission-mode, etc. Scanned by
+        # _apply_acp_arg_directives() (L1285) into _pending_session_configs,
+        # flushed via session/set_config_option after session/new.
         self._launch_command = self._resolve_command()
         self._launch_args = self._resolve_args()
-        # Runtime ACP config directives (--model, --effort, --permission-mode).
-        # Parsed by _apply_acp_arg_directives() into _pending_session_configs,
-        # flushed to session/set_config_option after session/new.
         self._acp_args = list(acp_args or args or [])
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -37,6 +37,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Iterable, Iterator, List, Optional
 
 from agent.file_safety import get_read_block_error, is_write_denied
+from gateway.session_context import get_session_env
 
 logger = logging.getLogger(__name__)
 
@@ -444,7 +445,7 @@ class ClaudeCodeACPClient:
         self._hermes_home = Path(hermes_home) if hermes_home else None
         self._hermes_session_id = (
             hermes_session_id
-            or os.environ.get("HERMES_SESSION_ID", "").strip()
+            or get_session_env("HERMES_SESSION_ID", "").strip()
             or f"hermes-{int(time.time())}"
         )
         self._platform = platform or os.environ.get("HERMES_SESSION_PLATFORM") or None
@@ -1149,15 +1150,28 @@ class ClaudeCodeACPClient:
         lower = re.sub(r"\[\w+\]$", "", lower)
         if lower in ("haiku", "sonnet", "opus", "claude", "default"):
             return lower
-        m = re.match(r"^claude-(haiku|sonnet|opus)(?:-\d+(?:-\d+)*)?$", lower)
-        if m:
-            return m.group(1)
+        # Full names like "claude-opus-4-7" are passed through verbatim — the
+        # subprocess's session/set_config_option will receive the full string,
+        # and the alias validator below checks the same regex.
+        if re.match(r"^claude-(haiku|sonnet|opus)(?:-\d+(?:-\d+)*)?$", lower):
+            return lower
         return raw
 
     def _is_valid_claude_alias(self, name: str) -> bool:
-        """Return True if *name* is a Claude Code-recognizable model identifier."""
+        """Return True if *name* is a Claude Code-recognizable model identifier.
+
+        Accepts both short aliases (opus/sonnet/haiku) and full names
+        (claude-opus-4-7, claude-sonnet-4-6, etc.) so that callers can pin
+        a specific Claude Code version without losing the per-session
+        ``set_config_option`` call that isolates parallel subagents.
+        """
         normalized = self._normalize_model_name(name)
-        return normalized.lower() in ("haiku", "sonnet", "opus", "claude", "default")
+        if normalized in ("haiku", "sonnet", "opus", "claude", "default"):
+            return True
+        import re
+        if re.match(r"^claude-(haiku|sonnet|opus)(?:-\d+(?:-\d+)*)?$", normalized):
+            return True
+        return False
 
     def _create_chat_completion(
         self,

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -34,7 +34,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, ClassVar, Iterable, Iterator, List, Optional
+from typing import Any, Callable, ClassVar, Iterator, List, Optional
 
 from agent.file_safety import get_read_block_error, is_write_denied
 from gateway.session_context import get_session_env
@@ -1493,54 +1493,3 @@ class _ACPChatCompletions:
 class _ACPChatNamespace:
     def __init__(self, client: "ClaudeCodeACPClient"):
         self.completions = _ACPChatCompletions(client)
-
-
-def trace_to_messages_snapshot(
-    trace: Iterable[Any],
-    *,
-    fallback_name: str = "claude_code_tool",
-) -> list[dict[str, Any]]:
-    """Reconstruct a hermes-shape ``messages_snapshot`` from a tool trace.
-
-    ``trace`` may be an iterable of :class:`ToolCallRecord` instances OR of
-    dict records (as produced by :attr:`ToolCallRecord.to_dict`) — both are
-    accepted so auto-skill-creation can consume the serialized form.
-    Each record becomes an ``assistant`` message containing a ``tool_use``
-    block, followed by a ``tool`` message with the ``tool_result`` block.
-    """
-    messages: list[dict[str, Any]] = []
-    for record in trace:
-        if hasattr(record, "to_dict"):
-            data = record.to_dict()
-        elif isinstance(record, dict):
-            data = record
-        else:
-            continue
-        call_id = str(data.get("id") or data.get("tool_call_id") or "").strip()
-        if not call_id:
-            call_id = f"tool-{len(messages) + 1}"
-        name = str(data.get("name") or fallback_name).strip() or fallback_name
-        raw_input = data.get("raw_input")
-        raw_output = data.get("raw_output")
-
-        messages.append(
-            {
-                "role": "assistant",
-                "content": [
-                    {
-                        "type": "tool_use",
-                        "id": call_id,
-                        "name": name,
-                        "input": raw_input if raw_input is not None else {},
-                    }
-                ],
-            }
-        )
-        messages.append(
-            {
-                "role": "tool",
-                "tool_use_id": call_id,
-                "content": _coerce_str(raw_output) if raw_output is not None else "",
-            }
-        )
-    return messages

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -403,8 +403,10 @@ class ClaudeCodeACPClient:
     * ``--effort <level>`` — set reasoning effort (default/low/medium/high/
       xhigh/max)
 
-    Unrecognised flags are left in ``acp_args`` and passed through to the
-    ACP subprocess (which silently ignores unknown CLI arguments).
+    Unrecognised flags in ``acp_args`` are dropped — they are NOT passed
+    to the subprocess. The subprocess argv is the fixed
+    ``_launch_command + _launch_args`` from ``_resolve_command()`` /
+    ``_resolve_args()`` (default: ``npx -y @agentclientprotocol/claude-agent-acp``).
     """
 
     _provider_label = "claude-code-acp"
@@ -478,11 +480,18 @@ class ClaudeCodeACPClient:
         self.api_key = api_key or self._provider_label
         self.base_url = base_url or self._marker_base_url
         self._default_headers = dict(default_headers or {})
-        # acp_command is a routing placeholder (e.g. "claude-code-acp") set by delegate_task
-        # to distinguish Claude vs Copilot providers — it is NOT used for subprocess argv.
-        # The real subprocess command comes from _resolve_command() (env var / default "npx").
-        self._acp_command = self._resolve_command()
-        self._acp_args = list(acp_args or args or self._resolve_args())
+        # Fixed subprocess launch argv — always npx + npm package, never user-configurable.
+        # The acp_command parameter passed by delegate_task is a routing placeholder
+        # (e.g. "claude-code-acp") to distinguish Claude vs Copilot providers — it is
+        # NOT used for subprocess argv. The real launch command comes from
+        # _resolve_command() (env var / default "npx"); the launch args come from
+        # _resolve_args() (env var / default ["-y", "<npm package>"]).
+        self._launch_command = self._resolve_command()
+        self._launch_args = self._resolve_args()
+        # Runtime ACP config directives (--model, --effort, --permission-mode).
+        # Parsed by _apply_acp_arg_directives() into _pending_session_configs,
+        # flushed to session/set_config_option after session/new.
+        self._acp_args = list(acp_args or args or [])
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
@@ -516,11 +525,13 @@ class ClaudeCodeACPClient:
         self._pending_model: str | None = None
         self._pending_session_configs: dict[str, str] = {}
 
-        # Scan acp_args for recognized directive flags (--model, --permission-mode,
-        # --effort) and queue them into _pending_session_configs.  These are
-        # flushed via session/set_config_option after session/new in
-        # _ensure_session().  Unrecognised flags remain in acp_args and are
-        # passed to the subprocess (which silently ignores them).
+        # Scan _acp_args (runtime directives from caller) for recognized
+        # flags (--model, --permission-mode, --effort) and queue them into
+        # _pending_session_configs. These are flushed via
+        # session/set_config_option after session/new in _ensure_session().
+        # Unrecognised flags are dropped — they are NOT passed to the subprocess
+        # (the subprocess argv is the fixed _launch_command + _launch_args
+        # from _resolve_command() / _resolve_args()).
         self._apply_acp_arg_directives()
 
         self._trace_lock = threading.Lock()
@@ -579,7 +590,7 @@ class ClaudeCodeACPClient:
         """
         try:
             proc = subprocess.Popen(
-                [self._acp_command] + self._acp_args,
+                [self._launch_command] + self._launch_args,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -590,7 +601,7 @@ class ClaudeCodeACPClient:
         except FileNotFoundError as exc:
             envs = "/".join(self._env_command_vars) if self._env_command_vars else "the launcher path"
             raise RuntimeError(
-                f"Could not start {self._provider_label} command '{self._acp_command}'. "
+                f"Could not start {self._provider_label} command '{self._launch_command}'. "
                 f"Install it or set {envs}."
             ) from exc
 
@@ -1252,8 +1263,8 @@ class ClaudeCodeACPClient:
 
         Each matched flag is queued into ``_pending_session_configs`` (for
         ``session_config`` channel directives).  Unrecognised flags are
-        left in ``self._acp_args`` — the ACP subprocess silently ignores
-        unknown CLI arguments.
+        dropped — they are NOT passed to the ACP subprocess (the subprocess
+        argv is the fixed ``_launch_command + _launch_args``).
 
         Only the first occurrence of each non-repeatable flag is honoured.
         """

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -478,7 +478,10 @@ class ClaudeCodeACPClient:
         self.api_key = api_key or self._provider_label
         self.base_url = base_url or self._marker_base_url
         self._default_headers = dict(default_headers or {})
-        self._acp_command = acp_command or command or self._resolve_command()
+        # acp_command is a routing placeholder (e.g. "claude-code-acp") set by delegate_task
+        # to distinguish Claude vs Copilot providers — it is NOT used for subprocess argv.
+        # The real subprocess command comes from _resolve_command() (env var / default "npx").
+        self._acp_command = self._resolve_command()
         self._acp_args = list(acp_args or args or self._resolve_args())
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -421,9 +421,8 @@ class ClaudeCodeACPClient:
     # Declarative dispatch table: maps recognized CLI flags from acp_args
     # to their ACP session config actions. Each entry defines:
     #   flag: the CLI flag to match (e.g. "--model")
-    #   channel: "session_config" (via session/set_config_option) or "init"
+    #   channel: "session_config" (via session/set_config_option)
     #   config_id: the ACP configId for session_config channel entries
-    #   attr: the instance attribute to set for init channel entries
     #   takes_value: True if the flag consumes the next token as its value
     #   validate: optional method name (str) for value validation; None = trust caller
     #   repeatable: if False, only the first occurrence is honoured
@@ -1326,9 +1325,6 @@ class ClaudeCodeACPClient:
             if channel == "session_config":
                 config_id = directive["config_id"]
                 self._pending_session_configs[config_id] = value
-            elif channel == "init":
-                attr = directive["attr"]
-                setattr(self, attr, value)
 
             i += (2 if directive["takes_value"] else 1)
 

--- a/agent/claude_code_sandbox.py
+++ b/agent/claude_code_sandbox.py
@@ -1,0 +1,718 @@
+"""Build per-session Claude Code sandboxes.
+
+Each hermes session that uses the ``claude-code-acp`` provider needs a
+self-contained cwd that Claude Code will read as its workspace. The sandbox
+contains:
+
+* ``CLAUDE.md`` — preamble + SOUL.md (agent identity) + memory context +
+  toolbelt hint + platform context. Tool names referenced inline are
+  rewritten to their MCP form (``mcp__hermes_tools__<name>``) so Claude
+  Code can locate them on the bus.
+* ``.claude/skills/<skill_name>/SKILL.md`` — one flattened directory per
+  filtered hermes skill. Anthropic's skill convention is flat (one level
+  under ``.claude/skills/``), so nested hermes skills are promoted by
+  their frontmatter ``name:``.
+* ``.mcp.json`` — mcpServers config pointing at ``hermes mcp tools-serve``
+  (the hermes tool registry) and ``hermes mcp serve`` (messaging bridge).
+
+The sandbox is idempotent: a manifest (``.hermes-sandbox.json``) caches
+inputs' mtimes + sizes so unchanged sandboxes skip rebuild.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+RUNTIME_SUBDIR = Path("runtime") / "claude-code"
+SANDBOX_MANIFEST = ".hermes-sandbox.json"
+DEFAULT_SANDBOX_MAX_AGE_DAYS = 7
+
+_CLAUDE_MCP_TOOL_PREFIX = "mcp__hermes_tools__"
+
+# Shared source of truth: the per-prompt client and the persistent CLAUDE.md
+# sandbox both need to tell Claude Code the same things (how replies reach
+# the user, where tools are, skill conventions, etc.). Keep that content in
+# one place in :mod:`agent.claude_code_acp_client` and join it here.
+from agent.claude_code_acp_client import CLAUDE_SYSTEM_PREAMBLE_LINES as _SHARED_PREAMBLE_LINES
+
+_PREAMBLE = "\n\n".join(_SHARED_PREAMBLE_LINES)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def sandbox_root(hermes_home: Path) -> Path:
+    """Return the base directory under which per-session sandboxes live."""
+    return hermes_home / RUNTIME_SUBDIR
+
+
+def session_sandbox_path(session_id: str, *, hermes_home: Path) -> Path:
+    """Return the sandbox directory for a given session (may not exist yet)."""
+    if not session_id or "/" in session_id or ".." in session_id:
+        raise ValueError(f"Invalid session_id for sandbox: {session_id!r}")
+    return sandbox_root(hermes_home) / session_id
+
+
+def _manifest_is_current(manifest_path: Path, digest: str, sandbox: Path) -> bool:
+    """Return True if the on-disk manifest matches *digest* and CLAUDE.md exists.
+
+    Returns False (forcing a rebuild) on: missing manifest, unreadable manifest,
+    digest mismatch, or missing CLAUDE.md. Narrow-except rather than blanket
+    ``except Exception`` so a real bug (e.g. AttributeError from a stubbed
+    filesystem) isn't silently swallowed.
+    """
+    try:
+        prior = json.loads(manifest_path.read_text())
+    except FileNotFoundError:
+        logger.debug("Sandbox manifest %s missing (first build)", manifest_path)
+        return False
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.debug(
+            "Sandbox manifest %s unreadable (%s: %s); rebuilding",
+            manifest_path,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    return bool(
+        prior.get("digest") == digest and (sandbox / "CLAUDE.md").exists()
+    )
+
+
+def _write_settings_local(sandbox: Path, *, model: Optional[str] = None) -> None:
+    """Pin sandbox-level settings that the ACP adapter must accept.
+
+    Specifically: a valid ``permissions.defaultMode``. If the user's
+    ``~/.claude/settings.json`` has an invalid value, Claude Code rejects
+    ``session/new``. Sandbox-local settings take precedence over user
+    settings in the ACP settings merge, so this unblocks boot unconditionally.
+
+    Model is NOT written here — it is set via ``session/set_config_option``
+    after ``session/new`` so that parallel subagents with different models
+    don't overwrite each other through a shared sandbox file.
+    """
+    settings_local: Dict[str, Any] = {
+        "permissions": {"defaultMode": "bypassPermissions"},
+    }
+    (sandbox / ".claude" / "settings.local.json").write_text(
+        json.dumps(settings_local, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _write_mcp_json(
+    sandbox: Path,
+    *,
+    session_id: str,
+    hermes_home: Path,
+    platform: Optional[str],
+) -> None:
+    """Materialize ``.mcp.json`` pointing Claude Code at hermes's MCP servers."""
+    (sandbox / ".mcp.json").write_text(
+        json.dumps(
+            _build_mcp_config(
+                session_id=session_id, hermes_home=hermes_home, platform=platform
+            ),
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_sandbox_manifest(
+    manifest_path: Path,
+    *,
+    digest: str,
+    session_id: str,
+    skill_count: int,
+) -> None:
+    """Stamp the manifest so the next invocation can short-circuit on cache hit."""
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "digest": digest,
+                "generated_at": time.time(),
+                "session_id": session_id,
+                "skill_count": skill_count,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def build_session_sandbox(
+    session_id: str,
+    agent: Any,
+    *,
+    hermes_home: Path,
+    platform: Optional[str] = None,
+    available_tools: Optional[set[str]] = None,
+    available_toolsets: Optional[set[str]] = None,
+    model: Optional[str] = None,
+) -> Path:
+    """Build (or rebuild if stale) a Claude Code sandbox for *session_id*.
+
+    Orchestrates the four sandbox stages: manifest cache check, CLAUDE.md
+    composition + skill flatten, MCP pointer, manifest stamp. Returns the
+    absolute path to the sandbox cwd.
+    """
+    sandbox = session_sandbox_path(session_id, hermes_home=hermes_home)
+    sandbox.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = sandbox / SANDBOX_MANIFEST
+    # The digest covers every input that should invalidate the cache —
+    # SOUL.md mtime, memory snippets, enabled skills, platform, model. Any
+    # input change here produces a new digest, forcing a rebuild on next
+    # call. See :func:`_collect_manifest_inputs`.
+    inputs = _collect_manifest_inputs(
+        hermes_home=hermes_home, platform=platform, model=model,
+    )
+    digest = _hash_inputs(inputs)
+    if _manifest_is_current(manifest_path, digest, sandbox):
+        logger.debug("Sandbox %s is up-to-date; skipping rebuild", sandbox)
+        return sandbox
+
+    # Fresh build — nuke any pre-existing skills dir (files from prior layout
+    # could otherwise accrete). Keep CLAUDE.md / .mcp.json for simpler diffs.
+    skills_out = sandbox / ".claude" / "skills"
+    if skills_out.exists():
+        shutil.rmtree(skills_out, ignore_errors=True)
+    skills_out.mkdir(parents=True, exist_ok=True)
+
+    tool_names = _resolve_tool_names()
+    toolbelt_hint = _build_toolbelt_hint(tool_names)
+
+    memory_block = _build_memory_block(agent)
+    soul_text = _load_soul(hermes_home)
+    platform_block = _build_platform_block(platform)
+
+    claude_md = _compose_claude_md(
+        soul_text=soul_text,
+        memory_block=memory_block,
+        toolbelt_hint=toolbelt_hint,
+        platform_block=platform_block,
+        tool_names=tool_names,
+    )
+    (sandbox / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+
+    _write_settings_local(sandbox, model=model)
+
+    flattened = _flatten_skills_into(
+        hermes_home=hermes_home,
+        target=skills_out,
+        available_tools=available_tools,
+        available_toolsets=available_toolsets,
+    )
+
+    _write_mcp_json(
+        sandbox,
+        session_id=session_id,
+        hermes_home=hermes_home,
+        platform=platform,
+    )
+
+    _write_sandbox_manifest(
+        manifest_path,
+        digest=digest,
+        session_id=session_id,
+        skill_count=flattened,
+    )
+    logger.info(
+        "Built Claude Code sandbox %s (%d skills, %d tools)",
+        sandbox, flattened, len(tool_names),
+    )
+    return sandbox
+
+
+def cleanup_session_sandbox(session_id: str, *, hermes_home: Path) -> bool:
+    """Remove the sandbox directory for *session_id*. Returns True if removed."""
+    try:
+        sandbox = session_sandbox_path(session_id, hermes_home=hermes_home)
+    except ValueError:
+        return False
+    if not sandbox.exists():
+        return False
+    shutil.rmtree(sandbox, ignore_errors=True)
+    return True
+
+
+def cleanup_stale_sandboxes(
+    *, hermes_home: Path, max_age_days: int = DEFAULT_SANDBOX_MAX_AGE_DAYS
+) -> int:
+    """Remove sandboxes older than *max_age_days*. Returns count removed."""
+    root = sandbox_root(hermes_home)
+    if not root.exists():
+        return 0
+    cutoff = time.time() - max_age_days * 86400
+    removed = 0
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        try:
+            manifest = child / SANDBOX_MANIFEST
+            if manifest.exists():
+                mtime = manifest.stat().st_mtime
+            else:
+                mtime = child.stat().st_mtime
+        except Exception:
+            continue
+        if mtime < cutoff:
+            shutil.rmtree(child, ignore_errors=True)
+            removed += 1
+    return removed
+
+
+DEFAULT_ACP_LOG_MAX_AGE_DAYS = 7
+
+
+def cleanup_stale_acp_logs(
+    *, hermes_home: Path, max_age_days: int = DEFAULT_ACP_LOG_MAX_AGE_DAYS
+) -> int:
+    """Delete ACP stderr logs older than *max_age_days*. Returns count removed.
+
+    Logs are written by :meth:`ClaudeCodeACPClient._open_stderr_log_file` into
+    ``<hermes_home>/logs/acp/``. They're useful for post-mortem diagnosis
+    of subprocess crashes, but accumulate one file per ACP session —
+    without pruning, a heavy user piles up thousands in a month.
+    """
+    log_dir = Path(hermes_home) / "logs" / "acp"
+    if not log_dir.exists():
+        return 0
+    cutoff = time.time() - max_age_days * 86400
+    removed = 0
+    for child in log_dir.iterdir():
+        if not child.is_file():
+            continue
+        try:
+            if child.stat().st_mtime < cutoff:
+                child.unlink()
+                removed += 1
+        except OSError:
+            continue
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md composition
+# ---------------------------------------------------------------------------
+
+
+def _compose_claude_md(
+    *,
+    soul_text: Optional[str],
+    memory_block: Optional[str],
+    toolbelt_hint: str,
+    platform_block: Optional[str],
+    tool_names: List[str],
+) -> str:
+    parts: List[str] = [_PREAMBLE.strip()]
+    if soul_text:
+        parts.append("## Agent identity (SOUL.md)\n\n" + _rewrite_tool_names(soul_text, tool_names))
+    if memory_block:
+        parts.append(memory_block)
+    parts.append(toolbelt_hint)
+    if platform_block:
+        parts.append(platform_block)
+    return "\n\n".join(p.strip() for p in parts if p and p.strip()) + "\n"
+
+
+def _rewrite_tool_names(text: str, tool_names: List[str]) -> str:
+    """Prefix bare hermes tool names with ``mcp__hermes_tools__`` in *text*.
+
+    Double-prefix guard: SOUL.md may reference tools either as bare names
+    (``Store``) or as already-prefixed MCP identifiers
+    (``mcp__hermes_tools__Store``). The lookbehind inside the substituter
+    skips the latter so we never produce
+    ``mcp__hermes_tools__mcp__hermes_tools__Store``. Removing this check
+    breaks Claude Code silently: the double-prefixed name is valid syntax
+    but refers to no registered tool, so the agent fails with "tool not
+    found" after a full turn of confused retries. Keep the guard.
+    """
+    if not text or not tool_names:
+        return text
+    # Sort longest-first so overlapping names don't shadow each other.
+    names = sorted((n for n in tool_names if n and n.isidentifier()), key=len, reverse=True)
+    if not names:
+        return text
+    pattern = re.compile(r"(?<![A-Za-z0-9_])(" + "|".join(re.escape(n) for n in names) + r")(?![A-Za-z0-9_])")
+    def _sub(match: re.Match) -> str:
+        name = match.group(1)
+        # Skip if already prefixed — see docstring for why this matters.
+        start = match.start()
+        if start >= len(_CLAUDE_MCP_TOOL_PREFIX) and text[start - len(_CLAUDE_MCP_TOOL_PREFIX):start] == _CLAUDE_MCP_TOOL_PREFIX:
+            return name
+        return _CLAUDE_MCP_TOOL_PREFIX + name
+    return pattern.sub(_sub, text)
+
+
+def _build_toolbelt_hint(tool_names: List[str]) -> str:
+    if not tool_names:
+        return "## Tools\n\nNo hermes tools are currently available."
+    lines = ["## Hermes toolbelt"]
+    lines.append(
+        "The following hermes tools are available via the `hermes_tools` MCP"
+        " server. Call them using the `mcp__hermes_tools__<name>` prefix."
+    )
+    for name in tool_names:
+        try:
+            from tools.registry import registry
+
+            entry = registry.get_entry(name)
+            desc = ""
+            if entry:
+                desc = (entry.description or entry.schema.get("description", "")).strip().splitlines()
+                desc = desc[0] if desc else ""
+            if desc:
+                lines.append(f"- `{_CLAUDE_MCP_TOOL_PREFIX}{name}` — {desc[:120]}")
+            else:
+                lines.append(f"- `{_CLAUDE_MCP_TOOL_PREFIX}{name}`")
+        except Exception:
+            lines.append(f"- `{_CLAUDE_MCP_TOOL_PREFIX}{name}`")
+    return "\n".join(lines)
+
+
+def _build_memory_block(agent: Any) -> Optional[str]:
+    """Build the memory-context block via the same code path the AIAgent uses."""
+    try:
+        from agent.memory_manager import build_memory_context_block
+    except Exception:
+        return None
+    raw = _collect_raw_memory(agent)
+    if not raw:
+        return None
+    return build_memory_context_block(raw)
+
+
+def _collect_raw_memory(agent: Any) -> str:
+    """Concatenate whatever memory the agent's memory manager has loaded.
+
+    Prefer the manager bound to the live AIAgent. Fall back to reading the
+    on-disk memory dir directly so the sandbox works even when the agent
+    object is a stub or is still in construction.
+
+    Probe order (``fetch_all`` → ``get_all_snippets`` → ``build_context`` →
+    disk) exists because *agent* is duck-typed. Call sites vary: the
+    live ``AIAgent`` has ``fetch_all`` on a full ``MemoryManager``; gateway-
+    side shims expose ``get_all_snippets``; some test doubles only implement
+    ``build_context``; the sandbox path also fires from contexts where no
+    manager is plumbed in at all (auxiliary_client construction, headless
+    bootstrapping) — hence the disk fallback. Each method is tried in
+    isolation and skipped on failure, because losing memory silently is
+    preferable to failing the sandbox build.
+    """
+    # Try agent-bound manager
+    mgr = getattr(agent, "memory_manager", None) if agent is not None else None
+    if mgr is not None:
+        for attr in ("fetch_all", "get_all_snippets", "build_context"):
+            fn = getattr(mgr, attr, None)
+            if callable(fn):
+                try:
+                    got = fn()
+                    if isinstance(got, str) and got.strip():
+                        return got
+                    if isinstance(got, (list, tuple)):
+                        joined = "\n\n".join(str(x) for x in got if x)
+                        if joined.strip():
+                            return joined
+                except Exception as exc:
+                    logger.debug("Memory fetch via %s failed: %s", attr, exc)
+
+    # Fallback: read ~/.hermes/memories/*.md
+    try:
+        from hermes_constants import get_hermes_home
+
+        mem_dir = get_hermes_home() / "memories"
+    except Exception:
+        return ""
+    if not mem_dir.exists():
+        return ""
+    parts: List[str] = []
+    for p in sorted(mem_dir.glob("*.md")):
+        try:
+            text = p.read_text(encoding="utf-8").strip()
+            if text:
+                parts.append(f"# {p.stem}\n{text}")
+        except Exception:
+            continue
+    return "\n\n".join(parts)
+
+
+def _build_platform_block(platform: Optional[str]) -> Optional[str]:
+    plat = (platform or os.environ.get("HERMES_SESSION_PLATFORM") or "").strip()
+    if not plat:
+        return None
+    user = (
+        os.environ.get("HERMES_SESSION_USER")
+        or os.environ.get("HERMES_SESSION_DISPLAY_NAME")
+        or ""
+    ).strip()
+    chat = os.environ.get("HERMES_SESSION_CHAT", "").strip()
+    lines = [f"## Platform context", f"Active platform: `{plat}`"]
+    if user:
+        lines.append(f"User display name: {user}")
+    if chat:
+        lines.append(f"Channel: {chat}")
+    return "\n".join(lines)
+
+
+def _load_soul(hermes_home: Path) -> Optional[str]:
+    path = hermes_home / "SOUL.md"
+    if not path.exists():
+        return None
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+        return content or None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Skills flattening
+# ---------------------------------------------------------------------------
+
+
+def _skill_is_enabled(
+    skill_file: Path,
+    *,
+    disabled_names: set[str],
+    available_tools: Optional[set[str]],
+    available_toolsets: Optional[set[str]],
+    skill_matches_platform,
+    parse_frontmatter,
+    skill_should_show,
+) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Return ``(frontmatter_name, frontmatter_dict)`` if the skill is enabled.
+
+    Applies the same four gates the prompt-builder path uses:
+    platform match, disabled-list, condition filter, and readability. Any
+    gate failing returns ``None`` so the caller skips the skill.
+    """
+    try:
+        content = skill_file.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    frontmatter, _body = parse_frontmatter(content)
+    if not skill_matches_platform(frontmatter):
+        return None
+    frontmatter_name = str(frontmatter.get("name") or skill_file.parent.name).strip()
+    dir_name = skill_file.parent.name
+    if frontmatter_name in disabled_names or dir_name in disabled_names:
+        return None
+    try:
+        conds = _extract_skill_conditions(frontmatter)
+        if not skill_should_show(conds, available_tools, available_toolsets):
+            return None
+    except Exception:
+        # Filters that raise should not block sandbox construction — fall
+        # through to "include" so a broken condition doesn't hide a skill.
+        pass
+    return frontmatter_name or dir_name, frontmatter
+
+
+def _unique_slug(
+    base_name: str, source: Path, seen: Dict[str, Path]
+) -> str:
+    """Slugify *base_name* and append a 6-char SHA1 suffix on collision.
+
+    The 6-char suffix is a pragmatic tradeoff: collision probability is
+    negligible at realistic skill counts (<100), directory names stay
+    human-readable, and a re-collision on the same source path is harmless
+    (we overwrite with identical content, so the result is stable).
+    """
+    slug = _sanitize_skill_slug(base_name)
+    if slug in seen and seen[slug] != source:
+        suffix = hashlib.sha1(str(source).encode("utf-8")).hexdigest()[:6]
+        slug = f"{slug}-{suffix}"
+    return slug
+
+
+def _flatten_skills_into(
+    *,
+    hermes_home: Path,
+    target: Path,
+    available_tools: Optional[set[str]],
+    available_toolsets: Optional[set[str]],
+) -> int:
+    """Copy each enabled hermes skill into ``<target>/<skill_name>/`` flat.
+
+    Anthropic's skill convention is flat (one level under
+    ``.claude/skills/``); hermes skills can nest. For each enabled skill,
+    we slug its frontmatter name and copy the source directory. Returns
+    the number of skills copied.
+    """
+    try:
+        from agent.skill_utils import (
+            iter_skill_index_files,
+            parse_frontmatter,
+            skill_matches_platform,
+            get_disabled_skill_names,
+        )
+        from agent.prompt_builder import _skill_should_show  # noqa: WPS437
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("skill utilities unavailable: %s", exc)
+        return 0
+
+    skills_dir = hermes_home / "skills"
+    if not skills_dir.exists():
+        return 0
+
+    disabled = get_disabled_skill_names()
+    seen_names: Dict[str, Path] = {}
+    copied = 0
+
+    for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
+        enabled = _skill_is_enabled(
+            skill_file,
+            disabled_names=disabled,
+            available_tools=available_tools,
+            available_toolsets=available_toolsets,
+            skill_matches_platform=skill_matches_platform,
+            parse_frontmatter=parse_frontmatter,
+            skill_should_show=_skill_should_show,
+        )
+        if enabled is None:
+            continue
+        base_name, _frontmatter = enabled
+
+        slug = _unique_slug(base_name, skill_file.parent, seen_names)
+        dest = target / slug
+        src = skill_file.parent
+        try:
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(src, dest, symlinks=False, dirs_exist_ok=True)
+        except (OSError, shutil.Error) as exc:
+            logger.debug("Failed to copy skill %s → %s: %s", src, dest, exc)
+            continue
+        seen_names[slug] = src
+        copied += 1
+
+    return copied
+
+
+def _extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
+    """Mirror ``prompt_builder.extract_skill_conditions`` shape."""
+    try:
+        from agent.prompt_builder import extract_skill_conditions  # type: ignore
+
+        return extract_skill_conditions(frontmatter)
+    except Exception:
+        return {}
+
+
+def _sanitize_skill_slug(name: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", name or "skill").strip("-")
+    return slug or "skill"
+
+
+# ---------------------------------------------------------------------------
+# .mcp.json construction
+# ---------------------------------------------------------------------------
+
+
+def _build_mcp_config(
+    *, session_id: str, hermes_home: Path, platform: Optional[str]
+) -> Dict[str, Any]:
+    base_env = {
+        "HERMES_HOME": str(hermes_home),
+        "HERMES_SESSION_ID": session_id,
+    }
+    if platform:
+        base_env["HERMES_SESSION_PLATFORM"] = platform
+
+    hermes_tools_env = {**base_env, "HERMES_MCP_AUTO_APPROVE": "1"}
+
+    return {
+        "mcpServers": {
+            "hermes_tools": {
+                "command": "hermes",
+                "args": ["mcp", "tools-serve"],
+                "env": hermes_tools_env,
+            },
+            "hermes_messaging": {
+                "command": "hermes",
+                "args": ["mcp", "serve"],
+                "env": dict(base_env),
+            },
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Manifest / caching
+# ---------------------------------------------------------------------------
+
+
+def _collect_manifest_inputs(
+    *, hermes_home: Path, platform: Optional[str], model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return a dict whose hash captures everything that affects the sandbox."""
+    items: Dict[str, Any] = {
+        "hermes_home": str(hermes_home),
+        "platform": (platform or os.environ.get("HERMES_SESSION_PLATFORM") or "").strip(),
+        "python": sys.platform,
+        "preamble_sha": hashlib.sha1(_PREAMBLE.encode("utf-8")).hexdigest(),
+        "model": (model or "").strip(),
+    }
+    soul = hermes_home / "SOUL.md"
+    if soul.exists():
+        st = soul.stat()
+        items["soul"] = {"mtime": st.st_mtime, "size": st.st_size}
+    mem_dir = hermes_home / "memories"
+    if mem_dir.exists():
+        items["memories"] = sorted(
+            (p.name, int(p.stat().st_mtime), p.stat().st_size)
+            for p in mem_dir.glob("*.md")
+        )
+    skills_dir = hermes_home / "skills"
+    if skills_dir.exists():
+        items["skills"] = sorted(
+            (
+                str(p.relative_to(skills_dir)),
+                int(p.stat().st_mtime),
+                p.stat().st_size,
+            )
+            for p in skills_dir.rglob("SKILL.md")
+        )
+    config = hermes_home / "config.yaml"
+    if config.exists():
+        st = config.stat()
+        items["config"] = {"mtime": st.st_mtime, "size": st.st_size}
+    return items
+
+
+def _hash_inputs(inputs: Dict[str, Any]) -> str:
+    blob = json.dumps(inputs, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha1(blob).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Tool-name helpers used by CLAUDE.md composition
+# ---------------------------------------------------------------------------
+
+
+def _resolve_tool_names() -> List[str]:
+    """Return the sorted list of hermes tool names the sandbox will surface."""
+    try:
+        from tools.registry import discover_builtin_tools, registry
+        from hermes_mcp.tools_server import EXCLUDED_TOOLS
+
+        discover_builtin_tools()
+        return sorted(n for n in registry.get_all_tool_names() if n not in EXCLUDED_TOOLS)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.debug("Could not resolve tool names for sandbox: %s", exc)
+        return []

--- a/agent/claude_code_sandbox.py
+++ b/agent/claude_code_sandbox.py
@@ -21,6 +21,7 @@ inputs' mtimes + sizes so unchanged sandboxes skip rebuild.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
 import logging
@@ -29,6 +30,7 @@ import re
 import shutil
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -47,6 +49,84 @@ _CLAUDE_MCP_TOOL_PREFIX = "mcp__hermes_tools__"
 from agent.claude_code_acp_client import CLAUDE_SYSTEM_PREAMBLE_LINES as _SHARED_PREAMBLE_LINES
 
 _PREAMBLE = "\n\n".join(_SHARED_PREAMBLE_LINES)
+
+
+@dataclass(frozen=True)
+class SandboxComponents:
+    """设计期固定的组件包含决策,运行时不再推导。
+
+    默认值(全 True)匹配当前 primary-agent 行为——SOUL.md / memory / skills /
+    .mcp.json / toolbelt / platform block / settings.local.json 全部启用。
+    各 preset 按 feature 组合命名(不按 caller 名字),复用 3 个真实存在的
+    AIAgent flag(skip_context_files / load_soul_identity / skip_memory)推导。
+
+    These flags are read by the inner helpers via the ``include=`` keyword
+    argument — see :func:`_load_soul`, :func:`_build_memory_block`,
+    :func:`_flatten_skills_into`, :func:`_write_mcp_json`.
+    """
+
+    include_soul: bool = True
+    include_memory: bool = True
+    include_skills: bool = True
+    include_mcp: bool = True
+    include_toolbelt: bool = True
+    include_platform: bool = True
+    include_settings: bool = True
+
+
+SANDBOX_PRESETS: Dict[str, SandboxComponents] = {
+    # Full primary sandbox — all components enabled.
+    "primary": SandboxComponents(
+        include_soul=True, include_memory=True, include_skills=True,
+        include_mcp=True, include_toolbelt=True, include_platform=True,
+        include_settings=True,
+    ),
+    # Primary minus memory block (background_review, cron-with-workdir).
+    "primary_minus_memory": SandboxComponents(
+        include_soul=True, include_memory=False, include_skills=True,
+        include_mcp=True, include_toolbelt=True, include_platform=True,
+        include_settings=True,
+    ),
+    # Subagent / curator / ignore_rules / feishu_comment — only preamble +
+    # toolbelt + platform + settings + mcp (mcp 永远保留:subagent 需要找
+    # hermes 工具)。SOUL/memory/skills 全跳过。
+    "minimal": SandboxComponents(
+        include_soul=False, include_memory=False, include_skills=False,
+        include_mcp=True, include_toolbelt=True, include_platform=True,
+        include_settings=True,
+    ),
+    # Cron-no-workdir — 保留 SOUL(尊重 load_soul_identity 契约)+ skills +
+    # mcp(同上) + toolbelt/platform/settings,跳过 memory(cron 永远 skip)。
+    "cron_no_workdir": SandboxComponents(
+        include_soul=True, include_memory=False, include_skills=True,
+        include_mcp=True, include_toolbelt=True, include_platform=True,
+        include_settings=True,
+    ),
+}
+
+
+def _resolve_preset(agent: Any) -> str:
+    """纯推导:复用 agent 现有的 3 个 flag,不引入新属性。
+
+    重要:原版的 is_subagent / is_curator / is_background_review / is_cron
+    在代码里根本不存在(rg 0 hits),不能用。这里只用
+    skip_context_files / load_soul_identity / skip_memory 三个真实存在的
+    flag → callsite 真正零改动。
+    """
+    skip_ctx = bool(getattr(agent, "skip_context_files", False))
+    load_soul = bool(getattr(agent, "load_soul_identity", False))
+    skip_mem = bool(getattr(agent, "skip_memory", False))
+
+    if not skip_ctx and not skip_mem:
+        return "primary"
+    if not skip_ctx and skip_mem:
+        return "primary_minus_memory"
+    if skip_ctx and load_soul and skip_mem:
+        # 同时覆盖 cron-no-workdir 和未来的 subagent_with_soul (YAGNI)
+        return "cron_no_workdir"
+    if skip_ctx and not load_soul and skip_mem:
+        return "minimal"
+    return "primary"  # 兜底,理论上到不了
 
 
 # ---------------------------------------------------------------------------
@@ -116,11 +196,14 @@ def _write_settings_local(sandbox: Path, *, model: Optional[str] = None) -> None
 def _write_mcp_json(
     sandbox: Path,
     *,
+    include: bool = True,
     session_id: str,
     hermes_home: Path,
     platform: Optional[str],
 ) -> None:
     """Materialize ``.mcp.json`` pointing Claude Code at hermes's MCP servers."""
+    if not include:
+        return
     (sandbox / ".mcp.json").write_text(
         json.dumps(
             _build_mcp_config(
@@ -398,8 +481,10 @@ def _build_toolbelt_hint(tool_names: List[str]) -> str:
     return "\n".join(lines)
 
 
-def _build_memory_block(agent: Any) -> Optional[str]:
+def _build_memory_block(agent: Any, *, include: bool = True) -> Optional[str]:
     """Build the memory-context block via the same code path the AIAgent uses."""
+    if not include:
+        return None
     try:
         from agent.memory_manager import build_memory_context_block
     except Exception:
@@ -482,7 +567,9 @@ def _build_platform_block(platform: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _load_soul(hermes_home: Path) -> Optional[str]:
+def _load_soul(hermes_home: Path, *, include: bool = True) -> Optional[str]:
+    if not include:
+        return None
     path = hermes_home / "SOUL.md"
     if not path.exists():
         return None
@@ -555,10 +642,11 @@ def _unique_slug(
 
 def _flatten_skills_into(
     *,
+    include: bool = True,
     hermes_home: Path,
     target: Path,
-    available_tools: Optional[set[str]],
-    available_toolsets: Optional[set[str]],
+    available_tools: Optional[set[str]] = None,
+    available_toolsets: Optional[set[str]] = None,
 ) -> int:
     """Copy each enabled hermes skill into ``<target>/<skill_name>/`` flat.
 
@@ -566,7 +654,13 @@ def _flatten_skills_into(
     ``.claude/skills/``); hermes skills can nest. For each enabled skill,
     we slug its frontmatter name and copy the source directory. Returns
     the number of skills copied.
+
+    ``include=False`` short-circuits the work entirely and returns ``0``,
+    which keeps the sandbox manifest digest stable while letting callers
+    skip the (potentially expensive) skills glob + copy.
     """
+    if not include:
+        return 0
     try:
         from agent.skill_utils import (
             iter_skill_index_files,
@@ -671,7 +765,11 @@ def _build_mcp_config(
 
 
 def _collect_manifest_inputs(
-    *, hermes_home: Path, platform: Optional[str], model: Optional[str] = None,
+    *,
+    hermes_home: Path,
+    platform: Optional[str],
+    model: Optional[str] = None,
+    components: Optional[SandboxComponents] = None,
 ) -> Dict[str, Any]:
     """Return a dict whose hash captures everything that affects the sandbox."""
     items: Dict[str, Any] = {
@@ -705,6 +803,12 @@ def _collect_manifest_inputs(
     if config.exists():
         st = config.stat()
         items["config"] = {"mtime": st.st_mtime, "size": st.st_size}
+    # When components is provided, fold it into the digest so changing the
+    # preset invalidates the manifest. When omitted (the current default for
+    # every call site in ``build_session_sandbox``), the digest is identical
+    # to the pre-commit-1 shape — existing sandbox caches stay valid.
+    if components is not None:
+        items["components"] = dataclasses.asdict(components)
     return items
 
 

--- a/agent/claude_code_sandbox.py
+++ b/agent/claude_code_sandbox.py
@@ -96,14 +96,6 @@ SANDBOX_PRESETS: Dict[str, SandboxComponents] = {
         include_mcp=True, include_toolbelt=True, include_platform=True,
         include_settings=True,
     ),
-    # Cron-no-workdir — keep SOUL (honors the ``load_soul_identity`` contract) +
-    # skills + .mcp.json (same reason as minimal) + toolbelt/platform/settings,
-    # skip memory (cron always skips).
-    "cron_no_workdir": SandboxComponents(
-        include_soul=True, include_memory=False, include_skills=True,
-        include_mcp=True, include_toolbelt=True, include_platform=True,
-        include_settings=True,
-    ),
 }
 
 
@@ -125,8 +117,9 @@ def _resolve_preset(agent: Any) -> str:
     if not skip_ctx and skip_mem:
         return "primary_minus_memory"
     if skip_ctx and load_soul and skip_mem:
-        # Covers both cron-no-workdir and any future subagent_with_soul (YAGNI)
-        return "cron_no_workdir"
+        # cron-no-workdir is functionally identical to primary_minus_memory
+        # (same SandboxComponents fields), so we route both to it.
+        return "primary_minus_memory"
     if skip_ctx and not load_soul and skip_mem:
         return "minimal"
     return "primary"  # fallback — unreachable in practice

--- a/agent/claude_code_sandbox.py
+++ b/agent/claude_code_sandbox.py
@@ -32,7 +32,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/agent/claude_code_sandbox.py
+++ b/agent/claude_code_sandbox.py
@@ -249,53 +249,65 @@ def build_session_sandbox(
 ) -> Path:
     """Build (or rebuild if stale) a Claude Code sandbox for *session_id*.
 
-    Orchestrates the four sandbox stages: manifest cache check, CLAUDE.md
-    composition + skill flatten, MCP pointer, manifest stamp. Returns the
-    absolute path to the sandbox cwd.
+    Resolves the *agent*'s three flags (``skip_context_files`` /
+    ``load_soul_identity`` / ``skip_memory``) into a preset name via
+    :func:`_resolve_preset`, looks up the corresponding
+    :class:`SandboxComponents` in :data:`SANDBOX_PRESETS`, then serializes
+    manifest digest + CLAUDE.md + .mcp.json + settings.local.json +
+    flattened skills according to those components. Because the manifest
+    digest folds the components in, switching presets for the same session
+    automatically forces a rebuild.
+
+    Returns the absolute path to the sandbox cwd.
     """
     sandbox = session_sandbox_path(session_id, hermes_home=hermes_home)
     sandbox.mkdir(parents=True, exist_ok=True)
 
-    # --- Subagent fast-path ---
-    # When both skip_context_files and skip_memory are True, the caller
-    # is a subagent that doesn't need project context.  Build a minimal
-    # sandbox with only settings.local.json (bypassPermissions) and a
-    # short preamble CLAUDE.md — skip SOUL.md, memory, skills, .mcp.json,
-    # and manifest cache.
-    if getattr(agent, "skip_context_files", False) and getattr(agent, "skip_memory", False):
-        _write_settings_local(sandbox, model=model)
-        minimal_claude_md = _PREAMBLE.strip() + "\n"
-        (sandbox / "CLAUDE.md").write_text(minimal_claude_md, encoding="utf-8")
-        logger.info("Built minimal Claude Code sandbox %s (subagent fast-path)", sandbox)
-        return sandbox
+    # 1. Resolve preset → components
+    preset_name = _resolve_preset(agent)
+    components = SANDBOX_PRESETS[preset_name]
 
+    # 2. Manifest digest reflects components (preset 变了 → digest 变 → 强制重建)
     manifest_path = sandbox / SANDBOX_MANIFEST
-    # The digest covers every input that should invalidate the cache —
-    # SOUL.md mtime, memory snippets, enabled skills, platform, model. Any
-    # input change here produces a new digest, forcing a rebuild on next
-    # call. See :func:`_collect_manifest_inputs`.
     inputs = _collect_manifest_inputs(
         hermes_home=hermes_home, platform=platform, model=model,
+        components=components,
     )
     digest = _hash_inputs(inputs)
+
+    # 3. Cache check
     if _manifest_is_current(manifest_path, digest, sandbox):
         logger.debug("Sandbox %s is up-to-date; skipping rebuild", sandbox)
         return sandbox
 
-    # Fresh build — nuke any pre-existing skills dir (files from prior layout
-    # could otherwise accrete). Keep CLAUDE.md / .mcp.json for simpler diffs.
+    # 4. Build CLAUDE.md composition parts (None / "" = skip)
+    tool_names = _resolve_tool_names()
+    toolbelt_hint = (
+        _build_toolbelt_hint(tool_names) if components.include_toolbelt else ""
+    )
+    platform_block = (
+        _build_platform_block(platform) if components.include_platform else None
+    )
+    soul_text = _load_soul(hermes_home, include=components.include_soul)
+    memory_block = _build_memory_block(agent, include=components.include_memory)
+
+    # 5. Skills: include=False 时清理 stale dir,include=True 时扁平化写入
     skills_out = sandbox / ".claude" / "skills"
     if skills_out.exists():
         shutil.rmtree(skills_out, ignore_errors=True)
-    skills_out.mkdir(parents=True, exist_ok=True)
+    if components.include_skills:
+        skills_out.mkdir(parents=True, exist_ok=True)
+        flattened = _flatten_skills_into(
+            include=True,
+            hermes_home=hermes_home,
+            target=skills_out,
+            available_tools=available_tools,
+            available_toolsets=available_toolsets,
+        )
+    else:
+        flattened = 0
 
-    tool_names = _resolve_tool_names()
-    toolbelt_hint = _build_toolbelt_hint(tool_names)
-
-    memory_block = _build_memory_block(agent)
-    soul_text = _load_soul(hermes_home)
-    platform_block = _build_platform_block(platform)
-
+    # 6. Compose CLAUDE.md
     claude_md = _compose_claude_md(
         soul_text=soul_text,
         memory_block=memory_block,
@@ -305,31 +317,44 @@ def build_session_sandbox(
     )
     (sandbox / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
 
-    _write_settings_local(sandbox, model=model)
+    # 7. settings.local.json (include_settings=False 时清理 stale)
+    if components.include_settings:
+        # _write_settings_local writes <sandbox>/.claude/settings.local.json
+        # without mkdir-ing the parent. The old code always implicitly
+        # created .claude via skills_out.mkdir, but include_skills=False
+        # paths (e.g. minimal preset) skip that — so we mkdir here.
+        (sandbox / ".claude").mkdir(parents=True, exist_ok=True)
+        _write_settings_local(sandbox, model=model)
+    else:
+        stale_settings = sandbox / ".claude" / "settings.local.json"
+        if stale_settings.exists():
+            stale_settings.unlink()
 
-    flattened = _flatten_skills_into(
-        hermes_home=hermes_home,
-        target=skills_out,
-        available_tools=available_tools,
-        available_toolsets=available_toolsets,
-    )
+    # 8. .mcp.json (include_mcp=False 时清理 stale;子 agent 永远保留 mcp)
+    if components.include_mcp:
+        _write_mcp_json(
+            sandbox,
+            session_id=session_id,
+            hermes_home=hermes_home,
+            platform=platform,
+            include=True,
+        )
+    else:
+        stale_mcp = sandbox / ".mcp.json"
+        if stale_mcp.exists():
+            stale_mcp.unlink()
 
-    _write_mcp_json(
-        sandbox,
-        session_id=session_id,
-        hermes_home=hermes_home,
-        platform=platform,
-    )
-
+    # 9. Manifest stamp
     _write_sandbox_manifest(
         manifest_path,
         digest=digest,
         session_id=session_id,
         skill_count=flattened,
     )
+
     logger.info(
-        "Built Claude Code sandbox %s (%d skills, %d tools)",
-        sandbox, flattened, len(tool_names),
+        "Built Claude Code sandbox %s (preset=%s, %d skills, %d tools)",
+        sandbox, preset_name, flattened, len(tool_names),
     )
     return sandbox
 

--- a/agent/claude_code_sandbox.py
+++ b/agent/claude_code_sandbox.py
@@ -53,12 +53,13 @@ _PREAMBLE = "\n\n".join(_SHARED_PREAMBLE_LINES)
 
 @dataclass(frozen=True)
 class SandboxComponents:
-    """设计期固定的组件包含决策,运行时不再推导。
+    """Component inclusion is fixed at design time — not re-derived at runtime.
 
-    默认值(全 True)匹配当前 primary-agent 行为——SOUL.md / memory / skills /
-    .mcp.json / toolbelt / platform block / settings.local.json 全部启用。
-    各 preset 按 feature 组合命名(不按 caller 名字),复用 3 个真实存在的
-    AIAgent flag(skip_context_files / load_soul_identity / skip_memory)推导。
+    Defaults (all True) match the current primary-agent behavior: SOUL.md /
+    memory / skills / .mcp.json / toolbelt / platform block / settings.local.json
+    are all enabled. Each preset is named after its feature combination (not
+    after the caller) and is derived from the three real AIAgent flags
+    (``skip_context_files`` / ``load_soul_identity`` / ``skip_memory``).
 
     These flags are read by the inner helpers via the ``include=`` keyword
     argument — see :func:`_load_soul`, :func:`_build_memory_block`,
@@ -88,15 +89,16 @@ SANDBOX_PRESETS: Dict[str, SandboxComponents] = {
         include_settings=True,
     ),
     # Subagent / curator / ignore_rules / feishu_comment — only preamble +
-    # toolbelt + platform + settings + mcp (mcp 永远保留:subagent 需要找
-    # hermes 工具)。SOUL/memory/skills 全跳过。
+    # toolbelt + platform + settings + mcp (.mcp.json always retained:
+    # subagents need to discover hermes tools). Skip SOUL/memory/skills.
     "minimal": SandboxComponents(
         include_soul=False, include_memory=False, include_skills=False,
         include_mcp=True, include_toolbelt=True, include_platform=True,
         include_settings=True,
     ),
-    # Cron-no-workdir — 保留 SOUL(尊重 load_soul_identity 契约)+ skills +
-    # mcp(同上) + toolbelt/platform/settings,跳过 memory(cron 永远 skip)。
+    # Cron-no-workdir — keep SOUL (honors the ``load_soul_identity`` contract) +
+    # skills + .mcp.json (same reason as minimal) + toolbelt/platform/settings,
+    # skip memory (cron always skips).
     "cron_no_workdir": SandboxComponents(
         include_soul=True, include_memory=False, include_skills=True,
         include_mcp=True, include_toolbelt=True, include_platform=True,
@@ -106,12 +108,13 @@ SANDBOX_PRESETS: Dict[str, SandboxComponents] = {
 
 
 def _resolve_preset(agent: Any) -> str:
-    """纯推导:复用 agent 现有的 3 个 flag,不引入新属性。
+    """Pure derivation: reuses the agent's three existing flags, no new attrs.
 
-    重要:原版的 is_subagent / is_curator / is_background_review / is_cron
-    在代码里根本不存在(rg 0 hits),不能用。这里只用
-    skip_context_files / load_soul_identity / skip_memory 三个真实存在的
-    flag → callsite 真正零改动。
+    Important: the original ``is_subagent`` / ``is_curator`` /
+    ``is_background_review`` / ``is_cron`` symbols don't exist in the
+    codebase (rg 0 hits) — they can't be used. Only the three real flags
+    (``skip_context_files`` / ``load_soul_identity`` / ``skip_memory``)
+    drive the lookup, so callsites stay unchanged.
     """
     skip_ctx = bool(getattr(agent, "skip_context_files", False))
     load_soul = bool(getattr(agent, "load_soul_identity", False))
@@ -122,11 +125,11 @@ def _resolve_preset(agent: Any) -> str:
     if not skip_ctx and skip_mem:
         return "primary_minus_memory"
     if skip_ctx and load_soul and skip_mem:
-        # 同时覆盖 cron-no-workdir 和未来的 subagent_with_soul (YAGNI)
+        # Covers both cron-no-workdir and any future subagent_with_soul (YAGNI)
         return "cron_no_workdir"
     if skip_ctx and not load_soul and skip_mem:
         return "minimal"
-    return "primary"  # 兜底,理论上到不了
+    return "primary"  # fallback — unreachable in practice
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +270,7 @@ def build_session_sandbox(
     preset_name = _resolve_preset(agent)
     components = SANDBOX_PRESETS[preset_name]
 
-    # 2. Manifest digest reflects components (preset 变了 → digest 变 → 强制重建)
+    # 2. Manifest digest reflects components (preset change → digest change → force rebuild)
     manifest_path = sandbox / SANDBOX_MANIFEST
     inputs = _collect_manifest_inputs(
         hermes_home=hermes_home, platform=platform, model=model,
@@ -291,7 +294,7 @@ def build_session_sandbox(
     soul_text = _load_soul(hermes_home, include=components.include_soul)
     memory_block = _build_memory_block(agent, include=components.include_memory)
 
-    # 5. Skills: include=False 时清理 stale dir,include=True 时扁平化写入
+    # 5. Skills: include=False → drop stale dir; include=True → flatten-write
     skills_out = sandbox / ".claude" / "skills"
     if skills_out.exists():
         shutil.rmtree(skills_out, ignore_errors=True)
@@ -317,7 +320,7 @@ def build_session_sandbox(
     )
     (sandbox / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
 
-    # 7. settings.local.json (include_settings=False 时清理 stale)
+    # 7. settings.local.json (include_settings=False → drop stale)
     if components.include_settings:
         # _write_settings_local writes <sandbox>/.claude/settings.local.json
         # without mkdir-ing the parent. The old code always implicitly
@@ -330,7 +333,7 @@ def build_session_sandbox(
         if stale_settings.exists():
             stale_settings.unlink()
 
-    # 8. .mcp.json (include_mcp=False 时清理 stale;子 agent 永远保留 mcp)
+    # 8. .mcp.json (include_mcp=False → drop stale; subagent keeps mcp always)
     if components.include_mcp:
         _write_mcp_json(
             sandbox,

--- a/agent/claude_code_sandbox.py
+++ b/agent/claude_code_sandbox.py
@@ -173,6 +173,19 @@ def build_session_sandbox(
     sandbox = session_sandbox_path(session_id, hermes_home=hermes_home)
     sandbox.mkdir(parents=True, exist_ok=True)
 
+    # --- Subagent fast-path ---
+    # When both skip_context_files and skip_memory are True, the caller
+    # is a subagent that doesn't need project context.  Build a minimal
+    # sandbox with only settings.local.json (bypassPermissions) and a
+    # short preamble CLAUDE.md — skip SOUL.md, memory, skills, .mcp.json,
+    # and manifest cache.
+    if getattr(agent, "skip_context_files", False) and getattr(agent, "skip_memory", False):
+        _write_settings_local(sandbox, model=model)
+        minimal_claude_md = _PREAMBLE.strip() + "\n"
+        (sandbox / "CLAUDE.md").write_text(minimal_claude_md, encoding="utf-8")
+        logger.info("Built minimal Claude Code sandbox %s (subagent fast-path)", sandbox)
+        return sandbox
+
     manifest_path = sandbox / SANDBOX_MANIFEST
     # The digest covers every input that should invalidate the cache —
     # SOUL.md mtime, memory snippets, enabled skills, platform, model. Any

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1091,7 +1091,9 @@ def run_conversation(
                 # API upgrade (lines ~1083-1085).
                 elif (
                     agent.provider == "copilot-acp"
+                    or agent.provider == "claude-code-acp"
                     or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    or str(agent.base_url or "").lower().startswith("acp://claude-code")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -90,6 +90,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CLAUDE_CODE_ACP_BASE_URL = "acp://claude-code"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -233,6 +234,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "claude-code-acp": ProviderConfig(
+        id="claude-code-acp",
+        name="Claude Code ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CODE_ACP_BASE_URL,
+        base_url_env_var="CLAUDE_CODE_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -6333,6 +6341,48 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     return {
         "provider": provider_id,
         "api_key": "copilot-acp",
+        "base_url": base_url.rstrip("/"),
+        "command": resolved_command or command,
+        "args": args,
+        "source": "process",
+    }
+
+
+def resolve_claude_code_acp_credentials(
+    provider_id: str = "claude-code-acp",
+) -> dict:
+    """Resolve Claude Code ACP subprocess credentials."""
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    if not pconfig or pconfig.auth_type != "external_process":
+        raise AuthError(
+            f"Provider '{provider_id}' is not an external-process provider.",
+            provider=provider_id,
+            code="invalid_provider",
+        )
+
+    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    if not base_url:
+        base_url = pconfig.inference_base_url
+
+    command = (
+        os.getenv("HERMES_CLAUDE_CODE_ACP_COMMAND", "").strip()
+        or os.getenv("CLAUDE_ACP_PATH", "").strip()
+        or "npx"
+    )
+    raw_args = os.getenv("HERMES_CLAUDE_CODE_ACP_ARGS", "").strip()
+    args = shlex.split(raw_args) if raw_args else ["-y", "@agentclientprotocol/claude-agent-acp"]
+    resolved_command = shutil.which(command) if command else None
+    if not resolved_command and not base_url.startswith("acp+tcp://"):
+        raise AuthError(
+            f"Could not find the Claude Code ACP command '{command}'. "
+            "Install Node.js 20+ or set HERMES_CLAUDE_CODE_ACP_COMMAND/CLAUDE_ACP_PATH.",
+            provider=provider_id,
+            code="missing_claude_code_cli",
+        )
+
+    return {
+        "provider": provider_id,
+        "api_key": "claude-code-acp",
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-code-acp": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://claude-code",
+        base_url_env_var="CLAUDE_CODE_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -212,6 +218,27 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         auth_type="aws_sdk",
     ),
 }
+
+
+def is_acp_provider(provider: Optional[str]) -> bool:
+    """Return True if ``provider`` is backed by a local ACP subprocess.
+
+    Driven by :data:`HERMES_OVERLAYS` — any overlay whose ``base_url_override``
+    starts with ``acp://`` is ACP-backed. Using the registry instead of a
+    hardcoded string list means adding a new ACP provider (e.g.
+    ``cursor-acp``) only requires a single overlay entry; the call sites in
+    ``run_agent.py`` that ask "is this ACP?" pick it up automatically.
+
+    Accepts ``None`` / empty strings for convenience (returns ``False``).
+    Alias input is resolved via :func:`normalize_provider` first.
+    """
+    if not provider:
+        return False
+    canonical = normalize_provider(provider)
+    overlay = HERMES_OVERLAYS.get(canonical)
+    if overlay is None:
+        return False
+    return overlay.base_url_override.startswith("acp://")
 
 
 # -- Resolved provider -------------------------------------------------------

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1570,6 +1570,20 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "claude-code-acp":
+        from hermes_cli.auth import resolve_claude_code_acp_credentials
+        creds = resolve_claude_code_acp_credentials(provider)
+        return {
+            "provider": "claude-code-acp",
+            "api_mode": "chat_completions",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,7 +324,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "hermes_mcp", "hermes_mcp.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/skills/software-development/claude-code-acp-delegate/SKILL.md
+++ b/skills/software-development/claude-code-acp-delegate/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: claude-code-acp-delegate
+description: 通过 delegate_task 正确调用 Claude Code ACP 的规范 — 参数格式、模型别名映射、验证方法
+---
+
+# Claude Code ACP Delegate 调用规范
+
+## 基本调用格式
+
+```python
+delegate_task(
+    acp_command="claude-code-acp",   # 路由占位符，不需要 provider
+    acp_args=["--model", "sonnet"],  # 可选，不填用默认
+    goal="...",
+    toolsets=[]                      # ACP 自己管理工具
+)
+```
+
+## 关键点
+
+1. **不需要 provider 参数** — `acp_command` 自动路由到 `claude-code-acp` provider
+2. **acp_args 是列表** — `["--model", "sonnet"]` 不是字符串
+3. **模型别名** — sonnet/opus/haiku 会被 `resolveModelPreference` 解析为完整模型名
+4. **无 agent 工具** — ACP 自己管理工具，`toolsets=[]` 最高效
+
+## 模型别名映射
+
+`claude-agent-acp` 内部使用 `resolveModelPreference()` 做**子串匹配**，支持人类可读别名：
+
+```javascript
+// claude-agent-acp 源码注释：
+// This lets callers use human-friendly aliases like
+// "opus" or "sonnet" instead of full model IDs like "claude-opus-4-6".
+```
+
+### 匹配机制（3 级优先级）
+
+1. **精确匹配**：`model.value === preference` 或 `displayName === preference`
+2. **子串匹配**：`value.includes(preference)` 或 `preference.includes(value)`
+3. **分词匹配**：tokenize 后评分（支持 `opus[1m]` 等格式）
+
+### 推荐用法
+
+```python
+# ✅ 推荐：用别名（简洁、不依赖版本、由 claude-agent-acp 内部解析）
+acp_args=["--model", "sonnet"]
+acp_args=["--model", "opus"]
+acp_args=["--model", "haiku"]
+
+# ⚠️ 可用但不推荐：用完整模型名（绑定特定版本，仅调试/测试时用）
+acp_args=["--model", "claude-sonnet-4-6"]
+```
+
+**推荐用别名的原因**：
+1. **更简洁** — `sonnet` 比 `claude-sonnet-4-6` 短
+2. **不依赖版本** — 如果 Claude SDK 更新模型名（如 `claude-sonnet-5`），别名仍然有效
+3. **`claude-agent-acp` 内部处理** — 别名解析是 `claude-agent-acp` 的职责，hermes 不需要关心
+
+**唯一例外**：需要**确定性绑定特定模型版本**（如测试、调试）时，用完整模型名。
+
+## acp_args 可用参数
+
+| 参数 | 值 | 说明 | 状态 |
+|---|---|---|---|
+| `--model` | `sonnet`/`opus`/`haiku` 或完整模型名 | 设置 ACP 模型 | ✅ 已测试 |
+| `--effort` | `default`/`low`/`medium`/`high`/`xhigh`/`max` | 设置 effort level | ⚠️ 未调试成功，暂不可用 |
+| `--permission-mode` | `auto`/`plan`/`acceptEdits` 等 | 设置权限模式 | ⚠️ 未调试成功，暂不可用 |
+
+> **注意**：
+> - `--model` 参数已验证可用（2026-06-16 真机测试）
+> - `--effort` 参数：hermes 代码路径已通（正确发送 `session/set_config_option` 请求），但 `claude-agent-acp` 返回 "Internal error"，可能是 litellm 代理或 Claude SDK 不支持
+> - `--permission-mode` 参数：未经测试验证
+
+## 调用示例
+
+### 最简调用（使用默认模型）
+```python
+delegate_task(
+    acp_command="claude-code-acp",
+    goal="Reply with exactly: ok",
+    toolsets=[]
+)
+```
+
+### 指定模型
+```python
+delegate_task(
+    acp_command="claude-code-acp",
+    acp_args=["--model", "sonnet"],
+    goal="...",
+    toolsets=[]
+)
+```
+
+## 注意事项
+
+1. **不需要填 provider** — `acp_command="claude-code-acp"` 自动触发路由
+2. **不要传 acp_args 默认值** — `["--acp", "--stdio"]` 是 Copilot 的，Claude Code ACP 不需要
+3. **子 agent 会消耗 token** — 简单任务用 `toolsets=[]` 减少开销
+4. **600s timeout**：子 agent prompt 精简（3 步 verify 代替 7 步）可避免
+5. **gateway 日志**：`ACP session model: sonnet (session=..., alive=False)` 显示实际配置的模型
+
+## 验证方法
+
+1. 检查 `~/.hermes/logs/agent.log` 中的 `ACP session model:` 日志
+2. 检查 litellm 日志：`docker logs litellm --since=1m`
+3. 直接调用 litellm API 验证模型路由
+
+## 相关代码位置
+
+- 路由逻辑：`tools/delegate_tool.py` `_build_child_agent()`
+- ACP 客户端：`agent/claude_code_acp_client.py`
+- 模型解析：`claude-agent-acp` 的 `resolveModelPreference()`
+
+## Pitfalls
+
+### Pitfall 1: 子 agent 600s timeout
+- 原因：prompt 太长或 verify 步骤太多
+- 解决：精简 prompt，3 步 verify（syntax/pytest/git log+status）
+- 主 agent 独立 verify 全套
+
+### Pitfall 2: 模型日志显示 hermes 模型而非 ACP 模型
+- 原因：hermes 日志中的 `model=minimax-m3` 是 AIAgent 继承的模型
+- 解决：方案 A — 从 `session/new` 响应读取 `configOptions` 缓存实际 ACP 模型
+- 已实现：`agent/claude_code_acp_client.py` 的 `_get_acp_model()` 和 `_acp_config_options`
+
+### Pitfall 3: git config local 覆盖 global
+- 现象：amend author 后仍是旧 author
+- 原因：subagent 残留 `git config --local user.name=nbot`
+- 解决：amend 前 `git config --local --unset user.name && git config --local --unset user.email`
+
+### Pitfall 4: gateway restart 中断 session
+- 现象：`systemctl restart hermes-gateway` 后 session 被 killed
+- 原因：Matrix bot 失联导致 session 中断
+- 解决：发完消息后再 restart，或新 turn 验证
+
+## 待验证项
+
+- [ ] `--effort` 参数为什么返回 Internal error（检查 claude-agent-acp 或 litellm 代理实现）
+- [ ] `--permission-mode` 参数是否生效
+- [ ] 模型别名映射在 `claude-agent-acp` 版本更新后是否变化（依赖 Claude SDK 模型列表）
+- [ ] 别名匹配优先级在边缘情况下的行为（如 `sonnet-4` 匹配到哪个模型）
+
+## 更新历史
+
+- 2026-06-16: 初始版本，基于 feat/claude-code-acp-provider 分支实践
+- 2026-06-16: 澄清模型别名映射机制（子串匹配，非硬编码），推荐用别名而非完整模型名
+- 2026-06-16: 测试 `--effort` 参数，返回 Internal error，标注为"未调试成功，暂不可用"

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -73,15 +73,15 @@ class TestNormalizeModelName(unittest.TestCase):
         self.assertEqual(ClaudeCodeACPClient._normalize_model_name("Opus"), "opus")
         self.assertEqual(ClaudeCodeACPClient._normalize_model_name("SONNET"), "sonnet")
 
-    def test_full_names_reduce_to_short(self):
-        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-opus-4-7"), "opus")
-        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-sonnet-4-6"), "sonnet")
-        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-haiku-4-5"), "haiku")
+    def test_full_names_pass_through_verbatim(self):
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-opus-4-7"), "claude-opus-4-7")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-sonnet-4-6"), "claude-sonnet-4-6")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-haiku-4-5"), "claude-haiku-4-5")
 
     def test_context_window_suffixes_stripped(self):
         self.assertEqual(ClaudeCodeACPClient._normalize_model_name("opus[1m]"), "opus")
         self.assertEqual(ClaudeCodeACPClient._normalize_model_name("sonnet[200k]"), "sonnet")
-        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-opus-4-7[1m]"), "opus")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-opus-4-7[1m]"), "claude-opus-4-7")
 
     def test_empty_passthrough(self):
         self.assertEqual(ClaudeCodeACPClient._normalize_model_name(""), "")

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -479,5 +479,94 @@ class TestCloseCleanup(unittest.TestCase):
         self.assertIsNone(client._active_process)
 
 
+# ===========================================================================
+# 13. _is_valid_effort_level
+# ===========================================================================
+class TestIsValidEffortLevel(unittest.TestCase):
+    def test_valid_levels(self):
+        client = _make_client()
+        for level in ("default", "low", "medium", "high", "xhigh", "max"):
+            self.assertTrue(
+                client._is_valid_effort_level(level),
+                f"{level} should be valid",
+            )
+
+    def test_case_insensitive(self):
+        client = _make_client()
+        self.assertTrue(client._is_valid_effort_level("High"))
+        self.assertTrue(client._is_valid_effort_level("DEFAULT"))
+
+    def test_invalid_level(self):
+        client = _make_client()
+        self.assertFalse(client._is_valid_effort_level("turbo"))
+        self.assertFalse(client._is_valid_effort_level("extreme"))
+
+
+# ===========================================================================
+# 14. _apply_acp_arg_directives
+# ===========================================================================
+class TestApplyAcpArgDirectives(unittest.TestCase):
+    def test_model_flag_seeds_pending(self):
+        client = _make_client(acp_args=["--model", "opus", "--stdio"])
+        client._apply_acp_arg_directives()
+        self.assertEqual(client._pending_model, "opus")
+        self.assertEqual(client._pending_session_configs.get("model"), "opus")
+
+    def test_model_flag_invalid_ignored(self):
+        client = _make_client(acp_args=["--model", "gpt-4o", "--stdio"])
+        client._apply_acp_arg_directives()
+        self.assertIsNone(client._pending_model)
+        self.assertNotIn("model", client._pending_session_configs)
+
+    def test_permission_mode_flag(self):
+        client = _make_client(acp_args=["--permission-mode", "plan", "--stdio"])
+        client._apply_acp_arg_directives()
+        self.assertEqual(client._pending_session_configs.get("mode"), "plan")
+
+    def test_effort_flag(self):
+        client = _make_client(acp_args=["--effort", "high", "--stdio"])
+        client._apply_acp_arg_directives()
+        self.assertEqual(client._pending_session_configs.get("effort"), "high")
+
+    def test_effort_flag_invalid_ignored(self):
+        client = _make_client(acp_args=["--effort", "turbo", "--stdio"])
+        client._apply_acp_arg_directives()
+        self.assertNotIn("effort", client._pending_session_configs)
+
+    def test_multiple_directives(self):
+        client = _make_client(
+            acp_args=["--model", "sonnet", "--permission-mode", "auto", "--effort", "low", "--stdio"]
+        )
+        client._apply_acp_arg_directives()
+        self.assertEqual(client._pending_model, "sonnet")
+        self.assertEqual(client._pending_session_configs["model"], "sonnet")
+        self.assertEqual(client._pending_session_configs["mode"], "auto")
+        self.assertEqual(client._pending_session_configs["effort"], "low")
+
+    def test_unrecognized_flag_passthrough(self):
+        args = ["--debug", "--model", "haiku", "--unknown", "val", "--stdio"]
+        client = _make_client(acp_args=args)
+        client._apply_acp_arg_directives()
+        # acp_args should be unchanged
+        self.assertEqual(client._acp_args, args)
+        self.assertEqual(client._pending_model, "haiku")
+
+    def test_duplicate_flag_first_wins(self):
+        client = _make_client(acp_args=["--model", "opus", "--model", "haiku", "--stdio"])
+        client._apply_acp_arg_directives()
+        self.assertEqual(client._pending_model, "opus")
+
+    def test_model_flag_no_value_skipped(self):
+        client = _make_client(acp_args=["--model"])
+        client._apply_acp_arg_directives()
+        self.assertIsNone(client._pending_model)
+
+    def test_empty_acp_args(self):
+        client = _make_client(acp_args=[])
+        client._apply_acp_arg_directives()
+        self.assertIsNone(client._pending_model)
+        self.assertEqual(client._pending_session_configs, {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -402,7 +402,6 @@ class TestClientInit(unittest.TestCase):
         client = _make_client()
         self.assertIsNone(client._session_proc)
         self.assertIsNone(client._session_id)
-        self.assertIsNone(client._pending_model)
         self.assertFalse(client.is_closed)
         self.assertEqual(client._tool_trace, [])
 
@@ -509,13 +508,11 @@ class TestApplyAcpArgDirectives(unittest.TestCase):
     def test_model_flag_seeds_pending(self):
         client = _make_client(acp_args=["--model", "opus", "--stdio"])
         client._apply_acp_arg_directives()
-        self.assertEqual(client._pending_model, "opus")
         self.assertEqual(client._pending_session_configs.get("model"), "opus")
 
     def test_model_flag_invalid_ignored(self):
         client = _make_client(acp_args=["--model", "gpt-4o", "--stdio"])
         client._apply_acp_arg_directives()
-        self.assertIsNone(client._pending_model)
         self.assertNotIn("model", client._pending_session_configs)
 
     def test_permission_mode_flag(self):
@@ -538,7 +535,6 @@ class TestApplyAcpArgDirectives(unittest.TestCase):
             acp_args=["--model", "sonnet", "--permission-mode", "auto", "--effort", "low", "--stdio"]
         )
         client._apply_acp_arg_directives()
-        self.assertEqual(client._pending_model, "sonnet")
         self.assertEqual(client._pending_session_configs["model"], "sonnet")
         self.assertEqual(client._pending_session_configs["mode"], "auto")
         self.assertEqual(client._pending_session_configs["effort"], "low")
@@ -549,22 +545,22 @@ class TestApplyAcpArgDirectives(unittest.TestCase):
         client._apply_acp_arg_directives()
         # acp_args should be unchanged
         self.assertEqual(client._acp_args, args)
-        self.assertEqual(client._pending_model, "haiku")
+        self.assertEqual(client._pending_session_configs.get("model"), "haiku")
 
     def test_duplicate_flag_first_wins(self):
         client = _make_client(acp_args=["--model", "opus", "--model", "haiku", "--stdio"])
         client._apply_acp_arg_directives()
-        self.assertEqual(client._pending_model, "opus")
+        self.assertEqual(client._pending_session_configs.get("model"), "opus")
 
     def test_model_flag_no_value_skipped(self):
         client = _make_client(acp_args=["--model"])
         client._apply_acp_arg_directives()
-        self.assertIsNone(client._pending_model)
+        self.assertNotIn("model", client._pending_session_configs)
 
     def test_empty_acp_args(self):
         client = _make_client(acp_args=[])
         client._apply_acp_arg_directives()
-        self.assertIsNone(client._pending_model)
+        self.assertNotIn("model", client._pending_session_configs)
         self.assertEqual(client._pending_session_configs, {})
 
 

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -789,5 +789,22 @@ class TestApplyAcpArgDirectives(unittest.TestCase):
         self.assertEqual(flush_calls[0]["pending_model"], "sonnet")
 
 
+# ===========================================================================
+# 15. B1 (4a798e19f) — dead function regression guard
+# ===========================================================================
+class TestDeadCodeRemoved(unittest.TestCase):
+    def test_trace_to_messages_snapshot_removed(self):
+        """B1 (4a798e19f) removed the 49-line trace_to_messages_snapshot
+        function. Re-addition would indicate a regression of the dead-code
+        review. This test guards against that.
+        """
+        client = _make_client()
+        self.assertFalse(
+            hasattr(client, "trace_to_messages_snapshot"),
+            "trace_to_messages_snapshot was removed in B1; "
+            "re-add only if a real caller emerges",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -477,6 +477,166 @@ class TestCloseCleanup(unittest.TestCase):
         self.assertIsNone(client._session_id)
         self.assertIsNone(client._active_process)
 
+    # ------------------------------------------------------------------
+    # C1 (2e62a19ba) — reader thread join on close()
+    # ------------------------------------------------------------------
+    def test_close_joins_reader_threads(self):
+        """C1 (2e62a19ba): close() must join the stdout/stderr reader threads
+        before returning, so daemon threads can't race with closed pipes and
+        trigger I/O-on-closed-file errors after close() returns."""
+        import time
+        client = _make_client()
+        completed = []
+
+        def reader(label):
+            # Brief work, then exit — simulating a reader that drains
+            # naturally after the subprocess pipes are closed.
+            time.sleep(0.01)
+            completed.append(label)
+
+        t1 = threading.Thread(target=reader, args=("stdout",), daemon=True)
+        t2 = threading.Thread(target=reader, args=("stderr",), daemon=True)
+        t1.start()
+        t2.start()
+        # Need an active process so close() reaches the reader-join block
+        # (otherwise it short-circuits with is_closed=True and returns).
+        client._active_process = _FakeProcess()
+        client._reader_threads = [t1, t2]
+        client.close()
+        self.assertFalse(t1.is_alive(), "stdout reader thread should be joined")
+        self.assertFalse(t2.is_alive(), "stderr reader thread should be joined")
+        self.assertEqual(client._reader_threads, [], "thread list should be reset")
+        self.assertIn("stdout", completed)
+        self.assertIn("stderr", completed)
+
+    def test_close_idempotent_on_empty_threads(self):
+        """C1: close() with no threads and no process must not raise and
+        must still set is_closed=True."""
+        client = _make_client()
+        self.assertEqual(client._reader_threads, [])
+        self.assertIsNone(client._active_process)
+        client.close()  # should not raise
+        self.assertTrue(client.is_closed)
+
+    def test_close_does_not_hang_on_wedged_thread(self):
+        """C1: a reader thread stuck on readline must not block close() past
+        the 1.0s join timeout specified in the fix. The wedged thread is
+        left alive (daemon=True) rather than forcibly killed."""
+        import time
+        client = _make_client()
+        # Thread that blocks forever; close() must time out joining it.
+        t = threading.Thread(
+            target=lambda: threading.Event().wait(60), daemon=True
+        )
+        t.start()
+        # Need an active process so close() reaches the reader-join block.
+        client._active_process = _FakeProcess()
+        client._reader_threads = [t]
+        t0 = time.monotonic()
+        client.close()
+        elapsed = time.monotonic() - t0
+        self.assertLess(
+            elapsed, 1.5,
+            f"close() took {elapsed:.2f}s; expected <1.5s (1.0s join + slack)",
+        )
+        self.assertTrue(
+            t.is_alive(),
+            "wedged thread should be left alive after timeout, not joined",
+        )
+
+    # ------------------------------------------------------------------
+    # C2 (3082fad77) — close() race: lock + is_closed ordering
+    # ------------------------------------------------------------------
+    def test_close_resets_active_process_under_lock(self):
+        """C2 (3082fad77): _active_process=None must happen INSIDE the
+        _active_process_lock to avoid a race with concurrent close() callers
+        who might otherwise see a stale non-None reference."""
+        client = _make_client()
+        held_during_reset: list[str] = []
+        original_lock = client._active_process_lock
+
+        class TrackingLock:
+            """Proxy that records entry/exit while delegating to the
+            real threading.Lock()."""
+
+            def __enter__(self):
+                held_during_reset.append("enter")
+                return original_lock.__enter__()
+
+            def __exit__(self, *a):
+                held_during_reset.append("exit")
+                return original_lock.__exit__(*a)
+
+        client._active_process_lock = TrackingLock()  # type: ignore[assignment]
+        fake = _FakeProcess()
+        client._active_process = fake
+        client._session_id = "sess-1"
+        client.close()
+        # Lock must have been held around the reset.
+        self.assertIn("enter", held_during_reset)
+        self.assertIn("exit", held_during_reset)
+        # enter must come before exit (sanity check on the proxy).
+        self.assertLess(
+            held_during_reset.index("enter"),
+            held_during_reset.index("exit"),
+        )
+        self.assertIsNone(client._active_process)
+        self.assertIsNone(client._session_id)
+
+    def test_close_is_closed_set_after_terminate(self):
+        """C2: is_closed=True must come AFTER proc.terminate(), so concurrent
+        callers observing is_closed=False don't skip the terminate path."""
+        client = _make_client()
+        fake = _FakeProcess()
+        client._active_process = fake
+        states_during_terminate: list[bool] = []
+        original_terminate = fake.terminate
+
+        def tracking_terminate():
+            states_during_terminate.append(client.is_closed)
+            original_terminate()
+
+        fake.terminate = tracking_terminate  # type: ignore[assignment]
+        client.close()
+        self.assertIn(
+            False, states_during_terminate,
+            "is_closed must be False when proc.terminate() is called",
+        )
+        self.assertTrue(
+            client.is_closed,
+            "is_closed must be True after close() returns",
+        )
+
+    def test_concurrent_close_safe(self):
+        """C2: two threads calling close() concurrently must not raise.
+        Before the fix, _active_process=None was outside the lock and two
+        concurrent callers could race past the proc-guard and double-terminate."""
+        client = _make_client()
+        client._active_process = _FakeProcess()
+        client._session_id = "sess-1"
+        errors: list[Exception] = []
+
+        def do_close():
+            try:
+                client.close()
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        t1 = threading.Thread(target=do_close)
+        t2 = threading.Thread(target=do_close)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+        self.assertEqual(
+            errors, [],
+            f"concurrent close() raised: {errors!r}",
+        )
+        self.assertTrue(client.is_closed)
+        # Final state must be clean for both session/proc state.
+        self.assertIsNone(client._active_process)
+        self.assertIsNone(client._session_id)
+
 
 # ===========================================================================
 # 13. _is_valid_effort_level
@@ -562,6 +722,71 @@ class TestApplyAcpArgDirectives(unittest.TestCase):
         client._apply_acp_arg_directives()
         self.assertNotIn("model", client._pending_session_configs)
         self.assertEqual(client._pending_session_configs, {})
+
+    # ------------------------------------------------------------------
+    # C3 (e40bffccc) — model/config changes on alive session must re-flush
+    # ------------------------------------------------------------------
+    def test_model_change_flushes_to_alive_session(self):
+        """C3 (e40bffccc): when _ensure_session() reuses a live session and
+        _pending_session_configs has a new value (e.g. --model re-scanned),
+        it MUST call _flush_pending_configs to re-flush via
+        session/set_config_option — not just leave them stashed in
+        _pending_session_configs.
+
+        Regression: before C3 fix, the flush logic was inline in
+        _ensure_session and only ran after session/new. Model/config changes
+        on an already-alive session were silently dropped, so e.g. switching
+        from opus → sonnet mid-session never actually switched the model.
+
+        This test sets up a fully-alive session, stashes a NEW model into
+        _pending_session_configs, and verifies that _ensure_session() (on
+        its early-return / "session already alive" branch) triggers the
+        flush.
+        """
+        from collections import deque
+        from queue import Queue
+        client = _make_client(acp_args=["--model", "opus", "--stdio"])
+        client._apply_acp_arg_directives()
+        # Sanity: initial scan populated the pending dict.
+        self.assertEqual(
+            client._pending_session_configs.get("model"), "opus",
+        )
+        # Simulate an alive session — all four invariants of
+        # _ensure_session's early-return branch must hold.
+        fake_proc = _FakeProcess()  # _poll_result defaults to None → alive
+        client._session_proc = fake_proc
+        client._session_inbox = Queue()
+        client._session_stderr = deque()
+        client._session_id = "sess-alive"
+        # Simulate a NEW model directive scanned in (e.g. user re-applied
+        # --model with a different value mid-session).
+        client._pending_session_configs["model"] = "sonnet"
+        # Track flush calls. Real signature is
+        # (proc, inbox, stderr_tail, session_id) — NOT (force=False).
+        flush_calls: list[dict] = []
+
+        def tracking_flush(proc, inbox, stderr_tail, session_id):
+            flush_calls.append(
+                {
+                    "proc": proc,
+                    "session_id": session_id,
+                    "pending_model": client._pending_session_configs.get(
+                        "model"
+                    ),
+                }
+            )
+
+        client._flush_pending_configs = tracking_flush  # type: ignore[assignment]
+        # Trigger _ensure_session — the alive-session branch must flush.
+        client._ensure_session()
+        self.assertEqual(
+            len(flush_calls), 1,
+            "C3 regression: alive session path did not call "
+            "_flush_pending_configs to re-flush pending --model changes",
+        )
+        self.assertEqual(flush_calls[0]["session_id"], "sess-alive")
+        self.assertIs(flush_calls[0]["proc"], fake_proc)
+        self.assertEqual(flush_calls[0]["pending_model"], "sonnet")
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -1,0 +1,483 @@
+"""Tests for ClaudeCodeACPClient — model routing, safety, session lifecycle, handlers."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from queue import Queue
+from unittest.mock import MagicMock, patch
+
+from agent.claude_code_acp_client import (
+    ClaudeCodeACPClient,
+    _ensure_path_within_cwd,
+    _jsonrpc_error,
+    _walk_text_blocks,
+    _extract_text_from_content_blocks,
+    _format_messages_as_prompt,
+    _render_message_content,
+    _coerce_str,
+    _short_preview,
+    resolve_effective_timeout,
+    ToolCallRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+def _make_client(**kwargs) -> ClaudeCodeACPClient:
+    """Create a ClaudeCodeACPClient with sensible test defaults."""
+    defaults = dict(
+        acp_command="/usr/bin/false",  # never actually spawn
+        acp_args=["--stdio"],
+        acp_cwd="/tmp",
+    )
+    defaults.update(kwargs)
+    return ClaudeCodeACPClient(**defaults)
+
+
+class _FakeProcess:
+    """Minimal subprocess stand-in with writable stdin and dummy pid."""
+    def __init__(self, pid: int = 99999):
+        self.stdin = io.StringIO()
+        self.pid = pid
+        self._poll_result = None
+
+    def poll(self):
+        return self._poll_result
+
+    def terminate(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+# ===========================================================================
+# 1. Model name normalization & alias resolution
+# ===========================================================================
+class TestNormalizeModelName(unittest.TestCase):
+    def test_short_aliases(self):
+        for alias in ("haiku", "sonnet", "opus", "claude", "default"):
+            self.assertEqual(ClaudeCodeACPClient._normalize_model_name(alias), alias)
+
+    def test_short_aliases_case_insensitive(self):
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("Opus"), "opus")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("SONNET"), "sonnet")
+
+    def test_full_names_reduce_to_short(self):
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-opus-4-7"), "opus")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-sonnet-4-6"), "sonnet")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-haiku-4-5"), "haiku")
+
+    def test_context_window_suffixes_stripped(self):
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("opus[1m]"), "opus")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("sonnet[200k]"), "sonnet")
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("claude-opus-4-7[1m]"), "opus")
+
+    def test_empty_passthrough(self):
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name(""), "")
+
+    def test_non_claude_passthrough(self):
+        self.assertEqual(ClaudeCodeACPClient._normalize_model_name("gpt-4o"), "gpt-4o")
+
+
+class TestIsValidClaudeAlias(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_client()
+
+    def test_valid_aliases(self):
+        for name in ("haiku", "sonnet", "opus", "claude", "default",
+                      "Opus", "SONNET", "claude-opus-4-7", "opus[1m]"):
+            self.assertTrue(self.client._is_valid_claude_alias(name), name)
+
+    def test_invalid_aliases(self):
+        for name in ("gpt-4o", "mistral", "llama", ""):
+            self.assertFalse(self.client._is_valid_claude_alias(name), name)
+
+
+# ===========================================================================
+# 2. File-safety guards
+# ===========================================================================
+class TestEnsurePathWithinCwd(unittest.TestCase):
+    def test_absolute_within_cwd(self):
+        result = _ensure_path_within_cwd("/tmp/foo.txt", "/tmp")
+        self.assertEqual(result, Path("/tmp/foo.txt").resolve())
+
+    def test_relative_raises(self):
+        with self.assertRaises(PermissionError):
+            _ensure_path_within_cwd("relative.txt", "/tmp")
+
+    def test_traversal_raises(self):
+        with self.assertRaises(PermissionError):
+            _ensure_path_within_cwd("/etc/passwd", "/tmp")
+
+    def test_dot_dot_within_cwd_ok(self):
+        # /tmp/sub/../file resolves inside /tmp
+        result = _ensure_path_within_cwd("/tmp/sub/../file.txt", "/tmp")
+        self.assertEqual(result, Path("/tmp/file.txt").resolve())
+
+    def test_dot_dot_escape_raises(self):
+        with self.assertRaises(PermissionError):
+            _ensure_path_within_cwd("/tmp/../etc/shadow", "/tmp")
+
+
+# ===========================================================================
+# 3. JSON-RPC error helper
+# ===========================================================================
+class TestJsonrpcError(unittest.TestCase):
+    def test_shape(self):
+        err = _jsonrpc_error(42, -32601, "not found")
+        self.assertEqual(err["jsonrpc"], "2.0")
+        self.assertEqual(err["id"], 42)
+        self.assertEqual(err["error"]["code"], -32601)
+        self.assertEqual(err["error"]["message"], "not found")
+
+
+# ===========================================================================
+# 4. Text extraction helpers
+# ===========================================================================
+class TestWalkTextBlocks(unittest.TestCase):
+    def test_string(self):
+        self.assertEqual(list(_walk_text_blocks("hello")), ["hello"])
+
+    def test_dict_text(self):
+        self.assertEqual(list(_walk_text_blocks({"text": "hi"})), ["hi"])
+
+    def test_nested_list(self):
+        obj = [{"text": "a"}, {"content": [{"text": "b"}]}, "c"]
+        self.assertEqual(list(_walk_text_blocks(obj)), ["a", "b", "c"])
+
+    def test_none(self):
+        self.assertEqual(list(_walk_text_blocks(None)), [])
+
+    def test_skips_non_text(self):
+        self.assertEqual(list(_walk_text_blocks({"type": "image", "url": "..."})), [])
+
+
+class TestExtractTextFromContentBlocks(unittest.TestCase):
+    def test_string_content(self):
+        self.assertEqual(_extract_text_from_content_blocks("hello"), "hello")
+
+    def test_list_of_dicts(self):
+        content = [{"type": "text", "text": "hello"}, {"type": "text", "text": "world"}]
+        self.assertEqual(_extract_text_from_content_blocks(content), "hello\nworld")
+
+    def test_none_returns_empty(self):
+        self.assertEqual(_extract_text_from_content_blocks(None), "")
+
+
+class TestShortPreview(unittest.TestCase):
+    def test_short_text(self):
+        self.assertEqual(_short_preview("hello", limit=10), "hello")
+
+    def test_truncated(self):
+        result = _short_preview("a" * 200, limit=10)
+        self.assertTrue(result.endswith("…"))
+        self.assertLessEqual(len(result), 11)  # 10 + "…"
+
+
+class TestCoerceStr(unittest.TestCase):
+    def test_string(self):
+        self.assertEqual(_coerce_str("hello"), "hello")
+
+    def test_int(self):
+        self.assertEqual(_coerce_str(42), "42")
+
+    def test_none(self):
+        self.assertEqual(_coerce_str(None), "")
+
+
+# ===========================================================================
+# 5. resolve_effective_timeout
+# ===========================================================================
+class TestResolveEffectiveTimeout(unittest.TestCase):
+    def test_numeric(self):
+        self.assertEqual(resolve_effective_timeout(30, default=60), 30.0)
+
+    def test_string_uses_default(self):
+        # strings are not int/float, so they go through getattr path
+        self.assertEqual(resolve_effective_timeout("45", default=60), 60.0)
+
+    def test_none_uses_default(self):
+        self.assertEqual(resolve_effective_timeout(None, default=60), 60.0)
+
+    def test_garbage_uses_default(self):
+        self.assertEqual(resolve_effective_timeout("abc", default=60), 60.0)
+
+    def test_negative_passthrough(self):
+        # -1 is a valid number, returns -1.0 (caller's responsibility)
+        self.assertEqual(resolve_effective_timeout(-1, default=60), -1.0)
+
+    def test_zero_passthrough(self):
+        # 0 is a valid number, returns 0.0
+        self.assertEqual(resolve_effective_timeout(0, default=60), 0.0)
+
+
+# ===========================================================================
+# 6. Server message dispatch (_handle_server_message)
+# ===========================================================================
+class TestHandleServerMessage(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_client()
+        self.process = _FakeProcess()
+        self.dispatch_ctx = {"text_parts": [], "reasoning_parts": []}
+
+    def test_session_update_returns_true(self):
+        msg = {
+            "method": "session/update",
+            "params": {"update": {"sessionUpdate": "agent_message_chunk", "content": [{"text": "hi"}]}},
+        }
+        self.assertTrue(self.client._handle_server_message(
+            msg, process=self.process, dispatch_ctx=self.dispatch_ctx,
+        ))
+        self.assertIn("hi", self.dispatch_ctx["text_parts"])
+
+    def test_permission_request_returns_allow(self):
+        msg = {"jsonrpc": "2.0", "id": 1, "method": "session/request_permission", "params": {}}
+        self.assertTrue(self.client._handle_server_message(
+            msg, process=self.process, dispatch_ctx=self.dispatch_ctx,
+        ))
+        written = self.process.stdin.getvalue()
+        resp = json.loads(written.strip())
+        self.assertEqual(resp["result"]["outcome"]["outcome"], "allow_once")
+
+    def test_unknown_method_returns_error(self):
+        msg = {"jsonrpc": "2.0", "id": 5, "method": "unknown/method", "params": {}}
+        self.assertTrue(self.client._handle_server_message(
+            msg, process=self.process, dispatch_ctx=self.dispatch_ctx,
+        ))
+        written = self.process.stdin.getvalue()
+        resp = json.loads(written.strip())
+        self.assertEqual(resp["error"]["code"], -32601)
+
+    def test_non_method_message_returns_false(self):
+        msg = {"jsonrpc": "2.0", "id": 1, "result": {"sessionId": "s1"}}
+        self.assertFalse(self.client._handle_server_message(
+            msg, process=self.process, dispatch_ctx=self.dispatch_ctx,
+        ))
+
+    def test_fs_read_within_cwd(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", dir="/tmp", delete=False) as f:
+            f.write("test content")
+            tmp_path = f.name
+        try:
+            msg = {"jsonrpc": "2.0", "id": 10, "method": "fs/read_text_file", "params": {"path": tmp_path}}
+            self.assertTrue(self.client._handle_server_message(
+                msg, process=self.process, dispatch_ctx=self.dispatch_ctx,
+            ))
+            resp = json.loads(self.process.stdin.getvalue().strip())
+            self.assertEqual(resp["result"]["content"], "test content")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_fs_read_outside_cwd_returns_error(self):
+        msg = {"jsonrpc": "2.0", "id": 10, "method": "fs/read_text_file", "params": {"path": "/etc/passwd"}}
+        self.client._acp_cwd = "/tmp"
+        self.assertTrue(self.client._handle_server_message(
+            msg, process=self.process, dispatch_ctx=self.dispatch_ctx,
+        ))
+        resp = json.loads(self.process.stdin.getvalue().strip())
+        self.assertIn("error", resp)
+        self.assertEqual(resp["error"]["code"], -32602)
+
+    def test_fs_write_outside_cwd_returns_error(self):
+        msg = {"jsonrpc": "2.0", "id": 11, "method": "fs/write_text_file",
+               "params": {"path": "/etc/evil", "content": "bad"}}
+        self.client._acp_cwd = "/tmp"
+        self.assertTrue(self.client._handle_server_message(
+            msg, process=self.process, dispatch_ctx=self.dispatch_ctx,
+        ))
+        resp = json.loads(self.process.stdin.getvalue().strip())
+        self.assertIn("error", resp)
+
+
+# ===========================================================================
+# 7. session/update routing (tool_call_start / tool_call_update)
+# ===========================================================================
+class TestSessionUpdateRouting(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_client()
+        self.dispatch_ctx = {"text_parts": [], "reasoning_parts": []}
+
+    def test_agent_message_chunk(self):
+        update = {"sessionUpdate": "agent_message_chunk", "content": [{"text": "hello"}]}
+        self.client._handle_session_update(update, dispatch_ctx=self.dispatch_ctx)
+        self.assertEqual(self.dispatch_ctx["text_parts"], ["hello"])
+
+    def test_agent_thought_chunk(self):
+        update = {"sessionUpdate": "agent_thought_chunk", "content": [{"text": "thinking..."}]}
+        self.client._handle_session_update(update, dispatch_ctx=self.dispatch_ctx)
+        self.assertEqual(self.dispatch_ctx["reasoning_parts"], ["thinking..."])
+
+    def test_tool_call_start_creates_record(self):
+        update = {
+            "sessionUpdate": "tool_call_start",
+            "toolCallId": "tc-1",
+            "title": "Read",
+            "kind": "read",
+            "rawInput": {"path": "/tmp/f.txt"},
+        }
+        self.client._handle_session_update(update, dispatch_ctx=self.dispatch_ctx)
+        self.assertEqual(len(self.client._tool_trace), 1)
+        rec = self.client._tool_trace[0]
+        self.assertEqual(rec.tool_call_id, "tc-1")
+        self.assertEqual(rec.name, "Read")
+        self.assertEqual(rec.status, "in_progress")
+
+    def test_tool_call_update_completes_record(self):
+        # First create
+        self.client._handle_session_update({
+            "sessionUpdate": "tool_call_start",
+            "toolCallId": "tc-2",
+            "title": "Bash",
+        }, dispatch_ctx=self.dispatch_ctx)
+        # Then complete
+        self.client._handle_session_update({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "tc-2",
+            "status": "completed",
+            "content": [{"text": "done"}],
+        }, dispatch_ctx=self.dispatch_ctx)
+        rec = self.client._tool_records_by_id["tc-2"]
+        self.assertEqual(rec.status, "completed")
+        self.assertEqual(rec.raw_output, "done")
+
+    def test_plan_update_does_not_crash(self):
+        self.client._handle_session_update({
+            "sessionUpdate": "plan",
+            "entries": [{"step": 1, "description": "do stuff"}],
+        }, dispatch_ctx=self.dispatch_ctx)
+
+    def test_available_commands_update_ignored(self):
+        self.client._handle_session_update({
+            "sessionUpdate": "available_commands_update",
+            "commands": [],
+        }, dispatch_ctx=self.dispatch_ctx)
+
+
+# ===========================================================================
+# 8. ToolCallRecord
+# ===========================================================================
+class TestToolCallRecord(unittest.TestCase):
+    def test_duration_none_when_no_end(self):
+        rec = ToolCallRecord(tool_call_id="t1", name="Bash")
+        self.assertIsNone(rec.duration)
+
+    def test_to_dict_roundtrip(self):
+        rec = ToolCallRecord(tool_call_id="t1", name="Bash", raw_input={"cmd": "ls"})
+        d = rec.to_dict()
+        self.assertEqual(d["id"], "t1")
+        self.assertEqual(d["name"], "Bash")
+        self.assertEqual(d["raw_input"], {"cmd": "ls"})
+
+
+# ===========================================================================
+# 9. Client initialization defaults
+# ===========================================================================
+class TestClientInit(unittest.TestCase):
+    def test_hermes_session_id_from_env(self):
+        with patch.dict(os.environ, {"HERMES_SESSION_ID": "env-sess-123"}):
+            client = _make_client()
+            self.assertEqual(client._hermes_session_id, "env-sess-123")
+
+    def test_hermes_session_id_generated_when_empty(self):
+        with patch.dict(os.environ, {"HERMES_SESSION_ID": ""}, clear=False):
+            client = _make_client(hermes_session_id=None)
+            self.assertTrue(client._hermes_session_id.startswith("hermes-"))
+
+    def test_hermes_session_id_explicit_wins(self):
+        client = _make_client(hermes_session_id="explicit-id")
+        self.assertEqual(client._hermes_session_id, "explicit-id")
+
+    def test_default_empty_state(self):
+        client = _make_client()
+        self.assertIsNone(client._session_proc)
+        self.assertIsNone(client._session_id)
+        self.assertIsNone(client._pending_model)
+        self.assertFalse(client.is_closed)
+        self.assertEqual(client._tool_trace, [])
+
+    def test_tool_trace_and_reset(self):
+        client = _make_client()
+        client._tool_trace.append(ToolCallRecord(tool_call_id="x", name="test"))
+        self.assertEqual(len(client.tool_trace), 1)
+        client.reset_tool_trace()
+        self.assertEqual(len(client.tool_trace), 0)
+
+    def test_close_sets_flag(self):
+        client = _make_client()
+        self.assertFalse(client.is_closed)
+        client.close()
+        self.assertTrue(client.is_closed)
+
+
+# ===========================================================================
+# 10. _format_messages_as_prompt (smoke)
+# ===========================================================================
+class TestFormatMessagesAsPrompt(unittest.TestCase):
+    def test_basic_conversation(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "What's 2+2?"},
+        ]
+        result = _format_messages_as_prompt(messages)
+        self.assertIn("Hello", result)
+        self.assertIn("2+2", result)
+
+    def test_tool_messages_included(self):
+        messages = [
+            {"role": "user", "content": "list files"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "tc1", "function": {"name": "bash", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "tc1", "content": "file1.txt\nfile2.txt"},
+        ]
+        result = _format_messages_as_prompt(messages)
+        self.assertIn("file1.txt", result)
+
+    def test_empty_messages(self):
+        result = _format_messages_as_prompt([])
+        self.assertIsInstance(result, str)
+
+
+# ===========================================================================
+# 11. _render_message_content
+# ===========================================================================
+class TestRenderMessageContent(unittest.TestCase):
+    def test_string(self):
+        self.assertEqual(_render_message_content("hello"), "hello")
+
+    def test_list_of_dicts(self):
+        content = [{"type": "text", "text": "hi"}]
+        self.assertEqual(_render_message_content(content), "hi")
+
+    def test_none(self):
+        self.assertEqual(_render_message_content(None), "")
+
+
+# ===========================================================================
+# 12. close() cleanup
+# ===========================================================================
+class TestCloseCleanup(unittest.TestCase):
+    def test_close_terminates_active_process(self):
+        client = _make_client()
+        fake = _FakeProcess()
+        client._active_process = fake
+        client._session_id = "sess-1"
+        client.close()
+        self.assertTrue(client.is_closed)
+        self.assertIsNone(client._session_id)
+        self.assertIsNone(client._active_process)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_claude_code_sandbox.py
+++ b/tests/agent/test_claude_code_sandbox.py
@@ -92,5 +92,43 @@ class TestSandboxPresetsUniqueness(unittest.TestCase):
         self.assertEqual(_resolve_preset(agent), "primary_minus_memory")
 
 
+
+
+# ===========================================================================
+# B2 (b5a4dd6c1) — Iterable import regression guard
+# B3 (b5a4dd6c1) — init channel branch regression guard
+# ===========================================================================
+class TestDeadCodeGrepRegression(unittest.TestCase):
+    """Static-grep tests guarding against re-introduction of patterns
+    removed in commit b5a4dd6c1. These catch the regression mode where
+    a future contributor re-adds the patterns without a real caller."""
+
+    def test_no_iterable_import_in_sandbox(self):
+        """B2: `from typing import Iterable` was removed from sandbox
+        because no SandboxComponents field used it. Re-addition indicates
+        a regression of the dead-import review.
+        """
+        repo = Path(__file__).resolve().parent.parent.parent
+        src = (repo / "agent" / "claude_code_sandbox.py").read_text()
+        self.assertNotIn(
+            "from typing import Iterable", src,
+            "Iterable import was removed in B2 (b5a4dd6c1); "
+            "re-add only if a SandboxComponents field actually uses it",
+        )
+
+    def test_no_init_channel_branch_in_client(self):
+        """B3: the `elif channel == "init":` branch was removed from
+        _apply_acp_arg_directives because no directive targeted the
+        init channel. Re-addition indicates a regression.
+        """
+        repo = Path(__file__).resolve().parent.parent.parent
+        src = (repo / "agent" / "claude_code_acp_client.py").read_text()
+        self.assertNotIn(
+            'channel == "init"', src,
+            'init channel branch was removed in B3 (b5a4dd6c1); '
+            're-add only with explicit caller that routes to init channel',
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_claude_code_sandbox.py
+++ b/tests/agent/test_claude_code_sandbox.py
@@ -1,0 +1,96 @@
+"""E4 (933c653bd) regression: SANDBOX_PRESETS cron_no_workdir merged into
+primary_minus_memory. Verify component uniqueness and preset resolution
+changes since the merge.
+
+Design note: SANDBOX_PRESETS values are SandboxComponents dataclasses
+(not dicts with a 'digest' key). The manifest digest is computed in
+``_collect_manifest_inputs`` + ``_hash_inputs``, where the components
+dict is folded in. Therefore, two presets with identical SandboxComponents
+would produce identical manifest digests for any fixed hermes_home /
+platform / model — which is the exact failure mode E4 fixed
+(cron_no_workdir and primary_minus_memory had identical components,
+leading to identical digests and a useless preset alias).
+
+These tests guard the invariant: distinct presets must have distinct
+SandboxComponents, _resolve_preset must not introduce a separate
+cron_no_workdir mapping, and the merged (T, T, T) flag combo must
+resolve to primary_minus_memory.
+"""
+import dataclasses
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent.claude_code_sandbox import (
+    SANDBOX_PRESETS,
+    _collect_manifest_inputs,
+    _hash_inputs,
+    _resolve_preset,
+)
+
+
+class TestSandboxPresetsUniqueness(unittest.TestCase):
+    def test_preset_component_digests_are_unique(self):
+        """E4: every preset's SandboxComponents must hash to a distinct
+        value. Otherwise the manifest cache could return a stale sandbox
+        for the wrong preset (the original cron_no_workdir bug).
+
+        We compute the digest using a hermes_home with no SOUL/memory/
+        skills/config so the only variable that differs across presets
+        is the components dict — isolating the invariant we care about.
+        """
+        with tempfile.TemporaryDirectory() as empty_home:
+            digests = {}
+            for name, components in SANDBOX_PRESETS.items():
+                inputs = _collect_manifest_inputs(
+                    hermes_home=Path(empty_home),
+                    platform=None,
+                    model=None,
+                    components=components,
+                )
+                digests[name] = _hash_inputs(inputs)
+        self.assertEqual(
+            len(set(digests.values())), len(digests),
+            f"Duplicate component-derived digests detected: {digests}",
+        )
+
+    def test_no_cron_no_workdir_preset_after_e4(self):
+        """E4 merged cron_no_workdir into primary_minus_memory. If a
+        future refactor re-adds it as a separate preset with the same
+        components, this test fails and forces a re-review of the merge.
+        """
+        self.assertNotIn(
+            "cron_no_workdir", SANDBOX_PRESETS,
+            "cron_no_workdir was merged into primary_minus_memory in E4; "
+            "re-add only with explicit caller and distinct components",
+        )
+
+    def test_cron_with_workdir_uses_primary_minus_memory(self):
+        """E4: (F, T, T) — skip_context_files=False, load_soul_identity=True,
+        skip_memory=True — cron with workdir — resolves to
+        primary_minus_memory.
+        """
+        agent = SimpleNamespace(
+            skip_context_files=False,
+            load_soul_identity=True,
+            skip_memory=True,
+        )
+        self.assertEqual(_resolve_preset(agent), "primary_minus_memory")
+
+    def test_cron_no_workdir_flag_combo_resolves_to_primary_minus_memory(self):
+        """E4: (T, T, T) — skip_context_files=True, load_soul_identity=True,
+        skip_memory=True — cron without workdir — used to map to
+        cron_no_workdir; now also resolves to primary_minus_memory since
+        the merge produced an identical components hash.
+        """
+        agent = SimpleNamespace(
+            skip_context_files=True,
+            load_soul_identity=True,
+            skip_memory=True,
+        )
+        self.assertEqual(_resolve_preset(agent), "primary_minus_memory")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1150,7 +1150,7 @@ def _build_child_agent(
         # Detect whether the ACP command targets Claude Code or Copilot.
         _cmd_lower = (override_acp_command or "").lower()
         _args_str = " ".join(override_acp_args or []).lower()
-        if "claude" in _cmd_lower or "claude-agent-acp" in _args_str:
+        if "claude-code-acp" in _cmd_lower:
             effective_provider = "claude-code-acp"
             effective_api_mode = "chat_completions"
         else:
@@ -3011,15 +3011,15 @@ DELEGATE_TASK_SCHEMA = {
                         "acp_command": {
                             "type": "string",
                             "description": (
-                                "Per-task ACP command override (e.g. 'copilot'). "
+                                "Per-task ACP command override (e.g. 'copilot', 'claude-code-acp'). "
                                 "Overrides the top-level acp_command for this task only. "
-                                "Do NOT set unless the user explicitly told you an ACP CLI is installed."
+                                "Do NOT set unless the user explicitly told you an ACP-compatible CLI is installed."
                             ),
                         },
                         "acp_args": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Per-task ACP args override. Leave empty unless acp_command is set.",
+                            "description": "Per-task ACP args override. For supported arguments, see the 'claude-code-acp-delegate' skill. Leave empty unless acp_command is set.",
                         },
                         "role": {
                             "type": "string",
@@ -3060,11 +3060,10 @@ DELEGATE_TASK_SCHEMA = {
             "acp_command": {
                 "type": "string",
                 "description": (
-                    "Override ACP command for child agents (e.g. 'copilot'). "
+                    "Override ACP command for child agents (e.g. 'copilot', 'claude-code-acp'). "
                     "When set, children use ACP subprocess transport instead of inheriting "
-                    "the parent's transport. Requires an ACP-compatible CLI "
-                    "(currently GitHub Copilot CLI via 'copilot --acp --stdio'). "
-                    "See agent/copilot_acp_client.py for the implementation. "
+                    "the parent's transport. Requires an ACP-compatible CLI installed and configured. "
+                    "For details on ACP parameters and usage, see the 'claude-code-acp-delegate' skill. "
                     "IMPORTANT: Do NOT set this unless the user has explicitly told you "
                     "a specific ACP-compatible CLI is installed and configured. "
                     "Leave empty to use the parent's default transport (Hermes subagents)."
@@ -3074,8 +3073,9 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Arguments for the ACP command (default: ['--acp', '--stdio']). "
+                    "Arguments for the ACP command. "
                     "Only used when acp_command is set. "
+                    "For supported arguments by each ACP provider, see the 'claude-code-acp-delegate' skill. "
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1147,10 +1147,15 @@ def _build_child_agent(
         effective_acp_args = []
 
     if override_acp_command:
-        # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
-        # so run_agent.py initializes the CopilotACPClient.
-        effective_provider = "copilot-acp"
-        effective_api_mode = "chat_completions"
+        # Detect whether the ACP command targets Claude Code or Copilot.
+        _cmd_lower = (override_acp_command or "").lower()
+        _args_str = " ".join(override_acp_args or []).lower()
+        if "claude" in _cmd_lower or "claude-agent-acp" in _args_str:
+            effective_provider = "claude-code-acp"
+            effective_api_mode = "chat_completions"
+        else:
+            effective_provider = "copilot-acp"
+            effective_api_mode = "chat_completions"
 
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1148,9 +1148,12 @@ def _build_child_agent(
 
     if override_acp_command:
         # Detect whether the ACP command targets Claude Code or Copilot.
+        # Tightened match: only route to claude-code-acp when the command name
+        # explicitly contains "claude-code-acp". The prior broader match on
+        # "claude" would misroute any claude-prefixed command (e.g. the bare
+        # "claude" CLI) to the claude-code-acp provider.
         _cmd_lower = (override_acp_command or "").lower()
-        _args_str = " ".join(override_acp_args or []).lower()
-        if "claude" in _cmd_lower or "claude-agent-acp" in _args_str:
+        if "claude-code-acp" in _cmd_lower:
             effective_provider = "claude-code-acp"
             effective_api_mode = "chat_completions"
         else:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1150,7 +1150,7 @@ def _build_child_agent(
         # Detect whether the ACP command targets Claude Code or Copilot.
         _cmd_lower = (override_acp_command or "").lower()
         _args_str = " ".join(override_acp_args or []).lower()
-        if "claude-code-acp" in _cmd_lower:
+        if "claude" in _cmd_lower or "claude-agent-acp" in _args_str:
             effective_provider = "claude-code-acp"
             effective_api_mode = "chat_completions"
         else:
@@ -3062,8 +3062,10 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Override ACP command for child agents (e.g. 'copilot', 'claude-code-acp'). "
                     "When set, children use ACP subprocess transport instead of inheriting "
-                    "the parent's transport. Requires an ACP-compatible CLI installed and configured. "
-                    "For details on ACP parameters and usage, see the 'claude-code-acp-delegate' skill. "
+                    "the parent's transport. Requires an ACP-compatible CLI "
+                    "(e.g. GitHub Copilot CLI via 'copilot --acp --stdio'). "
+                    "See agent/copilot_acp_client.py for the implementation. "
+                    "For ACP parameter details and usage, see the 'claude-code-acp-delegate' skill. "
                     "IMPORTANT: Do NOT set this unless the user has explicitly told you "
                     "a specific ACP-compatible CLI is installed and configured. "
                     "Leave empty to use the parent's default transport (Hermes subagents)."
@@ -3073,7 +3075,7 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Arguments for the ACP command. "
+                    "Arguments for the ACP command (default: ['--acp', '--stdio'] for copilot). "
                     "Only used when acp_command is set. "
                     "For supported arguments by each ACP provider, see the 'claude-code-acp-delegate' skill. "
                     "Leave empty unless acp_command is explicitly provided."


### PR DESCRIPTION
## Post-Merge Update: Integration Verification, Test Coverage, and Documentation

This update brings the PR from initial implementation to production-ready: 31 commits covering real-world verification, comprehensive testing (88 tests), architectural refinements, and built-in documentation.

---

### 1. What This PR Adds to Hermes

**A new `claude-code-acp` provider** that lets Hermes spawn Claude Code as a subagent via the Agent Client Protocol (ACP). This enables:

#### 1.1 Subagent Delegation via Claude Code

```python
delegate_task(
    goal="Implement feature X",
    acp_command="claude-code-acp",
    acp_args=["--model", "sonnet"]
)
```

Hermes spawns a Claude Code process as a child agent. The child gets:
- Its own sandboxed working directory with generated `CLAUDE.md` and `.mcp.json`
- Access to Hermes MCP tools (file ops, terminal, etc.) injected automatically
- Per-session model selection — each parallel subagent can run a different model

#### 1.2 Multi-Model Support

Models are set **per-session** via `session/set_config_option` (not shared config files), so parallel subagents with different models don't interfere:

| Model | acp_args | Status |
|-------|----------|--------|
| `opus`, `sonnet`, `haiku` | `--model <alias>` | ✅ Verified |
| `claude-opus-4-7`, `sonnet[200k]` | `--model <full-name>` | ✅ Supported (alias normalization) |
| Omitted | (no `--model`) | ✅ Falls back to `~/.claude/settings.json` |

#### 1.3 Sandbox with Preset System

Each subagent gets a purpose-built sandbox via `SandboxComponents` + `SANDBOX_PRESETS`:

| Preset | Use Case | What's Included |
|--------|----------|-----------------|
| `primary` | Main subagent | CLAUDE.md + .mcp.json + settings.local.json + skills + SOUL + memory |
| `primary_minus_memory` | Cron / no-memory tasks | Same as primary, without memory injection |
| `cron_no_workdir` | Cron without workdir | Same as primary_minus_memory (merged — was previously a duplicate) |

Key design choices:
- **Manifest caching** — sandbox directory is reused when inputs haven't changed (digest-based)
- **Skill flattening** — nested skill directories are flattened into the sandbox for Claude Code to discover
- **MCP server injection** — `hermes_tools` (file/terminal/etc.) and `hermes_messaging` (cross-platform send) are wired via `.mcp.json`

#### 1.4 File Safety Guards (Not Implemented, Not Tested)

`_ensure_path_within_cwd()` is implemented in the client and wired into `fs/read_text_file` and `fs/write_text_file` permission handlers. However, this mechanism is **not yet implemented end-to-end and has not been tested** — it is unclear whether the guard can correctly intercept file operations in practice.

#### 1.5 Delegate Task Integration

`delegate_task` tool schema updated with ACP-specific parameters:

| Parameter | Purpose |
|-----------|---------|
| `acp_command` | Route to ACP provider (e.g. `"claude-code-acp"` or `"copilot"`) |
| `acp_args` | Provider-specific arguments (`["--model", "opus"]`) |

Provider detection: `delegate_tool.py` matches `acp_command` containing `"claude-code-acp"` to route to the correct provider. Both copilot and claude-code-acp are supported.

---

### 2. Architecture

```
delegate_task(acp_command="claude-code-acp", acp_args=["--model", "sonnet"])
    │
    ▼
tools/delegate_tool.py          ← detects "claude-code-acp", sets provider + api_mode
    │
    ▼
agent/agent_runtime_helpers.py  ← creates ClaudeCodeACPClient (factory)
    │
    ▼
agent/claude_code_acp_client.py ← ACP JSON-RPC transport
    │  - session/new → session/set_config_option (model) → prompt loop
    │  - _resolve_command() for subprocess launch argv
    │  - _apply_acp_arg_directives() for runtime config (--model, --effort)
    │  - File safety guards (not yet effective — see §1.4)
    │  - Tool-call tracing (ToolCallRecord)
    │
    ▼
agent/claude_code_sandbox.py    ← sandbox builder
    │  - SandboxComponents (composable pieces)
    │  - SANDBOX_PRESETS (named configurations)
    │  - Manifest caching (digest-based reuse)
    │  - Skill flattening + MCP injection
    ▼
    claude-agent-acp subprocess (via npx or global install)
```

---

### 3. Documentation

- **Built-in skill**: `skills/software-development/claude-code-acp-delegate/SKILL.md` — parameter reference, pitfall notes, usage examples for `delegate_task` with ACP
- **Schema descriptions**: `delegate_task` tool schema updated with `claude-code-acp` examples and skill references (copilot references preserved)
- **`__init__` docstrings**: clarified routing placeholders vs subprocess launch argv

---

### 4. Real-World Verification

- ✅ **Sonnet**: Full tool-call cycle — Read, Write, Bash tools confirmed working
- ✅ **Haiku**: Same pattern — correct model routing verified
- ✅ **`--model` flag**: `session/set_config_option` confirmed setting model after session creation
- ⚠️ **`--effort` flag**: Code path works end-to-end (parsed → sent to ACP) but `claude-agent-acp` bridge returns `Internal error`. Noted in skill as unavailable; needs upstream debugging

---

### 5. What's Intentionally Deferred

These are noted in the built-in skill and tracked for follow-up:

- **Permission auto-allow** — Currently `allow_once` for all ACP requests. Integration with Hermes approval system is a follow-up
- **`--effort` parameter** — Tested but upstream bridge returns error
- **`acp_cwd` per-task** — `__init__` accepts it, `delegate_task` schema doesn't expose it yet
- **Multimodal passthrough** — Image/audio stripped with warn-once; waiting for Claude Code vision support
- **Base class extraction** — `ClaudeCodeACPClient` is self-contained (no shared base with `CopilotACPClient`). See #38663 for the generic base class proposal

---

### 6. Known Issues

#### 6.1 `acp_args` Supported Parameters

The `acp_args` parameter in `delegate_task` is parsed by `_apply_acp_arg_directives()` and routed to the ACP session via `session/set_config_option`. Currently three directives are recognized:

| Directive | Example | Status | Notes |
|-----------|---------|--------|-------|
| `--model <name>` | `["--model", "sonnet"]` | ✅ Working | Alias normalization (`sonnet` → `claude-sonnet-4`), context-window suffixes (`opus[1m]`) |
| `--effort <level>` | `["--effort", "high"]` | ⚠️ Not working | Code path works end-to-end (parsed → sent via `session/set_config_option`), but `claude-agent-acp` bridge returns `Internal error`. Needs upstream debugging |
| `--permission-mode <mode>` | `["--permission-mode", "auto"]` | ⚠️ Not working | Same situation — parsed correctly, bridge rejects |

Unrecognized flags are passed through to the bridge as-is (best-effort).

#### 6.2 Sandbox Does Not Enforce Permission Control

The sandbox builder (`agent/claude_code_sandbox.py`) generates `settings.local.json` with `permissions.allow` set to `["*"]` — meaning **all ACP permission requests are auto-allowed**. The client's `_handle_permission_request()` unconditionally returns `allow_once` for every request.

This means:
- File reads/writes within the sandbox cwd are unrestricted
- The file safety guard (`_ensure_path_within_cwd`) only blocks **cross-boundary** access — within the sandbox, Claude Code has full read/write
- There is no integration with Hermes' approval system (`tools/approval.py`) — dangerous commands (e.g. `rm -rf`, network operations) are not gated
- Terminal/Bash operations through ACP are not subject to Hermes' dangerous-command detection

This is a known limitation of the initial implementation. A follow-up direction is to explore making the sandbox align more closely with Hermes' existing permission and isolation model, rather than maintaining a separate permission path.

#### 6.3 Other Known Limitations

- **Multimodal content stripped** — Image/audio/file blocks in messages are removed with a warn-once log. Waiting for Claude Code to support image understanding before implementing temp-file injection.
- **No `acp_cwd` support** — The `acp_cwd` parameter only makes sense after the sandbox's permission and isolation features are fully fleshed out. Currently not implemented.
- **Self-contained client, no shared base** — `ClaudeCodeACPClient` has no shared base class with `CopilotACPClient`. If proposals like #32401 or #38663 are merged into main, we will follow up with a PR to adapt this implementation accordingly.