### PR TITLE
ci(deploy): allow workflow_dispatch to also trigger Vercel deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,7 +22,12 @@ concurrency:
 
 jobs:
   deploy-vercel:
-    if: github.event_name == 'release'
+    # Triggered automatically on release publish (production cuts) and
+    # manually via `gh workflow run deploy-site.yml` when an out-of-band
+    # main commit needs to ship live before the next release tag — e.g.
+    # a skills-index PR that doesn't touch website/** paths and so
+    # doesn't auto-deploy via the deploy-docs path.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Vercel Deploy


### PR DESCRIPTION
## Summary

Today's three skills-index PRs (#33748, #33809, #34025) all merged to main with green CI, but the live Vercel-hosted docs site (`hermes-agent.nousresearch.com`) didn't pick them up. The `deploy-vercel` job in `deploy-site.yml` is gated on `release` events only — so any out-of-band main commit between releases is invisible to Vercel until the next tag.

This is a one-line ci change: widen the gate to also include `workflow_dispatch` so `gh workflow run deploy-site.yml` can ship pending main commits on demand. Release-tag behaviour is unchanged.

## Changes

| file | change |
|---|---|
| `.github/workflows/deploy-site.yml` | `deploy-vercel` if-gate adds `workflow_dispatch`; comment explains when to use it |

## Validation

After merge: `gh workflow run deploy-site.yml` should trigger the Vercel webhook (curl POST to `VERCEL_DEPLOY_HOOK`), and the live site updates within a few minutes.

Will be used immediately to ship today's skills.sh fix to the live site.


## Infographic

![vercel-deploy-on-demand](https://v3b.fal.media/files/b/0a9c1022/5I7gW6cpEDnyoipr2DT5v_245jbn4T.png)
