### PR TITLE
fix(auth): inherit global Codex credential pool in profiles

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3656,19 +3656,14 @@ def _pool_codex_access_token() -> str:
     """Return the most-recent usable access_token from the openai-codex pool.
 
     Used as a fallback by ``resolve_codex_runtime_credentials`` when the
-    singleton has no creds.  Reads ``credential_pool.openai-codex`` entries
-    directly from auth.json and picks the first non-empty access_token,
-    preferring entries that are not currently in an exhaustion cooldown.
+    singleton has no creds.  Reads through ``read_credential_pool`` instead of
+    directly from the active profile store so named profiles with an empty
+    local Codex pool still inherit the global-root credential pool.
     Returns ``""`` when no usable entry is found (caller handles by raising
     the original AuthError).
     """
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return ""
-        entries = pool.get("openai-codex")
+        entries = read_credential_pool("openai-codex")
         if not isinstance(entries, list):
             return ""
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -367,6 +367,37 @@ def test_load_provider_state_malformed_global_does_not_break_profile(profile_env
     assert state["access_token"] == "profile-token"
 
 
+def test_codex_runtime_uses_global_pool_when_profile_singleton_is_empty(profile_env):
+    """Stale empty profile Codex state must not block the global credential pool."""
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "glob-codex",
+            "label": "global-codex",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "global-codex-access-token",
+            "refresh_token": "global-codex-refresh-token",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(
+        providers={
+            "openai-codex": {
+                "auth_mode": "chatgpt",
+                "tokens": {"access_token": "", "refresh_token": ""},
+            },
+        },
+        pool={"openai-codex": []},
+    ))
+
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert creds["source"] == "credential_pool"
+    assert creds["api_key"] == "global-codex-access-token"
+
+
 # ---------------------------------------------------------------------------
 # Classic mode — no fallback path should ever trigger
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes Codex runtime credential fallback for named profiles with stale empty local singleton auth state.
- Uses the existing `read_credential_pool("openai-codex")` path so profiles with no usable local Codex pool entries can inherit the global-root Codex credential pool.
- Adds a regression test covering empty profile Codex singleton state plus valid global pool credentials.

Fixes #34143

## Why

Hermes already supports profile/global auth fallback per provider. The Codex pool fallback helper was bypassing that behavior by reading only the active profile auth store directly, which could make a profile report missing Codex credentials even when global auth was valid.

This is cross-platform profile/auth logic, not Windows-specific. We caught it on Windows because Tony's Harness PM profile had stale empty per-profile Codex state, but the bug can affect any OS where a named profile shadows global Codex auth with empty local state.

## Test plan

    PYTHONPATH=. C:/Users/beast/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe -m pytest -o addopts='' tests/hermes_cli/test_auth_profile_fallback.py -q

Result:

    17 passed in 1.27s

## Safety

Focused added-line privacy scan found no personal paths, tokens, secrets, profile data, or generated runtime artifacts in the final PR diff.
