### PR TITLE
feat(models): add Claude Opus 4.8

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -77,16 +77,16 @@ ADAPTIVE_EFFORT_MAP = {
 # xhigh as a distinct level between high and max; older adaptive-thinking
 # models (4.6) reject it with a 400.  Keep this substring list in sync with
 # the Anthropic migration guide as new model families ship.
-_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7")
+_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8")
 
 # Models where extended thinking is deprecated/removed (4.6+ behavior: adaptive
 # is the only supported mode; 4.7 additionally forbids manual thinking entirely
 # and drops temperature/top_p/top_k).
-_ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7")
+_ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7", "4-8", "4.8")
 
 # Models where temperature/top_p/top_k return 400 if set to non-default values.
 # This is the Opus 4.7 contract; future 4.x+ models are expected to follow it.
-_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7")
+_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8")
 _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 
 # ── Max output token limits per Anthropic model ───────────────────────
@@ -94,6 +94,8 @@ _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
+    # Claude 4.8
+    "claude-opus-4-8":   128_000,
     # Claude 4.7
     "claude-opus-4-7":   128_000,
     # Claude 4.6

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -141,6 +141,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # fuzzy-match collisions (e.g. "anthropic/claude-sonnet-4" is a
     # substring of "anthropic/claude-sonnet-4.6").
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
+    "claude-opus-4-8": 1000000,
+    "claude-opus-4.8": 1000000,
     "claude-opus-4-7": 1000000,
     "claude-opus-4.7": 1000000,
     "claude-opus-4-6": 1000000,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -32,6 +32,7 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
+    ("anthropic/claude-opus-4.8",              ""),
     ("anthropic/claude-opus-4.7",              ""),
     ("anthropic/claude-opus-4.6",              ""),
     ("anthropic/claude-sonnet-4.6",            ""),
@@ -139,6 +140,7 @@ def _xai_curated_models() -> list[str]:
 
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
+        "anthropic/claude-opus-4.8",
         "anthropic/claude-opus-4.7",
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
@@ -290,6 +292,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2",
     ],
     "anthropic": [
+        "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-26T20:49:36Z",
+  "updated_at": "2026-05-28T17:29:32Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -12,6 +12,10 @@
         "note": "Descriptions drive picker badges. Live /api/v1/models filters curated ids by tool-calling support and free pricing."
       },
       "models": [
+        {
+          "id": "anthropic/claude-opus-4.8",
+          "description": ""
+        },
         {
           "id": "anthropic/claude-opus-4.7",
           "description": ""
@@ -144,6 +148,9 @@
         "note": "Free-tier gating is determined live via Portal pricing (partition_nous_models_by_tier), not this manifest."
       },
       "models": [
+        {
+          "id": "anthropic/claude-opus-4.8"
+        },
         {
           "id": "anthropic/claude-opus-4.7"
         },


### PR DESCRIPTION
## Summary

Adds Claude Opus 4.8 across all four layers Hermes uses to know an Anthropic model.

- **`hermes_cli/models.py`** — adds the model to `OPENROUTER_MODELS` (`anthropic/claude-opus-4.8`), `_PROVIDER_MODELS["nous"]`, and the native `_PROVIDER_MODELS["anthropic"]` list (`claude-opus-4-8`).
- **`agent/model_metadata.py`** — 1M context window for both `claude-opus-4-8` and `claude-opus-4.8`, inserted before the 4.7 entries to avoid fuzzy-match collisions.
- **`agent/anthropic_adapter.py`** — adds `4-8`/`4.8` to the substring gates so Opus 4.8 inherits the Opus 4.7 contract:
  - `_XHIGH_EFFORT_SUBSTRINGS` → `xhigh` adaptive effort (not downgraded to `max`)
  - `_ADAPTIVE_THINKING_SUBSTRINGS` → adaptive thinking
  - `_NO_SAMPLING_PARAMS_SUBSTRINGS` → omits temperature/top_p/top_k (4.7+ returns 400 otherwise)
  - `_ANTHROPIC_OUTPUT_LIMITS["claude-opus-4-8"] = 128_000`
- **`website/static/api/model-catalog.json`** — regenerated via `scripts/build_model_catalog.py` to keep the published manifest in sync with the curated lists.

## Verification

- Model ID confirmed **live** against the Anthropic API (`GET /v1/models` returns `claude-opus-4-8`, no dated suffix — same shape as `claude-opus-4-7`).
- Adapter gates assert `xhigh=True`, `adaptive=True`, `no-sampling=True` for `claude-opus-4-8`, `claude-opus-4.8`, and `anthropic/claude-opus-4.8`.
- Fuzzy-collision sanity: `'4-8' in 'claude-opus-4-7'` is `False`.

## Test Plan

- [x] `pytest tests/agent/test_anthropic_adapter.py tests/hermes_cli/test_models.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_model_validation.py` → **334 passed**
- [x] Manifest sync test (`test_in_repo_lists_match_manifest`) passes after regeneration