### PR TITLE
fix(docker): derive baked hermes UID in stage2 chown gate instead of hardcoding 10000

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -55,7 +55,7 @@ fi
 # mkdir -p block below seeds. Keep them in sync if the seed list changes.
 actual_hermes_uid=$(id -u hermes)
 needs_chown=false
-if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "10000" ]; then
+if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "$actual_hermes_uid" ]; then
     needs_chown=true
 elif [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
     needs_chown=true


### PR DESCRIPTION
## What does this PR do?

`docker/stage2-hook.sh` computes `actual_hermes_uid=$(id -u hermes)` and uses it for the data-volume chown, but the `needs_chown` gate just above it compares `$HERMES_UID` against the **literal `"10000"`** instead of that derived value:

```sh
actual_hermes_uid=$(id -u hermes)
needs_chown=false
if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "10000" ]; then   # hardcoded sentinel
    needs_chown=true
elif [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
    needs_chown=true
fi
```

On the stock image the baked UID *is* `10000`, so the two comparisons are equivalent and there's no observable difference today. But the gate is incorrect for any image whose `hermes` UID was built to a different value: a runtime `HERMES_UID` set equal to that baked UID would still evaluate `!= "10000"` as true, trip `needs_chown=true`, and trigger a needless recursive chown of the data subdirs on every boot — exactly the work the gate exists to avoid.

The fix derives the sentinel rather than hardcoding it, matching the UID-remap branch at the top of the same hook (`[ "$HERMES_UID" != "$(id -u hermes)" ]`), which already does this correctly.

This is the small, standalone correctness fix split out from #27437 per @benbarclay's request to separate it from the (now largely upstreamed) multi-stage rework.

## Related Issue

N/A — follow-up to #27437 (closed). @benbarclay: this is the standalone `stage2-hook.sh` UID-comparison fix you offered to merge on its own.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `docker/stage2-hook.sh`: in the `needs_chown` gate, compare `$HERMES_UID` against `$actual_hermes_uid` (already computed two lines above) instead of the hardcoded literal `"10000"`.

## How to Test

The bug is latent on the stock image (baked UID = 10000), so reproduction requires an image whose `hermes` UID differs from 10000:

1. Build an image that bakes a non-default UID, e.g. change `useradd -u 10000` to `useradd -u 1000` (or rebuild with such a UID).
2. **Before this fix:** run with `-e HERMES_UID=1000` (matching the baked UID). The hook logs `[stage2] Fixing ownership of $HERMES_HOME (targeted) …` and performs a recursive chown even though nothing needs changing.
3. **After this fix:** same run performs no chown — `needs_chown` stays `false` because `$HERMES_UID` equals `$actual_hermes_uid`.
4. Regression check on the stock 10000 image: behavior is unchanged in both the "remapped UID" and "unowned volume" paths.

`bash -n docker/stage2-hook.sh` passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: shell-only change to the s6 stage2 hook; no Python code paths are touched.
- [ ] I've added tests for my changes — no automated harness exists for the s6 `stage2-hook.sh` shell hook; manual reproduction documented above. Happy to add a test if there's an established pattern for this hook.
- [x] I've tested on my platform: Linux x86_64 (Debian-based runtime image)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no doc-visible behavior change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (Linux-only container entrypoint; POSIX `sh`, no new constructs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

`needs_chown` gate, before vs after:

```diff
-if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "10000" ]; then
+if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "$actual_hermes_uid" ]; then
```
