### PR TITLE
fix(dashboard): survive browser disconnects in /chat PTY

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -70,10 +70,17 @@ class PtyBridge:
     ``os.write`` on the master fd, which is safe.
     """
 
-    def __init__(self, proc: "ptyprocess.PtyProcess"):  # type: ignore[name-defined]
+    def __init__(
+        self,
+        proc: "ptyprocess.PtyProcess",  # type: ignore[name-defined]
+        *,
+        scrollback_bytes: int = 256 * 1024,
+    ):
         self._proc = proc
         self._fd: int = proc.fd
         self._closed = False
+        self._scrollback = bytearray()
+        self._scrollback_limit = max(0, int(scrollback_bytes))
 
     # -- lifecycle --------------------------------------------------------
 
@@ -91,6 +98,7 @@ class PtyBridge:
         env: Optional[dict] = None,
         cols: int = 80,
         rows: int = 24,
+        scrollback_bytes: int = 256 * 1024,
     ) -> "PtyBridge":
         """Spawn ``argv`` behind a new PTY and return a bridge.
 
@@ -125,7 +133,7 @@ class PtyBridge:
             env=spawn_env,
             dimensions=(rows, cols),
         )
-        return cls(proc)
+        return cls(proc, scrollback_bytes=scrollback_bytes)
 
     @property
     def pid(self) -> int:
@@ -140,6 +148,17 @@ class PtyBridge:
             return False
 
     # -- I/O --------------------------------------------------------------
+
+    def _append_scrollback(self, chunk: bytes) -> None:
+        if self._scrollback_limit <= 0 or not chunk:
+            return
+        self._scrollback.extend(chunk)
+        overflow = len(self._scrollback) - self._scrollback_limit
+        if overflow > 0:
+            del self._scrollback[:overflow]
+
+    def snapshot_scrollback(self) -> bytes:
+        return bytes(self._scrollback)
 
     def read(self, timeout: float = 0.2) -> Optional[bytes]:
         """Read up to 64 KiB of raw bytes from the PTY master.
@@ -169,6 +188,7 @@ class PtyBridge:
             raise
         if not data:
             return None
+        self._append_scrollback(data)
         return data
 
     def write(self, data: bytes) -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -23,6 +23,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -3368,9 +3369,87 @@ except ImportError as _pty_import_err:  # pragma: no cover - Windows-only path
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
 _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_PTY_RECONNECT_GRACE_ENV = "HERMES_PTY_RECONNECT_GRACE_SECONDS"
+_PTY_RECONNECT_GRACE_DEFAULT = 300.0
+_PTY_RECONNECT_GRACE_MAX = 3600.0
+_PTY_RECONNECT_MARKER = b"\r\n\x1b[90m[reconnected]\x1b[0m\r\n"
+
+
+@dataclass
+class _PtySession:
+    bridge: Any
+    argv: List[str]
+    cwd: Optional[str]
+    env: Optional[dict]
+    created_at: float
+    last_attached_at: float
+    attached: bool = False
+    subscribers: int = 0
+    eviction_task: Optional[asyncio.Task] = None
+
+
+_PTY_BY_CHANNEL: dict[str, _PtySession] = {}
+_PTY_REGISTRY_LOCK = asyncio.Lock()
+
 # Starlette's TestClient reports the peer as "testclient"; treat it as
 # loopback so tests don't need to rewrite request scope.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
+
+
+def _pty_reconnect_grace_seconds() -> float:
+    raw = os.environ.get(_PTY_RECONNECT_GRACE_ENV)
+    if raw is None:
+        return _PTY_RECONNECT_GRACE_DEFAULT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _PTY_RECONNECT_GRACE_DEFAULT
+    return max(0.0, min(value, _PTY_RECONNECT_GRACE_MAX))
+
+
+async def _evict_after_grace(channel: str, last_attached_at: float, grace_seconds: float) -> None:
+    await asyncio.sleep(grace_seconds)
+    async with _PTY_REGISTRY_LOCK:
+        session = _PTY_BY_CHANNEL.get(channel)
+        if (
+            session is None
+            or session.attached
+            or session.last_attached_at != last_attached_at
+        ):
+            return
+        _PTY_BY_CHANNEL.pop(channel, None)
+    session.bridge.close()
+
+
+async def _detach_pty_channel(channel: str, bridge: Any) -> None:
+    async with _PTY_REGISTRY_LOCK:
+        session = _PTY_BY_CHANNEL.get(channel)
+        if session is None or session.bridge is not bridge:
+            return
+        session.attached = False
+        session.subscribers = 0
+        session.last_attached_at = time.monotonic()
+        if session.eviction_task and not session.eviction_task.done():
+            session.eviction_task.cancel()
+        loop = asyncio.get_running_loop()
+        session.eviction_task = loop.create_task(
+            _evict_after_grace(
+                channel,
+                session.last_attached_at,
+                _pty_reconnect_grace_seconds(),
+            )
+        )
+
+
+@app.on_event("shutdown")
+async def _close_dashboard_pty_sessions() -> None:
+    async with _PTY_REGISTRY_LOCK:
+        sessions = list(_PTY_BY_CHANNEL.values())
+        _PTY_BY_CHANNEL.clear()
+    for session in sessions:
+        if session.eviction_task and not session.eviction_task.done():
+            session.eviction_task.cancel()
+        session.bridge.close()
 
 
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
@@ -3611,32 +3690,99 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=1011)
         return
 
-    # --- spawn PTY ------------------------------------------------------
+    # --- attach/spawn PTY -----------------------------------------------
+    # Browser disconnects detach the PTY instead of killing it. Reconnects
+    # with the same `channel` within HERMES_PTY_RECONNECT_GRACE_SECONDS
+    # (default 300s, capped at 3600s) reattach and replay scrollback.
     resume = ws.query_params.get("resume") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
+    bridge = None
+    retain_after_disconnect = False
+    reattached = False
 
-    try:
-        argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
-    except SystemExit as exc:
-        # _make_tui_argv calls sys.exit(1) when node/npm is missing.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
+    if channel:
+        async with _PTY_REGISTRY_LOCK:
+            session = _PTY_BY_CHANNEL.get(channel)
+            if session is not None and not session.bridge.is_alive():
+                if session.eviction_task and not session.eviction_task.done():
+                    session.eviction_task.cancel()
+                _PTY_BY_CHANNEL.pop(channel, None)
+                session.bridge.close()
+                session = None
+            if session is not None and session.attached:
+                await ws.send_bytes(
+                    b"\r\n\x1b[31m[chat already attached in another tab]\x1b[0m\r\n"
+                )
+                await ws.close(code=4409)
+                return
+            if session is not None:
+                if session.eviction_task and not session.eviction_task.done():
+                    session.eviction_task.cancel()
+                session.eviction_task = None
+                session.attached = True
+                session.subscribers = 1
+                session.last_attached_at = time.monotonic()
+                bridge = session.bridge
+                retain_after_disconnect = True
+                reattached = True
 
+    if bridge is None:
+        try:
+            argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+        except SystemExit as exc:
+            # _make_tui_argv calls sys.exit(1) when node/npm is missing.
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
 
-    try:
-        bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
-    except PtyUnavailableError as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-    except (FileNotFoundError, OSError) as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
+        try:
+            bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
+        except PtyUnavailableError as exc:
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+        except (FileNotFoundError, OSError) as exc:
+            await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+
+        if channel:
+            now = time.monotonic()
+            session = _PtySession(
+                bridge=bridge,
+                argv=list(argv),
+                cwd=cwd,
+                env=env,
+                created_at=now,
+                last_attached_at=now,
+                attached=True,
+                subscribers=1,
+            )
+            async with _PTY_REGISTRY_LOCK:
+                previous = _PTY_BY_CHANNEL.get(channel)
+                if previous is not None and previous.attached:
+                    bridge.close()
+                    await ws.send_bytes(
+                        b"\r\n\x1b[31m[chat already attached in another tab]\x1b[0m\r\n"
+                    )
+                    await ws.close(code=4409)
+                    return
+                if previous is not None:
+                    if previous.eviction_task and not previous.eviction_task.done():
+                        previous.eviction_task.cancel()
+                    previous.bridge.close()
+                _PTY_BY_CHANNEL[channel] = session
+            retain_after_disconnect = True
 
     loop = asyncio.get_running_loop()
+
+    if reattached:
+        replay = bridge.snapshot_scrollback()
+        if replay:
+            await ws.send_bytes(b"\x1b[2J\x1b[H")
+            await ws.send_bytes(replay)
+            await ws.send_bytes(_PTY_RECONNECT_MARKER)
 
     # --- reader task: PTY master → WebSocket ----------------------------
     async def pump_pty_to_ws() -> None:
@@ -3687,7 +3833,10 @@ async def pty_ws(ws: WebSocket) -> None:
             await reader_task
         except (asyncio.CancelledError, Exception):
             pass
-        bridge.close()
+        if retain_after_disconnect and channel:
+            await _detach_pty_channel(channel, bridge)
+        else:
+            bridge.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -171,6 +171,40 @@ class TestPtyBridgeEnv:
             bridge.close()
 
 
+@skip_on_windows
+class TestScrollback:
+    def test_scrollback_collects_recent_bytes(self):
+        bridge = PtyBridge.spawn([shutil.which("cat") or "cat"])
+        try:
+            bridge.write(b"scrollback-known-bytes\n")
+            output = _read_until(bridge, b"scrollback-known-bytes")
+            assert b"scrollback-known-bytes" in output
+            assert b"scrollback-known-bytes" in bridge.snapshot_scrollback()
+        finally:
+            bridge.close()
+
+    def test_scrollback_trims_to_limit(self):
+        bridge = PtyBridge.spawn(
+            ["/bin/sh", "-c", "printf '1111122222333334444455555'"],
+            scrollback_bytes=10,
+        )
+        try:
+            output = _read_until(bridge, b"55555")
+            assert b"11111" in output
+            snapshot = bridge.snapshot_scrollback()
+            assert len(snapshot) <= 10
+            assert snapshot.endswith(b"4444455555")
+        finally:
+            bridge.close()
+
+    def test_scrollback_empty_after_spawn(self):
+        bridge = PtyBridge.spawn(["/bin/sh", "-c", "sleep 1"])
+        try:
+            assert bridge.snapshot_scrollback() == b""
+        finally:
+            bridge.close()
+
+
 class TestPtyBridgeUnavailable:
     """Platform fallback semantics — PtyUnavailableError is importable and
     carries a user-readable message."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2371,6 +2371,163 @@ class TestPtyWebSocket:
         assert exc.value.code == 4400
 
 
+@skip_on_windows
+class TestPtySurvival:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch, _isolate_hermes_home):
+        from starlette.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        self.ws_module = ws
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        monkeypatch.setenv("HERMES_PTY_RECONNECT_GRACE_SECONDS", "0.2")
+        self.token = ws._SESSION_TOKEN
+        with TestClient(ws.app) as client:
+            self.client = client
+            self._clear_registry()
+            yield
+            self._clear_registry()
+
+    def _clear_registry(self):
+        for session in list(self.ws_module._PTY_BY_CHANNEL.values()):
+            if session.eviction_task and not session.eviction_task.done():
+                session.eviction_task.cancel()
+            session.bridge.close()
+        self.ws_module._PTY_BY_CHANNEL.clear()
+
+    def _url(self, channel: str) -> str:
+        from urllib.parse import urlencode
+
+        return f"/api/pty?{urlencode({'token': self.token, 'channel': channel})}"
+
+    def _wait_for(self, predicate, timeout: float = 2.0):
+        import time
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            value = predicate()
+            if value:
+                return value
+            time.sleep(0.01)
+        raise AssertionError("condition not reached before timeout")
+
+    def _recv_until(self, conn, needle: bytes, timeout: float = 2.0) -> bytes:
+        import queue
+        import threading
+        import time
+
+        buf = bytearray()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            recv_q: queue.Queue = queue.Queue()
+
+            def _recv():
+                try:
+                    recv_q.put(conn.receive_bytes())
+                except Exception as exc:
+                    recv_q.put(exc)
+
+            thread = threading.Thread(target=_recv, daemon=True)
+            thread.start()
+            try:
+                frame = recv_q.get(timeout=max(0.01, deadline - time.monotonic()))
+            except queue.Empty:
+                break
+            if isinstance(frame, Exception):
+                raise frame
+            buf.extend(frame)
+            if needle in buf:
+                break
+        return bytes(buf)
+
+    def _echo_argv(self):
+        return (
+            [
+                "/bin/sh",
+                "-c",
+                "while IFS= read -r line; do printf 'got:%s\\n' \"$line\"; done",
+            ],
+            None,
+            None,
+        )
+
+    def test_pty_survival_reattach_same_channel_reuses_pty(self, monkeypatch):
+        monkeypatch.setattr(
+            self.ws_module,
+            "_resolve_chat_argv",
+            lambda resume=None, sidecar_url=None: self._echo_argv(),
+        )
+
+        with self.client.websocket_connect(self._url("survive-same")) as conn:
+            conn.send_bytes(b"first\n")
+            assert b"got:first" in self._recv_until(conn, b"got:first")
+            first_pid = self.ws_module._PTY_BY_CHANNEL["survive-same"].bridge.pid
+
+        self._wait_for(
+            lambda: not self.ws_module._PTY_BY_CHANNEL["survive-same"].attached
+        )
+
+        with self.client.websocket_connect(self._url("survive-same")) as conn:
+            second_pid = self.ws_module._PTY_BY_CHANNEL["survive-same"].bridge.pid
+            assert conn is not None
+
+        assert second_pid == first_pid
+
+    def test_pty_grace_evicts_after_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            self.ws_module,
+            "_resolve_chat_argv",
+            lambda resume=None, sidecar_url=None: self._echo_argv(),
+        )
+
+        with self.client.websocket_connect(self._url("grace-evict")):
+            bridge = self.ws_module._PTY_BY_CHANNEL["grace-evict"].bridge
+
+        self._wait_for(
+            lambda: "grace-evict" not in self.ws_module._PTY_BY_CHANNEL,
+            timeout=3.0,
+        )
+        assert not bridge.is_alive()
+
+    def test_pty_reattach_replays_scrollback(self, monkeypatch):
+        monkeypatch.setattr(
+            self.ws_module,
+            "_resolve_chat_argv",
+            lambda resume=None, sidecar_url=None: self._echo_argv(),
+        )
+
+        with self.client.websocket_connect(self._url("replay-scrollback")) as conn:
+            conn.send_bytes(b"replay-me\n")
+            assert b"got:replay-me" in self._recv_until(conn, b"got:replay-me")
+
+        self._wait_for(
+            lambda: not self.ws_module._PTY_BY_CHANNEL["replay-scrollback"].attached
+        )
+
+        with self.client.websocket_connect(self._url("replay-scrollback")) as conn:
+            replay = self._recv_until(conn, b"[reconnected]")
+
+        assert b"got:replay-me" in replay
+        assert b"[reconnected]" in replay
+
+    def test_pty_second_concurrent_attach_rejected(self, monkeypatch):
+        from starlette.websockets import WebSocketDisconnect
+
+        monkeypatch.setattr(
+            self.ws_module,
+            "_resolve_chat_argv",
+            lambda resume=None, sidecar_url=None: self._echo_argv(),
+        )
+
+        with self.client.websocket_connect(self._url("conflict")):
+            with pytest.raises(WebSocketDisconnect) as exc:
+                with self.client.websocket_connect(self._url("conflict")) as second:
+                    second.receive_bytes()
+                    second.receive_bytes()
+            assert exc.value.code == 4409
+
+
 class TestDashboardPluginStaticAssetAllowlist:
     """``/dashboard-plugins/<name>/<path>`` is unauthenticated by design —
     the SPA loads plugin JS via ``<script src>`` and CSS via
@@ -2443,4 +2600,3 @@ class TestDashboardPluginStaticAssetAllowlist:
         # 403 traversal-blocked OR 404 (depending on URL decode order)
         # — never 200.
         assert resp.status_code in (403, 404)
-

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -51,15 +51,65 @@ function buildWsUrl(
   return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
 }
 
-// Channel id ties this chat tab's PTY child (publisher) to its sidebar
-// (subscriber).  Generated once per mount so a tab refresh starts a fresh
-// channel — the previous PTY child terminates with the old WS, and its
-// channel auto-evicts when no subscribers remain.
+const CHANNEL_STORAGE_KEY = "hermes.chat.channel";
+const CHANNEL_RESUME_STORAGE_KEY = "hermes.chat.channel_resume";
+const LAST_SESSION_STORAGE_KEY = "hermes.chat.last_session_id";
+const CHANNEL_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
 function generateChannelId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+function readLocalStorage(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocalStorage(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Private browsing and locked-down storage should fall back to ephemeral ids.
+  }
+}
+
+function removeLocalStorage(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Best effort only.
+  }
+}
+
+function storedChannelForResume(resume: string | null): string {
+  const previousResume = readLocalStorage(CHANNEL_RESUME_STORAGE_KEY);
+  const stored = readLocalStorage(CHANNEL_STORAGE_KEY);
+  if (resume && stored && previousResume !== resume) {
+    removeLocalStorage(CHANNEL_STORAGE_KEY);
+    const next = generateChannelId();
+    writeLocalStorage(CHANNEL_STORAGE_KEY, next);
+    writeLocalStorage(CHANNEL_RESUME_STORAGE_KEY, resume);
+    return next;
+  }
+
+  if (stored && CHANNEL_RE.test(stored)) {
+    writeLocalStorage(CHANNEL_RESUME_STORAGE_KEY, resume ?? "");
+    return stored;
+  }
+
+  const next = generateChannelId();
+  writeLocalStorage(CHANNEL_STORAGE_KEY, next);
+  writeLocalStorage(CHANNEL_RESUME_STORAGE_KEY, resume ?? "");
+  return next;
 }
 
 // Colors for the terminal body.  Matches the dashboard's dark teal canvas
@@ -159,17 +209,32 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const storedLastSessionId = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    return readLocalStorage(LAST_SESSION_STORAGE_KEY);
+  }, []);
+  const activeResumeParam = resumeParam || storedLastSessionId;
+  const channel = useMemo(
+    () => storedChannelForResume(activeResumeParam),
+    [activeResumeParam],
+  );
 
   useEffect(() => {
-    if (!resumeParam) return;
+    if (resumeParam || !storedLastSessionId) return;
+    const next = new URLSearchParams(searchParams);
+    next.set("resume", storedLastSessionId);
+    setSearchParams(next, { replace: true });
+  }, [resumeParam, searchParams, setSearchParams, storedLastSessionId]);
+
+  useEffect(() => {
+    if (!activeResumeParam) return;
 
     let cancelled = false;
 
     api
-      .getSessionLatestDescendant(resumeParam)
+      .getSessionLatestDescendant(activeResumeParam)
       .then((res) => {
-        if (cancelled || !res.session_id || res.session_id === resumeParam) {
+        if (cancelled || !res.session_id || res.session_id === activeResumeParam) {
           return;
         }
 
@@ -184,7 +249,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [resumeParam, searchParams, setSearchParams]);
+  }, [activeResumeParam, searchParams, setSearchParams]);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 1023px)");
@@ -559,13 +624,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     void (async () => {
       const authParam = await buildWsAuthParam();
       if (unmounting) return;
-      const url = buildWsUrl(authParam, resumeParam, channel);
+      const url = buildWsUrl(authParam, activeResumeParam, channel);
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
 
     ws.onopen = () => {
       setBanner(null);
+      if (activeResumeParam) {
+        writeLocalStorage(LAST_SESSION_STORAGE_KEY, activeResumeParam);
+      }
       // Send the initial RESIZE immediately so Ink has *a* size to lay
       // out against on its first paint.  The double-rAF block above will
       // follow up with the authoritative measurement — at worst Ink
@@ -666,7 +734,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam]);
+  }, [channel, activeResumeParam]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
# fix(dashboard): survive browser disconnects in /chat PTY

## Problem

The dashboard `/chat` tab opens a WebSocket to `/api/pty`, which spawns a `hermes --tui` child behind a POSIX pseudo-terminal. When the browser disconnects — laptop sleep, tab loses focus long enough for the WS to time out, network blip, etc. — the WS handler hits `WebSocketDisconnect`, `finally` calls `bridge.close()`, and the TUI child gets killed.

On reconnect, the front-end opens a fresh WS, the server spawns a **brand-new** `hermes --tui`, and the user's conversation appears lost even though the underlying session is still on disk. Hitting "Resume session" from the sidebar gets back to the session, but xterm.js scrollback is also gone because the front-end always generates a new channel id per mount, forcing a clean re-mount.

This is a recurring papercut for anyone using the in-browser dashboard chat across naturally bursty browsing patterns.

## Approach

Three coordinated changes — server-side PTY survival + scrollback ring buffer + stable client-side channel id:

### 1. Server: channel-keyed PTY registry with grace-period eviction

- New `_PTY_BY_CHANNEL: dict[str, _PtySession]` keyed by the same channel id `pty_ws` already accepts via query param.
- Browser disconnects no longer call `bridge.close()` immediately. Instead they mark the session detached, record `last_attached_at`, and schedule a one-shot `asyncio.Task` (`_evict_after_grace`) that closes the bridge after `HERMES_PTY_RECONNECT_GRACE_SECONDS` (default `300`s, capped at `3600`s) if no reattach happens.
- On WS connect: look up the channel; if a live bridge exists and isn't currently attached, cancel any pending eviction and reuse it. If the existing entry's bridge has already died (e.g. user typed `/quit`), evict and spawn fresh.
- Concurrent attach attempts on the same channel are rejected with WS close code `4409` + a one-line ANSI error frame, so a second tab can't hijack the active session.
- New `@app.on_event("shutdown")` closes all live bridges so `hermes dashboard` exit doesn't leak children. (We're aware FastAPI deprecates `on_event` in favor of `lifespan`; the rest of `web_server.py` still uses `on_event` so this stays consistent — happy to migrate the whole file in a follow-up PR if maintainers prefer.)

### 2. Server: PtyBridge scrollback ring buffer

- `PtyBridge.__init__` takes new `scrollback_bytes` (default `256 * 1024`).
- Every non-empty chunk returned from `read()` is appended via `_append_scrollback()` which trims FIFO to the configured limit.
- `snapshot_scrollback()` returns the buffer as `bytes` (safe to call from the event loop thread after the executor-side `read` completes; single-writer single-reader on the buffer).
- On **reattach** (not on fresh spawn), `pty_ws` sends `\x1b[2J\x1b[H` (clear + home), the snapshot bytes, then a grey `[reconnected]` marker before resuming the live pump. Fresh spawns are unchanged — TUI paints its own opening frame.

### 3. Client: stable channel id + last-session memory

- `ChatPage.tsx` now persists channel id in `localStorage["hermes.chat.channel"]` so a tab refresh reuses the same channel (and thus the same surviving PTY).
- Channel id is regenerated only when `?resume=` changes (tracked via `hermes.chat.channel_resume`) — so jumping to a different session lineage still gets a fresh PTY.
- Last session id is persisted in `localStorage["hermes.chat.last_session_id"]`; if the user lands on bare `/chat` (no `?resume=`), we set the URL param from storage so reload-without-bookmark also resumes.
- All `localStorage` access is wrapped in try/catch — Safari private browsing falls back to ephemeral ids without crashing.
- Channel id validated against the same `[A-Za-z0-9._-]{1,128}` regex `_VALID_CHANNEL_RE` enforces server-side; malformed stored values are discarded.

## What's intentionally NOT in this PR

- **No client-side WebSocket auto-reconnect loop.** Survival comes from the next *natural* mount (page refresh, navigation back, tab refocus that triggers React re-mount) reattaching successfully. An auto-reconnect-on-`onclose` loop is a separate feature with its own retry/backoff/auth-refresh edge cases.
- **No persistence across `hermes dashboard` process restart.** Registry is in-process only. Restart still loses live PTYs (TUI children die with the parent).
- **No changes to `tui_gateway` / Ink / the TUI itself.** This PR is purely the PTY plumbing.
- **No changes to `/api/ws` JSON-RPC sidebar.** That endpoint sits right next to `pty_ws` and was left untouched.

## Testing

Added `TestScrollback` (3 cases) and `TestPtySurvival` (4 cases):

- `test_scrollback_collects_recent_bytes` / `test_scrollback_trims_to_limit` / `test_scrollback_empty_after_spawn`
- `test_pty_survival_reattach_same_channel_reuses_pty` — connects, disconnects, reconnects with same channel, asserts identical bridge PID.
- `test_pty_grace_evicts_after_timeout` — disconnect + sleep past grace, asserts channel evicted and bridge dead. Grace overridden to `0.2s` via env var to keep test fast.
- `test_pty_reattach_replays_scrollback` — asserts the `[reconnected]` marker plus echoed bytes arrive on reattach.
- `test_pty_second_concurrent_attach_rejected` — second concurrent attach gets WS close `4409`.

Tests use `TestClient` with `_resolve_chat_argv` monkeypatched to a trivial `/bin/sh` echo loop, so they don't depend on a real `hermes --tui` build. All 4 `TestPtySurvival` tests pass; all 3 `TestScrollback` tests pass.

Verification run:

```
$ /home/apple/.hermes/hermes-agent/venv/bin/python -m pytest \
    tests/hermes_cli/test_pty_bridge.py \
    tests/hermes_cli/test_web_server.py -q
...
169 passed in ~17s

$ ruff check hermes_cli/web_server.py hermes_cli/pty_bridge.py \
    tests/hermes_cli/test_pty_bridge.py tests/hermes_cli/test_web_server.py
All checks passed!

$ cd web && npm run build
...build OK
```

Manual smoke-test against the real ASGI app via `TestClient`:

```
pid1: 919329
attached after disconnect: False
scrollback bytes captured: 30
pid2 (after reattach): 919329
SAME PID: True
```

## Files touched

| File | LOC |
|---|---|
| `hermes_cli/web_server.py` | +169 / -20 |
| `hermes_cli/pty_bridge.py` | +22 / -2 |
| `tests/hermes_cli/test_pty_bridge.py` | +34 / -0 |
| `tests/hermes_cli/test_web_server.py` | +158 / -1 |
| `web/src/pages/ChatPage.tsx` | +80 / -10 |
| **Total** | **+461 / -34** |

## Compatibility / config knobs

- `HERMES_PTY_RECONNECT_GRACE_SECONDS` — float seconds, default `300`, max `3600`, invalid values fall back to default.
- `localStorage` keys introduced: `hermes.chat.channel`, `hermes.chat.channel_resume`, `hermes.chat.last_session_id`. None collide with existing dashboard storage.
- Default behavior change for existing users: closing the browser tab no longer kills the dashboard chat's TUI process for 5 minutes. Memory cost per orphaned session: ~256 KiB scrollback + the running `hermes --tui` itself. Shutdown handler reaps everything on `hermes dashboard` exit so it's bounded.

## Notes for reviewers

- I'm a downstream user of the dashboard, not a Nous maintainer — happy to revise any of the design decisions (eviction grace default, scrollback size, channel-id storage strategy, `on_event` → `lifespan` migration) if you'd prefer a different shape.
- The deprecated `@app.on_event("shutdown")` is consistent with existing usages in the same file; flagged in case a sweep makes sense as a follow-up.
- The `4409` WS close code is a stretched-meaning use of HTTP 409 Conflict in the WS code-space (4000-4999 is the application-defined range, RFC 6455). Open to a different code if maintainers have a convention.
