### PR TITLE
fix(discord): fetch and inject reply context for incoming messages

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4861,7 +4861,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # Prepend reply context to the message text so the agent can
         # understand what the user is responding to.
         if reply_to_text:
-            reply_context = f'[Replying to: "{reply_to_text[:200]}"]\n' if len(reply_to_text) <= 200 else f'[Replying to: "{reply_to_text[:200]}..."]\n'
+            truncated = reply_to_text[:200]
+            suffix = "…" if len(reply_to_text) > 200 else ""
+            reply_context = f'[Replying to: "{truncated}{suffix}"]\n'
             event_text = reply_context + event_text
 
         event = MessageEvent(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4849,6 +4849,20 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
                 reply_to_text = getattr(message.reference.resolved, "content", None) or None
+            # When Discord doesn't provide the resolved message inline
+            # (common in high-traffic servers or for older messages),
+            # fetch it from the API so the agent has reply context.
+            if reply_to_text is None and reply_to_id:
+                try:
+                    ref_msg = await message.channel.fetch_message(int(reply_to_id))
+                    reply_to_text = getattr(ref_msg, "content", None) or None
+                except Exception:
+                    logger.debug("Could not fetch reply-to message %s", reply_to_id)
+        # Prepend reply context to the message text so the agent can
+        # understand what the user is responding to.
+        if reply_to_text:
+            reply_context = f'[Replying to: "{reply_to_text[:200]}"]\n' if len(reply_to_text) <= 200 else f'[Replying to: "{reply_to_text[:200]}..."]\n'
+            event_text = reply_context + event_text
 
         event = MessageEvent(
             text=event_text,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4861,9 +4861,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # Prepend reply context to the message text so the agent can
         # understand what the user is responding to.
         if reply_to_text:
-            truncated = reply_to_text[:200]
-            suffix = "…" if len(reply_to_text) > 200 else ""
-            reply_context = f'[Replying to: "{truncated}{suffix}"]\n'
+            max_len = 200
+            if len(reply_to_text) <= max_len:
+                reply_context = f'[Replying to: "{reply_to_text}"]\n'
+            else:
+                reply_context = f'[Replying to: "{reply_to_text[:max_len - 3]}..."]\n'
             event_text = reply_context + event_text
 
         event = MessageEvent(


### PR DESCRIPTION
## Summary
Fetches and injects reply context for incoming Discord messages so the agent knows what message a user is replying to.

## Changes
- plugins/platforms/discord/adapter.py: Added reply context fetching (14 lines)

## Testing
- Rebased onto latest main (file moved from gateway/platforms/discord.py to plugins/platforms/discord/adapter.py)