### PR TITLE
fix(tools_config): reject platform-bundle names in disabled_toolsets (#33924)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1358,6 +1358,24 @@ def _get_platform_tools(
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
     if disabled_toolsets:
         disabled_set = {str(ts) for ts in disabled_toolsets}
+        # Reject platform-bundle names (e.g. "hermes-yuanbao") that would
+        # silently wipe ALL tools in the gateway path (#33924). Bundle names
+        # belong in `toolsets:`, not `disabled_toolsets`.
+        from toolsets import TOOLSETS as _TS
+        bad = {ts for ts in disabled_set if ts in _TS and ts.startswith("hermes-")}
+        if bad:
+            for b in sorted(bad):
+                # Attempt to suggest the individual-toolset equivalent
+                suggestion = b[len("hermes-"):]
+                hint = f" Did you mean '{suggestion}'?" if suggestion in _TS else ""
+                logger.warning(
+                    "agent.disabled_toolsets contains platform-bundle name '%s' "
+                    "which would silently disable ALL tools in the gateway path. "
+                    "Ignoring.%s Bundle names belong in `toolsets:`, not "
+                    "`disabled_toolsets`. See #33924.",
+                    b, hint,
+                )
+            disabled_set -= bad
         enabled_toolsets -= disabled_set
 
     return enabled_toolsets


### PR DESCRIPTION
## What does this PR do?

Fixes #33924 — platform-bundle names (e.g. `hermes-yuanbao`) in `agent.disabled_toolsets` silently kill ALL tools in the gateway path (Telegram, cron, all messaging platforms). CLI path is unaffected.

**Root cause:** The disabled_toolsets subtraction is a plain set difference. When a `hermes-*` bundle name appears in the list, it matches the composite toolset key used by platform resolution, causing the entire tool set to be subtracted. No error, no warning — silent total tool loss.

**Fix:** Before applying the disabled_set subtraction, filter out any entry that is a known platform-bundle name (`hermes-*` key in `toolsets.TOOLSETS`). Each rejected entry emits a `logger.warning` that:
- Names the offending bundle
- Suggests the individual-toolset equivalent if one exists (e.g. "Did you mean yuanbao?")
- Explains that bundle names belong in `toolsets:`, not `disabled_toolsets`
- References #33924

The bad entries are removed from the disabled set before subtraction, so they are silently skipped (with warning) instead of silently nuking all tools.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issue

Fixes #33924

## Testing

- [x] Verified the fix is consistent with the existing lazy-import pattern (`from toolsets import ...` used at line 1123)
- [x] Warning message includes issue reference for traceability

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] No test changes needed (warning + guard logic, no behavior change for valid configs)