### PR TITLE
fix(gateway): fix explicit delivery target parsing for chat IDs containing colons

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 MAX_PLATFORM_OUTPUT = 4000
 TRUNCATED_VISIBLE = 3800
+_COLON_CHAT_ID_PLATFORMS = frozenset({"matrix", "teams", "yuanbao"})
 
 from .config import Platform, GatewayConfig
 from .session import SessionSource
@@ -110,18 +111,24 @@ class DeliveryTarget:
             return cls(platform=Platform.LOCAL)
         
         # Check for platform:chat_id or platform:chat_id:thread_id format.
-        # Keep this aligned with send_message_tool so explicit targets behave
-        # the same across cron, `hermes send`, and direct delivery routing.
+        # Most platforms still use the legacy "first extra colon means thread"
+        # convention. Only a small set have chat IDs that naturally contain
+        # colons, so keep the special parser narrowly scoped to those.
         if ":" in target_stripped:
             platform_str, target_ref = target_stripped.split(":", 1)
             platform_str = platform_str.lower()  # Platform names are case-insensitive
             try:
                 platform = Platform(platform_str)
-                from tools.send_message_tool import _parse_target_ref
+                if platform_str in _COLON_CHAT_ID_PLATFORMS:
+                    from tools.send_message_tool import _parse_target_ref
 
-                chat_id, thread_id, is_explicit = _parse_target_ref(platform_str, target_ref)
-                if not is_explicit:
-                    chat_id, thread_id = target_ref, None
+                    chat_id, thread_id, is_explicit = _parse_target_ref(platform_str, target_ref)
+                    if not is_explicit:
+                        chat_id, thread_id = target_ref, None
+                else:
+                    parts = target_stripped.split(":", 2)
+                    chat_id = parts[1] if len(parts) > 1 else None
+                    thread_id = parts[2] if len(parts) > 2 else None
                 return cls(
                     platform=platform,
                     chat_id=chat_id,

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -109,16 +109,25 @@ class DeliveryTarget:
         if target_lower == "local":
             return cls(platform=Platform.LOCAL)
         
-        # Check for platform:chat_id or platform:chat_id:thread_id format
-        # Use the original case for chat_id/thread_id to preserve case-sensitive IDs
+        # Check for platform:chat_id or platform:chat_id:thread_id format.
+        # Keep this aligned with send_message_tool so explicit targets behave
+        # the same across cron, `hermes send`, and direct delivery routing.
         if ":" in target_stripped:
-            parts = target_stripped.split(":", 2)
-            platform_str = parts[0].lower()  # Platform names are case-insensitive
-            chat_id = parts[1] if len(parts) > 1 else None
-            thread_id = parts[2] if len(parts) > 2 else None
+            platform_str, target_ref = target_stripped.split(":", 1)
+            platform_str = platform_str.lower()  # Platform names are case-insensitive
             try:
                 platform = Platform(platform_str)
-                return cls(platform=platform, chat_id=chat_id, thread_id=thread_id, is_explicit=True)
+                from tools.send_message_tool import _parse_target_ref
+
+                chat_id, thread_id, is_explicit = _parse_target_ref(platform_str, target_ref)
+                if not is_explicit:
+                    chat_id, thread_id = target_ref, None
+                return cls(
+                    platform=platform,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                    is_explicit=True,
+                )
             except ValueError:
                 # Unknown platform, treat as local
                 return cls(platform=Platform.LOCAL)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -359,6 +359,17 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_explicit_teams_chat_id_with_colon_is_preserved(self):
+        """deliver: 'teams:19:...' should keep the full Teams conversation ID."""
+        job = {
+            "deliver": "teams:19:abcDEF@thread.skype",
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "teams",
+            "chat_id": "19:abcDEF@thread.skype",
+            "thread_id": None,
+        }
+
     def test_list_form_deliver_is_normalized(self, monkeypatch):
         """deliver=['telegram'] (Python list) should resolve like 'telegram' string.
 

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -86,20 +86,18 @@ class TestCaseSensitiveChatIdParsing:
         assert target.thread_id == "thread123"
     
     def test_matrix_room_id_preserved(self):
-        """Matrix room IDs like !RoomABC:example.org should preserve case.
-        
-        Note: Matrix room IDs contain colons (e.g., !RoomABC:example.org).
-        Due to the platform:chat_id:thread_id format, these are parsed as
-        chat_id=!RoomABC and thread_id=example.org. This is a known limitation
-        of the current format. The fix preserves case but doesn't change the
-        parsing structure.
-        """
+        """Matrix room IDs like !RoomABC:example.org should stay intact."""
         target = DeliveryTarget.parse("matrix:!RoomABC:example.org")
         assert target.platform == Platform.MATRIX
-        # The room ID is split at the first colon after the platform prefix
-        # This is a format limitation - the case is preserved but the structure is split
-        assert target.chat_id == "!RoomABC"
-        assert target.thread_id == "example.org"
+        assert target.chat_id == "!RoomABC:example.org"
+        assert target.thread_id is None
+
+    def test_teams_chat_id_with_colon_is_preserved(self):
+        """Teams conversation IDs like 19:... should not be split as threads."""
+        target = DeliveryTarget.parse("teams:19:Meeting_ABC@thread.skype")
+        assert target.platform == Platform("teams")
+        assert target.chat_id == "19:Meeting_ABC@thread.skype"
+        assert target.thread_id is None
     
     def test_mixed_case_chat_id_roundtrip(self):
         """Mixed-case chat IDs should survive parse-to_string roundtrip."""
@@ -108,6 +106,14 @@ class TestCaseSensitiveChatIdParsing:
         s = target.to_string()
         reparsed = DeliveryTarget.parse(s)
         assert reparsed.chat_id == "ChatId123ABC"
+
+    def test_matrix_room_id_roundtrip(self):
+        """Matrix room IDs containing colons should survive roundtrip intact."""
+        original = "matrix:!RoomABC:example.org"
+        target = DeliveryTarget.parse(original)
+        reparsed = DeliveryTarget.parse(target.to_string())
+        assert reparsed.chat_id == "!RoomABC:example.org"
+        assert reparsed.thread_id is None
 
 
 class TestPlatformNameCaseInsensitivity:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1123,6 +1123,13 @@ class TestParseTargetRefMatrix:
         assert thread_id is None
         assert is_explicit is True
 
+    def test_teams_conversation_id_with_colon_is_explicit(self):
+        """Teams conversation IDs should bypass channel-name resolution."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("teams", "19:abcDEF@thread.skype")
+        assert chat_id == "19:abcDEF@thread.skype"
+        assert thread_id is None
+        assert is_explicit is True
+
     def test_matrix_alias_is_not_explicit(self):
         """Matrix room aliases (#) are NOT explicit — they need resolution."""
         chat_id, thread_id, is_explicit = _parse_target_ref("matrix", "#general:matrix.org")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -30,6 +30,7 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 # Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
+_TEAMS_TARGET_RE = re.compile(r"^\s*(\d+:[A-Za-z0-9@._-]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -368,6 +369,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # resolution path in send_message() can run.
             is_explicit = chat_id[0] not in {"U", "W"}
             return chat_id, None, is_explicit
+    if platform_name == "teams":
+        match = _TEAMS_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name == "matrix":
         trimmed = target_ref.strip()
         split_idx = trimmed.rfind(":$")


### PR DESCRIPTION
## Summary

This fixes explicit delivery target parsing for chat IDs that legitimately contain `:` characters.

`DeliveryTarget.parse()` now delegates explicit target parsing to the shared `send_message` target parser so delivery routing stays consistent across cron delivery, `hermes send`, and direct gateway delivery paths.

### What changed

- Preserved full Teams conversation IDs such as `teams:19:...` instead of incorrectly splitting them into `chat_id` and a fake `thread_id`
- Preserved full Matrix room IDs such as `matrix:!RoomABC:example.org` instead of incorrectly treating the server suffix as a thread
- Kept existing explicit thread/topic behavior intact for platforms that actually support `platform:chat_id:thread_id` targets, including Telegram, Slack, and Discord
- Added regression coverage for Teams, Matrix, and scheduler resolution paths

## Why

Some platforms use colon-bearing chat IDs as part of their normal identifier format. The previous `DeliveryTarget.parse()` logic split on `:` too early, which could misroute explicit delivery targets or make them fail entirely.

## Tests

Passed:

- `tests/gateway/test_delivery.py`
- `tests/tools/test_send_message_tool.py`
- `tests/cron/test_scheduler.py`

Command run:

- `./scripts/run_tests.sh tests/gateway/test_delivery.py tests/tools/test_send_message_tool.py tests/cron/test_scheduler.py -q`

Result:

- All targeted regression tests passed successfully

## Notes

This change is intentionally narrow:
- it fixes colon-bearing explicit chat IDs
- it does not broaden thread parsing semantics beyond the platforms that already support them
```