### PR TITLE
fix(security): reject symlink/hardlink members in curator rollback tar extract

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -605,12 +605,20 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
         with tarfile.open(archive, "r:gz") as tf:
             # Python 3.12+ supports filter='data' for safer extraction.
             # Fall back to the unfiltered call for older interpreters but
-            # still reject absolute paths and .. components defensively.
+            # still reject absolute paths, .. components, AND symlink /
+            # hardlink members defensively. On Python 3.11 the fallback
+            # extractall has no filter and would otherwise materialise
+            # a symlink member pointing outside skills/ (or to a sensitive
+            # system path), letting any later skill-read follow the link.
             for member in tf.getmembers():
                 name = member.name
                 if name.startswith("/") or ".." in Path(name).parts:
                     raise tarfile.TarError(
                         f"refusing to extract unsafe path: {name!r}"
+                    )
+                if member.issym() or member.islnk():
+                    raise tarfile.TarError(
+                        f"refusing to extract symlink member: {name!r}"
                     )
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -259,6 +259,39 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
 
 
+def test_rollback_rejects_symlink_tarball(backup_env):
+    """Symlink/hardlink members in a snapshot tarball must be refused.
+
+    Python 3.12+ rejects them via ``extractall(filter='data')``, but the
+    Python 3.11 fallback (project minimum) has no filter kwarg and would
+    otherwise materialise a symlink under ``skills/`` whose target points
+    outside the tree — a later ``read_file`` on the link would then leak
+    the symlink's target. Sibling defense to the update-ZIP and
+    skills-hub-quarantine symlink rejects.
+    """
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    cb.snapshot_skills(reason="legit")
+
+    rows = cb.list_backups()
+    snap_dir = Path(rows[0]["path"])
+    mal = snap_dir / "skills.tar.gz"
+    mal.unlink()
+    with tarfile.open(mal, "w:gz") as tf:
+        info = tarfile.TarInfo(name="pwn")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        tf.addfile(info)
+
+    ok, msg, _ = cb.rollback()
+    assert not ok, f"rollback should refuse a tarball with a symlink member, got: {msg}"
+    assert "symlink" in msg.lower(), f"error should mention symlink, got: {msg}"
+    # Belt: nothing materialised under skills/
+    assert not (skills / "pwn").exists()
+    assert not (skills / "pwn").is_symlink()
+
+
 # ---------------------------------------------------------------------------
 # Integration with run_curator_review
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## This is a sibling follow-up to commit `c26af4681` (skills-hub quarantine) and `bd2756dd2` (update ZIP)

- `c26af4681 fix(skills): reject symlinks in skill bundles before install` covered: filesystem-side bundle install in `tools/skills_hub.py` (explicit `_is_path_redirect` walk before `shutil.move`).
- `bd2756dd2 fix(update): reject symlink members in update ZIP` covered: ZIP-side extract path in `hermes_cli/main.py` (explicit `S_IFLNK` check before `extractall`).
- Neither parent touched: the third extract surface — `agent.curator_backup.rollback()` tar extraction into `~/.hermes/skills/`. Same threat model (an extractor materialising a symlink that any later skill read could follow), different format. This PR adds the same parse-time rejection there too.

## What does this PR do?

`agent.curator_backup.rollback()` extracts a snapshot tarball into `~/.hermes/skills/`. Python 3.12+ uses `extractall(filter='data')`, which rejects symlink/hardlink members. The `TypeError` fallback for older interpreters (Python 3.11.0–3.11.3, before `filter=` was backported in 3.11.4) has no such guard — a snapshot whose tarball contains a symlink member named e.g. `pwn` pointing to `/etc/passwd` (or any path outside `skills/`) would be materialised as a real symlink under `skills/`, and any subsequent `read_file` / `skill_view` traversal of that name would follow the link.

The existing parse-time validator (lines 609-614) already rejects absolute paths and `..` traversal in `member.name`. This PR widens it to also reject `member.issym() / member.islnk()`, so all three extract surfaces in the repo consistently reject symlinks/hardlinks **at parse time** rather than delegating to the extractor's filter argument:

| Surface | File | Pre-existing reject |
| --- | --- | --- |
| Update ZIP (`hermes update`) | `hermes_cli/main.py` | `bd2756dd2` (S_IFLNK check) |
| Skills hub bundle install | `tools/skills_hub.py` | `c26af4681` (rglob symlink check) |
| Curator rollback tar | `agent/curator_backup.py` | **this PR** (`issym() / islnk()`) |

## Related Issue

_None — this is a sibling-widening of `c26af4681` and `bd2756dd2`, which themselves landed without linked issues._

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/curator_backup.py` — extend the existing pre-extract validator loop with `member.issym() or member.islnk()` rejection; expand the docstring to name the threat (Python 3.11.0–3.11.3 fallback, post-rollback skill read following a planted link).
- `tests/agent/test_curator_backup.py` — add `test_rollback_rejects_symlink_tarball`: crafts a snapshot tarball whose only member is a `SYMTYPE` link to `/etc/passwd`, calls `rollback()`, asserts `(False, "...symlink...", None)` and that nothing materialised under `skills/`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/agent/test_curator_backup.py -v`
2. Expected: 26 passed (the existing 25 plus the new `test_rollback_rejects_symlink_tarball`).
3. Regression guard: with the new `issym()/islnk()` branch removed, the test fails on Python 3.11.4+ with `'pwn' is a link to an absolute path` (data-filter rejection, different error path), confirming the test discriminates the new explicit rejection from the filter-driven one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(security):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x with Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on the validator loop expanded
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — symlink rejection is platform-neutral (Windows tarfile reports the same `issym()`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

_N/A — backend-only security widening._

> Audited siblings: the third surface (`tools/environments/file_sync.py` `tar.extractall(staging, filter="data")` at line 327) already uses `filter="data"` unconditionally with no `TypeError` fallback, so no parse-time pre-check is needed there. No further widening needed.