### PR TITLE
security: CVE-2026-48710 BadHost defense-in-depth — use raw ASGI path in auth middleware

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -82,7 +82,10 @@ def _unauth_response(request: Request, *, reason: str) -> Response:
     """
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
-    path = request.url.path
+    # CVE-2026-48710 (BadHost): use the raw ASGI path so a poisoned Host header
+    # cannot bias the API-vs-HTML branching below (which decides between a
+    # JSON 401 envelope and a 302 redirect to the OAuth flow).
+    path = request.scope["path"]
     next_param = _safe_next_target(request)
     prefix = prefix_from_request(request)
     login_url = (
@@ -120,7 +123,13 @@ def _safe_next_target(request: Request) -> str:
     string return means the caller produces a bare ``/login`` URL — fine,
     user lands at the dashboard root after re-auth.
     """
-    path = request.url.path
+    # CVE-2026-48710 (BadHost): read the raw ASGI path so the open-redirect
+    # guard below ("must start with /, must not start with //") evaluates on
+    # what the server actually routed against, not the (attacker-poisoned)
+    # reconstructed URL. The risk here is narrower than the auth bypass since
+    # the path is only used to build a same-origin `next=` param, but the
+    # defense-in-depth fix is identical and free.
+    path = request.scope["path"]
     # Reject anything that doesn't start with "/" or starts with "//"
     # (protocol-relative URL — would open-redirect to an attacker host).
     if not path or not path.startswith("/") or path.startswith("//"):
@@ -151,7 +160,14 @@ async def gated_auth_middleware(
     if not getattr(request.app.state, "auth_required", False):
         return await call_next(request)
 
-    path = request.url.path
+    # CVE-2026-48710 (BadHost): read the raw ASGI path. The reconstructed
+    # request.url derives from the Host header — pre-Starlette 1.0.1, a Host
+    # containing `/`, `?`, or `#` shifts the parsed path boundary so a request
+    # for `/api/sensitive` re-parses as `/login` (in _path_is_public's
+    # allowlist), middleware lets it through, the router still dispatches to
+    # `/api/sensitive` → auth bypass on the OAuth-gated path.
+    # See https://www.cve.org/CVERecord?id=CVE-2026-48710
+    path = request.scope["path"]
     if _path_is_public(path):
         return await call_next(request)
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -273,7 +273,15 @@ async def auth_middleware(request: Request, call_next):
     # and is skipped here so the gate's session attachment isn't overridden.
     if getattr(request.app.state, "auth_required", False):
         return await call_next(request)
-    path = request.url.path
+    # CVE-2026-48710 (BadHost) defense-in-depth: read the raw ASGI path from
+    # scope, not request.url.path. The reconstructed request.url derives from
+    # the (attacker-controllable) Host header — pre-Starlette 1.0.1, a Host
+    # containing `/`, `?`, or `#` shifts the re-parsed path/query boundary so
+    # request.url.path no longer matches the path the ASGI server actually
+    # routed against. Middleware sees the poisoned path; the router dispatches
+    # on the real wire path → auth bypass.
+    # See https://www.cve.org/CVERecord?id=CVE-2026-48710
+    path = request.scope["path"]
     if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
         if not _has_valid_session_token(request):
             return JSONResponse(


### PR DESCRIPTION
## Summary

Defense-in-depth fix for [CVE-2026-48710](https://www.cve.org/CVERecord?id=CVE-2026-48710) ("BadHost") — Starlette host-header auth bypass disclosed 2026-05-21, patched in Starlette 1.0.1.

CVE-2026-48710 lets an attacker bias `request.url.path` via a crafted `Host` header. A Host containing `/`, `?`, or `#` shifts the re-parsed path/query boundary so the reconstructed URL no longer matches the path the ASGI server actually routed against — middleware sees the poisoned path, the router dispatches on the real wire path, and any auth check that reads `request.url.path` is bypassed.

Starlette 1.0.1 patched the URL-reconstruction logic, but the Starlette maintainers' own recommendation in the disclosure is also a defense-in-depth fix at every call site: read the raw ASGI path from `request.scope["path"]` instead of `request.url.path`. The scope path is set by the ASGI server from the wire request and matches what the router dispatches on; it can't be poisoned by the Host header. This change keeps `hermes-agent` safe even under a future Starlette regression or an older transitive resolution by a downstream packager.

## What this PR changes

Four sites across two files, all defense-in-depth:

### `hermes_cli/web_server.py` — `auth_middleware` (loopback session-token gate)

The legacy `_SESSION_TOKEN` path on `/api/*`. **Auth bypass shape:** attacker sends `Host: example.com/public-endpoint` to a request targeting `/api/sensitive`; pre-Starlette-1.0.1, `request.url.path` re-parses as `/public-endpoint`, the middleware skips the `_PUBLIC_API_PATHS` containment check, and the router still dispatches to `/api/sensitive`.

### `hermes_cli/dashboard_auth/middleware.py` — `gated_auth_middleware` (OAuth cookie gate)

The primary non-loopback auth gate (the cookie-based path used under the OAuth deployment). Same bypass shape via `_path_is_public(path)`.

### `hermes_cli/dashboard_auth/middleware.py` — `_unauth_response`

Chooses between JSON 401 envelope and 302 redirect by path prefix. Less severe (response formatting, not auth), but uses the same poisoned surface — fix is the same line.

### `hermes_cli/dashboard_auth/middleware.py` — `_safe_next_target`

Open-redirect guard on the OAuth `next=` query param. Validates the path starts with `/` and doesn't start with `//`. A poisoned Host can push unexpected content into the validated value; same drop-in fix.

## Not in this PR (intentionally)

The query-string handling at `_safe_next_target` line 138 (`request.url.query`) is preserving the query for the post-login redirect — it isn't used as a security decision, and `request.scope["query_string"]` returns bytes (not str), which would require a separate decoding layer. Left alone.

## No behavior change for normal traffic

`request.scope["path"]` returns the exact path string the ASGI server received and routed against, identical to `request.url.path` in the absence of Host poisoning. This is purely additive safety.

## Refs

- CVE-2026-48710: https://www.cve.org/CVERecord?id=CVE-2026-48710
- OSTIF disclosure: https://ostif.org/disclosing-the-badhost-vulnerability-in-starlette/
- Starlette 1.0.1 release: https://github.com/encode/starlette/releases/tag/1.0.1
- `firethering.com` writeup: https://firethering.com/badhost-starlette-critical-vulnerability-ai-agents/

🤖 Generated with [Claude Code](https://claude.com/claude-code)