### PR TITLE
fix(cli): use session-scoped yolo bypass in /yolo command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9609,18 +9609,24 @@ class HermesCLI:
 
     def _toggle_yolo(self):
         """Toggle YOLO mode — skip all dangerous command approval prompts."""
-        import os
         from hermes_cli.colors import Colors as _Colors
+        from tools.approval import (
+            disable_session_yolo,
+            enable_session_yolo,
+            get_current_session_key,
+            is_session_yolo_enabled,
+        )
 
-        current = is_truthy_value(os.environ.get("HERMES_YOLO_MODE"))
+        session_key = get_current_session_key()
+        current = is_session_yolo_enabled(session_key)
         if current:
-            os.environ.pop("HERMES_YOLO_MODE", None)
+            disable_session_yolo(session_key)
             _cprint(
                 f"  ⚠ YOLO mode {_Colors.BOLD}{_Colors.RED}OFF{_Colors.RESET}"
                 " — dangerous commands will require approval."
             )
         else:
-            os.environ["HERMES_YOLO_MODE"] = "1"
+            enable_session_yolo(session_key)
             _cprint(
                 f"  ⚡ YOLO mode {_Colors.BOLD}{_Colors.GREEN}ON{_Colors.RESET}"
                 " — all commands auto-approved. Use with caution."

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -12,6 +12,7 @@ from tools.approval import (
     detect_dangerous_command,
     disable_session_yolo,
     enable_session_yolo,
+    get_current_session_key,
     is_session_yolo_enabled,
     reset_current_session_key,
     set_current_session_key,
@@ -216,3 +217,28 @@ class TestYoloMode:
         approval_module.clear_session("session-a")
 
         assert is_session_yolo_enabled("session-a") is False
+
+    def test_cli_toggle_yolo_uses_session_yolo(self, monkeypatch):
+        """CLI /yolo must use enable_session_yolo, not the frozen env var."""
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_KEY", "cli-test")
+
+        # Simulate what cli._toggle_yolo now does
+        from tools.approval import get_current_session_key
+
+        session_key = get_current_session_key()
+        assert not is_session_yolo_enabled(session_key)
+
+        enable_session_yolo(session_key)
+        assert is_session_yolo_enabled(session_key)
+
+        # Approval check honours session-scoped yolo
+        token = set_current_session_key(session_key)
+        try:
+            result = check_dangerous_command("rm -rf /tmp/stuff", "local")
+            assert result["approved"] is True
+        finally:
+            reset_current_session_key(token)
+
+        disable_session_yolo(session_key)
+        assert not is_session_yolo_enabled(session_key)


### PR DESCRIPTION
## Summary

- CLI `/yolo` toggled `HERMES_YOLO_MODE` in `os.environ`, but `approval.py` freezes that flag at module-import time (`_YOLO_MODE_FROZEN`) to prevent prompt-injection escalation — the env var flip had no effect
- Switch to `enable_session_yolo()` / `disable_session_yolo()` keyed on `get_current_session_key()`, matching how the gateway and TUI handlers already work
- `/yolo` now actually bypasses approvals for the active CLI session without weakening the import-time freeze

## Test plan

- [x] New test `test_cli_toggle_yolo_uses_session_yolo` in `tests/tools/test_yolo_mode.py`
- [x] All 20 yolo mode tests pass

Closes #33925

🤖 Generated with [Claude Code](https://claude.com/claude-code)