### PR TITLE
fix: scrub secrets from terminal env snapshots

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -32,7 +32,7 @@ class TestWrapCommand:
         assert "cd -- /tmp" in wrapped or "cd -- '/tmp'" in wrapped
         assert "eval 'echo hello'" in wrapped
         assert "__hermes_ec=$?" in wrapped
-        assert "export -p >" in wrapped
+        assert "export -p | grep -Eiv" in wrapped
         assert "pwd -P >" in wrapped
         assert env._cwd_marker in wrapped
         assert "exit $__hermes_ec" in wrapped

--- a/tests/tools/test_init_session_cwd_respect.py
+++ b/tests/tools/test_init_session_cwd_respect.py
@@ -16,7 +16,11 @@ running ``pwd -P``, so the configured cwd is always what gets recorded.
 from tempfile import TemporaryFile
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment
+from tools.environments.base import (
+    BaseEnvironment,
+    _SNAPSHOT_SECRET_ENV_RE,
+    _snapshot_export_command,
+)
 
 
 class _TestableEnv(BaseEnvironment):
@@ -146,3 +150,82 @@ class TestInitSessionCwdRespect:
         assert "'/my project/with spaces'" in bootstrap, (
             "bootstrap cd must properly quote paths with spaces"
         )
+
+    def test_snapshot_capture_filters_secret_env_names(self):
+        env = _TestableEnv(cwd="/tmp")
+        captured = {}
+
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+            captured["cmd"] = cmd_string
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 0
+            stdout = TemporaryFile(mode="w+b")
+            stdout.seek(0)
+            mock.stdout = stdout
+            return mock
+
+        env._run_bash = mock_run_bash
+        env.init_session()
+
+        bootstrap = captured["cmd"]
+        assert "export -p | grep -Eiv" in bootstrap
+        assert "TOKEN" in bootstrap
+        assert "PASSWORD" in bootstrap
+        assert "KEY" in bootstrap
+        assert "CREDENTIALS?" in bootstrap
+        assert "AUTHORIZATION" in bootstrap
+        assert "BEARER" in bootstrap
+
+    def test_snapshot_refresh_filters_secret_env_names(self):
+        env = _TestableEnv(cwd="/tmp")
+        env._snapshot_ready = True
+
+        wrapped = env._wrap_command("true", "/tmp")
+
+        assert "export -p | grep -Eiv" in wrapped
+        assert "TOKEN" in wrapped
+        assert "PASSWORD" in wrapped
+        assert "KEY" in wrapped
+        assert "CREDENTIALS?" in wrapped
+        assert "AUTHORIZATION" in wrapped
+
+    def test_snapshot_filter_does_not_drop_auth_socket_names(self):
+        cmd = _snapshot_export_command("/tmp/snap.sh")
+        assert "AUTHORIZATION" in cmd
+        assert "BEARER" in cmd
+        assert "AUTH($|_)" not in cmd
+
+    def test_snapshot_filter_scrubs_common_secret_names_but_keeps_socket_names(self):
+        lines = "\n".join(
+            [
+                'declare -x OPENAI_API_KEY="secret"',
+                'declare -x api_key="secret"',
+                'declare -x OPENAI_KEY="secret"',
+                'declare -x GOOGLE_APPLICATION_CREDENTIALS="secret"',
+                'declare -x AWS_ACCESS_KEY_ID="secret"',
+                'declare -x NPM_CONFIG__AUTH_TOKEN="secret"',
+                'declare -x SSH_AUTH_SOCK="/tmp/ssh.sock"',
+                'declare -x XAUTHORITY="/tmp/auth"',
+                'declare -x TOKENIZER_PARALLELISM="false"',
+            ]
+        )
+        import subprocess
+
+        proc = subprocess.run(
+            ["grep", "-Eiv", _SNAPSHOT_SECRET_ENV_RE],
+            input=lines,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        snapshot = proc.stdout
+        assert "OPENAI_API_KEY" not in snapshot
+        assert "api_key" not in snapshot
+        assert "OPENAI_KEY" not in snapshot
+        assert "GOOGLE_APPLICATION_CREDENTIALS" not in snapshot
+        assert "AWS_ACCESS_KEY_ID" not in snapshot
+        assert "NPM_CONFIG__AUTH_TOKEN" not in snapshot
+        assert "SSH_AUTH_SOCK" in snapshot
+        assert "XAUTHORITY" in snapshot
+        assert "TOKENIZER_PARALLELISM" in snapshot

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -25,6 +25,24 @@ from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
 
+_SNAPSHOT_SECRET_ENV_RE = (
+    r"(^|[^[:alnum:]])(TOKEN|SECRET|PASSWORD|PASSWD|KEY|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|"
+    r"CREDENTIALS?|AUTHORIZATION|BEARER)([^[:alnum:]]|$)"
+)
+
+
+def _snapshot_export_command(target: str) -> str:
+    """Write non-secret exported variables to *target* for session replay."""
+    # ``export -p`` emits shell-safe declarations.  Keep the session snapshot
+    # useful for PATH/HOME/etc. but do not persist credentials into /tmp-backed
+    # hermes-snap-*.sh files.  Avoid a broad ``AUTH`` match so SSH_AUTH_SOCK and
+    # XAUTHORITY survive; explicit AUTHORIZATION/BEARER cover HTTP credentials.
+    return (
+        "export -p | "
+        f"grep -Eiv {shlex.quote(_SNAPSHOT_SECRET_ENV_RE)} "
+        f"> {target}"
+    )
+
 # Opt-in debug tracing for the interrupt/activity/poll machinery.  Set
 # HERMES_DEBUG_INTERRUPT=1 to log loop entry/exit, periodic heartbeats, and
 # every is_interrupted() state change from _wait_for_process.  Off by default
@@ -370,7 +388,7 @@ class BaseEnvironment(ABC):
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
         bootstrap = (
-            f"export -p > {_quoted_snap}\n"
+            f"{_snapshot_export_command(_quoted_snap)}\n"
             f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
             f"alias -p >> {_quoted_snap}\n"
             f"echo 'shopt -s expand_aliases' >> {_quoted_snap}\n"
@@ -449,9 +467,9 @@ class BaseEnvironment(ABC):
         parts.append(f"eval '{escaped}'")
         parts.append("__hermes_ec=$?")
 
-        # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
+        # Re-dump non-secret env vars to snapshot (last-writer-wins for concurrent calls)
         if self._snapshot_ready:
-            parts.append(f"export -p > {_quoted_snap} 2>/dev/null || true")
+            parts.append(f"{_snapshot_export_command(_quoted_snap)} 2>/dev/null || true")
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)
         parts.append(f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true")


### PR DESCRIPTION
## Summary
- Filter secret-like environment variable declarations out of terminal session snapshot files (`hermes-snap-*.sh`).
- Apply the same filtering on initial snapshot capture and subsequent snapshot refreshes.
- Avoid broad `AUTH` filtering so non-secret session helpers such as `SSH_AUTH_SOCK` and `XAUTHORITY` are preserved.

## Validation
- `scripts/run_tests.sh tests/tools/test_init_session_cwd_respect.py`
- `git diff --check`
- Added-line public hygiene scan: 0 private marker hits
