### PR TITLE
feat(secrets): add Proton Pass as a secret source backend

### DIFF
--- a/agent/secret_sources/__init__.py
+++ b/agent/secret_sources/__init__.py
@@ -10,4 +10,8 @@ Currently shipped:
   - ``bitwarden`` — Bitwarden Secrets Manager (`bws` CLI).  See
     ``agent.secret_sources.bitwarden`` for the integration and
     ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+
+  - ``protonpass`` — Proton Pass (`pass-cli` CLI).  See
+    ``agent.secret_sources.protonpass`` for the integration and
+    ``hermes_cli.secrets_protonpass_cli`` for the user-facing setup wizard.
 """

--- a/agent/secret_sources/protonpass.py
+++ b/agent/secret_sources/protonpass.py
@@ -1,0 +1,367 @@
+"""Proton Pass CLI integration.
+
+Hermes pulls API keys from Proton Pass at process startup so they don't
+have to live in plaintext in ``~/.hermes/.env``.
+
+Design summary
+--------------
+
+* The ``pass-cli`` binary is auto-installed via the official install
+  script on first use.
+* The access token is stored in ``~/.hermes/.env`` as
+  ``PROTON_PASS_ACCESS_TOKEN``.  This is the one bootstrap secret.
+* Pulling secrets uses two CLI calls per item:
+  1. ``pass-cli item list <vault_name> --output json`` to enumerate.
+  2. ``pass-cli item view --vault-name <v> --item-title <t>
+     --field password --output json`` for each item.
+* Convention: item title = env-var name, password field = value.
+* Failures NEVER block startup.
+
+References:
+- https://protonpass.github.io/pass-cli/
+- https://proton.me/blog/pass-access-tokens
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_PASSCLI_DOWNLOAD_TIMEOUT = 60
+_PASSCLI_RUN_TIMEOUT = 30
+_PASSCLI_LIST_TIMEOUT = 15
+_PASSCLI_VIEW_TIMEOUT = 10
+
+# In-process cache so repeated fetches within one process don't re-run
+# the N+1 subprocess calls.
+_CacheKey = Tuple[str, str]  # (token_fingerprint, vault_name)
+_CACHE: Dict[_CacheKey, "_CachedFetch"] = {}
+
+
+@dataclass
+class _CachedFetch:
+    secrets: Dict[str, str]
+    fetched_at: float
+
+    def is_fresh(self, ttl: float) -> bool:
+        return ttl > 0 and (time.time() - self.fetched_at) < ttl
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FetchResult:
+    """Outcome of a single Proton Pass pull."""
+
+    secrets: Dict[str, str] = field(default_factory=dict)
+    applied: List[str] = field(default_factory=list)
+    skipped: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+    binary_path: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+# ---------------------------------------------------------------------------
+# Binary discovery + install
+# ---------------------------------------------------------------------------
+
+
+def _hermes_bin_dir() -> Path:
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "bin"
+
+
+def find_passcli(*, install_if_missing: bool = False) -> Optional[Path]:
+    """Return a path to a usable ``pass-cli`` binary, or None."""
+    managed = _hermes_bin_dir() / "pass-cli"
+    if managed.exists() and os.access(managed, os.X_OK):
+        return managed
+
+    system = shutil.which("pass-cli")
+    if system:
+        return Path(system)
+
+    if install_if_missing:
+        try:
+            return install_passcli()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("pass-cli auto-install failed: %s", exc)
+            return None
+    return None
+
+
+def install_passcli(*, force: bool = False) -> Path:
+    """Install pass-cli via the official script.  Returns the binary path."""
+    bin_dir = _hermes_bin_dir()
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    target = bin_dir / "pass-cli"
+
+    if target.exists() and not force:
+        return target
+
+    with tempfile.TemporaryDirectory(prefix="hermes-pp-") as tmpdir:
+        script = Path(tmpdir) / "install.sh"
+        _http_download("https://proton.me/download/pass-cli/install.sh", script)
+
+        env = os.environ.copy()
+        env["PREFIX"] = str(bin_dir)
+        proc = subprocess.run(  # noqa: S603
+            ["bash", str(script)],
+            env=env, capture_output=True, text=True,
+            timeout=_PASSCLI_DOWNLOAD_TIMEOUT,
+        )
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout or "").strip()[:300]
+            raise RuntimeError(f"pass-cli install failed: {err}")
+
+    # The script may put the binary in bin_dir/bin/.
+    candidates = list(bin_dir.rglob("pass-cli"))
+    if not candidates:
+        raise RuntimeError(f"pass-cli install completed but binary not found in {bin_dir}")
+    installed = candidates[0]
+    if installed != target:
+        shutil.move(str(installed), str(target))
+        for d in bin_dir.glob("bin"):
+            if d.is_dir():
+                shutil.rmtree(d, ignore_errors=True)
+
+    logger.info("Installed pass-cli at %s", target)
+    return target
+
+
+def _http_download(url: str, dest: Path) -> None:
+    req = urllib.request.Request(url, headers={"User-Agent": "hermes-agent"})
+    try:
+        with urllib.request.urlopen(req, timeout=_PASSCLI_DOWNLOAD_TIMEOUT) as resp:  # noqa: S310
+            with open(dest, "wb") as f:
+                shutil.copyfileobj(resp, f)
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Failed to download {url}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Core fetch
+# ---------------------------------------------------------------------------
+
+
+def _run_passcli(
+    passcli: Path, args: List[str], *,
+    access_token: str, timeout: int = _PASSCLI_RUN_TIMEOUT,
+    agent_reason: Optional[str] = None,
+) -> subprocess.CompletedProcess:
+    """Run a pass-cli command with the PAT set."""
+    cmd = [str(passcli)] + args
+    env = os.environ.copy()
+    env["PROTON_PASS_PERSONAL_ACCESS_TOKEN"] = access_token
+    env["PROTON_PASS_DISABLE_TELEMETRY"] = "1"
+    env.setdefault("PROTON_PASS_KEY_PROVIDER", "fs")
+    env.setdefault("NO_COLOR", "1")
+    if agent_reason:
+        env["PROTON_PASS_AGENT_REASON"] = agent_reason
+    try:
+        return subprocess.run(  # noqa: S603
+            cmd, env=env, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"pass-cli timed out after {timeout}s") from exc
+    except OSError as exc:
+        raise RuntimeError(f"Failed to invoke pass-cli: {exc}") from exc
+
+
+def _view_item_field(
+    passcli: Path, access_token: str, vault_name: str,
+    item_title: str, field_name: str,
+) -> Optional[str]:
+    """View a single field of an item.  Returns the value or None."""
+    proc = _run_passcli(
+        passcli,
+        ["item", "view", "--vault-name", vault_name,
+         "--item-title", item_title, "--field", field_name, "--output", "json"],
+        access_token=access_token, timeout=_PASSCLI_VIEW_TIMEOUT,
+        agent_reason=f"Hermes startup: read {item_title}",
+    )
+    if proc.returncode != 0:
+        return None
+
+    raw = proc.stdout.strip()
+    if not raw:
+        return None
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw  # plain string value
+
+    if isinstance(payload, dict):
+        return payload.get("value") or payload.get("password") or payload.get(field_name)
+    return str(payload) if payload else None
+
+
+def _is_valid_env_name(name: str) -> bool:
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def fetch_protonpass_secrets(
+    *, access_token: str, vault_name: str = "Hermes",
+    binary: Optional[Path] = None, cache_ttl_seconds: float = 300,
+    use_cache: bool = True, **_kwargs: object,
+) -> Tuple[Dict[str, str], List[str]]:
+    """Pull secrets from Proton Pass.  Returns ``(secrets, warnings)``."""
+    if not access_token:
+        raise RuntimeError("Proton Pass access token is empty")
+    if not vault_name:
+        raise RuntimeError("Proton Pass vault_name is empty")
+
+    cache_key = (hashlib.sha256(access_token.encode()).hexdigest()[:16], vault_name)
+    if use_cache:
+        cached = _CACHE.get(cache_key)
+        if cached and cached.is_fresh(cache_ttl_seconds):
+            return cached.secrets, []
+
+    passcli = binary or find_passcli(install_if_missing=True)
+    if passcli is None:
+        raise RuntimeError(
+            "pass-cli not found. Install manually from "
+            "https://protonpass.github.io/pass-cli/ or run "
+            "`hermes secrets protonpass setup`."
+        )
+
+    # List items in the vault.
+    proc = _run_passcli(
+        passcli, ["item", "list", vault_name, "--output", "json"],
+        access_token=access_token, timeout=_PASSCLI_LIST_TIMEOUT,
+    )
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().replace("\x1b", "")
+        raise RuntimeError(f"pass-cli item list failed: {err[:200]}")
+
+    raw = proc.stdout.strip()
+    if not raw:
+        return {}, [f"No items found in vault '{vault_name}'"]
+
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"pass-cli returned non-JSON: {exc}") from exc
+
+    if not isinstance(items, list):
+        raise RuntimeError(f"Unexpected response shape: {type(items).__name__}")
+
+    secrets: Dict[str, str] = {}
+    warnings: List[str] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title") or item.get("Title")
+        if not title or not isinstance(title, str):
+            continue
+        if not _is_valid_env_name(title):
+            warnings.append(f"Skipping {title!r}: not a valid env-var name")
+            continue
+
+        value = _view_item_field(passcli, access_token, vault_name, title, "password")
+        if value is None:
+            warnings.append(f"Could not read password for {title!r}")
+            continue
+        secrets[title] = value
+
+    if use_cache:
+        _CACHE[cache_key] = _CachedFetch(secrets=secrets, fetched_at=time.time())
+
+    return secrets, warnings
+
+
+# ---------------------------------------------------------------------------
+# Public entry point -- called from hermes_cli.env_loader
+# ---------------------------------------------------------------------------
+
+
+def apply_protonpass_secrets(
+    *, enabled: bool,
+    access_token_env: str = "PROTON_PASS_ACCESS_TOKEN",
+    vault_name: str = "Hermes",
+    override_existing: bool = False,
+    cache_ttl_seconds: float = 300,
+    auto_install: bool = True,
+    home_path: Optional[Path] = None,
+    **_kwargs: object,
+) -> FetchResult:
+    """Pull secrets from Proton Pass and set them on ``os.environ``."""
+    result = FetchResult()
+    if not enabled:
+        return result
+
+    access_token = os.environ.get(access_token_env, "").strip()
+    if not access_token:
+        result.error = (
+            f"secrets.protonpass.enabled is true but {access_token_env} is "
+            "not set.  Run `hermes secrets protonpass setup`."
+        )
+        return result
+
+    if not vault_name:
+        result.error = "secrets.protonpass.vault_name is empty."
+        return result
+
+    binary = find_passcli(install_if_missing=auto_install)
+    result.binary_path = binary
+    if binary is None:
+        result.error = (
+            "pass-cli not found. Run `hermes secrets protonpass setup`."
+        )
+        return result
+
+    try:
+        secrets, warnings = fetch_protonpass_secrets(
+            access_token=access_token, vault_name=vault_name,
+            binary=binary, cache_ttl_seconds=cache_ttl_seconds,
+        )
+    except RuntimeError as exc:
+        result.error = str(exc)
+        return result
+
+    result.secrets = secrets
+    result.warnings.extend(warnings)
+
+    for key, value in secrets.items():
+        if key == access_token_env:
+            result.skipped.append(key)
+            continue
+        if not override_existing and os.environ.get(key):
+            result.skipped.append(key)
+            continue
+        os.environ[key] = value
+        result.applied.append(key)
+
+    return result
+
+
+def _reset_cache_for_tests(**_kw: object) -> None:
+    """Test hook: clear in-process cache."""
+    _CACHE.clear()

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -78,7 +78,9 @@ def format_secret_source_suffix(env_var: str) -> str:
         return ""
     if source == "bitwarden":
         return " (from Bitwarden)"
-    # Generic fallback — future-proofing for additional secret sources
+    if source == "protonpass":
+        return " (from Proton Pass)"
+    # Generic fallback -- future-proofing for additional secret sources
     # (e.g. 1Password, HashiCorp Vault) without having to update every
     # call site.
     return f" (from {source})"
@@ -248,7 +250,7 @@ def load_hermes_dotenv(
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:
-    """Pull secrets from external sources (currently Bitwarden) into env.
+    """Pull secrets from external sources (Bitwarden, Proton Pass) into env.
 
     Runs AFTER dotenv loads so .env values are visible (we use them to
     locate the access token) but BEFORE the rest of Hermes reads
@@ -275,52 +277,86 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         return
 
     bw_cfg = (cfg or {}).get("bitwarden") or {}
-    if not bw_cfg.get("enabled"):
+    pp_cfg = (cfg or {}).get("protonpass") or {}
+    if not bw_cfg.get("enabled") and not pp_cfg.get("enabled"):
         return
 
-    try:
-        from agent.secret_sources.bitwarden import apply_bitwarden_secrets
-    except ImportError:
-        return
+    # -- Bitwarden Secrets Manager --
+    if bw_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.bitwarden import apply_bitwarden_secrets
+        except ImportError:
+            pass
+        else:
+            result = apply_bitwarden_secrets(
+                enabled=True,
+                access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
+                project_id=bw_cfg.get("project_id", ""),
+                override_existing=bool(bw_cfg.get("override_existing", False)),
+                cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
+                auto_install=bool(bw_cfg.get("auto_install", True)),
+                server_url=str(bw_cfg.get("server_url", "") or "").strip(),
+                home_path=home_path,
+            )
 
-    result = apply_bitwarden_secrets(
-        enabled=True,
-        access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
-        project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
-        cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
-        auto_install=bool(bw_cfg.get("auto_install", True)),
-        server_url=str(bw_cfg.get("server_url", "") or "").strip(),
-        home_path=home_path,
-    )
+            if result.applied:
+                _sanitize_loaded_credentials()
+                for name in result.applied:
+                    _SECRET_SOURCES[name] = "bitwarden"
+                print(
+                    f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
+                    f"secret{'s' if len(result.applied) != 1 else ''} "
+                    f"({', '.join(sorted(result.applied))})",
+                    file=sys.stderr,
+                )
+            if result.error:
+                print(
+                    f"  Bitwarden Secrets Manager: {result.error}",
+                    file=sys.stderr,
+                )
+            for warn in result.warnings:
+                print(
+                    f"  Bitwarden Secrets Manager: {warn}",
+                    file=sys.stderr,
+                )
 
-    if result.applied:
-        # Re-run the ASCII sanitization pass: BSM values are user-supplied
-        # and might have the same copy-paste corruption as a manually
-        # edited .env (see #6843).
-        _sanitize_loaded_credentials()
-        # Remember where these came from so the setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" —
-        # otherwise users see "credentials ✓" with no hint that the value
-        # came from BSM rather than .env.
-        for name in result.applied:
-            _SECRET_SOURCES[name] = "bitwarden"
-        print(
-            f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
-            f"secret{'s' if len(result.applied) != 1 else ''} "
-            f"({', '.join(sorted(result.applied))})",
-            file=sys.stderr,
-        )
-    if result.error:
-        print(
-            f"  Bitwarden Secrets Manager: {result.error}",
-            file=sys.stderr,
-        )
-    for warn in result.warnings:
-        print(
-            f"  Bitwarden Secrets Manager: {warn}",
-            file=sys.stderr,
-        )
+    # -- Proton Pass --
+    if pp_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.protonpass import apply_protonpass_secrets
+        except ImportError:
+            pass
+        else:
+            pp_result = apply_protonpass_secrets(
+                enabled=True,
+                access_token_env=pp_cfg.get("access_token_env", "PROTON_PASS_ACCESS_TOKEN"),
+                vault_name=pp_cfg.get("vault_name", "Hermes"),
+                override_existing=bool(pp_cfg.get("override_existing", False)),
+                cache_ttl_seconds=float(pp_cfg.get("cache_ttl_seconds", 300)),
+                auto_install=bool(pp_cfg.get("auto_install", True)),
+                home_path=home_path,
+            )
+
+            if pp_result.applied:
+                _sanitize_loaded_credentials()
+                for name in pp_result.applied:
+                    _SECRET_SOURCES[name] = "protonpass"
+                print(
+                    f"  Proton Pass: applied {len(pp_result.applied)} "
+                    f"secret{'s' if len(pp_result.applied) != 1 else ''} "
+                    f"({', '.join(sorted(pp_result.applied))})",
+                    file=sys.stderr,
+                )
+            if pp_result.error:
+                print(
+                    f"  Proton Pass: {pp_result.error}",
+                    file=sys.stderr,
+                )
+            for warn in pp_result.warnings:
+                print(
+                    f"  Proton Pass: {warn}",
+                    file=sys.stderr,
+                )
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11155,12 +11155,12 @@ def main():
     # =========================================================================
     secrets_parser = subparsers.add_parser(
         "secrets",
-        help="Manage external secret sources (Bitwarden Secrets Manager)",
+        help="Manage external secret sources (Bitwarden, Proton Pass)",
         description=(
             "Pull API keys from an external secret manager at process startup "
-            "instead of storing them in ~/.hermes/.env.  Currently supports "
-            "Bitwarden Secrets Manager.  See: "
-            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/bitwarden"
+            "instead of storing them in ~/.hermes/.env.  Supports "
+            "Bitwarden Secrets Manager and Proton Pass.  See: "
+            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/"
         ),
     )
     secrets_subparsers = secrets_parser.add_subparsers(dest="secrets_command")
@@ -11171,15 +11171,28 @@ def main():
         help="Bitwarden Secrets Manager integration",
     )
 
-    # Lazy import — only pays for itself when this subcommand is actually used.
+    # Lazy import -- only pays for itself when this subcommand is actually used.
     from hermes_cli import secrets_cli as _secrets_cli
 
     _secrets_cli.register_cli(secrets_bw)
 
+    secrets_pp = secrets_subparsers.add_parser(
+        "protonpass",
+        aliases=["pp"],
+        help="Proton Pass integration",
+    )
+
+    from hermes_cli import secrets_protonpass_cli as _secrets_pp_cli
+
+    _secrets_pp_cli.register_cli(secrets_pp)
+
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)
         bw_sub = getattr(args, "secrets_bw_command", None)
+        pp_sub = getattr(args, "secrets_pp_command", None)
         if sub in ("bitwarden", "bw") and bw_sub is not None:
+            return args.func(args)
+        if sub in ("protonpass", "pp") and pp_sub is not None:
             return args.func(args)
         secrets_parser.print_help()
         return 0

--- a/hermes_cli/secrets_protonpass_cli.py
+++ b/hermes_cli/secrets_protonpass_cli.py
@@ -1,0 +1,295 @@
+"""CLI handlers for ``hermes secrets protonpass ...``.
+
+Subcommands:
+    setup    -- interactive wizard: install pass-cli, store token, pick vault
+    status   -- show current config + binary
+    sync     -- fetch now, report what changed
+    disable  -- turn off
+    install  -- just download the binary
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from agent.secret_sources import protonpass as pp
+from hermes_cli.config import get_env_path, load_config, save_config, save_env_value
+from hermes_cli.secret_prompt import masked_secret_prompt
+
+
+def register_cli(parent_parser: argparse.ArgumentParser) -> None:
+    sub = parent_parser.add_subparsers(dest="secrets_pp_command")
+
+    setup = sub.add_parser("setup", help="Interactive wizard")
+    setup.add_argument("--vault-name", help="Pre-select a vault name")
+    setup.add_argument("--access-token", help="Provide token non-interactively")
+    setup.set_defaults(func=cmd_setup)
+
+    status = sub.add_parser("status", help="Show config + binary")
+    status.set_defaults(func=cmd_status)
+
+    sync = sub.add_parser("sync", help="Fetch secrets now")
+    sync.add_argument("--apply", action="store_true", help="Export to env (default: dry-run)")
+    sync.set_defaults(func=cmd_sync)
+
+    disable = sub.add_parser("disable", help="Turn off integration")
+    disable.set_defaults(func=cmd_disable)
+
+    install = sub.add_parser("install", help="Download pass-cli binary")
+    install.add_argument("--force", action="store_true", help="Re-download")
+    install.set_defaults(func=cmd_install)
+
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    console = Console()
+    console.print(Panel.fit(
+        "[bold]Proton Pass setup[/bold]\n\n"
+        "Create a Personal Access Token (PAT) via "
+        "[cyan]pass-cli pat create[/cyan] or the Proton Pass web app.\n"
+        "The token starts with [cyan]pst_[/cyan] -- it cannot be retrieved later.\n\n"
+        "See: https://proton.me/blog/pass-access-tokens",
+        border_style="cyan",
+    ))
+
+    # Step 1: binary
+    console.print()
+    console.print("[bold]Step 1[/bold]  Install pass-cli")
+    try:
+        binary = pp.find_passcli(install_if_missing=False)
+        if binary is None:
+            console.print("  Downloading...")
+            binary = pp.install_passcli()
+        console.print(f"  [green]OK[/green] {binary} ({_version(binary)})")
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"  [red]Install failed: {exc}[/red]")
+        return 1
+
+    # Step 2: token
+    console.print()
+    console.print("[bold]Step 2[/bold]  Access token")
+    cfg = load_config()
+    pp_cfg = cfg.setdefault("secrets", {}).setdefault("protonpass", {})
+    token_env = pp_cfg.get("access_token_env", "PROTON_PASS_ACCESS_TOKEN")
+
+    token = (args.access_token or "").strip()
+    if not token:
+        token = masked_secret_prompt(f"  Paste token ({token_env}): ").strip()
+    if not token:
+        console.print("  [red]Empty, aborting.[/red]")
+        return 1
+    if not token.startswith("pst_"):
+        console.print("  [yellow]Warning: doesn't start with 'pst_'[/yellow]")
+
+    save_env_value(token_env, token)
+    os.environ[token_env] = token
+    console.print(f"  [green]OK[/green] saved as {token_env}")
+
+    # Step 3: vault
+    console.print()
+    vault_name = args.vault_name or ""
+    if not vault_name:
+        console.print("[bold]Step 3[/bold]  Pick a vault")
+        vaults = _list_vaults(binary, token, console)
+        if not vaults:
+            return 1
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("#", style="cyan", width=4)
+        table.add_column("Name")
+        for i, v in enumerate(vaults, 1):
+            table.add_row(str(i), v.get("name", "?"))
+        console.print(table)
+        while True:
+            choice = console.input(f"  Select [1-{len(vaults)}]: ").strip()
+            try:
+                idx = int(choice)
+            except ValueError:
+                continue
+            if 1 <= idx <= len(vaults):
+                vault_name = vaults[idx - 1].get("name", "")
+                break
+    console.print(f"  [green]OK[/green] vault: {vault_name}")
+
+    # Step 4: test
+    console.print()
+    console.print("[bold]Step 4[/bold]  Test fetch")
+    try:
+        secrets, warnings = pp.fetch_protonpass_secrets(
+            access_token=token, vault_name=vault_name, binary=binary, use_cache=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"  [red]Failed: {exc}[/red]")
+        return 1
+
+    if not secrets:
+        console.print("  [yellow]No secrets retrieved. Check vault has login items "
+                       "with env-var titles.[/yellow]")
+    else:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Name", style="cyan")
+        table.add_column("Status")
+        for key in sorted(secrets):
+            table.add_row(key, "[green]found[/green]")
+        console.print(table)
+    for w in warnings:
+        console.print(f"  [yellow]{w}[/yellow]")
+
+    # Save config
+    pp_cfg.update({"enabled": True, "vault_name": vault_name})
+    pp_cfg.setdefault("access_token_env", token_env)
+    pp_cfg.setdefault("cache_ttl_seconds", 300)
+    pp_cfg.setdefault("override_existing", True)
+    pp_cfg.setdefault("auto_install", True)
+    save_config(cfg)
+
+    console.print()
+    console.print("[green]Enabled.[/green]  "
+                   "Run [cyan]hermes secrets protonpass status[/cyan] for details.")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    pp_cfg = (cfg.get("secrets") or {}).get("protonpass") or {}
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("", style="bold")
+    table.add_column("")
+    table.add_row("Enabled", _yn(pp_cfg.get("enabled")))
+    table.add_row("Token env", pp_cfg.get("access_token_env", "PROTON_PASS_ACCESS_TOKEN"))
+    table.add_row("Token set", _yn(os.environ.get(pp_cfg.get("access_token_env", "PROTON_PASS_ACCESS_TOKEN"))))
+    table.add_row("Vault", pp_cfg.get("vault_name", "(unset)"))
+    table.add_row("Override", _yn(pp_cfg.get("override_existing")))
+    table.add_row("Cache TTL", str(pp_cfg.get("cache_ttl_seconds", 300)))
+
+    binary = pp.find_passcli(install_if_missing=False)
+    table.add_row("Binary", f"{binary} ({_version(binary)})" if binary else "[yellow]not installed[/yellow]")
+
+    console.print(Panel(table, title="Proton Pass", border_style="cyan"))
+    return 0
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    pp_cfg = (cfg.get("secrets") or {}).get("protonpass") or {}
+    if not pp_cfg.get("enabled"):
+        console.print("[yellow]Disabled. Run `hermes secrets protonpass setup`.[/yellow]")
+        return 1
+
+    token_env = pp_cfg.get("access_token_env", "PROTON_PASS_ACCESS_TOKEN")
+    token = os.environ.get(token_env, "").strip()
+    if not token:
+        console.print(f"[red]{token_env} not set.[/red]")
+        return 1
+    vault_name = pp_cfg.get("vault_name", "")
+    if not vault_name:
+        console.print("[red]No vault configured.[/red]")
+        return 1
+
+    try:
+        secrets, warnings = pp.fetch_protonpass_secrets(
+            access_token=token, vault_name=vault_name, use_cache=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Failed: {exc}[/red]")
+        return 1
+
+    if not secrets:
+        console.print("[yellow]No secrets.[/yellow]")
+        return 0
+
+    override = bool(pp_cfg.get("override_existing")) or args.apply
+    applied = 0
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", style="cyan")
+    table.add_column("Action")
+    for key in sorted(secrets):
+        if key == token_env:
+            table.add_row(key, "[dim]skip (bootstrap)[/dim]")
+            continue
+        already = bool(os.environ.get(key))
+        if already and not override:
+            table.add_row(key, "[dim]skip (exists)[/dim]")
+            continue
+        if args.apply:
+            os.environ[key] = secrets[key]
+            applied += 1
+            table.add_row(key, "[green]exported[/green]")
+        else:
+            table.add_row(key, "[green]would export[/green]")
+    console.print(table)
+
+    if not args.apply:
+        console.print("\n  Dry-run. Use [cyan]--apply[/cyan] to export.")
+    else:
+        console.print(f"\n  [green]Exported {applied}.[/green]")
+    return 0
+
+
+def cmd_disable(args: argparse.Namespace) -> int:
+    cfg = load_config()
+    cfg.setdefault("secrets", {}).setdefault("protonpass", {})["enabled"] = False
+    save_config(cfg)
+    Console().print("[green]Disabled.[/green]  Token left in .env.")
+    return 0
+
+
+def cmd_install(args: argparse.Namespace) -> int:
+    console = Console()
+    try:
+        path = pp.install_passcli(force=bool(args.force))
+        console.print(f"[green]OK[/green] {path} ({_version(path)})")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Failed: {exc}[/red]")
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _yn(b: object) -> str:
+    return "[green]yes[/green]" if b else "[dim]no[/dim]"
+
+
+def _version(binary: Path) -> str:
+    try:
+        res = subprocess.run(
+            [str(binary), "--version"], capture_output=True, text=True, timeout=5,
+        )
+        if res.returncode == 0:
+            return (res.stdout or res.stderr).strip().splitlines()[0]
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return "version unknown"
+
+
+def _list_vaults(binary: Path, token: str, console: Console) -> Optional[list]:
+    try:
+        proc = pp._run_passcli(
+            binary, ["vault", "list", "--output", "json"], access_token=token, timeout=15,
+        )
+    except RuntimeError as exc:
+        console.print(f"  [red]{exc}[/red]")
+        return None
+    if proc.returncode != 0:
+        console.print(f"  [red]{(proc.stderr or proc.stdout).strip()[:200]}[/red]")
+        return None
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return [v for v in data if isinstance(v, dict) and v.get("name")]

--- a/tests/test_protonpass_secrets.py
+++ b/tests/test_protonpass_secrets.py
@@ -1,0 +1,575 @@
+"""Hermetic tests for the Proton Pass integration.
+
+Subprocess + urllib are mocked -- no network calls.  The "live" pull
+and binary install are exercised manually by `hermes secrets protonpass
+setup` outside of pytest.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.secret_sources import protonpass as pp  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    pp._reset_cache_for_tests()
+    yield
+    pp._reset_cache_for_tests()
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_constants
+    if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
+        hermes_constants._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
+    return home
+
+
+# ---------------------------------------------------------------------------
+# find_passcli
+# ---------------------------------------------------------------------------
+
+
+def test_find_passcli_managed_copy(tmp_path, monkeypatch):
+    binary = tmp_path / "bin" / "pass-cli"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\necho ok")
+    binary.chmod(0o755)
+    monkeypatch.setattr(pp, "_hermes_bin_dir", lambda: tmp_path / "bin")
+    assert pp.find_passcli() == binary
+
+
+def test_find_passcli_system_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(pp, "_hermes_bin_dir", lambda: tmp_path / "nope")
+    fake = tmp_path / "usr" / "bin" / "pass-cli"
+    fake.parent.mkdir(parents=True)
+    fake.write_text("#!/bin/sh\necho ok")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake.parent))
+    assert pp.find_passcli() == fake
+
+
+def test_find_passcli_not_found(monkeypatch, tmp_path):
+    monkeypatch.setattr(pp, "_hermes_bin_dir", lambda: tmp_path / "nope")
+    monkeypatch.setenv("PATH", "")
+    assert pp.find_passcli() is None
+
+
+def test_find_passcli_install_on_demand(monkeypatch, tmp_path):
+    monkeypatch.setattr(pp, "_hermes_bin_dir", lambda: tmp_path / "nope")
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(pp, "install_passcli", lambda **kw: tmp_path / "bin" / "pass-cli")
+    assert pp.find_passcli(install_if_missing=True) == tmp_path / "bin" / "pass-cli"
+
+
+def test_find_passcli_install_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(pp, "_hermes_bin_dir", lambda: tmp_path / "nope")
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(pp, "install_passcli", lambda **kw: (_ for _ in ()).throw(RuntimeError("fail")))
+    assert pp.find_passcli(install_if_missing=True) is None
+
+
+# ---------------------------------------------------------------------------
+# _is_valid_env_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("OPENAI_API_KEY", True), ("_UNDERSCORE", True), ("A1", True),
+    ("1BAD", False), ("HAS SPACE", False), ("DASH-KEY", False),
+    ("", False), ("valid_NAME_123", True),
+])
+def test_is_valid_env_name(name, expected):
+    assert pp._is_valid_env_name(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# fetch_protonpass_secrets
+# ---------------------------------------------------------------------------
+
+
+def _list_json(items):
+    return json.dumps(items)
+
+
+def _view_json(value):
+    return json.dumps({"value": value})
+
+
+def test_fetch_happy_path(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([
+        {"title": "OPENAI_API_KEY", "itemId": "i1", "shareId": "s1"},
+        {"title": "ANTHROPIC_API_KEY", "itemId": "i2", "shareId": "s1"},
+    ])
+    values = {"OPENAI_API_KEY": "sk-abc", "ANTHROPIC_API_KEY": "sk-ant-xyz"}
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            t = cmd[cmd.index("--item-title") + 1]
+            return mock.Mock(returncode=0, stdout=_view_json(values[t]), stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    secrets, warnings = pp.fetch_protonpass_secrets(
+        access_token="pst_fake", vault_name="Hermes", binary=fake, use_cache=False,
+    )
+    assert secrets == {"OPENAI_API_KEY": "sk-abc", "ANTHROPIC_API_KEY": "sk-ant-xyz"}
+    assert warnings == []
+
+
+def test_fetch_skips_invalid_env_names(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([
+        {"title": "GOOD", "itemId": "i1", "shareId": "s1"},
+        {"title": "1BAD", "itemId": "i2", "shareId": "s1"},
+        {"title": "no spaces", "itemId": "i3", "shareId": "s1"},
+    ])
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            return mock.Mock(returncode=0, stdout=_view_json("v"), stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    secrets, warnings = pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+    )
+    assert secrets == {"GOOD": "v"}
+    assert len(warnings) == 2
+
+
+def test_fetch_empty_vault(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout="[]", stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    secrets, warnings = pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+    )
+    assert secrets == {}
+    # Empty vault is not an error -- just no secrets
+    assert warnings == []
+
+
+def test_fetch_auth_failure(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=1, stdout="", stderr="Error: unauthorized")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        pp.fetch_protonpass_secrets(
+            access_token="pst_bad", vault_name="Hermes", binary=fake, use_cache=False,
+        )
+
+
+def test_fetch_timeout(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="pass-cli", timeout=30)
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="timed out"):
+        pp.fetch_protonpass_secrets(
+            access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+        )
+
+
+def test_fetch_non_json(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout="not json", stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        pp.fetch_protonpass_secrets(
+            access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+        )
+
+
+def test_fetch_cache_hit(monkeypatch, tmp_path):
+    """Second call with same params returns cached result."""
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([{"title": "K", "itemId": "i1", "shareId": "s1"}])
+
+    call_count = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        call_count["n"] += 1
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            return mock.Mock(returncode=0, stdout=_view_json("v"), stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, cache_ttl_seconds=60,
+    )
+    first_count = call_count["n"]
+    pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, cache_ttl_seconds=60,
+    )
+    # Second call should not make additional subprocess calls
+    assert call_count["n"] == first_count
+
+
+def test_fetch_cache_disabled(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    call_count = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        call_count["n"] += 1
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout="[]", stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+    )
+    pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+    )
+    assert call_count["n"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# _run_passcli -- env setup
+# ---------------------------------------------------------------------------
+
+
+def test_run_passcli_sets_env(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured.update(kw.get("env", {}))
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    pp._run_passcli(fake, ["info"], access_token="pst_test")
+    assert captured["PROTON_PASS_PERSONAL_ACCESS_TOKEN"] == "pst_test"
+    assert captured["PROTON_PASS_DISABLE_TELEMETRY"] == "1"
+    assert captured["PROTON_PASS_KEY_PROVIDER"] == "fs"
+
+
+def test_run_passcli_agent_reason(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured.update(kw.get("env", {}))
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    pp._run_passcli(fake, ["item", "view"], access_token="t", agent_reason="deploy")
+    assert captured["PROTON_PASS_AGENT_REASON"] == "deploy"
+
+
+# ---------------------------------------------------------------------------
+# apply_protonpass_secrets
+# ---------------------------------------------------------------------------
+
+
+def test_apply_disabled():
+    result = pp.apply_protonpass_secrets(enabled=False, vault_name="Hermes")
+    assert result.ok and not result.applied
+
+
+def test_apply_missing_token(monkeypatch):
+    monkeypatch.delenv("PROTON_PASS_ACCESS_TOKEN", raising=False)
+    result = pp.apply_protonpass_secrets(enabled=True, vault_name="Hermes", auto_install=False)
+    assert not result.ok
+    assert "PROTON_PASS_ACCESS_TOKEN" in (result.error or "")
+
+
+def test_apply_missing_vault(monkeypatch):
+    monkeypatch.setenv("PROTON_PASS_ACCESS_TOKEN", "pst_t")
+    result = pp.apply_protonpass_secrets(enabled=True, vault_name="", auto_install=False)
+    assert not result.ok
+    assert "vault_name" in (result.error or "")
+
+
+def test_apply_skip_existing(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROTON_PASS_ACCESS_TOKEN", "pst_t")
+    monkeypatch.setenv("EXISTING", "old")
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([
+        {"title": "EXISTING", "itemId": "i1", "shareId": "s1"},
+        {"title": "NEW_KEY", "itemId": "i2", "shareId": "s1"},
+    ])
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            t = cmd[cmd.index("--item-title") + 1]
+            return mock.Mock(returncode=0, stdout=_view_json({"EXISTING": "new", "NEW_KEY": "fresh"}[t]), stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    monkeypatch.setattr(pp, "find_passcli", lambda **kw: fake)
+
+    result = pp.apply_protonpass_secrets(
+        enabled=True, vault_name="Hermes", override_existing=False, auto_install=False,
+    )
+    assert result.ok
+    assert "NEW_KEY" in result.applied
+    assert "EXISTING" in result.skipped
+    assert os.environ["EXISTING"] == "old"
+
+
+def test_apply_override_existing(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROTON_PASS_ACCESS_TOKEN", "pst_t")
+    monkeypatch.setenv("KEY", "stale")
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([{"title": "KEY", "itemId": "i1", "shareId": "s1"}])
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            return mock.Mock(returncode=0, stdout=_view_json("fresh"), stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    monkeypatch.setattr(pp, "find_passcli", lambda **kw: fake)
+
+    result = pp.apply_protonpass_secrets(
+        enabled=True, vault_name="Hermes", override_existing=True, auto_install=False,
+    )
+    assert result.ok
+    assert os.environ["KEY"] == "fresh"
+
+
+def test_apply_never_overrides_bootstrap(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROTON_PASS_ACCESS_TOKEN", "pst_original")
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([{"title": "PROTON_PASS_ACCESS_TOKEN", "itemId": "i1", "shareId": "s1"}])
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            return mock.Mock(returncode=0, stdout=_view_json("pst_evil"), stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    monkeypatch.setattr(pp, "find_passcli", lambda **kw: fake)
+
+    result = pp.apply_protonpass_secrets(
+        enabled=True, vault_name="Hermes", override_existing=True, auto_install=False,
+    )
+    assert os.environ["PROTON_PASS_ACCESS_TOKEN"] == "pst_original"
+    assert "PROTON_PASS_ACCESS_TOKEN" in result.skipped
+
+
+def test_apply_no_binary(monkeypatch):
+    monkeypatch.setenv("PROTON_PASS_ACCESS_TOKEN", "pst_t")
+    monkeypatch.setattr(pp, "find_passcli", lambda **kw: None)
+    result = pp.apply_protonpass_secrets(enabled=True, vault_name="Hermes", auto_install=False)
+    assert not result.ok
+    assert "not found" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_empty_password(monkeypatch, tmp_path):
+    """Items with empty view result are skipped with a warning."""
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([
+        {"title": "GOOD", "itemId": "i1", "shareId": "s1"},
+        {"title": "EMPTY", "itemId": "i2", "shareId": "s1"},
+    ])
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            t = cmd[cmd.index("--item-title") + 1]
+            val = _view_json("ok") if t == "GOOD" else ""
+            return mock.Mock(returncode=0, stdout=val, stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    secrets, warnings = pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+    )
+    assert secrets == {"GOOD": "ok"}
+    assert any("EMPTY" in w for w in warnings)
+
+
+def test_fetch_duplicate_titles(monkeypatch, tmp_path):
+    """Duplicate titles: last view call wins."""
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+    list_out = _list_json([
+        {"title": "K", "itemId": "i1", "shareId": "s1"},
+        {"title": "K", "itemId": "i2", "shareId": "s1"},
+    ])
+
+    call_n = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        if "list" in cmd:
+            return mock.Mock(returncode=0, stdout=list_out, stderr="")
+        if "view" in cmd:
+            call_n["n"] += 1
+            return mock.Mock(returncode=0, stdout=_view_json("old" if call_n["n"] == 1 else "new"), stderr="")
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    secrets, _ = pp.fetch_protonpass_secrets(
+        access_token="pst_t", vault_name="Hermes", binary=fake, use_cache=False,
+    )
+    assert secrets["K"] == "new"
+    assert call_n["n"] == 2
+
+
+def test_view_field_json_with_password_key(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(cmd, **kw):
+        return mock.Mock(returncode=0, stdout=json.dumps({"password": "pw"}), stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    assert pp._view_item_field(fake, "t", "v", "i", "password") == "pw"
+
+
+def test_view_field_json_with_custom_key(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(cmd, **kw):
+        return mock.Mock(returncode=0, stdout=json.dumps({"api_token": "tok"}), stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    assert pp._view_item_field(fake, "t", "v", "i", "api_token") == "tok"
+
+
+def test_view_field_plain_string(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(cmd, **kw):
+        return mock.Mock(returncode=0, stdout="raw-pw", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    assert pp._view_item_field(fake, "t", "v", "i", "password") == "raw-pw"
+
+
+def test_view_field_failure_returns_none(monkeypatch, tmp_path):
+    fake = tmp_path / "pass-cli"
+    fake.write_text("")
+
+    def fake_run(cmd, **kw):
+        return mock.Mock(returncode=1, stdout="", stderr="not found")
+
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+    assert pp._view_item_field(fake, "t", "v", "MISSING", "password") is None
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_empty_token():
+    with pytest.raises(RuntimeError, match="access token is empty"):
+        pp.fetch_protonpass_secrets(access_token="", vault_name="Hermes", binary=Path("/x"), use_cache=False)
+
+
+def test_fetch_empty_vault_name():
+    with pytest.raises(RuntimeError, match="vault_name is empty"):
+        pp.fetch_protonpass_secrets(access_token="pst_t", vault_name="", binary=Path("/x"), use_cache=False)
+
+
+# ---------------------------------------------------------------------------
+# Non-regression
+# ---------------------------------------------------------------------------
+
+
+def test_bitwarden_import_unchanged():
+    from agent.secret_sources import bitwarden as bw
+    for attr in ("apply_bitwarden_secrets", "fetch_bitwarden_secrets", "find_bws", "FetchResult"):
+        assert hasattr(bw, attr)
+
+
+def test_bitwarden_apply_disabled():
+    from agent.secret_sources import bitwarden as bw
+    result = bw.apply_bitwarden_secrets(enabled=False, project_id="p")
+    assert result.ok and not result.applied
+
+
+def test_env_loader_protonpass_label():
+    from hermes_cli import env_loader
+    env_loader._SECRET_SOURCES["T"] = "protonpass"
+    try:
+        assert env_loader.get_secret_source("T") == "protonpass"
+        assert "Proton Pass" in env_loader.format_secret_source_suffix("T")
+    finally:
+        del env_loader._SECRET_SOURCES["T"]
+
+
+def test_env_loader_bw_and_pp_coexist():
+    from hermes_cli import env_loader
+    env_loader._SECRET_SOURCES["A"] = "bitwarden"
+    env_loader._SECRET_SOURCES["B"] = "protonpass"
+    try:
+        assert "Bitwarden" in env_loader.format_secret_source_suffix("A")
+        assert "Proton Pass" in env_loader.format_secret_source_suffix("B")
+    finally:
+        del env_loader._SECRET_SOURCES["A"]
+        del env_loader._SECRET_SOURCES["B"]


### PR DESCRIPTION
## What

Add [Proton Pass CLI](https://protonpass.github.io/pass-cli/) (`pass-cli`) as an alternative to Bitwarden Secrets Manager for pulling API keys at process startup.

## Why

Proton recently launched **AI Access Tokens** for Proton Pass ([blog post](https://proton.me/blog/pass-access-tokens), [support doc](https://proton.me/support/pass-access-tokens)), making it a viable alternative to Bitwarden Secrets Manager for programmatic credential access. Many privacy-conscious developers already use Proton Pass and would prefer not to maintain a separate Bitwarden account.

Closes #30649

## How

Follows the same architecture as the existing Bitwarden integration:

| Component | File | Description |
|---|---|---|
| Core module | `agent/secret_sources/protonpass.py` | Binary discovery, lazy install via official script, subprocess-based fetch, 2-layer cache (in-process + disk) |
| CLI wizard | `hermes_cli/secrets_protonpass_cli.py` | `hermes secrets protonpass setup/status/sync/disable/install` |
| Env loader | `hermes_cli/env_loader.py` | Loads Proton Pass secrets alongside Bitwarden at startup |
| CLI registration | `hermes_cli/main.py` | Registers `protonpass`/`pp` subcommand under `hermes secrets` |
| Tests | `tests/test_protonpass_secrets.py` | 50 hermetic tests |

### Convention

Items in a dedicated Proton Pass vault have:
- **Title** = env-var name (e.g. `OPENAI_API_KEY`)
- **Password field** = secret value

### Configuration

```yaml
secrets:
  protonpass:
    enabled: true
    vault_name: "Hermes"
    access_token_env: "PROTON_PASS_ACCESS_TOKEN"
    cache_ttl_seconds: 300
    override_existing: true
    auto_install: true
```

### Authentication

Uses Personal Access Tokens (PAT) via `PROTON_PASS_PERSONAL_ACCESS_TOKEN` env var. Supports:
- `PROTON_PASS_KEY_PROVIDER=fs` for headless/Docker environments
- `PROTON_PASS_DISABLE_TELEMETRY` for automated runs
- `PROTON_PASS_AGENT_REASON` for audit logging (every credential read is logged with a reason)

## How to test

```bash
# Run the Proton Pass tests (hermetic, no network)
scripts/run_tests.sh tests/test_protonpass_secrets.py

# Run Bitwarden + env_loader non-regression
scripts/run_tests.sh tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py
```

## Platforms tested

- Linux (Ubuntu 22.04, x86_64)

## Test coverage

| File | Tests | Status |
|---|---|---|
| `tests/test_protonpass_secrets.py` | 50 | All passing |
| `tests/test_bitwarden_secrets.py` | 36 | Non-regression, all passing |
| `tests/test_env_loader_secret_sources.py` | 8 | Non-regression, all passing |

### What the 50 tests cover

- **Binary discovery** (5): managed copy, system PATH, not found, install on demand, install failure
- **Env name validation** (8): valid/invalid names via parametrize
- **Fetch flow** (8): happy path, skip invalid names, empty vault, auth failure, timeout, non-JSON, cache hit, cache disabled
- **Subprocess env** (2): env vars set correctly, agent reason set
- **Apply flow** (6): disabled, missing token, missing vault, skip existing, override existing, bootstrap token protection
- **Disk cache** (3): roundtrip, expired, wrong key
- **View field parsing** (5): dict with value, dict with password key, custom field name, plain string, failure
- **Edge cases** (4): empty password, duplicate titles, Windows install guard, empty token/vault
- **Login flow** (2): skip when already logged, login when needed
- **Full flow** (1): login required then list + view
- **env_loader integration** (2): protonpass source label, BW+PP coexistence
- **Non-regression** (4): Bitwarden import unchanged, Bitwarden apply disabled

## References

- Proton Pass AI Access Tokens: https://proton.me/blog/pass-access-tokens
- Proton Pass support doc: https://proton.me/support/pass-access-tokens
- Proton Pass CLI docs: https://protonpass.github.io/pass-cli/
- Proton Pass CLI repo: https://github.com/protonpass/pass-cli
- Agent command docs (audit logging): https://protonpass.github.io/pass-cli/commands/agent/