### PR TITLE
Fix gateway runtime hygiene regressions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -66,9 +66,16 @@ def _find_git_root(start: Path) -> Optional[Path]:
     Returns the directory containing ``.git``, or ``None`` if we hit the
     filesystem root without finding one.
     """
-    current = start.resolve()
+    try:
+        current = start.resolve()
+    except OSError:
+        current = start.absolute()
     for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
+        try:
+            has_git_marker = (parent / ".git").exists()
+        except OSError:
+            continue
+        if has_git_marker:
             return parent
     return None
 
@@ -84,12 +91,19 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     ``None`` if nothing is found.
     """
     stop_at = _find_git_root(cwd)
-    current = cwd.resolve()
+    try:
+        current = cwd.resolve()
+    except OSError:
+        current = cwd.absolute()
 
     for directory in [current, *current.parents]:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
-            if candidate.is_file():
+            try:
+                is_context_file = candidate.is_file()
+            except OSError:
+                continue
+            if is_context_file:
                 return candidate
         # Stop walking at the git root (or filesystem root).
         if stop_at and directory == stop_at:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -83,6 +83,24 @@ def _find_git_root(start: Path) -> Optional[Path]:
 _HERMES_MD_NAMES = (".hermes.md", "HERMES.md")
 
 
+def _safe_is_file(path: Path) -> bool:
+    """Return whether *path* is a file without surfacing cwd permission errors."""
+    try:
+        return path.is_file()
+    except OSError as e:
+        logger.debug("Could not stat context file %s: %s", path, e)
+        return False
+
+
+def _safe_is_dir(path: Path) -> bool:
+    """Return whether *path* is a directory without surfacing cwd permission errors."""
+    try:
+        return path.is_dir()
+    except OSError as e:
+        logger.debug("Could not stat context directory %s: %s", path, e)
+        return False
+
+
 def _find_hermes_md(cwd: Path) -> Optional[Path]:
     """Discover the nearest ``.hermes.md`` or ``HERMES.md``.
 
@@ -1365,7 +1383,7 @@ def _load_agents_md(cwd_path: Path) -> str:
     """AGENTS.md — top-level only (no recursive walk)."""
     for name in ["AGENTS.md", "agents.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
+        if _safe_is_file(candidate):
             try:
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
@@ -1381,7 +1399,7 @@ def _load_claude_md(cwd_path: Path) -> str:
     """CLAUDE.md / claude.md — cwd only."""
     for name in ["CLAUDE.md", "claude.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
+        if _safe_is_file(candidate):
             try:
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
@@ -1397,7 +1415,7 @@ def _load_cursorrules(cwd_path: Path) -> str:
     """.cursorrules + .cursor/rules/*.mdc — cwd only."""
     cursorrules_content = ""
     cursorrules_file = cwd_path / ".cursorrules"
-    if cursorrules_file.exists():
+    if _safe_is_file(cursorrules_file):
         try:
             content = cursorrules_file.read_text(encoding="utf-8").strip()
             if content:
@@ -1407,8 +1425,12 @@ def _load_cursorrules(cwd_path: Path) -> str:
             logger.debug("Could not read .cursorrules: %s", e)
 
     cursor_rules_dir = cwd_path / ".cursor" / "rules"
-    if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
-        mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
+    if _safe_is_dir(cursor_rules_dir):
+        try:
+            mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
+        except OSError as e:
+            logger.debug("Could not list cursor rules in %s: %s", cursor_rules_dir, e)
+            mdc_files = []
         for mdc_file in mdc_files:
             try:
                 content = mdc_file.read_text(encoding="utf-8").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1560,6 +1560,26 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+def _coerce_agent_result(agent_result: object, *, history_len: int = 0) -> dict:
+    """Return a dict-shaped agent result even when a lower layer violates the contract."""
+    if isinstance(agent_result, dict):
+        return agent_result
+
+    result_type = type(agent_result).__name__
+    response = "" if agent_result is None else str(agent_result)
+    return {
+        "final_response": response,
+        "messages": [],
+        "tools": [],
+        "history_offset": history_len,
+        "api_calls": 0,
+        "last_prompt_tokens": 0,
+        "failed": True,
+        "completed": False,
+        "error": f"agent returned non-dict result ({result_type})",
+    }
+
+
 def _normalize_empty_agent_response(
     agent_result: dict,
     response: str,
@@ -8802,6 +8822,13 @@ class GatewayRunner:
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
             )
+            if not isinstance(agent_result, dict):
+                logger.warning(
+                    "Agent returned non-dict result in session %s: %s; coercing to failure result",
+                    session_entry.session_id,
+                    type(agent_result).__name__,
+                )
+                agent_result = _coerce_agent_result(agent_result, history_len=len(history))
 
             # Stop persistent typing indicator now that the agent is done
             try:

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -62,6 +62,17 @@ def _record_track(task_id: str, session_id: str, path: Path, category: str) -> N
         _recent_test_tracks.setdefault(key, set()).add(str(path))
 
 
+def _is_single_line_path_candidate(path_str: str) -> bool:
+    """Return True for path-like strings that cannot contain copied shell output."""
+    return bool(
+        path_str
+        and "\n" not in path_str
+        and "\r" not in path_str
+        and "\\n" not in path_str
+        and "\\r" not in path_str
+    )
+
+
 def _drain(task_id: str, session_id: str) -> Set[str]:
     """Pop the set of test paths tracked during this turn."""
     key = _tracker_key(task_id, session_id)
@@ -71,23 +82,31 @@ def _drain(task_id: str, session_id: str) -> Set[str]:
 
 def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
     """Best-effort auto-track. Never raises."""
+    if not _is_single_line_path_candidate(path_str):
+        return
     try:
         p = Path(path_str).expanduser()
     except Exception:
         return
-    if not p.exists():
+    try:
+        if not p.is_absolute() or not dg.is_safe_path(p) or not p.exists():
+            return
+    except OSError:
         return
     category = dg.guess_category(p)
     if category is None:
         return
-    newly = dg.track(str(p), category, silent=True)
+    try:
+        newly = dg.track(str(p), category, silent=True)
+    except OSError:
+        return
     if newly:
         _record_track(task_id, session_id, p, category)
 
 
 def _extract_paths_from_write_file(args: Dict[str, Any]) -> Set[str]:
     path = args.get(_WRITE_FILE_PATH_KEY)
-    return {path} if isinstance(path, str) and path else set()
+    return {path} if isinstance(path, str) and _is_single_line_path_candidate(path) else set()
 
 
 def _extract_paths_from_patch(args: Dict[str, Any]) -> Set[str]:
@@ -97,7 +116,7 @@ def _extract_paths_from_patch(args: Dict[str, Any]) -> Set[str]:
     # the single-file `path` arg.  Track-then-cleanup is idempotent, so
     # re-tracking an already-tracked file is a no-op (dedup in track()).
     path = args.get("path")
-    return {path} if isinstance(path, str) and path else set()
+    return {path} if isinstance(path, str) and _is_single_line_path_candidate(path) else set()
 
 
 def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
@@ -110,14 +129,15 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
         # Tokenise the command — catches `touch /tmp/hermes-x/test_foo.py`
         try:
             for tok in shlex.split(cmd, posix=True):
-                if tok.startswith(("/", "~")):
+                if tok.startswith(("/", "~")) and _is_single_line_path_candidate(tok):
                     paths.add(tok)
         except ValueError:
             pass
     # Only scan the result text if it's a reasonable size (avoid 50KB dumps).
     if isinstance(result, str) and len(result) < 4096:
         for match in _TERMINAL_PATH_REGEX.findall(result):
-            paths.add(match)
+            if _is_single_line_path_candidate(match):
+                paths.add(match)
     return paths
 
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -163,9 +163,18 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         _log(f"WARN: unknown category '{category}', using 'other'")
         category = "other"
 
-    path = Path(path_str).resolve()
+    try:
+        path = Path(path_str).expanduser().resolve()
+    except OSError as exc:
+        _log(f"SKIP: {path_str} ({exc.__class__.__name__})")
+        return False
 
-    if not path.exists():
+    try:
+        exists = path.exists()
+    except OSError as exc:
+        _log(f"SKIP: {path} ({exc.__class__.__name__})")
+        return False
+    if not exists:
         _log(f"SKIP: {path} (does not exist)")
         return False
 
@@ -173,7 +182,11 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         _log(f"REJECT: {path} (outside HERMES_HOME)")
         return False
 
-    size = path.stat().st_size if path.is_file() else 0
+    try:
+        size = path.stat().st_size if path.is_file() else 0
+    except OSError as exc:
+        _log(f"SKIP: {path} ({exc.__class__.__name__})")
+        return False
     tracked = load_tracked()
 
     # Deduplicate

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -753,6 +754,18 @@ class TestFindGitRoot:
         if result is not None:
             assert (result / ".git").exists()
 
+    def test_skips_inaccessible_git_marker(self, tmp_path, monkeypatch):
+        real_exists = Path.exists
+
+        def fake_exists(path):
+            if path.name == ".git":
+                raise PermissionError("permission denied")
+            return real_exists(path)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+
+        assert _find_git_root(tmp_path) is None
+
 
 class TestStripYamlFrontmatter:
     def test_strips_frontmatter(self):
@@ -1192,6 +1205,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -508,6 +508,19 @@ class TestBuildContextFilesPrompt:
         assert "Ruff for linting" in result
         assert "Project Context" in result
 
+    def test_skips_inaccessible_context_file_candidates(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        (tmp_path / "hermes_home").mkdir()
+
+        def fake_is_file(path):
+            if path.name == "AGENTS.md":
+                raise PermissionError("blocked")
+            return False
+
+        monkeypatch.setattr(Path, "is_file", fake_is_file)
+
+        assert build_context_files_prompt(cwd=str(tmp_path), skip_soul=True) == ""
+
     def test_loads_cursorrules(self, tmp_path):
         (tmp_path / ".cursorrules").write_text("Always use type hints.")
         result = build_context_files_prompt(cwd=str(tmp_path))
@@ -1205,5 +1218,3 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -36,6 +36,7 @@ from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import (
     _auto_continue_freshness_window,
+    _coerce_agent_result,
     _coerce_gateway_timestamp,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
@@ -68,6 +69,16 @@ def test_resume_pending_is_cleared_only_after_successful_turn():
     assert _should_clear_resume_pending_after_turn({"failed": True}) is False
     assert _should_clear_resume_pending_after_turn({"partial": True}) is False
     assert _should_clear_resume_pending_after_turn({"error": "boom"}) is False
+
+
+def test_non_dict_agent_result_is_coerced_to_failed_result():
+    result = _coerce_agent_result("timeout fallback", history_len=3)
+
+    assert result["final_response"] == "timeout fallback"
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["history_offset"] == 3
+    assert "str" in result["error"]
 
 
 def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -373,6 +373,33 @@ async def test_first_run_non_slack_home_channel_onboarding_keeps_direct_command(
 
 
 @pytest.mark.asyncio
+async def test_handle_message_coerces_non_dict_agent_result(monkeypatch):
+    import gateway.run as gateway_run
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._run_agent = AsyncMock(return_value="timeout fallback")
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100000,
+    )
+
+    result = await runner._handle_message(_make_event("hello"))
+
+    assert result == "timeout fallback"
+    assert runner.session_store.append_to_transcript.called
+
+
+@pytest.mark.asyncio
 async def test_handle_message_discards_stale_result_after_session_invalidation(monkeypatch):
     import gateway.run as gateway_run
 

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -277,6 +277,19 @@ class TestPostToolCallHook:
         data = json.loads(tracked_file.read_text())
         assert any(Path(i["path"]) == p.resolve() for i in data)
 
+    def test_terminal_ignores_escaped_multiline_root_path(self, _isolate_env):
+        pi = _load_plugin_init()
+
+        pi._on_post_tool_call(
+            tool_name="terminal",
+            args={"command": "ssh host 'cd /root/LiveTalking'"},
+            result="Welcome\\n+ cd /root/LiveTalking\\n+ mkdir -p models",
+            task_id="t-root", session_id="s-root",
+        )
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+
     def test_ignores_unrelated_tool(self, _isolate_env):
         pi = _load_plugin_init()
         pi._on_post_tool_call(


### PR DESCRIPTION
Summary:
- coerce non-dict gateway agent results into failed dict-shaped results instead of letting downstream code crash
- harden disk-cleanup tracking against multiline/copied shell output and OSError path cases
- add focused regression coverage for gateway result coercion and disk-cleanup path parsing

Verification:
- venv/bin/python -m pytest -q tests/gateway/test_restart_resume_pending.py::test_non_dict_agent_result_is_coerced_to_failed_result tests/gateway/test_status_command.py::test_handle_message_coerces_non_dict_agent_result tests/plugins/test_disk_cleanup_plugin.py::TestPostToolCallHook::test_terminal_ignores_escaped_multiline_root_path
- venv/bin/python -m compileall -q gateway/run.py plugins/disk-cleanup/__init__.py plugins/disk-cleanup/disk_cleanup.py

Operational note:
- This was applied as a VPS hotfix after gateway update/restart regressions affected worker profiles. The runtime services have been restored separately with systemd Restart=always.
