### PR TITLE
fix(gateway): support markdown files in MEDIA tags

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|md|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -57,6 +57,14 @@ class TestExtractMediaImages:
         assert "/audio.ogg" in paths
         assert "/screenshot.png" in paths
 
+    def test_markdown_document_extracted(self):
+        content = "MD 对照附件\nMEDIA:/home/user/document_output/telegram_compare_test.md"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/home/user/document_output/telegram_compare_test.md"
+        assert "MEDIA:" not in cleaned
+        assert "MD 对照附件" in cleaned
+
 
 # ---------------------------------------------------------------------------
 # Telegram send_image_file tests


### PR DESCRIPTION
## Summary
- add `.md` to the `MEDIA:` extraction whitelist
- add a regression test covering `MEDIA:/.../*.md` extraction

## Why
`extract_local_files()` already treats `.md` as a deliverable document attachment, but `extract_media()` omitted it from the explicit `MEDIA:` regex whitelist. This caused `MEDIA:/path/file.md` to render as literal text instead of uploading the file on messaging platforms like Telegram.

## Testing
- `python3 -m pytest tests/gateway/test_send_image_file.py -q -o addopts=''`
- `python3 -m pytest tests/gateway/test_send_image_file.py tests/agent/test_prompt_builder.py -q -o addopts=''`