### PR TITLE
fix(tools): grep content search returns nothing under a hidden root (#18473)

### DIFF
--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -168,3 +168,67 @@ class TestIgnoreFileWritten:
         hub_mod._write_index_cache("test_key", {"data": "test"})
 
         assert ignore_file.read_text() == "# custom\ncustom-pattern\n"
+
+
+class TestGrepSearchesExplicitHiddenRoot:
+    """Regression for #18473: search_files(target='content') returned 0 results
+    when the search path itself contained a hidden directory component (e.g.
+    ~/.hermes/workspace). GNU grep's --exclude-dir matches every path component
+    INCLUDING the search root, so an unconditional exclude swallowed the whole
+    tree. _search_with_grep must omit --exclude-dir for hidden roots, mirroring
+    _search_files (fixed for target='files' in #16672).
+
+    Asserting on the generated command (not live grep output) keeps the test
+    deterministic across GNU grep and BSD grep, which differ in how
+    --exclude-dir treats the root.
+    """
+
+    @staticmethod
+    def _capture_env():
+        """Terminal env that records the command and returns no matches."""
+        class _Env:
+            def __init__(self):
+                self.cwd = "/tmp"
+                self.commands = []
+
+            def execute(self, command, cwd=None, timeout=None, **kwargs):
+                self.commands.append(command)
+                if "echo exists" in command or "test -e" in command:
+                    return {"output": "exists", "returncode": 0}
+                return {"output": "", "returncode": 1}
+
+        return _Env()
+
+    def test_grep_omits_exclude_dir_for_hidden_root(self):
+        from tools.file_operations import ShellFileOperations
+
+        env = self._capture_env()
+        ops = ShellFileOperations(env)
+        ops._has_command = lambda cmd: cmd == "grep"
+
+        ops.search("NAS", path="/home/user/.hermes/workspace/notes", target="content")
+
+        grep_cmds = [c for c in env.commands if c.strip().startswith("grep ")]
+        assert grep_cmds, f"no grep command was executed; got: {env.commands}"
+        cmd = grep_cmds[0]
+        assert "grep" in cmd
+        assert "--exclude-dir" not in cmd, (
+            "grep must NOT pass --exclude-dir when the search root is hidden — "
+            "GNU grep would exclude the root itself and return nothing (#18473)"
+        )
+
+    def test_grep_keeps_exclude_dir_for_visible_root(self):
+        from tools.file_operations import ShellFileOperations
+
+        env = self._capture_env()
+        ops = ShellFileOperations(env)
+        ops._has_command = lambda cmd: cmd == "grep"
+
+        ops.search("NAS", path="/home/user/workspace/notes", target="content")
+
+        grep_cmds = [c for c in env.commands if c.strip().startswith("grep ")]
+        assert grep_cmds, f"no grep command was executed; got: {env.commands}"
+        cmd = grep_cmds[0]
+        assert "--exclude-dir" in cmd, (
+            "grep must still exclude hidden descendants for a visible root (#1558)"
+        )

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1906,7 +1906,16 @@ class ShellFileOperations(FileOperations):
         
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.
-        cmd_parts.append("--exclude-dir='.*'")
+        # But GNU grep's --exclude-dir also matches the search root itself, so
+        # an unconditional exclude returns nothing when the root is hidden
+        # (e.g. ~/.hermes/workspace). Mirror _search_files: skip it for hidden
+        # roots so explicit hidden-root searches still work. (#18473)
+        has_hidden_path_ancestor = any(
+            part not in {".", ".."} and part.startswith(".")
+            for part in Path(path).parts
+        )
+        if not has_hidden_path_ancestor:
+            cmd_parts.append("--exclude-dir='.*'")
         
         # Add context if requested
         if context > 0:


### PR DESCRIPTION
## Summary

`search_files(..., target="content")` returns `total_count: 0` whenever the search path contains a hidden directory component (e.g. `~/.hermes/workspace/notes/`), even when matching content exists. `target="files"` works for the same paths (fixed in #16672), but the content/grep backend was still affected.

Fixes #18473.

## Root cause

`ShellFileOperations._search_with_grep` unconditionally appended `--exclude-dir='.*'`. GNU grep matches `--exclude-dir` against **every** path component, including the search root itself. When the root is (or lives under) a hidden directory, the entire tree is excluded and grep returns nothing.

## Fix

Mirror the logic already used by `_search_files` (the `target="files"` path fixed in #16672): compute whether the root has a hidden ancestor and only pass `--exclude-dir` when it doesn't. This keeps hidden **descendants** excluded for normal/visible roots (the #1558 prompt-injection regression protection) while allowing explicit hidden-root searches to work.

## Tests

Added `TestGrepSearchesExplicitHiddenRoot` with two cases:
- hidden root → command must **not** contain `--exclude-dir` (the #18473 regression)
- visible root → command must still contain `--exclude-dir` (preserves #1558)

The tests assert on the generated grep command rather than live grep output, so they're deterministic across GNU grep and BSD grep (which differ in how `--exclude-dir` treats the root). Verified the hidden-root test fails without the fix and passes with it. Full `test_file_operations*` + `test_search_hidden_dirs` suite: 123 passed.
