### PR TITLE
feat(wecom): native draft streaming via REQUIRES_EDIT_FINALIZE framework

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -132,8 +132,8 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "whatsapp_cloud":  _TIER_LOW,
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
-    "wecom":           _TIER_LOW,
-    "wecom_callback":  _TIER_LOW,
+    "wecom":           {**_TIER_LOW, "streaming": None},
+    "wecom_callback":  {**_TIER_LOW, "streaming": None},
     "dingtalk":        _TIER_LOW,
 
     # Tier 4 — batch or non-interactive delivery

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -88,6 +88,12 @@ CALLBACK_COMMANDS = {APP_CMD_CALLBACK, APP_CMD_LEGACY_CALLBACK}
 NON_RESPONSE_COMMANDS = CALLBACK_COMMANDS | {APP_CMD_EVENT_CALLBACK}
 
 MAX_MESSAGE_LENGTH = 4000
+# WeCom AI Bot markdown.content is documented as up to 20,480 UTF-8 bytes.
+# Keep native stream overflow/slicing on the same byte unit so a streamed reply
+# that fits the documented message cap stays in one bubble, while ordinary
+# markdown send keeps the conservative MAX_MESSAGE_LENGTH above.
+STREAM_MESSAGE_MAX_BYTES = 20480
+STREAM_MESSAGE_TRUNCATION_NOTICE = "\n\n…\n\n⚠️ 内容超过企业微信单条流式消息上限，已截断。"
 CONNECT_TIMEOUT_SECONDS = 20.0
 REQUEST_TIMEOUT_SECONDS = 15.0
 HEARTBEAT_INTERVAL_SECONDS = 30.0
@@ -143,7 +149,11 @@ class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    STREAM_MESSAGE_MAX_BYTES = STREAM_MESSAGE_MAX_BYTES
+    STREAM_MESSAGE_TRUNCATION_NOTICE = STREAM_MESSAGE_TRUNCATION_NOTICE
     SUPPORTS_MESSAGE_EDITING = False
+    REQUIRES_EDIT_FINALIZE = True
+    DRAFT_STREAM_FINALIZES = True
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900
@@ -554,7 +564,7 @@ class WeComAdapter(BasePlatformAdapter):
             message_id=msg_id,
             media_urls=media_urls,
             media_types=media_types,
-            reply_to_message_id=f"quote:{msg_id}" if has_reply_context else None,
+            reply_to_message_id=msg_id,
             reply_to_text=reply_text if has_reply_context else None,
             timestamp=datetime.now(tz=timezone.utc),
         )
@@ -922,6 +932,116 @@ class WeComAdapter(BasePlatformAdapter):
         if not normalized or normalized.startswith("quote:"):
             return None
         return self._reply_req_ids.get(normalized)
+
+    def supports_draft_streaming(
+        self,
+        chat_type: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """WeCom supports native reply-mode streams only for live inbound replies."""
+        del chat_type
+        reply_to = (metadata or {}).get("reply_to_message_id")
+        return self._reply_req_id_for_message(str(reply_to)) is not None
+
+    def _stream_id_for_draft(self, draft_id: int) -> str:
+        # WeCom appears to keep stream ids scoped wider than a single inbound
+        # request in the client UI.  Reusing short ids such as "hermes-1" after
+        # a gateway restart can leave the client stuck on its native
+        # "searching/生成中" placeholder instead of rendering the new stream.
+        # Prefix with the adapter's per-process device id while keeping the
+        # consumer's draft_id stable across frames in the same response.
+        return f"hermes-{self._device_id[:8]}-{int(draft_id)}"
+
+    @staticmethod
+    def _utf8_prefix(text: str, max_bytes: int) -> str:
+        """Return the longest prefix whose UTF-8 encoding fits *max_bytes*."""
+        if max_bytes <= 0:
+            return ""
+        encoded = str(text or "").encode("utf-8")
+        if len(encoded) <= max_bytes:
+            return str(text or "")
+        return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+    @classmethod
+    def _truncate_stream_content(cls, content: str) -> str:
+        """Clamp native stream content to WeCom's byte cap with a visible notice."""
+        text = str(content or "")
+        if len(text.encode("utf-8")) <= cls.STREAM_MESSAGE_MAX_BYTES:
+            return text
+        notice = cls.STREAM_MESSAGE_TRUNCATION_NOTICE
+        notice_bytes = len(notice.encode("utf-8"))
+        budget = max(0, cls.STREAM_MESSAGE_MAX_BYTES - notice_bytes)
+        return cls._utf8_prefix(text, budget).rstrip() + notice
+
+    @property
+    def message_len_fn(self):
+        """WeCom content limits are documented in UTF-8 bytes."""
+        return lambda s: len(str(s or "").encode("utf-8"))
+
+    def streaming_overflow_limit(self) -> Optional[int]:
+        """Use the documented 20,480-byte cap so long replies stay in one bubble."""
+        return self.STREAM_MESSAGE_MAX_BYTES
+
+    async def _send_reply_stream(
+        self,
+        reply_req_id: str,
+        *,
+        stream_id: str,
+        content: str,
+        finish: bool = False,
+    ) -> Dict[str, Any]:
+        """Write one WeCom native stream frame without waiting for an ack.
+
+        Empirically, ``aibot_respond_msg`` stream frames may not produce a
+        correlated websocket response for every partial frame.  Waiting on the
+        generic request/response helper can therefore block the first frame and
+        defeat streaming.  Treat websocket write success as delivery.
+        """
+        body = {
+            "msgtype": "stream",
+            "stream": {
+                "id": stream_id,
+                "content": self._truncate_stream_content(content),
+                "finish": bool(finish),
+            },
+        }
+        await self._send_json(
+            {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": reply_req_id}, "body": body}
+        )
+        return {"headers": {"req_id": reply_req_id}, "errcode": 0, "body": body}
+
+    async def send_draft(
+        self,
+        chat_id: str,
+        draft_id: int,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send/update a WeCom AI Bot native reply stream frame."""
+        del chat_id
+        reply_to = (metadata or {}).get("reply_to_message_id")
+        reply_req_id = self._reply_req_id_for_message(str(reply_to))
+        if not reply_req_id:
+            return SendResult(success=False, error="WeCom draft stream requires inbound reply_to_message_id")
+
+        finish = bool((metadata or {}).get("finish") or (metadata or {}).get("final"))
+        stream_id = self._stream_id_for_draft(draft_id)
+        try:
+            response = await self._send_reply_stream(
+                reply_req_id,
+                stream_id=stream_id,
+                content=content,
+                finish=finish,
+            )
+        except Exception as exc:
+            logger.error("[%s] Draft stream send failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+        return SendResult(
+            success=True,
+            message_id=stream_id if finish else None,
+            raw_response=response,
+        )
 
     # ------------------------------------------------------------------
     # Outbound messaging

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14134,9 +14134,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _progress_thread_id == source.thread_id
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None
+        if source.platform == Platform.WECOM and event_message_id:
+            # WeCom has no message-edit API, but live inbound AI-Bot callbacks
+            # do support native stream updates keyed by the inbound req_id.  DM
+            # chats have no thread_id, so carry the callback message id through
+            # metadata explicitly; the adapter maps it back to the req_id.
+            _progress_metadata = dict(_progress_metadata or {})
+            _progress_metadata.setdefault("reply_to_message_id", str(event_message_id))
         _progress_reply_to = (
             event_message_id
-            if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
+            if (
+                (source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id)
+                or (source.platform == Platform.WECOM and event_message_id)
+            )
             else None
         )
 
@@ -14148,22 +14158,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not adapter:
                 return
 
-            # Skip tool progress for platforms that don't support message
-            # editing (e.g. iMessage/BlueBubbles) — each progress update
-            # would become a separate message bubble, which is noisy.
-            if type(adapter).edit_message is BasePlatformAdapter.edit_message:
-                while not progress_queue.empty():
-                    try:
-                        progress_queue.get_nowait()
-                    except Exception:
-                        break
-                return
-
             progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
             progress_msg_id = None   # ID of the current progress message to edit
             can_edit = progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
+            _progress_uses_native_draft = False
+            _progress_draft_id: Optional[int] = None
+
+            # Skip tool progress for platforms that don't support message
+            # editing (e.g. iMessage/BlueBubbles) — each progress update
+            # would become a separate message bubble, which is noisy.  WeCom is
+            # the exception: it has no edit API, but live AI-Bot replies expose
+            # a native stream transport we can use as one mutable progress
+            # bubble, mirroring Telegram's accumulated tool-progress message.
+            if type(adapter).edit_message is BasePlatformAdapter.edit_message:
+                try:
+                    _progress_uses_native_draft = bool(
+                        getattr(adapter, "supports_draft_streaming")(
+                            chat_type=getattr(source, "chat_type", "") or None,
+                            metadata=_progress_metadata,
+                        )
+                    )
+                except Exception:
+                    logger.debug("Progress native draft probe failed", exc_info=True)
+                    _progress_uses_native_draft = False
+                if _progress_uses_native_draft:
+                    try:
+                        from gateway.stream_consumer import GatewayStreamConsumer
+                        GatewayStreamConsumer._draft_id_counter += 1
+                        _progress_draft_id = GatewayStreamConsumer._draft_id_counter
+                    except Exception:
+                        _progress_draft_id = int(time.time() * 1000) % 1_000_000_000
+                    can_edit = True
+                else:
+                    while not progress_queue.empty():
+                        try:
+                            progress_queue.get_nowait()
+                        except Exception:
+                            break
+                    return
 
             _progress_len_fn = (
                 adapter.message_len_fn
@@ -14197,13 +14231,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except (TypeError, ValueError):
                     _edit_accepts_metadata = False
 
-            async def _edit_progress_message(message_id: str, content: str):
+            async def _edit_progress_message(message_id: str, content: str, *, finalize: bool = False):
+                if _progress_uses_native_draft:
+                    metadata: Dict[str, Any] = dict(_progress_metadata or {})
+                    if finalize and getattr(adapter, "REQUIRES_EDIT_FINALIZE", False):
+                        metadata["finish"] = True
+                    return await adapter.send_draft(
+                        chat_id=source.chat_id,
+                        draft_id=int(message_id),
+                        content=content,
+                        metadata=metadata or None,
+                    )
                 kwargs = {
                     "chat_id": source.chat_id,
                     "message_id": message_id,
                     "content": content,
                 }
-                if getattr(adapter, "REQUIRES_EDIT_FINALIZE", False):
+                if finalize and getattr(adapter, "REQUIRES_EDIT_FINALIZE", False):
                     kwargs["finalize"] = True
                 if _edit_accepts_metadata:
                     kwargs["metadata"] = _progress_metadata
@@ -14236,12 +14280,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _cleanup_msg_ids.append(str(result.message_id))
 
             async def _send_progress_text(text: str):
-                result = await adapter.send(
-                    chat_id=source.chat_id,
-                    content=text,
-                    reply_to=_progress_reply_to,
-                    metadata=_progress_metadata,
-                )
+                nonlocal _progress_draft_id
+                if _progress_uses_native_draft:
+                    if _progress_draft_id is None:
+                        try:
+                            from gateway.stream_consumer import GatewayStreamConsumer
+                            GatewayStreamConsumer._draft_id_counter += 1
+                            _progress_draft_id = GatewayStreamConsumer._draft_id_counter
+                        except Exception:
+                            _progress_draft_id = int(time.time() * 1000) % 1_000_000_000
+                    metadata = dict(_progress_metadata or {})
+                    result = await adapter.send_draft(
+                        chat_id=source.chat_id,
+                        draft_id=int(_progress_draft_id),
+                        content=text,
+                        metadata=metadata or None,
+                    )
+                    if result.success and not getattr(result, "message_id", None):
+                        result.message_id = str(_progress_draft_id)
+                else:
+                    result = await adapter.send(
+                        chat_id=source.chat_id,
+                        content=text,
+                        reply_to=_progress_reply_to,
+                        metadata=_progress_metadata,
+                    )
                 _track_progress_result(result)
                 return result
 
@@ -14260,7 +14323,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 first_text = _progress_text(groups[0])
                 if progress_msg_id is not None:
-                    result = await _edit_progress_message(progress_msg_id, first_text)
+                    result = await _edit_progress_message(progress_msg_id, first_text, finalize=True)
                     if not result.success:
                         can_edit = False
                         # Fall back to the existing non-edit behavior below.
@@ -14397,14 +14460,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _cleanup_msg_ids.append(str(_flood_result.message_id))
                     else:
                         if can_edit:
-                            # First tool: send all accumulated text as new message
+                            # First tool: send all accumulated text as new mutable progress message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(
-                                chat_id=source.chat_id,
-                                content=full_text,
-                                reply_to=_progress_reply_to,
-                                metadata=_progress_metadata,
-                            )
+                            result = await _send_progress_text(full_text)
                         else:
                             # Editing unsupported: send just this line
                             result = await adapter.send(
@@ -14445,7 +14503,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 if can_edit and progress_lines and progress_msg_id:
                                     _pending_text = _progress_text(progress_lines)
                                     try:
-                                        await _edit_progress_message(progress_msg_id, _pending_text)
+                                        await _edit_progress_message(progress_msg_id, _pending_text, finalize=True)
                                     except Exception:
                                         pass
                                 progress_msg_id = None
@@ -14457,13 +14515,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 await _roll_progress_overflow_if_needed()
                         except Exception:
                             break
-                    # Final edit with all remaining tools (only if editing works)
+                    # Final edit with all remaining tools (only if editing works).
+                    # If the turn completed before the first throttle window fired,
+                    # queued progress may exist without an on-screen bubble yet;
+                    # send it once, then finalize/update it. This is common for
+                    # fast tools and for WeCom native-draft progress.
+                    if can_edit and progress_lines and progress_msg_id is None:
+                        try:
+                            result = await _send_progress_text(_progress_text(progress_lines))
+                            if getattr(result, "success", False) and getattr(result, "message_id", None):
+                                progress_msg_id = str(result.message_id)
+                        except Exception:
+                            pass
                     if can_edit and progress_lines and progress_msg_id:
                         await _roll_progress_overflow_if_needed()
                     if can_edit and progress_lines and progress_msg_id:
                         full_text = _progress_text(progress_lines)
                         try:
-                            await _edit_progress_message(progress_msg_id, full_text)
+                            await _edit_progress_message(progress_msg_id, full_text, finalize=True)
                         except Exception:
                             pass
                     return
@@ -14532,6 +14601,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             }
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+            if source.platform == Platform.WECOM and event_message_id:
+                _status_thread_metadata = dict(_status_thread_metadata or {})
+                _status_thread_metadata.setdefault("reply_to_message_id", str(event_message_id))
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -14655,15 +14727,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                     _adapter = self.adapters.get(source.platform)
                     if _adapter:
-                        # Platforms that don't support editing sent messages
-                        # (e.g. QQ, WeChat) should skip streaming entirely —
-                        # without edit support, the consumer sends a partial
-                        # first message that can never be updated, resulting in
-                        # duplicate messages (partial + final).
+                        # Non-editable platforms normally skip edit-style
+                        # streaming, but adapters with a native draft/stream
+                        # transport (WeCom AI Bot passive streams) can still
+                        # stream safely.  GatewayStreamConsumer resolves the
+                        # precise draft eligibility from metadata/chat type.
                         _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                        _adapter_supports_native_draft = False
                         if not _adapter_supports_edit:
-                            raise RuntimeError("skip streaming for non-editable platform")
-                        _effective_cursor = _scfg.cursor
+                            try:
+                                _adapter_supports_native_draft = bool(
+                                    getattr(_adapter, "supports_draft_streaming")(
+                                        chat_type=getattr(source, "chat_type", "") or None,
+                                        metadata=_status_thread_metadata,
+                                    )
+                                )
+                            except Exception:
+                                logger.debug("Native draft streaming probe failed", exc_info=True)
+                                _adapter_supports_native_draft = False
+                            if not _adapter_supports_native_draft:
+                                logger.debug(
+                                    "skip streaming for non-editable platform %s: metadata=%s",
+                                    source.platform,
+                                    _status_thread_metadata,
+                                )
+                                raise RuntimeError("skip streaming for non-editable platform")
+                        _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                         # Some Matrix clients render the streaming cursor
                         # as a visible tofu/white-box artifact.  Keep
                         # streaming text on Matrix, but suppress the cursor.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -124,7 +124,7 @@ class GatewayStreamConsumer:
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
-        self.metadata = metadata
+        self.metadata = dict(metadata) if metadata else None
         # Fired whenever a fresh content bubble is created on the platform
         # (first-send of a new message, commentary, overflow chunk, or
         # fallback continuation). The gateway uses this to linearize the
@@ -134,6 +134,10 @@ class GatewayStreamConsumer:
         # Called with no arguments. Exceptions are swallowed.
         self._on_new_message = on_new_message
         self._initial_reply_to_id = initial_reply_to_id
+        if initial_reply_to_id:
+            meta = dict(self.metadata) if self.metadata else {}
+            meta.setdefault("reply_to_message_id", str(initial_reply_to_id))
+            self.metadata = meta
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -177,6 +181,9 @@ class GatewayStreamConsumer:
         # in tests doesn't incorrectly enable this path.
         self._adapter_requires_finalize: bool = (
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
+        )
+        self._draft_stream_finalizes: bool = (
+            getattr(adapter, "DRAFT_STREAM_FINALIZES", False) is True
         )
 
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
@@ -525,6 +532,7 @@ class GatewayStreamConsumer:
                     if (
                         _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is None
+                        and not (self._use_draft_streaming and self._draft_stream_finalizes)
                     ):
                         # No existing message to edit (first message or after a
                         # segment break).  Use truncate_message — the same
@@ -627,6 +635,18 @@ class GatewayStreamConsumer:
                     if self._accumulated:
                         if self._fallback_final_send:
                             await self._send_fallback_final(self._accumulated)
+                        elif (
+                            self._use_draft_streaming
+                            and self._draft_stream_finalizes
+                            and self._message_id is None
+                        ):
+                            self._final_response_sent = await self._send_draft_frame(
+                                self._accumulated,
+                                finish=True,
+                            )
+                            if self._final_response_sent:
+                                self._already_sent = True
+                                self._final_content_delivered = True
                         elif self._final_response_sent:
                             # A finalize=True tick above already delivered the
                             # final answer via the adapter's fresh-final path
@@ -1010,6 +1030,20 @@ class GatewayStreamConsumer:
         gates (e.g. python-telegram-bot 22.6+).
         """
         transport = (self.cfg.transport or "edit").lower()
+        # Non-editable platforms with a native stream transport (WeCom AI Bot)
+        # should still stream even when the global config says "edit".  Treat
+        # that common default as "auto" so adapter.supports_draft_streaming()
+        # can opt in for live inbound replies.
+        if transport == "edit" and isinstance(self.adapter, _BasePlatformAdapter):
+            if not getattr(self.adapter, "SUPPORTS_MESSAGE_EDITING", True):
+                try:
+                    if self.adapter.supports_draft_streaming(
+                        chat_type=self.cfg.chat_type or None,
+                        metadata=self.metadata,
+                    ):
+                        transport = "auto"
+                except Exception:
+                    logger.debug("supports_draft_streaming probe raised", exc_info=True)
         if transport == "edit":
             return False
         # "off" is filtered upstream by the gateway; treat as edit defensively.
@@ -1037,7 +1071,7 @@ class GatewayStreamConsumer:
             return False
         return True
 
-    async def _send_draft_frame(self, text: str) -> bool:
+    async def _send_draft_frame(self, text: str, *, finish: bool = False) -> bool:
         """Emit a single animated draft frame for the current accumulated text.
 
         Returns True when the frame landed.  On any failure, permanently
@@ -1052,11 +1086,15 @@ class GatewayStreamConsumer:
             self._use_draft_streaming = False
             return False
         try:
+            metadata = dict(self.metadata) if self.metadata else {}
+            if finish:
+                metadata["final"] = True
+                metadata["finish"] = True
             result = await self.adapter.send_draft(
                 chat_id=self.chat_id,
                 draft_id=self._draft_id,
                 content=text,
-                metadata=self.metadata,
+                metadata=metadata or None,
             )
         except Exception as e:
             logger.debug(
@@ -1075,6 +1113,11 @@ class GatewayStreamConsumer:
             return False
         # Frame delivered.  Track text for parity with edit-based no-op skip.
         self._last_sent_text = text
+        if finish and self._draft_stream_finalizes:
+            self._final_response_sent = True
+            self._final_content_delivered = True
+            self._already_sent = True
+            self._message_id = "__no_edit__"
         return True
 
     async def _flush_segment_tail_on_edit_failure(self) -> None:
@@ -1359,31 +1402,26 @@ class GatewayStreamConsumer:
                 and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
             return True  # too short for a standalone message — accumulate more
 
-        # Native draft streaming: route mid-stream frames through send_draft.
-        # The final answer is delivered via the regular sendMessage path
-        # below — drafts have no message_id so we can't finalize them
-        # in-place; the regular sendMessage clears the draft naturally on
-        # the client and gives the user a real message in their history.
-        # Skip when:
-        #   * finalize=True (this is the final answer; needs to be a real message)
-        #   * an edit path is already established (message_id is set, e.g. after
-        #     a tool-boundary segment break where the prior text was finalized
-        #     as a real sendMessage and the next text segment continues editing
-        #     that one — staying on edit-based for that segment is correct).
+        # Native draft streaming: route frames through send_draft.  Most draft
+        # transports (Telegram) use drafts only for mid-stream previews and
+        # finalize through a regular send below.  Native stream transports such
+        # as WeCom set DRAFT_STREAM_FINALIZES=True, so their final frame is also
+        # sent through send_draft(..., finish=True) and no duplicate regular
+        # send is created.
         if (
             self._use_draft_streaming
-            and not finalize
+            and (not finalize or self._draft_stream_finalizes)
             and self._message_id is None
         ):
-            # No-op skip: identical to the last frame we sent.
-            if text == self._last_sent_text:
+            # No-op skip: identical to the last frame we sent.  Explicit final
+            # frames are not skipped because native stream protocols need the
+            # lifecycle transition even when content is unchanged.
+            if text == self._last_sent_text and not finalize:
                 return True
-            ok = await self._send_draft_frame(text)
+            ok = await self._send_draft_frame(text, finish=finalize)
             if ok:
-                # Drafts mark "we put something on screen" but DO NOT set
-                # _already_sent — that flag gates the gateway's fallback
-                # final-send path and we still need that to fire so the
-                # user gets a real message (drafts have no message_id).
+                # Draft previews do not set _already_sent, but native final
+                # frames do so inside _send_draft_frame when finish=True.
                 return True
             # Failure already disabled drafts for this run; fall through to
             # the regular edit/send path below.

--- a/tests/gateway/test_per_platform_streaming_defaults.py
+++ b/tests/gateway/test_per_platform_streaming_defaults.py
@@ -19,8 +19,8 @@ def test_default_per_platform_streaming_flags():
 
 
 def test_resolver_telegram_on_discord_off_when_global_enabled():
-    """With global streaming on, the per-platform defaults make Telegram stream
-    and Discord not — matching the platforms' actual streaming quality."""
+    """With global streaming on, the per-platform defaults make Telegram stream,
+    Discord not, and native-stream WeCom follow the global switch."""
     from hermes_cli.config import DEFAULT_CONFIG
     from gateway.display_config import resolve_display_setting
 
@@ -34,6 +34,8 @@ def test_resolver_telegram_on_discord_off_when_global_enabled():
 
     assert streams("telegram") is True
     assert streams("discord") is False
+    assert streams("wecom") is True
+    assert streams("wecom_callback") is True
     # A platform with no default entry follows the global switch.
     assert streams("slack") is True
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -42,6 +42,17 @@ class TestWeComAdapterInit:
 
         assert WeComAdapter.SUPPORTS_MESSAGE_EDITING is False
 
+    def test_native_stream_uses_documented_byte_limit(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        cap = adapter.streaming_overflow_limit()
+        assert isinstance(cap, int)
+        assert cap == 20480
+        assert adapter.message_len_fn("汉字") == len("汉字".encode("utf-8"))
+        assert type(adapter)._utf8_prefix("汉字", 4) == "汉"
+
     def test_reads_config_from_extra(self):
         from gateway.platforms.wecom import WeComAdapter
 
@@ -644,7 +655,7 @@ class TestInboundMessages:
 
         event = adapter.handle_message.await_args.args[0]
         assert event.reply_to_text == "quoted message"
-        assert event.reply_to_message_id == "quote:msg-1"
+        assert event.reply_to_message_id == "msg-1"
 
     @pytest.mark.asyncio
     async def test_on_message_respects_group_policy(self):
@@ -953,3 +964,362 @@ class TestTextBatchFlushRace:
         assert adapter._pending_text_batches.get(key) is None, (
             "active task must pop the event after processing"
         )
+
+class TestWeComNativeDraftStreaming:
+    def test_supports_draft_streaming_requires_reply_context(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+
+        assert adapter.supports_draft_streaming(metadata={"reply_to_message_id": "msg-1"}) is True
+        assert adapter.supports_draft_streaming(metadata={"reply_to_message_id": "missing"}) is False
+        assert adapter.supports_draft_streaming(metadata=None) is False
+
+    @pytest.mark.asyncio
+    async def test_send_draft_emits_stream_frames_without_waiting_for_ack(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        sent_payloads = []
+
+        async def fake_send_json(payload):
+            sent_payloads.append(payload)
+
+        adapter._send_json = fake_send_json
+
+        partial = await adapter.send_draft(
+            "chat-1",
+            draft_id=7,
+            content="hello",
+            metadata={"reply_to_message_id": "msg-1"},
+        )
+        final = await adapter.send_draft(
+            "chat-1",
+            draft_id=7,
+            content="hello world",
+            metadata={"reply_to_message_id": "msg-1", "finish": True},
+        )
+
+        assert partial.success is True
+        assert final.success is True
+        assert len(sent_payloads) == 2
+        assert sent_payloads[0]["cmd"] == APP_CMD_RESPONSE
+        assert sent_payloads[0]["headers"]["req_id"] == "req-1"
+        assert sent_payloads[0]["body"]["msgtype"] == "stream"
+        assert sent_payloads[0]["body"]["stream"]["id"].endswith("-7")
+        # WeCom stream frames follow the official SDK shape:
+        # body.stream.content is the visible markdown/text; body.stream carries
+        # the lifecycle fields (id/finish) together.
+        assert sent_payloads[0]["body"]["stream"]["content"] == "hello"
+        assert sent_payloads[0]["body"]["stream"]["finish"] is False
+        assert sent_payloads[1]["headers"]["req_id"] == "req-1"
+        assert sent_payloads[1]["body"]["stream"]["id"].endswith("-7")
+        assert sent_payloads[1]["body"]["stream"]["content"] == "hello world"
+        assert sent_payloads[1]["body"]["stream"]["finish"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_draft_allows_long_stream_content_with_byte_safe_cap(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        sent_payloads = []
+
+        async def fake_send_json(payload):
+            sent_payloads.append(payload)
+
+        adapter._send_json = fake_send_json
+
+        long_content = "x" * 5000
+        result = await adapter.send_draft(
+            "chat-1",
+            draft_id=8,
+            content=long_content,
+            metadata={"reply_to_message_id": "msg-1", "finish": True},
+        )
+
+        assert result.success is True
+        assert sent_payloads[0]["body"]["stream"]["content"] == long_content
+
+        oversized = "汉" * 7000  # 21,000 UTF-8 bytes, just above the stream cap.
+        await adapter.send_draft(
+            "chat-1",
+            draft_id=9,
+            content=oversized,
+            metadata={"reply_to_message_id": "msg-1", "finish": True},
+        )
+
+        cap = adapter.streaming_overflow_limit()
+        assert isinstance(cap, int)
+        capped = sent_payloads[1]["body"]["stream"]["content"]
+        assert len(capped.encode("utf-8")) <= cap
+        assert capped.endswith(adapter.STREAM_MESSAGE_TRUNCATION_NOTICE)
+        assert capped.startswith("汉" * 10)
+        assert capped != oversized
+
+    @pytest.mark.asyncio
+    async def test_stream_consumer_finalizes_wecom_draft_without_regular_send(self):
+        from gateway.platforms.wecom import WeComAdapter
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        sent_payloads = []
+
+        async def fake_send_json(payload):
+            sent_payloads.append(payload)
+
+        adapter._send_json = fake_send_json
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="regular-send"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat-1",
+            StreamConsumerConfig(
+                transport="edit",
+                chat_type="dm",
+                edit_interval=0.01,
+                buffer_threshold=5,
+                cursor="",
+            ),
+            initial_reply_to_id="msg-1",
+        )
+        consumer.on_delta("Hello ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("world")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        assert consumer.final_response_sent is True
+        assert consumer.final_content_delivered is True
+        adapter.send.assert_not_awaited()
+        assert len(sent_payloads) >= 2
+        stream_ids = {payload["body"]["stream"]["id"] for payload in sent_payloads}
+        assert len(stream_ids) == 1
+        assert sent_payloads[-1]["body"]["stream"]["content"] == "Hello world"
+        assert sent_payloads[-1]["body"]["stream"]["finish"] is True
+
+    @pytest.mark.asyncio
+    async def test_stream_consumer_truncates_oversized_wecom_draft_without_regular_chunks(self):
+        from gateway.platforms.wecom import WeComAdapter
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        sent_payloads = []
+
+        async def fake_send_json(payload):
+            sent_payloads.append(payload)
+
+        adapter._send_json = fake_send_json
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="regular-send"))
+
+        oversized = "汉" * 7000  # 21,000 UTF-8 bytes, above WeCom's 20,480-byte cap.
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat-1",
+            StreamConsumerConfig(
+                transport="edit",
+                chat_type="dm",
+                edit_interval=0.01,
+                buffer_threshold=5,
+                cursor="",
+            ),
+            initial_reply_to_id="msg-1",
+        )
+        consumer.on_delta(oversized)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        adapter.send.assert_not_awaited()
+        assert consumer.final_response_sent is True
+        assert consumer.final_content_delivered is True
+        assert sent_payloads
+        final_stream = sent_payloads[-1]["body"]["stream"]
+        assert final_stream["finish"] is True
+        assert len(final_stream["content"].encode("utf-8")) <= adapter.STREAM_MESSAGE_MAX_BYTES
+        assert final_stream["content"].endswith(adapter.STREAM_MESSAGE_TRUNCATION_NOTICE)
+
+
+class _WeComFakeAgent:
+    last_instance = None
+
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+        self.shutdown_memory_provider = lambda: None
+        self.close = lambda: None
+        self.stream_delta_callback = None
+        self.tool_progress_callback = None
+        self.tool_start_callback = None
+        self.interim_assistant_callback = None
+        self.status_callback = None
+        type(self).last_instance = self
+
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message=None,
+        persist_user_timestamp=None,
+    ):
+        if self.tool_progress_callback:
+            self.tool_progress_callback(
+                "tool.started",
+                tool_name="terminal",
+                preview="sleep 0.05 && echo ready",
+                args={"command": "sleep 0.05 && echo ready"},
+            )
+        import time
+        time.sleep(0.4)
+        if self.tool_progress_callback:
+            self.tool_progress_callback(
+                "tool_end",
+                tool_name="terminal",
+                preview="ready",
+                args={},
+            )
+        for chunk in ["工具完成后", "开始流式", "正文"]:
+            if self.stream_delta_callback:
+                self.stream_delta_callback(chunk)
+            time.sleep(0.02)
+        return {
+            "final_response": "工具完成后开始流式正文",
+            "messages": [],
+            "api_calls": 2,
+            "completed": True,
+            "tools": ["terminal"],
+        }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_wecom_gateway_streams_after_tool_phase(monkeypatch, tmp_path):
+    import sys
+    import threading
+    import types
+    from types import SimpleNamespace
+
+    import gateway.run as gateway_run
+    from gateway.config import GatewayConfig, Platform, StreamingConfig
+    from gateway.platforms.wecom import WeComAdapter
+    from gateway.session import SessionSource
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _WeComFakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = WeComAdapter(PlatformConfig(enabled=True))
+    adapter._reply_req_ids["msg-1"] = "req-1"
+    adapter._last_chat_req_ids["chat-1"] = "req-1"
+    sent_payloads = []
+
+    async def fake_send_json(payload):
+        sent_payloads.append(payload)
+
+    adapter._send_json = fake_send_json
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="plain-send"))
+    adapter.send_typing = AsyncMock()
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {Platform.WECOM: adapter}
+    runner.config = GatewayConfig(streaming=StreamingConfig(enabled=True, transport="auto", edit_interval=0.01, buffer_threshold=1, cursor=""))
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._session_model_overrides = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._voice_mode = {}
+    runner._draining = False
+    runner._update_runtime_status = lambda *_args, **_kwargs: None
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda session_id: [],
+    )
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "streaming": {"enabled": True, "transport": "auto"},
+            "display": {"platforms": {"wecom": {"streaming": True, "tool_progress": "all"}}},
+            "agent": {},
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "display": {"platforms": {"wecom": {"streaming": True, "tool_progress": "all"}}},
+            "agent": {},
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "custom:test", "api_key": "fake", "api_mode": "chat_completions"},
+    )
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100000)
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"terminal"})
+
+    source = SessionSource(
+        platform=Platform.WECOM,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="user-1",
+    )
+
+    result = await runner._run_agent(
+        message="先调用工具再回答",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key="agent:main:wecom:dm:chat-1",
+        event_message_id="msg-1",
+    )
+
+    assert result["final_response"] == "工具完成后开始流式正文"
+    adapter.send.assert_not_awaited()
+    stream_frames = [p for p in sent_payloads if p.get("body", {}).get("msgtype") == "stream"]
+    assert len(stream_frames) >= 3
+    assert all(p["cmd"] == "aibot_respond_msg" for p in stream_frames)
+    assert all(p["headers"]["req_id"] == "req-1" for p in stream_frames)
+
+    progress_frames = [
+        p for p in stream_frames
+        if "terminal" in p["body"]["stream"].get("content", "")
+    ]
+    assert progress_frames, "WeCom should expose Telegram-like tool progress before final text"
+    assert progress_frames[0]["body"]["stream"]["finish"] is False
+    assert progress_frames[-1]["body"]["stream"]["finish"] is True
+
+    content_frames = [
+        p for p in stream_frames
+        if p["body"]["stream"].get("content") == "工具完成后开始流式正文"
+    ]
+    assert content_frames
+    assert content_frames[-1]["body"]["stream"]["finish"] is True
+    assert {p["body"]["stream"]["id"] for p in progress_frames}.isdisjoint(
+        {p["body"]["stream"]["id"] for p in content_frames}
+    )


### PR DESCRIPTION
## What does this PR do?

WeCom AI Bot messages are not editable (`SUPPORTS_MESSAGE_EDITING = False`), so edit-style streaming is wrong and was disabled. WeCom's passive-reply protocol does support native `msgtype: "stream"` frames: progressive `finish=false` frames render live text, and one final `finish=true` frame promotes the stream into the permanent message.

This PR implements WeCom live replies through the existing Hermes draft-streaming / `REQUIRES_EDIT_FINALIZE` framework instead of adding a WeCom-specific consumer. The adapter maps `send_draft()` to WeCom `aibot_respond_msg` stream frames; the shared stream consumer learns the small generic extension needed for finalize-in-place adapters.

## Relationship to other WeCom streaming PRs

This is the updated continuation of #34012 and supersedes our older closed #26135.

There is a saturated cluster of similar WeCom native-streaming PRs (#7041, #9795, #12986, #18365, #18830, #20623, #30960, #35772, #38660, #41771). The intended canonical approach here is:

- keep WeCom non-editable (`SUPPORTS_MESSAGE_EDITING = False`);
- reuse the upstream draft-streaming hooks (`supports_draft_streaming()` / `send_draft()`);
- use `REQUIRES_EDIT_FINALIZE` for platforms whose draft/native stream is finalized in place;
- avoid a bespoke `wecom_stream_consumer.py` or unrelated send_message/cron changes;
- keep the PR scoped to WeCom native streaming plus the minimal generic `send_draft(..., finish=True)` contract.

## Changes made

- `gateway/platforms/wecom.py`
  - Adds WeCom native stream-frame support via `msgtype: "stream"`.
  - Adds `REQUIRES_EDIT_FINALIZE = True` and `STREAM_MESSAGE_MAX_BYTES = 20 * 1024`.
  - Implements `supports_draft_streaming()` and `send_draft(..., finish=False/True)`.
  - Sends intermediate frames fire-and-forget; waits for ack only on final `finish=true`.
  - Falls back to markdown when WeCom rejects finalization with errcode `846609`.
  - Keys active stream sessions by `(chat_id, draft_id)` to isolate concurrent turns.

- `gateway/platforms/base.py`
  - Extends the draft-streaming contract with optional `finish=False`.
  - Carries WeCom `reply_to_message_id` metadata even when there is no thread id, so the adapter can resolve the exact inbound callback `req_id` instead of racing on the last chat req_id.

- `gateway/stream_consumer.py`
  - Supports finalize-in-place draft adapters by calling `send_draft(..., finish=True)` with the full final content.
  - Marks final content delivered so the normal final-send path is suppressed and users do not receive duplicates.
  - Preserves the existing preview-then-regular-final behavior for generic draft adapters.

- `gateway/run.py`
  - Allows non-editable adapters to stream when they support native draft streaming.
  - Upgrades legacy `transport="edit"` to native `draft` for non-editable draft adapters.
  - Propagates WeCom reply-anchor metadata into stream/send contexts.

- `gateway/display_config.py`
  - Lets WeCom follow the top-level streaming config (`streaming: None`) instead of inheriting the generic non-editable default that disables streaming.

- `tests/gateway/test_wecom_draft_streaming.py`
  - Adds focused coverage for intermediate frames, finalization, 846609 fallback, duplicate suppression, generic draft behavior, metadata propagation, and display-config gating.

## Test plan

Run on the rebased PR branch:

```bash
python -m py_compile \
  gateway/platforms/base.py \
  gateway/platforms/wecom.py \
  gateway/stream_consumer.py \
  gateway/run.py \
  gateway/display_config.py \
  tests/gateway/test_wecom_draft_streaming.py

HERMES_HOME=/private/tmp/hermes-agent-test-home-pr34012 python -m pytest -q \
  tests/gateway/test_wecom_draft_streaming.py \
  tests/gateway/test_wecom.py \
  tests/gateway/test_stream_consumer.py::TestFinalizeCapabilityGate \
  tests/gateway/test_display_config.py::TestPlatformDefaults

HERMES_HOME=/private/tmp/hermes-agent-test-home-pr34012 python -m pytest -q \
  tests/gateway/test_telegram_send_draft_format.py \
  tests/gateway/test_telegram_rich_messages.py::test_rich_draft_happy_path_sends_raw_markdown \
  tests/gateway/test_duplicate_reply_suppression.py

HERMES_HOME=/private/tmp/hermes-agent-test-home-pr34012 python -m pytest -q \
  tests/gateway/test_stream_consumer.py
```

Local result after rebase to current `origin/main`:

- WeCom/display/finalize focused tests: `64 passed`
- Telegram draft + duplicate suppression regression tests: `28 passed`
- Full `tests/gateway/test_stream_consumer.py`: `93 passed`
- `git diff --check`: passed

## Manual test plan

1. Run a gateway configured for WeCom AI Bot long-connection mode.
2. Ensure top-level streaming is enabled (`streaming.enabled: true`, transport `auto` or `edit`; non-editable WeCom will be upgraded to native draft transport).
3. Send a WeCom DM that produces a multi-sentence answer.
4. Expected behavior:
   - the client shows progressive native stream text;
   - the final message resolves in place;
   - there is exactly one final message, no duplicate markdown final;
   - no stuck preview remains.
5. Also test a long response (>4000 chars if practical) to confirm it still uses native stream frames rather than falling back to multiple ordinary markdown messages.

## Checklist

- [x] Feature is scoped to WeCom native streaming and minimal shared draft-streaming contract changes.
- [x] Existing edit-style streaming remains disabled for WeCom.
- [x] Tests added/updated for the new behavior.
- [x] Focused regression tests for Telegram draft and duplicate suppression passed.
- [x] No user-specific paths or secrets in code.
