### PR TITLE
tools/mcp_tool: append anti-bypass reminder to MCP tool errors

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2454,9 +2454,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 for block in (result.content or []):
                     if hasattr(block, "text"):
                         error_text += block.text
+                sanitized = _sanitize_error(
+                    error_text or "MCP tool returned an error"
+                )
                 return json.dumps({
-                    "error": _sanitize_error(
-                        error_text or "MCP tool returned an error"
+                    "error": (
+                        sanitized
+                        + " Do not bypass this with terminal or direct "
+                        "filesystem operations — that skips the validation "
+                        "and access controls the MCP server enforces."
                     )
                 }, ensure_ascii=False)
 


### PR DESCRIPTION
## Summary

When an MCP tool call returns an error (`result.isError`), the error text
is surfaced to the agent as-is. In observed deployments, agents sometimes
respond by trying to accomplish the same goal through a different tool —
e.g., reaching a path the filesystem MCP denied by shelling out via the
`terminal` tool. That bypasses the validation and access controls the MCP
server enforces.

This appends a single one-line reminder to every MCP tool error result,
steering the agent away from bypassing the failed tool.

## Rationale

The change is intentionally unconditional (every `isError` result) rather
than pattern-matched against specific error strings, so it does not couple
to any individual MCP server's error wording. The reminder is always
valid: an agent should not work around a failed MCP operation by bypassing
the tool, regardless of why it failed.

## Scope

Single localized change to the `isError` branch of the tool-call path. No
change to control flow, breaker behavior, or the success path.

## Relationship to #33610

Independent of #33610 (which tightens the breaker-OPEN message). This PR
covers the general per-call error path; #33610 covers the breaker-open
path. They touch the same function but are separate logical changes.

## Test plan

- [ ] Error message renders with the appended reminder (string change, no logic change)
- [ ] Success path and breaker path unaffected