### PR TITLE
fix: add TYPE_CHECKING guard for PatchResult in patch_parser.py (F821)

### DIFF
--- a/tests/tools/test_lint_regression.py
+++ b/tests/tools/test_lint_regression.py
@@ -28,3 +28,20 @@ def test_tools_patch_parser_has_zero_f821_violations() -> None:
         f"tools/patch_parser.py has F821 violation(s):\n"
         f"{result.stdout}{result.stderr}"
     )
+
+
+def test_tools_browser_cdp_tool_has_zero_f401_violations() -> None:
+    """tools/browser_cdp_tool.py must have zero F401 (unused import) violations."""
+    target = REPO_ROOT / "tools" / "browser_cdp_tool.py"
+    assert target.exists(), f"Target file not found: {target}"
+
+    result = subprocess.run(
+        [PYTHON, "-m", "ruff", "check", "--select=F401",
+         "--output-format=concise", str(target)],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+
+    assert result.returncode == 0, (
+        f"tools/browser_cdp_tool.py has F401 violation(s):\n"
+        f"{result.stdout}{result.stderr}"
+    )

--- a/tests/tools/test_lint_regression.py
+++ b/tests/tools/test_lint_regression.py
@@ -62,3 +62,19 @@ def test_tools_browser_tool_has_zero_f401_violations() -> None:
         f"tools/browser_tool.py has F401 violation(s):\n"
         f"{result.stdout}{result.stderr}"
     )
+
+def test_tools_memory_tool_has_zero_f401_violations() -> None:
+    """tools/memory_tool.py must have zero F401 (unused import) violations."""
+    target = REPO_ROOT / "tools" / "memory_tool.py"
+    assert target.exists(), f"Target file not found: {target}"
+
+    result = subprocess.run(
+        [PYTHON, "-m", "ruff", "check", "--select=F401",
+         "--output-format=concise", str(target)],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+
+    assert result.returncode == 0, (
+        f"tools/memory_tool.py has F401 violation(s):\n"
+        f"{result.stdout}{result.stderr}"
+    )

--- a/tests/tools/test_lint_regression.py
+++ b/tests/tools/test_lint_regression.py
@@ -45,3 +45,20 @@ def test_tools_browser_cdp_tool_has_zero_f401_violations() -> None:
         f"tools/browser_cdp_tool.py has F401 violation(s):\n"
         f"{result.stdout}{result.stderr}"
     )
+
+
+def test_tools_browser_tool_has_zero_f401_violations() -> None:
+    """tools/browser_tool.py must have zero F401 (unused import) violations."""
+    target = REPO_ROOT / "tools" / "browser_tool.py"
+    assert target.exists(), f"Target file not found: {target}"
+
+    result = subprocess.run(
+        [PYTHON, "-m", "ruff", "check", "--select=F401",
+         "--output-format=concise", str(target)],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+
+    assert result.returncode == 0, (
+        f"tools/browser_tool.py has F401 violation(s):\n"
+        f"{result.stdout}{result.stderr}"
+    )

--- a/tests/tools/test_lint_regression.py
+++ b/tests/tools/test_lint_regression.py
@@ -1,0 +1,30 @@
+"""Lint regression tests for tools/ directory.
+
+These tests guard against reintroduction of previously-fixed lint violations.
+Each test asserts zero violations of a specific rule in a specific file.
+
+TDD: Write the test before fixing the violation. Watch it fail. Then fix.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PYTHON = sys.executable
+
+
+def test_tools_patch_parser_has_zero_f821_violations() -> None:
+    """tools/patch_parser.py must have zero F821 (undefined name) violations."""
+    target = REPO_ROOT / "tools" / "patch_parser.py"
+    assert target.exists(), f"Target file not found: {target}"
+
+    result = subprocess.run(
+        [PYTHON, "-m", "ruff", "check", "--select=F821",
+         "--output-format=concise", str(target)],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+
+    assert result.returncode == 0, (
+        f"tools/patch_parser.py has F821 violation(s):\n"
+        f"{result.stdout}{result.stderr}"
+    )

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -257,7 +257,6 @@ def _browser_cdp_via_supervisor(
         )
 
     # Dispatch onto the supervisor's loop.
-    import asyncio as _asyncio
     loop = supervisor._loop  # type: ignore[attr-defined]
     if loop is None or not loop.is_running():
         return tool_error(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -55,7 +55,6 @@ import json
 import logging
 import os
 import re
-import signal
 import subprocess
 import shutil
 import sys

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,7 +26,6 @@ Design:
 import json
 import logging
 import os
-import re
 import tempfile
 import time
 from contextlib import contextmanager

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -31,8 +31,11 @@ Usage:
 import difflib
 import re
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple, Any
+from typing import TYPE_CHECKING, List, Optional, Tuple, Any
 from enum import Enum
+
+if TYPE_CHECKING:
+    from tools.file_operations import PatchResult
 
 
 class OperationType(Enum):


### PR DESCRIPTION
## Summary
Fix F821 lint violation in `tools/patch_parser.py`: `PatchResult` is used as a
return type annotation (`-> 'PatchResult'`) but was not visible to ruff's static
analysis because it is imported locally inside the function body to avoid circular
imports.

## Changes
- Add `TYPE_CHECKING` to the existing `from typing import ...` line
- Add `if TYPE_CHECKING:` block importing `PatchResult` from `tools.file_operations`
- Keep the local runtime import unchanged

## TDD Verification
- **RED**: Wrote test confirming F821 violation exists
- **GREEN**: Applied fix — test passes
- **Regression**: All 25 existing `test_patch_parser.py` tests pass

## Test Plan
- [x] 25/25 patch_parser tests pass
- [x] Lint clean on modified file
- [x] Regression test added for F821


---

## Changes in this tick (2026-05-28)

- **Fix F401 (unused import):** Remove stale `import asyncio as _asyncio` from
  `tools/browser_cdp_tool.py:260`. The `asyncio` module-level import at line 20
  already provides the binding. The local `_asyncio` alias was never referenced.

- **Regression test:** Add `test_tools_browser_cdp_tool_has_zero_f401_violations`
  to guard against reintroduction of unused imports in `browser_cdp_tool.py`.

> **Label note:** The `needs-review` label could not be added because the
> authenticated token lacks admin rights on the upstream repository
> (`NousResearch/hermes-agent`). Label management requires admin-level
> permissions; write access is insufficient. Upon review, please add the
> label manually or merge directly.

## Changes in this tick (2026-05-28)

- **Fix F401 (unused import):** Remove unused `import signal` from
  `tools/browser_tool.py:58`. The `signal` module was imported at the top
  level but never referenced anywhere in the module.

- **Regression test:** Add `test_tools_browser_tool_has_zero_f401_violations`
  to guard against reintroduction of unused imports in `browser_tool.py`.

- **TDD:** RED (test fails with F401 violation) → GREEN (fix + test passes).


## Changes in this tick (2026-05-28)

- **Fix F401 (unused import):** Remove unused `import re` from `tools/memory_tool.py:29`. The `re` module was imported at line 29 but never referenced anywhere in the module body.

- **Regression test:** Add `test_tools_memory_tool_has_zero_f401_violations` to guard against reintroduction of unused imports in `tools/memory_tool.py`. The test was written first (RED), confirmed failing, then the import was removed (GREEN), confirmed passing.
