### PR TITLE
fix(9router): harden custom-provider Chat Completions fallback

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -955,6 +955,12 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if assistant_tool_calls:
         tool_calls = []
         for tool_call in assistant_tool_calls:
+            if tool_call is None:
+                # Some OpenAI-compatible routers can surface null entries in
+                # message.tool_calls (seen with 9Router cx/gpt-5.5 fallback).
+                # Ignore malformed placeholders instead of crashing the whole
+                # fallback turn with "'NoneType' object has no attribute 'type'".
+                continue
             raw_id = getattr(tool_call, "id", None)
             call_id = getattr(tool_call, "call_id", None)
             if not isinstance(call_id, str) or not call_id.strip():
@@ -980,14 +986,22 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                 response_item_id if isinstance(response_item_id, str) else None,
             )
 
+            _fn = getattr(tool_call, "function", None)
+            _fn_name = getattr(_fn, "name", "") if _fn else ""
+            _fn_args = getattr(_fn, "arguments", "{}") if _fn else "{}"
+            if not _fn_name:
+                # Malformed tool-call entry without a function payload. Treat
+                # it as router noise and continue; content/reasoning still
+                # gets delivered when no valid tool calls remain.
+                continue
             tc_dict = {
                 "id": call_id,
                 "call_id": call_id,
                 "response_item_id": response_item_id,
-                "type": tool_call.type,
+                "type": getattr(tool_call, "type", None) or "function",
                 "function": {
-                    "name": tool_call.function.name,
-                    "arguments": tool_call.function.arguments
+                    "name": _fn_name,
+                    "arguments": _fn_args,
                 },
             }
             # Defence-in-depth: redact credentials from tool call arguments

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1943,6 +1943,8 @@ def run_conversation(
                 break
 
             except Exception as api_error:
+                if isinstance(api_error, AttributeError) and "object has no attribute 'type'" in str(api_error):
+                    logging.exception("AttributeError .type during API call/fallback normalization")
                 # Stop spinner silently — retry status is buffered and
                 # only flushed when every retry+fallback is exhausted.
                 if thinking_spinner:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3390,6 +3390,12 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """
     if getattr(app.state, "auth_required", False):
         return True
+    # --insecure bind on non-loopback host: operator opted into LAN/tailnet
+    # exposure with the legacy ?token=<_SESSION_TOKEN> auth. Allow remote WS
+    # clients to match the REST behaviour; the Host/Origin guard still
+    # blocks DNS-rebinding.
+    if getattr(app.state, "allow_public", False):
+        return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return True
@@ -4844,6 +4850,7 @@ def start_server(
     # uses this to decide whether to refuse the bind, log the gate-on
     # banner, and enable uvicorn proxy_headers.
     app.state.auth_required = should_require_auth(host, allow_public)
+    app.state.allow_public = allow_public
 
     if app.state.auth_required:
         # Phase 3.5: the gate engages on non-loopback binds.  The legacy

--- a/run_agent.py
+++ b/run_agent.py
@@ -1212,9 +1212,12 @@ class AIAgent:
     ) -> bool:
         """Return True when this provider/model pair should use Responses API."""
         normalized_provider = (provider or "").strip().lower()
-        # Nous serves GPT-5.x models via its OpenAI-compatible chat
-        # completions endpoint; its /v1/responses endpoint returns 404.
-        if normalized_provider == "nous":
+        # OpenAI-compatible routers/custom providers can expose GPT-5.x slugs
+        # through Chat Completions only. Do not force Responses API for them;
+        # callers already separately enable Responses for direct OpenAI URLs.
+        # This keeps automatic fallback behavior aligned with manual /model
+        # switching for 9Router/local custom providers.
+        if normalized_provider in {"nous", "custom"}:
             return False
         if normalized_provider == "copilot":
             try:


### PR DESCRIPTION
Fixes a class of crashes seen when running Hermes against OpenAI-compatible custom routers (observed with 9Router `cx/gpt-5.5` fallback) and aligns auto-fallback with manual `/model` switching.

## Changes

- **`agent/chat_completion_helpers.py`** — tolerate null `tool_calls` entries and missing `function` payloads from OpenAI-compatible routers. Prevents `'NoneType' object has no attribute 'type'` crashes during fallback turns. Default `type` to `"function"` when the router omits it.
- **`run_agent.py`** — do not force Responses API for `custom` providers. They expose GPT-5.x slugs through Chat Completions only; their `/v1/responses` returns 404. Mirrors the existing `nous` exemption.
- **`hermes_cli/web_server.py`** — allow remote WS clients when `--insecure` is set on a non-loopback host. Operator opted into LAN/tailnet exposure via `?token=<_SESSION_TOKEN>`; the Host/Origin guard still blocks DNS-rebinding. Matches REST behaviour.
- **`agent/conversation_loop.py`** — log `AttributeError` `.type` stacktrace during API call/fallback normalization for future diagnosis.

## Repro context

Hit during multi-turn agent loops on Tailscale-bound dashboard (`hermes dashboard --insecure --host <tailnet-host>`) when the configured `custom` provider drops a tool-call entry mid-stream. Previously aborted the whole turn; now skipped with content/reasoning still delivered.

No new tests added — defensive null-checks on existing code paths. Verified against live 9Router cx/gpt-5.5 traffic for ~24h post-patch (no recurrence).