### PR TITLE
feat: support Slack table blocks

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -52,6 +52,127 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+
+_TABLE_DIVIDER_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
+_NUMERIC_TABLE_CELL_RE = re.compile(r"^\s*\$?-?\d[\d,]*(?:\.\d+)?%?\s*$")
+
+
+def _split_markdown_table_row(line: str) -> list[str] | None:
+    """Return cells for a simple pipe-delimited markdown table row."""
+    stripped = line.strip()
+    if "|" not in stripped:
+        return None
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    cells = [cell.strip() for cell in stripped.split("|")]
+    if len(cells) < 2:
+        return None
+    return cells
+
+
+def _looks_like_markdown_table_divider(line: str) -> bool:
+    return bool(_TABLE_DIVIDER_RE.match(line))
+
+
+def _table_cell(text: str) -> dict[str, str]:
+    # Slack's table block supports rich_text/raw_text/raw_number.  raw_text is
+    # accepted for all cell values and avoids guessing raw_number's exact value
+    # shape across Slack SDK/API versions.
+    return {"type": "raw_text", "text": text}
+
+
+def _section_blocks_from_text(text: str) -> list[dict[str, Any]]:
+    formatted = SlackAdapter.__new__(SlackAdapter).format_message(text.strip()) if text.strip() else ""
+    if not formatted:
+        return []
+    blocks = []
+    # Slack section text hard-limit is 3000 chars. Split conservatively.
+    for start in range(0, len(formatted), 2900):
+        chunk = formatted[start:start + 2900].strip()
+        if chunk:
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": chunk}})
+    return blocks
+
+
+def _markdown_tables_to_slack_blocks(content: str) -> list[dict[str, Any]] | None:
+    """Convert simple markdown tables in a message to Slack table blocks.
+
+    Returns ``None`` when the message has no convertible tables or would exceed
+    Slack Block Kit limits, so callers can fall back to plain mrkdwn.
+    """
+    lines = content.splitlines()
+    blocks: list[dict[str, Any]] = []
+    text_buf: list[str] = []
+    converted = False
+    i = 0
+    in_fence = False
+
+    def flush_text() -> None:
+        nonlocal text_buf, blocks
+        if text_buf:
+            blocks.extend(_section_blocks_from_text("\n".join(text_buf)))
+            text_buf = []
+
+    while i < len(lines):
+        line = lines[i]
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            text_buf.append(line)
+            i += 1
+            continue
+
+        next_line = lines[i + 1] if i + 1 < len(lines) else ""
+        header = _split_markdown_table_row(line) if not in_fence else None
+        if header and _looks_like_markdown_table_divider(next_line):
+            rows = [header]
+            i += 2
+            while i < len(lines):
+                row = _split_markdown_table_row(lines[i])
+                if row is None or len(row) != len(header):
+                    break
+                rows.append(row)
+                i += 1
+
+            if len(rows) > 100 or len(header) > 20:
+                return None
+
+            flush_text()
+            numeric_cols = {
+                idx
+                for idx in range(len(header))
+                if any((r[idx] or "").strip() for r in rows[1:])
+                and all(
+                    not (r[idx] or "").strip() or _NUMERIC_TABLE_CELL_RE.match(r[idx])
+                    for r in rows[1:]
+                )
+            }
+            column_settings = []
+            for idx in range(len(header)):
+                setting: dict[str, Any] = {}
+                if idx == 0:
+                    setting["is_wrapped"] = True
+                if idx in numeric_cols:
+                    setting["align"] = "right"
+                column_settings.append(setting)
+            blocks.append({
+                "type": "table",
+                "rows": [[_table_cell(cell) for cell in row] for row in rows],
+                "column_settings": column_settings,
+            })
+            converted = True
+            continue
+
+        text_buf.append(line)
+        i += 1
+
+    flush_text()
+    if not converted or len(blocks) > 50:
+        return None
+    return blocks
+
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -780,9 +901,14 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Convert standard markdown → Slack mrkdwn
             formatted = self.format_message(content)
-
-            # Split long messages, preserving code block boundaries
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            explicit_blocks = None
+            if metadata and metadata.get("blocks") is not None:
+                candidate = metadata.get("blocks")
+                if isinstance(candidate, dict):
+                    candidate = candidate.get("blocks")
+                if isinstance(candidate, list):
+                    explicit_blocks = candidate
+            table_blocks = explicit_blocks or _markdown_tables_to_slack_blocks(content)
 
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
@@ -791,19 +917,35 @@ class SlackAdapter(BasePlatformAdapter):
             # Controlled via platform config: gateway.slack.reply_broadcast
             broadcast = self.config.extra.get("reply_broadcast", False)
 
-            for i, chunk in enumerate(chunks):
+            if table_blocks:
                 kwargs = {
                     "channel": chat_id,
-                    "text": chunk,
+                    "text": formatted or " ",
                     "mrkdwn": True,
+                    "blocks": table_blocks,
                 }
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
-                    # Only broadcast the first chunk of the first reply
-                    if broadcast and i == 0:
+                    if broadcast:
                         kwargs["reply_broadcast"] = True
-
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            else:
+                # Split long messages, preserving code block boundaries
+                chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+
+                for i, chunk in enumerate(chunks):
+                    kwargs = {
+                        "channel": chat_id,
+                        "text": chunk,
+                        "mrkdwn": True,
+                    }
+                    if thread_ts:
+                        kwargs["thread_ts"] = thread_ts
+                        # Only broadcast the first chunk of the first reply
+                        if broadcast and i == 0:
+                            kwargs["reply_broadcast"] = True
+
+                    last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -93,6 +93,54 @@ def _redirect_cache(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# TestTableBlocks
+# ---------------------------------------------------------------------------
+
+class TestTableBlocks:
+    @pytest.mark.asyncio
+    async def test_send_converts_markdown_table_to_slack_table_block(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "123.456"})
+
+        result = await adapter.send(
+            chat_id="C123",
+            content=(
+                "Past week actuals\n\n"
+                "| Product | Units | Sales |\n"
+                "|---|---:|---:|\n"
+                "| Tito's | 103 | $3,087.94 |\n"
+                "| Steel 43 | 33 | $734.42 |\n"
+            ),
+        )
+
+        assert result.success
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert kwargs["text"].startswith("Past week actuals")
+        table_block = next(block for block in kwargs["blocks"] if block["type"] == "table")
+        assert table_block["rows"][0][0] == {"type": "raw_text", "text": "Product"}
+        assert table_block["rows"][1][0] == {"type": "raw_text", "text": "Tito's"}
+        assert table_block["rows"][2][2] == {"type": "raw_text", "text": "$734.42"}
+        assert table_block["column_settings"][1]["align"] == "right"
+        assert table_block["column_settings"][2]["align"] == "right"
+
+    @pytest.mark.asyncio
+    async def test_send_passes_explicit_metadata_blocks_through(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "123.456"})
+        blocks = [{"type": "table", "rows": [[{"type": "raw_text", "text": "A"}]]}]
+
+        result = await adapter.send(
+            chat_id="C123",
+            content="fallback",
+            metadata={"blocks": blocks, "thread_id": "111.222"},
+        )
+
+        assert result.success
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["blocks"] is blocks
+        assert kwargs["thread_ts"] == "111.222"
+
+
+# ---------------------------------------------------------------------------
 # TestSlashCommandSessionIsolation
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -596,6 +596,36 @@ class TestSendToPlatformChunking:
             "*hello* from <https://example.com|Hermes>",
         )
 
+    def test_slack_blocks_are_passed_to_slack_sender(self, monkeypatch):
+        _ensure_slack_mock(monkeypatch)
+
+        import gateway.platforms.slack as slack_mod
+
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        blocks = [{"type": "table", "rows": [[{"type": "raw_text", "text": "A"}]]}]
+        send = AsyncMock(return_value={"success": True, "message_id": "1"})
+
+        with patch("tools.send_message_tool._send_slack", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "C123",
+                    "fallback",
+                    thread_id="111.222",
+                    blocks=blocks,
+                )
+            )
+
+        assert result["success"] is True
+        send.assert_awaited_once_with(
+            "***",
+            "C123",
+            "fallback",
+            thread_id="111.222",
+            blocks=blocks,
+        )
+
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):
         """Bold+italic ***text*** survives tool-layer formatting."""
         _ensure_slack_mock(monkeypatch)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -140,6 +140,9 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> for a file under a Hermes media cache or HERMES_MEDIA_ALLOW_DIRS — the platform will deliver it as a native media attachment."
+            },
+            "blocks": {
+                "description": "Slack only: optional Block Kit blocks to pass through to chat.postMessage, for example a table block. Accepts either a blocks array, an object with a top-level 'blocks' array, or a JSON string containing either shape. 'message' is still used as fallback notification text."
             }
         },
         "required": []
@@ -166,12 +169,42 @@ def _handle_list():
         return json.dumps(_error(f"Failed to load channel directory: {e}"))
 
 
+def _normalize_slack_blocks_arg(blocks):
+    """Normalize a send_message Slack ``blocks`` argument to a Block Kit list.
+
+    Accepts either the raw blocks array, a ``{"blocks": [...]}`` wrapper, or a
+    JSON string containing either shape.  Validation here is intentionally light:
+    Slack remains the source of truth for per-block schemas, while Hermes catches
+    common wrong-shape mistakes before making an API call.
+    """
+    if isinstance(blocks, str):
+        try:
+            blocks = json.loads(blocks)
+        except Exception as exc:
+            return None, f"Slack blocks must be valid JSON when provided as a string: {exc}"
+
+    if isinstance(blocks, dict):
+        blocks = blocks.get("blocks")
+
+    if not isinstance(blocks, list):
+        return None, "Slack blocks must be a list of Block Kit block objects or an object with a top-level 'blocks' list"
+    if not blocks:
+        return None, "Slack blocks cannot be empty"
+    if len(blocks) > 50:
+        return None, "Slack blocks cannot contain more than 50 top-level blocks"
+    for idx, block in enumerate(blocks):
+        if not isinstance(block, dict) or not isinstance(block.get("type"), str):
+            return None, f"Slack block at index {idx} must be an object with a string 'type' field"
+    return blocks, None
+
+
 def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
-    if not target or not message:
-        return tool_error("Both 'target' and 'message' are required when action='send'")
+    blocks = args.get("blocks")
+    if not target or (not message and blocks is None):
+        return tool_error("Both 'target' and 'message' are required when action='send' unless Slack 'blocks' are provided")
 
     parts = target.split(":", 1)
     platform_name = parts[0].strip().lower()
@@ -183,6 +216,15 @@ def _handle_send(args):
         chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
     else:
         is_explicit = False
+
+    if blocks is not None and platform_name != "slack":
+        return tool_error("The 'blocks' parameter is only supported for Slack targets")
+
+    normalized_blocks = None
+    if blocks is not None:
+        normalized_blocks, blocks_error = _normalize_slack_blocks_arg(blocks)
+        if blocks_error:
+            return tool_error(blocks_error)
 
     # Resolve human-friendly channel names to numeric IDs
     if target_ref and not is_explicit:
@@ -300,15 +342,20 @@ def _handle_send(args):
 
     try:
         from model_tools import _run_async
+        send_kwargs = {
+            "thread_id": thread_id,
+            "media_files": media_files,
+            "force_document": force_document_attachments,
+        }
+        if normalized_blocks is not None:
+            send_kwargs["blocks"] = normalized_blocks
         result = _run_async(
             _send_to_platform(
                 platform,
                 pconfig,
                 chat_id,
                 cleaned_message,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document_attachments,
+                **send_kwargs,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -555,7 +602,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, blocks=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -581,6 +628,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         _feishu_available = False
 
     media_files = media_files or []
+
+    if blocks is not None:
+        if platform != Platform.SLACK:
+            return {"error": "Block Kit blocks are only supported for Slack targets"}
+        return await _send_slack(pconfig.token, chat_id, message or "", thread_id=thread_id, blocks=blocks)
 
     if platform == Platform.SLACK and message:
         try:
@@ -752,7 +804,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            if thread_id:
+                result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
+            else:
+                result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1034,7 +1089,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None, blocks=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1047,7 +1102,11 @@ async def _send_slack(token, chat_id, message):
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
-            payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            payload = {"channel": chat_id, "text": message or " ", "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
+            if blocks is not None:
+                payload["blocks"] = blocks
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary\n- pass Slack Block Kit blocks through from send_message to chat.postMessage\n- auto-convert simple Markdown pipe tables in Slack gateway responses to native table blocks\n- add focused Slack adapter and send_message tests\n\n## Tests\n- uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_slack.py tests/tools/test_send_message_tool.py -q -o 'addopts='\n- attempted full suite with needed ACP/websocket deps; it did not complete within 600s and showed unrelated pre-existing broad-suite failures/timeouts before timing out\n