### PR TITLE
Add source-aware artifact compaction

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1240,6 +1240,23 @@ def init_agent(
     compression_abort_on_summary_failure = str(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
+    def _artifact_int_config(key: str, default: int) -> int:
+        try:
+            value = int(_compression_cfg.get(key, default))
+            if value <= 0:
+                raise ValueError
+            return value
+        except (TypeError, ValueError):
+            return default
+
+    agent.artifact_compaction_min_chars = _artifact_int_config("artifact_min_chars", 8_000)
+    agent.artifact_compaction_min_tokens = _artifact_int_config("artifact_min_tokens", 2_000)
+    agent.artifact_compaction_max_summary_tokens = _artifact_int_config("artifact_max_summary_tokens", 800)
+    agent.artifact_retrieve_max_chars = _artifact_int_config("artifact_retrieve_max_chars", 12_000)
+    agent.context_budget_target_tokens = _artifact_int_config("target_active_context_tokens", 60_000)
+    agent.context_budget_warning_tokens = _artifact_int_config("warning_tokens", 80_000)
+    agent.context_budget_emergency_tokens = _artifact_int_config("emergency_compaction_tokens", 120_000)
+    agent.raw_generated_artifact_budget_fraction = float(_compression_cfg.get("raw_generated_artifact_budget_fraction", 0.20) or 0.20)
 
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via
@@ -1440,6 +1457,9 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
         )
+        agent.context_compressor.artifact_min_chars = agent.artifact_compaction_min_chars
+        agent.context_compressor.artifact_min_tokens = agent.artifact_compaction_min_tokens
+        agent.context_compressor.artifact_max_summary_tokens = agent.artifact_compaction_max_summary_tokens
         if not agent.quiet_mode:
             _ra().logger.info("Using context engine: %s", _selected_engine.name)
     else:
@@ -1457,6 +1477,9 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            artifact_min_chars=agent.artifact_compaction_min_chars,
+            artifact_min_tokens=agent.artifact_compaction_min_tokens,
+            artifact_max_summary_tokens=agent.artifact_compaction_max_summary_tokens,
         )
     agent.compression_enabled = compression_enabled
 

--- a/agent/artifact_compaction.py
+++ b/agent/artifact_compaction.py
@@ -1,0 +1,901 @@
+"""Artifact-aware context compaction for large scientific/tool outputs.
+
+Large OpenQP logs, Molden files, JSON dumps, and parser outputs are too
+expensive to keep verbatim in the active LLM context.  This module replaces
+those raw payloads with compact, reproducible summary cards and stores the
+original bytes under ``$HERMES_HOME/artifacts`` using a content hash.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+from agent.model_metadata import estimate_tokens_rough
+
+PARSER_VERSION = "artifact-aware-compaction-v1"
+DEFAULT_MIN_CHARS = 8_000
+DEFAULT_MIN_TOKENS = 2_000
+DEFAULT_MAX_SUMMARY_TOKENS = 800
+DEFAULT_RETRIEVE_MAX_CHARS = 12_000
+SUMMARY_HEAD_LINES = 18
+SUMMARY_TAIL_LINES = 12
+MAX_SECTIONS_IN_CARD = 18
+
+ARTIFACT_CARD_PREFIX = "[HERMES ARTIFACT SUMMARY CARD]"
+_ARTIFACT_CARD_PREFIX = ARTIFACT_CARD_PREFIX
+
+
+class ArtifactCompactionResult(dict):
+    """Dict report with attribute aliases for compaction statistics."""
+
+    def __getattr__(self, name: str) -> Any:
+        aliases = {
+            "compacted_count": "artifact_count",
+            "tokens_before": "before_total_tokens",
+            "tokens_after": "after_total_tokens",
+            "before_profile": "largest_before",
+            "after_profile": "largest_after",
+        }
+        key = aliases.get(name, name)
+        try:
+            return self[key]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+@dataclass(frozen=True)
+class DetectedSection:
+    name: str
+    start_line: int
+    end_line: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class ArtifactMetadata:
+    artifact_id: str
+    sha256: str
+    path: str
+    metadata_path: str
+    parser_version: str
+    timestamp: str
+    artifact_type: str
+    byte_count: int
+    char_count: int
+    line_count: int
+    token_estimate: int
+    detected_sections: List[Dict[str, Any]]
+
+
+def artifact_root() -> Path:
+    root = Path(get_hermes_home()) / "artifacts"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _line_count(text: str) -> int:
+    return text.count("\n") + (0 if text.endswith("\n") or not text else 1)
+
+
+def _extension_for_type(kind: str) -> str:
+    return {
+        "openqp_log": ".openqp.log",
+        "molden": ".molden",
+        "cube": ".cube",
+        "xyz": ".xyz",
+        "pdb": ".pdb",
+        "cif": ".cif",
+        "json": ".json",
+        "source_code": ".source.txt",
+        "documentation": ".md",
+        "compiler_output": ".build.log",
+        "parser_output": ".txt",
+        "large_text": ".txt",
+    }.get(kind, ".txt")
+
+
+def _looks_like_json(text: str) -> bool:
+    stripped = text.lstrip()
+    if not stripped.startswith(("{", "[")):
+        return False
+    if len(stripped) < 400:
+        return False
+    try:
+        json.loads(stripped)
+        return True
+    except Exception:
+        # Very large tool dumps are sometimes truncated/non-strict but still
+        # recognizable enough to compact as JSON-ish output.
+        return bool(re.search(r'"[A-Za-z0-9_ -]{2,}"\s*:', stripped[:20_000]))
+
+
+
+SOURCE_EXTENSIONS = (".f90", ".F90", ".f", ".F", ".for", ".c", ".h", ".cpp", ".cxx", ".hpp", ".py", ".sh", ".bash", ".yaml", ".yml", ".json")
+_SOURCE_LANG_HINTS = {
+    "fortran": [r"^\s*(module|subroutine|function|program)\s+\w+", r"^\s*use\s+\w+", r"!\$omp"],
+    "python": [r"^\s*(def|class)\s+\w+", r"^\s*import\s+\w+", r"^\s*from\s+\w+\s+import"],
+    "c_cpp": [r"^\s*#\s*include\b", r"^\s*(?:static\s+)?(?:inline\s+)?[A-Za-z_][\w:<>\s\*&]+\s+[A-Za-z_]\w*\s*\([^;]*\)\s*\{"],
+    "shell": [r"^\s*#!/.*\b(?:bash|sh)\b", r"^\s*[A-Za-z_]\w*\s*\(\)\s*\{"],
+}
+
+
+def _unwrap_tool_json_text(text: str) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Return the human payload inside common tool JSON wrappers, if any."""
+    try:
+        obj = json.loads(text)
+    except Exception:
+        return text, None
+    if isinstance(obj, dict):
+        for key in ("content", "output", "stdout", "text"):
+            value = obj.get(key)
+            if isinstance(value, str) and value:
+                return value, obj
+    return text, obj if isinstance(obj, dict) else None
+
+
+def _strip_numbered_lines(text: str) -> str:
+    """Remove read_file-style ``123|`` gutters without touching normal code."""
+    lines = []
+    stripped_count = 0
+    for line in text.splitlines():
+        new = re.sub(r"^\s*\d+\|", "", line)
+        if new != line:
+            stripped_count += 1
+        lines.append(new)
+    if stripped_count >= max(3, len(lines) // 3):
+        return "\n".join(lines)
+    return text
+
+
+def _looks_like_source(text: str) -> bool:
+    payload, wrapper = _unwrap_tool_json_text(text)
+    if wrapper:
+        path_hint = str(wrapper.get("path") or wrapper.get("file") or wrapper.get("filename") or "")
+        if path_hint.endswith(SOURCE_EXTENSIONS):
+            return True
+        if payload is text and not any(isinstance(wrapper.get(k), str) for k in ("content", "output", "stdout", "text")):
+            return False
+    src = _strip_numbered_lines(payload)
+    if "diff --git" in src and re.search(r"(?m)^\+\+\+ b/.*\.(?:py|f90|F90|c|cpp|h|hpp|sh|ya?ml|json)$", src):
+        return True
+    lines = src.splitlines()[:400]
+    if not lines:
+        return False
+    score = 0
+    joined = "\n".join(lines)
+    for patterns in _SOURCE_LANG_HINTS.values():
+        if any(re.search(pat, joined, re.MULTILINE) for pat in patterns):
+            score += 2
+    codey = sum(1 for line in lines if re.search(r"(::|;\s*$|\{\s*$|\}\s*$|^\s*(if|do|end|call|use|def|class|return|import|from)\b)", line, re.I))
+    if codey >= 8:
+        score += 2
+    prose = sum(1 for line in lines if len(line.split()) > 14 and not line.lstrip().startswith(("#", "!", "//", "*")))
+    return score >= 2 and prose < max(25, len(lines) // 2)
+
+
+def _looks_like_documentation(text: str) -> bool:
+    payload, _wrapper = _unwrap_tool_json_text(text)
+    head = payload[:20_000]
+    headings = len(re.findall(r"(?m)^\s{0,3}#{1,6}\s+\S", head))
+    return headings >= 3 or ("```" in head and headings >= 1)
+
+
+def _looks_like_scientific_artifact(text: str) -> Optional[str]:
+    payload, _wrapper = _unwrap_tool_json_text(text)
+    low = payload[:40_000].lower()
+    if "[molden format]" in low or ("[atoms]" in low and "[gto]" in low and "[mo]" in low):
+        return "molden"
+    if re.search(r"(?m)^\s*\d+\s*$", payload[:2000]) and len(re.findall(r"(?m)^\s*[A-Z][a-z]?\s+[-+0-9.eE]+\s+[-+0-9.eE]+\s+[-+0-9.eE]+", payload[:20_000])) >= 3:
+        return "xyz"
+    if "data_file" in low and ("loop_" in low or "_atom_site" in low):
+        return "cif"
+    if re.search(r"(?m)^(ATOM  |HETATM)", payload[:20_000]):
+        return "pdb"
+    if "cube" in low[:1000] and len(re.findall(r"[-+]?\d+\.\d+(?:[Ee][-+]?\d+)?", payload[:20_000])) > 200:
+        return "cube"
+    return None
+
+
+def classify_artifact_content(text: str, *, min_chars: int = DEFAULT_MIN_CHARS) -> Optional[str]:
+    """Classify large incoming content by source-aware context policy type."""
+    if not isinstance(text, str) or len(text) < min_chars:
+        return None
+    if _looks_like_source(text):
+        return "source_code"
+    scientific = _looks_like_scientific_artifact(text)
+    if scientific:
+        return scientific
+    if _looks_like_json(text):
+        return "json"
+    if _looks_like_documentation(text):
+        return "documentation"
+    return None
+
+
+def _source_payload(text: str) -> str:
+    payload, _wrapper = _unwrap_tool_json_text(text)
+    return _strip_numbered_lines(payload)
+
+
+def _source_language(src: str) -> str:
+    low = src[:20_000].lower()
+    if re.search(r"(?m)^\s*(module|subroutine|function|program)\s+\w+", src, re.I) or "!$omp" in low:
+        return "fortran"
+    if re.search(r"(?m)^\s*(def|class)\s+\w+", src):
+        return "python"
+    if "#include" in src[:5000] or re.search(r"(?m)^\s*[A-Za-z_][\w:<>\s\*&]+\s+[A-Za-z_]\w*\s*\([^;]*\)", src):
+        return "c_cpp"
+    if src.startswith("#!") or re.search(r"(?m)^\s*[A-Za-z_]\w*\s*\(\)\s*\{", src):
+        return "shell"
+    return "source"
+
+
+def _detect_source_sections(text: str) -> List[DetectedSection]:
+    src = _source_payload(text)
+    lines = src.splitlines()
+    starts: List[Tuple[str, int]] = []
+    lang = _source_language(src)
+    if lang == "fortran":
+        pat = re.compile(r"^\s*(module(?!\s+procedure)|subroutine|function|program|type|interface)\s+(?:,\s*[^:]+::\s*)?(\w+)?", re.I)
+        for idx, line in enumerate(lines, 1):
+            m = pat.match(line)
+            if m:
+                kind = m.group(1).lower()
+                name = m.group(2) or kind
+                starts.append((f"{kind} {name}", idx))
+    elif lang == "python":
+        for idx, line in enumerate(lines, 1):
+            m = re.match(r"^\s*(def|class)\s+(\w+)", line)
+            if m:
+                starts.append((f"{m.group(1)} {m.group(2)}", idx))
+    else:
+        func = re.compile(r"^\s*(?:static\s+)?(?:inline\s+)?[A-Za-z_][\w:<>\s\*&]+\s+([A-Za-z_]\w*)\s*\([^;]*\)\s*\{?\s*$")
+        for idx, line in enumerate(lines, 1):
+            m = func.match(line)
+            if m and m.group(1) not in {"if", "for", "while", "switch"}:
+                starts.append((f"function {m.group(1)}", idx))
+    return _sections_from_starts(starts[:MAX_SECTIONS_IN_CARD * 4], len(lines), "source")
+
+
+def _source_index(text: str) -> Dict[str, Any]:
+    src = _source_payload(text)
+    lines = src.splitlines()
+    modules: List[str] = []
+    routines: List[str] = []
+    types: List[str] = []
+    interfaces: List[str] = []
+    used: List[str] = []
+    omp: List[str] = []
+    arrays: List[str] = []
+    for idx, line in enumerate(lines, 1):
+        stripped = line.strip()
+        m = re.match(r"module\s+(?!procedure\b)(\w+)", stripped, re.I)
+        if m: modules.append(m.group(1))
+        m = re.match(r"(?:public\s*(?:::)?\s*)?(subroutine|function)\s+(\w+)", stripped, re.I)
+        if m: routines.append(m.group(2))
+        m = re.match(r"type\s*(?:,\s*[^:]+)?(?:::)?\s*(\w+)?", stripped, re.I)
+        if m and m.group(1): types.append(m.group(1))
+        m = re.match(r"interface\s*(\w+)?", stripped, re.I)
+        if m: interfaces.append(m.group(1) or f"interface@{idx}")
+        m = re.match(r"use\s*(?:,\s*[^:]+)?(?:::)?\s*(\w+)", stripped, re.I)
+        if m: used.append(m.group(1))
+        if stripped.lower().startswith("!$omp"):
+            omp.append(f"line {idx}: {stripped[:100]}")
+        if "::" in stripped and "(" in stripped:
+            left, right = stripped.split("::", 1)
+            if re.search(r"\b(real|integer|logical|complex|character|type)\b", left, re.I):
+                for name, dims in re.findall(r"\b(\w+)\s*\(([^)]{1,80})\)", right):
+                    arrays.append(f"{name}({dims})")
+    def uniq(values: List[str], n: int = 40) -> List[str]:
+        return list(dict.fromkeys(values))[:n]
+    return {
+        "language": _source_language(src),
+        "line_count": len(lines),
+        "modules": uniq(modules),
+        "public_routines": uniq(routines),
+        "contained_procedures": uniq(routines),
+        "derived_types": uniq(types),
+        "interfaces": uniq(interfaces),
+        "used_modules": uniq(used),
+        "openmp_directives": omp[:30],
+        "major_arrays": uniq(arrays, 50),
+    }
+
+
+def _scientific_metadata(text: str, kind: str) -> Dict[str, Any]:
+    payload, _wrapper = _unwrap_tool_json_text(text)
+    nums = len(re.findall(r"[-+]?\d*\.\d+(?:[Ee][-+]?\d+)?", payload[:200_000]))
+    atoms = len(re.findall(r"(?m)^\s*(?:ATOM  |HETATM|[A-Z][a-z]?\s+[-+0-9.eE]+\s+[-+0-9.eE]+\s+[-+0-9.eE]+)", payload[:200_000]))
+    return {"kind": kind, "line_count": _line_count(payload), "numeric_values_sampled": nums, "atom_like_records_sampled": atoms}
+
+def detect_artifact_type(text: str, *, min_chars: int = DEFAULT_MIN_CHARS) -> Optional[str]:
+    """Return artifact type if *text* should be externalized."""
+    classified = classify_artifact_content(text, min_chars=min_chars)
+    if classified:
+        return classified
+    if not isinstance(text, str) or len(text) < min_chars:
+        return None
+    head = text[:40_000]
+    low = head.lower()
+    openqp_markers = [
+        "openqp",
+        "pyoqp",
+        "open quantum platform",
+        "mrsf-dft",
+        "mrsf-dft energy gradient calculation",
+        "gradient (hartree/bohr)",
+        "scf",
+        "scf converg",
+        "total energy",
+        "geometry optimization",
+        "z-vector",
+        "tddft",
+        "alternative_scf",
+    ]
+    if sum(1 for marker in openqp_markers if marker in low) >= 2:
+        return "openqp_log"
+    parser_markers = [
+        "traceback",
+        "parse summary",
+        "parsed records",
+        "validation_controls",
+        "abs_diff_ha_per_bohr",
+        "parser output",
+        "records processed",
+    ]
+    if sum(1 for marker in parser_markers if marker in low) >= 2:
+        return "parser_output"
+    compiler_markers = ["undefined reference", "compilation terminated", "error:", "warning:", "make:", "cmake error", "ninja:", "ld:"]
+    if sum(1 for marker in compiler_markers if marker in low) >= 2:
+        return "compiler_output"
+    # Large line-oriented output with many repeated structured rows is still
+    # worth externalizing, but avoid compacting normal prose just because it is
+    # long.
+    lines = text.splitlines()
+    if len(lines) > 250 and (sum(1 for line in lines[:300] if len(line) > 120) > 40):
+        return "large_text"
+    return None
+
+
+def _detect_molden_sections(lines: List[str]) -> List[DetectedSection]:
+    starts: List[Tuple[str, int]] = []
+    for idx, line in enumerate(lines, start=1):
+        if re.match(r"^\s*\[[^\]]+\]", line):
+            starts.append((line.strip(), idx))
+    return _sections_from_starts(starts, len(lines), "molden")
+
+
+def _detect_json_sections(text: str, lines: List[str]) -> List[DetectedSection]:
+    try:
+        obj = json.loads(text)
+    except Exception:
+        obj = None
+    sections: List[DetectedSection] = []
+    if isinstance(obj, dict):
+        for key in list(obj.keys())[:MAX_SECTIONS_IN_CARD * 2]:
+            pattern = re.compile(rf'^\s*{re.escape(json.dumps(str(key)))}\s*:')
+            start = next((i for i, line in enumerate(lines, start=1) if pattern.search(line)), 1)
+            sections.append(DetectedSection(str(key), start, start, "json_key"))
+    elif isinstance(obj, list):
+        sections.append(DetectedSection("json_array", 1, len(lines), "json_array"))
+    else:
+        starts = []
+        for idx, line in enumerate(lines, start=1):
+            m = re.match(r'^\s*"([^"\\]{1,80})"\s*:', line)
+            if m:
+                starts.append((m.group(1), idx))
+        sections = _sections_from_starts(starts[:MAX_SECTIONS_IN_CARD * 2], len(lines), "json_key")
+    return sections
+
+
+def _detect_openqp_sections(lines: List[str]) -> List[DetectedSection]:
+    patterns = [
+        ("input", re.compile(r"input|coordinates|basis", re.I)),
+        ("scf", re.compile(r"\bscf\b|self-consistent|alternative_scf|trah", re.I)),
+        ("mrsf_tddft", re.compile(r"mrsf|tddft|excitation|target state", re.I)),
+        ("z_vector", re.compile(r"z-vector|z vector|gmres|cg solver", re.I)),
+        ("gradient", re.compile(r"gradient \(hartree/bohr\)|energy gradient", re.I)),
+        ("timing", re.compile(r"timing|wall time|total time|normal termination", re.I)),
+        ("errors", re.compile(r"error|traceback|failed|abort|segmentation", re.I)),
+    ]
+    starts: List[Tuple[str, int]] = []
+    seen: set[str] = set()
+    for idx, line in enumerate(lines, start=1):
+        for name, pat in patterns:
+            if name not in seen and pat.search(line):
+                starts.append((name, idx))
+                seen.add(name)
+    return _sections_from_starts(starts, len(lines), "openqp")
+
+
+def _detect_parser_sections(lines: List[str]) -> List[DetectedSection]:
+    starts: List[Tuple[str, int]] = []
+    for idx, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if re.match(r"^(#{1,6}\s+|[-=]{5,}\s*$|[A-Z][A-Za-z0-9 _/-]{3,}:$)", stripped):
+            starts.append((stripped[:80].strip("#:-= "), idx))
+    if not starts:
+        starts = [("head", 1)]
+    return _sections_from_starts(starts[:MAX_SECTIONS_IN_CARD * 2], len(lines), "parser")
+
+
+def _sections_from_starts(starts: Iterable[Tuple[str, int]], total_lines: int, kind: str) -> List[DetectedSection]:
+    clean: List[Tuple[str, int]] = []
+    seen: set[Tuple[str, int]] = set()
+    for name, start in starts:
+        key = (name, start)
+        if start < 1 or key in seen:
+            continue
+        seen.add(key)
+        clean.append((name or f"section_{start}", start))
+    sections: List[DetectedSection] = []
+    for idx, (name, start) in enumerate(clean):
+        end = (clean[idx + 1][1] - 1) if idx + 1 < len(clean) else total_lines
+        sections.append(DetectedSection(name=name, start_line=start, end_line=max(start, end), kind=kind))
+    return sections
+
+
+def detect_sections(text: str, artifact_type: str) -> List[DetectedSection]:
+    lines = text.splitlines()
+    if not lines:
+        return []
+    if artifact_type == "source_code":
+        sections = _detect_source_sections(text)
+    elif artifact_type == "molden":
+        sections = _detect_molden_sections(lines)
+    elif artifact_type in {"cube", "xyz", "pdb", "cif"}:
+        sections = _sections_from_starts([("metadata", 1), ("tail", max(1, len(lines) - 40))], len(lines), artifact_type)
+    elif artifact_type == "json":
+        sections = _detect_json_sections(text, lines)
+    elif artifact_type == "documentation":
+        starts = []
+        for idx, line in enumerate(lines, start=1):
+            if re.match(r"^\s{0,3}#{1,6}\s+", line):
+                starts.append((line.strip(" #")[:80], idx))
+        sections = _sections_from_starts(starts[:MAX_SECTIONS_IN_CARD * 2] or [("document", 1)], len(lines), "documentation")
+    elif artifact_type == "openqp_log":
+        sections = _detect_openqp_sections(lines)
+    elif artifact_type in {"parser_output", "compiler_output"}:
+        sections = _detect_parser_sections(lines)
+    else:
+        sections = _sections_from_starts([("head", 1), ("tail", max(1, len(lines) - 80))], len(lines), artifact_type)
+    if not sections:
+        sections = [DetectedSection("full", 1, len(lines), artifact_type)]
+    return sections[:MAX_SECTIONS_IN_CARD]
+
+
+def _sample_lines(text: str) -> Tuple[List[str], List[str]]:
+    lines = text.splitlines()
+    return lines[:SUMMARY_HEAD_LINES], lines[-SUMMARY_TAIL_LINES:] if len(lines) > SUMMARY_HEAD_LINES else []
+
+
+def _compact_json_preview(text: str) -> str:
+    try:
+        obj = json.loads(text)
+    except Exception:
+        return ""
+    if isinstance(obj, dict):
+        keys = list(obj.keys())[:20]
+        return "top-level keys: " + ", ".join(map(str, keys))
+    if isinstance(obj, list):
+        return f"array length: {len(obj)}"
+    return f"json scalar: {type(obj).__name__}"
+
+
+def _enforce_summary_token_limit(card: str, max_summary_tokens: Optional[int]) -> str:
+    if not max_summary_tokens or max_summary_tokens <= 0:
+        return card
+    if estimate_tokens_rough(card) <= max_summary_tokens:
+        return card
+    retrieval = "Retrieval: use artifact_retrieve with artifact_id or path plus section/line_range/regex to load only the needed raw slice."
+    truncation = "\n[...summary card truncated to configured artifact_max_summary_tokens...]\n"
+    # estimate_tokens_rough is roughly chars/4, so use a conservative char cap.
+    max_chars = max(200, int(max_summary_tokens * 3.6))
+    budget = max(0, max_chars - len(retrieval) - len(truncation))
+    return card[:budget].rstrip() + truncation + retrieval
+
+
+def _summary_card(meta: ArtifactMetadata, text: str, *, max_summary_tokens: int = DEFAULT_MAX_SUMMARY_TOKENS) -> str:
+    head, tail = _sample_lines(text)
+    sections = meta.detected_sections[:MAX_SECTIONS_IN_CARD]
+    section_lines = [
+        f"- {s['name']} [{s['kind']}] lines {s['start_line']}-{s['end_line']}"
+        for s in sections
+    ]
+    preview = _compact_json_preview(text) if meta.artifact_type == "json" else ""
+    if meta.artifact_type == "source_code":
+        idx = _source_index(text)
+        def fmt(values: List[str]) -> str:
+            return ", ".join(values) if values else "(none detected)"
+        section_lines = [
+            f"- {s['name']} [{s['kind']}] lines {s['start_line']}-{s['end_line']}"
+            for s in sections
+        ]
+        card = (
+            f"{_ARTIFACT_CARD_PREFIX}\n"
+            f"artifact_label: Source code summary\n"
+            f"artifact_type: {meta.artifact_type}\n"
+            f"artifact_id: {meta.artifact_id}\n"
+            f"path: {meta.path}\n"
+            f"sha256: {meta.sha256}\n"
+            f"parser_version: {meta.parser_version}\n"
+            f"timestamp: {meta.timestamp}\n"
+            f"file path: {meta.path}\n"
+            f"size: {meta.byte_count} bytes, {idx['line_count']} source lines\n"
+            f"token_estimate: {meta.token_estimate}\n"
+            f"language: {idx['language']}\n"
+            "source_index:\n"
+            f"- modules: {fmt(idx['modules'])}\n"
+            f"- public routines: {fmt(idx['public_routines'])}\n"
+            f"- contained procedures: {fmt(idx['contained_procedures'])}\n"
+            f"- derived types: {fmt(idx['derived_types'])}\n"
+            f"- interfaces: {fmt(idx['interfaces'])}\n"
+            f"- used modules: {fmt(idx['used_modules'])}\n"
+            f"- OpenMP directives: {fmt(idx['openmp_directives'])}\n"
+            f"- major arrays/dimensions: {fmt(idx['major_arrays'])}\n"
+            "detected_symbols:\n"
+            + ("\n".join(section_lines) if section_lines else "- full")
+            + "\nRetrieval: use artifact_retrieve with artifact_id/path plus section=symbol name, regex, or line range. For source files over 5,000 lines, retrieve only relevant routines."
+        )
+        return _enforce_summary_token_limit(card, max_summary_tokens)
+    if meta.artifact_type in {"molden", "cube", "xyz", "pdb", "cif"}:
+        sci = _scientific_metadata(text, meta.artifact_type)
+        card = (
+            f"{_ARTIFACT_CARD_PREFIX}\n"
+            f"artifact_label: Scientific artifact metadata\n"
+            f"artifact_type: {meta.artifact_type}\n"
+            f"artifact_id: {meta.artifact_id}\n"
+            f"path: {meta.path}\n"
+            f"sha256: {meta.sha256}\n"
+            f"parser_version: {meta.parser_version}\n"
+            f"timestamp: {meta.timestamp}\n"
+            f"size: {meta.byte_count} bytes, {meta.line_count} lines\n"
+            f"token_estimate: {meta.token_estimate}\n"
+            "metadata_summary:\n"
+            f"- kind: {sci['kind']}\n"
+            f"- line_count: {sci['line_count']}\n"
+            f"- atom_like_records_sampled: {sci['atom_like_records_sampled']}\n"
+            f"- numeric_values_sampled: {sci['numeric_values_sampled']}\n"
+            "policy: raw coordinates, grids, orbital coefficients, and trajectory values are stored but not injected.\n"
+            "Retrieval: use artifact_retrieve only for focused metadata/line ranges when explicitly needed."
+        )
+        return _enforce_summary_token_limit(card, max_summary_tokens)
+    head_preview = "\n".join(line[:240] for line in head[:10])
+    tail_preview = "\n".join(line[:240] for line in tail[-6:])
+    artifact_label = {
+        "openqp_log": "OpenQP log",
+        "molden": "Molden file",
+        "cube": "Cube file",
+        "xyz": "XYZ coordinates",
+        "pdb": "PDB structure",
+        "cif": "CIF structure",
+        "json": "JSON dump",
+        "source_code": "Source code summary",
+        "documentation": "documentation",
+        "compiler_output": "compiler output",
+        "parser_output": "parser output",
+        "large_text": "large text artifact",
+    }.get(meta.artifact_type, meta.artifact_type)
+    header = (
+        f"{_ARTIFACT_CARD_PREFIX}\n"
+        f"artifact_label: {artifact_label}\n"
+        f"artifact_type: {meta.artifact_type}\n"
+        f"artifact_id: {meta.artifact_id}\n"
+        f"path: {meta.path}\n"
+        f"sha256: {meta.sha256}\n"
+        f"parser_version: {meta.parser_version}\n"
+        f"timestamp: {meta.timestamp}\n"
+        f"size: {meta.byte_count} bytes, {meta.line_count} lines\n"
+        f"token_estimate: {meta.token_estimate}\n"
+        "detected_sections:\n"
+        "Detected sections:\n"
+        + ("\n".join(section_lines) if section_lines else "- full")
+        + "\n"
+    )
+    if preview:
+        header += f"Preview: {preview}\n"
+    card = header + (
+        "Head sample:\n"
+        f"```text\n{head_preview}\n```\n"
+        "Tail sample:\n"
+        f"```text\n{tail_preview}\n```\n"
+        "Retrieval: use artifact_retrieve with artifact_id or path plus section/line_range/regex to load only the needed raw slice."
+    )
+    return _enforce_summary_token_limit(card, max_summary_tokens)
+
+
+def externalize_artifact(
+    text: str,
+    artifact_type: Optional[str] = None,
+    *,
+    max_summary_tokens: int = DEFAULT_MAX_SUMMARY_TOKENS,
+) -> Tuple[str, ArtifactMetadata]:
+    """Persist *text* as an artifact and return ``(summary_card, metadata)``."""
+    artifact_type = artifact_type or detect_artifact_type(text) or "large_text"
+    stored_text = _source_payload(text) if artifact_type == "source_code" else text
+    raw = stored_text.encode("utf-8", errors="replace")
+    digest = sha256(raw).hexdigest()
+    root = artifact_root()
+    artifact_id = digest[:16]
+    data_path = root / f"{digest}{_extension_for_type(artifact_type)}"
+    meta_path = root / f"{digest}.metadata.json"
+    if not data_path.exists():
+        data_path.write_bytes(raw)
+    sections = detect_sections(stored_text, artifact_type)
+    meta = ArtifactMetadata(
+        artifact_id=artifact_id,
+        sha256=digest,
+        path=str(data_path),
+        metadata_path=str(meta_path),
+        parser_version=PARSER_VERSION,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        artifact_type=artifact_type,
+        byte_count=len(raw),
+        char_count=len(stored_text),
+        line_count=_line_count(stored_text),
+        token_estimate=estimate_tokens_rough(stored_text),
+        detected_sections=[asdict(s) for s in sections],
+    )
+    meta_path.write_text(json.dumps(asdict(meta), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return _summary_card(meta, stored_text, max_summary_tokens=max_summary_tokens), meta
+
+
+def _message_text(content: Any) -> Optional[str]:
+    if isinstance(content, str):
+        return content
+    return None
+
+
+def _message_token_estimate(message: Dict[str, Any]) -> int:
+    content = message.get("content")
+    if isinstance(content, str):
+        tokens = estimate_tokens_rough(content)
+    else:
+        tokens = estimate_tokens_rough(json.dumps(content, ensure_ascii=False, default=str))
+    for tc in message.get("tool_calls") or []:
+        try:
+            tokens += estimate_tokens_rough(json.dumps(tc, ensure_ascii=False, default=str))
+        except Exception:
+            tokens += estimate_tokens_rough(str(tc))
+    return tokens + 8
+
+
+def profile_largest_messages(messages: List[Dict[str, Any]], *, limit: int = 8) -> List[Dict[str, Any]]:
+    rows = []
+    for idx, msg in enumerate(messages):
+        text = _message_text(msg.get("content"))
+        token_estimate = _message_token_estimate(msg)
+        rows.append({
+            "index": idx,
+            "role": msg.get("role", ""),
+            "token_estimate": token_estimate,
+            "tokens_estimate": token_estimate,
+            "char_count": len(text) if text is not None else len(str(msg.get("content") or "")),
+            "artifact_card": bool(text and text.startswith(_ARTIFACT_CARD_PREFIX)),
+            "preview": (text or str(msg.get("content") or ""))[:120].replace("\n", " "),
+        })
+    rows.sort(key=lambda r: r["token_estimate"], reverse=True)
+    return rows[:limit]
+
+
+
+
+def _message_category(message: Dict[str, Any]) -> str:
+    text = _message_text(message.get("content")) or ""
+    if text.startswith(_ARTIFACT_CARD_PREFIX):
+        m = re.search(r"^artifact_type:\s*(\S+)", text, re.MULTILINE)
+        kind = m.group(1) if m else "artifact_card"
+    else:
+        kind = detect_artifact_type(text, min_chars=1000) or "conversation"
+    if kind in {"openqp_log", "compiler_output", "parser_output", "large_text"}:
+        return "logs"
+    if kind in {"molden", "cube", "xyz", "pdb", "cif"}:
+        return "scientific_artifacts"
+    if kind == "json":
+        return "structured_data"
+    if kind == "source_code":
+        return "source_code"
+    if kind == "documentation":
+        return "documentation"
+    return kind
+
+
+def context_budget_profile(messages: List[Dict[str, Any]], *, top_n: int = 20) -> Dict[str, Any]:
+    total = sum(_message_token_estimate(m) for m in messages)
+    by_category: Dict[str, int] = {}
+    raw_large_artifact_tokens = 0
+    for m in messages:
+        tokens = _message_token_estimate(m)
+        cat = _message_category(m)
+        by_category[cat] = by_category.get(cat, 0) + tokens
+        text = _message_text(m.get("content")) or ""
+        if cat in {"logs", "scientific_artifacts", "structured_data"} and not text.startswith(_ARTIFACT_CARD_PREFIX):
+            raw_large_artifact_tokens += tokens
+    status = "ok"
+    if total > 120_000:
+        status = "emergency_compaction"
+    elif total > 80_000:
+        status = "warning"
+    expected_after = total - raw_large_artifact_tokens + min(raw_large_artifact_tokens, max(0, int(total * 0.02)))
+    return {
+        "total_estimated_tokens": total,
+        "status": status,
+        "target_active_context_tokens": 60_000,
+        "warning_tokens": 80_000,
+        "emergency_compaction_tokens": 120_000,
+        "top_20_largest_messages": profile_largest_messages(messages, limit=top_n),
+        "token_contribution_by_category": dict(sorted(by_category.items(), key=lambda kv: kv[1], reverse=True)),
+        "raw_logs_generated_artifacts_token_cap": int(60_000 * 0.20),
+        "raw_large_artifact_tokens": raw_large_artifact_tokens,
+        "expected_reduction_after_compaction": max(0, total - expected_after),
+        "expected_tokens_after_compaction": expected_after,
+    }
+
+def compact_artifacts_in_messages(
+    messages: List[Dict[str, Any]],
+    *,
+    min_chars: int = DEFAULT_MIN_CHARS,
+    min_tokens: int = DEFAULT_MIN_TOKENS,
+    max_summary_tokens: int = DEFAULT_MAX_SUMMARY_TOKENS,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Replace large artifact-like message contents with summary cards.
+
+    Returns ``(new_messages, profile)``.  Input messages are not mutated.
+    """
+    before_context_profile = context_budget_profile(messages, top_n=20)
+    before = before_context_profile["top_20_largest_messages"]
+    new_messages: List[Dict[str, Any]] = []
+    artifacts: List[Dict[str, Any]] = []
+    for idx, msg in enumerate(messages):
+        content = msg.get("content")
+        text = _message_text(content)
+        text_tokens = estimate_tokens_rough(text) if text else 0
+        kind = (
+            detect_artifact_type(text or "", min_chars=min_chars)
+            if text and len(text) >= min_chars and text_tokens >= min_tokens
+            else None
+        )
+        if text and kind and not text.startswith(_ARTIFACT_CARD_PREFIX):
+            card, meta = externalize_artifact(
+                text,
+                kind,
+                max_summary_tokens=max_summary_tokens,
+            )
+            new_msg = {**msg, "content": card}
+            new_messages.append(new_msg)
+            artifacts.append({"message_index": idx, **asdict(meta)})
+        else:
+            new_messages.append(msg.copy())
+    after_context_profile = context_budget_profile(new_messages, top_n=20)
+    after = after_context_profile["top_20_largest_messages"]
+    before_tokens = sum(_message_token_estimate(m) for m in messages)
+    after_tokens = sum(_message_token_estimate(m) for m in new_messages)
+    profile = ArtifactCompactionResult({
+        "parser_version": PARSER_VERSION,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "artifact_count": len(artifacts),
+        "min_chars": min_chars,
+        "min_tokens": min_tokens,
+        "max_summary_tokens": max_summary_tokens,
+        "before_total_tokens": before_tokens,
+        "after_total_tokens": after_tokens,
+        "saved_tokens": max(0, before_tokens - after_tokens),
+        "largest_before": before,
+        "largest_after": after,
+        "context_budget_before": before_context_profile,
+        "context_budget_after": after_context_profile,
+        "token_contribution_by_category": after_context_profile["token_contribution_by_category"],
+        "top_20_largest_messages": after_context_profile["top_20_largest_messages"],
+        "expected_reduction_after_compaction": before_context_profile["expected_reduction_after_compaction"],
+        "artifacts": artifacts,
+    })
+    return new_messages, profile
+
+
+def profile_message_sizes(messages: List[Dict[str, Any]], *, top_n: int = 8) -> List[Dict[str, Any]]:
+    """Public profiler for largest messages, ordered by estimated tokens."""
+    rows = profile_largest_messages(messages, limit=top_n)
+    for row in rows:
+        if "token_estimate" in row:
+            row.setdefault("tokens_estimate", row["token_estimate"])
+    return rows
+
+
+def load_artifact_metadata(identifier: str) -> ArtifactMetadata:
+    root = artifact_root()
+    candidate = Path(identifier).expanduser()
+    if candidate.exists() and candidate.name.endswith(".metadata.json"):
+        data = json.loads(candidate.read_text(encoding="utf-8"))
+    elif candidate.exists():
+        digest = sha256(candidate.read_bytes()).hexdigest()
+        data = json.loads((root / f"{digest}.metadata.json").read_text(encoding="utf-8"))
+    else:
+        matches = list(root.glob(f"{identifier}*.metadata.json"))
+        if not matches:
+            raise FileNotFoundError(f"No artifact metadata found for {identifier!r}")
+        data = json.loads(matches[0].read_text(encoding="utf-8"))
+    return ArtifactMetadata(**data)
+
+
+def retrieve_artifact_section(
+    identifier: Optional[str] = None,
+    *,
+    sha256: Optional[str] = None,
+    section: Optional[str] = None,
+    start_line: Optional[int] = None,
+    end_line: Optional[int] = None,
+    line_start: Optional[int] = None,
+    line_end: Optional[int] = None,
+    regex: Optional[str] = None,
+    context_lines: int = 20,
+    max_chars: int = DEFAULT_RETRIEVE_MAX_CHARS,
+) -> Dict[str, Any]:
+    """Load a focused slice of a stored artifact."""
+    identifier = identifier or sha256
+    if not identifier:
+        return {"success": False, "error": "identifier, sha256, or path is required"}
+    if line_start is not None and start_line is None:
+        start_line = line_start
+    if line_end is not None and end_line is None:
+        end_line = line_end
+    meta = load_artifact_metadata(identifier)
+    path = Path(meta.path)
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    selected_name = section
+    if section:
+        lowered = section.lower()
+        hit = next((s for s in meta.detected_sections if s.get("name", "").lower() == lowered), None)
+        if hit is None:
+            hit = next((s for s in meta.detected_sections if lowered in s.get("name", "").lower()), None)
+        if hit:
+            start_line = int(hit["start_line"])
+            end_line = int(hit["end_line"])
+            selected_name = hit["name"]
+    if regex:
+        pat = re.compile(regex, re.MULTILINE)
+        match = pat.search(text)
+        if match:
+            prefix = text[:match.start()]
+            line_no = prefix.count("\n") + 1
+            start_line = max(1, line_no - context_lines)
+            end_line = min(len(lines), line_no + context_lines)
+            selected_name = f"regex:{regex}"
+        else:
+            return {"success": False, "error": f"regex not found: {regex}", "artifact": asdict(meta)}
+    if start_line is None:
+        start_line = 1
+    if end_line is None:
+        end_line = min(len(lines), start_line + 200 - 1)
+    start_line = max(1, int(start_line))
+    end_line = min(len(lines), int(end_line))
+    snippet_lines = lines[start_line - 1:end_line]
+    snippet = "\n".join(snippet_lines)
+    truncated = False
+    if len(snippet) > max_chars:
+        snippet = snippet[:max_chars].rstrip() + "\n[...artifact slice truncated...]"
+        truncated = True
+    return {
+        "success": True,
+        "artifact": asdict(meta),
+        "artifact_id": meta.artifact_id,
+        "sha256": meta.sha256,
+        "path": meta.path,
+        "section": selected_name or "line_range",
+        "line_start": start_line,
+        "line_end": end_line,
+        "start_line": start_line,
+        "end_line": end_line,
+        "truncated": truncated,
+        "content": snippet,
+    }

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -31,6 +31,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
 )
 from agent.redact import redact_sensitive_text
+from agent.artifact_compaction import compact_artifacts_in_messages
 
 logger = logging.getLogger(__name__)
 
@@ -524,6 +525,9 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        artifact_min_chars: int = 8_000,
+        artifact_min_tokens: int = 2_000,
+        artifact_max_summary_tokens: int = 800,
     ):
         self.model = model
         self.base_url = base_url
@@ -540,6 +544,9 @@ class ContextCompressor(ContextEngine):
         # When False (default = historical behavior), insert a static
         # "summary unavailable" placeholder and drop the middle window.
         self.abort_on_summary_failure = abort_on_summary_failure
+        self.artifact_min_chars = artifact_min_chars
+        self.artifact_min_tokens = artifact_min_tokens
+        self.artifact_max_summary_tokens = artifact_max_summary_tokens
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -598,6 +605,7 @@ class ContextCompressor(ContextEngine):
         # this flag to know "compression was attempted but aborted, freeze
         # the chat until the user manually retries via /compress".
         self._last_compress_aborted: bool = False
+        self._last_artifact_profile: Dict[str, Any] = {}
         # When a user-configured summary model fails and we recover by
         # retrying on the main model, record the failure so gateway /
         # CLI callers can still warn the user even though compression
@@ -1522,12 +1530,39 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._last_artifact_profile = {}
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
         # this, /compress would silently no-op for 30-60s after a failure.
         if force and self._summary_failure_cooldown_until > 0.0:
             self._summary_failure_cooldown_until = 0.0
+
+        # Phase 0: Externalize large reproducible artifacts before any
+        # head/tail decisions. This prevents a single fresh OpenQP log,
+        # Molden file, JSON dump, or parser output from remaining verbatim in
+        # the protected tail and keeping active context above threshold.
+        messages, artifact_profile = compact_artifacts_in_messages(
+            messages,
+            min_chars=getattr(self, "artifact_min_chars", 8_000),
+            min_tokens=getattr(self, "artifact_min_tokens", 2_000),
+            max_summary_tokens=getattr(self, "artifact_max_summary_tokens", 800),
+        )
+        self._last_artifact_profile = artifact_profile
+        if artifact_profile.get("artifact_count") and not self.quiet_mode:
+            logger.info(
+                "Artifact compaction: %d artifact(s), ~%d tokens -> ~%d tokens (saved ~%d)",
+                artifact_profile.get("artifact_count", 0),
+                artifact_profile.get("before_total_tokens", 0),
+                artifact_profile.get("after_total_tokens", 0),
+                artifact_profile.get("saved_tokens", 0),
+            )
+            logger.info(
+                "Artifact compaction largest messages before=%s after=%s",
+                artifact_profile.get("largest_before", []),
+                artifact_profile.get("largest_after", []),
+            )
+
         n_messages = len(messages)
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1001,6 +1001,36 @@ def run_conversation(
                 native_anthropic=agent._use_native_cache_layout,
             )
 
+        # Artifact-aware compaction: large OpenQP logs, Molden files, JSON
+        # dumps, and parser output are stored by content hash under
+        # $HERMES_HOME/artifacts and replaced in the active LLM request by a
+        # compact summary card.  This is API-boundary only: transcripts keep
+        # their normal history, while the model avoids replaying 200K+ raw
+        # tokens.  Details remain recoverable with artifact_retrieve.
+        try:
+            from agent.artifact_compaction import compact_artifacts_in_messages
+            _artifact_min_chars = int(getattr(agent, "artifact_compaction_min_chars", 8000) or 8000)
+            _artifact_min_tokens = int(getattr(agent, "artifact_compaction_min_tokens", 2000) or 2000)
+            _artifact_max_summary_tokens = int(getattr(agent, "artifact_compaction_max_summary_tokens", 800) or 800)
+            api_messages, _artifact_report = compact_artifacts_in_messages(
+                api_messages,
+                min_chars=_artifact_min_chars,
+                min_tokens=_artifact_min_tokens,
+                max_summary_tokens=_artifact_max_summary_tokens,
+            )
+            agent._last_context_profiler_report = _artifact_report.get("context_budget_after", {})
+            logger.info("context budget profile: %s", agent._last_context_profiler_report)
+            if _artifact_report.get("artifact_count"):
+                agent._last_artifact_compaction_report = _artifact_report
+                logger.info("artifact compaction: %s", _artifact_report)
+                if not getattr(agent, "_artifact_compaction_notice_sent", False):
+                    agent._artifact_compaction_notice_sent = True
+                    agent._emit_status(
+                        "📦 Compacted large raw artifact(s) into summary cards; raw content saved under ~/.hermes/artifacts."
+                    )
+        except Exception as _artifact_exc:
+            logger.debug("artifact compaction skipped: %s", _artifact_exc)
+
         # Safety net: strip orphaned tool results / add stubs for missing
         # results before sending to the API.  Runs unconditionally — not
         # gated on context_compressor — so orphans from session loading or

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -944,6 +944,14 @@ DEFAULT_CONFIG = {
                                       # Default False matches historical behavior; set to
                                       # True if you'd rather pause than silently lose
                                       # context turns when your aux model is flaky.
+        "artifact_min_chars": 8_000,  # raw artifact payloads above this size are stored under ~/.hermes/artifacts and replaced with summary cards at the API boundary
+        "artifact_min_tokens": 2_000,  # also require this rough token estimate before artifact externalization
+        "artifact_max_summary_tokens": 800,  # maximum rough tokens for each artifact summary card
+        "artifact_retrieve_max_chars": 12_000,  # default focused raw slice returned by artifact_retrieve
+        "target_active_context_tokens": 60_000,  # source-aware context profiler target budget
+        "warning_tokens": 80_000,  # profiler warning threshold
+        "emergency_compaction_tokens": 120_000,  # profiler emergency threshold
+        "raw_generated_artifact_budget_fraction": 0.20,  # raw logs/generated artifacts should stay below this fraction of the target context
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/tests/agent/test_artifact_compaction.py
+++ b/tests/agent/test_artifact_compaction.py
@@ -1,0 +1,199 @@
+import hashlib
+import json
+from pathlib import Path
+
+from agent.artifact_compaction import (
+    compact_artifacts_in_messages,
+    detect_artifact_type,
+    estimate_tokens_rough,
+    retrieve_artifact_section,
+)
+
+
+def test_detects_openqp_log_and_stores_summary_card(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = (
+        "Open Quantum Platform\n"
+        "PyOQP Test Report\n"
+        "MRSF-EKT ionization potentials (hartree)\n"
+        "Z-vector converged\n"
+        "state     energy           strength\n"
+        + "SCF iteration line with a long OpenQP diagnostic payload " + "x" * 140 + "\n"
+        + ("SCF converged alternative_scf z-vector tddft diagnostic " + "y" * 140 + "\n") * 900
+        + "ERROR final diagnostic\n"
+    )
+    messages = [{"role": "user", "content": raw}]
+
+    compacted, report = compact_artifacts_in_messages(messages, min_chars=1000)
+
+    digest = hashlib.sha256(raw.encode()).hexdigest()
+    meta = report["artifacts"][0]
+    artifact = Path(meta["path"])
+    metadata = Path(meta["metadata_path"])
+    assert artifact == tmp_path / "artifacts" / f"{digest}.openqp.log"
+    assert metadata == tmp_path / "artifacts" / f"{digest}.metadata.json"
+    assert artifact.exists()
+    assert metadata.exists()
+    assert artifact.read_text() == raw
+    saved_meta = json.loads(metadata.read_text(encoding="utf-8"))
+    assert saved_meta["sha256"] == digest
+    assert saved_meta["metadata_path"] == str(metadata)
+    assert saved_meta["detected_sections"]
+    card = compacted[0]["content"]
+    assert "[HERMES ARTIFACT SUMMARY CARD]" in card
+    assert digest in card
+    assert "artifact_retrieve" in card
+    assert report["artifact_count"] == 1
+    assert report["after_total_tokens"] < report["before_total_tokens"]
+    assert report["largest_after"][0]["token_estimate"] < report["largest_before"][0]["token_estimate"]
+
+
+def test_retrieve_artifact_section_by_detected_name(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = "Open Quantum Platform\nMRSF-EKT ionization potentials\nZ-vector converged\nroot 1\nSCF section\ncycle 1\n" + "tail\n" * 300
+    compacted, report = compact_artifacts_in_messages(
+        [{"role": "tool", "content": raw}],
+        min_chars=100,
+        min_tokens=0,
+    )
+    meta = report["artifacts"][0]
+
+    result = retrieve_artifact_section(meta["artifact_id"], section="mrsf_tddft")
+
+    assert result["artifact"]["sha256"] == meta["sha256"]
+    assert "MRSF-EKT ionization potentials" in result["content"]
+    assert result["start_line"] <= result["end_line"]
+
+
+def test_json_dump_compaction_records_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = json.dumps({"records": [{"i": i, "value": "x" * 50} for i in range(400)]}, indent=2)
+
+    compacted, report = compact_artifacts_in_messages([{"role": "user", "content": raw}], min_chars=1000)
+
+    assert detect_artifact_type(raw) == "json"
+    meta = report["artifacts"][0]
+    assert meta["artifact_type"] == "json"
+    assert meta["parser_version"] == "artifact-aware-compaction-v1"
+    assert meta["token_estimate"] > 1000
+    assert "Detected sections:" in compacted[0]["content"]
+
+
+def test_artifact_min_tokens_prevents_compacting_small_token_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = "Open Quantum Platform\nSCF\n" + ("x" * 30 + "\n") * 300
+
+    compacted, report = compact_artifacts_in_messages(
+        [{"role": "tool", "content": raw}],
+        min_chars=1000,
+        min_tokens=10_000,
+    )
+
+    assert compacted[0]["content"] == raw
+    assert report["artifact_count"] == 0
+    assert not (tmp_path / "artifacts").exists()
+
+
+def test_artifact_summary_card_respects_token_budget(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = (
+        "Open Quantum Platform\nPyOQP Test Report\n"
+        + ("SCF converged alternative_scf z-vector tddft diagnostic " + "x" * 180 + "\n") * 900
+    )
+
+    compacted, report = compact_artifacts_in_messages(
+        [{"role": "tool", "content": raw}],
+        min_chars=1000,
+        min_tokens=100,
+        max_summary_tokens=120,
+    )
+
+    assert report["artifact_count"] == 1
+    card = compacted[0]["content"]
+    assert estimate_tokens_rough(card) <= 120
+    assert "artifact_retrieve" in card
+    assert raw not in card
+
+
+def test_retrieve_artifact_default_max_chars_is_12k(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = "Open Quantum Platform\nSCF section\n" + ("line " + "x" * 100 + "\n") * 500
+    _compacted, report = compact_artifacts_in_messages(
+        [{"role": "tool", "content": raw}],
+        min_chars=100,
+        min_tokens=0,
+    )
+    meta = report["artifacts"][0]
+
+    result = retrieve_artifact_section(meta["artifact_id"], section="scf")
+
+    assert result["truncated"] is True
+    assert len(result["content"]) <= 12_100
+    assert "[...artifact slice truncated...]" in result["content"]
+
+
+
+def test_source_code_gets_symbol_summary_and_symbol_retrieval(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    source = (
+        "module m_test\n"
+        "  use omp_lib\n"
+        "  implicit none\n"
+        "  real :: work(nroot, nmo), grad(3, natom)\n"
+        "contains\n"
+        "  subroutine build_sigma(vec)\n"
+        "!$omp parallel do\n"
+        "    real :: vec(:)\n"
+        "  end subroutine build_sigma\n"
+        "  function energy() result(e)\n"
+        "    real :: e\n"
+        "  end function energy\n"
+        "end module m_test\n"
+    ) * 120
+    wrapped = json.dumps({
+        "content": "\n".join(f"{i + 1:6}|{line}" for i, line in enumerate(source.splitlines())),
+        "total_lines": len(source.splitlines()),
+    })
+
+    compacted, report = compact_artifacts_in_messages(
+        [{"role": "tool", "content": wrapped}],
+        min_chars=1000,
+        min_tokens=0,
+    )
+
+    assert detect_artifact_type(wrapped, min_chars=1000) == "source_code"
+    meta = report["artifacts"][0]
+    assert meta["artifact_type"] == "source_code"
+    assert meta["path"].endswith(".source.txt")
+    assert Path(meta["path"]).read_text(encoding="utf-8").startswith("module m_test")
+    card = compacted[0]["content"]
+    assert "artifact_label: Source code summary" in card
+    assert "modules: m_test" in card
+    assert "build_sigma" in card
+    assert "OpenMP directives" in card
+    assert "work(nroot, nmo)" in card
+
+    result = retrieve_artifact_section(meta["artifact_id"], section="build_sigma", max_chars=500)
+    assert result["success"] is True
+    assert result["section"] == "subroutine build_sigma"
+    assert "subroutine build_sigma" in result["content"]
+
+
+def test_scientific_artifact_metadata_omits_raw_coordinates(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = ("5\ncomment\nC 0.0 0.0 0.0\nH 0.0 0.0 1.0\nH 0.0 1.0 0.0\nH 1.0 0.0 0.0\nH 1.0 1.0 1.0\n" * 250)
+
+    compacted, report = compact_artifacts_in_messages(
+        [{"role": "tool", "content": raw}],
+        min_chars=1000,
+        min_tokens=0,
+    )
+
+    assert detect_artifact_type(raw, min_chars=1000) == "xyz"
+    meta = report["artifacts"][0]
+    assert meta["artifact_type"] == "xyz"
+    card = compacted[0]["content"]
+    assert "Scientific artifact metadata" in card
+    assert "raw coordinates" in card
+    assert "C 0.0 0.0 0.0" not in card
+    assert report["context_budget_after"]["token_contribution_by_category"]["scientific_artifacts"] > 0

--- a/tools/artifact_tools.py
+++ b/tools/artifact_tools.py
@@ -1,0 +1,86 @@
+"""Retrieve sections from raw artifacts saved by artifact-aware compaction."""
+
+import json
+
+from agent.artifact_compaction import DEFAULT_RETRIEVE_MAX_CHARS, retrieve_artifact_section
+from tools.registry import registry
+
+
+ARTIFACT_RETRIEVE_SCHEMA = {
+    "name": "artifact_retrieve",
+    "description": "Load a targeted section, line range, or regex match from a raw artifact saved under ~/.hermes/artifacts by artifact-aware context compaction. Use this instead of reading the full artifact when a summary card needs details.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "artifact_id": {"type": "string", "description": "Artifact id from the summary card (first 16 sha256 chars)."},
+            "sha256": {"type": "string", "description": "Full sha256 fingerprint from the summary card."},
+            "path": {"type": "string", "description": "Artifact path from the summary card."},
+            "section": {"type": "string", "description": "Optional detected section/symbol name or substring."},
+            "symbol_name": {"type": "string", "description": "Optional source-code symbol name to retrieve (module, subroutine, function, type, interface)."},
+            "module_name": {"type": "string", "description": "Optional Fortran module name to retrieve."},
+            "subroutine_name": {"type": "string", "description": "Optional Fortran subroutine/function name to retrieve."},
+            "line_start": {"type": "integer", "description": "Optional 1-indexed start line."},
+            "line_end": {"type": "integer", "description": "Optional 1-indexed end line."},
+            "regex": {"type": "string", "description": "Optional regex; returns a small context window around the first match."},
+            "context_lines": {"type": "integer", "description": "Context lines for regex retrieval.", "default": 20},
+            "max_chars": {"type": "integer", "description": "Maximum characters to return.", "default": DEFAULT_RETRIEVE_MAX_CHARS},
+        },
+        "anyOf": [
+            {"required": ["artifact_id"]},
+            {"required": ["sha256"]},
+            {"required": ["path"]},
+        ],
+    },
+}
+
+# Backwards-compatible schema name for callers/tests that already discovered it.
+RETRIEVE_ARTIFACT_SECTION_SCHEMA = {
+    **ARTIFACT_RETRIEVE_SCHEMA,
+    "name": "retrieve_artifact_section",
+}
+
+
+def _configured_default_max_chars() -> int:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config().get("compression", {}) or {}
+        return int(cfg.get("artifact_retrieve_max_chars") or DEFAULT_RETRIEVE_MAX_CHARS)
+    except Exception:
+        return DEFAULT_RETRIEVE_MAX_CHARS
+
+
+def _handler(args, **kwargs):
+    identifier = args.get("artifact_id") or args.get("sha256") or args.get("path") or ""
+    section = args.get("section")
+    if not section:
+        if args.get("symbol_name"):
+            section = args.get("symbol_name")
+        elif args.get("module_name"):
+            section = f"module {args.get('module_name')}"
+        elif args.get("subroutine_name"):
+            section = args.get("subroutine_name")
+    return json.dumps(retrieve_artifact_section(
+        identifier,
+        section=section,
+        line_start=args.get("line_start"),
+        line_end=args.get("line_end"),
+        regex=args.get("regex"),
+        context_lines=int(args.get("context_lines") or 20),
+        max_chars=int(args.get("max_chars") or _configured_default_max_chars()),
+    ), ensure_ascii=False)
+
+
+registry.register(
+    name="artifact_retrieve",
+    toolset="file",
+    schema=ARTIFACT_RETRIEVE_SCHEMA,
+    handler=_handler,
+)
+
+registry.register(
+    name="retrieve_artifact_section",
+    toolset="file",
+    schema=RETRIEVE_ARTIFACT_SECTION_SCHEMA,
+    handler=_handler,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -34,7 +34,7 @@ _HERMES_CORE_TOOLS = [
     # Terminal + process management
     "terminal", "process",
     # File manipulation
-    "read_file", "write_file", "patch", "search_files",
+    "read_file", "write_file", "patch", "search_files", "artifact_retrieve",
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills


### PR DESCRIPTION
## Summary

Adds source-aware artifact compaction at the API boundary so large scientific/tool outputs do not dominate active LLM context while remaining reproducible and retrievable.

- Store large OpenQP logs, Molden/scientific artifacts, JSON dumps, parser/compiler outputs, documentation, and source payloads under `~/.hermes/artifacts` by SHA256.
- Replace compactable active-context messages with structured summary cards containing path, sha256, parser version, timestamp, token estimate, and detected sections.
- Add `artifact_retrieve` / `retrieve_artifact_section` tools for targeted retrieval by artifact id, sha256/path, section, line range, regex, and source-oriented symbol/module/subroutine names.
- Add source-aware handling: source code is indexed into symbol summaries instead of being aggressively prose-summarized; Fortran extraction includes modules, routines, derived types, interfaces, `use` dependencies, OpenMP directives, and major arrays/dimensions.
- Add context budget profiling: top 20 largest messages, category token contribution, before/after totals, and expected reduction after compaction.
- Wire compaction into `conversation_loop` before API calls and expose config defaults under `compression`.

## Tests

- `venv/bin/python -m pytest -q tests/agent/test_artifact_compaction.py tests/test_toolsets.py`
- `venv/bin/python -m py_compile agent/artifact_compaction.py tools/artifact_tools.py agent/conversation_loop.py agent/agent_init.py agent/context_compressor.py hermes_cli/config.py toolsets.py`
