### PR TITLE
docs(plugins): clarify project discovery vs profile-global enable scope

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1152,15 +1152,17 @@ Unified plugin management — general plugins, memory providers, and context eng
 | `install <identifier> [--force]` | Install a plugin from a Git URL or `owner/repo`. |
 | `update <name>` | Pull latest changes for an installed plugin. |
 | `remove <name>` (aliases: `rm`, `uninstall`) | Remove an installed plugin. |
-| `enable <name>` | Enable a disabled plugin. |
-| `disable <name>` | Disable a plugin without removing it. |
+| `enable <name>` | Enable a disabled plugin (writes to `plugins.enabled` in the active profile config). |
+| `disable <name>` | Disable a plugin without removing it (removes from `plugins.enabled` and adds to `plugins.disabled`). |
 | `list` (alias: `ls`) | List installed plugins with enabled/disabled status. |
 
 Provider plugin selections are saved to `config.yaml`:
 - `memory.provider` — active memory provider (empty = built-in only)
 - `context.engine` — active context engine (`"compressor"` = built-in default)
 
-General plugin disabled list is stored in `config.yaml` under `plugins.disabled`.
+General plugin state is stored in `config.yaml` under `plugins.enabled` and `plugins.disabled` (active profile config; `~/.hermes/config.yaml` by default).
+
+`hermes plugins enable/disable` currently has no per-repository scope flag; changes apply to the active profile.
 
 See [Plugins](../user-guide/features/plugins.md) and [Build a Hermes Plugin](../guides/build-a-hermes-plugin.md).
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -89,7 +89,9 @@ def register(ctx):
 
 Drop both files into `~/.hermes/plugins/hello-world/`, restart Hermes, and the model can immediately call `hello_world`. The hook prints a log line after every tool invocation.
 
-Project-local plugins under `./.hermes/plugins/` are disabled by default. Enable them only for trusted repositories by setting `HERMES_ENABLE_PROJECT_PLUGINS=true` before starting Hermes.
+Project-local plugins under `./.hermes/plugins/` are disabled by default. Enable project discovery only for trusted repositories by setting `HERMES_ENABLE_PROJECT_PLUGINS=true` before starting Hermes.
+
+Discovery is project-local, but enable/disable state is profile-global: `hermes plugins enable/disable` updates `plugins.enabled` / `plugins.disabled` in the active profile config (`~/.hermes/config.yaml` by default), not a repo-local `.hermes/config.yaml`.
 
 ## What plugins can do
 
@@ -164,6 +166,8 @@ hermes plugins                    # interactive toggle (space to check/uncheck)
 hermes plugins enable <name>      # add to allow-list
 hermes plugins disable <name>     # remove from allow-list + add to disabled
 ```
+
+Scope note: these commands write to the active profile config (`~/.hermes/config.yaml` by default), so the setting follows that profile across repositories/sessions.
 
 After `hermes plugins install owner/repo`, you're asked `Enable 'name' now? [y/N]` — defaults to no. Skip the prompt for scripted installs with `--enable` or `--no-enable`.
 


### PR DESCRIPTION
## Summary
This PR resolves docs/config ambiguity around plugin scope by making one distinction explicit everywhere it matters:

- `HERMES_ENABLE_PROJECT_PLUGINS` controls **project-local discovery** of `./.hermes/plugins/`
- `hermes plugins enable/disable` controls **profile-global activation state** in the active profile config

## What changed
- `website/docs/user-guide/features/plugins.md`
  - Clarified that project-local plugins are a discovery scope toggle, not a separate activation config scope.
  - Added explicit scope note: enable/disable writes to `plugins.enabled` / `plugins.disabled` in active profile config (`~/.hermes/config.yaml` by default).
- `website/docs/reference/cli-commands.md`
  - Updated `enable`/`disable` subcommand descriptions to reflect exact config effects.
  - Corrected storage wording from only `plugins.disabled` to both `plugins.enabled` and `plugins.disabled`.
  - Added note that there is currently no per-repository scope flag for enable/disable.

## Why
Issue #34117 showed that docs could be read as if project discovery implied project-scoped activation. This PR aligns wording with actual CLI behavior and current implementation.

## Validation
- Scope check: only the two docs files above were changed.
- No runtime/code-path changes.

Closes #34117