### PR TITLE
feat: add claude-opus-4.8 and claude-opus-4.8-fast

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -77,16 +77,16 @@ ADAPTIVE_EFFORT_MAP = {
 # xhigh as a distinct level between high and max; older adaptive-thinking
 # models (4.6) reject it with a 400.  Keep this substring list in sync with
 # the Anthropic migration guide as new model families ship.
-_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7")
+_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8")
 
 # Models where extended thinking is deprecated/removed (4.6+ behavior: adaptive
 # is the only supported mode; 4.7 additionally forbids manual thinking entirely
 # and drops temperature/top_p/top_k).
-_ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7")
+_ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7", "4-8", "4.8")
 
 # Models where temperature/top_p/top_k return 400 if set to non-default values.
 # This is the Opus 4.7 contract; future 4.x+ models are expected to follow it.
-_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7")
+_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8")
 _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 
 # ── Max output token limits per Anthropic model ───────────────────────
@@ -94,6 +94,8 @@ _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
+    # Claude 4.8
+    "claude-opus-4-8":   128_000,
     # Claude 4.7
     "claude-opus-4-7":   128_000,
     # Claude 4.6

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -141,6 +141,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # fuzzy-match collisions (e.g. "anthropic/claude-sonnet-4" is a
     # substring of "anthropic/claude-sonnet-4.6").
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
+    "claude-opus-4-8": 1000000,
+    "claude-opus-4.8": 1000000,
     "claude-opus-4-7": 1000000,
     "claude-opus-4.7": 1000000,
     "claude-opus-4-6": 1000000,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -83,6 +83,34 @@ _UTC_NOW = lambda: datetime.now(timezone.utc)
 # Official docs snapshot entries. Models whose published pricing and cache
 # semantics are stable enough to encode exactly.
 _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
+    # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
+    # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
+    # model ID with 2x premium (vs the 6x premium on older Opus generations).
+    # Source: https://openrouter.ai/anthropic/claude-opus-4.8
+    (
+        "anthropic",
+        "claude-opus-4-8",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-05",
+    ),
+    (
+        "anthropic",
+        "claude-opus-4-8-fast",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        source="official_docs_snapshot",
+        source_url="https://openrouter.ai/anthropic/claude-opus-4.8-fast",
+        pricing_version="anthropic-pricing-2026-05",
+    ),
     # ── Anthropic Claude 4.7 ─────────────────────────────────────────────
     # Opus 4.5/4.6/4.7 share $5/$25 pricing (new tokenizer, up to 35% more
     # tokens for the same text).

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -32,6 +32,8 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
+    ("anthropic/claude-opus-4.8",              ""),
+    ("anthropic/claude-opus-4.8-fast",         "2x price, higher output speed"),
     ("anthropic/claude-opus-4.7",              ""),
     ("anthropic/claude-opus-4.6",              ""),
     ("anthropic/claude-sonnet-4.6",            ""),
@@ -139,6 +141,7 @@ def _xai_curated_models() -> list[str]:
 
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
+        "anthropic/claude-opus-4.8",
         "anthropic/claude-opus-4.7",
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
@@ -290,6 +293,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2",
     ],
     "anthropic": [
+        "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1188,16 +1188,27 @@ class TestBuildAnthropicKwargs:
         # params through its signature, we exercise the strip behavior by
         # calling the internal predicate directly.
         from agent.anthropic_adapter import _forbids_sampling_params
+        assert _forbids_sampling_params("claude-opus-4-8") is True
+        assert _forbids_sampling_params("claude-opus-4-8-fast") is True
         assert _forbids_sampling_params("claude-opus-4-7") is True
         assert _forbids_sampling_params("claude-opus-4-6") is False
         assert _forbids_sampling_params("claude-sonnet-4-5") is False
 
     def test_supports_fast_mode_predicate(self):
-        """Fast mode is Opus 4.6 only — Opus 4.7 and others must be excluded."""
+        """Fast mode is Opus 4.6 only — Opus 4.7 and others must be excluded.
+
+        For Opus 4.8 the fast variant is a separate model ID
+        (anthropic/claude-opus-4.8-fast) routed through the normal model
+        field, NOT via the ``speed: "fast"`` request parameter. So
+        ``_supports_fast_mode`` (which gates the parameter) must stay
+        False for both opus-4-8 and opus-4-8-fast.
+        """
         from agent.anthropic_adapter import _supports_fast_mode
         assert _supports_fast_mode("claude-opus-4-6") is True
         assert _supports_fast_mode("anthropic/claude-opus-4-6") is True
         assert _supports_fast_mode("claude-opus-4-7") is False
+        assert _supports_fast_mode("claude-opus-4-8") is False
+        assert _supports_fast_mode("claude-opus-4-8-fast") is False
         assert _supports_fast_mode("claude-sonnet-4-6") is False
         assert _supports_fast_mode("claude-haiku-4-5") is False
         assert _supports_fast_mode("") is False

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -131,10 +131,10 @@ class TestDefaultContextLengths:
         for key, value in DEFAULT_CONTEXT_LENGTHS.items():
             if "claude" not in key:
                 continue
-            # Claude 4.6+ models (4.6 and 4.7) have 1M context at standard
+            # Claude 4.6+ models (4.6, 4.7, 4.8) have 1M context at standard
             # API pricing (no long-context premium).  Older Claude 4.x and
             # 3.x models cap at 200k.
-            if any(tag in key for tag in ("4.6", "4-6", "4.7", "4-7")):
+            if any(tag in key for tag in ("4.6", "4-6", "4.7", "4-7", "4.8", "4-8")):
                 assert value == 1000000, f"{key} should be 1000000"
             else:
                 assert value == 200000, f"{key} should be 200000"

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-26T20:49:36Z",
+  "updated_at": "2026-05-28T17:19:08Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -12,6 +12,14 @@
         "note": "Descriptions drive picker badges. Live /api/v1/models filters curated ids by tool-calling support and free pricing."
       },
       "models": [
+        {
+          "id": "anthropic/claude-opus-4.8",
+          "description": ""
+        },
+        {
+          "id": "anthropic/claude-opus-4.8-fast",
+          "description": "2x price, higher output speed"
+        },
         {
           "id": "anthropic/claude-opus-4.7",
           "description": ""
@@ -144,6 +152,9 @@
         "note": "Free-tier gating is determined live via Portal pricing (partition_nous_models_by_tier), not this manifest."
       },
       "models": [
+        {
+          "id": "anthropic/claude-opus-4.8"
+        },
         {
           "id": "anthropic/claude-opus-4.7"
         },


### PR DESCRIPTION
## Summary

Anthropic released **Claude Opus 4.8** on 2026-05-27, with a fast-mode variant priced at 2x of the base model (vs the 6x premium on Opus 4.6/4.7 fast variants). Both are live on OpenRouter, Anthropic, Amazon Bedrock, and Claude Platform on AWS:

- https://openrouter.ai/anthropic/claude-opus-4.8
- https://openrouter.ai/anthropic/claude-opus-4.8-fast

This PR wires the new models through every static surface (picker lists, context-length table, anthropic-adapter behavior gates, pricing table, model-catalog manifest) using the same patterns established for opus-4.7.

The fast variant on 4.8 is a **separate model ID** (Anthropic shipped it via the OpenRouter model slug rather than as a `speed: "fast"` request parameter). `_supports_fast_mode` — which gates the `speed: "fast"` request parameter — stays scoped to opus-4.6 only, since that's still the only model where the parameter is accepted.

## Changes

| File | Change |
|---|---|
| `hermes_cli/models.py` | Add `anthropic/claude-opus-4.8` + `…-fast` to the OpenRouter fallback snapshot and the Nous Portal curated list; add `claude-opus-4-8` to the Anthropic-native picker list. |
| `agent/model_metadata.py` | Register 1M context length for `claude-opus-4-8` / `claude-opus-4.8` (matches 4.6/4.7). |
| `agent/anthropic_adapter.py` | Extend `_XHIGH_EFFORT_SUBSTRINGS`, `_ADAPTIVE_THINKING_SUBSTRINGS`, `_NO_SAMPLING_PARAMS_SUBSTRINGS` with `"4-8"/"4.8"`. Add `claude-opus-4-8: 128_000` to `_ANTHROPIC_OUTPUT_LIMITS` (substring match also covers `…-fast` and date-stamped variants). |
| `agent/usage_pricing.py` | Add `_OFFICIAL_DOCS_PRICING` entries: `claude-opus-4-8` at **$5/$25** input/output ($0.50 / $6.25 cache), `claude-opus-4-8-fast` at **$10/$50** ($1.00 / $12.50 cache). OpenRouter routes continue to pull pricing from the live `/models` API. |
| `tests/agent/test_model_metadata.py` | Extend the Claude 4.6+ context-length tag list with `"4.8"/"4-8"`. |
| `website/static/api/model-catalog.json` | Regenerated via `scripts/build_model_catalog.py`. |

Net diff: **+53 / -6 across 6 files**, no new mechanisms — every addition follows the existing 4.7 pattern.

## Why Opus 4.8 inherits the 4.7 API contract

Per Anthropic's [migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide), 4.7 introduced:

1. Adaptive thinking only (extended thinking with `budget_tokens` → 400)
2. Sampling parameters removed (`temperature`/`top_p`/`top_k` non-default → 400)
3. `xhigh` effort level (between high and max)
4. `display: "omitted"` thinking default

The comment on `_NO_SAMPLING_PARAMS_SUBSTRINGS` already says *"This is the Opus 4.7 contract; future 4.x+ models are expected to follow it."* — 4.8 honors that expectation. If Anthropic later relaxes the 4.8 contract, the substring tuples are the single source of truth.

## Test plan

E2E verification with isolated import against the worktree (clean `sys.modules`, prepend worktree to `sys.path`):

```
=== Substring gate checks ===
claude-opus-4.8                     adaptive=True  xhigh=True  forbid_sampling=True  fast_param=False max_out=128000
claude-opus-4.8-fast                adaptive=True  xhigh=True  forbid_sampling=True  fast_param=False max_out=128000
anthropic/claude-opus-4.8           adaptive=True  xhigh=True  forbid_sampling=True  fast_param=False max_out=128000
anthropic/claude-opus-4.8-fast      adaptive=True  xhigh=True  forbid_sampling=True  fast_param=False max_out=128000
claude-opus-4.7                     adaptive=True  xhigh=True  forbid_sampling=True  fast_param=False max_out=128000   (regression OK)
claude-opus-4-6                     adaptive=True  xhigh=False forbid_sampling=False fast_param=True  max_out=128000   (regression OK)

=== Context lengths ===
  claude-opus-4-8 / claude-opus-4.8: 1_000_000

=== Pricing via route + normalization (dot AND dash notation) ===
  anthropic/claude-opus-4.8              → OK input=$5.00/M  output=$25.00/M
  anthropic/claude-opus-4.8-fast         → OK input=$10.00/M output=$50.00/M
  anthropic/claude-opus-4-8              → OK input=$5.00/M  output=$25.00/M
  anthropic/claude-opus-4-8-fast         → OK input=$10.00/M output=$50.00/M
  anthropic/claude-opus-4.7              → OK input=$5.00/M  output=$25.00/M   (regression OK)
```

Unit tests run from the worktree:

```bash
python -m pytest \
  tests/agent/test_usage_pricing.py \
  tests/agent/test_model_metadata.py \
  tests/hermes_cli/test_model_catalog.py \
  tests/hermes_cli/test_models.py \
  tests/hermes_cli/test_model_validation.py \
  tests/hermes_cli/test_models_dev_preferred_merge.py
# 305 passed in 6.16s

python -m pytest tests/agent/test_anthropic_adapter.py \
  -k "fast_mode or sampling or adaptive or xhigh or output_limit"
# 10 passed, 143 deselected
```

The 14 pre-existing `TestResolveAnthropicToken / TestResolveWithRefresh / TestRunOauthSetupToken` failures in `test_anthropic_adapter.py` are unrelated to this PR — they reproduce identically on `origin/main` with `bash scripts/run_tests.sh tests/agent/test_anthropic_adapter.py`.
