### PR TITLE
fix(auth): share Codex OAuth pool across profiles

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -60,6 +60,7 @@ AUTH_TYPE_OAUTH = "oauth"
 AUTH_TYPE_API_KEY = "api_key"
 
 SOURCE_MANUAL = "manual"
+CODEX_SHARED_POOL_SOURCES = {"device_code", "manual:device_code"}
 
 STRATEGY_FILL_FIRST = "fill_first"
 STRATEGY_ROUND_ROBIN = "round_robin"
@@ -496,7 +497,7 @@ class CredentialPool:
         return entry
 
     def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
-        """Sync a Codex device_code pool entry from auth.json if tokens differ.
+        """Sync a Codex device-code-backed pool entry from auth.json if tokens differ.
 
         When a Codex OAuth access token expires (or the ChatGPT account hits
         its 5h/weekly quota), the pool entry gets marked ``STATUS_EXHAUSTED``
@@ -508,13 +509,53 @@ class CredentialPool:
         though fresh credentials are sitting on disk — and every request
         fails with "no available entries (all exhausted or empty)".
 
-        Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
-        auth.json shadow to sync from.
+        In profile mode, ``credential_pool.openai-codex`` is shared from the
+        global-root auth store because Codex refresh tokens are single-use.
+        Prefer that shared pool copy, then fall back to the singleton provider
+        state for legacy stores that have not materialised a pool entry yet.
         """
-        if self.provider != "openai-codex" or entry.source != "device_code":
+        if (
+            self.provider != "openai-codex"
+            or entry.auth_type != AUTH_TYPE_OAUTH
+            or entry.source not in CODEX_SHARED_POOL_SOURCES
+        ):
             return entry
         try:
+            shared_entries = read_credential_pool("openai-codex")
+            shared_payload = None
+            for payload in shared_entries:
+                if not isinstance(payload, dict):
+                    continue
+                if payload.get("id") == entry.id:
+                    shared_payload = payload
+                    break
+            if shared_payload is None:
+                for payload in shared_entries:
+                    if not isinstance(payload, dict):
+                        continue
+                    if payload.get("source") == entry.source:
+                        shared_payload = payload
+                        break
+            if isinstance(shared_payload, dict):
+                shared_entry = PooledCredential.from_dict("openai-codex", shared_payload)
+                if shared_entry.access_token and (
+                    shared_entry.access_token != (entry.access_token or "")
+                    or (
+                        shared_entry.refresh_token
+                        and shared_entry.refresh_token != (entry.refresh_token or "")
+                    )
+                    or shared_entry.last_status != entry.last_status
+                    or shared_entry.last_error_code != entry.last_error_code
+                    or shared_entry.last_error_reset_at != entry.last_error_reset_at
+                ):
+                    logger.debug(
+                        "Pool entry %s: syncing Codex tokens from shared credential pool",
+                        entry.id,
+                    )
+                    self._replace_entry(entry, shared_entry)
+                    return shared_entry
+            if entry.source != "device_code":
+                return entry
             with _auth_store_lock():
                 auth_store = _load_auth_store()
                 state = _load_provider_state(auth_store, "openai-codex")
@@ -818,6 +859,8 @@ class CredentialPool:
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
+                    if not self._entry_needs_refresh(entry):
+                        return entry
                 refreshed = auth_mod.refresh_codex_oauth_pure(
                     entry.access_token,
                     entry.refresh_token,
@@ -978,7 +1021,14 @@ class CredentialPool:
             # if they have rotated since.
             if self.provider == "openai-codex":
                 synced = self._sync_codex_entry_from_auth_store(entry)
-                if synced.refresh_token != entry.refresh_token:
+                if (
+                    synced is not entry
+                    and (
+                        synced.refresh_token != entry.refresh_token
+                        or synced.access_token != entry.access_token
+                        or not self._entry_needs_refresh(synced)
+                    )
+                ):
                     logger.debug(
                         "Codex OAuth refresh failed but auth.json has newer tokens — adopting"
                     )
@@ -1180,14 +1230,12 @@ class CredentialPool:
                 if synced is not entry:
                     entry = synced
                     cleared_any = True
-            # For openai-codex entries, same pattern: the user may have
-            # re-authed via `hermes model` / `hermes auth` after a 429/401,
-            # leaving fresh tokens on disk while the pool entry is still
-            # frozen behind last_error_reset_at (can be hours in the
-            # future for ChatGPT weekly windows).
+            # For openai-codex entries, sync before status checks even when
+            # they are not exhausted yet. In profile mode the global-root pool
+            # is the single source of truth for single-use refresh tokens.
             if (self.provider == "openai-codex"
-                    and entry.source == "device_code"
-                    and entry.last_status == STATUS_EXHAUSTED):
+                    and entry.auth_type == AUTH_TYPE_OAUTH
+                    and entry.source in CODEX_SHARED_POOL_SOURCES):
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -113,6 +113,7 @@ STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+SHARED_CREDENTIAL_POOL_PROVIDERS = frozenset({"openai-codex"})
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
@@ -869,15 +870,19 @@ def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any
 # Auth Store — persistence layer for ~/.hermes/auth.json
 # =============================================================================
 
-def _auth_file_path() -> Path:
-    path = get_hermes_home() / "auth.json"
+def _assert_test_safe_auth_path(path: Path) -> Path:
     # Seat belt: if pytest is running and HERMES_HOME resolves to the real
     # user's auth store, refuse rather than silently corrupt it. This catches
     # tests that forgot to monkeypatch HERMES_HOME, tests invoked without the
     # hermetic conftest, or sandbox escapes via threads/subprocesses. In
     # production (no PYTEST_CURRENT_TEST) this is a single dict lookup.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_auth = (Path.home() / ".hermes" / "auth.json").resolve(strict=False)
+        real_home_env = os.environ.get("HOME", "")
+        real_home_auth = (
+            Path(real_home_env) / ".hermes" / "auth.json"
+            if real_home_env
+            else Path.home() / ".hermes" / "auth.json"
+        ).resolve(strict=False)
         try:
             resolved = path.resolve(strict=False)
         except Exception:
@@ -889,6 +894,10 @@ def _auth_file_path() -> Path:
                 "via scripts/run_tests.sh for hermetic CI-parity env."
             )
     return path
+
+
+def _auth_file_path() -> Path:
+    return _assert_test_safe_auth_path(get_hermes_home() / "auth.json")
 
 
 def _global_auth_file_path() -> Optional[Path]:
@@ -963,6 +972,7 @@ def _auth_lock_path() -> Path:
 
 
 _auth_lock_holder = threading.local()
+_global_auth_lock_holder = threading.local()
 
 
 @contextmanager
@@ -1056,6 +1066,24 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         yield
 
 
+@contextmanager
+def _global_auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Cross-process lock for global-root auth.json writes in profile mode."""
+    global_auth_file = _global_auth_file_path()
+    if global_auth_file is None:
+        with _auth_store_lock(timeout_seconds=timeout_seconds):
+            yield
+        return
+    global_auth_file = _assert_test_safe_auth_path(global_auth_file)
+    with _file_lock(
+        global_auth_file.with_suffix(".lock"),
+        _global_auth_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for global auth store lock",
+    ):
+        yield
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
@@ -1096,8 +1124,8 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
 
-def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
-    auth_file = _auth_file_path()
+def _save_auth_store(auth_store: Dict[str, Any], auth_file: Optional[Path] = None) -> Path:
+    auth_file = _assert_test_safe_auth_path(auth_file or _auth_file_path())
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
@@ -1214,18 +1242,14 @@ def get_auth_provider_display_name(provider_id: str) -> str:
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
-    In profile mode, the profile's credential pool is authoritative. If a
-    provider has no entries in the profile, entries from the global-root
-    ``auth.json`` are used as a read-only fallback — so workers spawned in a
-    profile can see providers that were only authenticated at global scope.
+    In profile mode, most providers keep profile-local pools and use the
+    global-root ``auth.json`` as a read-only fallback only when the profile has
+    no entries. Providers in ``SHARED_CREDENTIAL_POOL_PROVIDERS`` use the
+    global-root pool first because their OAuth refresh tokens are single-use
+    and cannot be safely duplicated across profile-local pools.
 
-    Profile entries always win: the global fallback only applies per-provider
-    when the profile has zero entries for that provider. Once the user runs
-    ``hermes auth add <provider>`` inside the profile, profile entries
-    fully shadow global for that provider on the next read.
-
-    Writes always go to the profile (``write_credential_pool`` is unchanged).
-    See issue #18594 follow-up.
+    Writes for shared providers go to the global-root auth store in profile
+    mode. Writes for all other providers remain profile-local.
     """
     auth_store = _load_auth_store()
     pool = auth_store.get("credential_pool")
@@ -1243,12 +1267,20 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
         for gp_key, gp_entries in global_pool.items():
             if not isinstance(gp_entries, list) or not gp_entries:
                 continue
+            if gp_key in SHARED_CREDENTIAL_POOL_PROVIDERS:
+                merged[gp_key] = list(gp_entries)
+                continue
             # Per-provider shadowing: profile wins whenever it has ANY entries.
             existing = merged.get(gp_key)
             if isinstance(existing, list) and existing:
                 continue
             merged[gp_key] = list(gp_entries)
         return merged
+
+    if provider_id in SHARED_CREDENTIAL_POOL_PROVIDERS:
+        global_entries = global_pool.get(provider_id)
+        if isinstance(global_entries, list) and global_entries:
+            return list(global_entries)
 
     provider_entries = pool.get(provider_id)
     if isinstance(provider_entries, list) and provider_entries:
@@ -1265,8 +1297,14 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
     credentials. Callers may pass raw dictionaries, so sanitize here even when
     ``PooledCredential.to_dict()`` already did the same work upstream.
     """
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    shared_auth_file = (
+        _global_auth_file_path()
+        if provider_id in SHARED_CREDENTIAL_POOL_PROVIDERS
+        else None
+    )
+    lock = _global_auth_store_lock if shared_auth_file is not None else _auth_store_lock
+    with lock():
+        auth_store = _load_auth_store(shared_auth_file)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1276,7 +1314,7 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
             if isinstance(entry, dict) else entry
             for entry in entries
         ]
-        return _save_auth_store(auth_store)
+        return _save_auth_store(auth_store, auth_file=shared_auth_file)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:
@@ -3378,10 +3416,78 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
+def _clone_pool_entries(entries: Any) -> List[Any]:
+    if not isinstance(entries, list):
+        return []
+    return [dict(entry) if isinstance(entry, dict) else entry for entry in entries]
+
+
+def _append_codex_device_code_pool_entry(
+    entries: List[Any],
+    tokens: Dict[str, str],
+    last_refresh: Optional[str],
+) -> None:
+    access_token = tokens.get("access_token")
+    if not access_token:
+        return
+    entry = {
+        "id": uuid.uuid4().hex[:6],
+        "source": "device_code",
+        "auth_type": "oauth",
+        "priority": 0,
+        "label": "device_code",
+        "access_token": access_token,
+        "base_url": DEFAULT_CODEX_BASE_URL,
+        "last_status": None,
+        "last_status_at": None,
+        "last_error_code": None,
+        "last_error_reason": None,
+        "last_error_message": None,
+        "last_error_reset_at": None,
+    }
+    refresh_token = tokens.get("refresh_token")
+    if refresh_token:
+        entry["refresh_token"] = refresh_token
+    if last_refresh:
+        entry["last_refresh"] = last_refresh
+    entries.append(entry)
+
+
+def _sync_shared_codex_pool_entries(
+    tokens: Dict[str, str],
+    last_refresh: Optional[str],
+    profile_entries: List[Any],
+) -> None:
+    """Mirror Codex device-code entries into the global-root pool in profile mode."""
+    global_auth_file = _global_auth_file_path()
+    if global_auth_file is None:
+        return
+    with _global_auth_store_lock():
+        auth_store = _load_auth_store(global_auth_file)
+        pool = auth_store.get("credential_pool")
+        if not isinstance(pool, dict):
+            pool = {}
+            auth_store["credential_pool"] = pool
+        if not isinstance(pool.get("openai-codex"), list) and profile_entries:
+            pool["openai-codex"] = _clone_pool_entries(profile_entries)
+        _sync_codex_pool_entries(auth_store, tokens, last_refresh)
+        entries = pool.get("openai-codex")
+        if not isinstance(entries, list):
+            entries = []
+            pool["openai-codex"] = entries
+        if (
+            not any(isinstance(entry, dict) and entry.get("source") == "device_code" for entry in entries)
+            and not is_source_suppressed("openai-codex", "device_code")
+        ):
+            _append_codex_device_code_pool_entry(entries, tokens, last_refresh)
+        _save_auth_store(auth_store, auth_file=global_auth_file)
+
+
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    profile_entries: List[Any] = []
     with _auth_store_lock():
         auth_store = _load_auth_store()
         state = _load_provider_state(auth_store, "openai-codex") or {}
@@ -3390,7 +3496,11 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         state["auth_mode"] = "chatgpt"
         _save_provider_state(auth_store, "openai-codex", state)
         _sync_codex_pool_entries(auth_store, tokens, last_refresh)
+        profile_entries = _clone_pool_entries(
+            (auth_store.get("credential_pool") or {}).get("openai-codex")
+        )
         _save_auth_store(auth_store)
+    _sync_shared_codex_pool_entries(tokens, last_refresh, profile_entries)
 
 
 def refresh_codex_oauth_pure(
@@ -3653,21 +3763,15 @@ def _pool_codex_access_token() -> str:
     """Return the most-recent usable access_token from the openai-codex pool.
 
     Used as a fallback by ``resolve_codex_runtime_credentials`` when the
-    singleton has no creds.  Reads ``credential_pool.openai-codex`` entries
-    directly from auth.json and picks the first non-empty access_token,
+    singleton has no creds.  Reads ``credential_pool.openai-codex`` through
+    ``read_credential_pool`` so profile-mode workers use the shared global
+    Codex pool, then picks the first non-empty access_token,
     preferring entries that are not currently in an exhaustion cooldown.
     Returns ``""`` when no usable entry is found (caller handles by raising
     the original AuthError).
     """
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return ""
-        entries = pool.get("openai-codex")
-        if not isinstance(entries, list):
-            return ""
+        entries = read_credential_pool("openai-codex")
 
         def _entry_usable(entry: Dict[str, Any]) -> bool:
             if not isinstance(entry, dict):

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -6,12 +6,18 @@ import base64
 import json
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
 
 def _write_auth_store(tmp_path, payload: dict) -> None:
     hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+
+
+def _write_auth_store_at(hermes_home, payload: dict) -> None:
     hermes_home.mkdir(parents=True, exist_ok=True)
     (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
 
@@ -2207,6 +2213,65 @@ def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
 
     synced = pool._sync_codex_entry_from_auth_store(entry)
     assert synced is entry
+
+
+def test_sync_codex_manual_device_code_entry_from_shared_profile_pool(tmp_path, monkeypatch):
+    """Profile workers should adopt fresh Codex OAuth tokens from the shared root pool."""
+    root_home = tmp_path / ".hermes"
+    profile_home = root_home / "profiles" / "worker"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _write_auth_store_at(root_home, {
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "manual-device",
+                    "source": "manual:device_code",
+                    "auth_type": "oauth",
+                    "access_token": "old-at",
+                    "refresh_token": "old-rt",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                    "last_error_reset_at": time.time() + 3600,
+                },
+            ],
+        },
+    })
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is None
+    entry = pool._entries[0]
+
+    _write_auth_store_at(root_home, {
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "manual-device",
+                    "source": "manual:device_code",
+                    "auth_type": "oauth",
+                    "access_token": "fresh-at",
+                    "refresh_token": "fresh-rt",
+                    "last_status": None,
+                    "last_error_code": None,
+                    "last_error_reset_at": None,
+                },
+            ],
+        },
+    })
+
+    synced = pool._sync_codex_entry_from_auth_store(entry)
+    assert synced is not entry
+    assert synced.access_token == "fresh-at"
+    assert synced.refresh_token == "fresh-rt"
+    assert synced.last_status is None
+    assert synced.last_error_code is None
+    assert synced.last_error_reset_at is None
 
 
 def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -385,6 +385,136 @@ def test_save_codex_tokens_syncs_manual_device_code_entries(tmp_path, monkeypatc
     assert "refresh_token" not in api_key or api_key.get("refresh_token") is None
 
 
+def test_codex_pool_reads_global_root_in_profile_mode(tmp_path, monkeypatch):
+    root_home = tmp_path / ".hermes"
+    profile_home = root_home / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    root_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    (root_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "shared",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "root-at",
+                    "refresh_token": "root-rt",
+                },
+            ],
+        },
+    }))
+    (profile_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "shared",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "profile-at",
+                    "refresh_token": "profile-rt",
+                },
+            ],
+        },
+    }))
+
+    from hermes_cli.auth import read_credential_pool
+
+    entries = read_credential_pool("openai-codex")
+    assert entries[0]["access_token"] == "root-at"
+    assert read_credential_pool(None)["openai-codex"][0]["refresh_token"] == "root-rt"
+
+
+def test_codex_pool_writes_global_root_in_profile_mode(tmp_path, monkeypatch):
+    root_home = tmp_path / ".hermes"
+    profile_home = root_home / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    root_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    from hermes_cli.auth import write_credential_pool
+
+    write_credential_pool("openai-codex", [
+        {
+            "id": "shared",
+            "source": "device_code",
+            "auth_type": "oauth",
+            "access_token": "root-at",
+            "refresh_token": "root-rt",
+        }
+    ])
+
+    root_auth = json.loads((root_home / "auth.json").read_text())
+    assert root_auth["credential_pool"]["openai-codex"][0]["access_token"] == "root-at"
+    assert not (profile_home / "auth.json").exists()
+
+
+def test_save_codex_tokens_syncs_global_pool_in_profile_mode(tmp_path, monkeypatch):
+    root_home = tmp_path / ".hermes"
+    profile_home = root_home / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    root_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    (root_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "seeded",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "old-at",
+                    "refresh_token": "old-rt",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                },
+                {
+                    "id": "manual-device",
+                    "source": "manual:device_code",
+                    "auth_type": "oauth",
+                    "access_token": "old-manual-at",
+                    "refresh_token": "old-manual-rt",
+                },
+                {
+                    "id": "api-key",
+                    "source": "manual:api_key",
+                    "auth_type": "api_key",
+                    "access_token": "user-api-key",
+                },
+            ],
+        },
+    }))
+
+    _save_codex_tokens(
+        {"access_token": "fresh-at", "refresh_token": "fresh-rt"},
+        last_refresh="2026-05-28T00:00:00Z",
+    )
+
+    root_auth = json.loads((root_home / "auth.json").read_text())
+    root_pool = root_auth["credential_pool"]["openai-codex"]
+    seeded = next(entry for entry in root_pool if entry["id"] == "seeded")
+    manual_device = next(entry for entry in root_pool if entry["id"] == "manual-device")
+    api_key = next(entry for entry in root_pool if entry["id"] == "api-key")
+
+    assert seeded["access_token"] == "fresh-at"
+    assert seeded["refresh_token"] == "fresh-rt"
+    assert seeded["last_status"] is None
+    assert seeded["last_error_code"] is None
+    assert manual_device["access_token"] == "fresh-at"
+    assert manual_device["refresh_token"] == "fresh-rt"
+    assert api_key["access_token"] == "user-api-key"
+
+    profile_auth = json.loads((profile_home / "auth.json").read_text())
+    assert profile_auth["providers"]["openai-codex"]["tokens"]["access_token"] == "fresh-at"
+
+
 def test_import_codex_cli_tokens(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-cli"
     codex_home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Share `openai-codex` credential-pool entries from the global root auth store in profile mode.
- Persist profile-mode Codex pool writes to the shared root store while leaving other providers profile-local.
- Sync device-code-backed Codex pool entries from the shared pool before status and refresh decisions.
- Preserve independent manual API-key entries when Codex OAuth tokens rotate.

## Why
Codex OAuth refresh tokens are single-use. If profile-local pools keep separate copies, one profile can refresh and rotate the token while another profile keeps using a stale refresh token. Sharing the Codex pool in profile mode gives workers one source of truth for the active token pair.

## Tests
- `scripts/run_tests.sh -j 2 tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py -- -q`
- `scripts/run_tests.sh -j 2 tests/hermes_cli/test_auth_commands.py -- -q -k 'codex or credential_pool or write_credential_pool'`
- `.venv/bin/python -m py_compile hermes_cli/auth.py agent/credential_pool.py`
- `git diff --check`
