### PR TITLE
fix(codex): make no-byte TTFB watchdog opt-in

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -279,17 +279,15 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # mode where it accepts the connection but never emits a single stream
     # event (observed directly: 0 events, no HTTP status, the socket just
     # hangs). A fresh reconnect succeeds in ~2s, but the wall-clock stale
-    # timeout (often 180–900s) makes us wait minutes before retrying. While no
-    # stream event has arrived yet we apply a much shorter TTFB cutoff so the
-    # main retry loop can reconnect promptly. Large subscription-backed Codex
-    # requests can legitimately spend tens of seconds in backend admission /
-    # prompt prefill before the first SSE event, so the no-byte TTFB watchdog
-    # is disabled for large chatgpt.com/backend-api/codex requests. A second
-    # failure mode emits an opening SSE frame and then stalls forever in SSL
-    # read; for that we watch the gap since the last Codex stream event. This
-    # matches Codex CLI's stream_idle_timeout model: any valid SSE event is
-    # activity. Operators can tune via HERMES_CODEX_TTFB_TIMEOUT_SECONDS and
-    # HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables each).
+    # timeout (often 180–900s) makes us wait minutes before retrying. A short
+    # no-byte TTFB cutoff is risky for subscription-backed Codex requests,
+    # which can legitimately spend a while in backend admission / prompt
+    # prefill before the first SSE event, so that watchdog is opt-in via
+    # HERMES_CODEX_TTFB_TIMEOUT_SECONDS. A second failure mode emits an opening
+    # SSE frame and then stalls forever in SSL read; for that we watch the gap
+    # since the last Codex stream event. This matches Codex CLI's
+    # stream_idle_timeout model: any valid SSE event is activity. Operators can
+    # tune via HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables it).
     _codex_watchdog_enabled = agent.api_mode == "codex_responses"
     _openai_codex_backend = _is_openai_codex_backend(agent)
     _est_tokens_for_codex_watchdog = estimate_request_context_tokens(api_kwargs)
@@ -310,8 +308,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
     else:
         _codex_idle_timeout_default = 12.0
 
-    _ttfb_enabled = _codex_watchdog_enabled
-    _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 12.0)
+    _ttfb_env = os.environ.get("HERMES_CODEX_TTFB_TIMEOUT_SECONDS")
+    _ttfb_enabled = _codex_watchdog_enabled and _ttfb_env is not None
+    _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 0.0)
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
     elif _openai_codex_backend:

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -2,11 +2,11 @@
 
 The chatgpt.com/backend-api/codex endpoint has an intermittent failure mode
 where it accepts the connection but never emits a single stream event. The
-watchdog in ``interruptible_api_call`` kills such a connection at a short TTFB
-cutoff (instead of waiting out the much longer wall-clock stale timeout) so the
-retry loop can reconnect promptly. Once any stream event arrives, the TTFB
-watchdog is satisfied and a separate idle watchdog handles streams that stop
-emitting SSE events.
+watchdog in ``interruptible_api_call`` can kill such a connection at a short
+TTFB cutoff so the retry loop can reconnect promptly, but that no-byte watchdog
+is opt-in because backend admission / prefill can legitimately take longer
+than a fixed first-byte cutoff. Once any stream event arrives, a separate idle
+watchdog handles streams that stop emitting SSE events.
 
 The "bytes flowing" signal is ``agent._codex_stream_last_event_ts``, set on
 *any* event by ``codex_runtime.run_codex_stream`` — so reasoning-only or
@@ -100,6 +100,39 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
         assert elapsed < 15, f"TTFB watchdog took {elapsed:.1f}s"
     finally:
         stop["flag"] = True
+
+
+def test_ttfb_is_disabled_by_default(tmp_path, monkeypatch):
+    """No-byte TTFB reconnects are opt-in. Without the env var, a slow first
+    event should get the normal provider/SDK stale-timeout window."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", raising=False)
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent, "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        time.sleep(2.0)
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    resp = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+    assert resp is sentinel
+    assert "codex_ttfb_kill" not in closes
 
 
 def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Makes the Codex no-first-byte stream watchdog opt-in instead of enabled by default.

Hermes recently added a Codex stream watchdog that aborts a request if no SSE event arrives within `HERMES_CODEX_TTFB_TIMEOUT_SECONDS`, defaulting to 12 seconds. That helps with one failure mode where the Codex endpoint accepts a connection and never emits any stream event, but it is too aggressive as a default for normal backend admission / prompt prefill delays.

The OpenAI Python SDK already has much longer default transport behavior. In OpenAI SDK 2.24.0, `openai/_constants.py` defines `DEFAULT_TIMEOUT = httpx.Timeout(timeout=600, connect=5.0)` and `DEFAULT_MAX_RETRIES = 2`; `openai/_base_client.py` uses those as the base client defaults. Hermes' default 12s no-byte watchdog can therefore abort a stream long before the SDK/provider timeout path would have treated it as failed.

This change keeps the post-first-event Codex idle watchdog in place, but requires operators to explicitly set `HERMES_CODEX_TTFB_TIMEOUT_SECONDS` before Hermes will kill a stream that has not emitted its first SSE event yet.

## Related Issue

No GitHub issue filed. This came from Discord support reports where Codex requests failed through all retries with `Codex stream produced no bytes within 12s (TTFB threshold: 12s)`.

Related PR: #33434 is adjacent, but it takes a fail-fast / circuit-breaker approach for zero-event stalls. This PR takes the narrower default-behavior approach: do not kill no-byte streams early unless the operator explicitly opts in, while keeping the existing post-first-event idle watchdog.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/chat_completion_helpers.py` so the no-byte Codex TTFB watchdog is disabled unless `HERMES_CODEX_TTFB_TIMEOUT_SECONDS` is explicitly set.
- Preserved `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS` behavior for streams that emit at least one SSE event and then stall.
- Added regression coverage in `tests/agent/test_codex_ttfb_watchdog.py` for the default-disabled TTFB behavior.

## How to Test

1. Leave `HERMES_CODEX_TTFB_TIMEOUT_SECONDS` unset.
2. Run a Codex stream path where the first SSE event is delayed but the request eventually returns.
3. Confirm Hermes does not abort the request with `codex_ttfb_kill` before the provider/SDK timeout path.

Focused local test:

`before=${HERMES_HOME-}; scripts/run_tests.sh -j 4 tests/agent/test_codex_ttfb_watchdog.py; status=$?; after=${HERMES_HOME-}; printf '\nHERMES_HOME before=%s after=%s\n' "$before" "$after"; exit $status`

Result: `9 passed`.

`HERMES_HOME` was unchanged before/after the focused run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux, focused test only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Example failure this is meant to avoid:

`Codex stream produced no bytes within 12s (TTFB threshold: 12s)`

That retry loop can discard still-valid provider connections before the SDK's normal timeout behavior has a chance to run. This PR changes that first-byte kill path from default behavior to an explicit operator override.
