### PR TITLE
fix: surface usage-limit reset details without retrying

### DIFF
--- a/agent/api_error_utils.py
+++ b/agent/api_error_utils.py
@@ -1,0 +1,91 @@
+"""Shared API error classification and display helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Optional
+
+
+def _api_error_object(error: BaseException) -> Optional[dict[str, Any]]:
+    """Return the provider error object from nested or flat SDK bodies."""
+    body = getattr(error, "body", None)
+    if not isinstance(body, dict):
+        return None
+    nested_error = body.get("error")
+    return nested_error if isinstance(nested_error, dict) else body
+
+
+def is_usage_limit_reached_error(error: BaseException) -> bool:
+    """Return True for provider account usage-limit payloads.
+
+    These errors are distinct from transient rate limits: the provider is
+    reporting that the account has exhausted its current usage window.
+    """
+    err_obj = _api_error_object(error)
+    return bool(err_obj and err_obj.get("type") == "usage_limit_reached")
+
+
+def summarize_api_error(
+    error: BaseException,
+    *,
+    detail_decorator: Optional[Callable[[str], str]] = None,
+) -> str:
+    """Extract a compact human-readable one-liner from an API error."""
+    raw = str(error)
+
+    if isinstance(error, ValueError) and "expected ident at line" in raw.lower():
+        return f"Malformed provider streaming response: {raw[:300]}"
+
+    if "<!DOCTYPE" in raw or "<html" in raw:
+        match = re.search(r"<title[^>]*>([^<]+)</title>", raw, re.IGNORECASE)
+        title = match.group(1).strip() if match else "HTML error page (title not found)"
+        ray = re.search(r"Cloudflare Ray ID:\s*<strong[^>]*>([^<]+)</strong>", raw)
+        ray_id = ray.group(1).strip() if ray else None
+        status_code = getattr(error, "status_code", None)
+        parts = []
+        if status_code:
+            parts.append(f"HTTP {status_code}")
+        parts.append(title)
+        if ray_id:
+            parts.append(f"Ray {ray_id}")
+        return " — ".join(parts)
+
+    err_obj = _api_error_object(error)
+    if err_obj is not None:
+        msg = err_obj.get("message")
+        if msg:
+            status_code = getattr(error, "status_code", None)
+            prefix = f"HTTP {status_code}: " if status_code else ""
+            details = []
+            if err_obj.get("type") == "usage_limit_reached":
+                resets_in = err_obj.get("resets_in_seconds")
+                if isinstance(resets_in, (int, float)) and resets_in > 0:
+                    seconds = int(resets_in)
+                    hours, rem = divmod(seconds, 3600)
+                    minutes, _ = divmod(rem, 60)
+                    details.append(
+                        f"resets_in_seconds={seconds}; reset_hhmm={hours:02d}:{minutes:02d}"
+                    )
+                resets_at = err_obj.get("resets_at")
+                if resets_at:
+                    details.append(f"resets_at={resets_at}")
+                plan_type = err_obj.get("plan_type")
+                if plan_type:
+                    details.append(f"plan={plan_type}")
+            suffix = f" ({'; '.join(details)})" if details else ""
+            detail = f"{prefix}{str(msg)[:300]}{suffix}"
+            return detail_decorator(detail) if detail_decorator else detail
+
+    status_code = getattr(error, "status_code", None)
+    prefix = f"HTTP {status_code}: " if status_code else ""
+    detail = f"{prefix}{raw[:500]}"
+    return detail_decorator(detail) if detail_decorator else detail
+
+
+def usage_limit_error_message(
+    error: BaseException,
+    *,
+    detail_decorator: Optional[Callable[[str], str]] = None,
+) -> str:
+    """Return the canonical user-facing usage-limit error message."""
+    return f"API usage limit reached: {summarize_api_error(error, detail_decorator=detail_decorator)}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2552,6 +2552,47 @@ def run_conversation(
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                 }
+                usage_limit_reached = agent._is_usage_limit_reached_error(api_error)
+                if usage_limit_reached and agent._fallback_index < len(agent._fallback_chain):
+                    # OpenAI/Codex-style account usage limits include an
+                    # explicit reset window in the payload. Retrying the
+                    # primary cannot succeed before that reset, but a
+                    # configured fallback provider can. Prefer failover over
+                    # terminating the turn; only surface the reset message if
+                    # the fallback chain is exhausted or unavailable.
+                    agent._buffer_status("⚠️ API usage limit reached — switching to fallback provider...")
+                    if agent._try_activate_fallback(reason=classified.reason):
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+
+                if usage_limit_reached:
+                    # No fallback recovered. Surface the actionable reset
+                    # window immediately instead of wasting calls.
+                    agent._flush_status_buffer()
+                    _final_summary = agent._summarize_api_error(api_error)
+                    _usage_limit_message = agent._usage_limit_error_message(api_error)
+                    agent._emit_status(f"❌ {_usage_limit_message}")
+                    logger.error(
+                        "%sAPI usage limit reached. %s | provider=%s model=%s msgs=%s tokens=~%s",
+                        agent.log_prefix, _final_summary,
+                        _provider, _model, len(api_messages), f"{approx_tokens:,}",
+                    )
+                    if api_kwargs is not None:
+                        agent._dump_api_request_debug(
+                            api_kwargs, reason="usage_limit_reached", error=api_error,
+                        )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": _usage_limit_message,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": _final_summary,
+                    }
+
                 if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit

--- a/run_agent.py
+++ b/run_agent.py
@@ -100,6 +100,11 @@ from agent.process_bootstrap import (
     _SafeWriter,  # noqa: F401  # re-exported for tests that `from run_agent import _SafeWriter`
     _get_proxy_for_base_url,
 )
+from agent.api_error_utils import (
+    is_usage_limit_reached_error,
+    summarize_api_error,
+    usage_limit_error_message,
+)
 from agent.iteration_budget import IterationBudget
 
 
@@ -1011,6 +1016,9 @@ class AIAgent:
 
     def _emit_auxiliary_failure(self, task: str, exc: BaseException) -> None:
         """Surface a compact warning for failed auxiliary work."""
+        if self._is_usage_limit_reached_error(exc):
+            self._emit_warning(f"⚠ {self._usage_limit_error_message(exc)}")
+            return
         try:
             detail = self._summarize_api_error(exc)
         except Exception:
@@ -1729,6 +1737,11 @@ class AIAgent:
         return False
 
     @staticmethod
+    def _is_usage_limit_reached_error(error: Exception) -> bool:
+        """Return True for provider account usage-limit payloads."""
+        return is_usage_limit_reached_error(error)
+
+    @staticmethod
     def _decorate_xai_entitlement_error(detail: str) -> str:
         """Append a neutral hint when xAI's OAuth surface returns the
         permission-denied 403.
@@ -1787,49 +1800,19 @@ class AIAgent:
 
     @staticmethod
     def _summarize_api_error(error: Exception) -> str:
-        """Extract a human-readable one-liner from an API error.
+        """Extract a human-readable one-liner from an API error."""
+        return summarize_api_error(
+            error,
+            detail_decorator=AIAgent._decorate_xai_entitlement_error,
+        )
 
-        Handles Cloudflare HTML error pages (502, 503, etc.) by pulling the
-        <title> tag instead of dumping raw HTML.  Falls back to a truncated
-        str(error) for everything else.
-        """
-        raw = str(error)
-
-        if (
-            isinstance(error, ValueError)
-            and "expected ident at line" in raw.lower()
-        ):
-            return f"Malformed provider streaming response: {raw[:300]}"
-
-        # Cloudflare / proxy HTML pages: grab the <title> for a clean summary
-        if "<!DOCTYPE" in raw or "<html" in raw:
-            m = re.search(r"<title[^>]*>([^<]+)</title>", raw, re.IGNORECASE)
-            title = m.group(1).strip() if m else "HTML error page (title not found)"
-            # Also grab Cloudflare Ray ID if present
-            ray = re.search(r"Cloudflare Ray ID:\s*<strong[^>]*>([^<]+)</strong>", raw)
-            ray_id = ray.group(1).strip() if ray else None
-            status_code = getattr(error, "status_code", None)
-            parts = []
-            if status_code:
-                parts.append(f"HTTP {status_code}")
-            parts.append(title)
-            if ray_id:
-                parts.append(f"Ray {ray_id}")
-            return " — ".join(parts)
-
-        # JSON body errors from OpenAI/Anthropic SDKs
-        body = getattr(error, "body", None)
-        if isinstance(body, dict):
-            msg = body.get("error", {}).get("message") if isinstance(body.get("error"), dict) else body.get("message")
-            if msg:
-                status_code = getattr(error, "status_code", None)
-                prefix = f"HTTP {status_code}: " if status_code else ""
-                return AIAgent._decorate_xai_entitlement_error(f"{prefix}{msg[:300]}")
-
-        # Fallback: truncate the raw string but give more room than 200 chars
-        status_code = getattr(error, "status_code", None)
-        prefix = f"HTTP {status_code}: " if status_code else ""
-        return AIAgent._decorate_xai_entitlement_error(f"{prefix}{raw[:500]}")
+    @staticmethod
+    def _usage_limit_error_message(error: Exception) -> str:
+        """Return the canonical user-facing usage-limit error message."""
+        return usage_limit_error_message(
+            error,
+            detail_decorator=AIAgent._decorate_xai_entitlement_error,
+        )
 
     def _mask_api_key_for_logs(self, key: Any) -> Optional[str]:
         # Azure Foundry Entra ID bearer providers are callables — never

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -18,6 +18,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agent.api_error_utils import (
+    is_usage_limit_reached_error,
+    usage_limit_error_message,
+)
 from agent.codex_responses_adapter import _normalize_codex_response
 
 import run_agent
@@ -73,6 +77,101 @@ def agent():
         )
         a.client = MagicMock()
         return a
+
+
+
+
+def test_summarize_api_error_includes_usage_limit_reset_seconds(agent):
+    error = SimpleNamespace(
+        status_code=429,
+        body={
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "plan_type": "plus",
+                "resets_at": 1779987634,
+                "resets_in_seconds": 8464,
+            }
+        },
+    )
+
+    summary = agent._summarize_api_error(error)
+
+    assert "HTTP 429" in summary
+    assert "usage limit" in summary.lower()
+    assert "8464" in summary
+    assert "reset_hhmm=02:21" in summary
+    assert "2h 21m" not in summary
+    assert "resets_at=1779987634" in summary
+
+
+def test_summarize_api_error_includes_usage_limit_reset_seconds_from_flat_body(agent):
+    error = SimpleNamespace(
+        status_code=429,
+        body={
+            "type": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "plan_type": "plus",
+            "resets_at": 1780080252,
+            "resets_in_seconds": 1591,
+        },
+    )
+
+    summary = agent._summarize_api_error(error)
+
+    assert "HTTP 429" in summary
+    assert "usage limit" in summary.lower()
+    assert "1591" in summary
+    assert "reset_hhmm=00:26" in summary
+    assert "resets_at=1780080252" in summary
+
+
+def test_usage_limit_error_message_is_canonical_for_nested_and_flat_bodies():
+    nested = SimpleNamespace(
+        status_code=429,
+        body={
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "resets_in_seconds": 8464,
+            }
+        },
+    )
+    flat = SimpleNamespace(
+        status_code=429,
+        body={
+            "type": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "resets_in_seconds": 8464,
+        },
+    )
+
+    assert is_usage_limit_reached_error(nested) is True
+    assert is_usage_limit_reached_error(flat) is True
+    assert usage_limit_error_message(nested) == usage_limit_error_message(flat)
+    assert usage_limit_error_message(nested).startswith("API usage limit reached: HTTP 429:")
+    assert "reset_hhmm=02:21" in usage_limit_error_message(nested)
+
+
+def test_emit_auxiliary_failure_uses_canonical_usage_limit_message(agent):
+    error = SimpleNamespace(
+        status_code=429,
+        body={
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "resets_in_seconds": 8464,
+            }
+        },
+    )
+    agent._emit_warning = MagicMock()
+
+    agent._emit_auxiliary_failure("title generation", error)
+
+    emitted = agent._emit_warning.call_args.args[0]
+    assert emitted.startswith("⚠ API usage limit reached: HTTP 429:")
+    assert "Auxiliary title generation failed" not in emitted
+    assert "reset_hhmm=02:21" in emitted
 
 
 @pytest.fixture()
@@ -2220,6 +2319,130 @@ class TestExecuteToolCalls:
         output = captured.getvalue()
         assert "API call failed" not in output
         assert "Rate limit reached" not in output
+
+
+    def test_run_conversation_usage_limit_reached_returns_reset_without_retrying(self, agent):
+        class _UsageLimitError(Exception):
+            status_code = 429
+            body = {
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "plan_type": "plus",
+                    "resets_at": 1779987634,
+                    "resets_in_seconds": 8464,
+                }
+            }
+
+            def __str__(self):
+                return "Error code: 429 - usage limit reached"
+
+        calls = {"count": 0}
+
+        def _fake_api_call(api_kwargs):
+            calls["count"] += 1
+            raise _UsageLimitError()
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        with patch("run_agent.time.sleep", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["failed"] is True
+        assert calls["count"] == 1
+        assert "API usage limit reached" in result["final_response"]
+        assert "8464" in result["final_response"]
+        assert "reset_hhmm=02:21" in result["final_response"]
+        assert "after 3 retries" not in result["final_response"]
+
+
+    def test_run_conversation_usage_limit_reached_uses_configured_fallback(self, agent):
+        class _UsageLimitError(Exception):
+            status_code = 429
+            body = {
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "plan_type": "plus",
+                    "resets_at": 1779987634,
+                    "resets_in_seconds": 8464,
+                }
+            }
+
+            def __str__(self):
+                return "Error code: 429 - usage limit reached"
+
+        responses = [_UsageLimitError(), _mock_response(content="Recovered via fallback")]
+        calls = {"count": 0}
+        fallback_reasons = []
+
+        def _fake_api_call(api_kwargs):
+            calls["count"] += 1
+            result = responses.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        def _fake_fallback(reason=None):
+            fallback_reasons.append(reason)
+            agent._fallback_index = 1
+            agent.provider = "gemini"
+            agent.model = "gemini-2.5-flash"
+            return True
+
+        agent._fallback_chain = [{"provider": "gemini", "model": "gemini-2.5-flash"}]
+        agent._fallback_index = 0
+        agent._interruptible_api_call = _fake_api_call
+        agent._try_activate_fallback = _fake_fallback
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        with patch("run_agent.time.sleep", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered via fallback"
+        assert calls["count"] == 2
+        assert fallback_reasons == [FailoverReason.rate_limit]
+
+
+    def test_run_conversation_flat_usage_limit_reached_returns_reset_without_retrying(self, agent):
+        class _UsageLimitError(Exception):
+            status_code = 429
+            body = {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "plan_type": "plus",
+                "resets_at": 1780080252,
+                "resets_in_seconds": 1591,
+            }
+
+            def __str__(self):
+                return "Error code: 429 - {'error': {'type': 'usage_limit_reached'}}"
+
+        calls = {"count": 0}
+
+        def _fake_api_call(api_kwargs):
+            calls["count"] += 1
+            raise _UsageLimitError()
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        with patch("run_agent.time.sleep", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["failed"] is True
+        assert calls["count"] == 1
+        assert "API usage limit reached" in result["final_response"]
+        assert "1591" in result["final_response"]
+        assert "reset_hhmm=00:26" in result["final_response"]
+        assert "after 3 retries" not in result["final_response"]
 
 
 class TestConcurrentToolExecution:


### PR DESCRIPTION
## Summary
- include OpenAI/Codex `usage_limit_reached` reset details in user-facing API error summaries
- format `resets_in_seconds` as both raw seconds and `reset_hhmm=HH:MM`
- treat `usage_limit_reached` as terminal/actionable instead of retrying three times, since the provider already reports the reset window

## Why
OpenAI/Codex returns useful structured 429 payloads like:

```text
{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"plus","resets_at":1779987634,"resets_in_seconds":8464}}
```

Before this patch, Hermes collapsed that into:

```text
API call failed after 3 retries: HTTP 429: The usage limit has been reached
```

That hides the actual recovery time and burns extra calls before telling the user anything useful.

## Test Plan
- [x] `python -m pytest tests/run_agent/test_run_agent.py -q -o addopts=`

Result locally:

```text
347 passed, 1 warning
```
