### PR TITLE
fix(error_classifier): classify 409 model-pool lock as non-retryable, no fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4850,25 +4850,31 @@ def run_conversation(
 
                 if is_client_error:
                     # Try fallback before aborting — a different provider may
-                    # not have the same issue (rate limit, auth, etc.). Only
-                    # announce the attempt when a fallback chain actually
-                    # exists; otherwise "trying fallback..." is a lie and the
-                    # session looks like it's recovering when it's about to
-                    # abort silently (#35314, #17446).
-                    if agent._has_pending_fallback():
-                        if classified.reason == FailoverReason.content_policy_blocked:
-                            agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
-                        elif classified.reason == FailoverReason.ssl_cert_verification:
-                            agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
-                        else:
-                            agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
-                        active_system_prompt = _sync_failover_system_message(
-                            agent, api_messages, active_system_prompt)
-                        retry_count = 0
-                        compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
-                        continue
+                    # not have the same issue (rate limit, auth, etc.) — UNLESS
+                    # the classifier says fallback won't help (should_fallback
+                    # is False, e.g. a shared-pool/policy block that rejects
+                    # every model swap on this endpoint). In that case cycling
+                    # the chain just burns the budget and ends in a cryptic
+                    # abort, so skip straight to the actionable error.
+                    if classified.should_fallback:
+                        # Only announce the attempt when a fallback chain
+                        # actually exists; otherwise "trying fallback..." is a
+                        # lie and the session looks like it's recovering when
+                        # it's about to abort silently (#35314, #17446).
+                        if agent._has_pending_fallback():
+                            if classified.reason == FailoverReason.content_policy_blocked:
+                                agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
+                            elif classified.reason == FailoverReason.ssl_cert_verification:
+                                agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
+                            else:
+                                agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                        if agent._try_activate_fallback():
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,
@@ -4942,6 +4948,8 @@ def run_conversation(
                             agent._vprint(f"{agent.log_prefix}      • Does your account have access to {_model}?", force=True)
                             if base_url_host_matches(str(_base), "openrouter.ai"):
                                 agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
+                    elif classified.reason == FailoverReason.provider_policy_blocked:
+                        agent._vprint(f"{agent.log_prefix}   💡 The endpoint refused model {_model} (HTTP {status_code}): it serves only a fixed/compatible model pool and won't accept a forced swap. Fallback won't help — every model hits the same policy. Use a model this endpoint serves, or point at an endpoint that allows {_model}.", force=True)
                     else:
                         agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
                     # Content-policy blocks deserve their own actionable

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1104,6 +1104,34 @@ def _classify_by_status(
             should_fallback=True,
         )
 
+    if status_code == 409:
+        # A model-routing gateway/proxy returns 409 when asked for a model it
+        # won't serve on this endpoint — e.g. a shared-pool router that refuses
+        # to swap to a model outside its compatible pool
+        # ("model_not_allowed_for_remote_chat": "Remote chat is limited to the
+        # compatible shared model pool so it cannot force protected model
+        # swaps."). Falling back to *other* models is futile — the same
+        # endpoint policy rejects every protected swap, so cycling the chain
+        # just burns the retry budget and ends in a cryptic abort. Treat it
+        # like provider_policy_blocked (non-retryable, no fallback) so the real
+        # reason is surfaced. Other 409s (genuine state conflicts) fall through
+        # to the generic non-retryable 4xx handling below.
+        _remote_chat_locked = (
+            "model_not_allowed_for_remote_chat",
+            "remote chat is limited",
+            "compatible shared model pool",
+            "force protected model swaps",
+            "protected model swap",
+        )
+        if error_code.lower() == "model_not_allowed_for_remote_chat" or any(
+            p in error_msg for p in _remote_chat_locked
+        ):
+            return result_fn(
+                FailoverReason.provider_policy_blocked,
+                retryable=False,
+                should_fallback=False,
+            )
+
     if status_code == 400:
         return _classify_400(
             error_msg, error_code, body,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -2051,6 +2051,7 @@ class TestMultimodalToolContentUnsupported:
         """Make sure the patterns don't false-positive on normal 400s."""
         e = MockAPIError("bad request: missing field 'model'", status_code=400)
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
+        assert result.reason != FailoverReason.multimodal_tool_content_unsupported
 
 
 class TestOpenRouterUpstreamRateLimit:
@@ -2327,3 +2328,23 @@ class TestExpandedOverflowPatterns:
         assert result.reason == FailoverReason.context_overflow
 
 
+class TestRemoteChatModelLocked409:
+    """A 409 model-routing/policy lock must not churn the fallback chain."""
+
+    def test_model_not_allowed_for_remote_chat_is_policy_blocked(self):
+        e = MockAPIError(
+            "Remote chat is limited to the compatible shared model pool so it cannot force protected model swaps.",
+            status_code=409,
+            body={"error": {"type": "model_not_allowed_for_remote_chat",
+                            "message": "Remote chat is limited to the compatible shared model pool so it cannot force protected model swaps."}},
+        )
+        r = classify_api_error(e)
+        assert r.reason == FailoverReason.provider_policy_blocked
+        assert r.retryable is False
+        assert r.should_fallback is False
+
+    def test_generic_409_falls_through_to_non_retryable(self):
+        e = MockAPIError("resource conflict", status_code=409, body={})
+        r = classify_api_error(e)
+        assert r.retryable is False
+        assert r.should_fallback is True


### PR DESCRIPTION
## What does this PR do?

A model-routing gateway/proxy returns **HTTP 409** when asked for a model it won't serve on the current endpoint — e.g. a shared-pool router that refuses to swap to a model outside its compatible pool:

> `model_not_allowed_for_remote_chat` — "Remote chat is limited to the compatible shared model pool so it cannot force protected model swaps."

`classify_api_error` had **no `409` branch**, so a 409 fell through to the generic non-retryable 4xx rule with `should_fallback=True`. The conversation loop then cycled the **entire** fallback chain — every model hit the same endpoint policy and 409'd — burning the whole retry budget before a cryptic abort.

This classifies the model-pool-lock 409 as `provider_policy_blocked` (non-retryable, no fallback — mirroring the existing OpenRouter `provider_policy_blocked` 404), and makes the loop respect `should_fallback` so such errors abort immediately with actionable guidance instead of churning. Other (genuine state-conflict) 409s fall through to the existing generic 4xx handling unchanged.

## Related Issue

N/A.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: add a `409` branch — model-pool-lock signature → `provider_policy_blocked` (`retryable=False`, `should_fallback=False`); other 409s fall through to the generic 4xx path.
- `agent/conversation_loop.py`: gate the `is_client_error` fallback attempt on `classified.should_fallback` (so `should_fallback=False` reasons — this 409 and the existing OpenRouter 404 — skip the futile chain-churn); add actionable guidance for `provider_policy_blocked` aborts.
- `tests/agent/test_error_classifier.py`: tests for the locked-409 (policy-blocked) and generic-409 (fallthrough) cases.

## How to Test

```
pytest tests/agent/test_error_classifier.py -q
```

- Locked 409 (`model_not_allowed_for_remote_chat` / "compatible shared model pool") → `provider_policy_blocked`, `should_fallback=False`.
- Generic 409 → non-retryable, `should_fallback=True` (unchanged generic-4xx behavior).

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (3 files)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran tests/agent/test_error_classifier.py: 157 passed incl. 2 new; full suite not run on this focused branch -->
- [x] I've added tests for my changes
