### PR TITLE
fix(docker): validate HERMES_UID/GID to prevent privilege escalation in stage2-hook

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -32,12 +32,19 @@ INSTALL_DIR="/opt/hermes"
 # is a no-op if the dir already exists. (#18482, salvages #18488)
 mkdir -p "$HERMES_HOME"
 
+# Numeric UID/GID validation: must be digits only, 1000-65534
+validate_uid_gid() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) [ "$1" -ge 1000 ] && [ "$1" -le 65534 ] ;;
+    esac
+}
 # --- UID/GID remap ---
-if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "$(id -u hermes)" ]; then
+if [ -n "${HERMES_UID:-}" ] && validate_uid_gid "$HERMES_UID" && [ "$HERMES_UID" != "$(id -u hermes)" ]; then
     echo "[stage2] Changing hermes UID to $HERMES_UID"
     usermod -u "$HERMES_UID" hermes
 fi
-if [ -n "${HERMES_GID:-}" ] && [ "$HERMES_GID" != "$(id -g hermes)" ]; then
+if [ -n "${HERMES_GID:-}" ] && validate_uid_gid "$HERMES_GID" && [ "$HERMES_GID" != "$(id -g hermes)" ]; then
     echo "[stage2] Changing hermes GID to $HERMES_GID"
     # -o allows non-unique GID (e.g. macOS GID 20 "staff" may already
     # exist as "dialout" in the Debian-based container image).


### PR DESCRIPTION
## What does this PR do?
Adds numeric validation for `HERMES_UID` and `HERMES_GID` environment variables before passing them to `usermod`/`groupmod` in `docker/stage2-hook.sh`.

## Type of Change
- [x] Bug fix

## Changes Made
- Added `validate_uid_gid()` helper function: rejects non-numeric values and enforces range 1000–65534
- Wrapped both `HERMES_UID` and `HERMES_GID` conditions with the validator
- Prevents `HERMES_UID=0` or `HERMES_GID=0` from silently granting root-level privileges to the hermes user

## How to Test
- Set `HERMES_UID=0` → usermod should NOT fire
- Set `HERMES_UID=999` → usermod should NOT fire  
- Set `HERMES_UID=1001` → usermod fires normally
- Set `HERMES_GID=0` → groupmod should NOT fire

## Checklist
- [x] Single focused commit
- [x] No secrets or API keys
- [x] Existing UID remap behavior preserved for valid values (1000–65534)