### PR TITLE
Add Hermes operator gate receipts

### DIFF
--- a/docs/plans/2026-05-28-hermes-operator-gate.md
+++ b/docs/plans/2026-05-28-hermes-operator-gate.md
@@ -1,0 +1,45 @@
+# Hermes Operator Gate
+
+Purpose: make Hermes maintenance start from live runtime truth, an isolated
+worktree, and a small profile eval gate.
+
+## Boundary
+
+- Live Sawyer gateway root: `/Users/sawbeck/.hermes/hermes-agent`
+- Sawyer profile state: `/Users/sawbeck/.hermes/profiles/sawyer`
+- Do not assume `/Users/sawbeck/Projects/hermes-agent` is live.
+- Do not patch `main` for non-trivial work. Use `.worktrees/codex-*`.
+
+## Required Sequence
+
+1. Run repo inventory from the live root:
+   `python3 /Users/sawbeck/.codex/skills/repo-dev-setup/scripts/repo_inventory.py "$(git rev-parse --show-toplevel)" --report`
+2. If changing agent, skill, workflow, MCP, or command surfaces, run:
+   `python3 /Users/sawbeck/.codex/skills/agent-surface-audit/scripts/audit_agent_surfaces.py "$(git rev-parse --show-toplevel)"`
+3. Create an isolated worktree:
+   `git worktree add .worktrees/codex-<task> -b codex/<task>`
+4. Capture live runtime status before editing:
+   `python3 scripts/operator_status_receipt.py --profile sawyer --since "YYYY-MM-DD HH:MM:SS"`
+5. Run the small operator eval gate before and after meaningful Slack, memory,
+   tool, or wrapper changes:
+   `python3 scripts/operator_eval_gate.py --profile-root /Users/sawbeck/.hermes/profiles/sawyer`
+6. Verify with targeted tests through `scripts/run_tests.sh`.
+7. Only restart the live gateway after the branch payload is verified and the
+   intended runtime root is confirmed.
+
+## Acceptance Gate
+
+A Hermes operator change is not complete until it has:
+
+- an isolated worktree branch
+- targeted tests
+- a status receipt showing the live gateway root and PID
+- an eval receipt for the relevant Sawyer profile batch, when the change affects
+  Slack behavior, memory, tools, wrappers, or answer shaping
+- a final git status that separates intended code changes from runtime residue
+
+## Why This Exists
+
+Hermes has multiple local checkouts and runtime/profile surfaces. The failure
+to prevent is simple: patching the wrong checkout or trusting a clean code diff
+while the live gateway is running somewhere else.

--- a/scripts/operator_eval_gate.py
+++ b/scripts/operator_eval_gate.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Run a profile trajectory eval batch and write a compact receipt."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def newest_batch(profile_root: Path) -> Path:
+    batches = sorted((profile_root / "evals" / "batches").glob("*.json"))
+    if not batches:
+        raise FileNotFoundError(f"No eval batch specs found under {profile_root / 'evals' / 'batches'}")
+    return max(batches, key=lambda path: path.stat().st_mtime_ns)
+
+
+def default_report_path(profile_root: Path, spec: Path) -> Path:
+    return profile_root / "evals" / "runs" / f"{spec.stem}.md"
+
+
+def run_eval(profile_root: Path, spec: Path, report: Path) -> dict:
+    runner = profile_root / "evals" / "run_relative_trajectory_batch.py"
+    if not runner.exists():
+        raise FileNotFoundError(f"Eval runner not found: {runner}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    command = [sys.executable, str(runner), str(spec), "--output", str(report)]
+    proc = subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "command": command,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout[-4000:],
+        "stderr": proc.stderr[-4000:],
+    }
+
+
+def write_receipt(profile_root: Path, spec: Path, report: Path, result: dict) -> tuple[Path, Path]:
+    now = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    receipt_dir = profile_root / "evals" / "runs" / "receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    json_path = receipt_dir / f"operator-eval-gate-{now}.json"
+    md_path = receipt_dir / f"operator-eval-gate-{now}.md"
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "profile_root": str(profile_root),
+        "spec": str(spec),
+        "report": str(report),
+        "report_sha256": sha256_file(report) if report.exists() else None,
+        "passed": result["returncode"] == 0,
+        **result,
+    }
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    md = "\n".join(
+        [
+            "# Hermes Operator Eval Gate",
+            "",
+            f"- Passed: `{payload['passed']}`",
+            f"- Spec: `{spec}`",
+            f"- Report: `{report}`",
+            f"- Report SHA256: `{payload['report_sha256']}`",
+            f"- Return code: `{payload['returncode']}`",
+            "",
+            "## Command",
+            "",
+            "```text",
+            " ".join(result["command"]),
+            "```",
+        ]
+    )
+    md_path.write_text(md + "\n", encoding="utf-8")
+    return json_path, md_path
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile-root",
+        type=Path,
+        default=Path.home() / ".hermes" / "profiles" / "sawyer",
+    )
+    parser.add_argument("--spec", type=Path, help="Eval batch spec JSON. Defaults to newest profile batch.")
+    parser.add_argument("--report", type=Path, help="Rendered markdown report path.")
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    profile_root = args.profile_root.expanduser().resolve()
+    spec = (args.spec or newest_batch(profile_root)).expanduser().resolve()
+    report = (args.report or default_report_path(profile_root, spec)).expanduser().resolve()
+    result = run_eval(profile_root, spec, report)
+    json_path, md_path = write_receipt(profile_root, spec, report, result)
+    print(f"receipt_json={json_path}")
+    print(f"receipt_md={md_path}")
+    return result["returncode"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operator_status_receipt.py
+++ b/scripts/operator_status_receipt.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Emit a small operator receipt for the live Hermes gateway.
+
+This script is intentionally read-only. It answers the question that tends to
+matter during Hermes maintenance: which checkout is the gateway actually
+running, on which branch, with which profile logs?
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+ISSUE_PATTERNS = (
+    "NoneType",
+    "Traceback",
+    "Non-retryable client error",
+    "responses.stream",
+    "finalizer",
+    "output=null",
+    "response.output=None",
+)
+
+
+@dataclass
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_command(args: list[str], *, cwd: Path | None = None) -> CommandResult:
+    try:
+        proc = subprocess.run(
+            args,
+            cwd=str(cwd) if cwd else None,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return CommandResult(127, "", str(exc))
+    return CommandResult(proc.returncode, proc.stdout, proc.stderr)
+
+
+def parse_launchctl(text: str) -> dict[str, str]:
+    fields = {}
+    wanted = {
+        "pid",
+        "program",
+        "working directory",
+        "stdout path",
+        "stderr path",
+        "state",
+    }
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if " = " not in line:
+            continue
+        key, value = line.split(" = ", 1)
+        key = key.strip()
+        if key in wanted:
+            fields[key.replace(" ", "_")] = value.strip()
+    return fields
+
+
+def git_info(repo_root: Path) -> dict[str, str]:
+    def _git(*args: str) -> str:
+        result = run_command(["git", *args], cwd=repo_root)
+        if result.returncode != 0:
+            return ""
+        return result.stdout.strip()
+
+    return {
+        "root": str(repo_root),
+        "branch": _git("branch", "--show-current"),
+        "head": _git("rev-parse", "--short", "HEAD"),
+        "status_short": _git("status", "--short", "--branch"),
+    }
+
+
+def timestamped_issue_lines(path: Path, *, since: str | None = None) -> list[str]:
+    if not path.exists():
+        return []
+    hits = []
+    for line in path.read_text(errors="replace").splitlines():
+        if since:
+            line_stamp = line[:19]
+            if len(line_stamp) < 19 or line_stamp[4:5] != "-" or line_stamp[13:14] != ":":
+                continue
+            if line_stamp < since[:19]:
+                continue
+        if any(pattern in line for pattern in ISSUE_PATTERNS):
+            hits.append(line)
+    return hits
+
+
+def compact_status_flags(status_text: str) -> dict[str, bool]:
+    return {
+        "slack_configured": "Slack" in status_text and "✓ configured" in status_text,
+        "gateway_running": "Gateway Service" in status_text and "✓ running" in status_text,
+        "openai_codex_logged_in": "OpenAI Codex" in status_text and "✓ logged in" in status_text,
+    }
+
+
+def build_receipt(profile: str, repo_root: Path, since: str | None = None) -> dict:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    profile_root = Path.home() / ".hermes" / "profiles" / profile
+
+    status_result = run_command(["hermes", "--profile", profile, "status"], cwd=repo_root)
+    launchctl_fields: dict[str, str] = {}
+    launchctl_result = CommandResult(0, "", "")
+    if platform.system() == "Darwin":
+        label = f"gui/{os.getuid()}/ai.hermes.gateway-{profile}"
+        launchctl_result = run_command(["launchctl", "print", label], cwd=repo_root)
+        if launchctl_result.returncode == 0:
+            launchctl_fields = parse_launchctl(launchctl_result.stdout)
+
+    stdout_log = Path(
+        launchctl_fields.get("stdout_path")
+        or profile_root / "logs" / "gateway.log"
+    )
+    stderr_log = Path(
+        launchctl_fields.get("stderr_path")
+        or profile_root / "logs" / "gateway.error.log"
+    )
+    stdout_hits = timestamped_issue_lines(stdout_log, since=since)
+    stderr_hits = timestamped_issue_lines(stderr_log, since=since)
+
+    return {
+        "generated_at": now,
+        "profile": profile,
+        "repo": git_info(repo_root),
+        "profile_root": str(profile_root),
+        "launchctl": {
+            "available": launchctl_result.returncode == 0,
+            **launchctl_fields,
+        },
+        "status_flags": compact_status_flags(status_result.stdout),
+        "status_returncode": status_result.returncode,
+        "logs": {
+            "stdout_path": str(stdout_log),
+            "stderr_path": str(stderr_log),
+            "since": since,
+            "issue_patterns": list(ISSUE_PATTERNS),
+            "stdout_issue_count": len(stdout_hits),
+            "stderr_issue_count": len(stderr_hits),
+            "stdout_recent_issues": stdout_hits[-10:],
+            "stderr_recent_issues": stderr_hits[-10:],
+        },
+    }
+
+
+def render_markdown(receipt: dict) -> str:
+    repo = receipt["repo"]
+    launch = receipt["launchctl"]
+    logs = receipt["logs"]
+    flags = receipt["status_flags"]
+    lines = [
+        "# Hermes Operator Status Receipt",
+        "",
+        f"- Generated: `{receipt['generated_at']}`",
+        f"- Profile: `{receipt['profile']}`",
+        f"- Repo root: `{repo['root']}`",
+        f"- Branch: `{repo['branch']}`",
+        f"- HEAD: `{repo['head']}`",
+        f"- Gateway PID: `{launch.get('pid', 'unknown')}`",
+        f"- Gateway cwd: `{launch.get('working_directory', 'unknown')}`",
+        f"- Slack configured: `{flags['slack_configured']}`",
+        f"- Gateway running: `{flags['gateway_running']}`",
+        f"- OpenAI Codex logged in: `{flags['openai_codex_logged_in']}`",
+        f"- Log window start: `{logs.get('since') or 'full file scan'}`",
+        f"- Stdout issue hits: `{logs['stdout_issue_count']}`",
+        f"- Stderr issue hits: `{logs['stderr_issue_count']}`",
+        "",
+        "## Git Status",
+        "",
+        "```text",
+        repo["status_short"],
+        "```",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(receipt: dict, output: Path | None, json_output: Path | None) -> None:
+    markdown = render_markdown(receipt)
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(markdown, encoding="utf-8")
+    else:
+        print(markdown, end="")
+    if json_output:
+        json_output.parent.mkdir(parents=True, exist_ok=True)
+        json_output.write_text(json.dumps(receipt, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", default=os.getenv("HERMES_PROFILE", "sawyer"))
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--since", help="Only count timestamped log issues after YYYY-MM-DD HH:MM:SS")
+    parser.add_argument("--output", type=Path, help="Markdown receipt output path")
+    parser.add_argument("--json-output", type=Path, help="JSON receipt output path")
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    receipt = build_receipt(args.profile, args.repo_root.resolve(), since=args.since)
+    write_outputs(receipt, args.output, args.json_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_operator_eval_gate.py
+++ b/tests/scripts/test_operator_eval_gate.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "operator_eval_gate.py"
+spec = importlib.util.spec_from_file_location("operator_eval_gate", MODULE_PATH)
+operator_eval_gate = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = operator_eval_gate
+spec.loader.exec_module(operator_eval_gate)
+
+
+def test_newest_batch_uses_mtime(tmp_path):
+    batch_dir = tmp_path / "evals" / "batches"
+    batch_dir.mkdir(parents=True)
+    older = batch_dir / "older.json"
+    newer = batch_dir / "newer.json"
+    older.write_text("{}")
+    newer.write_text("{}")
+
+    assert operator_eval_gate.newest_batch(tmp_path) == newer
+
+
+def test_eval_gate_writes_receipts(tmp_path):
+    runner = tmp_path / "evals" / "run_relative_trajectory_batch.py"
+    runner.parent.mkdir(parents=True)
+    runner.write_text(
+        "import pathlib, sys\n"
+        "out = pathlib.Path(sys.argv[sys.argv.index('--output') + 1])\n"
+        "out.write_text('report ok')\n"
+    )
+    spec = tmp_path / "evals" / "batches" / "batch.json"
+    spec.parent.mkdir(parents=True)
+    spec.write_text("{}")
+    report = tmp_path / "evals" / "runs" / "batch.md"
+
+    result = operator_eval_gate.run_eval(tmp_path, spec, report)
+    json_path, md_path = operator_eval_gate.write_receipt(tmp_path, spec, report, result)
+
+    assert result["returncode"] == 0
+    assert report.read_text() == "report ok"
+    assert json_path.exists()
+    assert md_path.exists()
+    assert "Passed: `True`" in md_path.read_text()

--- a/tests/scripts/test_operator_status_receipt.py
+++ b/tests/scripts/test_operator_status_receipt.py
@@ -1,0 +1,78 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "operator_status_receipt.py"
+spec = importlib.util.spec_from_file_location("operator_status_receipt", MODULE_PATH)
+operator_status_receipt = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = operator_status_receipt
+spec.loader.exec_module(operator_status_receipt)
+
+
+def test_parse_launchctl_extracts_runtime_fields():
+    text = """
+    state = running
+    program = /tmp/hermes/venv/bin/python
+    working directory = /tmp/hermes
+    stdout path = /tmp/profile/logs/gateway.log
+    stderr path = /tmp/profile/logs/gateway.error.log
+    pid = 12345
+    """
+
+    parsed = operator_status_receipt.parse_launchctl(text)
+
+    assert parsed["state"] == "running"
+    assert parsed["program"] == "/tmp/hermes/venv/bin/python"
+    assert parsed["working_directory"] == "/tmp/hermes"
+    assert parsed["stdout_path"] == "/tmp/profile/logs/gateway.log"
+    assert parsed["stderr_path"] == "/tmp/profile/logs/gateway.error.log"
+    assert parsed["pid"] == "12345"
+
+
+def test_timestamped_issue_lines_honors_since(tmp_path):
+    log = tmp_path / "gateway.log"
+    log.write_text(
+        "\n".join(
+            [
+                "2026-05-28 17:00:00,000 ERROR root: Non-retryable client error: old",
+                "Traceback (most recent call last):",
+                "2026-05-28 18:00:00,000 ERROR root: Non-retryable client error: 'NoneType' object is not iterable",
+                "2026-05-28 18:01:00,000 INFO gateway.run: Gateway running with 1 platform(s)",
+            ]
+        )
+    )
+
+    hits = operator_status_receipt.timestamped_issue_lines(log, since="2026-05-28 18:00:00")
+
+    assert len(hits) == 1
+    assert "NoneType" in hits[0]
+
+
+def test_render_markdown_includes_live_cwd():
+    receipt = {
+        "generated_at": "2026-05-28T22:00:00+00:00",
+        "profile": "sawyer",
+        "repo": {
+            "root": "/tmp/hermes",
+            "branch": "codex/test",
+            "head": "abc123",
+            "status_short": "## codex/test",
+        },
+        "launchctl": {"pid": "123", "working_directory": "/tmp/hermes"},
+        "status_flags": {
+            "slack_configured": True,
+            "gateway_running": True,
+            "openai_codex_logged_in": True,
+        },
+        "logs": {
+            "since": "2026-05-28 18:00:00",
+            "stdout_issue_count": 0,
+            "stderr_issue_count": 0,
+        },
+    }
+
+    markdown = operator_status_receipt.render_markdown(receipt)
+
+    assert "Gateway cwd: `/tmp/hermes`" in markdown
+    assert "Slack configured: `True`" in markdown


### PR DESCRIPTION
## Summary
- add a read-only operator status receipt script for live gateway cwd/PID/log health
- add an operator eval gate wrapper around existing profile trajectory batches
- document the Hermes operator gate sequence for worktree, status, eval, and verification discipline

## Verification
- scripts/run_tests.sh tests/scripts/test_operator_status_receipt.py tests/scripts/test_operator_eval_gate.py tests/hermes_cli/test_status.py tests/gateway/test_session_hygiene.py
- python3 scripts/operator_status_receipt.py --profile sawyer --repo-root /Users/sawbeck/.hermes/hermes-agent --since "2026-05-28 18:03:38"
- python3 scripts/operator_eval_gate.py --profile-root /Users/sawbeck/.hermes/profiles/sawyer

## Local runtime receipt
- Sawyer gateway PID 37633 from /Users/sawbeck/.hermes/hermes-agent
- Slack configured/running and OpenAI Codex logged in
- 0 timestamped post-restart stdout/stderr issue hits since 2026-05-28 18:03:38
- profile eval receipt: /Users/sawbeck/.hermes/profiles/sawyer/evals/runs/receipts/operator-eval-gate-20260528T221712Z.md