### PR TITLE
fix(docker): set hermes home for host-user containers

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "draihan@student.ubc.ca": "0xdany",
     "9592417+adam91holt@users.noreply.github.com": "adam91holt",
     "kchuang1015@users.noreply.github.com": "kchuang1015",
     "45688690+fujinice@users.noreply.github.com": "fujinice",

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -236,12 +236,13 @@ class _FakePopen:
         return self.returncode
 
 
-def _make_execute_only_env(forward_env=None):
+def _make_execute_only_env(forward_env=None, env_values=None):
     env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
     env.cwd = "/root"
     env.timeout = 60
     env._forward_env = forward_env or []
-    env._env = {}
+    env._env = docker_env._normalize_env_dict(env_values or {})
+    env._env.setdefault("HERMES_HOME", "/root/.hermes")
     env._prepare_command = lambda command: (command, None)
     env._timeout_result = lambda timeout: {"output": f"timed out after {timeout}", "returncode": 124}
     env._container_id = "test-container"
@@ -304,15 +305,73 @@ def test_docker_env_appears_in_run_command(monkeypatch):
     assert "GNUPGHOME=/root/.gnupg" in run_args_str
 
 
+def test_docker_env_defaults_hermes_home_in_run_command(monkeypatch):
+    """Docker sandboxes should resolve Hermes home to the mounted tree by default."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env()
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args = run_calls[0][0]
+    assert "-e" in run_args
+    env_flags = [
+        run_args[i + 1]
+        for i, flag in enumerate(run_args[:-1])
+        if flag == "-e"
+    ]
+    assert "HERMES_HOME=/root/.hermes" in env_flags
+
+
+def test_docker_env_preserves_explicit_hermes_home(monkeypatch):
+    """Users can still override container HERMES_HOME via terminal.docker_env."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(env={"HERMES_HOME": "/workspace/hermes"})
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args = run_calls[0][0]
+    env_flags = [
+        run_args[i + 1]
+        for i, flag in enumerate(run_args[:-1])
+        if flag == "-e"
+    ]
+    assert "HERMES_HOME=/workspace/hermes" in env_flags
+    assert "HERMES_HOME=/root/.hermes" not in env_flags
+
+
 def test_docker_env_appears_in_init_env_args(monkeypatch):
     """Explicit docker_env values should appear in _build_init_env_args."""
-    env = _make_execute_only_env()
-    env._env = {"MY_VAR": "my_value"}
+    env = _make_execute_only_env(env_values={"MY_VAR": "my_value"})
 
     args = env._build_init_env_args()
     args_str = " ".join(args)
 
     assert "MY_VAR=my_value" in args_str
+
+
+def test_init_env_args_defaults_hermes_home(monkeypatch):
+    """The init-session snapshot should inherit the Docker Hermes home default."""
+    env = _make_execute_only_env()
+
+    args = env._build_init_env_args()
+    args_str = " ".join(args)
+
+    assert "HERMES_HOME=/root/.hermes" in args_str
+
+
+def test_init_env_args_preserves_explicit_hermes_home(monkeypatch):
+    """Explicit HERMES_HOME should survive into init-session env args."""
+    env = _make_execute_only_env(env_values={"HERMES_HOME": "/workspace/hermes"})
+
+    args = env._build_init_env_args()
+    args_str = " ".join(args)
+
+    assert "HERMES_HOME=/workspace/hermes" in args_str
+    assert "HERMES_HOME=/root/.hermes" not in args_str
 
 
 def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
@@ -439,6 +498,26 @@ def test_run_as_host_user_passes_uid_gid(monkeypatch):
     assert run_args[idx + 1] == "1234:5678", (
         f"expected --user 1234:5678, got --user {run_args[idx + 1]}"
     )
+
+
+def test_run_as_host_user_keeps_default_hermes_home(monkeypatch):
+    """Host-user containers should still look up skills and credentials under /root/.hermes."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env.os, "getuid", lambda: 1234, raising=False)
+    monkeypatch.setattr(docker_env.os, "getgid", lambda: 5678, raising=False)
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(run_as_host_user=True)
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args = run_calls[0][0]
+    env_flags = [
+        run_args[i + 1]
+        for i, flag in enumerate(run_args[:-1])
+        if flag == "-e"
+    ]
+    assert "HERMES_HOME=/root/.hermes" in env_flags
 
 
 def test_run_as_host_user_drops_setuid_setgid_caps(monkeypatch):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -31,6 +31,7 @@ _DOCKER_SEARCH_PATHS = [
 
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DEFAULT_CONTAINER_HERMES_HOME = "/root/.hermes"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -312,6 +313,7 @@ class DockerEnvironment(BaseEnvironment):
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
+        self._env.setdefault("HERMES_HOME", _DEFAULT_CONTAINER_HERMES_HOME)
         self._container_id: Optional[str] = None
         logger.info(f"DockerEnvironment volumes: {volumes}")
         # Ensure volumes is a list (config.yaml could be malformed)


### PR DESCRIPTION
## What does this PR do?

Sets a default `HERMES_HOME=/root/.hermes` inside Docker terminal sandboxes so Hermes skills and credential lookups resolve to the same in-container tree where credential files, skills, and cache directories are already mounted.

This fixes `terminal.docker_run_as_host_user: true` for images whose non-root runtime user has a different `$HOME` (for example `/home/pn`). Without an explicit `HERMES_HOME`, bundled skills call `Path.home() / ".hermes"` and miss tokens mounted under `/root/.hermes`.

The default is only applied when the user has not already set `terminal.docker_env.HERMES_HOME`, so the documented workaround and custom container layouts keep working.

## Related Issue

Fixes #34026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/docker.py`: default Docker sandbox env to `HERMES_HOME=/root/.hermes` unless `docker_env` already provides `HERMES_HOME`.
- `tests/tools/test_docker_environment.py`: add regression coverage for Docker run env injection, init-session env args, explicit override preservation, and `docker_run_as_host_user=True`.
- `scripts/release.py`: add the contributor email mapping needed by the attribution check for this commit author.

## How to Test

1. Configure Docker terminal backend with `terminal.docker_run_as_host_user: true` and no explicit `terminal.docker_env.HERMES_HOME`.
2. Use a bundled skill that reads credentials from Hermes home, such as google-workspace.
3. Confirm the skill resolves credentials under `/root/.hermes`, matching the existing credential/skills/cache mount destinations.

Validation run locally:

```bash
git diff --check
uv run --with pytest --with pytest-timeout pytest tests/tools/test_docker_environment.py tests/tools/test_credential_files.py tests/skills/test_google_workspace_credential_files.py -q
scripts/run_tests.sh tests/tools/test_docker_environment.py tests/tools/test_credential_files.py tests/skills/test_google_workspace_credential_files.py
.venv/bin/python -m py_compile tools/environments/docker.py scripts/release.py
```

Results:

- `git diff --check` passed
- Focused pytest: `60 passed`
- `scripts/run_tests.sh`: `60 tests passed, 0 failed`
- `py_compile` passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, focused Docker backend unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add or modify a skill.

## Screenshots / Logs

```text
$ uv run --with pytest --with pytest-timeout pytest tests/tools/test_docker_environment.py tests/tools/test_credential_files.py tests/skills/test_google_workspace_credential_files.py -q
............................................................             [100%]
60 passed, 1 warning in 0.65s

$ scripts/run_tests.sh tests/tools/test_docker_environment.py tests/tools/test_credential_files.py tests/skills/test_google_workspace_credential_files.py
=== Summary: 3 files, 60 tests passed, 0 failed (100% complete) in 3.6s (16 workers) ===
```
