### PR TITLE
fix(packaging): include plugin manifests in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
 plugins = [
+  "**/plugin.yaml",
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,10 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_plugin_package_data_includes_plugin_manifests():
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    package_data = data["tool"]["setuptools"]["package-data"]["plugins"]
+
+    assert "**/plugin.yaml" in package_data


### PR DESCRIPTION
## Summary of Changes
- Add `**/plugin.yaml` to the packaged plugin data globs in `pyproject.toml` so bundled platform/provider manifests ship in wheels and sdists.
- Add a regression test that asserts the packaging config includes the plugin manifest glob.

Closes #34034

## Optional Details
- Verified the built wheel contains 69 `plugin.yaml` files, including bundled platform and model-provider manifests.

## Validation Plan
- `python -m pytest -o addopts='' tests/test_packaging_metadata.py`
- `python -m build`
- Confirmed `dist/hermes_agent-0.15.0-py3-none-any.whl` contains `plugin.yaml` entries