### PR TITLE
Clarify command approval prompt intent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2878,6 +2878,18 @@ def save_config_value(key_path: str, value: any) -> bool:
 # HermesCLI Class
 # ============================================================================
 
+def _approval_display_model(command: str, description: str, approval_data: dict | None = None) -> dict:
+    """Return human-readable approval prompt content for CLI rendering."""
+    from gateway.approval_brief import build_exec_approval_brief
+
+    brief = build_exec_approval_brief(command, description, approval_data)
+    intent = brief.get("Intent") or "Run the shown command"
+    return {
+        "title": f"Approve: {intent}",
+        "brief": brief,
+    }
+
+
 class HermesCLI:
     """
     Interactive CLI for the Hermes Agent.
@@ -11288,7 +11300,8 @@ class HermesCLI:
         return ""
 
     def _approval_callback(self, command: str, description: str,
-                           *, allow_permanent: bool = True) -> str:
+                           *, allow_permanent: bool = True,
+                           approval_data: dict | None = None) -> str:
         """
         Prompt for dangerous command approval through the prompt_toolkit UI.
 
@@ -11311,6 +11324,7 @@ class HermesCLI:
             self._approval_state = {
                 "command": command,
                 "description": description,
+                "approval_data": approval_data or {},
                 "choices": self._approval_choices(command, allow_permanent=allow_permanent),
                 "selected": 0,
                 "response_queue": response_queue,
@@ -11437,11 +11451,15 @@ class HermesCLI:
 
         command = state["command"]
         description = state["description"]
+        approval_data = state.get("approval_data") or {}
         choices = state["choices"]
         selected = state.get("selected", 0)
         show_full = state.get("show_full", False)
 
-        title = "⚠️  Dangerous Command"
+        display_model = _approval_display_model(command, description, approval_data)
+        title = display_model["title"]
+        if len(title) > 72:
+            title = title[:71].rstrip() + "…"
         cmd_display = command if show_full or len(command) <= 70 else command[:70] + '...'
         choice_labels = {
             "once": "Allow once",
@@ -11451,7 +11469,13 @@ class HermesCLI:
             "view": "Show full command",
         }
 
-        preview_lines = _wrap_panel_text(description, 60)
+        brief = dict(display_model["brief"])
+        brief["Command summary"] = cmd_display
+        detail_text = "\n".join(f"{label}: {value}" for label, value in brief.items() if value)
+
+        preview_lines = []
+        for detail_line in detail_text.splitlines():
+            preview_lines.extend(_wrap_panel_text(detail_line, 60))
         preview_lines.extend(_wrap_panel_text(cmd_display, 60))
         for i, choice in enumerate(choices):
             prefix = '❯ ' if i == selected else '  '
@@ -11525,7 +11549,13 @@ class HermesCLI:
         # Even on huge terminals, cap description height so the panel stays compact.
         available_for_desc = max(0, min(available_for_desc, 10))
 
-        desc_wrapped = _wrap_panel_text(description, inner_text_width) if description else []
+        desc_wrapped = []
+        if detail_text:
+            for detail_line in detail_text.splitlines():
+                if len(detail_line) > inner_text_width:
+                    desc_wrapped.append(detail_line[: max(0, inner_text_width - 1)].rstrip() + "…")
+                else:
+                    desc_wrapped.append(detail_line)
         if available_for_desc < 1 or not desc_wrapped:
             desc_wrapped = []
         elif len(desc_wrapped) > available_for_desc:

--- a/gateway/approval_brief.py
+++ b/gateway/approval_brief.py
@@ -1,0 +1,291 @@
+"""Human-readable dangerous command approval summaries for gateway UIs."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from typing import Any, Mapping
+
+
+_SCRIPT_FLAG_RE = re.compile(
+    r"(?:^|[;&|()\s])(?P<interp>python\d*(?:\.\d+)?|node|ruby|perl|php|bash|sh|zsh)\b[^\n]*\s-(?P<flag>[ce])(?:\s|=|$)",
+    re.IGNORECASE,
+)
+
+
+_DETECTOR_ONLY_DESCRIPTIONS = {
+    "dangerous command",
+    "command flagged",
+    "flagged as dangerous",
+    "launchctl kickstart/bootstrap",
+    "script execution via -c flag",
+    "script execution via -e flag",
+}
+
+
+def _first_nonempty(*values: Any) -> str:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _truncate(value: str, limit: int = 220) -> str:
+    value = " ".join((value or "").split())
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _argv(command: str) -> list[str]:
+    try:
+        return shlex.split(command or "")
+    except ValueError:
+        return []
+
+
+def _cmd_base(argv: list[str]) -> str:
+    if not argv:
+        return ""
+    return os.path.basename(argv[0])
+
+
+def _find_launchd_label(argv: list[str]) -> str:
+    for token in reversed(argv):
+        if token.startswith("-"):
+            continue
+        if "/" in token:
+            token = token.rsplit("/", 1)[-1]
+        if token and token not in {"launchctl", "bootstrap", "bootout", "kickstart"}:
+            return token
+    return "the selected LaunchAgent/LaunchDaemon"
+
+
+def _launchd_scope(argv: list[str]) -> str:
+    joined = " ".join(argv).lower()
+    if " system/" in f" {joined}" or any(t.startswith("/library/launchdaemons") for t in joined.split()):
+        return "system launchd service"
+    if " gui/" in f" {joined}" or "~/library/launchagents" in joined:
+        return "local user LaunchAgent"
+    return "local launchd service"
+
+
+def _summarize_launchctl(argv: list[str]) -> tuple[str, str, str, str]:
+    subcmd = argv[1] if len(argv) > 1 else ""
+    label = _find_launchd_label(argv)
+    scope = _launchd_scope(argv)
+    if subcmd == "kickstart":
+        return (
+            f"Restart the local LaunchAgent {label}" if "LaunchAgent" in scope else f"Restart {label} with launchd",
+            "Stops and restarts a macOS launchd job so its latest configuration/runtime is active.",
+            scope,
+            "Can interrupt that local service and may run the service with updated code or environment immediately.",
+        )
+    if subcmd == "bootstrap":
+        return (
+            f"Load the LaunchAgent {label} into launchd" if "LaunchAgent" in scope else f"Load {label} into launchd",
+            "Uses launchctl bootstrap to register/start a macOS launchd job from the referenced plist.",
+            scope,
+            "Can start a persistent background service and apply new launchd configuration.",
+        )
+    if subcmd == "bootout":
+        return (
+            f"Unload the LaunchAgent {label} from launchd" if "LaunchAgent" in scope else f"Unload {label} from launchd",
+            "Uses launchctl bootout to stop/unregister a macOS launchd job.",
+            scope,
+            "Can stop a background service until it is loaded again.",
+        )
+    return (
+        "Manage a local launchd service",
+        "Runs launchctl to inspect or modify a macOS launchd job.",
+        scope,
+        "May affect background services on this machine.",
+    )
+
+
+def _summarize_command(command: str, description: str = "") -> dict[str, str]:
+    argv = _argv(command)
+    base = _cmd_base(argv)
+    desc_l = (description or "").lower()
+    command_l = (command or "").lower()
+
+    if base == "launchctl":
+        intent, what, scope, risks = _summarize_launchctl(argv)
+        return {"intent": intent, "what": what, "scope": scope, "risks": risks}
+
+    if base == "git" and len(argv) > 1:
+        sub = argv[1]
+        if sub == "push":
+            return {
+                "intent": "Push local commits to the remote git repository",
+                "what": "Uploads local commits/refs to the configured remote named in the command.",
+                "scope": "project git repository and configured remote",
+                "risks": "Can publish commits or branch updates that affect collaborators or automation.",
+            }
+        if sub in {"commit", "reset", "clean", "checkout", "restore", "rebase", "merge"}:
+            return {
+                "intent": f"Run git {sub} in the current repository",
+                "what": "Changes repository history, index, working tree files, or branch state as shown in the command.",
+                "scope": "project git repository",
+                "risks": "May discard local work or alter history; remote impact occurs if later pushed.",
+            }
+
+    if base in {"rm", "unlink", "shred"} or re.search(r"\brm\b|\bunlink\b|\bshred\b", command_l):
+        return {
+            "intent": "Remove files or directories named in the command",
+            "what": "Remove files or directories matching the target paths/globs shown in the command.",
+            "scope": "local filesystem paths referenced by the command",
+            "risks": "Data loss if a target path, glob, or recursive flag is broader than intended.",
+        }
+
+    if base in {"curl", "wget"}:
+        return {
+            "intent": "Fetch content from a remote URL",
+            "what": "Contacts the remote URL and downloads or sends data according to the command flags.",
+            "scope": "network request plus any local output path named in the command",
+            "risks": "Remote content may be untrusted; uploads or headers could expose credentials if present.",
+        }
+
+    if base in {"npm", "pnpm", "yarn"}:
+        sub = argv[1] if len(argv) > 1 else "command"
+        return {
+            "intent": f"Run {base} {sub} for the project",
+            "what": "Runs the package-manager action shown in the command.",
+            "scope": "project dependencies/scripts and local filesystem",
+            "risks": "Package scripts can execute arbitrary code with this session's filesystem and credential access.",
+        }
+
+    if base.startswith("python") or base in {"node", "ruby", "perl", "php", "bash", "sh", "zsh"}:
+        inline = _SCRIPT_FLAG_RE.search(command or "") or "script execution via -c" in desc_l or "script execution via -e" in desc_l
+        return {
+            "intent": f"Run {'inline ' if inline else ''}{base} code",
+            "what": "Runs code with the arguments shown in the command block.",
+            "scope": "current execution environment and referenced files/services",
+            "risks": "Code can read/write files, spawn processes, or use credentials available to this session.",
+        }
+
+    if base in {"sudo", "systemctl"} or "/etc/" in command_l or "/private/etc/" in command_l:
+        return {
+            "intent": "Modify local system configuration or services",
+            "what": "Runs a system-level command or touches system configuration paths shown above.",
+            "scope": "local system",
+            "risks": "May affect all users, services, or network/system behavior on this machine.",
+        }
+
+    if argv:
+        return {
+            "intent": f"Run {base} with the shown arguments",
+            "what": f"Executes `{base}` exactly as shown in the command block.",
+            "scope": "current execution environment and referenced resources",
+            "risks": "May have side effects beyond read-only inspection depending on the command arguments.",
+        }
+    return {
+        "intent": "Run the shown shell command",
+        "what": "Executes the shell command shown in the command block.",
+        "scope": "current execution environment",
+        "risks": "May have side effects depending on the command.",
+    }
+
+
+def _command_summary(command: str) -> str:
+    return _truncate(command, 240) if command else "(empty command)"
+
+
+def _explicit_intent(data: Mapping[str, Any], nested: Mapping[str, Any]) -> str:
+    return _first_nonempty(
+        nested.get("intent"),
+        nested.get("approval_description"),
+        nested.get("approval_reason"),
+        nested.get("purpose"),
+        nested.get("goal"),
+        data.get("intent"),
+        data.get("approval_description"),
+        data.get("approval_reason"),
+        data.get("purpose"),
+        data.get("goal"),
+    )
+
+
+def command_category(command: str, description: str = "") -> str:
+    """Return a legacy concise category for approval-triggering command."""
+    command_l = (command or "").lower()
+    desc_l = (description or "").lower()
+    match = _SCRIPT_FLAG_RE.search(command or "")
+    if match or "script execution via -c" in desc_l or "script execution via -e" in desc_l:
+        interp = match.group("interp") if match else "interpreter"
+        flag = match.group("flag") if match else ("e" if "-e" in desc_l else "c")
+        return f"Inline script execution ({interp} -{flag})"
+    if "launchctl" in command_l:
+        return "macOS launchd service management"
+    if re.search(r"\brm\b|\bunlink\b|\bshred\b", command_l):
+        return "File deletion/destructive filesystem operation"
+    if re.search(r"\bmv\b|\bcp\b|\bchmod\b|\bchown\b|\btee\b|>|\bpatch\b", command_l):
+        return "Filesystem modification"
+    if re.search(r"\bcurl\b|\bwget\b|\bssh\b|\bscp\b|\brsync\b", command_l):
+        return "Network or remote command"
+    if re.search(r"\bsudo\b|/etc/|/private/etc/|\bsystemctl\b", command_l):
+        return "Elevated/system configuration command"
+    if re.search(r"\bgit\s+(reset|clean|checkout|restore|push|commit|rebase)\b", command_l):
+        return "Git repository mutation"
+    return "Shell command flagged by safety detector"
+
+
+def build_exec_approval_brief(
+    command: str,
+    description: str = "dangerous command",
+    approval_data: Mapping[str, Any] | None = None,
+) -> dict[str, str]:
+    """Build a structured approval brief centered on human intent.
+
+    Explicit caller-provided intent/purpose fields win. Otherwise a best-effort
+    command-family summarizer produces an action title, command summary, scope,
+    and risk so UIs do not expose only low-level detector categories.
+    """
+    data = _as_mapping(approval_data)
+    nested = _as_mapping(data.get("approval_brief") or data.get("brief"))
+    summary = _summarize_command(command, description)
+    explicit_intent = _explicit_intent(data, nested)
+
+    intent = explicit_intent or summary["intent"]
+    what = _first_nonempty(
+        nested.get("what_it_does"), nested.get("what"), data.get("what_it_does"), data.get("what")
+    ) or summary["what"]
+    scope = _first_nonempty(nested.get("scope"), data.get("scope")) or summary["scope"]
+    risks = _first_nonempty(nested.get("risks"), data.get("risks")) or summary["risks"]
+
+    detector_reason = (description or "").strip()
+    if detector_reason and detector_reason.lower() not in _DETECTOR_ONLY_DESCRIPTIONS:
+        risks = _truncate(f"{risks} Detector reason: {detector_reason}.", 280)
+
+    rollback = _first_nonempty(
+        nested.get("stop_rollback_plan"),
+        nested.get("rollback_plan"),
+        nested.get("stop_plan"),
+        data.get("stop_rollback_plan"),
+        data.get("rollback_plan"),
+        data.get("stop_plan"),
+    ) or "Deny to stop before execution; if approved and changes occur, use checkpoints/backups/git restore or service rollback where applicable."
+
+    return {
+        "Intent": _truncate(intent),
+        "Command summary": _command_summary(command),
+        "Scope": _truncate(scope, 240),
+        "What it does": _truncate(what, 260),
+        "Risks": _truncate(risks, 280),
+        "Stop/rollback plan": _truncate(rollback, 260),
+    }
+
+
+def format_exec_approval_brief_text(
+    command: str,
+    description: str = "dangerous command",
+    approval_data: Mapping[str, Any] | None = None,
+) -> str:
+    """Format the approval brief as plain labeled lines for chat surfaces."""
+    brief = build_exec_approval_brief(command, description, approval_data)
+    return "\n".join(f"{label}: {value}" for label, value in brief.items())

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -65,6 +65,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.approval_brief import format_exec_approval_brief_text
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -2592,12 +2593,17 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            approval_data = (metadata or {}).get("approval_data") if isinstance(metadata, dict) else None
+            brief_text = format_exec_approval_brief_text(command, description, approval_data)
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+            if len(brief_text) > 3800:
+                brief_text = brief_text[:3800] + "..."
             text = (
-                f"⚠️ <b>Command Approval Required</b>\n\n"
-                f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
-                f"Reason: {_html.escape(description)}"
+                "⚠️ <b>Command Approval Required</b>\n\n"
+                f"<pre>{_html.escape(brief_text)}</pre>"
             )
+            if cmd_preview not in brief_text:
+                text += f"\n\n<pre>{_html.escape(cmd_preview)}</pre>"
 
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -151,10 +151,35 @@ class TestCliApprovalUi:
         lines = rendered.splitlines()
 
         assert lines[0].startswith("╭")
-        assert "Dangerous Command" not in lines[0]
-        assert any("Dangerous Command" in line for line in lines[1:3])
+        assert "Approve:" not in lines[0]
+        assert any("Approve:" in line for line in lines[1:3])
         assert "Show full command" in rendered
         assert "githubcli-archive-keyring.gpg" not in rendered
+
+    def test_approval_display_surfaces_human_readable_intent(self):
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "launchctl kickstart -k gui/501/com.crucible.agent",
+            "description": "launchctl kickstart/bootstrap",
+            "approval_data": {
+                "approval_description": "Restart the local LaunchAgent com.crucible.agent",
+                "approval_reason": "Activate the updated Crucible wrapper/runtime",
+            },
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+
+        fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+
+        assert "Dangerous Command" not in rendered
+        assert "Approve: Restart the local LaunchAgent com.crucible.agent" in rendered
+        assert "Intent: Restart the local LaunchAgent com.crucible.agent" in rendered
+        assert "Command summary: launchctl kickstart" in rendered
+        assert "Scope:" in rendered
+        assert "Risks:" in rendered
+        assert "Stop/rollback plan:" in rendered
 
     def test_approval_display_shows_full_command_after_view(self):
         cli = _make_cli_stub()

--- a/tests/gateway/test_approval_brief.py
+++ b/tests/gateway/test_approval_brief.py
@@ -1,0 +1,37 @@
+from gateway.approval_brief import build_exec_approval_brief, format_exec_approval_brief_text
+
+
+def test_launchctl_kickstart_gets_human_intent_not_detector_category():
+    command = "launchctl kickstart -k gui/501/com.crucible.agent"
+
+    brief = build_exec_approval_brief(command, "launchctl kickstart/bootstrap")
+
+    assert brief["Intent"] == "Restart the local LaunchAgent com.crucible.agent"
+    assert brief["Scope"] == "local user LaunchAgent"
+    assert "restarts a macOS launchd job" in brief["What it does"]
+    assert "Command category" not in brief
+
+
+def test_explicit_approval_description_wins_over_heuristics():
+    command = "rm -rf build/cache"
+
+    brief = build_exec_approval_brief(
+        command,
+        "destructive rm",
+        {"approval_description": "Remove stale build cache before rerunning tests"},
+    )
+
+    assert brief["Intent"] == "Remove stale build cache before rerunning tests"
+    assert "Remove files or directories" in brief["What it does"]
+
+
+def test_common_command_summary_includes_command_scope_and_risk():
+    text = format_exec_approval_brief_text(
+        "git push origin fix/approval-intent-prompts",
+        "git repository mutation",
+    )
+
+    assert "Intent: Push local commits to the remote git repository" in text
+    assert "Command summary: git push origin fix/approval-intent-prompts" in text
+    assert "Scope: project git repository and configured remote" in text
+    assert "Risks:" in text

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -219,6 +219,58 @@ class TestTelegramExecApproval:
         assert "alpha\\_beta" in sent["text"]
 
     @pytest.mark.asyncio
+    async def test_includes_structured_human_approval_brief_for_detector_reason(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+
+        await adapter.send_exec_approval(
+            chat_id="12345",
+            command="python -c \"open('out.txt','w').write('hi')\"",
+            session_key="s",
+            description="script execution via -c flag",
+        )
+
+        text = adapter._bot.send_message.call_args[1]["text"]
+        assert "Intent: Run inline python code" in text
+        assert "Command summary: python -c" in text
+        assert "What it does:" in text
+        assert "Scope:" in text
+        assert "Risks:" in text
+        assert "Stop/rollback plan:" in text
+        # Regression guard: the prompt must not be only a detector-label popup.
+        assert "Reason: script execution via -c flag" not in text
+
+    @pytest.mark.asyncio
+    async def test_uses_richer_approval_metadata_when_available(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+
+        await adapter.send_exec_approval(
+            chat_id="12345",
+            command="python -c \"print('x')\"",
+            session_key="s",
+            description="script execution via -c flag",
+            metadata={
+                "approval_data": {
+                    "goal": "Inspect generated report files",
+                    "command_category": "Report inspection script",
+                    "what_it_does": "Reads report files and prints a summary",
+                    "scope": "Current repository only",
+                    "risks": "Should be read-only unless the inline code is wrong",
+                    "rollback_plan": "Deny to stop; no changes expected",
+                }
+            },
+        )
+
+        text = adapter._bot.send_message.call_args[1]["text"]
+        assert "Intent: Inspect generated report files" in text
+        assert "Command summary: python -c" in text
+        assert "What it does: Reads report files and prints a summary" in text
+        assert "Scope: Current repository only" in text
+        assert "Risks: Should be read-only unless the inline code is wrong" in text
+        assert "Stop/rollback plan: Deny to stop; no changes expected" in text
+
+    @pytest.mark.asyncio
     async def test_truncates_long_command(self):
         adapter = _make_adapter()
         mock_msg = MagicMock()

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -146,6 +146,38 @@ class TestApproveAndCheckSession:
         assert is_approved(key, "rm") is True
 
 
+class TestApprovalIntentPayload:
+    def test_gateway_payload_carries_explicit_approval_description(self):
+        session_key = "intent_payload_session"
+        _clear_session(session_key)
+        seen = []
+
+        def notify(data):
+            seen.append(data)
+            approval_module.resolve_gateway_approval(session_key, "deny")
+
+        with mock_patch.dict("os.environ", {"HERMES_EXEC_ASK": "1"}, clear=False), \
+             mock_patch.object(approval_module, "_get_approval_mode", return_value="manual"), \
+             mock_patch.object(approval_module, "detect_hardline_command", return_value=(False, None)), \
+             mock_patch.object(approval_module, "_check_sudo_stdin_guard", return_value=(False, None)), \
+             mock_patch.object(approval_module, "detect_dangerous_command", return_value=(True, "launchctl", "launchctl kickstart/bootstrap")), \
+             mock_patch.object(approval_module, "_is_gateway_approval_context", return_value=True):
+            token = approval_module.set_current_session_key(session_key)
+            approval_module.register_gateway_notify(session_key, notify)
+            try:
+                approval_module.check_all_command_guards(
+                    "launchctl kickstart -k gui/501/com.crucible.agent",
+                    "local",
+                    approval_description="Restart the local Crucible LaunchAgent to activate the new wrapper/runtime",
+                )
+            finally:
+                approval_module.unregister_gateway_notify(session_key)
+                approval_module.reset_current_session_key(token)
+
+        assert seen
+        assert seen[0]["approval_description"] == "Restart the local Crucible LaunchAgent to activate the new wrapper/runtime"
+
+
 class TestSessionKeyContext:
     def test_context_session_key_overrides_process_env(self):
         token = approval_module.set_current_session_key("alice")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -703,7 +703,8 @@ def save_permanent_allowlist(patterns: set):
 def prompt_dangerous_approval(command: str, description: str,
                               timeout_seconds: int | None = None,
                               allow_permanent: bool = True,
-                              approval_callback=None) -> str:
+                              approval_callback=None,
+                              approval_data: dict | None = None) -> str:
     """Prompt the user to approve a dangerous command (CLI only).
 
     Args:
@@ -722,7 +723,20 @@ def prompt_dangerous_approval(command: str, description: str,
     if approval_callback is not None:
         try:
             return approval_callback(command, description,
-                                     allow_permanent=allow_permanent)
+                                     allow_permanent=allow_permanent,
+                                     approval_data=approval_data)
+        except TypeError as e:
+            # Backward compatibility for tests/plugins with the pre-brief
+            # callback signature: (command, description, *, allow_permanent).
+            if "approval_data" not in str(e):
+                logger.error("Approval callback failed: %s", e, exc_info=True)
+                return "deny"
+            try:
+                return approval_callback(command, description,
+                                         allow_permanent=allow_permanent)
+            except Exception as inner:
+                logger.error("Approval callback failed: %s", inner, exc_info=True)
+                return "deny"
         except Exception as e:
             logger.error("Approval callback failed: %s", e, exc_info=True)
             return "deny"
@@ -761,8 +775,14 @@ def prompt_dangerous_approval(command: str, description: str,
         from agent.i18n import t
         while True:
             print()
-            print(f"  {t('approval.dangerous_header', description=description)}")
-            print(f"      {command}")
+            try:
+                from gateway.approval_brief import format_exec_approval_brief_text
+                brief_text = format_exec_approval_brief_text(command, description, approval_data)
+            except Exception:
+                brief_text = f"Intent: {description}\nCommand summary: {command}"
+            print("  Approval requested")
+            for line in brief_text.splitlines():
+                print(f"      {line}")
             print()
             if allow_permanent:
                 print(t("approval.choose_long"))
@@ -1051,7 +1071,9 @@ def _format_tirith_description(tirith_result: dict) -> str:
 
 
 def check_all_command_guards(command: str, env_type: str,
-                             approval_callback=None) -> dict:
+                             approval_callback=None,
+                             approval_description: str | None = None,
+                             approval_reason: str | None = None) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -1208,6 +1230,10 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_keys": all_keys,
                 "description": combined_desc,
             }
+            if approval_description:
+                approval_data["approval_description"] = approval_description
+            if approval_reason:
+                approval_data["approval_reason"] = approval_reason
             entry = _ApprovalEntry(approval_data)
             with _lock:
                 _gateway_queues.setdefault(session_key, []).append(entry)
@@ -1355,12 +1381,17 @@ def check_all_command_guards(command: str, env_type: str,
 
         # Fallback: no gateway callback registered (e.g. cron, batch).
         # Return approval_required for backward compat.
-        submit_pending(session_key, {
+        pending_data = {
             "command": command,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
             "description": combined_desc,
-        })
+        }
+        if approval_description:
+            pending_data["approval_description"] = approval_description
+        if approval_reason:
+            pending_data["approval_reason"] = approval_reason
+        submit_pending(session_key, pending_data)
         return {
             "approved": False,
             "pattern_key": primary_key,
@@ -1368,6 +1399,8 @@ def check_all_command_guards(command: str, env_type: str,
             "approval_pending": True,
             "command": command,
             "description": combined_desc,
+            "approval_description": approval_description or "",
+            "approval_reason": approval_reason or "",
             "message": (
                 f"⚠️ {combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{command}\n```"
             ),
@@ -1375,6 +1408,11 @@ def check_all_command_guards(command: str, env_type: str,
 
     # CLI interactive: single combined prompt
     # Hide [a]lways when any tirith warning is present
+    approval_data = {}
+    if approval_description:
+        approval_data["approval_description"] = approval_description
+    if approval_reason:
+        approval_data["approval_reason"] = approval_reason
     _fire_approval_hook(
         "pre_approval_request",
         command=command,
@@ -1386,7 +1424,8 @@ def check_all_command_guards(command: str, env_type: str,
     )
     choice = prompt_dangerous_approval(command, combined_desc,
                                        allow_permanent=not has_tirith,
-                                       approval_callback=approval_callback)
+                                       approval_callback=approval_callback,
+                                       approval_data=approval_data)
     _fire_approval_hook(
         "post_approval_response",
         command=command,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -258,10 +258,20 @@ from tools.approval import (
 )
 
 
-def _check_all_guards(command: str, env_type: str) -> dict:
+def _check_all_guards(
+    command: str,
+    env_type: str,
+    approval_description: Optional[str] = None,
+    approval_reason: Optional[str] = None,
+) -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
-    return _check_all_guards_impl(command, env_type,
-                                  approval_callback=_get_approval_callback())
+    return _check_all_guards_impl(
+        command,
+        env_type,
+        approval_callback=_get_approval_callback(),
+        approval_description=approval_description,
+        approval_reason=approval_reason,
+    )
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -1590,6 +1600,8 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    approval_description: Optional[str] = None,
+    approval_reason: Optional[str] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -1604,6 +1616,8 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        approval_description: Optional human-readable intent/purpose for approval prompts. If omitted, Hermes summarizes the command.
+        approval_reason: Optional additional reason/context for approval prompts.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -1783,7 +1797,7 @@ def terminal_tool(
         # Skip check if force=True (user has confirmed they want to run it)
         approval_note = None
         if not force:
-            approval = _check_all_guards(command, env_type)
+            approval = _check_all_guards(command, env_type, approval_description, approval_reason)
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
                 if approval.get("status") == "pending_approval":
@@ -1796,6 +1810,8 @@ def terminal_tool(
                         "command": approval.get("command", command),
                         "description": approval.get("description", "command flagged"),
                         "pattern_key": approval.get("pattern_key", ""),
+                        "approval_description": approval.get("approval_description", ""),
+                        "approval_reason": approval.get("approval_reason", ""),
                     }, ensure_ascii=False)
                 # Command was blocked
                 desc = approval.get("description", "command flagged")
@@ -2378,6 +2394,14 @@ TERMINAL_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Strings to watch for in background process output. HARD RATE LIMIT: at most 1 notification per 15 seconds per process — matches arriving inside the cooldown are dropped. After 3 consecutive 15-second windows with dropped matches, watch_patterns is automatically disabled for that process and promoted to notify_on_complete behavior (one notification on exit, no more mid-process spam). USE ONLY for truly rare, one-shot mid-process signals on LONG-LIVED processes that will never exit on their own — e.g. ['Application startup complete'] on a server so you know when to hit its endpoint, or ['migration done'] on a daemon. DO NOT use for: (1) end-of-run markers like 'DONE'/'PASS' — use notify_on_complete instead; (2) error patterns like 'ERROR'/'Traceback' in loops or multi-item batch jobs — they fire on every iteration and you'll hit the strike limit fast; (3) anything you'd ever combine with notify_on_complete. When in doubt, choose notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both."
+            },
+            "approval_description": {
+                "type": "string",
+                "description": "Optional concise human intent/purpose for any approval prompt this command triggers, e.g. 'Restart the local Crucible LaunchAgent to activate the new wrapper/runtime'. This wins over Hermes' command summarizer."
+            },
+            "approval_reason": {
+                "type": "string",
+                "description": "Optional extra context/rationale to show with the approval prompt."
             }
         },
         "required": ["command"]
@@ -2395,6 +2419,8 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        approval_description=args.get("approval_description"),
+        approval_reason=args.get("approval_reason"),
     )
 
 


### PR DESCRIPTION
## Summary
- Adds intent-centered approval briefs for terminal command approvals
- Carries explicit approval descriptions through terminal/gateway approval payloads
- Updates CLI and Telegram approval rendering away from vague detector/category labels toward human-readable purpose, command summary, scope, risk, and rollback context

## Test plan
- python -m pytest -q tests/gateway/test_approval_brief.py tests/gateway/test_telegram_approval_buttons.py tests/tools/test_approval.py::TestApprovalIntentPayload::test_gateway_payload_carries_explicit_approval_description tests/cli/test_cli_approval_ui.py

## Notes
- Clean PR branch contains exactly one commit over current upstream main.
- Gateway/CLI processes need restart to pick up the prompt rendering changes.