### PR TITLE
fix(skills): clarify infographic image generation

### DIFF
--- a/skills/creative/baoyu-infographic/SKILL.md
+++ b/skills/creative/baoyu-infographic/SKILL.md
@@ -209,12 +209,13 @@ Save the assembled prompt to `prompts/infographic.md` using `write_file`.
 
 ### Step 6: Generate Image
 
-Use the `image_generate` tool with the assembled prompt from Step 5.
+Use the Hermes `image_generate` tool with the assembled prompt from Step 5. This skill is designed to prompt the configured Hermes image-generation backend, not to silently replace the generation step with a handmade/scripted graphic.
 
 - Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`
 - For custom ratios, pick the closest named aspect
 - On failure, auto-retry once
 - Save the resulting image URL/path to the output directory
+- If exact, readable text is more important than illustration quality, explicitly tell the user that a deterministic HTML/SVG/Pillow overlay may be better before switching away from `image_generate`. Do not substitute a scripted infographic without saying so.
 
 ### Step 7: Output Summary
 

--- a/skills/creative/baoyu-infographic/SKILL.md
+++ b/skills/creative/baoyu-infographic/SKILL.md
@@ -139,6 +139,7 @@ Slug: 2-4 words kebab-case from topic. Conflict: append `-YYYYMMDD-HHMMSS`.
 - Preserve source data faithfully — no summarization or rephrasing (but **strip any credentials, API keys, tokens, or secrets** before including in outputs)
 - Define learning objectives before structuring content
 - Structure for visual communication (headlines, labels, visual elements)
+- Honor the user's configured image generation backend: use the Hermes `image_generate` tool, not a scripted substitute
 
 ## Workflow
 
@@ -209,7 +210,7 @@ Save the assembled prompt to `prompts/infographic.md` using `write_file`.
 
 ### Step 6: Generate Image
 
-Use the Hermes `image_generate` tool with the assembled prompt from Step 5. This skill is designed to prompt the configured Hermes image-generation backend, not to silently replace the generation step with a handmade/scripted graphic.
+**You MUST use** the Hermes `image_generate` tool with the assembled prompt from Step 5. This skill is designed to prompt the configured Hermes image-generation backend, not to silently replace the generation step with a handmade/scripted graphic.
 
 - Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`
 - For custom ratios, pick the closest named aspect
@@ -236,3 +237,4 @@ Report: topic, layout, style, aspect, language, output path, files created.
 3. **One message per section** — each infographic section should convey one clear concept. Overloading sections reduces readability.
 4. **Style consistency** — the style definition from the references file must be applied consistently across the entire infographic. Don't mix styles.
 5. **image_generate aspect ratios** — the tool only supports `landscape`, `portrait`, and `square`. Custom ratios like `3:4` should map to the nearest option (portrait in that case).
+6. **Do not silently substitute image generation**: this skill is designed to use the configured Hermes `image_generate` tool. A scripted or handmade infographic (HTML/SVG/Pillow) bypasses the user's chosen image backend. If text readability is a concern, tell the user before switching away from `image_generate`.

--- a/website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
@@ -228,12 +228,13 @@ Save the assembled prompt to `prompts/infographic.md` using `write_file`.
 
 ### Step 6: Generate Image
 
-Use the `image_generate` tool with the assembled prompt from Step 5.
+Use the Hermes `image_generate` tool with the assembled prompt from Step 5. This skill is designed to prompt the configured Hermes image-generation backend, not to silently replace the generation step with a handmade/scripted graphic.
 
 - Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`
 - For custom ratios, pick the closest named aspect
 - On failure, auto-retry once
 - Save the resulting image URL/path to the output directory
+- If exact, readable text is more important than illustration quality, explicitly tell the user that a deterministic HTML/SVG/Pillow overlay may be better before switching away from `image_generate`. Do not substitute a scripted infographic without saying so.
 
 ### Step 7: Output Summary
 

--- a/website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
@@ -158,6 +158,7 @@ Slug: 2-4 words kebab-case from topic. Conflict: append `-YYYYMMDD-HHMMSS`.
 - Preserve source data faithfully — no summarization or rephrasing (but **strip any credentials, API keys, tokens, or secrets** before including in outputs)
 - Define learning objectives before structuring content
 - Structure for visual communication (headlines, labels, visual elements)
+- Honor the user's configured image generation backend: use the Hermes `image_generate` tool, not a scripted substitute
 
 ## Workflow
 
@@ -228,7 +229,7 @@ Save the assembled prompt to `prompts/infographic.md` using `write_file`.
 
 ### Step 6: Generate Image
 
-Use the Hermes `image_generate` tool with the assembled prompt from Step 5. This skill is designed to prompt the configured Hermes image-generation backend, not to silently replace the generation step with a handmade/scripted graphic.
+**You MUST use** the Hermes `image_generate` tool with the assembled prompt from Step 5. This skill is designed to prompt the configured Hermes image-generation backend, not to silently replace the generation step with a handmade/scripted graphic.
 
 - Map aspect ratio to image_generate's format: `16:9` → `landscape`, `9:16` → `portrait`, `1:1` → `square`
 - For custom ratios, pick the closest named aspect
@@ -255,3 +256,4 @@ Report: topic, layout, style, aspect, language, output path, files created.
 3. **One message per section** — each infographic section should convey one clear concept. Overloading sections reduces readability.
 4. **Style consistency** — the style definition from the references file must be applied consistently across the entire infographic. Don't mix styles.
 5. **image_generate aspect ratios** — the tool only supports `landscape`, `portrait`, and `square`. Custom ratios like `3:4` should map to the nearest option (portrait in that case).
+6. **Do not silently substitute image generation**: this skill is designed to use the configured Hermes `image_generate` tool. A scripted or handmade infographic (HTML/SVG/Pillow) bypasses the user's chosen image backend. If text readability is a concern, tell the user before switching away from `image_generate`.


### PR DESCRIPTION
## What does this PR do?

Clarifies the bundled `baoyu-infographic` skill so agents do not silently bypass the configured Hermes image-generation backend.

The skill already pointed at `image_generate`, but the guidance was loose enough that an agent could substitute a scripted/handmade infographic when trying to improve text readability. This PR makes the expected behaviour explicit: use the Hermes `image_generate` tool with the assembled prompt, and only switch to a deterministic HTML/SVG/Pillow overlay after telling the user why.

## Related Issue

Fixes #34046

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `skills/creative/baoyu-infographic/SKILL.md` Step 6 to explicitly require the Hermes `image_generate` tool.
- Updated the bundled docs mirror at `website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md`.
- Added guidance that deterministic text-overlay workflows should be disclosed before switching away from `image_generate`.

## How to Test

1. Inspect the `baoyu-infographic` skill Step 6.
2. Confirm it instructs agents to use the Hermes `image_generate` tool with the assembled prompt.
3. Confirm it warns against silently substituting a scripted infographic when exact readable text is needed.

Local verification:

```bash
git diff --check -- skills/creative/baoyu-infographic/SKILL.md website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md
python - <<'PY'
from pathlib import Path
for p in ['skills/creative/baoyu-infographic/SKILL.md','website/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic.md']:
    text = Path(p).read_text()
    assert 'Use the Hermes `image_generate` tool' in text
    assert 'Do not substitute a scripted infographic without saying so.' in text
print('docs/skill text assertions passed')
PY
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` change is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` change is N/A
- [x] I've considered cross-platform impact: N/A, markdown-only skill guidance
- [x] Tool descriptions/schemas change is N/A

## For New Skills

N/A. This updates an existing bundled skill.

## Screenshots / Logs

N/A. Markdown-only skill guidance update.
