### PR TITLE
test: harden yolo and kanban signal tests on macOS

### DIFF
--- a/tests/cli/test_cli_yolo_toggle.py
+++ b/tests/cli/test_cli_yolo_toggle.py
@@ -40,6 +40,11 @@ SESSION_KEY = "test-cli-yolo-session"
 def _clear_approval_state(monkeypatch):
     """Clear the YOLO bypass + env var around every test so cases are independent."""
     monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    # The value is intentionally frozen at tools.approval import time. Local
+    # Hermes-driven test runs may inherit HERMES_YOLO_MODE=1 from the parent
+    # agent process, so make the default test state hermetic; the one test that
+    # covers startup-frozen YOLO explicitly patches it back to True.
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
     approval_module.clear_session(SESSION_KEY)
     approval_module.clear_session("default")
     yield

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -103,6 +103,22 @@ def _is_alive_like_dispatcher(pid: int) -> bool:
                         break
         except (FileNotFoundError, PermissionError, OSError):
             pass
+    elif sys.platform == "darwin":
+        try:
+            proc = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=1,
+                check=False,
+            )
+            if proc.returncode != 0:
+                return False
+            if "Z" in (proc.stdout or "").strip():
+                return False
+        except (OSError, subprocess.SubprocessError, TimeoutError):
+            pass
     return True
 
 


### PR DESCRIPTION
## Summary
- Makes the CLI `/yolo` regression test hermetic when the parent process already has `HERMES_YOLO_MODE=1` frozen at import time.
- Mirrors the production kanban dispatcher macOS zombie check (`ps -o stat`) in the SIGTERM regression test helper.
- Keeps the existing startup-frozen YOLO coverage explicit via targeted monkeypatching.

## Test Plan
- `venv/bin/python -m py_compile tests/cli/test_cli_yolo_toggle.py tests/hermes_cli/test_signal_handler_kanban_worker.py`
- `venv/bin/python -m pytest tests/cli/test_cli_yolo_toggle.py tests/hermes_cli/test_signal_handler_kanban_worker.py -q`