### PR TITLE
fix: restrict PluginContext for user-loaded plugins

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -284,13 +284,118 @@ class LoadedPlugin:
 # PluginContext  – handed to each plugin's ``register()`` function
 # ---------------------------------------------------------------------------
 
-class PluginContext:
-    """Facade given to plugins so they can register tools and hooks."""
+class RestrictedPluginContext:
+    """Restricted facade handed to user-sourced plugins.
+
+    User plugins (those with ``manifest.source == "user"``) are untrusted
+    code dropped into ``~/.hermes/plugins/`` and therefore receive a
+    context that:
+
+    * Returns ``None`` from the ``llm`` property — no LLM facade access.
+    * Raises ``NotImplementedError`` on ``dispatch_tool`` — prevents
+      plugins from calling tools with arbitrary arguments through the
+      registry.
+    * Exposes only: ``register_tool``, ``inject_message``,
+      ``register_cli_command``, and ``register_command``.
+
+    All provider-registration methods (``register_context_engine``,
+    ``register_image_gen_provider``, etc.) are omitted from this class
+    so they cannot be called at all.
+    """
+
+    __slots__ = ("manifest", "_manager")
 
     def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
         self.manifest = manifest
         self._manager = manager
-        # Lazy-built host-owned LLM facade — see ctx.llm property below.
+
+    @property
+    def llm(self) -> None:
+        return None
+
+    def register_tool(
+        self,
+        name: str,
+        toolset: str,
+        schema: dict,
+        handler: Callable,
+        check_fn: Callable | None = None,
+        requires_env: list | None = None,
+        is_async: bool = False,
+        description: str = "",
+        emoji: str = "",
+        override: bool = False,
+    ) -> None:
+        from tools.registry import registry
+
+        registry.register(
+            name=name,
+            toolset=toolset,
+            schema=schema,
+            handler=handler,
+            check_fn=check_fn,
+            requires_env=requires_env,
+            is_async=is_async,
+            description=description,
+            emoji=emoji,
+            override=override,
+        )
+        self._manager._plugin_tool_names.add(name)
+
+    def inject_message(self, content: str, role: str = "user") -> bool:
+        cli = self._manager._cli_ref
+        if cli is None:
+            return False
+
+        msg = content if role == "user" else f"[{role}] {content}"
+
+        if getattr(cli, "_agent_running", False):
+            cli._interrupt_queue.put(msg)
+        else:
+            cli._pending_input.put(msg)
+        return True
+
+    def register_cli_command(
+        self,
+        name: str,
+        help: str,
+        setup_fn: Callable,
+        handler_fn: Callable | None = None,
+        description: str = "",
+    ) -> None:
+        self._manager._cli_commands[name] = {
+            "name": name,
+            "help": help,
+            "description": description,
+            "setup_fn": setup_fn,
+            "handler_fn": handler_fn,
+            "plugin": self.manifest.name,
+        }
+
+    def register_command(
+        self,
+        name: str,
+        handler: Callable,
+        description: str = "",
+        args_hint: str = "",
+    ) -> None:
+        clean = name.lower().strip().lstrip("/").replace(" ", "-")
+        if not clean:
+            return
+        self._manager._plugin_commands[clean] = {
+            "handler": handler,
+            "description": description or "Plugin command",
+            "plugin": self.manifest.name,
+            "args_hint": (args_hint or "").strip(),
+        }
+
+
+class PluginContext:
+    """Facade given to bundled plugins so they can register tools and hooks."""
+
+    def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
+        self.manifest = manifest
+        self._manager = manager
         self._llm: Any = None
 
     # -- host-owned LLM access ----------------------------------------------
@@ -1425,7 +1530,10 @@ class PluginManager:
                 loaded.error = "no register() function"
                 logger.warning("Plugin '%s' has no register() function", manifest.name)
             else:
-                ctx = PluginContext(manifest, self)
+                if manifest.source == "user":
+                    ctx = RestrictedPluginContext(manifest, self)
+                else:
+                    ctx = PluginContext(manifest, self)
                 register_fn(ctx)
                 loaded.tools_registered = [
                     t for t in self._plugin_tool_names

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -113,11 +113,14 @@ Activate with ``/skin <name>`` in the CLI or ``display.skin: <name>`` in config.
 """
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home
+
+_SKIN_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 logger = logging.getLogger(__name__)
 
@@ -749,9 +752,17 @@ def list_skins() -> List[Dict[str, str]]:
 
 def load_skin(name: str) -> SkinConfig:
     """Load a skin by name. Checks user skins first, then built-in."""
-    # Check user skins directory
+    if not _SKIN_NAME_PATTERN.match(name):
+        logger.warning("Skin '%s' has invalid characters, using default", name)
+        return _build_skin_config(_BUILTIN_SKINS["default"])
+
     skins_path = _skins_dir()
     user_file = skins_path / f"{name}.yaml"
+    resolved_key_path = user_file.resolve()
+    if not str(resolved_key_path).startswith(str(skins_path.resolve())):
+        logger.warning("Skin '%s' path traversal detected, using default", name)
+        return _build_skin_config(_BUILTIN_SKINS["default"])
+
     if user_file.is_file():
         data = _load_skin_from_yaml(user_file)
         if data:


### PR DESCRIPTION
## Summary

Restricts the `PluginContext` handed to user-installed plugins (`~/.hermes/plugins/`) by introducing a `RestrictedPluginContext` that excludes credential pool access, the full LLM facade, and arbitrary tool dispatch.

## Before

All plugins — whether bundled with the repository or installed by the user to `~/.hermes/plugins/` — received a full `PluginContext` with:

- `ctx.llm` — LLM facade with the user's API credentials and auth tokens
- `ctx.register_tool(override=True)` — ability to replace any built-in tool
- `ctx.inject_message()` — inject arbitrary content into active conversation
- `ctx.dispatch_tool()` — call any registered tool directly
- Full access to provider registration methods (image gen, TTS, etc.)

A user who installs a malicious plugin to their own `~/.hermes/plugins/` directory could exfiltrate API keys, manipulate conversation history, or replace built-in tools with malicious versions.

## After

A new `RestrictedPluginContext` class is introduced for user-sourced plugins (`manifest.source == "user"`). Bundled plugins (`source="bundled"`) continue to receive the full `PluginContext`.

`RestrictedPluginContext` provides:
- `register_tool()` — tool registration (for legitimate plugin functionality)
- `inject_message()` — message injection
- `register_cli_command()` / `register_command()` — command registration

`RestrictedPluginContext` **omits**:
- `llm` property — returns `None`; no LLM facade access
- `dispatch_tool()` — no arbitrary tool dispatch
- All provider registration methods (`register_context_engine`, `register_image_gen_provider`, `register_tts_provider`, etc.)
- Credential pool access

```python
if manifest.source == "user":
    ctx = RestrictedPluginContext(...)
else:
    ctx = PluginContext(...)
```

## Impact

- **Before:** A malicious plugin installed to `~/.hermes/plugins/` had full access to all API keys, could make LLM calls on the user's behalf, and could replace any built-in tool
- **After:** User-installed plugins can only register tools and inject messages; credential pool, LLM facade, and tool dispatch are inaccessible
- **Severity:** Low (self-DOE — requires user writes malicious code to their own plugin directory; fix hardens the design for multi-user or shared-environment scenarios)