### PR TITLE
feat(agent): per-platform request_overrides via platform_request_overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -136,6 +136,99 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _platform_request_overrides_for_agent(
+    *,
+    platform: Optional[str],
+    config: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Resolve the ``platform_request_overrides[<platform>]`` config block.
+
+    Reads the top-level ``platform_request_overrides`` mapping (platform
+    key → ``request_overrides``-shaped dict).  Platform keys are matched
+    case-insensitively against ``agent.platform`` (e.g. ``"api_server"``,
+    ``"telegram"``, ``"cli"``) — the same keys used by ``platform_toolsets``
+    and the gateway's ``Platform`` enum values.
+
+    Returns ``None`` when no block applies so callers can short-circuit.
+    Defensive ``isinstance`` guards protect against YAML deserialisation
+    surprises (e.g. a list where a dict was expected).
+    """
+    if not platform:
+        return None
+    if not isinstance(config, dict):
+        return None
+    raw = config.get("platform_request_overrides")
+    if not isinstance(raw, dict):
+        return None
+    key = str(platform).strip().lower()
+    if not key:
+        return None
+    entry = raw.get(key)
+    if not isinstance(entry, dict) or not entry:
+        return None
+    return dict(entry)
+
+
+def _merge_platform_request_overrides(
+    agent,
+    config: Dict[str, Any],
+    caller_overrides: Optional[Dict[str, Any]],
+) -> None:
+    """Layer per-platform request overrides into ``agent.request_overrides``.
+
+    Precedence (high → low):
+
+      1. Caller-supplied ``request_overrides`` (passed to ``init_agent``).
+      2. ``platform_request_overrides[<platform>]`` (this layer).
+      3. ``custom_providers[].extra_body`` (resolved earlier by
+         :func:`_merge_custom_provider_extra_body`).
+
+    For ``extra_body`` the merge is shallow at the second level so a
+    platform can set one nested key (e.g. ``chat_template_kwargs``)
+    without erasing a sibling key (e.g. ``reasoning_effort``) that a
+    custom-provider entry already supplied.
+
+    Caller-supplied keys always win — the platform layer only fills
+    keys the caller did not pass explicitly.  This preserves the
+    existing contract for code paths that already thread
+    ``request_overrides`` through (auxiliary clients, kanban workers,
+    delegated subagents) — those callers stay in control.
+
+    No-op when no ``platform_request_overrides`` block applies, so
+    untouched configs behave exactly as before.
+    """
+    platform_overrides = _platform_request_overrides_for_agent(
+        platform=getattr(agent, "platform", None),
+        config=config,
+    )
+    if not platform_overrides:
+        return
+
+    caller_top_keys = set((caller_overrides or {}).keys())
+    caller_extra_body = (caller_overrides or {}).get("extra_body")
+    if not isinstance(caller_extra_body, dict):
+        caller_extra_body = {}
+
+    current = dict(getattr(agent, "request_overrides", {}) or {})
+
+    platform_extra_body = platform_overrides.pop("extra_body", None)
+    if isinstance(platform_extra_body, dict) and platform_extra_body:
+        merged = dict(current.get("extra_body") or {})
+        for k, v in platform_extra_body.items():
+            if k in caller_extra_body:
+                continue
+            merged[k] = v
+        if merged:
+            current["extra_body"] = merged
+
+    for k, v in platform_overrides.items():
+        if k in caller_top_keys:
+            continue
+        current[k] = v
+
+    agent.request_overrides = current
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1290,6 +1383,7 @@ def init_agent(
     # compression model context-length detection needs the same list).
     agent._custom_providers = _custom_providers
     _merge_custom_provider_extra_body(agent, _custom_providers)
+    _merge_platform_request_overrides(agent, _agent_cfg, request_overrides)
 
     # Check custom_providers per-model context_length
     if _config_context_length is None and _custom_providers:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -676,6 +676,65 @@ platform_toolsets:
   google_chat: [hermes-google_chat]
 
 # =============================================================================
+# Platform Request Overrides (per-platform LLM request params)
+# =============================================================================
+# Override OpenAI-compatible chat-completion request fields per platform.
+# Useful when one surface needs different LLM behaviour from another —
+# e.g. lower `reasoning_effort` on a latency-sensitive HTTP integration,
+# a different `service_tier` for cron-scheduled runs, or
+# template-specific extra-body flags only some endpoints accept.
+#
+# Layered between the global `custom_providers[].extra_body` (low) and
+# caller-supplied `request_overrides` (high), so callers that already
+# thread overrides through (auxiliary clients, kanban workers, delegated
+# subagents) keep their precedence.
+#
+# Scope: applies to the main conversational LLM call inside the agent
+# loop (OpenAI chat completions, Anthropic messages, Codex responses)
+# for every platform that has a matching entry. It does NOT cover:
+#   * auxiliary model calls (vision, web_extract, compression, skills
+#     hub, etc.) — each of those has its own `auxiliary.<task>.extra_body`
+#     knob in the `auxiliary:` section above
+#   * non-conversational tool requests (embeddings, image generation,
+#     TTS / STT) — those are tool implementations with their own config
+#
+# Platform keys match the `Platform` enum / `platform_toolsets` keys:
+#   cli, telegram, discord, whatsapp, slack, signal, qqbot, teams,
+#   google_chat, homeassistant, api_server, yuanbao
+#
+# Shape: each platform maps to a `request_overrides`-shaped dict.  The
+# `extra_body` sub-key is shallow-merged onto whatever
+# `custom_providers[].extra_body` already supplied, so a platform can
+# add a key without erasing sibling keys.  Top-level keys (e.g.
+# `reasoning_effort`, `service_tier`) replace wholesale.
+#
+# Examples:
+#
+#   # Trim reasoning effort on the OpenAI-compatible HTTP endpoint
+#   # (api_server) while keeping CLI / messaging surfaces at the default.
+#   platform_request_overrides:
+#     api_server:
+#       reasoning_effort: minimal
+#
+#   # Use the priority service tier on CLI but the default everywhere else.
+#   platform_request_overrides:
+#     cli:
+#       service_tier: priority
+#
+#   # Pass a provider-specific extra_body flag for one surface only.
+#   # Example: hybrid-thinking model templates that accept
+#   # `chat_template_kwargs.enable_thinking` (Qwen3, GLM-4.6, Hunyuan, etc.).
+#   platform_request_overrides:
+#     api_server:
+#       extra_body:
+#         chat_template_kwargs:
+#           enable_thinking: false
+#     telegram:
+#       extra_body:
+#         chat_template_kwargs:
+#           enable_thinking: true
+
+# =============================================================================
 # Gateway Platform Settings
 # =============================================================================
 # Optional per-platform messaging settings.

--- a/tests/agent/test_platform_request_overrides.py
+++ b/tests/agent/test_platform_request_overrides.py
@@ -1,0 +1,243 @@
+"""Tests for ``platform_request_overrides`` config-driven per-platform
+``request_overrides`` layering.
+
+Mirrors the structure of :mod:`tests.agent.test_custom_provider_extra_body`
+since the two layers compose: ``custom_providers[].extra_body`` resolves
+first, then per-platform overrides layer in for keys the caller did not
+pass explicitly.
+"""
+from types import SimpleNamespace
+
+from agent.agent_init import (
+    _merge_platform_request_overrides,
+    _platform_request_overrides_for_agent,
+)
+
+
+def _agent(platform="api_server", request_overrides=None):
+    return SimpleNamespace(
+        platform=platform,
+        request_overrides=dict(request_overrides or {}),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _platform_request_overrides_for_agent
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_resolver_returns_none_for_missing_block():
+    assert _platform_request_overrides_for_agent(
+        platform="api_server",
+        config={},
+    ) is None
+
+
+def test_resolver_returns_none_for_unknown_platform():
+    cfg = {
+        "platform_request_overrides": {
+            "telegram": {"extra_body": {"reasoning_effort": "high"}},
+        }
+    }
+    assert _platform_request_overrides_for_agent(
+        platform="api_server",
+        config=cfg,
+    ) is None
+
+
+def test_resolver_returns_none_when_platform_empty():
+    cfg = {"platform_request_overrides": {"api_server": {"reasoning_effort": "low"}}}
+    assert _platform_request_overrides_for_agent(platform="", config=cfg) is None
+    assert _platform_request_overrides_for_agent(platform=None, config=cfg) is None
+
+
+def test_resolver_case_insensitive_platform_key():
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
+        }
+    }
+    result = _platform_request_overrides_for_agent(
+        platform="API_Server",
+        config=cfg,
+    )
+    assert result == {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
+
+
+def test_resolver_returns_copy_not_reference():
+    """The resolver must hand back a copy so a caller mutating its result
+    can't corrupt the parsed config dict shared with other agents."""
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {"reasoning_effort": "minimal"},
+        }
+    }
+    result = _platform_request_overrides_for_agent(platform="api_server", config=cfg)
+    assert result == {"reasoning_effort": "minimal"}
+    result["reasoning_effort"] = "high"
+    assert cfg["platform_request_overrides"]["api_server"]["reasoning_effort"] == "minimal"
+
+
+def test_resolver_tolerates_non_dict_config():
+    assert _platform_request_overrides_for_agent(platform="cli", config=None) is None
+    assert _platform_request_overrides_for_agent(platform="cli", config=[]) is None
+
+
+def test_resolver_tolerates_non_dict_section():
+    cfg = {"platform_request_overrides": ["api_server"]}
+    assert _platform_request_overrides_for_agent(platform="api_server", config=cfg) is None
+
+
+def test_resolver_tolerates_non_dict_entry():
+    cfg = {"platform_request_overrides": {"api_server": "no thinking"}}
+    assert _platform_request_overrides_for_agent(platform="api_server", config=cfg) is None
+
+
+def test_resolver_treats_empty_dict_entry_as_none():
+    cfg = {"platform_request_overrides": {"api_server": {}}}
+    assert _platform_request_overrides_for_agent(platform="api_server", config=cfg) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _merge_platform_request_overrides
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_merge_noop_when_no_block():
+    agent = _agent()
+    _merge_platform_request_overrides(agent, config={}, caller_overrides=None)
+    assert agent.request_overrides == {}
+
+
+def test_merge_noop_when_platform_unmatched():
+    agent = _agent(platform="cli")
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=None)
+    assert agent.request_overrides == {}
+
+
+def test_merge_writes_extra_body_for_matching_platform():
+    agent = _agent(platform="api_server")
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {
+                "extra_body": {
+                    "chat_template_kwargs": {"enable_thinking": False},
+                }
+            }
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=None)
+    assert agent.request_overrides == {
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+    }
+
+
+def test_merge_top_level_keys_pass_through():
+    agent = _agent(platform="api_server")
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {"service_tier": "priority", "reasoning_effort": "minimal"}
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=None)
+    assert agent.request_overrides == {
+        "service_tier": "priority",
+        "reasoning_effort": "minimal",
+    }
+
+
+def test_merge_layers_on_top_of_custom_provider_extra_body():
+    """When a custom_provider has already populated ``extra_body``, the
+    platform layer should overlay its own extra_body keys without
+    erasing siblings.
+    """
+    agent = _agent(
+        platform="api_server",
+        request_overrides={"extra_body": {"reasoning_effort": "high"}},
+    )
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {
+                "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+            }
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=None)
+    assert agent.request_overrides == {
+        "extra_body": {
+            "reasoning_effort": "high",
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+    }
+
+
+def test_merge_respects_caller_extra_body_keys():
+    """The caller may explicitly set ``extra_body.enable_thinking``; the
+    platform layer must not overwrite it."""
+    caller = {"extra_body": {"enable_thinking": True}}
+    agent = _agent(
+        platform="api_server",
+        request_overrides=caller,
+    )
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {"extra_body": {"enable_thinking": False, "reasoning_effort": "low"}}
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=caller)
+    assert agent.request_overrides == {
+        "extra_body": {
+            "enable_thinking": True,         # caller wins
+            "reasoning_effort": "low",        # platform fills the gap
+        }
+    }
+
+
+def test_merge_respects_caller_top_level_keys():
+    caller = {"service_tier": "default"}
+    agent = _agent(
+        platform="api_server",
+        request_overrides=caller,
+    )
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {
+                "service_tier": "priority",
+                "reasoning_effort": "minimal",
+            }
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=caller)
+    assert agent.request_overrides == {
+        "service_tier": "default",           # caller wins
+        "reasoning_effort": "minimal",       # platform fills the gap
+    }
+
+
+def test_merge_ignores_unparseable_extra_body():
+    agent = _agent(platform="api_server")
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {"extra_body": "should be a dict", "reasoning_effort": "low"}
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=None)
+    # Bad extra_body shape is silently dropped; valid top-level keys still apply.
+    assert agent.request_overrides == {"reasoning_effort": "low"}
+
+
+def test_merge_does_not_create_empty_extra_body():
+    agent = _agent(platform="api_server")
+    cfg = {
+        "platform_request_overrides": {
+            "api_server": {"extra_body": {}, "reasoning_effort": "minimal"}
+        }
+    }
+    _merge_platform_request_overrides(agent, config=cfg, caller_overrides=None)
+    assert "extra_body" not in agent.request_overrides
+    assert agent.request_overrides["reasoning_effort"] == "minimal"


### PR DESCRIPTION
## What does this PR do?

Adds a top-level `platform_request_overrides` config key that lets users layer OpenAI-compatible chat-completion request fields per platform. When the same `AIAgent` configuration drives multiple surfaces (`cli`, `telegram`, `api_server`, etc.), each platform can now carry its own `extra_body`, `reasoning_effort`, and `service_tier` overrides — without forking the global config or running a separate process per surface.

**Resolution order (high → low):**

1. Caller-supplied `request_overrides` (highest — preserves the existing contract for auxiliary clients, kanban workers, delegated subagents).
2. `platform_request_overrides[<platform>]` (new layer).
3. `custom_providers[].extra_body` (existing global, resolved earlier by `_merge_custom_provider_extra_body`).

`extra_body` is shallow-merged at the second level so a platform setting one nested key (e.g. `chat_template_kwargs`) doesn't erase siblings (e.g. `reasoning_effort`) a custom-provider entry already supplied. Top-level keys (`service_tier`, `reasoning_effort`) replace wholesale.

No-op when `platform_request_overrides` is absent or the current platform key has no entry — untouched configs behave exactly as before.

**Scope of the override**: applies to the main conversational LLM call (OpenAI chat completions / Anthropic messages / Codex responses) for every platform that has a matching entry. Does NOT cover auxiliary model calls (those have their own `auxiliary.<task>.extra_body` knob) or non-conversational tool requests (embeddings, image generation, TTS / STT). Documented inline in `cli-config.yaml.example`.

## Related Issue

Fixes #34006

Adjacent (open) PRs reviewed before designing this, in case reviewers want context:

- #12427 — global `chat_template_kwargs.enable_thinking=false` for llama.cpp / vLLM (this PR enables the same knob per-platform)
- #31589 — provider-scoped `agent.reasoning_effort` overrides (same shape, different axis)
- #32813 — per-auxiliary `reasoning_effort` configuration (same shape on the auxiliary axis)
- #33329 — channel-model bindings (closest architectural precedent for per-surface LLM-param config)
- #29858 — custom-provider `extra_body` pass-through (merged baseline this PR extends)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/agent_init.py` — new `_platform_request_overrides_for_agent` resolver (keyword-only args, defensive `isinstance` guards, returns a copy so callers can't corrupt parsed config) + `_merge_platform_request_overrides` applier; hooked in at agent init immediately after `_merge_custom_provider_extra_body`. Naming + signature shape mirror the existing `_custom_provider_extra_body_for_agent` / `_merge_custom_provider_extra_body` pair.
- `tests/agent/test_platform_request_overrides.py` — 18 new tests mirroring `tests/agent/test_custom_provider_extra_body.py` style: resolver edge cases (missing block, unknown platform, empty/non-string key, case-insensitive matching, non-dict config tolerance, copy semantics), `_merge_*` correctness (no-op paths, `extra_body` shallow-merge, top-level passthrough, layering on top of a custom-provider entry, caller-precedence for both nested and top-level keys, malformed `extra_body` tolerance, no-empty-dict policy).
- `cli-config.yaml.example` — new "Platform Request Overrides" section between `Platform Toolsets` and `Gateway Platform Settings`. Includes resolution-order doc, scope clarification (what's covered vs what isn't), and three concrete examples (per-platform `reasoning_effort`, per-platform `service_tier`, per-platform `chat_template_kwargs.enable_thinking`).

Diffstat: `3 files changed, 396 insertions(+)` — `+94` prod (`agent_init.py`), `+251` tests, `+59` docs.

## How to Test

**Automated:**

```bash
scripts/run_tests.sh tests/agent/test_platform_request_overrides.py
# 18 passed in <1s

scripts/run_tests.sh tests/agent/test_custom_provider_extra_body.py \
                    tests/agent/test_platform_request_overrides.py \
                    tests/agent/test_auxiliary_client.py \
                    tests/hermes_cli/test_runtime_provider_resolution.py
# 321 passed, 0 failed in 2.2s (adjacent code paths to confirm no regression)
```

**Manual (config + behavior):**

1. Add to `~/.hermes/config.yaml`:

   ```yaml
   platform_request_overrides:
     api_server:
       extra_body:
         chat_template_kwargs:
           enable_thinking: false
   ```

2. Start the gateway with an `api_server` platform pointed at a local llama.cpp running a hybrid-thinking model (e.g. Qwen3-derived).

3. POST a chat completion to the `api_server` endpoint and observe `usage.completion_tokens` and round-trip time. With the override, both drop substantially because the model skips its hidden thinking block. CLI and Telegram surfaces (no entry for them) keep the default behaviour.

4. Verify CLI is unaffected: `hermes chat -q "what is the capital of France?"` — same thinking-mode behaviour as before the change.

**Tested on:** macOS 15.5 (Darwin 25.5), Python 3.11.15.

**Concrete measurement** (Qwen3.6-35B-A3B + llama.cpp + the `api_server` platform via an OpenAI-compatible client): a "what time is it?" turn that requires one tool call (`GetDateTime` via Home Assistant MCP) drops from ~10.1s / 244 completion tokens to ~1.5s / 25 completion tokens with `chat_template_kwargs.enable_thinking: false` set only for `api_server`. CLI and Telegram (no entry) unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (closest open: #12427, #31589, #32813, #33329 — all adjacent, none the same)
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the new file and 3 adjacent files: 321 passed, 0 failed
- [x] I've added tests for my changes — 18 new tests covering resolver + merge semantics, edge cases, and precedence
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — added a new section in `cli-config.yaml.example` with usage examples and a scope note
- [x] I've updated `cli-config.yaml.example` because this adds a new config key
- [x] N/A — no architecture or workflow changes that need `CONTRIBUTING.md` / `AGENTS.md` updates
- [x] I've considered cross-platform impact — pure dict manipulation in Python; no syscalls, no shell, no path handling. `scripts/check-windows-footguns.py` reports clean on the diff.
- [x] N/A — no tool descriptions/schemas changed