### PR TITLE
fix(gateway): preserve Telegram DM topic routing metadata in synthetic notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3452,9 +3452,13 @@ class GatewayRunner:
                     )
                     continue
 
-                # Include thread_id if present so the message lands in the
-                # correct forum topic / thread.
-                metadata = {"thread_id": thread_id} if thread_id else None
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    chat_id,
+                    thread_id,
+                    chat_type=getattr(source, "chat_type", None) if source is not None else None,
+                    adapter=adapter,
+                )
 
                 result = await adapter.send(chat_id, msg, metadata=metadata)
                 if result is not None and getattr(result, "success", True) is False:
@@ -3500,7 +3504,12 @@ class GatewayRunner:
                 continue
 
             try:
-                metadata = {"thread_id": home.thread_id} if home.thread_id else None
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    home.chat_id,
+                    home.thread_id,
+                    adapter=adapter,
+                )
                 if metadata:
                     result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
                 else:
@@ -10048,6 +10057,7 @@ class GatewayRunner:
             notify_data = {
                 "platform": event.source.platform.value if event.source.platform else None,
                 "chat_id": event.source.chat_id,
+                "chat_type": event.source.chat_type,
             }
             if event.source.thread_id:
                 notify_data["thread_id"] = event.source.thread_id
@@ -13822,13 +13832,34 @@ class GatewayRunner:
         reply_to_message_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
-        thread_id = getattr(source, "thread_id", None)
+        return self._thread_metadata_for_target(
+            getattr(source, "platform", None),
+            getattr(source, "chat_id", None),
+            getattr(source, "thread_id", None),
+            chat_type=getattr(source, "chat_type", None),
+            reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
+        )
+
+    def _thread_metadata_for_target(
+        self,
+        platform: Optional[Platform],
+        chat_id: Optional[str],
+        thread_id: Optional[str],
+        *,
+        chat_type: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        adapter: Optional[Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Build thread metadata for synthetic sends that only have routing state."""
         if thread_id is None:
             return None
         metadata: Dict[str, Any] = {"thread_id": thread_id}
-        if (
-            getattr(source, "platform", None) == Platform.TELEGRAM
-            and getattr(source, "chat_type", None) == "dm"
+        if self._is_telegram_dm_topic_target(
+            platform,
+            chat_id,
+            thread_id,
+            chat_type=chat_type,
+            adapter=adapter,
         ):
             metadata["telegram_dm_topic_reply_fallback"] = True
             # Telegram DM topic lanes need direct_messages_topic_id in metadata
@@ -13837,10 +13868,31 @@ class GatewayRunner:
             tid = str(thread_id)
             if tid and tid not in {"", "1"}:
                 metadata["direct_messages_topic_id"] = tid
-            anchor = reply_to_message_id or getattr(source, "message_id", None)
-            if anchor is not None:
-                metadata["telegram_reply_to_message_id"] = str(anchor)
+            if reply_to_message_id is not None:
+                metadata["telegram_reply_to_message_id"] = str(reply_to_message_id)
         return metadata
+
+    @staticmethod
+    def _is_telegram_dm_topic_target(
+        platform: Optional[Platform],
+        chat_id: Optional[str],
+        thread_id: Optional[str],
+        *,
+        chat_type: Optional[str] = None,
+        adapter: Optional[Any] = None,
+    ) -> bool:
+        """Return True when a target is a Telegram private DM topic lane."""
+        if platform != Platform.TELEGRAM or thread_id is None:
+            return False
+        if chat_type == "dm":
+            return True
+        get_dm_topic_info = getattr(adapter, "_get_dm_topic_info", None)
+        if callable(get_dm_topic_info) and chat_id:
+            try:
+                return bool(get_dm_topic_info(str(chat_id), str(thread_id)))
+            except Exception:
+                logger.debug("Failed to inspect Telegram DM topic metadata", exc_info=True)
+        return False
 
     @staticmethod
     def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
@@ -14050,6 +14102,7 @@ class GatewayRunner:
         pending = {
             "platform": event.source.platform.value,
             "chat_id": event.source.chat_id,
+            "chat_type": event.source.chat_type,
             "user_id": event.source.user_id,
             "session_key": session_key,
             "timestamp": datetime.now().isoformat(),
@@ -14200,12 +14253,19 @@ class GatewayRunner:
                     pending = json.loads(path.read_text())
                     platform_str = pending.get("platform")
                     chat_id = pending.get("chat_id")
+                    chat_type = pending.get("chat_type")
                     session_key = pending.get("session_key")
                     thread_id = pending.get("thread_id")
-                    metadata = {"thread_id": thread_id} if thread_id else None
                     if platform_str and chat_id:
                         platform = Platform(platform_str)
                         adapter = self.adapters.get(platform)
+                        metadata = self._thread_metadata_for_target(
+                            platform,
+                            chat_id,
+                            thread_id,
+                            chat_type=chat_type,
+                            adapter=adapter,
+                        )
                         # Fallback session key if not stored (old pending files)
                         if not session_key:
                             session_key = f"{platform_str}:{chat_id}"
@@ -14409,6 +14469,7 @@ class GatewayRunner:
             pending = json.loads(claimed_path.read_text())
             platform_str = pending.get("platform")
             chat_id = pending.get("chat_id")
+            chat_type = pending.get("chat_type")
             thread_id = pending.get("thread_id")
 
             if not exit_code_path.exists():
@@ -14431,7 +14492,13 @@ class GatewayRunner:
             adapter = self.adapters.get(platform)
 
             if adapter and chat_id:
-                metadata = {"thread_id": thread_id} if thread_id else None
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    chat_id,
+                    thread_id,
+                    chat_type=chat_type,
+                    adapter=adapter,
+                )
                 # Strip ANSI escape codes for clean display
                 output = re.sub(r'\x1b\[[0-9;]*m', '', output).strip()
                 if output:
@@ -14473,6 +14540,7 @@ class GatewayRunner:
             data = json.loads(notify_path.read_text())
             platform_str = data.get("platform")
             chat_id = data.get("chat_id")
+            chat_type = data.get("chat_type")
             thread_id = data.get("thread_id")
 
             if not platform_str or not chat_id:
@@ -14495,7 +14563,13 @@ class GatewayRunner:
                 )
                 return None
 
-            metadata = {"thread_id": thread_id} if thread_id else None
+            metadata = self._thread_metadata_for_target(
+                platform,
+                chat_id,
+                thread_id,
+                chat_type=chat_type,
+                adapter=adapter,
+            )
             result = await adapter.send(
                 str(chat_id),
                 "♻ Gateway restarted successfully. Your session continues.",
@@ -14559,7 +14633,12 @@ class GatewayRunner:
                 continue
 
             try:
-                metadata = {"thread_id": home.thread_id} if home.thread_id else None
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    home.chat_id,
+                    home.thread_id,
+                    adapter=adapter,
+                )
                 if metadata:
                     result = await adapter.send(str(home.chat_id), message, metadata=metadata)
                 else:

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -60,6 +60,7 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
     data = json.loads(notify_path.read_text())
     assert data["platform"] == "telegram"
     assert data["chat_id"] == "42"
+    assert data["chat_type"] == "dm"
     assert "thread_id" not in data  # no thread → omitted
 
 
@@ -113,8 +114,7 @@ async def test_restart_command_preserves_thread_id(tmp_path, monkeypatch):
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
 
-    source = make_restart_source(chat_id="99")
-    source.thread_id = "topic_7"
+    source = make_restart_source(chat_id="99", thread_id="777")
 
     event = MessageEvent(
         text="/restart",
@@ -126,7 +126,8 @@ async def test_restart_command_preserves_thread_id(tmp_path, monkeypatch):
     await runner._handle_restart_command(event)
 
     data = json.loads((tmp_path / ".restart_notify.json").read_text())
-    assert data["thread_id"] == "topic_7"
+    assert data["chat_type"] == "dm"
+    assert data["thread_id"] == "777"
 
 
 @pytest.mark.asyncio
@@ -259,17 +260,22 @@ async def test_send_home_channel_startup_notification_preserves_thread_metadata(
         platform=Platform.TELEGRAM,
         chat_id="parent-42",
         name="Ops Topic",
-        thread_id="topic-7",
+        thread_id="777",
     )
+    adapter._get_dm_topic_info = MagicMock(return_value={"name": "Ops Topic"})
     adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
 
     delivered = await runner._send_home_channel_startup_notifications()
 
-    assert delivered == {("telegram", "parent-42", "topic-7")}
+    assert delivered == {("telegram", "parent-42", "777")}
     adapter.send.assert_called_once_with(
         "parent-42",
         "♻️ Gateway online — Hermes is back and ready.",
-        metadata={"thread_id": "topic-7"},
+        metadata={
+            "thread_id": "777",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "777",
+        },
     )
 
 
@@ -374,7 +380,8 @@ async def test_send_restart_notification_with_thread(tmp_path, monkeypatch):
     notify_path.write_text(json.dumps({
         "platform": "telegram",
         "chat_id": "99",
-        "thread_id": "topic_7",
+        "chat_type": "dm",
+        "thread_id": "777",
     }))
 
     runner, adapter = make_restart_runner()
@@ -382,9 +389,13 @@ async def test_send_restart_notification_with_thread(tmp_path, monkeypatch):
 
     delivered_target = await runner._send_restart_notification()
 
-    assert delivered_target == ("telegram", "99", "topic_7")
+    assert delivered_target == ("telegram", "99", "777")
     call_args = adapter.send.call_args
-    assert call_args[1]["metadata"] == {"thread_id": "topic_7"}
+    assert call_args[1]["metadata"] == {
+        "thread_id": "777",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "777",
+    }
     assert not notify_path.exists()
 
 

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -212,6 +212,7 @@ class TestHandleUpdateCommand:
         data = json.loads(pending_path.read_text())
         assert data["platform"] == "telegram"
         assert data["chat_id"] == "99999"
+        assert data["chat_type"] == "dm"
         assert "timestamp" in data
         assert not (hermes_home / ".update_exit_code").exists()
 
@@ -471,6 +472,7 @@ class TestSendUpdateNotification:
         pending = {
             "platform": "telegram",
             "chat_id": "67890",
+            "chat_type": "dm",
             "thread_id": "777",
             "user_id": "12345",
         }
@@ -484,7 +486,11 @@ class TestSendUpdateNotification:
         with patch("gateway.run._hermes_home", hermes_home):
             await runner._send_update_notification()
 
-        assert mock_adapter.send.call_args.kwargs["metadata"] == {"thread_id": "777"}
+        assert mock_adapter.send.call_args.kwargs["metadata"] == {
+            "thread_id": "777",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "777",
+        }
 
     @pytest.mark.asyncio
     async def test_strips_ansi_codes(self, tmp_path):


### PR DESCRIPTION
## Summary

Preserve Telegram DM topic routing metadata in synthetic gateway notifications.

This change fixes a routing gap where synthetic notifications such as `/update`, `/restart`, and startup home-channel messages could bypass the shared Telegram DM topic metadata path and send with only `thread_id`. For Telegram DM topic lanes, that could route notifications outside the intended topic.

## What Changed

- Centralized synthetic thread metadata generation through the same helper logic used by normal thread-aware replies.
- Preserved `chat_type` in update and restart marker payloads so post-restart notification paths can reconstruct Telegram DM topic routing correctly.
- Added Telegram DM topic fallback metadata for synthetic sends when the target is a DM topic:
  - `telegram_dm_topic_reply_fallback`
  - `direct_messages_topic_id`
- Kept home-channel startup notifications on the same metadata path so configured Telegram DM topic homes stay correctly routed.
- Tightened regression coverage to assert the full Telegram DM topic metadata, not just `thread_id`.

## Testing

Focused regression verification:
- `tests/gateway/test_update_command.py::TestHandleUpdateCommand::test_writes_pending_marker` — passed
- `tests/gateway/test_update_command.py::TestHandleUpdateCommand::test_writes_pending_marker_with_thread_id` — passed
- `tests/gateway/test_update_command.py::TestSendUpdateNotification::test_sends_notification_with_thread_metadata` — passed
- `tests/gateway/test_update_command.py::TestSendUpdateNotification::test_defers_notification_while_update_still_running` — passed
- `tests/gateway/test_update_command.py::TestSendUpdateNotification::test_sends_generic_message_when_no_output` — passed
- `tests/gateway/test_restart_notification.py::test_restart_command_writes_notify_file` — passed
- `tests/gateway/test_restart_notification.py::test_restart_command_preserves_thread_id` — passed
- `tests/gateway/test_restart_notification.py::test_send_home_channel_startup_notification_preserves_thread_metadata` — passed
- `tests/gateway/test_restart_notification.py::test_send_restart_notification_with_thread` — passed
- `tests/gateway/test_restart_notification.py::test_shutdown_notifications_use_cached_live_thread_source_when_origin_missing` — passed

Focused regression result:
- 10 passed

Broader targeted suite command:
```text
pytest tests/gateway/test_update_command.py tests/gateway/test_restart_notification.py -v --timeout-method=thread
```

Broader targeted suite result:
- 53 collected
- 47 passed
- 6 failed

Remaining failures from the broader targeted suite:
- `tests/gateway/test_update_command.py::TestHandleUpdateCommand::test_spawns_setsid`
- `tests/gateway/test_update_command.py::TestHandleUpdateCommand::test_fallback_when_no_setsid`
- `tests/gateway/test_update_command.py::TestSendUpdateNotification::test_sends_notification_with_output`
- `tests/gateway/test_update_command.py::TestSendUpdateNotification::test_strips_ansi_codes`
- `tests/gateway/test_update_command.py::TestSendUpdateNotification::test_cleans_up_files_after_notification`
- `tests/gateway/test_update_command.py::TestSendUpdateNotification::test_cleans_up_on_error`

## Notes

The scoped regression coverage for this fix is green. The remaining failures are outside the routing change itself and should be handled separately.