### PR TITLE
feat(agent): add max_system_prompt_tokens stable-tier ceiling

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1201,6 +1201,13 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # Deterministic system-prompt stable-tier ceiling (tokens). 0 = unlimited.
+    # Enforced in build_system_prompt_parts via _apply_stable_budget.
+    try:
+        agent._max_system_prompt_tokens = max(int(_agent_section.get("max_system_prompt_tokens", 0)), 0)
+    except (TypeError, ValueError):
+        agent._max_system_prompt_tokens = 0
+
     # App-level API retry count (wraps each model API call).  Default 3,
     # overridable via agent.api_max_retries in config.yaml.  See #11616.
     try:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -24,8 +24,9 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
+import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
@@ -40,6 +41,47 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_stable_budget(sections: List[Tuple[int, str]], budget: int) -> str:
+    """Join stable-tier sections, dropping whole sections to fit ``budget``.
+
+    ``sections`` is a list of ``(drop_priority, text)`` in render order.
+    Higher ``drop_priority`` is dropped first; ``0`` is never dropped
+    (identity-critical: SOUL/identity, core tool guidance).  ``budget`` is
+    a token ceiling estimated with :func:`estimate_tokens_rough`; ``budget
+    <= 0`` disables truncation entirely.
+
+    Surviving sections keep their original render order.  The result is a
+    pure function of its inputs — it runs once per session at build time,
+    so it never invalidates the upstream prefix cache mid-conversation.
+    """
+    from agent.model_metadata import estimate_tokens_rough
+
+    def render(secs: List[Tuple[int, str]]) -> str:
+        return "\n\n".join(t.strip() for _, t in secs if t and t.strip())
+
+    if budget <= 0:
+        return render(sections)
+
+    kept = list(sections)
+    while estimate_tokens_rough(render(kept)) > budget:
+        # Drop the most-droppable section: highest priority, latest in order.
+        droppable = [(i, prio) for i, (prio, _) in enumerate(kept) if prio > 0]
+        if not droppable:
+            logger.warning(
+                "System prompt stable tier is %d tokens, over "
+                "max_system_prompt_tokens=%d, but only identity-critical "
+                "sections remain — keeping them un-truncated.",
+                estimate_tokens_rough(render(kept)), budget,
+            )
+            break
+        idx = max(droppable, key=lambda x: (x[1], x[0]))[0]
+        del kept[idx]
+
+    return render(kept)
 
 
 def _ra():
@@ -81,7 +123,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _r = _ra()
 
     # ── Stable tier ────────────────────────────────────────────────
-    stable_parts: List[str] = []
+    # Each entry is (drop_priority, text). Higher priority is dropped first
+    # when agent._max_system_prompt_tokens caps the tier; 0 = never dropped.
+    stable_parts: List[Tuple[int, str]] = []
+
+    def _add(text: str, drop_priority: int = 0) -> None:
+        if text and text.strip():
+            stable_parts.append((drop_priority, text))
 
     # Try SOUL.md as primary identity unless the caller explicitly skipped it.
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
@@ -90,15 +138,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if agent.load_soul_identity or not agent.skip_context_files:
         _soul_content = _r.load_soul_md()
         if _soul_content:
-            stable_parts.append(_soul_content)
+            _add(_soul_content)
             _soul_loaded = True
 
     if not _soul_loaded:
         # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+        _add(DEFAULT_AGENT_IDENTITY)
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    _add(HERMES_AGENT_HELP_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
@@ -119,17 +167,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
-        stable_parts.append(" ".join(tool_guidance))
+        _add(" ".join(tool_guidance))
 
     # Computer-use (macOS) — goes in as its own block rather than being
     # merged into tool_guidance because the content is multi-paragraph.
     if "computer_use" in agent.valid_tool_names:
         from agent.prompt_builder import COMPUTER_USE_GUIDANCE
-        stable_parts.append(COMPUTER_USE_GUIDANCE)
+        _add(COMPUTER_USE_GUIDANCE)
 
     nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
     if nous_subscription_prompt:
-        stable_parts.append(nous_subscription_prompt)
+        _add(nous_subscription_prompt)
     # Tool-use enforcement: tells the model to actually call tools instead
     # of describing intended actions.  Controlled by config.yaml
     # agent.tool_use_enforcement:
@@ -152,19 +200,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             model_lower = (agent.model or "").lower()
             _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
         if _inject:
-            stable_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
+            _add(TOOL_USE_ENFORCEMENT_GUIDANCE, drop_priority=1)
             _model_lower = (agent.model or "").lower()
             # Google model operational guidance (conciseness, absolute
             # paths, parallel tool calls, verify-before-edit, etc.)
             if "gemini" in _model_lower or "gemma" in _model_lower:
-                stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
+                _add(GOOGLE_MODEL_OPERATIONAL_GUIDANCE, drop_priority=1)
             # OpenAI GPT/Codex execution discipline (tool persistence,
             # prerequisite checks, verification, anti-hallucination).
             # Also applied to xAI Grok — same failure modes (claims completion
             # without tool calls, suggests workarounds instead of using
             # existing tools, replies with plans instead of executing).
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
-                stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+                _add(OPENAI_MODEL_EXECUTION_GUIDANCE, drop_priority=1)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:
@@ -182,7 +230,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         skills_prompt = ""
     if skills_prompt:
-        stable_parts.append(skills_prompt)
+        _add(skills_prompt, drop_priority=5)
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
@@ -191,7 +239,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # at construction time.
     if agent.provider == "alibaba":
         _model_short = agent.model.split("/")[-1] if "/" in agent.model else agent.model
-        stable_parts.append(
+        _add(
             f"You are powered by the model named {_model_short}. "
             f"The exact model ID is {agent.model}. "
             f"When asked what model you are, always answer based on this information, "
@@ -203,7 +251,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Stable for the lifetime of the process.
     _env_hints = _r.build_environment_hints()
     if _env_hints:
-        stable_parts.append(_env_hints)
+        _add(_env_hints, drop_priority=4)
 
     # Active-profile hint — names the Hermes profile the agent is running
     # under so it doesn't conflate ~/.hermes/skills/ (default profile) with
@@ -218,16 +266,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     except Exception:
         active_profile = "default"
     if active_profile == "default":
-        stable_parts.append(
+        _add(
             "Active Hermes profile: default. Other profiles (if any) live "
             "under ~/.hermes/profiles/<name>/. Each profile has its own "
             "skills/, plugins/, cron/, and memories/ that affect a different "
             "session than this one. Do not modify another profile's "
             "skills/plugins/cron/memories unless the user explicitly directs "
-            "you to."
+            "you to.",
+            drop_priority=3,
         )
     else:
-        stable_parts.append(
+        _add(
             f"Active Hermes profile: {active_profile}. This session reads "
             f"and writes ~/.hermes/profiles/{active_profile}/. The default "
             f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
@@ -236,19 +285,20 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "
             f"refuse such writes by default; pass cross_profile=True only "
-            f"after explicit direction."
+            f"after explicit direction.",
+            drop_priority=3,
         )
 
     platform_key = (agent.platform or "").lower().strip()
     if platform_key in PLATFORM_HINTS:
-        stable_parts.append(PLATFORM_HINTS[platform_key])
+        _add(PLATFORM_HINTS[platform_key], drop_priority=2)
     elif platform_key:
         # Check plugin registry for platform-specific LLM guidance
         try:
             from gateway.platform_registry import platform_registry
             _entry = platform_registry.get(platform_key)
             if _entry and _entry.platform_hint:
-                stable_parts.append(_entry.platform_hint)
+                _add(_entry.platform_hint, drop_priority=2)
         except Exception:
             pass
 
@@ -312,7 +362,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     volatile_parts.append(timestamp_line)
 
     return {
-        "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
+        "stable":   _apply_stable_budget(stable_parts, getattr(agent, "_max_system_prompt_tokens", 0)),
         "context":  "\n\n".join(p.strip() for p in context_parts  if p and p.strip()),
         "volatile": "\n\n".join(p.strip() for p in volatile_parts if p and p.strip()),
     }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -586,7 +586,17 @@ agent:
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
-  
+
+  # Deterministic ceiling on the stable tier of the system prompt, in tokens
+  # (rough ~4-chars/token estimate). 0 = unlimited (default). When set, lower-
+  # priority stable sections are dropped whole — skills index first, then
+  # environment / profile / platform hints, then model-family guidance — until
+  # the stable tier fits the budget. Identity, core tool guidance, context
+  # files, and the volatile tier (memory / user profile / timestamp) are never
+  # truncated. Computed once per session, so it never invalidates the prompt
+  # cache. Useful for small-context models that need a predictable ceiling.
+  # max_system_prompt_tokens: 0
+
   # Enable verbose logging
   verbose: false
   

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -669,6 +669,18 @@ DEFAULT_CONFIG = {
         # (force on/off for all models), or a list of model-name substrings
         # to match (e.g. ["gpt", "codex", "gemini", "qwen"]).
         "tool_use_enforcement": "auto",
+        # Deterministic ceiling on the stable tier of the system prompt, in
+        # tokens (rough ~4-chars/token estimate).  0 = unlimited (default —
+        # byte-identical to prior behavior).  When set, lower-priority stable
+        # sections are dropped whole — skills index first, then environment /
+        # profile / platform hints, then model-family guidance — until the
+        # stable tier fits the budget.  Identity (SOUL.md / default identity),
+        # core tool guidance, context files, and the volatile tier (memory /
+        # user profile / timestamp) are never truncated.  Computed once per
+        # session at build time so it never invalidates the prompt cache.
+        # Useful for small-context models that need a predictable ceiling
+        # regardless of how many skills or context files accumulate.
+        "max_system_prompt_tokens": 0,
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/tests/agent/test_system_prompt_budget.py
+++ b/tests/agent/test_system_prompt_budget.py
@@ -1,0 +1,107 @@
+"""Tests for the stable-tier system-prompt budget allocator.
+
+``_apply_stable_budget`` enforces ``agent.max_system_prompt_tokens`` by
+dropping whole lower-priority sections from the stable tier until the
+joined estimate fits the budget.  It is deterministic (computed once per
+session at build time) so it never invalidates the upstream prefix cache.
+
+Drop priority convention: higher number = dropped first; ``0`` = never
+dropped (identity-critical).  Budget ``0`` = unlimited (no truncation).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent.model_metadata import estimate_tokens_rough
+from agent.system_prompt import _apply_stable_budget
+
+
+def _join(*texts: str) -> str:
+    return "\n\n".join(t.strip() for t in texts if t and t.strip())
+
+
+class TestBudgetDisabled:
+    def test_budget_zero_keeps_everything_in_order(self):
+        sections = [(0, "alpha"), (5, "beta"), (4, "gamma")]
+        assert _apply_stable_budget(sections, 0) == _join("alpha", "beta", "gamma")
+
+    def test_negative_budget_treated_as_unlimited(self):
+        sections = [(0, "alpha"), (5, "beta")]
+        assert _apply_stable_budget(sections, -1) == _join("alpha", "beta")
+
+    def test_empty_and_whitespace_sections_excluded(self):
+        sections = [(0, "alpha"), (5, "   "), (4, ""), (3, "gamma")]
+        assert _apply_stable_budget(sections, 0) == _join("alpha", "gamma")
+
+
+class TestUnderBudget:
+    def test_keeps_everything_when_already_under_budget(self):
+        sections = [(0, "a" * 40), (5, "b" * 40)]
+        # ~20 tokens total; budget far above
+        result = _apply_stable_budget(sections, 10_000)
+        assert ("a" * 40) in result
+        assert ("b" * 40) in result
+
+
+class TestTruncation:
+    def test_drops_highest_priority_section_first(self):
+        protected = "P" * 40   # ~10 tok
+        skills = "S" * 400      # ~100 tok, drop_priority 5
+        env = "E" * 200         # ~50 tok, drop_priority 4
+        sections = [(0, protected), (5, skills), (4, env)]
+
+        # Full ~161 tok; dropping only skills drops to ~61 tok.
+        result = _apply_stable_budget(sections, 100)
+
+        assert skills not in result          # highest priority dropped
+        assert protected in result
+        assert env in result                 # lower priority survived
+        assert estimate_tokens_rough(result) <= 100
+
+    def test_drops_in_priority_order_until_under_budget(self):
+        protected = "P" * 40    # ~10 tok
+        skills = "S" * 400      # drop_priority 5
+        env = "E" * 200         # drop_priority 4
+        sections = [(0, protected), (5, skills), (4, env)]
+
+        # Budget 20 forces dropping both skills (5) then env (4).
+        result = _apply_stable_budget(sections, 20)
+
+        assert skills not in result
+        assert env not in result
+        assert protected in result
+        assert estimate_tokens_rough(result) <= 20
+
+    def test_survivors_keep_original_order(self):
+        sections = [(0, "first"), (5, "B" * 400), (0, "third")]
+        result = _apply_stable_budget(sections, 5)
+        assert result == _join("first", "third")
+
+
+class TestProtectedSections:
+    def test_protected_sections_never_dropped_even_over_budget(self, caplog):
+        protected = "P" * 400  # ~100 tok, drop_priority 0
+        sections = [(0, protected)]
+
+        with caplog.at_level(logging.WARNING, logger="agent.system_prompt"):
+            result = _apply_stable_budget(sections, 10)
+
+        assert result == protected
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_no_warning_when_within_budget(self, caplog):
+        sections = [(0, "P" * 40)]
+        with caplog.at_level(logging.WARNING, logger="agent.system_prompt"):
+            _apply_stable_budget(sections, 10_000)
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestDeterminism:
+    def test_identical_inputs_produce_identical_output(self):
+        sections = [(0, "P" * 40), (5, "S" * 400), (4, "E" * 200), (2, "X" * 100)]
+        a = _apply_stable_budget(sections, 70)
+        b = _apply_stable_budget(sections, 70)
+        assert a == b

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5665,3 +5665,55 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+
+class TestMaxSystemPromptTokens:
+    """Tests for the agent.max_system_prompt_tokens budget ceiling.
+
+    Verifies the budget wired through config -> agent -> build_system_prompt_parts
+    truncates the droppable stable-tier sections (e.g. the skills index) while
+    preserving identity-critical content. The allocator itself is unit-tested in
+    tests/agent/test_system_prompt_budget.py; these tests cover the wiring.
+    """
+
+    # build_skills_system_prompt is patched and called at prompt-build time,
+    # so the prompt MUST be built while the patch context is still open
+    # (otherwise the real helper runs against the hermetic empty HERMES_HOME
+    # and returns ""). Hence this helper builds and returns the prompt itself.
+    _SKILLS_MARKER = "SKILLS_" + "X" * 4000
+
+    def _build_prompt(self, max_tokens):
+        tools = _make_tool_defs("skills_list", "skill_view", "skill_manage")
+        toolset_map = {"skills_list": "skills", "skill_view": "skills", "skill_manage": "skills"}
+        with (
+            patch("run_agent.get_tool_definitions", return_value=tools),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.get_toolset_for_tool", create=True, side_effect=toolset_map.get),
+            patch("run_agent.build_skills_system_prompt", return_value=self._SKILLS_MARKER),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"max_system_prompt_tokens": max_tokens}},
+            ),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            return agent._build_system_prompt()
+
+    def test_default_zero_keeps_full_skills_index(self):
+        """Default (0 = unlimited) leaves the large skills block intact."""
+        prompt = self._build_prompt(0)
+        assert self._SKILLS_MARKER in prompt
+        assert DEFAULT_AGENT_IDENTITY in prompt
+
+    def test_tiny_budget_drops_skills_but_keeps_identity(self):
+        """A budget below the skills block forces it out; identity survives."""
+        prompt = self._build_prompt(50)
+        assert self._SKILLS_MARKER not in prompt
+        assert DEFAULT_AGENT_IDENTITY in prompt


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `agent.max_system_prompt_tokens` config knob that puts a **deterministic ceiling on the stable tier of the system prompt**. When the assembled stable tier exceeds the budget, whole lower-priority sections are dropped — skills index first, then environment / profile / platform hints, then model-family guidance — until it fits.

**Never truncated:** identity (SOUL.md / default identity), core tool guidance, context files, and the entire volatile tier (memory / user profile / timestamp).

**Why this approach:** This is about a *predictable context-window ceiling* for small-context models, not cost — tool and prompt definitions are already provider-cached, as noted in #4379's discussion. As skills and context files accumulate, the stable tier can grow unbounded; a hard cap lets operators of 32K-class models guarantee headroom for conversation.

Truncation is a **pure function computed once per session** in `build_system_prompt_parts`, alongside the rest of the stable tier. It is *not* per-turn or input-dependent, so it never invalidates the upstream prefix cache mid-conversation. Default `0` = unlimited, **byte-identical to current behavior** (the allocator's `budget <= 0` path returns the same join as before).

## Related Issue

Refs #4379 — one of the suggestions in that token-overhead analysis. This PR addresses the *system-prompt growth* angle specifically; it does not attempt the tool-filtering or compression-tuning items also discussed there, which are orthogonal.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/system_prompt.py` — new `_apply_stable_budget(sections, budget)` allocator; `stable_parts` now carries `(drop_priority, text)` via a local `_add()` helper; stable tier routed through the allocator in `build_system_prompt_parts`.
- `hermes_cli/config.py` — `agent.max_system_prompt_tokens` default `0` (off), documented.
- `agent/agent_init.py` — read into `agent._max_system_prompt_tokens` (clamped to ≥ 0, falls back to 0 on bad input).
- `cli-config.yaml.example` — document the new key.
- `tests/agent/test_system_prompt_budget.py` — 10 unit tests for the allocator (disabled/under/over budget, drop order, protected sections + warning, determinism).
- `tests/run_agent/test_run_agent.py` — 2 wiring tests (budget 0 keeps the skills block; tiny budget drops skills while keeping identity).

Drop-priority order (higher = dropped first): skills `5` → environment hints `4` → active-profile hint `3` → platform hint `2` → model-family / tool-use-enforcement guidance `1`. Identity-critical sections are `0` (never dropped). If even the protected set exceeds budget, it is emitted un-truncated with a WARNING.

## How to Test

1. Default behavior is unchanged: with `max_system_prompt_tokens: 0` (default) the system prompt is byte-identical to before.
2. Set `agent.max_system_prompt_tokens: 2000` in config and run with many skills installed — the `<available_skills>` block is dropped first when over budget; identity and tool guidance remain.
3. Run the tests:
   - `pytest tests/agent/test_system_prompt_budget.py -q` → 10 passed
   - `pytest tests/run_agent/test_run_agent.py::TestMaxSystemPromptTokens -q` → 2 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the suites covering the touched code — `test_system_prompt_budget`, `test_run_agent`, `test_prompt_builder`, `test_system_prompt_restore`, `test_config`, `test_config_validation`, `test_memory_provider` — all pass (TZ=UTC, PYTHONHASHSEED=0). See the test-environment note below.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — config key documented in `cli-config.yaml.example` + docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no workflow/architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string/token logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool changes)

## Screenshots / Logs

```
$ pytest tests/agent/test_system_prompt_budget.py -q
..........                                                               [100%]
10 passed

$ pytest tests/run_agent/test_run_agent.py::TestMaxSystemPromptTokens -q
..                                                                       [100%]
2 passed
```

### Test-environment note

A broader local run of `tests/agent/` + `tests/hermes_cli/` showed 9227 passed, 33 failed. The 33 failures are **pre-existing and unrelated to this change** — they reproduce identically on `origin/main` with this branch's commit absent, and live entirely in signal/PTY/process/LSP/migration areas this dev box can't satisfy (no language server for `lsp/test_client_e2e`, signal-delivery guard for `test_signal_handler_kanban_worker`/`test_pty_bridge`/`test_run_with_idle_timeout`, and `test_migrate_xai`/`test_auth_xai_oauth`/`test_kanban_core`/`test_shell_hooks`). None touch the system-prompt or config code paths in this PR. Maintainer CI (with full per-file isolation via `scripts/run_tests.sh`) should be the source of truth for the unrelated suites.
