### PR TITLE
feat(gateway): make Telegram command-menu cap configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1015,7 +1015,7 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(group_allowed_chats, list):
                         group_allowed_chats = ",".join(str(v) for v in group_allowed_chats)
                     os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
-                for _telegram_extra_key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages"):
+                for _telegram_extra_key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages", "menu_max_commands"):
                     if _telegram_extra_key in telegram_cfg:
                         plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
                         if not isinstance(plat_data, dict):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -105,6 +105,12 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 }
 
 
+# Default cap for the Telegram bot-command menu (per scope). Telegram's Bot API
+# permits up to 100 commands per scope, but the total setMyCommands payload has
+# an undocumented ~4KB ceiling, so the default stays conservative. Override per
+# instance with ``telegram.menu_max_commands`` in config.yaml (clamped 1..100) —
+# useful to surface plugin/profile slash commands (e.g. /finance) that would
+# otherwise be trimmed when core + skill commands fill the default 30 slots.
 MAX_COMMANDS_PER_SCOPE = 30
 
 
@@ -409,6 +415,12 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
+        # Bot-command menu cap (per scope). Defaults to MAX_COMMANDS_PER_SCOPE;
+        # raise via ``telegram.menu_max_commands`` to surface plugin/profile slash
+        # commands that would otherwise be trimmed. Clamped to Telegram's 1..100.
+        self._menu_max_commands: int = self._coerce_int_extra(
+            "menu_max_commands", MAX_COMMANDS_PER_SCOPE, min_value=1, max_value=100
+        )
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
@@ -852,6 +864,27 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
             return default
         return bool(value)
+
+    def _coerce_int_extra(
+        self,
+        key: str,
+        default: int,
+        *,
+        min_value: Optional[int] = None,
+        max_value: Optional[int] = None,
+    ) -> int:
+        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None:
+            return default
+        try:
+            result = int(value)
+        except (TypeError, ValueError):
+            return default
+        if min_value is not None:
+            result = max(min_value, result)
+        if max_value is not None:
+            result = min(max_value, result)
+        return result
 
     def _link_preview_kwargs(self) -> Dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
@@ -1694,9 +1727,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 from hermes_cli.commands import telegram_menu_commands
                 # Telegram allows up to 100 commands but has an undocumented
-                # payload size limit (~4KB total).  Limit to 30 core commands
-                # to stay well under the threshold while covering all categories.
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                # payload size limit (~4KB total).  Cap the menu (default 30,
+                # configurable via telegram.menu_max_commands) to stay under the
+                # threshold while covering all categories.
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=self._menu_max_commands)
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
@@ -4929,7 +4963,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     return
                 from telegram import BotCommand, BotCommandScopeChat
                 from hermes_cli.commands import telegram_menu_commands
-                menu_commands, _ = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                menu_commands, _ = telegram_menu_commands(max_commands=self._menu_max_commands)
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)

--- a/tests/gateway/test_telegram_menu_cap.py
+++ b/tests/gateway/test_telegram_menu_cap.py
@@ -1,0 +1,83 @@
+"""Tests for the configurable Telegram bot-command menu cap.
+
+``telegram.menu_max_commands`` lets an operator raise the per-scope command
+menu cap above the conservative default (``MAX_COMMANDS_PER_SCOPE``) so plugin
+and profile slash commands (e.g. ``/finance``) surface in Telegram's "/" menu
+instead of being trimmed once core + skill commands fill the default slots.
+Telegram hard-limits 100 commands per scope, so the value is clamped to 1..100.
+"""
+import sys
+from unittest.mock import MagicMock
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    """Mock the python-telegram-bot package if it's not installed."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+def _adapter(extra=None):
+    _ensure_telegram_mock()
+    from gateway.platforms.telegram import TelegramAdapter
+
+    cfg = PlatformConfig(enabled=True, token="fake-token", extra=extra or {})
+    return TelegramAdapter(cfg)
+
+
+def test_menu_cap_defaults_to_constant():
+    from gateway.platforms.telegram import MAX_COMMANDS_PER_SCOPE
+
+    assert _adapter()._menu_max_commands == MAX_COMMANDS_PER_SCOPE
+
+
+def test_menu_cap_override_is_honored():
+    assert _adapter({"menu_max_commands": 50})._menu_max_commands == 50
+
+
+def test_menu_cap_accepts_string_encoded_int():
+    # config/env round-trips can yield strings
+    assert _adapter({"menu_max_commands": "45"})._menu_max_commands == 45
+
+
+def test_menu_cap_clamped_to_telegram_maximum():
+    assert _adapter({"menu_max_commands": 500})._menu_max_commands == 100
+
+
+def test_menu_cap_clamped_to_minimum():
+    assert _adapter({"menu_max_commands": 0})._menu_max_commands == 1
+
+
+def test_menu_cap_invalid_value_falls_back_to_default():
+    from gateway.platforms.telegram import MAX_COMMANDS_PER_SCOPE
+
+    assert (
+        _adapter({"menu_max_commands": "not-an-int"})._menu_max_commands
+        == MAX_COMMANDS_PER_SCOPE
+    )
+
+
+def test_config_loader_passes_menu_max_commands_into_extra(tmp_path, monkeypatch):
+    """Top-level ``telegram.menu_max_commands`` must reach PlatformConfig.extra
+    (mirrors disable_link_previews) so the adapter can read it."""
+    from gateway.config import load_gateway_config, Platform
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n  enabled: true\n  token: fake-token\n  menu_max_commands: 50\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    cfg = load_gateway_config()
+    tg = cfg.platforms.get(Platform.TELEGRAM)
+
+    assert tg is not None
+    assert (tg.extra or {}).get("menu_max_commands") == 50

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -48,6 +48,15 @@ sethome - Set this chat as the home channel
 ```
 :::
 
+:::note Hermes populates the command menu for you
+Hermes auto-registers the `/` command menu from its command registry, so you usually don't need `/setcommands`. The menu is capped per scope (default **30**) to stay under Telegram's command-payload limit. If you run plugins that add slash commands (e.g. a profile router exposing `/finance`, `/trend`) and they don't show up in the `/` menu, raise the cap in `~/.hermes/config.yaml` (clamped to Telegram's 1–100):
+
+```yaml
+telegram:
+  menu_max_commands: 50
+```
+:::
+
 ## Step 3: Privacy Mode (Critical for Groups)
 
 Telegram bots have a **privacy mode** that is **enabled by default**. This is the single most common source of confusion when using bots in groups.


### PR DESCRIPTION
## What & why

The Telegram bot-command menu (`set_my_commands`) is capped at `MAX_COMMANDS_PER_SCOPE = 30` per scope to stay under Telegram's undocumented ~4KB `setMyCommands` payload limit. The menu is built in priority order — core commands → plugin slash commands → skill commands (skills trimmed first). When core + skill commands fill the 30 slots, **plugin/profile slash commands get trimmed and never reach the "/" menu**. They still work when typed, but aren't discoverable.

Concretely: a profile-router plugin that registers `/finance`, `/trend`, etc. via `ctx.register_command(...)` has its commands silently omitted from the menu on instances with many core/skill commands — `getMyCommands` returns 30 with none of the plugin commands.

## Change

Make the cap configurable via `telegram.menu_max_commands` (read from the platform `extra` config, clamped to Telegram's documented 1–100), **defaulting to the existing `MAX_COMMANDS_PER_SCOPE` (30)** so behavior is unchanged unless opted in. Both registration sites honor it:

- startup all-scopes registration (`connect()`)
- lazy per-forum-scope registration (`_ensure_forum_commands()`)

```yaml
telegram:
  menu_max_commands: 50   # 1..100; default 30
```

A new `_coerce_int_extra` helper mirrors the existing `_coerce_bool_extra` (invalid/missing → default, with optional clamping).

## How to test

Set `telegram: { menu_max_commands: 50 }` in `config.yaml`, run a plugin that registers slash commands, restart the gateway, and confirm `getMyCommands` lists them. Unit tests added in `tests/gateway/test_telegram_menu_cap.py` cover: default, override, string-encoded int, clamp-high (→100), clamp-low (→1), and invalid (→default).

```
scripts/run_tests.sh tests/gateway/test_telegram_menu_cap.py
```

## Platforms tested

Linux. Pure config read + clamp — no OS-specific code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
