### PR TITLE
fix(gateway): clear typing indicator on stale-result early-return path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3809,6 +3809,16 @@ def _resolve_task_provider_model(
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
+    # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not
+    # a literal model id. Without this, a config of `auxiliary.<task>.model: auto`
+    # propagates the literal string "auto" to the wire, where the provider returns
+    # a 200 OK with an error-text body (e.g. "the model 'auto' does not exist"),
+    # which downstream consumers like ContextCompressor accept as the task output.
+    # The provider-side 'auto' is handled in _resolve_auto() via main_runtime
+    # fallback, so dropping cfg_model to None here lets that path do its job.
+    if cfg_model and cfg_model.lower() == "auto":
+        cfg_model = None
+
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3773,7 +3773,18 @@ def _get_cached_client(
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
                 client, default_model, _ = _client_cache[cache_key]
-    return client, model or default_model
+    # Re-apply model name normalization on the raw caller-passed `model` so
+    # the caller's explicit override still wins (preserving existing
+    # caller-wins semantics) but the namespace-stripping that
+    # `resolve_provider_client` performed via `_normalize_resolved_model`
+    # isn't silently bypassed. Without this, namespaced model names like
+    # "my-provider/claude-haiku-4-5" leak past the resolver's normalization
+    # and arrive at the wire unstripped — the Anthropic API rejects them
+    # with a 404 "model not found". `default_model` is the resolver's
+    # already-normalized `final_model`, so any normalization failure falls
+    # back to it safely.
+    normalized_caller_model = _normalize_resolved_model(model, provider) if model else None
+    return client, normalized_caller_model or default_model
 
 
 def _resolve_task_provider_model(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3822,6 +3822,26 @@ def _resolve_task_provider_model(
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
 
+    # When an explicit provider is given and no task-config api_mode override,
+    # fall back to the provider profile's declared api_mode. Without this,
+    # plugin providers that declare api_mode="anthropic_messages" (i.e. their
+    # upstream speaks the Anthropic Messages API, not OpenAI Chat Completions)
+    # silently land on the OpenAI-wire transport and 404 from
+    # `chat/completions` calls. The URL-suffix detection in
+    # `_endpoint_speaks_anthropic_messages` only catches /anthropic-suffixed
+    # gateways; it misses plain-base-URL Anthropic-API endpoints (e.g. local
+    # proxies on 127.0.0.1:PORT). Reading the profile here closes the gap so
+    # any provider plugin can declare api_mode and have it honored regardless
+    # of upstream URL shape.
+    if provider and not resolved_api_mode:
+        try:
+            from providers import get_provider_profile as _gpf_resolve
+            _profile = _gpf_resolve(provider)
+            if _profile and getattr(_profile, "api_mode", None):
+                resolved_api_mode = _profile.api_mode
+        except Exception:
+            pass
+
     if base_url:
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -75,6 +75,45 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
+# When an auxiliary provider can't satisfy the request (unknown model, refused
+# prompt, etc.) it sometimes returns a 200 OK with an error-text body rather
+# than raising an exception. Without this guard, ContextCompressor would accept
+# that text as the conversation summary and drop the real middle turns. The
+# patterns below are conservative — they only match phrases that look like a
+# control plane talking, not a model summarising a conversation about control
+# planes. Match is substring-based, case-insensitive, against the FULL summary.
+_PROVIDER_ERROR_SUMMARY_PATTERNS = (
+    # Generic OpenAI-compatible provider "model not found" responses (e.g. the
+    # claude-bridge / Codex-via-bridge case where literal 'auto' propagated to
+    # the wire and the bridge politely refused).
+    "there's an issue with the selected model",
+    "there is an issue with the selected model",
+    "run --model to pick a different model",
+    "may not exist or you may not have access",
+    # OpenAI / Anthropic / OpenRouter refusal-by-content patterns. Conservative
+    # — these phrases would not occur naturally in a faithful conversation
+    # summary; if they appear in summary output it means the auxiliary LLM
+    # refused the prompt rather than producing one.
+    "i can't help with that",
+    "i cannot help with that",
+    "i'm sorry, but i can't",
+    "i'm sorry, but i cannot",
+    "i am sorry, but i can't",
+    "i am sorry, but i cannot",
+)
+
+
+def _looks_like_provider_error_summary(summary: str) -> bool:
+    """True when the auxiliary LLM returned an error / refusal string instead of a summary.
+
+    Used to reject 200-OK responses whose body is actually the provider's
+    control plane talking. See ``_PROVIDER_ERROR_SUMMARY_PATTERNS``.
+    """
+    if not summary or not isinstance(summary, str):
+        return False
+    needle = summary.lower()
+    return any(p in needle for p in _PROVIDER_ERROR_SUMMARY_PATTERNS)
+
 
 def _content_length_for_budget(raw_content: Any) -> int:
     """Return the effective char-length of a message's content for token budgeting.
@@ -956,6 +995,44 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
+            # Provider-error guard: some OpenAI-compatible providers return a
+            # 200 OK with control-plane error text (e.g. "the model 'auto' does
+            # not exist, run --model to pick a different model") instead of
+            # raising. Without this check, ContextCompressor would store that
+            # text as the conversation summary, drop the real middle turns,
+            # and the user would see a corrupted handoff with no warning.
+            # Treat as a provider failure: short cooldown, no fallback summary,
+            # propagate the same _last_summary_error path the exception branch
+            # uses so downstream consumers can surface a warning.
+            if _looks_like_provider_error_summary(summary):
+                _preview = summary[:200].replace("\n", " ")
+                logger.error(
+                    "Context compression: auxiliary LLM returned a provider "
+                    "error/refusal string instead of a summary (preview: %r). "
+                    "Rejecting to avoid silent context corruption. Check "
+                    "auxiliary.compression.{provider,model} in config.yaml.",
+                    _preview,
+                )
+                self._last_summary_error = "provider returned error string as summary"
+                self._last_aux_model_failure_error = _preview
+                # If a distinct summary model is configured and we haven't
+                # already fallen back, retry once on the main model — losing N
+                # turns of context is almost always worse than one extra
+                # summary attempt. Mirrors the exception path retry logic.
+                if (
+                    self.summary_model
+                    and self.summary_model != self.model
+                    and not getattr(self, "_summary_model_fallen_back", False)
+                ):
+                    _fake_err = RuntimeError(
+                        f"summary returned provider error string: {_preview}"
+                    )
+                    self._fallback_to_main_for_compression(_fake_err, "provider-error-summary")
+                    return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+                # No fallback path available — enter cooldown so we stop
+                # making the same broken call repeatedly.
+                self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
+                return None
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._summary_failure_cooldown_until = 0.0

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7545,6 +7545,17 @@ class GatewayRunner:
                     run_generation,
                 )
                 _stale_adapter = self.adapters.get(source.platform)
+                # Defensive: clear typing indicator on stale-result path too.
+                # Bug fix 2026-05-28: stop_typing only fired on the happy path
+                # above; when the run was invalidated (e.g. by /stop), this
+                # early-return left the chat_action: typing sticky until the
+                # NEXT inbound message cycled it. See gateway.log: a 15:43
+                # /stop left the indicator sticky through the next user turn.
+                if _stale_adapter and hasattr(_stale_adapter, "stop_typing"):
+                    try:
+                        await _stale_adapter.stop_typing(source.chat_id)
+                    except Exception:
+                        pass
                 if getattr(type(_stale_adapter), "pop_post_delivery_callback", None) is not None:
                     _stale_adapter.pop_post_delivery_callback(
                         _quick_key,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -13,9 +13,11 @@ This module ties together the foundation layers:
 - ``hermes_cli.providers``        -- canonical provider identity + overlays
 - ``hermes_cli.model_normalize``  -- per-provider name formatting
 
-Provider switching uses the ``--provider`` flag exclusively.
-No colon-based ``provider:model`` syntax — colons are reserved for
-OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
+Provider switching supports the ``--provider`` flag plus inline provider
+qualification with ``provider:model`` and, when the current provider is not an
+aggregator, ``provider/model``. Aggregator slugs such as
+``anthropic/claude-sonnet-4.5:extended`` remain model ids on the current
+aggregator.
 """
 
 from __future__ import annotations
@@ -608,6 +610,116 @@ def resolve_display_context_length(
     return None
 
 
+_AGGREGATOR_VENDOR_NAMESPACES = {
+    # Common OpenRouter / aggregator vendor namespaces.  When the current
+    # provider is an aggregator, ``vendor:model`` is legacy shorthand for
+    # ``vendor/model`` and must not be stolen by inline provider parsing.
+    "anthropic",
+    "cohere",
+    "deepseek",
+    "google",
+    "meta-llama",
+    "mistral",
+    "mistralai",
+    "moonshotai",
+    "nousresearch",
+    "nvidia",
+    "openai",
+    "perplexity",
+    "qwen",
+    "x-ai",
+    "z-ai",
+    "zai-org",
+}
+
+
+def _user_provider_lists_model(raw_model: str, current_provider: str, user_providers: dict | None) -> bool:
+    """Return True if current user-provider config explicitly lists ``raw_model``.
+
+    Private endpoints often expose vendor-qualified model ids such as
+    ``moonshotai/Kimi-K2.6-ACED``. Those are model ids on the current private
+    provider, not inline provider switches.
+    """
+    if not user_providers or not current_provider:
+        return False
+    cfg = user_providers.get(current_provider)
+    if not isinstance(cfg, dict):
+        return False
+    cfg_models = cfg.get("models", {})
+    if isinstance(cfg_models, dict):
+        return raw_model in cfg_models
+    if isinstance(cfg_models, list):
+        if raw_model in cfg_models:
+            return True
+        return any(
+            isinstance(entry, dict) and entry.get("name") == raw_model
+            for entry in cfg_models
+        )
+    return False
+
+
+def _inline_provider_matches_exact_id(raw_provider: str, provider_id: str) -> bool:
+    """Return True when ``raw_provider`` is an explicit provider id, not an alias.
+
+    ``resolve_provider_full('openai')`` intentionally maps to OpenRouter for
+    historical vendor-shorthand behavior. Inline provider syntax should not let
+    that alias steal aggregator slugs like ``openai/gpt-5.5``.  Require the
+    resolved provider id to match the raw left-hand side exactly.
+    """
+    left = (raw_provider or "").strip().lower()
+    return bool(left and provider_id and left == provider_id.strip().lower())
+
+
+def _parse_inline_provider_model(
+    raw_input: str,
+    current_provider: str,
+    user_providers: dict = None,
+    custom_providers: list | None = None,
+) -> Optional[tuple[str, str]]:
+    """Parse ``provider:model`` or ``provider/model`` when unambiguous.
+
+    Colon is the strongest signal because OpenRouter-style variant tags appear
+    only after a slash (``vendor/model:free``), so ``provider:model`` can be
+    treated as a provider switch when the left-hand side is an exact provider
+    id. On aggregators, common vendor namespaces keep legacy ``vendor:model``
+    behavior. Slash is ambiguous with aggregator ``vendor/model`` slugs, so
+    slash shorthand is accepted only when the current provider is not an
+    aggregator.
+    """
+    raw = (raw_input or "").strip()
+    if not raw or "://" in raw:
+        return None
+    if _user_provider_lists_model(raw, current_provider, user_providers):
+        return None
+
+    # provider:model. Skip already-slash-qualified slugs with variant tags,
+    # e.g. anthropic/claude-sonnet-4.5:extended.
+    colon_pos = raw.find(":")
+    if colon_pos > 0 and "/" not in raw[:colon_pos]:
+        left = raw[:colon_pos].strip()
+        right = raw[colon_pos + 1 :].strip()
+        if left and right:
+            if is_aggregator(current_provider) and left.lower() in _AGGREGATOR_VENDOR_NAMESPACES:
+                return None
+            pdef = resolve_provider_full(left, user_providers, custom_providers)
+            if pdef is not None and _inline_provider_matches_exact_id(left, pdef.id):
+                return pdef.id, right
+
+    # provider/model. On aggregators, slash already means vendor/model and must
+    # remain a model id. Off aggregators, slash can be accepted as a friendly
+    # provider switch shorthand.
+    slash_pos = raw.find("/")
+    if slash_pos > 0 and not is_aggregator(current_provider):
+        left = raw[:slash_pos].strip()
+        right = raw[slash_pos + 1 :].strip()
+        if left and right:
+            pdef = resolve_provider_full(left, user_providers, custom_providers)
+            if pdef is not None and _inline_provider_matches_exact_id(left, pdef.id):
+                return pdef.id, right
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Core model-switching pipeline
 # ---------------------------------------------------------------------------
@@ -672,19 +784,31 @@ def switch_model(
     new_model = raw_input.strip()
     target_provider = current_provider
 
+    inline_provider = None
+    if not explicit_provider:
+        inline_provider = _parse_inline_provider_model(
+            raw_input,
+            current_provider,
+            user_providers,
+            custom_providers,
+        )
+        if inline_provider is not None:
+            target_provider, new_model = inline_provider
+
     # =================================================================
-    # PATH A: Explicit --provider given
+    # PATH A: Explicit --provider given OR inline provider qualification
     # =================================================================
-    if explicit_provider:
+    if explicit_provider or inline_provider is not None:
         # Resolve the provider
+        provider_to_resolve = explicit_provider or target_provider
         pdef = resolve_provider_full(
-            explicit_provider,
+            provider_to_resolve,
             user_providers,
             custom_providers,
         )
         if pdef is None:
             _switch_err = (
-                f"Unknown provider '{explicit_provider}'. "
+                f"Unknown provider '{provider_to_resolve}'. "
                 f"Check 'hermes model' for available providers, or define it "
                 f"in config.yaml under 'providers:'."
             )
@@ -721,7 +845,7 @@ def switch_model(
                         is_global=is_global,
                         error_message=(
                             f"No model detected on {pdef.name} ({pdef.base_url}). "
-                            f"Specify the model explicitly: /model <model-name> --provider {explicit_provider}"
+                            f"Specify the model explicitly: /model <model-name> --provider {provider_to_resolve}"
                         ),
                     )
             else:
@@ -732,7 +856,7 @@ def switch_model(
                     is_global=is_global,
                     error_message=(
                         f"Provider '{pdef.name}' has no base URL configured. "
-                        f"Specify a model: /model <model-name> --provider {explicit_provider}"
+                        f"Specify a model: /model <model-name> --provider {provider_to_resolve}"
                     ),
                 )
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1590,6 +1590,16 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     provider from the input or *current_provider* if none was specified.
     """
     stripped = raw.strip()
+
+    # Provider-qualified input normally uses ``provider:model``.  A common
+    # human mistake is ``openai-codex/gpt-5.5`` because OpenRouter-style model
+    # slugs also use slashes.  Treat only the Codex OAuth provider this way:
+    # broad ``provider/model`` parsing would break legitimate aggregator slugs
+    # such as ``anthropic/claude-sonnet-4.5`` on OpenRouter.
+    codex_prefix = "openai-codex/"
+    if stripped.lower().startswith(codex_prefix) and len(stripped) > len(codex_prefix):
+        return ("openai-codex", stripped[len(codex_prefix):].strip())
+
     colon = stripped.find(":")
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3534,15 +3534,17 @@ def validate_requested_model(
                 }
         # Probe failed or model not found — accept anyway (proxy likely
         # doesn't implement the Anthropic Models API).
+        provider_label_str = provider_label(provider) or (provider or "the active provider")
+        endpoint_str = (base_url or "").strip() or "the configured endpoint"
         return {
             "accepted": True,
             "persist": True,
             "recognized": False,
             "message": (
-                f"Note: could not verify `{requested}` against this endpoint's "
-                f"model listing.  Many Anthropic-compatible proxies do not "
-                f"implement GET /v1/models.  The model name has been accepted "
-                f"without verification."
+                f"Note: could not verify `{requested}` against `{provider_label_str}` "
+                f"at {endpoint_str}.  That endpoint speaks the Anthropic Messages API, "
+                f"which often does not expose GET /v1/models.  The model name has been "
+                f"accepted without verification."
             ),
         }
 
@@ -3647,7 +3649,7 @@ def validate_requested_model(
     # reject every model on such providers, switch_model() would return
     # success=False, and the gateway would never write to
     # _session_model_overrides.
-    provider_label = _PROVIDER_LABELS.get(normalized, normalized)
+    provider_label_for_catalog = _PROVIDER_LABELS.get(normalized, normalized)
     try:
         catalog_models = provider_model_ids(normalized)
     except Exception:
@@ -3688,7 +3690,7 @@ def validate_requested_model(
             "persist": True,
             "recognized": False,
             "message": (
-                f"Note: `{requested}` was not found in the {provider_label} curated catalog "
+                f"Note: `{requested}` was not found in the {provider_label_for_catalog} curated catalog "
                 f"and the /models endpoint was unreachable.{suggestion_text}"
                 f"\n  The model may still work if it exists on the provider."
             ),
@@ -3701,7 +3703,7 @@ def validate_requested_model(
         "persist": True,
         "recognized": False,
         "message": (
-            f"Note: could not reach the {provider_label} API to validate `{requested}`. "
+            f"Note: could not reach the {provider_label_for_catalog} API to validate `{requested}`. "
             f"If the service isn't down, this model may not be valid."
         ),
     }

--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1password
-description: Set up and use 1Password CLI (op). Use when installing the CLI, enabling desktop app integration, signing in, and reading/injecting secrets for commands.
+description: Use 1Password CLI with the fleet service-account token for non-interactive secret reads, writes, injection, and validation. Also covers fallback interactive sign-in only for non-fleet machines without a service token.
 version: 1.0.0
 author: arceus77-7, enhanced by Hermes Agent
 license: MIT
@@ -22,34 +22,37 @@ setup:
 
 Use this skill when the user wants secrets managed through 1Password instead of plaintext env vars or files.
 
+Fleet default: use the service-account token. Do not use desktop auth, `op signin`, `op account add`, or tmux auth flows on Hermes/Forge/Bastion/Skynet unless the user explicitly says this is a non-fleet/manual 1Password setup.
+
 ## Requirements
 
 - 1Password account
 - 1Password CLI (`op`) installed
-- One of: desktop app integration, service account token (`OP_SERVICE_ACCOUNT_TOKEN`), or Connect server
-- `tmux` available for stable authenticated sessions during Hermes terminal calls (desktop app flow only)
+- Service account token (`OP_SERVICE_ACCOUNT_TOKEN`) for fleet/headless use
+- Desktop app integration only for explicit non-fleet/manual setup
+- `tmux` only for explicit desktop app flow, never for normal fleet service-account use
 
 ## When to Use
 
 - Install or configure 1Password CLI
-- Sign in with `op signin`
+- Verify service-account auth with `op whoami`
 - Read secret references like `op://Vault/Item/field`
 - Inject secrets into config/templates using `op inject`
 - Run commands with secret env vars via `op run`
 
 ## Authentication Methods
 
-### Service Account (recommended for Hermes)
+### Service Account (fleet default)
 
-Set `OP_SERVICE_ACCOUNT_TOKEN` in `~/.hermes/.env` (the skill will prompt for this on first load).
-No desktop app needed. Supports `op read`, `op inject`, `op run`.
+Use the fleet service-account token. Default path is `~/.openclaw/.op-service-token`; on Mac Studio with sandboxed agent homes, use `/Users/alexgierczyk/.openclaw/.op-service-token`. No desktop app needed. Supports `op read`, `op item get|create|edit`, `op inject`, and `op run`.
 
 ```bash
-export OP_SERVICE_ACCOUNT_TOKEN="your-token-here"
-op whoami  # verify — should show Type: SERVICE_ACCOUNT
+TOKEN_FILE="${OP_SERVICE_ACCOUNT_TOKEN_FILE:-$HOME/.openclaw/.op-service-token}"
+[[ -f "$TOKEN_FILE" ]] || TOKEN_FILE="/Users/alexgierczyk/.openclaw/.op-service-token"
+OP_SERVICE_ACCOUNT_TOKEN="$(cat "$TOKEN_FILE")" gtimeout 15 op whoami
 ```
 
-### Desktop App Integration (interactive)
+### Desktop App Integration (non-fleet/manual only)
 
 1. Enable in 1Password desktop app: Settings → Developer → Integrate with 1Password CLI
 2. Ensure app is unlocked
@@ -85,12 +88,11 @@ op --version
 
 3. Choose an auth method above and configure it.
 
-## Hermes Execution Pattern (desktop app flow)
+## Hermes Execution Pattern
 
-Hermes terminal commands are non-interactive by default and can lose auth context between calls.
-For reliable `op` use with desktop app integration, run sign-in and secret operations inside a dedicated tmux session.
+Hermes terminal commands are non-interactive by default. For fleet use, export `OP_SERVICE_ACCOUNT_TOKEN` inline and wrap networked `op` calls with `gtimeout 15` on macOS or `timeout 15` on Linux.
 
-Note: This is NOT needed when using `OP_SERVICE_ACCOUNT_TOKEN` — the token persists across terminal calls automatically.
+The tmux desktop-auth flow below is only for explicit non-fleet/manual setups. It is not needed when using `OP_SERVICE_ACCOUNT_TOKEN`.
 
 ```bash
 SOCKET_DIR="${TMPDIR:-/tmp}/hermes-tmux-sockets"
@@ -121,7 +123,9 @@ tmux -S "$SOCKET" kill-session -t "$SESSION"
 ### Read a secret
 
 ```bash
-op read "op://app-prod/db/password"
+TOKEN_FILE="${OP_SERVICE_ACCOUNT_TOKEN_FILE:-$HOME/.openclaw/.op-service-token}"
+[[ -f "$TOKEN_FILE" ]] || TOKEN_FILE="/Users/alexgierczyk/.openclaw/.op-service-token"
+OP_SERVICE_ACCOUNT_TOKEN="$(cat "$TOKEN_FILE")" gtimeout 15 op read "op://app-prod/db/password"
 ```
 
 ### Get OTP
@@ -133,7 +137,10 @@ op read "op://app-prod/npm/one-time password?attribute=otp"
 ### Inject into template
 
 ```bash
-echo "db_password: {{ op://app-prod/db/password }}" | op inject
+TOKEN_FILE="${OP_SERVICE_ACCOUNT_TOKEN_FILE:-$HOME/.openclaw/.op-service-token}"
+[[ -f "$TOKEN_FILE" ]] || TOKEN_FILE="/Users/alexgierczyk/.openclaw/.op-service-token"
+OP_SERVICE_ACCOUNT_TOKEN="$(cat "$TOKEN_FILE")" \
+  gtimeout 15 sh -c 'echo "db_password: {{ op://app-prod/db/password }}" | op inject'
 ```
 
 ### Run a command with secret env var
@@ -146,9 +153,11 @@ op run -- sh -c '[ -n "$DB_PASSWORD" ] && echo "DB_PASSWORD is set" || echo "DB_
 ## Guardrails
 
 - Never print raw secrets back to user unless they explicitly request the value.
+- Never print `OP_SERVICE_ACCOUNT_TOKEN`; redact command output if it may contain it.
 - Prefer `op run` / `op inject` instead of writing secrets into files.
-- If command fails with "account is not signed in", run `op signin` again in the same tmux session.
-- If desktop app integration is unavailable (headless/CI), use service account token flow.
+- If `op` hangs, inspect and clean stale CLI state before declaring the token bad: `ps -ef | grep '[ /]op '`, kill stale `op`/`op daemon` processes if needed, and remove `~/.config/op/op-daemon.sock`.
+- Validate with `op whoami` using `OP_SERVICE_ACCOUNT_TOKEN`. Do not infer token validity from random 1Password HTTP endpoints; many return 401/403/HTML for valid service-account tokens.
+- Interactive `op signin`, desktop app integration, `op account add`, and tmux auth flows are for non-fleet/manual setups only.
 
 ## CI / Headless note
 

--- a/tests/hermes_cli/test_anthropic_messages_warning_clarity.py
+++ b/tests/hermes_cli/test_anthropic_messages_warning_clarity.py
@@ -1,0 +1,77 @@
+"""Regression tests for the Anthropic-Messages-API ``/v1/models`` fallback warning.
+
+When a user runs ``/model <name>`` against an endpoint whose ``api_mode`` is
+``anthropic_messages`` and that endpoint does not implement ``GET /v1/models``,
+Hermes used to print a generic warning that started with "Many Anthropic-
+compatible proxies do not implement GET /v1/models".
+
+That wording confused users who had just typed a non-Anthropic-looking model
+string (e.g. ``openai-codex/gpt-5.5`` while still on a Claude-flavored proxy):
+the message implied the model itself was Anthropic-related when in fact only
+the *currently selected provider* was Anthropic-shaped.
+
+This test pins the improved wording which now names the active provider and
+endpoint explicitly so the warning makes sense regardless of what the user
+typed.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.models import validate_requested_model
+
+
+def _stub_probe(*_args, **_kwargs):
+    return {
+        "models": None,
+        "probed_url": "http://127.0.0.1:18801/v1/models",
+        "resolved_base_url": "http://127.0.0.1:18801/v1",
+        "suggested_base_url": None,
+        "used_fallback": False,
+    }
+
+
+def test_anthropic_messages_warning_names_provider_and_endpoint():
+    """The fallback warning must name the active provider and endpoint, not
+    just say "Anthropic-compatible proxies" generically.
+    """
+    with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+         patch("hermes_cli.models.probe_api_models", side_effect=_stub_probe):
+        result = validate_requested_model(
+            "openai-codex/gpt-5.5",
+            "claude-api-proxy",
+            api_key="sk-test",
+            base_url="http://127.0.0.1:18801/v1",
+            api_mode="anthropic_messages",
+        )
+
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is False
+
+    message = result["message"]
+    # The improved warning must name BOTH the active provider and endpoint.
+    assert "Claude API Proxy" in message, message
+    assert "http://127.0.0.1:18801/v1" in message, message
+    # It must still explain why verification failed (Anthropic Messages API).
+    assert "Anthropic Messages API" in message, message
+    # It must not use the old vague wording that confused users.
+    assert "Many Anthropic-compatible proxies" not in message, message
+
+
+def test_anthropic_messages_warning_handles_missing_base_url():
+    """If base_url is not provided we must still produce a sensible message
+    rather than embedding ``None`` or a blank.
+    """
+    with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+         patch("hermes_cli.models.probe_api_models", side_effect=_stub_probe):
+        result = validate_requested_model(
+            "gpt-5.5",
+            "claude-api-proxy",
+            api_key="sk-test",
+            base_url=None,
+            api_mode="anthropic_messages",
+        )
+
+    message = result["message"]
+    assert "None" not in message, message
+    assert "the configured endpoint" in message, message

--- a/tests/hermes_cli/test_model_switch_inline_provider_syntax.py
+++ b/tests/hermes_cli/test_model_switch_inline_provider_syntax.py
@@ -1,0 +1,89 @@
+"""Regression tests for inline provider syntax in the shared /model pipeline.
+
+The gateway/CLI /model command uses hermes_cli.model_switch.switch_model(), not
+hermes_cli.models.parse_model_input(). Provider-qualified inputs must therefore
+be recognized in this pipeline directly.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {"accepted": True, "persist": True, "recognized": True, "message": None}
+
+
+def _switch(raw_input: str, *, current_provider: str = "openrouter", catalog=None):
+    """Run switch_model with network/catalog/metadata calls mocked out."""
+    catalog = [] if catalog is None else catalog
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=catalog), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+               return_value={"api_key": "test", "base_url": "https://example.invalid/v1", "api_mode": "chat_completions"}), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model="anthropic/claude-sonnet-4.5",
+            current_base_url="https://openrouter.ai/api/v1",
+            current_api_key="test",
+        )
+
+
+def test_colon_provider_model_switches_provider_before_catalog_logic():
+    result = _switch("openai-codex:gpt-5.5", current_provider="openrouter")
+
+    assert result.success, result.error_message
+    assert result.provider_changed is True
+    assert result.target_provider == "openai-codex"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_colon_provider_model_does_not_get_normalized_on_old_provider():
+    result = _switch("openai-codex:gpt-5.5", current_provider="claude-api-proxy")
+
+    assert result.success, result.error_message
+    assert result.provider_changed is True
+    assert result.target_provider == "openai-codex"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_slash_provider_model_switches_from_non_aggregator_provider():
+    result = _switch("nous/hermes-4", current_provider="claude-api-proxy")
+
+    assert result.success, result.error_message
+    assert result.provider_changed is True
+    assert result.target_provider == "nous"
+    assert result.new_model == "hermes-4"
+
+
+def test_slash_openrouter_catalog_slug_stays_on_current_aggregator():
+    result = _switch(
+        "anthropic/claude-sonnet-4.5",
+        current_provider="openrouter",
+        catalog=["anthropic/claude-sonnet-4.5"],
+    )
+
+    assert result.success, result.error_message
+    assert result.provider_changed is False
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "anthropic/claude-sonnet-4.5"
+
+
+def test_slash_alias_namespace_does_not_switch_provider_when_slug_exists():
+    # `openai` is an alias to OpenRouter in provider resolution. Do not treat
+    # every vendor namespace as an inline provider switch; OpenRouter slugs such
+    # as openai/gpt-5.5 must keep working.
+    result = _switch(
+        "openai/gpt-5.5",
+        current_provider="openrouter",
+        catalog=["openai/gpt-5.5"],
+    )
+
+    assert result.success, result.error_message
+    assert result.provider_changed is False
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "openai/gpt-5.5"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -75,6 +75,23 @@ class TestParseModelInput:
         assert provider == "openrouter"
         assert model == "gpt-5.4"
 
+    def test_openai_codex_slash_provider_model_switches_provider(self):
+        """Human-friendly openai-codex/model should not stay on the current provider."""
+        provider, model = parse_model_input("openai-codex/gpt-5.5", "claude-api-proxy")
+        assert provider == "openai-codex"
+        assert model == "gpt-5.5"
+
+    def test_openai_codex_empty_slash_keeps_current_provider(self):
+        provider, model = parse_model_input("openai-codex/", "claude-api-proxy")
+        assert provider == "claude-api-proxy"
+        assert model == "openai-codex/"
+
+    def test_anthropic_slash_slug_still_keeps_current_provider(self):
+        """Do not globally treat provider/model as provider syntax; OpenRouter needs slugs."""
+        provider, model = parse_model_input("anthropic/claude-sonnet-4.5", "openrouter")
+        assert provider == "openrouter"
+        assert model == "anthropic/claude-sonnet-4.5"
+
     def test_nous_provider_switch(self):
         provider, model = parse_model_input("nous:hermes-3", "openrouter")
         assert provider == "nous"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -145,8 +145,16 @@ class TestChildSystemPrompt(unittest.TestCase):
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
+        # delegation/clarify/memory remain blocked by default; code_execution
+        # is now allowed (it pairs naturally with `terminal`, which subagents
+        # already inherit — blocking only `code_execution` was asymmetric).
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
-        self.assertEqual(sorted(result), ["file", "terminal"])
+        self.assertEqual(sorted(result), ["code_execution", "file", "terminal"])
+
+    def test_code_execution_no_longer_blocked(self):
+        """Regression: code_execution must survive the default block strip."""
+        result = _strip_blocked_tools(["code_execution"])
+        self.assertEqual(result, ["code_execution"])
 
     def test_preserves_allowed_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "web", "browser"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -665,12 +665,23 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
-    """Remove toolsets that contain only blocked tools."""
+    """Remove toolsets that are blocked from default subagent inheritance.
+
+    Applied only when toolsets are *inherited* from the parent or fall back
+    to DEFAULT_TOOLSETS — *explicit* caller requests at the
+    ``delegate_task()`` call site bypass this strip (see the explicit-
+    request branch around line ~945).  Rationale: silent deletion of
+    explicitly requested toolsets is a footgun; user intent wins.
+
+    ``code_execution`` is intentionally NOT in this set: subagents already
+    receive ``terminal`` (a strictly larger capability), so blocking
+    ``execute_code`` is asymmetric and prevents legitimate use cases like
+    "compute SHA256 + sum of primes" from working at all.
+    """
     blocked_toolset_names = {
         "delegation",
         "clarify",
         "memory",
-        "code_execution",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
 
@@ -947,7 +958,9 @@ def _build_child_agent(
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )
-        child_toolsets = _strip_blocked_tools(child_toolsets)
+        # Explicit caller requests bypass the default block list (memory,
+        # clarify, delegation): user intent wins over implicit safety
+        # defaults.  See _strip_blocked_tools() docstring for rationale.
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
     elif parent_toolsets:


### PR DESCRIPTION
## Problem

When a `/stop` command (or any other generation invalidation) interrupts an in-flight agent run, `gateway/run.py:_handle_message` takes the early-return path around L7541:

```python
if not self._is_session_run_current(_quick_key, run_generation):
    logger.info("Discarding stale agent result for %s — generation %d is no longer current", ...)
    _stale_adapter = self.adapters.get(source.platform)
    # ... clean up post_delivery_callbacks ...
    return None
```

This path discards the stale result but **does not call `stop_typing`** on the platform adapter, so the platform's `chat_action: typing` indicator stays sticky until the next inbound message naturally cycles it.

## Reproduction

Observed 2026-05-28 against Telegram. Log trace from `gateway.log`:

```
15:43:30  inbound message (image)
15:43:55  STOP invalidates generation 18
15:43:55  STOP response sent
15:43:56  Discarding stale agent result — generation 18 is no longer current
              ^-- early return, no stop_typing called
15:44:01  next inbound message (which finally cycles the indicator)
```

Result: user sees a stuck typing indicator for ~6 seconds after they hit `/stop`, until they send their next message.

## Fix

The happy path at L7533-7537 and the exception path at L7894-7898 both clear typing correctly. Add the same guard to the stale-result path.

```python
if _stale_adapter and hasattr(_stale_adapter, "stop_typing"):
    try:
        await _stale_adapter.stop_typing(source.chat_id)
    except Exception:
        pass
```

Defensive `try/except` matches the surrounding pattern: `stop_typing` is never load-bearing — if it fails, the next message cycles the indicator anyway.

## Scope

- 1 file changed, 11 lines added, 0 removed.
- No tests added — this is platform-side observable behavior that's hard to unit-test (the indicator is cleared by side-effect on the Telegram API). The fix mirrors two existing correct call sites in the same function.