### PR TITLE
Guard fallback status messages when no fallback exists

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1469,8 +1469,10 @@ def run_conversation(
                     agent._buffer_vprint(f"   ⏱️  {_failure_hint}")
                     
                     if retry_count >= max_retries:
-                        # Try fallback before giving up
-                        agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
+                        # Try fallback before giving up, but do not tell users
+                        # a fallback path exists when the chain is empty.
+                        if agent._fallback_index < len(agent._fallback_chain):
+                            agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
                         if agent._try_activate_fallback():
                             retry_count = 0
                             compression_attempts = 0
@@ -3074,10 +3076,11 @@ def run_conversation(
                 if is_client_error:
                     # Try fallback before aborting — a different provider
                     # may not have the same issue (rate limit, auth, etc.)
-                    if classified.reason == FailoverReason.content_policy_blocked:
-                        agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
-                    else:
-                        agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                    if agent._fallback_index < len(agent._fallback_chain):
+                        if classified.reason == FailoverReason.content_policy_blocked:
+                            agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
+                        else:
+                            agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -3219,8 +3222,10 @@ def run_conversation(
                         primary_recovery_attempted = True
                         retry_count = 0
                         continue
-                    # Try fallback before giving up entirely
-                    agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
+                    # Try fallback before giving up entirely, but do not tell
+                    # users a fallback path exists when the chain is empty.
+                    if agent._fallback_index < len(agent._fallback_chain):
+                        agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0

--- a/tests/run_agent/test_jsondecodeerror_retryable.py
+++ b/tests/run_agent/test_jsondecodeerror_retryable.py
@@ -154,3 +154,29 @@ class TestAgentLoopSourceHasNoneTypeCarveOut:
             "agent/conversation_loop.py must carve out 'NoneType is not iterable' "
             "TypeErrors from the is_local_validation_error classification — see #33136."
         )
+
+
+class TestAgentLoopFallbackStatusGuards:
+    """Do not advertise fallback recovery when no fallback provider exists."""
+
+    def test_trying_fallback_statuses_are_guarded_by_available_fallback_chain(self):
+        import inspect
+        from agent import conversation_loop
+
+        src = inspect.getsource(conversation_loop)
+        guarded_messages = [
+            "Max retries ({max_retries}) for invalid responses — trying fallback",
+            "Non-retryable error (HTTP {status_code}) — trying fallback",
+            "Provider safety filter blocked this request — trying fallback",
+            "Max retries ({max_retries}) exhausted — trying fallback",
+        ]
+        guard = "agent._fallback_index < len(agent._fallback_chain)"
+
+        for message in guarded_messages:
+            idx = src.find(message)
+            assert idx != -1, f"missing fallback status message: {message}"
+            guard_window = src[max(0, idx - 700):idx]
+            assert guard in guard_window, (
+                f"{message!r} must be guarded so users do not see 'trying fallback' "
+                "when no fallback provider is configured."
+            )


### PR DESCRIPTION
## Summary
- Guard user-visible `trying fallback` status messages behind an available fallback provider check.
- Keep `_try_activate_fallback()` behavior unchanged; this only prevents misleading status output when the fallback chain is empty.
- Add a regression guard so future retry/fallback status strings stay guarded.

## Context
A downstream Telegram gateway incident surfaced `Non-retryable error (HTTP None) — trying fallback...` even though no fallback provider was configured. Current `main` already has the Codex null-output stream recovery and TypeError retryability fixes; this PR only covers the remaining misleading fallback-status path.

## Validation
- `python3 -m py_compile agent/conversation_loop.py`
- `uv run --locked --extra dev pytest tests/run_agent/test_jsondecodeerror_retryable.py -q`
- `uv run --locked --extra dev pytest tests/gateway/test_telegram_noise_filter.py -q`
- `uv run --locked --extra dev pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_ignores_completed_response_with_null_output tests/run_agent/test_codex_no_tools_nonetype.py -q`