### PR TITLE
fix: register shell hooks in TUI gateway

### DIFF
--- a/tests/test_tui_gateway_entry_hooks.py
+++ b/tests/test_tui_gateway_entry_hooks.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from tui_gateway import entry
+
+
+def test_prepare_tui_gateway_hooks_registers_shell_hooks(monkeypatch):
+    calls = []
+
+    def fake_discover_plugins():
+        calls.append(("discover_plugins",))
+
+    def fake_load_config():
+        calls.append(("load_config",))
+        return {"hooks": {"post_llm_call": [{"command": "echo {}", "timeout": 5}]}}
+
+    def fake_register_from_config(cfg, *, accept_hooks=False):
+        calls.append(("register_from_config", cfg, accept_hooks))
+
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", fake_discover_plugins)
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr(
+        "agent.shell_hooks.register_from_config",
+        fake_register_from_config,
+    )
+
+    entry._prepare_tui_gateway_hooks()
+
+    assert calls == [
+        ("discover_plugins",),
+        ("load_config",),
+        (
+            "register_from_config",
+            {"hooks": {"post_llm_call": [{"command": "echo {}", "timeout": 5}]}},
+            False,
+        ),
+    ]
+
+
+def test_main_prepares_hooks_before_gateway_ready(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(
+        entry,
+        "_install_sidecar_publisher",
+        lambda: events.append("sidecar"),
+    )
+    monkeypatch.setattr(
+        entry,
+        "_prepare_tui_gateway_hooks",
+        lambda: events.append("hooks"),
+    )
+    monkeypatch.setattr(entry, "resolve_skin", lambda: "default")
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {"mcp_servers": {}},
+    )
+    monkeypatch.setattr(
+        entry,
+        "_log_exit",
+        lambda reason: events.append(("exit", reason)),
+    )
+
+    def fake_write_json(payload):
+        events.append(("write_json", payload["params"]["type"]))
+        return False
+
+    monkeypatch.setattr(entry, "write_json", fake_write_json)
+
+    with pytest.raises(SystemExit):
+        entry.main()
+
+    assert events[:3] == [
+        "sidecar",
+        "hooks",
+        ("write_json", "gateway.ready"),
+    ]

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -184,8 +184,32 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
+def _prepare_tui_gateway_hooks() -> None:
+    """Register plugins and declarative shell hooks in the TUI gateway process.
+
+    The outer ``hermes --tui`` launcher is a different Python process from this
+    gateway subprocess.  Agent turns run here, so conversation hooks such as
+    ``post_llm_call`` must be registered here as well; registering them only in
+    the launcher leaves TUI responses with an empty hook manager.
+    """
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        pass
+
+
 def main():
     _install_sidecar_publisher()
+    _prepare_tui_gateway_hooks()
 
     # MCP tool discovery — inline is safe here: TUI entry is a plain
     # sync loop with no asyncio event loop to block.  Previously ran as


### PR DESCRIPTION
## Summary

Register declarative shell hooks inside the TUI gateway subprocess.

The outer `hermes --tui` launcher and the actual TUI gateway are separate Python processes. Agent turns in the TUI are handled by `python -m tui_gateway.entry`, so conversation hooks such as `post_llm_call` need to be registered in that process as well.

Before this change, `hermes hooks test post_llm_call` could succeed while real TUI responses did not fire the same hook, because the test command registered hooks in its own process but the TUI gateway hook manager remained empty.

## Why

This fixes a TUI-specific process-boundary bug:

- CLI / hook-test paths can register and invoke shell hooks successfully.
- TUI response generation runs in `tui_gateway.entry`.
- Without registering hooks in that subprocess, `post_llm_call` and similar lifecycle hooks do not fire after real TUI responses.

One visible symptom is that the existing cmux integration hook:

```bash
cmux hooks hermes-agent agent-response
```

can work under `hermes hooks test post_llm_call` but fail to run after an actual TUI assistant response.

## Changes

- Add `_prepare_tui_gateway_hooks()` to `tui_gateway/entry.py`.
- Call it during TUI gateway startup before emitting `gateway.ready`.
- Keep failures best-effort/non-fatal, matching existing gateway startup behavior.
- Add regression tests covering TUI gateway shell hook registration and startup ordering.

## Test Plan

- [x] `./venv/bin/python -m py_compile tui_gateway/entry.py`
- [x] `./venv/bin/python -m pytest tests/test_tui_gateway_entry_hooks.py tests/agent/test_shell_hooks.py tests/agent/test_shell_hooks_consent.py -q -o 'addopts='`
- [x] Manually verified with the existing cmux integration hook that `post_llm_call` now fires after real TUI assistant responses once the TUI is restarted.
