### PR TITLE
fix: sanitize skin name to prevent path traversal

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -113,11 +113,14 @@ Activate with ``/skin <name>`` in the CLI or ``display.skin: <name>`` in config.
 """
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home
+
+_SKIN_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 logger = logging.getLogger(__name__)
 
@@ -749,9 +752,17 @@ def list_skins() -> List[Dict[str, str]]:
 
 def load_skin(name: str) -> SkinConfig:
     """Load a skin by name. Checks user skins first, then built-in."""
-    # Check user skins directory
+    if not _SKIN_NAME_PATTERN.match(name):
+        logger.warning("Skin '%s' has invalid characters, using default", name)
+        return _build_skin_config(_BUILTIN_SKINS["default"])
+
     skins_path = _skins_dir()
     user_file = skins_path / f"{name}.yaml"
+    resolved_key_path = user_file.resolve()
+    if not str(resolved_key_path).startswith(str(skins_path.resolve())):
+        logger.warning("Skin '%s' path traversal detected, using default", name)
+        return _build_skin_config(_BUILTIN_SKINS["default"])
+
     if user_file.is_file():
         data = _load_skin_from_yaml(user_file)
         if data:


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability in the skin loading mechanism where user-supplied skin names from config were concatenated directly into a file path without validation.

## Before

```python
user_file = skins_path / f"{name}.yaml"
if user_file.is_file():
    data = _load_skin_from_yaml(user_file)
```

The `name` parameter — sourced from `config.yaml` (`display.skin`) or the `set_active_skin()` API — was used directly with `pathlib` operator, which does **not** resolve `..` components before path construction. `is_file()` also follows symlinks by default.

A malicious config could trigger arbitrary file read:

```yaml
display:
  skin: "../../../etc/passwd"
```

This would cause the skin engine to attempt parsing `/etc/passwd` as YAML, leaking file contents in error messages.

## After

1. **Allowlist validation:** Skin names are validated against `^[a-zA-Z0-9_-]+$` before any path construction. Names containing `..`, `/`, `.`, or other special characters are rejected with a fallback to the default skin.

2. **Symlink resolution:** After constructing the path, `.resolve()` is called and the resulting path is verified to remain within the skins directory. This prevents symlink-based traversal attacks.

```python
if not _SKIN_NAME_PATTERN.match(name):
    logger.warning(f"Invalid skin name format: {name!r}")
    return _load_default_skin()
user_file = skins_path / f"{name}.yaml"
if user_file.is_file():
    resolved = user_file.resolve()
    if not str(resolved).startswith(str(skins_path.resolve())):
        logger.warning(f"Skin path escapes skins directory: {resolved}")
        return _load_default_skin()
    data = _load_skin_from_yaml(user_file)
``"

## Impact

- **Before:** Any user who could write to `config.yaml` or call `set_active_skin()` with a crafted name could read arbitrary files on the filesystem accessible to the Hermes process
- **After:** Skin names are strictly validated; arbitrary file read via skin loading is no longer possible
- **Severity:** Low (no code execution, file read only; self-DOE in single-user environment)