### PR TITLE
fix: strip provider prefix before passing model name to aggregator APIs

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -390,6 +390,11 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
+        name = _strip_matching_provider_prefix(name, provider)
+        # If the input had a provider prefix (e.g. openrouter/moonshotai/kimi-k2.5),
+        # strip it first so only the vendor/model slug reaches the aggregator.
+        # Without this, _prepend_vendor sees a slash and returns the full string
+        # including the provider prefix, which aggregator APIs reject.
         return _prepend_vendor(name)
 
     # --- OpenCode Zen / OpenCode Go: flat-namespace resellers.


### PR DESCRIPTION
## Problem

When a model is configured with a Hermes provider prefix (e.g. `openrouter/moonshotai/kimi-k2.5`), `normalize_model_for_provider` passes the full string — including the `openrouter/` prefix — to `_prepend_vendor()`. Since `_prepend_vendor` sees a `/` in the string, it returns it as-is.

**Result:** OpenRouter receives `openrouter/moonshotai/kimi-k2.5` as the model ID and rejects it with: `openrouter/moonshotai/kimi-k2.5 is not a valid model ID`. This affects all users selecting models through the instance webchat GUI.

## Fix

Add `_strip_matching_provider_prefix(name, provider)` before `_prepend_vendor(name)` in the aggregator branch (5 lines). This strips the `openrouter/` (or `nous/`, `ai-gateway/`, `kilocode/`) prefix so only the `vendor/model` slug reaches the aggregator.

Other provider branches (`_MATCHING_PREFIX_STRIP_PROVIDERS` etc.) already do this — the aggregator path was simply missing it.

### Before
`openrouter/moonshotai/kimi-k2.5` → sent as-is → ❌ rejected

### After
`openrouter/moonshotai/kimi-k2.5` → stripped to `moonshotai/kimi-k2.5` → ✅ accepted