### PR TITLE
fix(packaging): include plugin.yaml in PyPI package-data (#34034)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",
+  "**/plugin.yaml",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## What does this PR do?

Fixes #34034 — v0.15.0 PyPI release breaks all plugins because `plugin.yaml` manifest files are not included in the package.

The `[tool.setuptools.package-data]` section for `plugins` only included dashboard assets but missed `plugin.yaml` files. This means any plugin installed from PyPI (model-providers, skills-plugins, etc.) fails to load because the manifest is missing.

## Fix

Add `"**/plugin.yaml"` to the `plugins` package-data glob in `pyproject.toml`. Single line change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #34034

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] Tested: verified `**/plugin.yaml` glob matches all plugin manifest paths